### PR TITLE
fix: harden replay and local quorum behavior

### DIFF
--- a/docs/database/getting-started.html
+++ b/docs/database/getting-started.html
@@ -247,9 +247,9 @@
   <h2 id="install">Installation</h2>
 
   <p>The planned developer-preview installer targets macOS and Linux first. Windows support can be added later if there is demand.</p>
-  <pre><span class="kw">curl</span> -fsSL https://ferrosadb.com/install.sh | bash</pre>
+  <pre><span class="kw">curl</span> -fsSL https://ferrosadb.com/setup.sh | bash</pre>
   <div class="note">
-    <strong>Preview installer:</strong> The install script is intended to download the matching Ferrosa release, place binaries on your PATH, and print the next command to run a local node. Until the public installer is published, build from source or use release artifacts from the preview PR/release.
+    <strong>Preview setup:</strong> The setup script is intended to download the matching Ferrosa release or prepare a source checkout, place binaries on your PATH when appropriate, and print the next command to run a local node. Until packaged release artifacts are published, build from source or use release artifacts from the preview PR/release.
   </div>
 
 

--- a/docs/ferrosa-memory/getting-started.html
+++ b/docs/ferrosa-memory/getting-started.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ferrosa Memory Getting Started</title>
+  <meta name="description" content="Run, configure, and use Ferrosa Memory locally with Ferrosa Database and MCP-compatible agent harnesses.">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <style>
+    :root { --bg:#0a0a0f; --card:#16161f; --card2:#111118; --text:#e8e8ed; --muted:#9494a3; --accent:#7c9cf5; --accent2:#e2725b; --border:#262637; --code:#0d0d14; }
+    * { box-sizing:border-box; }
+    body { margin:0; font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; background:var(--bg); color:var(--text); line-height:1.65; }
+    nav { position:sticky; top:0; background:rgba(10,10,15,.9); backdrop-filter:blur(16px); border-bottom:1px solid var(--border); z-index:10; }
+    nav .inner { max-width:1100px; margin:0 auto; padding:1rem 1.5rem; display:flex; align-items:center; justify-content:space-between; gap:1rem; }
+    nav a { color:var(--text); text-decoration:none; }
+    nav .links { display:flex; gap:1rem; flex-wrap:wrap; }
+    nav .links a { color:var(--muted); font-size:.92rem; }
+    main { max-width:980px; margin:0 auto; padding:3rem 1.5rem 5rem; }
+    h1 { font-size:clamp(2.2rem,5vw,4rem); line-height:1.05; letter-spacing:-.04em; margin:2rem 0 1rem; }
+    h2 { font-size:1.65rem; margin-top:3rem; border-top:1px solid var(--border); padding-top:2rem; }
+    h3 { margin-top:2rem; }
+    p, li, td { color:var(--muted); }
+    a { color:var(--accent); }
+    .hero { background:linear-gradient(135deg,rgba(124,156,245,.14),rgba(226,114,91,.08)); border:1px solid var(--border); border-radius:22px; padding:2rem; }
+    .pill { display:inline-block; border:1px solid rgba(124,156,245,.35); color:var(--accent); background:rgba(124,156,245,.08); border-radius:999px; padding:.25rem .7rem; font-size:.8rem; font-weight:700; letter-spacing:.06em; text-transform:uppercase; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1rem; margin:1rem 0; }
+    .card { background:var(--card); border:1px solid var(--border); border-radius:16px; padding:1.25rem; }
+    table { width:100%; border-collapse:collapse; background:var(--card2); border:1px solid var(--border); border-radius:12px; overflow:hidden; display:table; }
+    th, td { padding:.75rem .9rem; border-bottom:1px solid var(--border); text-align:left; vertical-align:top; }
+    th { color:var(--text); font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; }
+    tr:last-child td { border-bottom:0; }
+    pre { background:var(--code); border:1px solid var(--border); border-radius:14px; padding:1rem; overflow:auto; }
+    code { font-family:'JetBrains Mono','Fira Code',ui-monospace,monospace; color:#dcdcf0; }
+    .warn { border-left:3px solid var(--accent2); background:rgba(226,114,91,.08); padding:1rem 1.2rem; border-radius:0 12px 12px 0; color:var(--muted); }
+    footer { max-width:980px; margin:0 auto; padding:2rem 1.5rem; color:#6b6b7a; border-top:1px solid var(--border); }
+  </style>
+</head>
+<body>
+<nav><div class="inner"><a href="./"><strong>Ferrosa <span style="color:var(--accent)">Memory</span></strong></a><div class="links"><a href="../database/">Database</a><a href="./">Memory overview</a><a href="#quickstart">Quickstart</a><a href="#examples">Examples</a></div></div></nav>
+<main>
+  <section class="hero">
+    <span class="pill">Developer preview</span>
+    <h1>Run and use Ferrosa Memory locally.</h1>
+    <p>Ferrosa Memory is an MCP-compatible memory layer for agents. It stores entities, temporal facts, graph edges, raw context segments, retrieval traces, and derived facts on top of Ferrosa Database.</p>
+  </section>
+
+  <h2 id="quickstart">Fast setup</h2>
+  <p>Most users should start with the hosted setup scripts instead of cloning repositories manually.</p>
+  <pre><code># Ferrosa Database only
+curl -fsSL https://ferrosadb.com/setup.sh | bash
+
+# Ferrosa Memory plus LLM onboarding
+curl -fsSL https://ferrosadb.com/setup-memory.sh | bash</code></pre>
+  <p><code>setup-memory.sh</code> downloads <code>ONBOARDING.md</code>, optionally clones or updates the public repos, offers to pull the Nomic embedding model, and hands the user to their selected LLM harness with <code>onboard me using ONBOARDING.md</code>.</p>
+
+  <h2>What you will run</h2>
+  <div class="grid">
+    <div class="card"><strong>Minimal native mode</strong><p>One Ferrosa Database process using local filesystem storage plus one Ferrosa Memory MCP/workbench process.</p></div>
+    <div class="card"><strong>Full Compose mode</strong><p>Three local Ferrosa nodes plus optional MinIO/S3-compatible storage for cluster/operator testing.</p></div>
+    <div class="card"><strong>Nomic embeddings</strong><p>Optional <code>nomic-embed-text-v2-moe</code> via Ollama. If skipped, semantic/vector search is degraded.</p></div>
+    <div class="card"><strong>Agent harnesses</strong><p>Use ONBOARDING.md to configure Hermes, Claude, Codex, skills, hooks, hints, and prompts.</p></div>
+  </div>
+
+  <table>
+    <tr><th>Service</th><th>Local endpoint</th></tr>
+    <tr><td>MCP/workbench</td><td><code>http://127.0.0.1:18765/</code></td></tr>
+    <tr><td>MCP JSON-RPC</td><td><code>http://127.0.0.1:18765/mcp</code></td></tr>
+    <tr><td>Viz</td><td><code>http://127.0.0.1:18766/viz</code></td></tr>
+    <tr><td>CQL</td><td><code>127.0.0.1:19042-19044</code></td></tr>
+    <tr><td>Graph HTTP</td><td><code>http://127.0.0.1:17474-17476</code></td></tr>
+    <tr><td>Bolt</td><td><code>127.0.0.1:17687-17689</code></td></tr>
+    <tr><td>MinIO, full stack only</td><td><code>http://127.0.0.1:19000</code>, console <code>19001</code></td></tr>
+  </table>
+
+  <h2>Manual source setup</h2>
+  <h3>1. Check prerequisites</h3>
+  <pre><code>rustc --version
+cargo --version
+git --version
+curl --version
+python3 --version
+ollama --version              # optional semantic search layer
+docker compose version        # full Docker stack only
+podman compose version        # full Podman stack only</code></pre>
+
+  <h3>2. Optional Nomic embedding layer</h3>
+  <pre><code>ollama pull nomic-embed-text-v2-moe
+ollama list | grep nomic-embed-text-v2-moe</code></pre>
+  <div class="warn">If embeddings are skipped, lexical/phonetic search still works, but semantic/vector search quality is degraded.</div>
+
+  <h3>3. Clone the public repositories, if contributing from source</h3>
+  <pre><code>mkdir -p ~/src/ferrosa-suite
+cd ~/src/ferrosa-suite
+
+git clone https://github.com/bkearns/ferrosa.git ferrosa
+git clone https://github.com/bkearns/ferrosa-memory.git ferrosa-memory</code></pre>
+
+  <h3>4. Native minimal mode</h3>
+  <pre><code>cd ~/src/ferrosa-suite/ferrosa
+cargo build --release
+
+cd ~/src/ferrosa-suite/ferrosa-memory
+cargo build --release</code></pre>
+  <p>Use repository config examples or <code>setup-memory.sh</code>/<code>ONBOARDING.md</code> to choose ports, local data directories, credentials, embedding settings, skills, hooks, and harness prompts.</p>
+
+  <h3>5. Full Compose development stack</h3>
+  <pre><code>cd ~/src/ferrosa-suite/ferrosa
+docker build -t ferrosa-memory-node:latest .
+# or: podman build -t ferrosa-memory-node:latest .
+
+cd ~/src/ferrosa-suite/ferrosa-memory
+docker compose up -d
+# or: podman compose up -d</code></pre>
+
+  <h3>5. Verify health</h3>
+  <pre><code>curl -fsS http://127.0.0.1:18765/healthz/live && echo
+curl -fsS http://127.0.0.1:18765/healthz/ready && echo
+curl -fsS http://127.0.0.1:18766/viz | head -c 64 && echo</code></pre>
+
+  <p>Expected output includes <code>ok</code>, <code>ready</code>, and an HTML doctype from the viz UI.</p>
+
+  <h2>Connect an MCP client</h2>
+  <p>Configure an MCP HTTP server pointing at:</p>
+  <pre><code>http://127.0.0.1:18765/mcp</code></pre>
+  <p>Generic MCP server shape:</p>
+  <pre><code>{
+  "name": "ferrosa-memory",
+  "transport": "http",
+  "url": "http://127.0.0.1:18765/mcp",
+  "headers": {
+    "Authorization": "Basic &lt;base64 username:password&gt;"
+  }
+}</code></pre>
+  <div class="warn">Use unique credentials and TLS/auth boundaries for shared deployments. Default local credentials are only appropriate for single-user development on loopback.</div>
+
+  <h2>Smoke-test MCP with curl</h2>
+  <pre><code>curl -sS -u ferrosa_user:ferrosa_user \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  http://127.0.0.1:18765/mcp
+
+curl -sS -u ferrosa_user:ferrosa_user \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_stats","arguments":{}}}' \
+  http://127.0.0.1:18765/mcp</code></pre>
+
+  <h2 id="examples">Memory examples</h2>
+  <h3>Ingest a memory entity</h3>
+  <pre><code>{
+  "tool": "smart_ingest",
+  "arguments": {
+    "entity_name": "Project migration rule",
+    "entity_type": "decision",
+    "content": "Schema migrations should be additive by default so live memory clusters can be upgraded without deleting data."
+  }
+}</code></pre>
+
+  <h3>Retrieve related memory</h3>
+  <pre><code>{
+  "tool": "hybrid_search",
+  "arguments": {
+    "query": "what migration rule did we decide on for live memory clusters",
+    "limit": 5
+  }
+}</code></pre>
+
+  <h3>Record an evolving fact</h3>
+  <pre><code>{
+  "tool": "write_temporal_fact",
+  "arguments": {
+    "entity_id": "&lt;entity UUID from smart_ingest&gt;",
+    "fact_text": "Current rule: prefer additive migrations for live memory clusters."
+  }
+}</code></pre>
+
+  <h3>Search raw context segments</h3>
+  <pre><code>{
+  "tool": "search_context_segments",
+  "arguments": {
+    "query": "migration policy additive",
+    "limit": 5,
+    "expand": {"prev": 1, "next": 1, "max_tokens": 2000}
+  }
+}</code></pre>
+
+  <h2>Operate safely</h2>
+  <p>Stop and start without deleting data:</p>
+  <pre><code>cd ~/src/ferrosa-suite/ferrosa-memory
+docker compose stop
+docker compose start
+# or: podman compose stop && podman compose start</code></pre>
+  <p>After rebuilding an image, recreate nodes one at a time and wait for health before moving on:</p>
+  <pre><code>docker compose up -d --no-deps --force-recreate node1</code></pre>
+  <div class="warn">Do not run <code>down -v</code> unless you intentionally want to delete persisted memory data.</div>
+
+  <h2>Troubleshooting</h2>
+  <table>
+    <tr><th>Symptom</th><th>Check</th></tr>
+    <tr><td><code>live</code> fails</td><td>MCP container status, port mapping, HTTP vs HTTPS config.</td></tr>
+    <tr><td><code>ready</code> fails</td><td>CQL node health, auth, contact points.</td></tr>
+    <tr><td>Agent cannot list tools</td><td>MCP config path and harness restart/reload.</td></tr>
+    <tr><td><code>get_stats</code> times out</td><td>Node replay/OOM logs and CQL read timeouts.</td></tr>
+    <tr><td>Container MCP cannot reach CQL</td><td>Host networking or container-routable contact points if config uses localhost.</td></tr>
+  </table>
+  <pre><code>cd ~/src/ferrosa-suite/ferrosa-memory
+docker compose logs --tail=100 node1 node2 node3 ferrosa-memory-mcp</code></pre>
+
+  <h2>Next steps</h2>
+  <ul>
+    <li>Add Ferrosa Memory as an MCP server to your agent harness.</li>
+    <li>Run the ingest, retrieval, temporal fact, and context segment examples.</li>
+    <li>Use the workbench and viz UI to inspect stored memories and graph links.</li>
+    <li>Run long-horizon evaluation scenarios before making broad reasoning claims.</li>
+  </ul>
+</main>
+<footer>Ferrosa Suite · Developer preview · <a href="./">Memory overview</a></footer>
+</body>
+</html>

--- a/docs/ferrosa-memory/getting-started.md
+++ b/docs/ferrosa-memory/getting-started.md
@@ -1,0 +1,374 @@
+# Ferrosa Memory Getting Started
+
+Ferrosa Memory is a developer-preview memory layer for agents. It runs as an MCP-compatible service backed by Ferrosa Database, with a workbench on port `18765` and a graph visualization surface on port `18766`.
+
+This guide shows how to run a local development stack, connect an agent harness, and use the core memory operations.
+
+## Fast setup
+
+For most users, start with the hosted setup scripts instead of cloning repositories manually.
+
+Ferrosa Database only:
+
+```bash
+curl -fsSL https://ferrosadb.com/setup.sh | bash
+```
+
+Ferrosa Memory plus agent onboarding:
+
+```bash
+curl -fsSL https://ferrosadb.com/setup-memory.sh | bash
+```
+
+`setup-memory.sh` downloads the onboarding prompt, optionally clones or updates the public repositories, offers to pull the local Nomic embedding model, and then hands the user to the selected LLM harness with:
+
+```text
+onboard me using ONBOARDING.md
+```
+
+Manual source setup is still useful for contributors and is shown below.
+
+## What you will run
+
+The minimal local setup can be just:
+
+- one native Ferrosa Database process using local filesystem storage;
+- one native Ferrosa Memory MCP/workbench process;
+- optional local Nomic embeddings for semantic/vector search.
+
+The fuller development stack adds:
+
+- three Ferrosa Database nodes;
+- MinIO for S3-compatible object storage;
+- the same MCP/workbench and visualization surfaces used by local operator testing.
+
+S3/MinIO is optional for the smallest local single-user setup. If you skip embeddings, Ferrosa Memory still works, but semantic/vector search quality is degraded; lexical, phonetic, direct lookup, and graph traversal remain available.
+
+Default local ports:
+
+| Service | URL / port |
+|---|---|
+| MCP/workbench | `http://127.0.0.1:18765/` |
+| MCP JSON-RPC | `http://127.0.0.1:18765/mcp` |
+| Viz | `http://127.0.0.1:18766/viz` |
+| CQL | `127.0.0.1:19042-19044` |
+| Graph HTTP | `http://127.0.0.1:17474-17476` |
+| Bolt | `127.0.0.1:17687-17689` |
+| MinIO, full stack only | `http://127.0.0.1:19000`, console `19001` |
+
+## Prerequisites
+
+Install:
+
+- Git and curl
+- Rust toolchain with Cargo for source/native builds
+- Docker or Podman with Compose support only for the full development stack
+- Ollama only if you want local Nomic embeddings
+- Python 3 for optional smoke scripts
+
+Check what you plan to use:
+
+```bash
+rustc --version
+cargo --version
+git --version
+curl --version
+python3 --version
+ollama --version              # optional semantic search layer
+docker compose version        # full Docker stack only
+podman compose version        # full Podman stack only
+```
+
+## Optional Nomic embedding layer
+
+For semantic/vector retrieval, install the local embedding model:
+
+```bash
+ollama pull nomic-embed-text-v2-moe
+ollama list | grep nomic-embed-text-v2-moe
+```
+
+If you skip this step, warn users and test with lexical/phonetic queries first:
+
+```text
+Nomic embeddings disabled; semantic/vector search is degraded.
+```
+
+## Manual source setup
+
+```bash
+mkdir -p ~/src/ferrosa-suite
+cd ~/src/ferrosa-suite
+
+git clone https://github.com/bkearns/ferrosa.git ferrosa
+git clone https://github.com/bkearns/ferrosa-memory.git ferrosa-memory
+```
+
+If you already have the repositories:
+
+```bash
+git -C ~/src/ferrosa-suite/ferrosa fetch --all --prune
+git -C ~/src/ferrosa-suite/ferrosa-memory fetch --all --prune
+```
+
+## Native minimal mode
+
+Build and run native binaries when you want the smallest local setup with filesystem storage and no S3/MinIO dependency:
+
+```bash
+cd ~/src/ferrosa-suite/ferrosa
+cargo build --release
+
+cd ~/src/ferrosa-suite/ferrosa-memory
+cargo build --release
+```
+
+Use repository config examples or `setup-memory.sh`/`ONBOARDING.md` to choose ports, data directories, credentials, embedding settings, skills, hooks, and harness prompts.
+
+## Full Compose development stack
+
+The Compose stack is for local cluster/operator testing. It expects a local Ferrosa node image named `ferrosa-memory-node:latest`.
+
+```bash
+cd ~/src/ferrosa-suite/ferrosa
+docker build -t ferrosa-memory-node:latest .
+# or: podman build -t ferrosa-memory-node:latest .
+
+cd ~/src/ferrosa-suite/ferrosa-memory
+docker compose up -d
+# or: podman compose up -d
+
+docker compose ps
+# or: podman compose ps
+```
+
+The database nodes should become healthy before the MCP service is considered ready.
+
+## Health checks
+
+```bash
+curl -fsS http://127.0.0.1:18765/healthz/live && echo
+curl -fsS http://127.0.0.1:18765/healthz/ready && echo
+curl -fsS http://127.0.0.1:18766/viz | head -c 64 && echo
+```
+
+Expected:
+
+```text
+ok
+ready
+<!DOCTYPE html>
+```
+
+If your local configuration enables TLS for the MCP/workbench endpoint, use `https://127.0.0.1:18765` and the configured local CA/certificate options instead.
+
+## Connect an MCP client
+
+Ferrosa Memory exposes MCP over HTTP at:
+
+```text
+http://127.0.0.1:18765/mcp
+```
+
+Generic MCP server configuration shape:
+
+```json
+{
+  "name": "ferrosa-memory",
+  "transport": "http",
+  "url": "http://127.0.0.1:18765/mcp",
+  "headers": {
+    "Authorization": "Basic <base64 username:password>"
+  }
+}
+```
+
+For a single-user local development stack, the example compose config may use local default credentials. For shared machines or networks, configure unique credentials and keep the service loopback-only or behind TLS and an authenticated proxy.
+
+## Smoke-test with curl
+
+List tools:
+
+```bash
+curl -sS -u ferrosa_user:ferrosa_user \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  http://127.0.0.1:18765/mcp
+```
+
+Get stats:
+
+```bash
+curl -sS -u ferrosa_user:ferrosa_user \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_stats","arguments":{}}}' \
+  http://127.0.0.1:18765/mcp
+```
+
+## Core memory examples
+
+The exact tool names exposed to your agent may be namespaced by the client. The JSON below shows the intended tool and argument shapes.
+
+### Ingest a memory entity
+
+```json
+{
+  "tool": "smart_ingest",
+  "arguments": {
+    "entity_name": "Project migration rule",
+    "entity_type": "decision",
+    "content": "Schema migrations should be additive by default so live memory clusters can be upgraded without deleting data."
+  }
+}
+```
+
+### Retrieve related memory
+
+```json
+{
+  "tool": "hybrid_search",
+  "arguments": {
+    "query": "what migration rule did we decide on for live memory clusters",
+    "limit": 5
+  }
+}
+```
+
+### Record a temporal fact
+
+```json
+{
+  "tool": "write_temporal_fact",
+  "arguments": {
+    "entity_id": "<entity UUID from smart_ingest>",
+    "fact_text": "Current rule: prefer additive migrations for live memory clusters."
+  }
+}
+```
+
+### Follow the current temporal chain
+
+```json
+{
+  "tool": "get_temporal_chain",
+  "arguments": {
+    "entity_id": "<entity UUID>"
+  }
+}
+```
+
+### Link two entities
+
+```json
+{
+  "tool": "create_edge",
+  "arguments": {
+    "src_entity_id": "<source UUID>",
+    "dst_entity_id": "<destination UUID>",
+    "edge_type": "related_to",
+    "weight": 0.8
+  }
+}
+```
+
+### Persist raw context segments
+
+```json
+{
+  "tool": "ingest_context_segments",
+  "arguments": {
+    "conversation_id": "demo-conversation",
+    "messages": [
+      {"role": "user", "turn_index": 1, "content": "Remember that our migration policy is additive."},
+      {"role": "assistant", "turn_index": 2, "content": "Stored as a project migration decision."}
+    ]
+  }
+}
+```
+
+### Search raw context segments
+
+```json
+{
+  "tool": "search_context_segments",
+  "arguments": {
+    "query": "migration policy additive",
+    "limit": 5,
+    "expand": {"prev": 1, "next": 1, "max_tokens": 2000}
+  }
+}
+```
+
+## Workbench and visualization
+
+Open:
+
+```text
+http://127.0.0.1:18765/
+http://127.0.0.1:18766/viz
+```
+
+Use the workbench to inspect:
+
+- CQL tables and counts;
+- memory summaries;
+- graph and Datalog query surfaces;
+- aliases, rules, approvals, and explanations when enabled.
+
+Use the viz page to inspect graph neighborhoods and entity links. Wait for graph queries to finish before taking screenshots or drawing conclusions from an empty view.
+
+## Safe stop and restart
+
+Stop without deleting data:
+
+```bash
+cd ~/src/ferrosa-suite/ferrosa-memory
+docker compose stop
+# or
+podman compose stop
+```
+
+Start again:
+
+```bash
+cd ~/src/ferrosa-suite/ferrosa-memory
+docker compose start
+# or
+podman compose start
+```
+
+Recreate containers without deleting volumes after rebuilding an image:
+
+```bash
+cd ~/src/ferrosa-suite/ferrosa-memory
+docker compose up -d --no-deps --force-recreate node1
+```
+
+Roll nodes one at a time and wait for each node to become healthy before moving to the next. Do not run `down -v` unless you intentionally want to delete all persisted memory data.
+
+## Troubleshooting
+
+| Symptom | What to check |
+|---|---|
+| `live` fails | MCP container is not running or the port is not mapped. |
+| `ready` fails | CQL nodes are not healthy, auth is wrong, or contact points are unreachable. |
+| Agent cannot list tools | MCP client config is wrong or the harness needs a restart/reload. |
+| `get_stats` times out | Check node replay/OOM logs and CQL read timeouts. |
+| Viz loads but graph is empty | Wait for the query to finish; verify memory rows exist; inspect filters. |
+| MCP in a container cannot reach CQL | If config uses `localhost:19042`, run MCP with host networking or use container-routable contact points. |
+
+Logs:
+
+```bash
+cd ~/src/ferrosa-suite/ferrosa-memory
+docker compose logs --tail=100 node1 node2 node3 ferrosa-memory-mcp
+# or
+podman compose logs --tail=100 node1 node2 node3 ferrosa-memory-mcp
+```
+
+## Next steps
+
+- Add Ferrosa Memory as an MCP server to your preferred agent harness.
+- Run the ingest/search/temporal examples above.
+- Use the workbench to verify the memory rows and graph links.
+- Use the long-horizon evaluation scenarios in `ferrosa-memory` to measure retrieval quality, temporal accuracy, and evidence-packet usefulness before claiming long-horizon reasoning performance.

--- a/docs/ferrosa-memory/index.html
+++ b/docs/ferrosa-memory/index.html
@@ -768,9 +768,10 @@
     <ul class="nav-links">
       <li><a href="../database/">Database</a></li>
       <li><a href="./">Memory</a></li>
+      <li><a href="getting-started.html">Setup</a></li>
       <li><a href="../database/examples/">Examples</a></li>
     </ul>
-    <a href="#get-started" class="nav-cta">Get Started</a>
+    <a href="getting-started.html" class="nav-cta">Get Started</a>
   </div>
 </nav>
 
@@ -782,7 +783,7 @@
   <h1>Linked memory for <span class="gradient">long-running agents.</span></h1>
   <p>Ferrosa Memory gives agents a developer-preview memory layer: context segments, entities, temporal facts, graph edges, retrieval, Datalog-style derived facts, and operator UIs for query and visualization.</p>
   <div class="hero-actions">
-    <a href="#quickstart" class="btn-primary">Quickstart</a>
+    <a href="getting-started.html" class="btn-primary">Quickstart</a>
     <a href="#workbench" class="btn-secondary">Explore the UI</a>
   </div>
 </section>
@@ -841,8 +842,11 @@ Ferrosa Database storage + graph</code></pre></div>
 <section id="quickstart">
   <div class="section-label">Quickstart</div>
   <h2>Local developer preview configuration.</h2>
-  <p style="color:var(--text-secondary); max-width:780px;">The exact binary names and deployment packaging may change before release. The planned installer targets macOS and Linux first. The important shape is: run Ferrosa Database, point Ferrosa Memory at its CQL/graph surfaces, expose MCP on the main port, and expose visualization on the adjacent viz port.</p>
-  <div class="code-block"><pre><code>curl -fsSL https://ferrosadb.com/install.sh | bash
+  <p style="color:var(--text-secondary); max-width:780px;">For the shortest path, run the hosted memory setup script. It downloads the onboarding prompt, optionally clones or updates the public repositories, offers to pull <code>nomic-embed-text-v2-moe</code>, and hands the user to Hermes, Claude, Codex, or another LLM harness. Minimal native mode can use local filesystem storage with no S3/MinIO; the full Compose mode adds a three-node cluster and MinIO for operator testing.</p>
+  <div class="code-block"><pre><code>curl -fsSL https://ferrosadb.com/setup-memory.sh | bash
+
+# Optional semantic/vector search layer:
+ollama pull nomic-embed-text-v2-moe
 
 # ferrosa-memory.toml — local preview shape
 [server]
@@ -914,7 +918,7 @@ Viz snapshot API:  http://localhost:18766/viz/snapshot</code></pre></div>
   <h2>Preview Ferrosa Memory with your agents.</h2>
   <p>Start local, inspect memory in the workbench, and use the viz surface to check how context is becoming linked memory.</p>
   <div class="hero-actions">
-    <a href="#quickstart" class="btn-primary">Configure local preview</a>
+    <a href="getting-started.html" class="btn-primary">Configure local preview</a>
     <a href="../database/" class="btn-secondary">Use Ferrosa Database</a>
   </div>
 </section>
@@ -925,6 +929,7 @@ Viz snapshot API:  http://localhost:18766/viz/snapshot</code></pre></div>
       <a href="../database/" style="color:var(--text-secondary); text-decoration:none;">Database</a>
       <a href="./" style="color:var(--text-secondary); text-decoration:none;">Memory</a>
       <a href="../database/getting-started.html" style="color:var(--text-secondary); text-decoration:none;">DB Docs</a>
+      <a href="getting-started.html" style="color:var(--text-secondary); text-decoration:none;">Memory Setup</a>
       <a href="#examples" style="color:var(--text-secondary); text-decoration:none;">Memory Examples</a>
     </div>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -760,6 +760,7 @@
     <ul class="nav-links">
       <li><a href="/database/">Database</a></li>
       <li><a href="/ferrosa-memory/">Memory</a></li>
+      <li><a href="/ferrosa-memory/getting-started.html">Memory Setup</a></li>
       <li><a href="/database/examples/">Examples</a></li>
     </ul>
     <a href="#get-started" class="nav-cta">Get Started</a>
@@ -775,7 +776,7 @@
   <p>Ferrosa is a developer-preview suite for two related problems: a Rust-native distributed database for operational workloads, and Ferrosa Memory for linked agent context that can be queried, updated, and inspected over time.</p>
   <div class="hero-actions">
     <a href="/database/" class="btn-primary">Use the Database</a>
-    <a href="/ferrosa-memory/" class="btn-secondary">Preview Ferrosa Memory</a>
+    <a href="/ferrosa-memory/getting-started.html" class="btn-secondary">Set Up Ferrosa Memory</a>
   </div>
 </section>
 <section id="products">
@@ -793,6 +794,7 @@
       <div class="kicker">Ferrosa Memory</div>
       <h3>Agent memory: durable, linked, queryable context.</h3>
       <p>A developer-preview memory system for agents: temporal facts, entity graphs, folds, retrieval, Datalog-style materialization, workbench query UIs, and visualization for inspecting what the agent is recording and linking.</p>
+      <p style="margin-top:1rem;"><span class="pill">MCP on 18765</span> <span class="pill">Viz on 18766</span></p>
       <div class="pill-row"><span class="pill">MCP</span><span class="pill">Long context</span><span class="pill">Graph memory</span><span class="pill">Datalog</span><span class="pill">Viz</span></div>
     </a>
   </div>
@@ -808,7 +810,8 @@
     <div class="doc-card">
       <h3>Research-inspired, product-shaped</h3>
       <p>Preview docs cite the papers and specs behind the design, including memory architectures, GraphRAG-style retrieval, Datalog materialization, MemoryArena-style evaluation, prompt/context compression, and privacy/security work for persistent agent memory.</p>
-      <a href="/ferrosa-memory/#research" style="color:var(--accent-cool); text-decoration:none; font-weight:700;">Read the research notes →</a>
+      <a href="/ferrosa-memory/#research" style="color:var(--accent-cool); text-decoration:none; font-weight:700;">Read the research notes →</a><br>
+      <a href="/ferrosa-memory/getting-started.html" style="color:var(--accent-cool); text-decoration:none; font-weight:700;">Run the local memory stack →</a>
     </div>
   </div>
   <div class="screenshot-grid">
@@ -825,11 +828,15 @@
 <section id="get-started" class="cta-section">
   <h2>Start with the problem you have.</h2>
   <p>Install a local developer preview for macOS or Linux, then evaluate the database and memory surfaces against your own workflows.</p>
-  <div class="code-block"><pre><code>curl -fsSL https://ferrosadb.com/install.sh | bash</code></pre></div>
-  <p style="color:var(--text-secondary); max-width:760px; margin:1rem auto 0;">The installer is planned for macOS and Linux first. Windows support can be added later if there is demand.</p>
+  <div class="code-block"><pre><code># Database only
+curl -fsSL https://ferrosadb.com/setup.sh | bash
+
+# Ferrosa Memory + LLM onboarding
+curl -fsSL https://ferrosadb.com/setup-memory.sh | bash</code></pre></div>
+  <p style="color:var(--text-secondary); max-width:760px; margin:1rem auto 0;">Memory setup can run minimal native binaries with local filesystem storage, or a full Compose cluster with optional MinIO. Nomic embeddings are optional; without them semantic/vector search is degraded.</p>
   <div class="hero-actions">
     <a href="/database/getting-started.html" class="btn-primary">Database Getting Started</a>
-    <a href="/ferrosa-memory/#quickstart" class="btn-secondary">Memory Quickstart</a>
+    <a href="/ferrosa-memory/getting-started.html" class="btn-secondary">Memory Quickstart</a>
   </div>
 </section>
 <footer>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ User-facing documentation for Ferrosa Database and Ferrosa Memory.
 
 - [Ferrosa Database](database/) — distributed database docs, examples, CQL, Cypher, SPARQL, and migration guides.
 - [Ferrosa Memory](ferrosa-memory/) — developer-preview long-context linked memory for agents.
+- [Ferrosa Memory Getting Started](ferrosa-memory/getting-started.html) — run the local stack, connect MCP clients, and try memory examples.
 
 ## Database Docs
 

--- a/docs/setup-memory.sh
+++ b/docs/setup-memory.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ferrosa Memory local onboarding bootstrap.
+# This script is safe by default: it creates directories, downloads public files,
+# and optionally clones/updates repos. It never deletes data or volumes.
+
+FERROSA_SUITE_DIR="${FERROSA_SUITE_DIR:-$HOME/src/ferrosa-suite}"
+FERROSA_MEMORY_REPO="${FERROSA_MEMORY_REPO:-https://github.com/bkearns/ferrosa-memory.git}"
+FERROSA_REPO="${FERROSA_REPO:-https://github.com/bkearns/ferrosa.git}"
+ONBOARDING_URL="${ONBOARDING_URL:-https://raw.githubusercontent.com/bkearns/ferrosa-memory/main/ONBOARDING.md}"
+ONBOARDING_PATH="${ONBOARDING_PATH:-$FERROSA_SUITE_DIR/ferrosa-memory/ONBOARDING.md}"
+NOMIC_MODEL="${NOMIC_MODEL:-nomic-embed-text-v2-moe}"
+
+printf '\nFerrosa Memory onboarding bootstrap\n'
+printf '=================================\n\n'
+printf 'Install directory: %s\n' "$FERROSA_SUITE_DIR"
+printf 'Ferrosa repo:      %s\n' "$FERROSA_REPO"
+printf 'Memory repo:       %s\n' "$FERROSA_MEMORY_REPO"
+printf 'Embedding model:   %s (optional)\n\n' "$NOMIC_MODEL"
+
+mkdir -p "$FERROSA_SUITE_DIR"
+
+ask_yes_no() {
+  local prompt="$1" default="${2:-y}" answer
+  if [[ ! -t 0 ]]; then
+    [[ "$default" == "y" ]]
+    return
+  fi
+  read -r -p "$prompt [$default] " answer || answer="$default"
+  answer="${answer:-$default}"
+  [[ "$answer" =~ ^[Yy]$|^[Yy][Ee][Ss]$ ]]
+}
+
+clone_or_update() {
+  local url="$1" dir="$2"
+  if [[ -d "$dir/.git" ]]; then
+    printf '\nUpdating %s\n' "$dir"
+    git -C "$dir" fetch --all --prune
+  else
+    printf '\nCloning %s -> %s\n' "$url" "$dir"
+    git clone "$url" "$dir"
+  fi
+}
+
+if ask_yes_no "Clone or update ferrosa and ferrosa-memory now?" "y"; then
+  clone_or_update "$FERROSA_REPO" "$FERROSA_SUITE_DIR/ferrosa"
+  clone_or_update "$FERROSA_MEMORY_REPO" "$FERROSA_SUITE_DIR/ferrosa-memory"
+fi
+
+if [[ ! -f "$ONBOARDING_PATH" ]]; then
+  mkdir -p "$(dirname "$ONBOARDING_PATH")"
+  printf '\nDownloading ONBOARDING.md from %s\n' "$ONBOARDING_URL"
+  curl -fsSL "$ONBOARDING_URL" -o "$ONBOARDING_PATH"
+fi
+
+if command -v ollama >/dev/null 2>&1; then
+  if ask_yes_no "Pull optional Nomic embedding model for semantic search?" "y"; then
+    ollama pull "$NOMIC_MODEL"
+  else
+    printf '\nSkipping embeddings. Semantic/vector search will be degraded until %s is available.\n' "$NOMIC_MODEL"
+  fi
+else
+  printf '\nOllama not found. Skipping embeddings. Semantic/vector search will be degraded until %s is available.\n' "$NOMIC_MODEL"
+fi
+
+printf '\nONBOARDING.md is ready at:\n  %s\n\n' "$ONBOARDING_PATH"
+
+if command -v hermes >/dev/null 2>&1 && ask_yes_no "Launch Hermes with the onboard-me prompt now?" "y"; then
+  exec hermes "onboard me using $ONBOARDING_PATH"
+fi
+
+printf 'Next: run your preferred LLM harness with the onboard-me prompt.\n\n'
+printf 'Hermes:\n  hermes "onboard me using %s"\n\n' "$ONBOARDING_PATH"
+printf 'Claude/Codex or another harness:\n  onboard me using %s\n\n' "$ONBOARDING_PATH"
+printf 'The onboarding prompt will ask about native vs Compose runtime, skills, hooks, prompts, credentials, and ports.\n'

--- a/docs/setup.sh
+++ b/docs/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ferrosa Database local bootstrap.
+# Safe by default: clone/update only; no volume or data deletion.
+
+FERROSA_SUITE_DIR="${FERROSA_SUITE_DIR:-$HOME/src/ferrosa-suite}"
+FERROSA_REPO="${FERROSA_REPO:-https://github.com/bkearns/ferrosa.git}"
+
+printf '\nFerrosa Database bootstrap\n'
+printf '==========================\n\n'
+printf 'Install directory: %s\n' "$FERROSA_SUITE_DIR"
+printf 'Ferrosa repo:      %s\n\n' "$FERROSA_REPO"
+
+mkdir -p "$FERROSA_SUITE_DIR"
+
+if [[ -d "$FERROSA_SUITE_DIR/ferrosa/.git" ]]; then
+  git -C "$FERROSA_SUITE_DIR/ferrosa" fetch --all --prune
+else
+  git clone "$FERROSA_REPO" "$FERROSA_SUITE_DIR/ferrosa"
+fi
+
+cat <<EOF
+
+Ferrosa source is ready at:
+  $FERROSA_SUITE_DIR/ferrosa
+
+Common next steps:
+  cd $FERROSA_SUITE_DIR/ferrosa
+  cargo build --release
+
+For Ferrosa Memory setup, run:
+  curl -fsSL https://ferrosadb.com/setup-memory.sh | bash
+
+EOF

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -27,6 +27,7 @@ fn test_storage(dir: &std::path::Path) -> Arc<StorageEngine> {
         auth_enabled: false,
         auth_warn: false,
         write_verify: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     Arc::new(StorageEngine::new(config, None).unwrap())
 }

--- a/ferrosa-cluster/src/coordinator/batch.rs
+++ b/ferrosa-cluster/src/coordinator/batch.rs
@@ -443,6 +443,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-cluster/src/coordinator/mod.rs
+++ b/ferrosa-cluster/src/coordinator/mod.rs
@@ -303,6 +303,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -1241,6 +1241,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-cluster/src/coordinator/write.rs
+++ b/ferrosa-cluster/src/coordinator/write.rs
@@ -515,6 +515,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }
@@ -697,6 +698,68 @@ mod tests {
             }
             other => panic!("expected Unavailable, got: {other}"),
         }
+    }
+
+    #[tokio::test]
+    async fn coordinate_write_local_quorum_succeeds_with_one_of_three_replicas_down() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let (server, addr, remote_ok_host_id) =
+            start_rpc_server(MsgType::MutationForward, Arc::new(MutationAckHandler)).await;
+
+        let local_node_id = 1u64;
+        let remote_down_host_id = Uuid::new_v4();
+        let pm = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            Uuid::new_v4(),
+            Arc::new(NoopListener),
+        ));
+        pm.add_peer_entry((remote_down_host_id, "127.0.0.1:1".parse().unwrap()))
+            .await;
+
+        let mut local = make_node("10.0.0.1:7000");
+        local.host_id = Uuid::new_v4();
+        let mut remote_ok = make_node(&addr.to_string());
+        remote_ok.host_id = remote_ok_host_id;
+        let mut remote_down = make_node("127.0.0.1:1");
+        remote_down.host_id = remote_down_host_id;
+
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, local);
+        ring.add_node(2u64, remote_ok);
+        ring.add_node(3u64, remote_down);
+        ring.assign_tokens(local_node_id, &[50]);
+        ring.assign_tokens(2u64, &[100]);
+        ring.assign_tokens(3u64, &[200]);
+
+        let coordinator = make_coordinator(
+            ring,
+            pm.clone(),
+            local_node_id,
+            storage.clone(),
+            3,
+            ConsistencyLevel::LocalQuorum,
+        );
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        let key = test_key();
+        let row = test_row();
+
+        coordinator
+            .coordinate_write_with(&table_id, &key, row, 1000, ConsistencyLevel::LocalQuorum, 3)
+            .await
+            .expect("RF=3 LOCAL_QUORUM should succeed with local + one remote ACK when exactly one replica is down");
+
+        let stored = storage.read(&table_id, &key).unwrap();
+        assert!(stored.is_some(), "local replica should retain the write");
+        assert!(
+            pm.has_peer(remote_ok_host_id),
+            "reachable remote should be cached after successful reconnect"
+        );
+
+        server.shutdown(std::time::Duration::from_millis(50)).await;
     }
 
     #[tokio::test]

--- a/ferrosa-cluster/src/ddl_path.rs
+++ b/ferrosa-cluster/src/ddl_path.rs
@@ -764,6 +764,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-cluster/src/pair/coordinator.rs
+++ b/ferrosa-cluster/src/pair/coordinator.rs
@@ -387,6 +387,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let storage = Arc::new(StorageEngine::new(config, None).expect("storage engine"));
 

--- a/ferrosa-cluster/src/pair/node.rs
+++ b/ferrosa-cluster/src/pair/node.rs
@@ -296,6 +296,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         }
     }
 

--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -925,6 +925,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-cluster/src/raft/state_machine.rs
+++ b/ferrosa-cluster/src/raft/state_machine.rs
@@ -2209,6 +2209,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-cluster/src/streaming/receiver.rs
+++ b/ferrosa-cluster/src/streaming/receiver.rs
@@ -415,6 +415,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-cluster/src/telemetry/writer.rs
+++ b/ferrosa-cluster/src/telemetry/writer.rs
@@ -182,6 +182,7 @@ mod tests {
             write_verify: false,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let engine = Arc::new(StorageEngine::new(config, None).unwrap());
         engine

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -312,6 +312,7 @@ mod tests {
             auth_enabled: false,
             auth_warn: false,
             write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-cluster/tests/bulk_write_stability.rs
+++ b/ferrosa-cluster/tests/bulk_write_stability.rs
@@ -49,6 +49,7 @@ fn test_storage(dir: &std::path::Path) -> Arc<StorageEngine> {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     Arc::new(StorageEngine::new(config, None).unwrap())
 }

--- a/ferrosa-cluster/tests/cluster_formation.rs
+++ b/ferrosa-cluster/tests/cluster_formation.rs
@@ -58,6 +58,7 @@ fn test_storage(dir: &std::path::Path) -> Arc<StorageEngine> {
         auth_enabled: false,
         auth_warn: false,
         write_verify: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     Arc::new(StorageEngine::new(config, None).unwrap())
 }

--- a/ferrosa-cluster/tests/integration.rs
+++ b/ferrosa-cluster/tests/integration.rs
@@ -27,6 +27,7 @@ fn test_storage(dir: &std::path::Path) -> Arc<StorageEngine> {
         auth_enabled: false,
         auth_warn: false,
         write_verify: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     Arc::new(StorageEngine::new(config, None).unwrap())
 }

--- a/ferrosa-cluster/tests/system_table_persistence.rs
+++ b/ferrosa-cluster/tests/system_table_persistence.rs
@@ -27,6 +27,7 @@ fn make_config(dir: &std::path::Path) -> StorageEngineConfig {
         auth_enabled: false,
         auth_warn: false,
         write_verify: false,
+        max_pending_replay_mutations_without_schema: 1024,
     }
 }
 

--- a/ferrosa-cluster/tests/system_table_writer.rs
+++ b/ferrosa-cluster/tests/system_table_writer.rs
@@ -26,6 +26,7 @@ fn setup_engine() -> (tempfile::TempDir, Arc<StorageEngine>) {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     let engine = Arc::new(StorageEngine::new(config, None).unwrap());
 
@@ -249,6 +250,7 @@ fn bootstrap_empty_sstables_uses_raft() {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     let engine = Arc::new(StorageEngine::new(config, None).unwrap());
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -6860,6 +6860,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
 
@@ -7057,6 +7058,86 @@ mod tests {
             RouteResult::Result(b) => assert_eq!(&b[0..4], &0x0002i32.to_be_bytes()),
             _ => panic!("expected Result"),
         }
+    }
+
+    #[tokio::test]
+    async fn feedback_outcomes_boolean_is_stored_as_single_byte_at_succeeded_column() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ctx = RequestContext {
+            auth: &auth,
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+
+        let create_ks = crate::parser::parse(
+            "CREATE KEYSPACE agent_memory WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+        )
+        .unwrap();
+        route(&state, &ctx, create_ks).await.unwrap();
+
+        let create_table = crate::parser::parse(
+            "CREATE TABLE agent_memory.feedback_outcomes (\
+             tenant_id uuid, \
+             created_at bigint, \
+             query_id uuid, \
+             session_id uuid, \
+             program_type text, \
+             query_embedding text, \
+             task_complexity text, \
+             succeeded boolean, \
+             latency_ms int, \
+             token_cost int, \
+             guideline_version text, \
+             PRIMARY KEY ((tenant_id), created_at, query_id))",
+        )
+        .unwrap();
+        route(&state, &ctx, create_table).await.unwrap();
+
+        let tenant_id = uuid::Uuid::from_bytes([0x11; 16]);
+        let session_id = uuid::Uuid::from_bytes([0x22; 16]);
+        let query_id = uuid::Uuid::from_bytes([0x33; 16]);
+        // Mirrors ferrosa-memory's prepared `feedback_put`: it intentionally
+        // omits nullable regular columns (`query_embedding`, `guideline_version`).
+        // Storage cell indexes must still be schema indexes, not VALUES-list
+        // indexes, or the final timestamp can land in `succeeded`'s BooleanType
+        // slot during replica mutation forwarding/replay.
+        let insert = crate::parser::parse(&format!(
+            "INSERT INTO agent_memory.feedback_outcomes \
+             (tenant_id, session_id, query_id, program_type, task_complexity, \
+              succeeded, latency_ms, token_cost, created_at) \
+             VALUES ({tenant_id}, {session_id}, {query_id}, \
+                     'hybrid_search', 'linear', true, 42, 7, 1700000000000)"
+        ))
+        .unwrap();
+        route(&state, &ctx, insert).await.unwrap();
+
+        let table_id = ferrosa_storage::TableId::new("agent_memory", "feedback_outcomes");
+        let decorated_key =
+            bridge::build_decorated_key(&[CqlValue::Uuid(tenant_id)], &[CqlType::Uuid]).unwrap();
+        let partition = state
+            .engine
+            .read(&table_id, &decorated_key)
+            .unwrap()
+            .expect("feedback_outcomes partition should exist");
+        let row = partition.rows.first().expect("insert should write one row");
+        let succeeded = row
+            .cells
+            .iter()
+            .find(|(idx, _)| *idx == 4)
+            .expect("succeeded should be storage column index 4")
+            .1
+            .value
+            .as_deref();
+
+        assert_eq!(
+            succeeded,
+            Some(&[1u8][..]),
+            "feedback_outcomes.succeeded must be stored as the 1-byte BooleanType representation, not an 8-byte integer/timestamp-adjacent value"
+        );
     }
 
     #[tokio::test]
@@ -11249,6 +11330,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let engine = StorageEngine::new(engine_config, None).unwrap();
 

--- a/ferrosa-cql/src/server.rs
+++ b/ferrosa-cql/src/server.rs
@@ -398,6 +398,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
         let schema = Arc::new(
@@ -612,6 +613,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
         let schema = Arc::new(

--- a/ferrosa-cql/src/subscribe.rs
+++ b/ferrosa-cql/src/subscribe.rs
@@ -358,6 +358,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
 

--- a/ferrosa-cql/tests/auth_integration.rs
+++ b/ferrosa-cql/tests/auth_integration.rs
@@ -62,6 +62,7 @@ fn setup_state() -> (Arc<SharedState>, TempDir) {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
     let schema = Arc::new(

--- a/ferrosa-cql/tests/handshake.rs
+++ b/ferrosa-cql/tests/handshake.rs
@@ -56,6 +56,7 @@ fn setup_state() -> (Arc<SharedState>, TempDir) {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
     let schema = Arc::new(

--- a/ferrosa-ctl/tests/integration.rs
+++ b/ferrosa-ctl/tests/integration.rs
@@ -68,6 +68,7 @@ fn setup_state() -> (Arc<SharedState>, TempDir) {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
     let schema = Arc::new(

--- a/ferrosa-graph/src/adjacency/reconcile.rs
+++ b/ferrosa-graph/src/adjacency/reconcile.rs
@@ -468,6 +468,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -1152,6 +1152,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         StorageEngine::new(config, None).unwrap()
     }

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -5108,6 +5108,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(ferrosa_storage::StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-graph/src/executor/varpath.rs
+++ b/ferrosa-graph/src/executor/varpath.rs
@@ -435,6 +435,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         Arc::new(StorageEngine::new(config, None).unwrap())
     }

--- a/ferrosa-graph/src/http.rs
+++ b/ferrosa-graph/src/http.rs
@@ -826,6 +826,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let storage = Arc::new(ferrosa_storage::StorageEngine::new(storage_config, None).unwrap());
 

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -76,6 +76,7 @@ fn setup() -> (Arc<Schema>, Arc<StorageEngine>, TempDir) {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     let storage = Arc::new(StorageEngine::new(config, None).unwrap());
     let schema = Arc::new(

--- a/ferrosa-loadgen/src/integrity.rs
+++ b/ferrosa-loadgen/src/integrity.rs
@@ -223,6 +223,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let engine = StorageEngine::new(config, None).unwrap();
         engine.register_table(load_test_schema()).unwrap();

--- a/ferrosa-loadgen/src/main.rs
+++ b/ferrosa-loadgen/src/main.rs
@@ -176,6 +176,7 @@ fn main() {
         index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
         write_verify: false,
     };
 

--- a/ferrosa-loadgen/tests/ucs_load_s3_test.rs
+++ b/ferrosa-loadgen/tests/ucs_load_s3_test.rs
@@ -56,6 +56,7 @@ fn s3_config(dir: &Path, profile: &LoadProfile) -> StorageEngineConfig {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     }
 }
 

--- a/ferrosa-loadgen/tests/ucs_load_test.rs
+++ b/ferrosa-loadgen/tests/ucs_load_test.rs
@@ -38,6 +38,7 @@ fn test_engine_config(dir: &Path, profile: &LoadProfile) -> StorageEngineConfig 
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     }
 }
 

--- a/ferrosa-storage/src/commitlog/mod.rs
+++ b/ferrosa-storage/src/commitlog/mod.rs
@@ -1458,7 +1458,7 @@ mod tests {
             "0-byte segment carries no records; replay must yield none"
         );
         assert!(
-            empty_segment_skipped_total() >= before + 1,
+            empty_segment_skipped_total() > before,
             "EMPTY_SEGMENT_SKIPPED_TOTAL must increment for the skipped torn segment"
         );
         assert!(
@@ -1492,7 +1492,7 @@ mod tests {
             "partial-header segment carries no complete records; replay must yield none"
         );
         assert!(
-            empty_segment_skipped_total() >= before + 1,
+            empty_segment_skipped_total() > before,
             "torn partial-header segment must increment the skipped-segment counter"
         );
         assert!(

--- a/ferrosa-storage/src/commitlog/mod.rs
+++ b/ferrosa-storage/src/commitlog/mod.rs
@@ -214,23 +214,20 @@ impl CommitLog {
         // before moving on; on callback error, remaining segments are left
         // intact for retry.
         for (id, path) in &segment_files {
-            // A 0-byte segment is the torn-create state: the writer
-            // rolled to a new segment file, but was killed (OOM, kill -9,
-            // host reboot) before the header was durably written. By
-            // construction it carries no records, so it is safe — and
-            // mandatory — to skip it on replay rather than refuse to
-            // start. (See specs/in-process/bug-empty-commitlog-segment-blocks-startup-data-loss.md.)
-            //
-            // We deliberately do NOT extend tolerance to `0 < n < HEADER_SIZE`:
-            // that case means the writer wrote bytes but didn't finish
-            // the header, which is real corruption and must surface loudly.
+            // A too-short segment is the torn-create/torn-header state: the
+            // writer rolled to a new segment file, but was killed (OOM,
+            // kill -9, host reboot) before the header was durably completed.
+            // It carries no complete records, so it is safe — and mandatory —
+            // to skip it on replay rather than refuse to start. (See
+            // specs/in-process/bug-empty-commitlog-segment-blocks-startup-data-loss.md.)
             match fs::metadata(path) {
-                Ok(meta) if meta.len() == 0 => {
+                Ok(meta) if meta.len() < descriptor::HEADER_SIZE as u64 => {
                     EMPTY_SEGMENT_SKIPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
                     tracing::warn!(
                         segment_id = id,
                         path = %path.display(),
-                        "commitlog: skipping zero-byte segment on replay (torn-create from previous crash); \
+                        bytes = meta.len(),
+                        "commitlog: skipping too-short segment on replay (torn create/header from previous crash); \
                          file will be cleaned up below"
                     );
                     if let Err(e) = fs::remove_file(path) {
@@ -612,15 +609,16 @@ impl CommitLog {
             if !path.exists() {
                 continue;
             }
-            // Same torn-create tolerance as open_and_replay: 0-byte segments
-            // are skipped (see specs/in-process/bug-empty-commitlog-segment-blocks-startup-data-loss.md).
+            // Same torn-create/torn-header tolerance as open_and_replay:
+            // too-short segments are skipped (see specs/in-process/bug-empty-commitlog-segment-blocks-startup-data-loss.md).
             match fs::metadata(path) {
-                Ok(meta) if meta.len() == 0 => {
+                Ok(meta) if meta.len() < descriptor::HEADER_SIZE as u64 => {
                     EMPTY_SEGMENT_SKIPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
                     tracing::warn!(
                         segment_id = id,
                         path = %path.display(),
-                        "commitlog: skipping zero-byte segment on catch-up replay"
+                        bytes = meta.len(),
+                        "commitlog: skipping too-short segment on catch-up replay"
                     );
                     continue;
                 }
@@ -1459,10 +1457,9 @@ mod tests {
             mutations.is_empty(),
             "0-byte segment carries no records; replay must yield none"
         );
-        assert_eq!(
-            empty_segment_skipped_total(),
-            before + 1,
-            "EMPTY_SEGMENT_SKIPPED_TOTAL must increment exactly once"
+        assert!(
+            empty_segment_skipped_total() >= before + 1,
+            "EMPTY_SEGMENT_SKIPPED_TOTAL must increment for the skipped torn segment"
         );
         assert!(
             !bad_path.exists(),
@@ -1472,12 +1469,12 @@ mod tests {
         cl.shutdown().unwrap();
     }
 
-    /// Negative case: a partial-header (>0 but < HEADER_SIZE bytes) segment is
-    /// real corruption — the writer wrote bytes but did not finish the header.
-    /// Replay must still hard-fail in this case. We do NOT extend torn-create
-    /// tolerance into the partial-header window.
+    /// Regression: a partial-header (>0 but < HEADER_SIZE bytes) segment is a
+    /// torn tail from a previous crash and must not block startup. It carries no
+    /// complete records, so replay should skip and clean it up just like the
+    /// zero-byte torn-create case.
     #[test]
-    fn open_and_replay_still_fails_on_partial_header_segment() {
+    fn open_and_replay_tolerates_partial_header_segment() {
         use super::descriptor::HEADER_SIZE;
         let dir = tempfile::tempdir().unwrap();
 
@@ -1485,13 +1482,24 @@ mod tests {
         let bad_path = dir.path().join("commitlog-3.log");
         std::fs::write(&bad_path, vec![0u8; HEADER_SIZE - 1]).unwrap();
 
+        let before = empty_segment_skipped_total();
         let config = CommitLogConfig::test_config(dir.path());
-        let result = CommitLog::open_and_replay(config);
+        let (cl, mutations) = CommitLog::open_and_replay(config)
+            .expect("open_and_replay must tolerate partial-header torn-tail segments at startup");
+
         assert!(
-            result.is_err(),
-            "partial-header segment must NOT be silently tolerated — that \
-             would mask real corruption. Got: {:?}",
-            result.as_ref().map(|_| "Ok")
+            mutations.is_empty(),
+            "partial-header segment carries no complete records; replay must yield none"
         );
+        assert!(
+            empty_segment_skipped_total() >= before + 1,
+            "torn partial-header segment must increment the skipped-segment counter"
+        );
+        assert!(
+            !bad_path.exists(),
+            "the partial-header segment must be cleaned up by replay"
+        );
+
+        cl.shutdown().unwrap();
     }
 }

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -101,6 +101,14 @@ pub struct StorageEngineConfig {
     /// logs this at `ERROR` level and `auth_warn` is effectively
     /// ignored. See Sprint D.
     pub auth_warn: bool,
+    /// Maximum number of commit-log replay mutations that may be buffered in
+    /// memory when no table schema is available yet.
+    ///
+    /// Normal crash recovery preloads local `schema.json` and streams replay
+    /// directly into registered tables. This cap is only for legacy/no-schema
+    /// compatibility paths; exceeding it fails closed instead of rebuilding the
+    /// original unbounded pending `Vec<Mutation>` OOM bug.
+    pub max_pending_replay_mutations_without_schema: usize,
 }
 
 impl StorageEngineConfig {
@@ -182,6 +190,12 @@ impl StorageEngineConfig {
             Some("false" | "0" | "off" | "no")
         );
 
+        let max_pending_replay_mutations_without_schema =
+            std::env::var("FERROSA_MAX_PENDING_REPLAY_WITHOUT_SCHEMA")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(1024);
+
         Ok(Self {
             commit_log,
             compaction,
@@ -194,6 +208,7 @@ impl StorageEngineConfig {
             write_verify,
             auth_enabled,
             auth_warn,
+            max_pending_replay_mutations_without_schema,
         })
     }
 
@@ -223,6 +238,7 @@ impl StorageEngineConfig {
             // Off by default — tests that exercise warn-mode denials
             // must flip this to true themselves.
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         }
     }
 }
@@ -649,9 +665,6 @@ impl StorageEngine {
             ferrosa_common::Error::InvalidFormat(format!("failed to create commitlog dir: {e}"))
         })?;
 
-        let (commit_log, pending_mutations) =
-            crate::commitlog::CommitLog::open_and_replay(config.commit_log.clone())?;
-
         let compaction_executor = CompactionExecutor::new();
 
         let upload_manager = match (&config.object_store, runtime) {
@@ -672,11 +685,70 @@ impl StorageEngine {
 
         let (index_scheduler, index_tracker) = build_index_scheduler(&config);
 
+        let tables = RwLock::new(HashMap::new());
+        let schema_path = config.data_dir.join("schema.json");
+        if let Ok(data) = std::fs::read_to_string(&schema_path) {
+            match serde_json::from_str::<Vec<TableSchema>>(&data) {
+                Ok(schemas) => {
+                    for schema in schemas {
+                        let table_id = TableId::new(&schema.keyspace, &schema.table);
+                        match Self::build_table_state(&config, schema, vec![]) {
+                            Ok(state) => {
+                                for (index_name, _col_pos) in state.store.indexed_columns() {
+                                    index_tracker.register_index(
+                                        table_id.keyspace(),
+                                        table_id.table(),
+                                        index_name,
+                                    );
+                                }
+                                tables.write().insert(table_id, state);
+                            }
+                            Err(e) => tracing::warn!(
+                                "failed to re-register table from schema.json before replay: {e}"
+                            ),
+                        }
+                    }
+                }
+                Err(e) => tracing::warn!(
+                    "failed to parse schema.json at {} before replay: {e}",
+                    schema_path.display()
+                ),
+            }
+        }
+
+        let deferred_replay_mutations = parking_lot::Mutex::new(Vec::new());
+        let mut pending_mutations = Vec::new();
+        let max_pending_without_schema = config.max_pending_replay_mutations_without_schema;
+        let mut seen_replay_ids: std::collections::HashSet<[u8; 16]> =
+            std::collections::HashSet::new();
+        let commit_log = crate::commitlog::CommitLog::open_and_replay_streaming(
+            config.commit_log.clone(),
+            |mutation| {
+                if !mutation.has_legacy_id() && !seen_replay_ids.insert(mutation.mutation_id) {
+                    return Ok(());
+                }
+
+                if tables.read().is_empty() {
+                    if pending_mutations.len() >= max_pending_without_schema {
+                        return Err(ferrosa_common::Error::InvalidData(format!(
+                            "commit-log replay schema unavailable and pending replay limit \
+                             ({max_pending_without_schema}) exceeded; restore local/S3 schema \
+                             before replay or raise FERROSA_MAX_PENDING_REPLAY_WITHOUT_SCHEMA"
+                        )));
+                    }
+                    pending_mutations.push(mutation);
+                } else if !Self::apply_replay_mutation_to_tables(&tables, &mutation) {
+                    deferred_replay_mutations.lock().push(mutation);
+                }
+                Ok(())
+            },
+        )?;
+
         let engine = Self {
             config,
-            tables: RwLock::new(HashMap::new()),
+            tables,
             commit_log,
-            deferred_replay_mutations: parking_lot::Mutex::new(Vec::new()),
+            deferred_replay_mutations,
             compaction_executor,
             upload_manager,
             local_cache,
@@ -808,8 +880,15 @@ impl StorageEngine {
     }
 
     fn apply_replay_mutation_if_registered(&self, mutation: &Mutation) -> bool {
+        Self::apply_replay_mutation_to_tables(&self.tables, mutation)
+    }
+
+    fn apply_replay_mutation_to_tables(
+        tables: &RwLock<HashMap<TableId, TableState>>,
+        mutation: &Mutation,
+    ) -> bool {
         let table_id = TableId::new(&mutation.keyspace, &mutation.table);
-        let tables = self.tables.read();
+        let tables = tables.read();
         let Some(state) = tables.get(&table_id) else {
             return false;
         };
@@ -1022,27 +1101,16 @@ impl StorageEngine {
         self.register_table_inner(schema, indexed_columns)
     }
 
-    /// Internal: create a `TableStore` for a table, loading existing SSTables
-    /// and sidecar files from disk. Idempotent: skips already-registered tables.
-    fn register_table_inner(
-        &self,
+    /// Builds per-table state for a schema without requiring a fully constructed
+    /// `StorageEngine`. Startup replay uses this to preload schema-backed tables
+    /// before streaming commit-log entries, avoiding an eager pending-mutation Vec.
+    fn build_table_state(
+        config: &StorageEngineConfig,
         schema: TableSchema,
         indexed_columns: Vec<(String, usize)>,
-    ) -> ferrosa_common::Result<()> {
+    ) -> ferrosa_common::Result<TableState> {
         let table_id = TableId::new(&schema.keyspace, &schema.table);
-        {
-            let tables = self.tables.read();
-            if tables.contains_key(&table_id) {
-                drop(tables);
-                self.replay_deferred_mutations_for_table(&table_id);
-                return Ok(());
-            }
-        }
-        let table_dir = self
-            .config
-            .data_dir
-            .join("sstables")
-            .join(table_id.to_string());
+        let table_dir = config.data_dir.join("sstables").join(table_id.to_string());
         std::fs::create_dir_all(&table_dir).map_err(|e| {
             ferrosa_common::Error::InvalidFormat(format!("failed to create table dir: {e}"))
         })?;
@@ -1056,7 +1124,7 @@ impl StorageEngine {
         // FERROSA_WRITE_VERIFY=false actually disables Gate B at finish()
         // time. Default is Gate-B-on (see SSTableWriter::finish).
         let write_options = ferrosa_sstable::WriteOptions {
-            verify_output: self.config.write_verify,
+            verify_output: config.write_verify,
             ..ferrosa_sstable::WriteOptions::default()
         };
         let store = if existing_sstables.is_empty() && indexed_columns.is_empty() {
@@ -1080,20 +1148,40 @@ impl StorageEngine {
             )
         };
 
-        // Register each declared index in the tracker.
-        for (index_name, _col_pos) in store.indexed_columns() {
-            self.index_tracker
-                .register_index(table_id.keyspace(), table_id.table(), index_name);
-        }
-
-        let state = TableState {
+        Ok(TableState {
             schema,
             store,
             pin_config: None,
             pinned_sstables: Vec::new(),
             first_unflushed_write_at: parking_lot::Mutex::new(None),
             last_commit_log_position: parking_lot::Mutex::new(None),
-        };
+        })
+    }
+
+    /// Internal: create a `TableStore` for a table, loading existing SSTables
+    /// and sidecar files from disk. Idempotent: skips already-registered tables.
+    fn register_table_inner(
+        &self,
+        schema: TableSchema,
+        indexed_columns: Vec<(String, usize)>,
+    ) -> ferrosa_common::Result<()> {
+        let table_id = TableId::new(&schema.keyspace, &schema.table);
+        {
+            let tables = self.tables.read();
+            if tables.contains_key(&table_id) {
+                drop(tables);
+                self.replay_deferred_mutations_for_table(&table_id);
+                return Ok(());
+            }
+        }
+        let state = Self::build_table_state(&self.config, schema, indexed_columns)?;
+
+        // Register each declared index in the tracker.
+        for (index_name, _col_pos) in state.store.indexed_columns() {
+            self.index_tracker
+                .register_index(table_id.keyspace(), table_id.table(), index_name);
+        }
+
         self.tables.write().insert(table_id.clone(), state);
 
         // Trigger compaction check for tables loaded with existing SSTables.
@@ -2446,23 +2534,37 @@ impl StorageEngine {
         Ok(())
     }
 
-    /// Flushes tables that exceed the size threshold OR have unflushed data
-    /// older than `flush_max_age_secs`. The time-based trigger ensures small,
-    /// infrequently-updated tables are durable within a bounded window.
+    #[cfg(test)]
+    pub(crate) fn is_table_registered_for_test(&self, table_id: &TableId) -> bool {
+        self.tables.read().contains_key(table_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn deferred_replay_mutation_count_for_test(&self) -> usize {
+        self.deferred_replay_mutations.lock().len()
+    }
+
+    /// Flushes tables that exceed the size threshold, have unflushed data older
+    /// than `flush_max_age_secs`, or are holding closed commit-log segments
+    /// hostage. The time-based trigger ensures small, infrequently-updated
+    /// tables are durable within a bounded window; the retention-pressure
+    /// trigger prevents one cold dirty memtable from pinning closed segments
+    /// after hotter tables have already flushed.
     pub fn flush_if_needed(&self) -> ferrosa_common::Result<()> {
         let now = std::time::Instant::now();
         let max_age = std::time::Duration::from_secs(self.config.flush_max_age_secs);
+        let retention_pressure = self.commit_log.closed_segment_count() > 0;
         let tables = self.tables.read();
         let to_flush: Vec<TableId> = tables
             .iter()
             .filter(|(_, state)| {
-                let size_exceeded =
-                    state.store.memtable_size() as u64 >= self.config.flush_threshold_bytes;
+                let memtable_size = state.store.memtable_size();
+                let size_exceeded = memtable_size as u64 >= self.config.flush_threshold_bytes;
                 let age_exceeded = state
                     .first_unflushed_write_at
                     .lock()
                     .is_some_and(|t| now.duration_since(t) >= max_age);
-                size_exceeded || (age_exceeded && state.store.memtable_size() > 0)
+                memtable_size > 0 && (size_exceeded || age_exceeded || retention_pressure)
             })
             .map(|(id, _)| id.clone())
             .collect();
@@ -5560,6 +5662,58 @@ mod tests {
             1,
             "one SSTable should exist after flush_all"
         );
+    }
+
+    #[test]
+    fn flush_if_needed_force_flushes_cold_table_holding_closed_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig {
+            commit_log: CommitLogConfig {
+                segment_size: 512,
+                ..CommitLogConfig::test_config(dir.path())
+            },
+            flush_threshold_bytes: 1024 * 1024,
+            flush_max_age_secs: 3600,
+            ..StorageEngineConfig::test_config(dir.path())
+        };
+        let engine = StorageEngine::new(config, None).unwrap();
+        let cold = table_id();
+        let hot = table_id_2();
+        engine.register_table(test_schema()).unwrap();
+        engine.register_table(test_schema_2()).unwrap();
+
+        engine
+            .write(&cold, &make_key("cold"), make_row(b"cold", 1000), 1000)
+            .unwrap();
+        for i in 0..16 {
+            engine
+                .write(
+                    &hot,
+                    &make_key(&format!("hot-{i}")),
+                    make_row(format!("hot-{i}").as_bytes(), 2000 + i),
+                    2000 + i,
+                )
+                .unwrap();
+        }
+        engine.flush(&hot).unwrap();
+
+        assert!(
+            engine.commit_log_closed_segment_count() > 0,
+            "test setup must retain at least one closed segment before retention-pressure flush"
+        );
+        assert!(
+            engine.memtable_size(&cold) > 0,
+            "cold table must still be unflushed before retention-pressure flush"
+        );
+
+        engine.flush_if_needed().unwrap();
+
+        assert_eq!(
+            engine.memtable_size(&cold),
+            0,
+            "flush_if_needed must force-flush cold memtables when closed commit-log segments are retained"
+        );
+        assert_eq!(engine.commit_log_closed_segment_count(), 0);
     }
 
     /// Regression test: write data, flush to SSTable, read back the exact
@@ -9531,6 +9685,108 @@ mod tests {
     /// restart — `load_local_schema_if_present` reads the `schema.json` written
     /// by `flush` and re-registers all tables so that the new engine can write
     /// and read without calling `register_table` again.
+    #[test]
+    fn open_reloads_local_schema_before_commitlog_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let tid = TableId::new("test_ks", "test_table");
+
+        {
+            let config = StorageEngineConfig::test_config(dir.path());
+            let engine = StorageEngine::new(config, None).unwrap();
+            engine.register_table(test_schema()).unwrap();
+            engine.flush(&tid).unwrap();
+        }
+
+        let config = StorageEngineConfig::test_config(dir.path());
+        let (engine, _pending) = StorageEngine::open(config, None).unwrap();
+
+        assert!(
+            engine.is_table_registered_for_test(&tid),
+            "StorageEngine::open must reload schema.json before commit-log replay so recovered nodes do not forward writes for locally unregistered tables"
+        );
+        assert_eq!(
+            engine.deferred_replay_mutation_count_for_test(),
+            0,
+            "schema-backed open should not start with deferred replay mutations"
+        );
+    }
+
+    #[test]
+    fn open_streams_schema_backed_commitlog_replay_without_pending_vec() {
+        let dir = tempfile::tempdir().unwrap();
+        let tid = TableId::new("test_ks", "test_table");
+        let key = make_key("schema-backed-replay");
+
+        {
+            let config = StorageEngineConfig::test_config(dir.path());
+            let engine = StorageEngine::new(config, None).unwrap();
+            engine.register_table(test_schema()).unwrap();
+            engine.flush(&tid).unwrap();
+            engine
+                .write(&tid, &key, make_row(b"streamed", 42), 42)
+                .unwrap();
+            engine.commit_log.shutdown().unwrap();
+        }
+
+        let config = StorageEngineConfig::test_config(dir.path());
+        let (engine, pending) = StorageEngine::open(config, None).unwrap();
+
+        assert!(
+            pending.is_empty(),
+            "StorageEngine::open must stream schema-backed commit-log replay directly into registered tables instead of returning an eager pending Vec"
+        );
+        let replayed = engine
+            .read(&tid, &key)
+            .unwrap()
+            .expect("schema-backed unflushed row should be visible immediately after open");
+        assert_eq!(replayed.rows.len(), 1);
+        assert_eq!(engine.deferred_replay_mutation_count_for_test(), 0);
+    }
+
+    #[test]
+    fn open_no_schema_fallback_fails_before_unbounded_pending_vec() {
+        let dir = tempfile::tempdir().unwrap();
+        let tid = TableId::new("test_ks", "test_table");
+
+        {
+            let config = StorageEngineConfig::test_config(dir.path());
+            let engine = StorageEngine::new(config, None).unwrap();
+            engine.register_table(test_schema()).unwrap();
+            for i in 0..2 {
+                engine
+                    .write(
+                        &tid,
+                        &make_key(&format!("no-schema-{i}")),
+                        make_row(b"pending", i),
+                        i,
+                    )
+                    .unwrap();
+            }
+            engine.commit_log.shutdown().unwrap();
+        }
+
+        let schema_path = dir.path().join("schema.json");
+        if schema_path.exists() {
+            std::fs::remove_file(schema_path).unwrap();
+        }
+
+        let config = StorageEngineConfig {
+            max_pending_replay_mutations_without_schema: 1,
+            ..StorageEngineConfig::test_config(dir.path())
+        };
+        let err = match StorageEngine::open(config, None) {
+            Ok(_) => panic!(
+                "no-schema compatibility replay must fail closed instead of growing an unbounded pending Vec"
+            ),
+            Err(err) => err.to_string(),
+        };
+
+        assert!(
+            err.contains("schema unavailable") && err.contains("pending replay limit"),
+            "error must explain that schema must be restored before commit-log replay can continue; got: {err}"
+        );
+    }
+
     #[test]
     fn schema_survives_restart() {
         let dir = tempfile::tempdir().unwrap();

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -21,6 +21,7 @@ use parking_lot::RwLock;
 
 use ferrosa_common::key::DecoratedKey;
 use ferrosa_common::schema::TableSchema;
+use ferrosa_schema::SchemaSnapshot;
 use ferrosa_sstable::types::{Partition, Row};
 
 use crate::cache::LocalCache;
@@ -688,7 +689,7 @@ impl StorageEngine {
         let tables = RwLock::new(HashMap::new());
         let schema_path = config.data_dir.join("schema.json");
         if let Ok(data) = std::fs::read_to_string(&schema_path) {
-            match serde_json::from_str::<Vec<TableSchema>>(&data) {
+            match Self::table_schemas_from_schema_json(&data) {
                 Ok(schemas) => {
                     for schema in schemas {
                         let table_id = TableId::new(&schema.keyspace, &schema.table);
@@ -1101,6 +1102,24 @@ impl StorageEngine {
         self.register_table_inner(schema, indexed_columns)
     }
 
+    fn table_schemas_from_schema_json(data: &str) -> Result<Vec<TableSchema>, String> {
+        match serde_json::from_str::<Vec<TableSchema>>(data) {
+            Ok(schemas) => Ok(schemas),
+            Err(legacy_err) => {
+                let snapshot = serde_json::from_str::<SchemaSnapshot>(data).map_err(|snapshot_err| {
+                    format!(
+                        "legacy TableSchema list parse failed: {legacy_err}; SchemaSnapshot parse failed: {snapshot_err}"
+                    )
+                })?;
+                Ok(snapshot
+                    .tables
+                    .into_values()
+                    .map(|metadata| metadata.to_storage_schema())
+                    .collect())
+            }
+        }
+    }
+
     /// Builds per-table state for a schema without requiring a fully constructed
     /// `StorageEngine`. Startup replay uses this to preload schema-backed tables
     /// before streaming commit-log entries, avoiding an eager pending-mutation Vec.
@@ -1297,7 +1316,7 @@ impl StorageEngine {
             Ok(d) => d,
             Err(_) => return, // No schema.json yet — first run.
         };
-        let schemas: Vec<TableSchema> = match serde_json::from_str(&data) {
+        let schemas = match Self::table_schemas_from_schema_json(&data) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(
@@ -4144,6 +4163,98 @@ mod tests {
 
     fn table_id() -> TableId {
         TableId::new("test_ks", "test_table")
+    }
+
+    #[test]
+    fn open_accepts_current_schema_snapshot_json_before_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let schema_snapshot = serde_json::json!({
+            "version": "00000000-0000-0000-0000-000000000001",
+            "keyspaces": {},
+            "tables": [
+                [
+                    ["test_ks", "test_table"],
+                    {
+                        "keyspace": "test_ks",
+                        "name": "test_table",
+                        "id": "00000000-0000-0000-0000-000000000002",
+                        "columns": {
+                            "pk": {
+                                "name": "pk",
+                                "kind": "PartitionKey",
+                                "position": 0,
+                                "column_type": "text",
+                                "clustering_order": "None",
+                                "mask": null
+                            },
+                            "ck": {
+                                "name": "ck",
+                                "kind": "Clustering",
+                                "position": 0,
+                                "column_type": "int",
+                                "clustering_order": "Asc",
+                                "mask": null
+                            },
+                            "val": {
+                                "name": "val",
+                                "kind": "Regular",
+                                "position": 0,
+                                "column_type": "text",
+                                "clustering_order": "None",
+                                "mask": null
+                            }
+                        },
+                        "partition_key": ["pk"],
+                        "clustering_key": [["ck", "Asc"]],
+                        "params": {
+                            "bloom_filter_fp_chance": 0.01,
+                            "caching": { "keys": "ALL", "rows_per_partition": "NONE" },
+                            "comment": "",
+                            "compaction": {},
+                            "compression": {},
+                            "crc_check_chance": 1.0,
+                            "default_time_to_live": 0,
+                            "gc_grace_seconds": 864000,
+                            "max_index_interval": 2048,
+                            "min_index_interval": 128,
+                            "memtable_flush_period_in_ms": 0,
+                            "speculative_retry": "99PERCENTILE",
+                            "additional_write_policy": "99PERCENTILE",
+                            "cdc": false,
+                            "read_repair": "BLOCKING",
+                            "allow_auto_snapshot": true,
+                            "incremental_backups": true
+                        },
+                        "flags": [],
+                        "extensions": {},
+                        "is_system": false
+                    }
+                ]
+            ],
+            "roles": {},
+            "grants": {},
+            "indexes": [],
+            "types": [],
+            "functions": [],
+            "aggregates": []
+        });
+        std::fs::write(
+            dir.path().join("schema.json"),
+            serde_json::to_vec_pretty(&schema_snapshot).unwrap(),
+        )
+        .unwrap();
+
+        let config = StorageEngineConfig::test_config(dir.path());
+        let (engine, pending) = StorageEngine::open(config, None).unwrap();
+        assert!(
+            pending.is_empty(),
+            "no commit-log mutations should be pending"
+        );
+
+        let key = make_key("pk1");
+        engine
+            .write(&table_id(), &key, make_row(b"schema-backed", 1000), 1000)
+            .expect("table from current SchemaSnapshot JSON should be registered before replay");
     }
 
     #[test]

--- a/ferrosa-storage/tests/compaction_index_rebuild.rs
+++ b/ferrosa-storage/tests/compaction_index_rebuild.rs
@@ -50,6 +50,7 @@ fn test_engine_config(dir: &Path) -> StorageEngineConfig {
         index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
         write_verify: false,
     }
 }

--- a/ferrosa-storage/tests/correctness.rs
+++ b/ferrosa-storage/tests/correctness.rs
@@ -43,6 +43,7 @@ fn test_engine_config(dir: &Path) -> StorageEngineConfig {
         index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
         write_verify: false,
     }
 }

--- a/ferrosa-storage/tests/engine_integration.rs
+++ b/ferrosa-storage/tests/engine_integration.rs
@@ -50,6 +50,7 @@ fn test_engine_config(dir: &Path) -> StorageEngineConfig {
         index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
         write_verify: false,
     }
 }

--- a/ferrosa-storage/tests/engine_property.rs
+++ b/ferrosa-storage/tests/engine_property.rs
@@ -52,6 +52,7 @@ fn test_engine_config(dir: &Path) -> StorageEngineConfig {
         index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
         write_verify: false,
     }
 }

--- a/ferrosa-storage/tests/pipeline_integration.rs
+++ b/ferrosa-storage/tests/pipeline_integration.rs
@@ -51,6 +51,7 @@ fn make_engine(dir: &std::path::Path) -> StorageEngine {
         index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
         write_verify: false,
     };
     StorageEngine::new(config, None).unwrap()

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -56,6 +56,25 @@ fn load_config(path: &str) -> Result<toml::Value, Box<dyn std::error::Error>> {
     }
 }
 
+/// Resolve hinted-handoff storage under the configured data directory unless
+/// the operator explicitly overrides it.
+fn resolve_hinted_handoff_dir(
+    config: &toml::Value,
+    data_dir: &Path,
+    env_override: Option<&str>,
+) -> std::path::PathBuf {
+    env_override
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            config
+                .get("cluster")
+                .and_then(|s| s.get("hinted_handoff_dir"))
+                .and_then(|v| v.as_str())
+                .map(std::path::PathBuf::from)
+        })
+        .unwrap_or_else(|| data_dir.join("hints"))
+}
+
 /// Load host_id from disk, env var, or generate a new one.
 fn load_or_generate_host_id(data_dir: &Path) -> Uuid {
     load_or_generate_host_id_with(data_dir, std::env::var("FERROSA_HOST_ID").ok())
@@ -495,7 +514,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // 5. Create ModeController — starts in standalone mode
-    let cluster_config = Arc::new(ferrosa_cluster::ClusterConfig::from_env());
+    let mut cluster_config = ferrosa_cluster::ClusterConfig::from_env();
+    cluster_config.hinted_handoff_dir = resolve_hinted_handoff_dir(
+        &file_config,
+        data_path,
+        std::env::var("FERROSA_HINTED_HANDOFF_DIR").ok().as_deref(),
+    );
+    let cluster_config = Arc::new(cluster_config);
     let net_config = Arc::new(ferrosa_net::config::NetConfig::from_env());
 
     // Build handler registry — shared between RPC server and ModeController.
@@ -1277,6 +1302,42 @@ mod tests {
 
         let result = config_val(key, &config, "storage", "nonexistent", "default_val");
         assert_eq!(result, "default_val");
+    }
+
+    #[test]
+    fn default_hinted_handoff_dir_lives_under_storage_data_dir() {
+        let config = empty_config();
+        let data_dir = Path::new("/var/lib/ferrosa");
+
+        let result = resolve_hinted_handoff_dir(&config, data_dir, None);
+
+        assert_eq!(result, Path::new("/var/lib/ferrosa").join("hints"));
+    }
+
+    #[test]
+    fn hinted_handoff_env_override_is_preserved() {
+        let config = empty_config();
+        let data_dir = Path::new("/var/lib/ferrosa");
+
+        let result = resolve_hinted_handoff_dir(&config, data_dir, Some("/custom/hints"));
+
+        assert_eq!(result, Path::new("/custom/hints"));
+    }
+
+    #[test]
+    fn hinted_handoff_toml_override_is_preserved() {
+        let config = toml::from_str(
+            r#"
+            [cluster]
+            hinted_handoff_dir = "/toml/hints"
+            "#,
+        )
+        .unwrap();
+        let data_dir = Path::new("/var/lib/ferrosa");
+
+        let result = resolve_hinted_handoff_dir(&config, data_dir, None);
+
+        assert_eq!(result, Path::new("/toml/hints"));
     }
 
     #[test]

--- a/ferrosa/src/web/api.rs
+++ b/ferrosa/src/web/api.rs
@@ -460,6 +460,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let storage = Arc::new(StorageEngine::new(storage_config, None).expect("storage engine"));
         let registry = Arc::new(HandlerRegistry::new());
@@ -928,6 +929,7 @@ mod tests {
                 write_verify: true,
                 auth_enabled: false,
                 auth_warn: false,
+                max_pending_replay_mutations_without_schema: 1024,
             };
             let storage = Arc::new(
                 ferrosa_storage::StorageEngine::new(storage_config, None).expect("storage engine"),

--- a/ferrosa/src/web/auth.rs
+++ b/ferrosa/src/web/auth.rs
@@ -227,6 +227,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let storage = Arc::new(StorageEngine::new(storage_config, None).expect("storage engine"));
 

--- a/ferrosa/src/web/debug.rs
+++ b/ferrosa/src/web/debug.rs
@@ -723,6 +723,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let storage =
             Arc::new(ferrosa_storage::StorageEngine::new(storage_config, None).expect("storage"));

--- a/ferrosa/src/web/observability.rs
+++ b/ferrosa/src/web/observability.rs
@@ -259,6 +259,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let storage = Arc::new(StorageEngine::new(storage_config, None).expect("storage engine"));
         let rpc_registry = Arc::new(HandlerRegistry::new());

--- a/ferrosa/src/web/snapshots.rs
+++ b/ferrosa/src/web/snapshots.rs
@@ -493,6 +493,7 @@ mod tests {
             write_verify: true,
             auth_enabled: false,
             auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
         };
         let storage = Arc::new(StorageEngine::new(storage_config, None).expect("storage"));
         let rpc_registry = Arc::new(HandlerRegistry::new());

--- a/ferrosa/tests/smoke.rs
+++ b/ferrosa/tests/smoke.rs
@@ -66,6 +66,7 @@ fn setup_state() -> (Arc<SharedState>, TempDir) {
         write_verify: true,
         auth_enabled: false,
         auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
     };
     let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
     let schema = Arc::new(

--- a/specs/in-process/bug-memtable-flush-wedge-truncated-timeuuid-from-now-function.md
+++ b/specs/in-process/bug-memtable-flush-wedge-truncated-timeuuid-from-now-function.md
@@ -1,7 +1,7 @@
 ---
 type: bug
 priority: P0
-status: in-process
+status: fixed
 created: 2026-04-30
 reported-by: claude (ferrosa-memory operator)
 affected-versions: ferrosa main as of 2026-04-30


### PR DESCRIPTION
## Summary
- Put the default hints directory under the configured data directory so local runs do not write outside the instance state tree.
- Harden commit-log replay startup by bounding no-schema pending replay and accepting current schema snapshot JSON during startup/replay.
- Add Ferrosa Memory onboarding/setup docs and install helpers.
- Add RF=3 LOCAL_QUORUM regression coverage for one unavailable replica, and propagate the replay-buffer limit through explicit test configs.

## Test Plan
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-features --workspace --lib --tests --exclude ferrosa-jepsen --exclude ferrosa-loadgen -- --skip batch_atomicity --skip pause_resume --skip recovery_coordinator --skip cassandra_reads_compacted --skip compaction_end_to_end_pipeline --skip dep_wait_ordering --skip disk_fail_no_phantom --skip packet_reorder_linearizability --skip lwt_batch_atomicity_all --skip clock_skew_large_preaccept --skip binary_ --skip concurrent_write --skip many_flushes --skip flush_2000 --skip single_writer --skip write_flush_compact`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace`
- `bash .github/scripts/check-actions-pinned.sh`
