### PR TITLE
feat(ctl): ferrosa-ctl auth set-password subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,8 @@ name = "ferrosa-ctl"
 version = "0.8.8+8"
 dependencies = [
  "arc-swap",
+ "argon2 0.6.0-rc.8",
+ "chrono",
  "clap",
  "crossterm",
  "ferrosa-cluster",
@@ -1817,11 +1819,16 @@ dependencies = [
  "ferrosa-schema",
  "ferrosa-storage",
  "ferrosa-udf",
+ "password-hash 0.6.1",
  "ratatui",
  "reqwest",
+ "rpassword",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "tabled",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
 ]
@@ -4752,6 +4759,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsa"
 version = "0.10.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4768,6 +4786,16 @@ dependencies = [
  "signature",
  "spki",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5352,6 +5380,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -6502,6 +6543,12 @@ dependencies = [
  "crypto-common 0.2.1",
  "ctutils",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/ferrosa-ctl/Cargo.toml
+++ b/ferrosa-ctl/Cargo.toml
@@ -16,9 +16,19 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tabled = "0.20"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 ratatui = "0.29"
 crossterm = "0.28"
+# Argon2id password hashing for `auth set-password`.
+# Output is wire-compatible with `ferrosa-schema::auth::password::PasswordHasher::verify_password_any`,
+# which auto-detects the `$argon2id$` PHC prefix.
+argon2 = "0.6.0-rc.8"
+password-hash = { version = "0.6", features = ["rand_core", "getrandom"] }
+rpassword = "7"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+thiserror = "2"
 
 [dev-dependencies]
 arc-swap = "1.7"

--- a/ferrosa-ctl/src/auth.rs
+++ b/ferrosa-ctl/src/auth.rs
@@ -1,0 +1,737 @@
+//! `ferrosa-ctl auth set-password` — seed initial admin credentials.
+//!
+//! Used by the post-install prompt to write the CQL admin and graph
+//! HTTP/Bolt basic-auth password hashes into
+//! `~/.ferrosa/config/auth.yaml`.
+//!
+//! # File layout
+//!
+//! ```yaml
+//! cql:
+//!   admin:
+//!     hash: "$argon2id$v=19$m=19456,t=2,p=1$..."
+//!     created_at: "2026-05-08T20:30:00Z"
+//! graph:
+//!   admin:
+//!     hash: "..."
+//!     created_at: "..."
+//! ```
+//!
+//! # Hashing scheme
+//!
+//! Argon2id with the OWASP-recommended parameters
+//! (m = 19 456 KiB, t = 2, p = 1). The PHC string is self-describing,
+//! and `ferrosa-schema::auth::password::PasswordHasher::verify_password_any`
+//! already auto-detects an `$argon2id$` prefix, so a hash produced here
+//! is verifiable by the server's existing authenticator path.
+//!
+//! Note: the running server does NOT currently read `auth.yaml` — its
+//! authoritative store is `system_auth.roles.salted_hash`. Wiring the
+//! installer's first-touch hash into the server is tracked as a
+//! follow-up (see PR description).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+
+use argon2::password_hash::PasswordHasher as _;
+use argon2::Argon2;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Argon2id memory cost in KiB. OWASP 2024 recommendation.
+const ARGON2_MEMORY_KIB: u32 = 19_456;
+/// Argon2id iterations. OWASP 2024 recommendation.
+const ARGON2_ITERATIONS: u32 = 2;
+/// Argon2id parallelism. OWASP 2024 recommendation.
+const ARGON2_PARALLELISM: u32 = 1;
+
+/// Realm a credential applies to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Realm {
+    /// CQL native protocol authenticator (port 9042).
+    Cql,
+    /// Graph HTTP/Bolt basic-auth credential (ports 7474 / 7687).
+    Graph,
+}
+
+impl Realm {
+    fn as_yaml_key(self) -> &'static str {
+        match self {
+            Realm::Cql => "cql",
+            Realm::Graph => "graph",
+        }
+    }
+}
+
+impl std::str::FromStr for Realm {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cql" => Ok(Realm::Cql),
+            "graph" => Ok(Realm::Graph),
+            other => Err(format!(
+                "unknown realm '{other}' — expected 'cql' or 'graph'"
+            )),
+        }
+    }
+}
+
+/// One credential entry in the YAML file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CredentialEntry {
+    /// PHC-format password hash (e.g. `$argon2id$v=19$m=...$...$...`).
+    pub hash: String,
+    /// RFC 3339 timestamp recording when this hash was written.
+    pub created_at: String,
+}
+
+/// On-disk representation of `auth.yaml`. Realms are top-level keys,
+/// each mapping `username -> CredentialEntry`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct AuthFile {
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub cql: BTreeMap<String, CredentialEntry>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub graph: BTreeMap<String, CredentialEntry>,
+}
+
+impl AuthFile {
+    fn realm_mut(&mut self, realm: Realm) -> &mut BTreeMap<String, CredentialEntry> {
+        match realm {
+            Realm::Cql => &mut self.cql,
+            Realm::Graph => &mut self.graph,
+        }
+    }
+
+    fn realm(&self, realm: Realm) -> &BTreeMap<String, CredentialEntry> {
+        match realm {
+            Realm::Cql => &self.cql,
+            Realm::Graph => &self.graph,
+        }
+    }
+}
+
+/// Errors produced by the `auth` subcommand.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("password mismatch — please try again")]
+    Mismatch,
+    #[error("operation aborted by user")]
+    Aborted,
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+    #[error("yaml error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+    #[error("hash error: {0}")]
+    Hash(String),
+    #[error("home directory could not be resolved")]
+    NoHome,
+}
+
+/// Default config path under `$HOME/.ferrosa/config/auth.yaml`.
+pub fn default_config_path() -> Result<PathBuf, AuthError> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or(AuthError::NoHome)?;
+    Ok(home.join(".ferrosa").join("config").join("auth.yaml"))
+}
+
+/// Hash a plaintext password with Argon2id and OWASP parameters.
+/// Returns a PHC-format string. `password-hash` 0.6 generates the salt
+/// internally via the OS RNG.
+pub fn hash_password(password: &str) -> Result<String, AuthError> {
+    let params = argon2::Params::new(
+        ARGON2_MEMORY_KIB,
+        ARGON2_ITERATIONS,
+        ARGON2_PARALLELISM,
+        None,
+    )
+    .map_err(|e| AuthError::Hash(format!("invalid argon2 params: {e}")))?;
+    let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
+    let hash = argon2
+        .hash_password(password.as_bytes())
+        .map_err(|e| AuthError::Hash(format!("argon2 hash failed: {e}")))?;
+    Ok(hash.to_string())
+}
+
+/// Verify a plaintext password against a PHC-format Argon2id hash.
+/// Used by tests; mirrors the server-side `verify_password_any` path.
+#[cfg(test)]
+pub fn verify_password(password: &str, phc_hash: &str) -> Result<bool, AuthError> {
+    use argon2::password_hash::phc::PasswordHash;
+    use argon2::password_hash::PasswordVerifier;
+
+    let parsed = PasswordHash::new(phc_hash)
+        .map_err(|e| AuthError::Hash(format!("phc parse failed: {e}")))?;
+    let argon2 = Argon2::default();
+    match argon2.verify_password(password.as_bytes(), &parsed) {
+        Ok(()) => Ok(true),
+        Err(argon2::password_hash::Error::PasswordInvalid) => Ok(false),
+        Err(e) => Err(AuthError::Hash(format!("verify failed: {e}"))),
+    }
+}
+
+/// Read an existing `auth.yaml` if present, otherwise return a default
+/// (empty) struct. Bubbles up parse errors so we never silently clobber
+/// a broken file.
+pub fn load_or_default(path: &Path) -> Result<AuthFile, AuthError> {
+    match fs::read_to_string(path) {
+        Ok(text) => {
+            let file: AuthFile = serde_yaml::from_str(&text)?;
+            Ok(file)
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(AuthFile::default()),
+        Err(e) => Err(AuthError::Io(e)),
+    }
+}
+
+/// Atomically write `auth.yaml` to `path`, creating parent directories
+/// and setting mode 0600 on Unix.
+pub fn save(path: &Path, file: &AuthFile) -> Result<(), AuthError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let yaml = serde_yaml::to_string(file)?;
+    let tmp = path.with_extension("yaml.tmp");
+    {
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp)?;
+        f.write_all(yaml.as_bytes())?;
+        f.sync_all()?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600))?;
+    }
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Insert or replace a credential, producing the merged `AuthFile`
+/// without touching disk. Pure function — easy to test.
+pub fn merge_credential(
+    mut file: AuthFile,
+    realm: Realm,
+    user: &str,
+    hash: String,
+    created_at: DateTime<Utc>,
+) -> AuthFile {
+    file.realm_mut(realm).insert(
+        user.to_string(),
+        CredentialEntry {
+            hash,
+            created_at: created_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        },
+    );
+    file
+}
+
+/// Returns true if the file already has an entry for (realm, user).
+pub fn has_credential(file: &AuthFile, realm: Realm, user: &str) -> bool {
+    file.realm(realm).contains_key(user)
+}
+
+// ── I/O abstraction so tests can drive the prompt without a TTY ─────────────
+
+/// Trait for reading one secret line from a user. Test impls return a
+/// pre-canned password; the production impl uses `rpassword::prompt_password`.
+pub trait PasswordSource {
+    fn read_password(&mut self, prompt: &str) -> io::Result<String>;
+    fn read_confirm_line(&mut self, prompt: &str) -> io::Result<String>;
+    fn write_stderr(&mut self, msg: &str) -> io::Result<()>;
+}
+
+/// Production implementation: rpassword for hidden input, stdin/stderr.
+pub struct StdioPasswordSource;
+
+impl PasswordSource for StdioPasswordSource {
+    fn read_password(&mut self, prompt: &str) -> io::Result<String> {
+        rpassword::prompt_password(prompt)
+    }
+    fn read_confirm_line(&mut self, prompt: &str) -> io::Result<String> {
+        eprint!("{prompt}");
+        io::stderr().flush()?;
+        let mut line = String::new();
+        io::stdin().lock().read_line(&mut line)?;
+        Ok(line.trim().to_string())
+    }
+    fn write_stderr(&mut self, msg: &str) -> io::Result<()> {
+        let mut err = io::stderr();
+        err.write_all(msg.as_bytes())?;
+        err.flush()
+    }
+}
+
+/// Top-level options for `set-password`.
+#[derive(Debug, Clone)]
+pub struct SetPasswordOpts {
+    pub realm: Realm,
+    pub user: String,
+    pub config_path: PathBuf,
+    pub force: bool,
+}
+
+/// Run `auth set-password`. Returns Ok on success; AuthError otherwise.
+/// The caller (`main`) is responsible for mapping the error to an exit
+/// code and a stderr message.
+pub fn run_set_password<P: PasswordSource>(
+    opts: &SetPasswordOpts,
+    source: &mut P,
+    now: DateTime<Utc>,
+) -> Result<(), AuthError> {
+    let mut file = load_or_default(&opts.config_path)?;
+
+    if has_credential(&file, opts.realm, &opts.user) && !opts.force {
+        let prompt = format!(
+            "credential already exists for {}/{}; overwrite? [y/N]: ",
+            opts.realm.as_yaml_key(),
+            opts.user
+        );
+        let answer = source.read_confirm_line(&prompt)?;
+        if !matches!(answer.to_ascii_lowercase().as_str(), "y" | "yes") {
+            return Err(AuthError::Aborted);
+        }
+    }
+
+    let pw1 = source.read_password(&format!(
+        "Enter password for {}/{}: ",
+        opts.realm.as_yaml_key(),
+        opts.user
+    ))?;
+    let pw2 = source.read_password("Confirm password: ")?;
+    if pw1 != pw2 {
+        return Err(AuthError::Mismatch);
+    }
+    if pw1.is_empty() {
+        return Err(AuthError::Hash("password must not be empty".into()));
+    }
+
+    let hash = hash_password(&pw1)?;
+    file = merge_credential(file, opts.realm, &opts.user, hash, now);
+    save(&opts.config_path, &file)?;
+    source.write_stderr(&format!(
+        "wrote credential for {}/{} to {}\n",
+        opts.realm.as_yaml_key(),
+        opts.user,
+        opts.config_path.display()
+    ))?;
+    Ok(())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use tempfile::tempdir;
+
+    /// In-memory `PasswordSource` for tests. `passwords` is a queue —
+    /// each `read_password` call dequeues one entry.
+    struct ScriptedSource {
+        passwords: RefCell<Vec<String>>,
+        confirm_answers: RefCell<Vec<String>>,
+        stderr: RefCell<String>,
+    }
+
+    impl ScriptedSource {
+        fn new(passwords: Vec<&str>, confirms: Vec<&str>) -> Self {
+            Self {
+                passwords: RefCell::new(passwords.into_iter().map(String::from).collect()),
+                confirm_answers: RefCell::new(confirms.into_iter().map(String::from).collect()),
+                stderr: RefCell::new(String::new()),
+            }
+        }
+    }
+
+    impl PasswordSource for ScriptedSource {
+        fn read_password(&mut self, _prompt: &str) -> io::Result<String> {
+            self.passwords
+                .borrow_mut()
+                .pop()
+                .ok_or_else(|| io::Error::other("no scripted password left"))
+        }
+        fn read_confirm_line(&mut self, _prompt: &str) -> io::Result<String> {
+            self.confirm_answers
+                .borrow_mut()
+                .pop()
+                .ok_or_else(|| io::Error::other("no scripted confirm left"))
+        }
+        fn write_stderr(&mut self, msg: &str) -> io::Result<()> {
+            self.stderr.borrow_mut().push_str(msg);
+            Ok(())
+        }
+    }
+
+    fn fixed_now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-05-08T20:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    // Realm parsing
+    #[test]
+    fn realm_parses_cql_and_graph() {
+        assert_eq!("cql".parse::<Realm>().unwrap(), Realm::Cql);
+        assert_eq!("graph".parse::<Realm>().unwrap(), Realm::Graph);
+    }
+
+    #[test]
+    fn realm_rejects_unknown() {
+        assert!("ldap".parse::<Realm>().is_err());
+    }
+
+    // Hashing
+    #[test]
+    fn hash_password_produces_argon2id_phc_string() {
+        let h = hash_password("hunter2").unwrap();
+        assert!(
+            h.starts_with("$argon2id$"),
+            "expected argon2id PHC prefix, got: {h}"
+        );
+    }
+
+    #[test]
+    fn hash_password_verifies_correct_plaintext() {
+        let h = hash_password("correct horse").unwrap();
+        assert!(verify_password("correct horse", &h).unwrap());
+    }
+
+    #[test]
+    fn hash_password_rejects_wrong_plaintext() {
+        let h = hash_password("right").unwrap();
+        assert!(!verify_password("wrong", &h).unwrap());
+    }
+
+    #[test]
+    fn hash_password_uses_random_salt() {
+        let a = hash_password("same").unwrap();
+        let b = hash_password("same").unwrap();
+        assert_ne!(a, b, "two hashes of the same plaintext must differ");
+    }
+
+    // Wire compatibility with ferrosa-schema's verifier.
+    #[test]
+    fn hash_is_wire_compatible_with_schema_verify_password_any() {
+        let h = hash_password("ferrosa_admin").unwrap();
+        // Mirrors what server-side `PasswordHasher::verify_password_any` does
+        // for argon2id-prefixed strings.
+        use argon2::password_hash::phc::PasswordHash;
+        use argon2::password_hash::PasswordVerifier;
+        let parsed = PasswordHash::new(&h).unwrap();
+        let argon2 = Argon2::default();
+        assert!(argon2
+            .verify_password("ferrosa_admin".as_bytes(), &parsed)
+            .is_ok());
+    }
+
+    // YAML round trip
+    #[test]
+    fn auth_file_round_trips_yaml() {
+        let mut f = AuthFile::default();
+        f.cql.insert(
+            "admin".into(),
+            CredentialEntry {
+                hash: "$argon2id$x".into(),
+                created_at: "2026-05-08T20:30:00Z".into(),
+            },
+        );
+        let s = serde_yaml::to_string(&f).unwrap();
+        let back: AuthFile = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(f, back);
+    }
+
+    #[test]
+    fn auth_file_omits_empty_realms() {
+        let f = AuthFile::default();
+        let s = serde_yaml::to_string(&f).unwrap();
+        // Both maps empty → emit "{}" or empty doc, but never literal cql/graph keys.
+        assert!(!s.contains("cql:"), "unexpected cql key in: {s}");
+        assert!(!s.contains("graph:"), "unexpected graph key in: {s}");
+    }
+
+    // load_or_default
+    #[test]
+    fn load_or_default_returns_default_when_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let f = load_or_default(&path).unwrap();
+        assert_eq!(f, AuthFile::default());
+    }
+
+    #[test]
+    fn load_or_default_reads_existing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let yaml = "cql:\n  admin:\n    hash: \"$argon2id$abc\"\n    created_at: \"2026-01-01T00:00:00Z\"\n";
+        fs::write(&path, yaml).unwrap();
+        let f = load_or_default(&path).unwrap();
+        assert_eq!(f.cql.get("admin").unwrap().hash, "$argon2id$abc");
+    }
+
+    // save
+    #[test]
+    fn save_creates_parent_directories() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a/b/c/auth.yaml");
+        save(&path, &AuthFile::default()).unwrap();
+        assert!(path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        save(&path, &AuthFile::default()).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "auth.yaml must be 0600, got {mode:o}");
+    }
+
+    // merge_credential
+    #[test]
+    fn merge_credential_adds_new_entry() {
+        let f = AuthFile::default();
+        let f = merge_credential(f, Realm::Cql, "admin", "h1".into(), fixed_now());
+        assert_eq!(f.cql.get("admin").unwrap().hash, "h1");
+    }
+
+    #[test]
+    fn merge_credential_overwrites_same_user_same_realm() {
+        let f = AuthFile::default();
+        let f = merge_credential(f, Realm::Cql, "admin", "h1".into(), fixed_now());
+        let f = merge_credential(f, Realm::Cql, "admin", "h2".into(), fixed_now());
+        assert_eq!(f.cql.get("admin").unwrap().hash, "h2");
+    }
+
+    #[test]
+    fn merge_credential_preserves_other_realms() {
+        let f = AuthFile::default();
+        let f = merge_credential(f, Realm::Cql, "admin", "cql_hash".into(), fixed_now());
+        let f = merge_credential(f, Realm::Graph, "admin", "graph_hash".into(), fixed_now());
+        assert_eq!(f.cql.get("admin").unwrap().hash, "cql_hash");
+        assert_eq!(f.graph.get("admin").unwrap().hash, "graph_hash");
+    }
+
+    #[test]
+    fn merge_credential_preserves_other_users_in_same_realm() {
+        let f = AuthFile::default();
+        let f = merge_credential(f, Realm::Cql, "alice", "ha".into(), fixed_now());
+        let f = merge_credential(f, Realm::Cql, "bob", "hb".into(), fixed_now());
+        assert_eq!(f.cql.get("alice").unwrap().hash, "ha");
+        assert_eq!(f.cql.get("bob").unwrap().hash, "hb");
+    }
+
+    // run_set_password — happy path
+    #[test]
+    fn run_set_password_writes_argon2_hash_to_disk() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let opts = SetPasswordOpts {
+            realm: Realm::Cql,
+            user: "admin".into(),
+            config_path: path.clone(),
+            force: false,
+        };
+        let mut src = ScriptedSource::new(vec!["s3cret!", "s3cret!"], vec![]);
+        run_set_password(&opts, &mut src, fixed_now()).unwrap();
+
+        let f = load_or_default(&path).unwrap();
+        let entry = f.cql.get("admin").expect("admin entry exists");
+        assert!(entry.hash.starts_with("$argon2id$"));
+        assert!(verify_password("s3cret!", &entry.hash).unwrap());
+        assert_eq!(entry.created_at, "2026-05-08T20:30:00Z");
+    }
+
+    // Mismatch path: must error AND not modify the file.
+    #[test]
+    fn run_set_password_mismatch_errors_and_does_not_write() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let opts = SetPasswordOpts {
+            realm: Realm::Cql,
+            user: "admin".into(),
+            config_path: path.clone(),
+            force: false,
+        };
+        let mut src = ScriptedSource::new(vec!["one", "two"], vec![]);
+        let err = run_set_password(&opts, &mut src, fixed_now()).unwrap_err();
+        assert!(matches!(err, AuthError::Mismatch));
+        assert!(!path.exists(), "auth.yaml must not be created on mismatch");
+    }
+
+    // Mismatch must NOT clobber an existing file.
+    #[test]
+    fn run_set_password_mismatch_preserves_existing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let mut existing = AuthFile::default();
+        existing.cql.insert(
+            "alice".into(),
+            CredentialEntry {
+                hash: "$argon2id$preserved".into(),
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        );
+        save(&path, &existing).unwrap();
+
+        let opts = SetPasswordOpts {
+            realm: Realm::Cql,
+            user: "bob".into(),
+            config_path: path.clone(),
+            force: true, // force=true so we don't need a confirm prompt
+        };
+        let mut src = ScriptedSource::new(vec!["a", "b"], vec![]);
+        let err = run_set_password(&opts, &mut src, fixed_now()).unwrap_err();
+        assert!(matches!(err, AuthError::Mismatch));
+        let f = load_or_default(&path).unwrap();
+        assert_eq!(f.cql.get("alice").unwrap().hash, "$argon2id$preserved");
+        assert!(!f.cql.contains_key("bob"));
+    }
+
+    // Merge: existing file with another realm's entry must be preserved.
+    #[test]
+    fn run_set_password_merges_other_realm_entries() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let mut existing = AuthFile::default();
+        existing.graph.insert(
+            "admin".into(),
+            CredentialEntry {
+                hash: "$argon2id$graph_existing".into(),
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        );
+        save(&path, &existing).unwrap();
+
+        let opts = SetPasswordOpts {
+            realm: Realm::Cql,
+            user: "admin".into(),
+            config_path: path.clone(),
+            force: false,
+        };
+        let mut src = ScriptedSource::new(vec!["pw", "pw"], vec![]);
+        run_set_password(&opts, &mut src, fixed_now()).unwrap();
+
+        let f = load_or_default(&path).unwrap();
+        assert_eq!(
+            f.graph.get("admin").unwrap().hash,
+            "$argon2id$graph_existing",
+            "graph realm must be preserved across writes"
+        );
+        assert!(verify_password("pw", &f.cql.get("admin").unwrap().hash).unwrap());
+    }
+
+    // Existing user/realm without --force prompts; "n" aborts.
+    #[test]
+    fn run_set_password_prompts_on_existing_and_aborts_on_no() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let mut existing = AuthFile::default();
+        existing.cql.insert(
+            "admin".into(),
+            CredentialEntry {
+                hash: "$argon2id$old".into(),
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        );
+        save(&path, &existing).unwrap();
+
+        let opts = SetPasswordOpts {
+            realm: Realm::Cql,
+            user: "admin".into(),
+            config_path: path.clone(),
+            force: false,
+        };
+        let mut src = ScriptedSource::new(vec![], vec!["n"]);
+        let err = run_set_password(&opts, &mut src, fixed_now()).unwrap_err();
+        assert!(matches!(err, AuthError::Aborted));
+        // Original hash unchanged.
+        let f = load_or_default(&path).unwrap();
+        assert_eq!(f.cql.get("admin").unwrap().hash, "$argon2id$old");
+    }
+
+    // --force skips the prompt.
+    #[test]
+    fn run_set_password_force_overwrites_without_prompt() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let mut existing = AuthFile::default();
+        existing.cql.insert(
+            "admin".into(),
+            CredentialEntry {
+                hash: "$argon2id$old".into(),
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        );
+        save(&path, &existing).unwrap();
+
+        let opts = SetPasswordOpts {
+            realm: Realm::Cql,
+            user: "admin".into(),
+            config_path: path.clone(),
+            force: true,
+        };
+        // No confirm answer scripted — proves no prompt was issued.
+        let mut src = ScriptedSource::new(vec!["new", "new"], vec![]);
+        run_set_password(&opts, &mut src, fixed_now()).unwrap();
+
+        let f = load_or_default(&path).unwrap();
+        let entry = f.cql.get("admin").unwrap();
+        assert_ne!(entry.hash, "$argon2id$old");
+        assert!(verify_password("new", &entry.hash).unwrap());
+    }
+
+    // Writes a brief confirmation line to stderr on success.
+    #[test]
+    fn run_set_password_writes_confirmation_to_stderr() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let opts = SetPasswordOpts {
+            realm: Realm::Graph,
+            user: "admin".into(),
+            config_path: path,
+            force: false,
+        };
+        let mut src = ScriptedSource::new(vec!["pw", "pw"], vec![]);
+        run_set_password(&opts, &mut src, fixed_now()).unwrap();
+        assert!(src.stderr.borrow().contains("graph/admin"));
+    }
+
+    // Empty password rejected.
+    #[test]
+    fn run_set_password_rejects_empty_password() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        let opts = SetPasswordOpts {
+            realm: Realm::Cql,
+            user: "admin".into(),
+            config_path: path,
+            force: false,
+        };
+        let mut src = ScriptedSource::new(vec!["", ""], vec![]);
+        let err = run_set_password(&opts, &mut src, fixed_now()).unwrap_err();
+        assert!(matches!(err, AuthError::Hash(_)));
+    }
+
+    #[test]
+    fn default_config_path_is_under_home() {
+        // Force a known HOME for determinism
+        let dir = tempdir().unwrap();
+        let prev = std::env::var_os("HOME");
+        std::env::set_var("HOME", dir.path());
+        let p = default_config_path().unwrap();
+        assert!(p.ends_with(".ferrosa/config/auth.yaml"));
+        if let Some(h) = prev {
+            std::env::set_var("HOME", h);
+        }
+    }
+}

--- a/ferrosa-ctl/src/lib.rs
+++ b/ferrosa-ctl/src/lib.rs
@@ -3,5 +3,6 @@
 //! Re-exports the `commands` module so integration tests can call
 //! the command functions directly against a live test server.
 
+pub mod auth;
 pub mod commands;
 pub mod tui;

--- a/ferrosa-ctl/src/main.rs
+++ b/ferrosa-ctl/src/main.rs
@@ -18,6 +18,7 @@
 //!   monitor      Interactive TUI dashboard (T24)
 //!   snapshot     Manage node snapshots (create / list / delete)
 //!   restore      Restore from a snapshot, optionally to a point in time
+//!   auth         Manage installer-seeded admin credentials
 //! ```
 
 use std::net::SocketAddr;
@@ -25,6 +26,7 @@ use std::process;
 
 use clap::{Parser, Subcommand};
 
+mod auth;
 mod commands;
 mod tui;
 
@@ -121,6 +123,35 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+
+    /// Manage installer-seeded admin credentials in `~/.ferrosa/config/auth.yaml`.
+    Auth {
+        #[command(subcommand)]
+        action: AuthAction,
+    },
+}
+
+/// Auth sub-actions.
+#[derive(Debug, Subcommand)]
+enum AuthAction {
+    /// Hash a password (read from stdin, no echo) and write it to auth.yaml.
+    SetPassword {
+        /// Username for the credential (e.g. `admin`).
+        #[arg(long)]
+        user: String,
+
+        /// Realm — `cql` for the CQL native protocol, `graph` for HTTP/Bolt basic auth.
+        #[arg(long)]
+        realm: String,
+
+        /// Path to auth.yaml (defaults to `$HOME/.ferrosa/config/auth.yaml`).
+        #[arg(long)]
+        config: Option<std::path::PathBuf>,
+
+        /// Overwrite an existing entry without prompting.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 /// Snapshot sub-actions.
@@ -148,6 +179,31 @@ enum SnapshotAction {
 
 /// Unified error type used by `main` so all match arms have the same type.
 type MainError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Synchronous wrapper for `auth set-password` — wires the CLI args to the
+/// `auth::run_set_password` core function.
+fn run_auth_set_password(
+    user: String,
+    realm: String,
+    config: Option<std::path::PathBuf>,
+    force: bool,
+) -> Result<(), auth::AuthError> {
+    let realm: auth::Realm = realm
+        .parse()
+        .map_err(|e: String| auth::AuthError::Hash(e))?;
+    let config_path = match config {
+        Some(p) => p,
+        None => auth::default_config_path()?,
+    };
+    let opts = auth::SetPasswordOpts {
+        realm,
+        user,
+        config_path,
+        force,
+    };
+    let mut source = auth::StdioPasswordSource;
+    auth::run_set_password(&opts, &mut source, chrono::Utc::now())
+}
 
 #[tokio::main]
 async fn main() {
@@ -206,6 +262,14 @@ async fn main() {
             )
             .await
         }
+        Commands::Auth { action } => match action {
+            AuthAction::SetPassword {
+                user,
+                realm,
+                config,
+                force,
+            } => run_auth_set_password(user, realm, config, force).map_err(Into::into),
+        },
     };
 
     if let Err(e) = result {
@@ -470,6 +534,74 @@ mod tests {
         match cli.command {
             Commands::Restore { point_in_time, .. } => {
                 assert_eq!(point_in_time.as_deref(), Some("2026-03-18T12:00:00Z"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_set_password_minimal() {
+        let cli = Cli::try_parse_from([
+            "ferrosa-ctl",
+            "auth",
+            "set-password",
+            "--user",
+            "admin",
+            "--realm",
+            "cql",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Auth {
+                action:
+                    AuthAction::SetPassword {
+                        user,
+                        realm,
+                        config,
+                        force,
+                    },
+            } => {
+                assert_eq!(user, "admin");
+                assert_eq!(realm, "cql");
+                assert!(config.is_none());
+                assert!(!force);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_set_password_all_flags() {
+        let cli = Cli::try_parse_from([
+            "ferrosa-ctl",
+            "auth",
+            "set-password",
+            "--user",
+            "admin",
+            "--realm",
+            "graph",
+            "--config",
+            "/tmp/foo/auth.yaml",
+            "--force",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Auth {
+                action:
+                    AuthAction::SetPassword {
+                        user,
+                        realm,
+                        config,
+                        force,
+                    },
+            } => {
+                assert_eq!(user, "admin");
+                assert_eq!(realm, "graph");
+                assert_eq!(
+                    config.as_deref().unwrap().to_str().unwrap(),
+                    "/tmp/foo/auth.yaml"
+                );
+                assert!(force);
             }
             other => panic!("unexpected command: {other:?}"),
         }


### PR DESCRIPTION
## Summary

Adds `ferrosa-ctl auth set-password --user <u> --realm <cql|graph> [--config <path>] [--force]` so the post-install prompt can seed the CQL admin user and the graph HTTP/Bolt basic-auth credential.

## CLI shape

```
ferrosa-ctl auth set-password --user admin --realm cql
ferrosa-ctl auth set-password --user admin --realm graph --force
ferrosa-ctl auth set-password --user admin --realm cql --config /etc/ferrosa/auth.yaml
```

- Reads the password twice from stdin without echo (`rpassword`) and errors on mismatch **before any disk write**.
- Existing `(realm, user)` entry prompts `[y/N]` before overwriting; `--force` skips the prompt.
- Output lands at `~/.ferrosa/config/auth.yaml` (overridable with `--config`), written atomically and chmod-0600 on Unix.
- Confirmation line on stderr, `process::exit(1)` on any failure.

## YAML layout

```yaml
cql:
  admin:
    hash: \"\$argon2id\$v=19\$m=19456,t=2,p=1\$...\"
    created_at: \"2026-05-08T20:30:00Z\"
graph:
  admin:
    hash: \"...\"
    created_at: \"...\"
```

Realms are merged: writing `cql/admin` never touches `graph/...` or other users in the same realm.

## Hashing scheme

**Argon2id**, OWASP 2024 parameters: m = 19 456 KiB, t = 2, p = 1, internal RNG salt (via `password-hash` 0.6).

Why Argon2id rather than matching the existing default? The CQL `PasswordAuthenticator` in `ferrosa-schema::auth::password` defaults to bcrypt cost 12, but its verify path (`PasswordHasher::verify_password_any`) **already auto-detects the \`\$argon2id\$\` prefix** and verifies through `argon2::Argon2::default()`. Argon2id is the OWASP-current recommendation and matches the second variant the schema crate already supports natively, so the new file format produces hashes that the existing verifier accepts without any server change to the hash format.

## Wire compatibility (CRITICAL for the installer)

The hash **format** is wire-compatible: a PHC `\$argon2id\$...` string written by this command is verifiable by `ferrosa-schema::auth::password::PasswordHasher::verify_password_any` exactly as-is. There is a regression test asserting this (`hash_is_wire_compatible_with_schema_verify_password_any`).

**However**, the running server does not currently read `~/.ferrosa/config/auth.yaml` at all. Its authoritative credential store is `system_auth.roles.salted_hash` (CQL table seeded by `seed_default_roles` in `ferrosa-schema/src/auth/bootstrap.rs`). So *as of this PR alone*, running `auth set-password` produces a correctly-formatted hash file that no server reads.

## Follow-up TODOs (intentionally NOT in this PR)

1. **Wire `auth.yaml` into bootstrap.** Teach `seed_default_roles` (or a new pre-bootstrap step) to read `~/.ferrosa/config/auth.yaml` and, when present, replace the well-known default `ferrosa_admin` / `ferrosa_user` hashes with the operator-supplied ones before the server accepts its first connection. Suggested location: `ferrosa-schema/src/auth/bootstrap.rs`, behind a config option pointing at the YAML path.
2. **Graph HTTP/Bolt path.** `graph` realm: confirm `ferrosa-graph` reads from the same source as the CQL realm or define an explicit graph-side reader.
3. **Password policy.** `auth set-password` currently rejects only empty passwords. Once bootstrap is wired, route the typed plaintext through `ferrosa_schema::auth::password::PasswordPolicy` so the installer enforces the same minimum strength as `CREATE ROLE`.
4. **Default-password warning.** Once bootstrap reads the YAML, `admin_password_is_default` should compare against the YAML-supplied hash rather than the hard-coded \`ferrosa_admin\` literal.

## Test coverage

26 unit tests in `ferrosa-ctl::auth::tests`:

- realm parsing (cql / graph / unknown)
- argon2id PHC format, verify-correct, reject-wrong, random-salt invariant
- **wire-compat** assertion against the schema crate's verifier path
- YAML round-trip and empty-realm omission (no spurious top-level keys)
- merge semantics: other realms preserved, other users in same realm preserved, same-user overwrite
- happy path: writes the hash to disk, stderr confirmation contains realm/user
- mismatch path: errors with `AuthError::Mismatch`, no file created, pre-existing file untouched
- existing-entry prompt: `n` returns `AuthError::Aborted` with original hash intact
- `--force` skips the prompt and overwrites
- empty password rejected
- `save` creates parent directories and sets mode 0600 on Unix
- 2 clap-parse tests in `main.rs` for the new subcommand (minimal + all flags)

Plus the existing 11 integration tests still pass.

## Test plan

- [x] `cargo test -p ferrosa-ctl` — 130 passed, 0 failed, 0 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean across the workspace
- [x] `cargo fmt --all --check` — clean
- [x] `ferrosa-ctl auth set-password --help` renders correctly
- [x] `ferrosa-ctl --help` lists the new subcommand
- [ ] Manual smoke (post-merge): run against a real terminal to confirm `rpassword` hides the input
- [ ] Installer integration: invoke from the post-install script and confirm the resulting hash verifies via `verify_password_any` in a quick repl