### PR TITLE
fix(ci): stage script looked for .yaml, ship the .toml that actually exists

### DIFF
--- a/.github/scripts/stage-release-tarball.sh
+++ b/.github/scripts/stage-release-tarball.sh
@@ -9,7 +9,7 @@
 #   LICENSE
 #   NOTICE
 #   README.md
-#   config/ferrosa.example.yaml      (if present in repo at tag time)
+#   config/ferrosa.example.toml      (if present in repo at tag time)
 #   launchd/com.ferrosadb.ferrosa.plist (if present)
 #   systemd/ferrosa.service          (if present)
 #
@@ -71,7 +71,7 @@ done
 # Platform integration directories — bundle if present at tag time.
 # (Created by Task #7. Tarball must succeed even before that lands.)
 for entry in \
-    "config/ferrosa.example.yaml" \
+    "config/ferrosa.example.toml" \
     "launchd/com.ferrosadb.ferrosa.plist" \
     "systemd/ferrosa.service"; do
   if [[ -f "$entry" ]]; then


### PR DESCRIPTION
End-to-end smoke test of v0.8.8+8 caught this: `stage-release-tarball.sh` was bundling `config/ferrosa.example.yaml` (never existed) instead of `config/ferrosa.example.toml` (Task #7's actual output). Result: tarballs shipped without the default config, and install.sh's first-run config copy failed silently. Single character fix; smoke test will confirm post-re-tag.