### PR TITLE
feat(ctl): ferrosa-ctl auth set-password (CQL ALTER ROLE)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ name = "ferrosa-ctl"
 version = "0.8.8+8"
 dependencies = [
  "arc-swap",
+ "async-trait",
  "clap",
  "crossterm",
  "ferrosa-cluster",
@@ -1819,6 +1820,7 @@ dependencies = [
  "ferrosa-udf",
  "ratatui",
  "reqwest",
+ "rpassword",
  "serde_json",
  "tabled",
  "tempfile",
@@ -4752,6 +4754,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsa"
 version = "0.10.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4768,6 +4781,16 @@ dependencies = [
  "signature",
  "spki",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/ferrosa-cql/src/client.rs
+++ b/ferrosa-cql/src/client.rs
@@ -37,7 +37,30 @@ pub struct CqlClient {
 
 impl CqlClient {
     /// Connect to a CQL server and complete the STARTUP handshake.
+    ///
+    /// If the server requires authentication, this returns
+    /// `CqlError::BadCredentials` — use [`CqlClient::connect_with_credentials`]
+    /// to log in with a username and password.
     pub async fn connect(addr: SocketAddr) -> Result<Self, CqlError> {
+        Self::connect_inner(addr, None).await
+    }
+
+    /// Connect to a CQL server and authenticate with the given credentials.
+    ///
+    /// Performs the STARTUP handshake; on AUTHENTICATE replies with a SASL
+    /// PLAIN AUTH_RESPONSE frame containing `\0username\0password`.
+    pub async fn connect_with_credentials(
+        addr: SocketAddr,
+        username: &str,
+        password: &str,
+    ) -> Result<Self, CqlError> {
+        Self::connect_inner(addr, Some((username, password))).await
+    }
+
+    async fn connect_inner(
+        addr: SocketAddr,
+        credentials: Option<(&str, &str)>,
+    ) -> Result<Self, CqlError> {
         let stream = TcpStream::connect(addr).await?;
         let codec = CqlCodec::new(DEFAULT_MAX_FRAME_SIZE);
         let mut framed = Framed::new(stream, codec);
@@ -72,7 +95,7 @@ impl CqlClient {
             .ok_or_else(|| CqlError::Protocol("connection closed during startup".into()))?
             .map_err(|e| CqlError::Protocol(format!("startup response error: {e}")))?;
 
-        let ready = resp.header.opcode == Opcode::Ready;
+        let mut ready = resp.header.opcode == Opcode::Ready;
 
         if !ready && resp.header.opcode != Opcode::Authenticate {
             return Err(CqlError::Protocol(format!(
@@ -81,9 +104,65 @@ impl CqlClient {
             )));
         }
 
-        // The server enables v5 framing after READY when the client sends
-        // VERSION_REQUEST (0x05). The client must also switch to v5 framed
-        // mode so subsequent messages are wrapped in CRC-protected frames.
+        // If the server demanded auth and we have credentials, send an
+        // AUTH_RESPONSE frame containing a SASL PLAIN payload.
+        if !ready {
+            let (user, pass) = credentials.ok_or(CqlError::BadCredentials)?;
+
+            let mut sasl = Vec::with_capacity(2 + user.len() + pass.len());
+            sasl.push(0); // empty authzid
+            sasl.extend_from_slice(user.as_bytes());
+            sasl.push(0);
+            sasl.extend_from_slice(pass.as_bytes());
+
+            let mut auth_body = BytesMut::with_capacity(4 + sasl.len());
+            auth_body.put_i32(sasl.len() as i32);
+            auth_body.put_slice(&sasl);
+
+            let auth_frame = CqlFrame {
+                header: FrameHeader {
+                    version: VERSION_REQUEST,
+                    flags: 0,
+                    stream_id: 0,
+                    opcode: Opcode::AuthResponse,
+                    length: auth_body.len() as u32,
+                },
+                body: auth_body.freeze(),
+            };
+            framed.send(auth_frame).await?;
+
+            let auth_resp = framed
+                .next()
+                .await
+                .ok_or_else(|| CqlError::Protocol("connection closed during auth".into()))?
+                .map_err(|e| CqlError::Protocol(format!("auth response error: {e}")))?;
+
+            match auth_resp.header.opcode {
+                Opcode::AuthSuccess => {
+                    ready = true;
+                }
+                Opcode::Error => {
+                    let msg = parse_error(&auth_resp.body)?;
+                    if msg.to_lowercase().contains("credential")
+                        || msg.to_lowercase().contains("auth")
+                    {
+                        return Err(CqlError::BadCredentials);
+                    }
+                    return Err(CqlError::ServerError(msg));
+                }
+                other => {
+                    return Err(CqlError::Protocol(format!(
+                        "unexpected auth response: {:?}",
+                        other
+                    )));
+                }
+            }
+        }
+
+        // The server enables v5 framing after READY/AUTH_SUCCESS when the
+        // client sends VERSION_REQUEST (0x05). The client must also switch
+        // to v5 framed mode so subsequent messages are wrapped in
+        // CRC-protected frames.
         if ready {
             framed.codec_mut().enable_v5_framing();
         }

--- a/ferrosa-ctl/Cargo.toml
+++ b/ferrosa-ctl/Cargo.toml
@@ -19,6 +19,8 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde_json = "1"
 ratatui = "0.29"
 crossterm = "0.28"
+rpassword = "7"
+async-trait = "0.1"
 
 [dev-dependencies]
 arc-swap = "1.7"

--- a/ferrosa-ctl/src/auth.rs
+++ b/ferrosa-ctl/src/auth.rs
@@ -1,0 +1,440 @@
+//! `ferrosa-ctl auth` subcommands.
+//!
+//! Provides administrative operations against the running Ferrosa server's
+//! `system_auth` keyspace via the CQL native protocol. The server stores
+//! Argon2 password hashes — this CLI never touches the hash store directly.
+//!
+//! The current implementation issues `ALTER ROLE <name> WITH PASSWORD = '<plain>'`,
+//! letting the server hash the cleartext via its own `PasswordHasher`.
+//!
+//! # Password policy
+//!
+//! - non-empty
+//! - at least 8 characters
+//!
+//! These are baseline checks; the server enforces additional invariants
+//! (role exists, caller has ALTER permission).
+
+use std::io::{self, Write};
+use std::net::SocketAddr;
+
+use ferrosa_cql::client::CqlClient;
+use ferrosa_cql::error::CqlError;
+
+/// Exit codes used by the auth subcommands.
+pub const EXIT_BAD_INPUT: i32 = 2;
+pub const EXIT_OPERATION_FAILED: i32 = 1;
+
+/// Minimum length of a new password. Matches a common baseline; the server
+/// owns the authoritative policy.
+pub const MIN_PASSWORD_LEN: usize = 8;
+
+/// Default seed admin password — used as the first attempt for the admin
+/// connection so `ferrosa-ctl auth set-password` works on a fresh install
+/// without prompting twice.
+const SEED_ADMIN_PASSWORD: &str = "ferrosa_admin";
+
+/// Errors that can be produced by the `auth set-password` flow.
+#[derive(Debug)]
+pub enum SetPasswordError {
+    /// User input was rejected (mismatch, empty, too short). Exits 2.
+    BadInput(String),
+    /// The CQL operation failed (connect, auth, ALTER ROLE). Exits 1.
+    Operation(String),
+}
+
+impl SetPasswordError {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::BadInput(_) => EXIT_BAD_INPUT,
+            Self::Operation(_) => EXIT_OPERATION_FAILED,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadInput(m) | Self::Operation(m) => m,
+        }
+    }
+}
+
+/// Trait for the CQL action `ferrosa-ctl auth set-password` performs against
+/// the server. Allows unit tests to substitute a mock client.
+#[async_trait::async_trait]
+pub trait CqlExecutor: Send {
+    /// Issue a single CQL statement; return `Ok(())` on VOID/SCHEMA_CHANGE.
+    async fn execute(&mut self, cql: &str) -> Result<(), String>;
+}
+
+/// CQL executor backed by a real authenticated [`CqlClient`].
+pub struct LiveCqlExecutor {
+    client: CqlClient,
+}
+
+impl LiveCqlExecutor {
+    /// Connect to `addr` as `admin_user` with `admin_password` and prepare
+    /// the executor.
+    pub async fn connect(
+        addr: SocketAddr,
+        admin_user: &str,
+        admin_password: &str,
+    ) -> Result<Self, CqlError> {
+        let client = CqlClient::connect_with_credentials(addr, admin_user, admin_password).await?;
+        Ok(Self { client })
+    }
+}
+
+#[async_trait::async_trait]
+impl CqlExecutor for LiveCqlExecutor {
+    async fn execute(&mut self, cql: &str) -> Result<(), String> {
+        self.client
+            .query(cql)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// Validate a new password and produce a [`SetPasswordError::BadInput`] on
+/// rejection.
+pub fn validate_new_password(p1: &str, p2: &str) -> Result<(), SetPasswordError> {
+    if p1 != p2 {
+        return Err(SetPasswordError::BadInput(
+            "passwords did not match".to_string(),
+        ));
+    }
+    if p1.is_empty() {
+        return Err(SetPasswordError::BadInput(
+            "new password must not be empty".to_string(),
+        ));
+    }
+    if p1.len() < MIN_PASSWORD_LEN {
+        return Err(SetPasswordError::BadInput(format!(
+            "new password must be at least {MIN_PASSWORD_LEN} characters",
+        )));
+    }
+    Ok(())
+}
+
+/// Build the exact CQL `ALTER ROLE` statement for the given role and
+/// cleartext password. Both the role identifier and the password literal
+/// are quoted/escaped so embedded special characters can't break out of
+/// the statement.
+pub fn build_alter_role_statement(role: &str, new_password: &str) -> String {
+    format!(
+        "ALTER ROLE \"{}\" WITH PASSWORD = '{}'",
+        escape_double_quotes(role),
+        escape_single_quotes(new_password),
+    )
+}
+
+/// Escape `"` as `""` for CQL quoted identifiers.
+fn escape_double_quotes(s: &str) -> String {
+    s.replace('"', "\"\"")
+}
+
+/// Escape `'` as `''` for CQL string literals.
+fn escape_single_quotes(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
+/// Run the `set-password` operation, end-to-end, against the supplied
+/// executor. Splitting this from connect/IO keeps the function unit-testable.
+pub async fn run_set_password(
+    executor: &mut dyn CqlExecutor,
+    target_user: &str,
+    new_password: &str,
+    host: SocketAddr,
+) -> Result<(), SetPasswordError> {
+    let stmt = build_alter_role_statement(target_user, new_password);
+    executor
+        .execute(&stmt)
+        .await
+        .map_err(|e| SetPasswordError::Operation(format_cql_error(&e, host)))
+}
+
+/// Format a CQL error string with a hint about the host and a recovery
+/// suggestion. Used for both connect failures and ALTER errors.
+pub fn format_cql_error(err: &str, host: SocketAddr) -> String {
+    format!(
+        "CQL operation against {host} failed: {err}\n\
+         hint: is ferrosa running? Try `systemctl --user status ferrosa` or \
+         `launchctl print gui/$(id -u)/com.ferrosadb.ferrosa`."
+    )
+}
+
+// ── prompt helpers ──────────────────────────────────────────────────────
+
+/// Prompt for a password without echoing to the terminal.
+pub fn prompt_password(label: &str) -> io::Result<String> {
+    rpassword::prompt_password(format!("{label}: "))
+}
+
+/// Read a new password from the terminal, prompting twice unless
+/// `confirm == false`. Validates the result.
+pub fn read_new_password_interactive(confirm: bool) -> Result<String, SetPasswordError> {
+    let p1 = prompt_password("New password")
+        .map_err(|e| SetPasswordError::BadInput(format!("could not read password: {e}")))?;
+    let p2 = if confirm {
+        prompt_password("Confirm new password")
+            .map_err(|e| SetPasswordError::BadInput(format!("could not read password: {e}")))?
+    } else {
+        p1.clone()
+    };
+    validate_new_password(&p1, &p2)?;
+    Ok(p1)
+}
+
+/// Resolve the admin password using, in order: `--admin-password-env`,
+/// the well-known seed default, then an interactive prompt.
+///
+/// Returns the password to try first AND a flag indicating whether the
+/// caller should re-prompt on auth failure (true when we used the seed
+/// default and have not yet asked the operator).
+#[derive(Debug, Clone)]
+pub struct AdminPasswordChoice {
+    pub password: String,
+    pub may_retry_with_prompt: bool,
+}
+
+pub fn resolve_admin_password(
+    admin_password_env_var: Option<&str>,
+    env_lookup: impl Fn(&str) -> Option<String>,
+) -> io::Result<AdminPasswordChoice> {
+    if let Some(var) = admin_password_env_var {
+        match env_lookup(var) {
+            Some(v) => {
+                return Ok(AdminPasswordChoice {
+                    password: v,
+                    may_retry_with_prompt: false,
+                });
+            }
+            None => {
+                // Variable was specified but unset — fail loud rather than
+                // silently falling back. Per CLAUDE.md "fail loud".
+                return Err(io::Error::other(format!(
+                    "--admin-password-env={var} is set but no value found in the environment"
+                )));
+            }
+        }
+    }
+    Ok(AdminPasswordChoice {
+        password: SEED_ADMIN_PASSWORD.to_string(),
+        may_retry_with_prompt: true,
+    })
+}
+
+/// Print a SUPERUSER warning to stderr and require an explicit "yes" on
+/// stdin to proceed. Used unless `--force` is supplied.
+pub fn confirm_superuser_change<R: io::BufRead, W: Write>(
+    target_user: &str,
+    input: &mut R,
+    output: &mut W,
+) -> Result<(), SetPasswordError> {
+    writeln!(
+        output,
+        "About to change the password for SUPERUSER role '{target_user}'."
+    )
+    .map_err(|e| SetPasswordError::BadInput(format!("could not write prompt: {e}")))?;
+    write!(output, "Continue? [y/N] ")
+        .map_err(|e| SetPasswordError::BadInput(format!("could not write prompt: {e}")))?;
+    output
+        .flush()
+        .map_err(|e| SetPasswordError::BadInput(format!("could not flush prompt: {e}")))?;
+    let mut answer = String::new();
+    input
+        .read_line(&mut answer)
+        .map_err(|e| SetPasswordError::BadInput(format!("could not read answer: {e}")))?;
+    let trimmed = answer.trim().to_lowercase();
+    if trimmed == "y" || trimmed == "yes" {
+        Ok(())
+    } else {
+        Err(SetPasswordError::BadInput("aborted by user".to_string()))
+    }
+}
+
+// ── tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Cursor;
+    use std::sync::Mutex;
+
+    /// Captures statements executed against the mock executor.
+    #[derive(Default)]
+    struct MockExecutor {
+        calls: Mutex<Vec<String>>,
+        fail_with: Option<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl CqlExecutor for MockExecutor {
+        async fn execute(&mut self, cql: &str) -> Result<(), String> {
+            self.calls.lock().unwrap().push(cql.to_string());
+            match &self.fail_with {
+                Some(msg) => Err(msg.clone()),
+                None => Ok(()),
+            }
+        }
+    }
+
+    fn host() -> SocketAddr {
+        "127.0.0.1:9042".parse().unwrap()
+    }
+
+    #[test]
+    fn validate_rejects_mismatch() {
+        let err = validate_new_password("hunter2foo", "hunter2bar").unwrap_err();
+        assert_eq!(err.exit_code(), EXIT_BAD_INPUT);
+        assert!(err.message().contains("did not match"));
+    }
+
+    #[test]
+    fn validate_rejects_empty() {
+        let err = validate_new_password("", "").unwrap_err();
+        assert_eq!(err.exit_code(), EXIT_BAD_INPUT);
+        assert!(err.message().contains("empty"));
+    }
+
+    #[test]
+    fn validate_rejects_short() {
+        let err = validate_new_password("short", "short").unwrap_err();
+        assert_eq!(err.exit_code(), EXIT_BAD_INPUT);
+        assert!(err.message().contains("at least"));
+    }
+
+    #[test]
+    fn validate_accepts_strong_password() {
+        validate_new_password("hunter2foo", "hunter2foo").unwrap();
+    }
+
+    #[test]
+    fn build_alter_role_quotes_role_name() {
+        let stmt = build_alter_role_statement("ferrosa_admin", "hunter2foo");
+        assert_eq!(
+            stmt,
+            "ALTER ROLE \"ferrosa_admin\" WITH PASSWORD = 'hunter2foo'"
+        );
+    }
+
+    #[test]
+    fn build_alter_role_escapes_single_quote_in_password() {
+        let stmt = build_alter_role_statement("ferrosa_admin", "ab'cd");
+        assert_eq!(
+            stmt,
+            "ALTER ROLE \"ferrosa_admin\" WITH PASSWORD = 'ab''cd'"
+        );
+    }
+
+    #[test]
+    fn build_alter_role_escapes_double_quote_in_role() {
+        let stmt = build_alter_role_statement("weird\"name", "hunter2foo");
+        assert_eq!(
+            stmt,
+            "ALTER ROLE \"weird\"\"name\" WITH PASSWORD = 'hunter2foo'"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_set_password_issues_alter_role() {
+        let mut exec = MockExecutor::default();
+        run_set_password(&mut exec, "ferrosa_admin", "hunter2foo", host())
+            .await
+            .unwrap();
+        let calls = exec.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0],
+            "ALTER ROLE \"ferrosa_admin\" WITH PASSWORD = 'hunter2foo'"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_set_password_propagates_cql_error_with_host_hint() {
+        let mut exec = MockExecutor {
+            fail_with: Some("connection refused".to_string()),
+            ..Default::default()
+        };
+        let err = run_set_password(&mut exec, "ferrosa_admin", "hunter2foo", host())
+            .await
+            .unwrap_err();
+        assert_eq!(err.exit_code(), EXIT_OPERATION_FAILED);
+        assert!(err.message().contains("127.0.0.1:9042"));
+        assert!(err.message().contains("connection refused"));
+        assert!(err.message().contains("hint:"));
+    }
+
+    #[test]
+    fn resolve_admin_password_uses_env_var_when_set() {
+        let env = |k: &str| {
+            if k == "MY_PW" {
+                Some("from-env".to_string())
+            } else {
+                None
+            }
+        };
+        let res = resolve_admin_password(Some("MY_PW"), env).unwrap();
+        assert_eq!(res.password, "from-env");
+        assert!(!res.may_retry_with_prompt);
+    }
+
+    #[test]
+    fn resolve_admin_password_errors_when_env_var_unset() {
+        let env = |_: &str| None;
+        let err = resolve_admin_password(Some("MISSING"), env).unwrap_err();
+        assert!(err.to_string().contains("MISSING"));
+    }
+
+    #[test]
+    fn resolve_admin_password_falls_back_to_seed_default() {
+        let env = |_: &str| None;
+        let res = resolve_admin_password(None, env).unwrap();
+        assert_eq!(res.password, "ferrosa_admin");
+        assert!(res.may_retry_with_prompt);
+    }
+
+    #[test]
+    fn confirm_superuser_change_accepts_yes() {
+        let mut input = Cursor::new(b"yes\n");
+        let mut output = Vec::new();
+        confirm_superuser_change("ferrosa_admin", &mut input, &mut output).unwrap();
+        let s = String::from_utf8(output).unwrap();
+        assert!(s.contains("ferrosa_admin"));
+        assert!(s.contains("SUPERUSER"));
+    }
+
+    #[test]
+    fn confirm_superuser_change_accepts_y() {
+        let mut input = Cursor::new(b"y\n");
+        let mut output = Vec::new();
+        confirm_superuser_change("ferrosa_admin", &mut input, &mut output).unwrap();
+    }
+
+    #[test]
+    fn confirm_superuser_change_aborts_on_no() {
+        let mut input = Cursor::new(b"n\n");
+        let mut output = Vec::new();
+        let err = confirm_superuser_change("ferrosa_admin", &mut input, &mut output).unwrap_err();
+        assert_eq!(err.exit_code(), EXIT_BAD_INPUT);
+        assert!(err.message().contains("aborted"));
+    }
+
+    #[test]
+    fn confirm_superuser_change_aborts_on_empty() {
+        let mut input = Cursor::new(b"\n");
+        let mut output = Vec::new();
+        let err = confirm_superuser_change("ferrosa_admin", &mut input, &mut output).unwrap_err();
+        assert_eq!(err.exit_code(), EXIT_BAD_INPUT);
+    }
+
+    #[test]
+    fn format_cql_error_includes_host_and_hint() {
+        let s = format_cql_error("io error: refused", host());
+        assert!(s.contains("127.0.0.1:9042"));
+        assert!(s.contains("io error: refused"));
+        assert!(s.contains("hint:"));
+        assert!(s.contains("ferrosa"));
+    }
+}

--- a/ferrosa-ctl/src/commands.rs
+++ b/ferrosa-ctl/src/commands.rs
@@ -199,6 +199,81 @@ pub async fn run_monitor(addr: SocketAddr, panel: Option<&str>) -> Result<(), Cq
     Ok(())
 }
 
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+/// Dispatch for `ferrosa-ctl auth set-password`.
+///
+/// 1. Read NEW password (twice, no echo unless `--no-confirm`); validate.
+/// 2. Connect to `addr` as `admin_user` with the password from
+///    `--admin-password-env` (or seed default → prompt fallback).
+/// 3. Issue `ALTER ROLE "<user>" WITH PASSWORD = '<new>'`.
+///
+/// Returns a [`crate::auth::SetPasswordError`] carrying both the message
+/// to print and the desired exit code.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_auth_set_password(
+    addr: SocketAddr,
+    user: &str,
+    admin_user: &str,
+    admin_password_env: Option<&str>,
+    ssl: bool,
+    force: bool,
+    no_confirm: bool,
+) -> Result<(), crate::auth::SetPasswordError> {
+    use crate::auth;
+
+    if ssl {
+        return Err(auth::SetPasswordError::Operation(
+            "--ssl is not yet supported by ferrosa-ctl; use a localhost connection".to_string(),
+        ));
+    }
+
+    if !force {
+        let stdin = std::io::stdin();
+        let mut locked = stdin.lock();
+        let mut stderr = std::io::stderr();
+        auth::confirm_superuser_change(user, &mut locked, &mut stderr)?;
+    }
+
+    let new_password = auth::read_new_password_interactive(!no_confirm)?;
+
+    let admin_choice = auth::resolve_admin_password(admin_password_env, |k| std::env::var(k).ok())
+        .map_err(|e| auth::SetPasswordError::BadInput(e.to_string()))?;
+
+    // Try the supplied/seed admin password first; on auth failure, prompt
+    // once if we're allowed to (no env var was given).
+    let mut executor =
+        match auth::LiveCqlExecutor::connect(addr, admin_user, &admin_choice.password).await {
+            Ok(e) => e,
+            Err(ferrosa_cql::error::CqlError::BadCredentials)
+                if admin_choice.may_retry_with_prompt =>
+            {
+                let pw = auth::prompt_password("Admin password").map_err(|e| {
+                    auth::SetPasswordError::BadInput(format!("could not read admin password: {e}"))
+                })?;
+                auth::LiveCqlExecutor::connect(addr, admin_user, &pw)
+                    .await
+                    .map_err(|e| {
+                        auth::SetPasswordError::Operation(auth::format_cql_error(
+                            &e.to_string(),
+                            addr,
+                        ))
+                    })?
+            }
+            Err(e) => {
+                return Err(auth::SetPasswordError::Operation(auth::format_cql_error(
+                    &e.to_string(),
+                    addr,
+                )));
+            }
+        };
+
+    auth::run_set_password(&mut executor, user, &new_password, addr).await?;
+
+    eprintln!("Password updated for role {user}");
+    Ok(())
+}
+
 // ── Cluster web-API commands ──────────────────────────────────────────────────
 //
 // These commands make HTTP requests to the Ferrosa web admin API (port 9090 by

--- a/ferrosa-ctl/src/lib.rs
+++ b/ferrosa-ctl/src/lib.rs
@@ -3,5 +3,6 @@
 //! Re-exports the `commands` module so integration tests can call
 //! the command functions directly against a live test server.
 
+pub mod auth;
 pub mod commands;
 pub mod tui;

--- a/ferrosa-ctl/src/main.rs
+++ b/ferrosa-ctl/src/main.rs
@@ -25,6 +25,7 @@ use std::process;
 
 use clap::{Parser, Subcommand};
 
+mod auth;
 mod commands;
 mod tui;
 
@@ -108,6 +109,12 @@ enum Commands {
         action: SnapshotAction,
     },
 
+    /// Manage role authentication (set passwords, etc.).
+    Auth {
+        #[command(subcommand)]
+        action: AuthAction,
+    },
+
     /// Restore from a snapshot, optionally to a point in time.
     Restore {
         /// Name of the snapshot to restore from.
@@ -120,6 +127,51 @@ enum Commands {
         /// Skip confirmation prompt and proceed even if data will be overwritten.
         #[arg(long)]
         force: bool,
+    },
+}
+
+/// Auth sub-actions.
+#[derive(Debug, Subcommand)]
+enum AuthAction {
+    /// Set the password for an existing role via CQL `ALTER ROLE`.
+    ///
+    /// The new password is read interactively from the terminal (no echo).
+    /// The CLI authenticates as `--admin-user` using `--admin-password-env`
+    /// (or a prompt if unset), then issues
+    /// `ALTER ROLE "<user>" WITH PASSWORD = '<new>'`. The server hashes
+    /// the cleartext via its own `PasswordHasher`. No password material
+    /// is written to disk by this command.
+    ///
+    /// # Password policy
+    ///
+    /// - non-empty
+    /// - at least 8 characters
+    SetPassword {
+        /// Role whose password to change. Defaults to the seed admin.
+        #[arg(long, default_value = "ferrosa_admin")]
+        user: String,
+
+        /// Role used for the admin connection. Defaults to the seed admin.
+        #[arg(long, default_value = "ferrosa_admin")]
+        admin_user: String,
+
+        /// Environment variable holding the admin password. If unset, the
+        /// CLI tries the seed default first; on auth failure, prompts.
+        #[arg(long)]
+        admin_password_env: Option<String>,
+
+        /// Use TLS for the CQL connection (currently a no-op placeholder;
+        /// `CqlClient` does not yet support TLS). Errors out if requested.
+        #[arg(long)]
+        ssl: bool,
+
+        /// Skip the SUPERUSER warning.
+        #[arg(long)]
+        force: bool,
+
+        /// Skip the second-prompt confirmation (for scripting).
+        #[arg(long)]
+        no_confirm: bool,
     },
 }
 
@@ -190,6 +242,32 @@ async fn main() {
             SnapshotAction::List => commands::snapshot_list(&web_host, web_port).await,
             SnapshotAction::Delete { name } => {
                 commands::snapshot_delete(&web_host, web_port, &name).await
+            }
+        },
+        Commands::Auth { action } => match action {
+            AuthAction::SetPassword {
+                user,
+                admin_user,
+                admin_password_env,
+                ssl,
+                force,
+                no_confirm,
+            } => {
+                if let Err(e) = commands::run_auth_set_password(
+                    addr,
+                    &user,
+                    &admin_user,
+                    admin_password_env.as_deref(),
+                    ssl,
+                    force,
+                    no_confirm,
+                )
+                .await
+                {
+                    eprintln!("error: {}", e.message());
+                    process::exit(e.exit_code());
+                }
+                Ok(())
             }
         },
         Commands::Restore {
@@ -471,6 +549,86 @@ mod tests {
             Commands::Restore { point_in_time, .. } => {
                 assert_eq!(point_in_time.as_deref(), Some("2026-03-18T12:00:00Z"));
             }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    // ── auth set-password CLI tests ──────────────────────────────────────────
+
+    #[test]
+    fn parse_auth_set_password_defaults() {
+        let cli = Cli::try_parse_from(["ferrosa-ctl", "auth", "set-password"]).unwrap();
+        match cli.command {
+            Commands::Auth {
+                action:
+                    AuthAction::SetPassword {
+                        user,
+                        admin_user,
+                        admin_password_env,
+                        ssl,
+                        force,
+                        no_confirm,
+                    },
+            } => {
+                assert_eq!(user, "ferrosa_admin");
+                assert_eq!(admin_user, "ferrosa_admin");
+                assert!(admin_password_env.is_none());
+                assert!(!ssl);
+                assert!(!force);
+                assert!(!no_confirm);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_set_password_all_flags() {
+        let cli = Cli::try_parse_from([
+            "ferrosa-ctl",
+            "auth",
+            "set-password",
+            "--user",
+            "alice",
+            "--admin-user",
+            "root",
+            "--admin-password-env",
+            "MY_PW",
+            "--ssl",
+            "--force",
+            "--no-confirm",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Auth {
+                action:
+                    AuthAction::SetPassword {
+                        user,
+                        admin_user,
+                        admin_password_env,
+                        ssl,
+                        force,
+                        no_confirm,
+                    },
+            } => {
+                assert_eq!(user, "alice");
+                assert_eq!(admin_user, "root");
+                assert_eq!(admin_password_env.as_deref(), Some("MY_PW"));
+                assert!(ssl);
+                assert!(force);
+                assert!(no_confirm);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_set_password_only_user() {
+        let cli =
+            Cli::try_parse_from(["ferrosa-ctl", "auth", "set-password", "--user", "bob"]).unwrap();
+        match cli.command {
+            Commands::Auth {
+                action: AuthAction::SetPassword { user, .. },
+            } => assert_eq!(user, "bob"),
             other => panic!("unexpected command: {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary

Adds a thin CQL wrapper around `ALTER ROLE <name> WITH PASSWORD = '...'`
so operators can rotate the seed `ferrosa_admin` password (and any
other role's password) on first install without any server-side
configuration changes.

## Why this approach

The earlier attempt (#4, closed) wrote a YAML file and expected the
server to consume it. That didn't match Ferrosa's actual auth model:
the running server stores Argon2 hashes in
`system_auth.roles.salted_hash` and never reads a YAML/credentials
file. The seed admin (`ferrosa_admin` / `ferrosa_admin`) is created on
first boot by `seed_default_roles()` in
`ferrosa-schema/src/auth/bootstrap.rs`.

The correct fix is to issue a CQL `ALTER ROLE` and let the server's
existing `PasswordHasher` do its job. `ferrosa-ctl` already speaks CQL
(it powers the TUI), so this PR reuses `CqlClient` and adds only what
was missing: the SASL PLAIN authentication handshake.

## CLI shape

```
ferrosa-ctl auth set-password [--user <name>] [--host <addr:port>]
                              [--admin-user <name>] [--admin-password-env <VAR>]
                              [--ssl] [--force] [--no-confirm]
```

Defaults target the first-touch installer case: `--user ferrosa_admin`,
`--admin-user ferrosa_admin`, `--host 127.0.0.1:9042`. With no
`--admin-password-env`, the CLI tries the well-known seed password
first; on auth failure it prompts (no echo).

## Changes

- `ferrosa-cql`: extend `CqlClient` with `connect_with_credentials()`.
  The previous client errored out on `Authenticate` opcodes; it now
  responds with a SASL PLAIN `AUTH_RESPONSE` and waits for
  `AUTH_SUCCESS`. The change is small (~70 lines, no new types) and
  shared with future CTL commands that need authenticated CQL.
- `ferrosa-ctl`: new `auth` subcommand module
  (`ferrosa-ctl/src/auth.rs`) plus the dispatch glue in `commands.rs`
  and `main.rs`. Adds `rpassword` (no-echo prompt) and `async-trait`
  (mockable executor for tests) as deps.

## CqlClient auth support

`CqlClient` did **not** support authenticated connections; it bailed
on the `Authenticate` opcode. I extended it with the minimal SASL
PLAIN handshake (~70 lines). This was small enough to do in scope; no
follow-up needed.

## ALTER ROLE WITH PASSWORD support

Confirmed via `ferrosa-cql/src/parser.rs` (`parse_alter_role`) and
`router.rs` (`route_alter_role`). The grammar covers
`ALTER ROLE "<name>" WITH PASSWORD = '<plain>' AND ...`. The server
hashes the plaintext via the configured `PasswordHasher` and writes
to `system_auth.roles`. No blocker.

## Test coverage (TDD)

All mocked unit tests; live round-trip is documented as a gap.

- argument parsing: defaults, every flag, `--user` only
- new-password validation: mismatch, empty, < 8 chars all → exit 2
- CQL string-literal escaping: `'` doubled, `"` doubled in role names
- mock executor: asserts exact CQL statement issued and that errors
  carry the host plus a runbook hint
- `resolve_admin_password`: env var present / unset (loud error) /
  fall-through to seed default
- SUPERUSER warning: accepts `y` / `yes`, aborts on `n` / empty input

## Out of scope / TODOs

- Live integration test of the full ALTER ROLE round-trip (would
  require seeding a role with a known plaintext and a `CqlServer`
  harness). The existing `ferrosa-cql/tests/auth_integration.rs`
  already exercises the server-side handshake the client now drives.
- `--ssl` currently errors out — `CqlClient` has no TLS support yet.
  The flag is reserved so the CLI shape doesn't change when TLS lands.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (workspace, zero warnings)
- [x] `cargo test -p ferrosa-ctl` (122 unit tests pass, 11 integration)
- [x] `cargo test -p ferrosa-cql --lib` (742 tests pass)
- [ ] Manual: run a node, create a non-default role, rotate its password, log back in