### PR TITLE
docs: point Pages to www.ferrosadb.com

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-ferrosadb.com
+www.ferrosadb.com


### PR DESCRIPTION
## Summary
- Switch `docs/CNAME` from apex `ferrosadb.com` to `www.ferrosadb.com` so GitHub Pages treats `www` as canonical
- DNS CNAME `www → ferrosadb.github.io` has been added at GoDaddy
- Once merged, GH will reissue the Let's Encrypt cert to cover both hosts and auto-redirect apex → www

## Test plan
- [ ] After merge + GH Pages rebuild, `dig +short www.ferrosadb.com` returns `ferrosadb.github.io` and GH IPs
- [ ] `curl -sI https://www.ferrosadb.com` returns 200
- [ ] `curl -sI https://ferrosadb.com` returns 301 → https://www.ferrosadb.com/
- [ ] `gh api repos/:owner/:repo/pages | jq '.https_certificate.domains'` lists both domains
- [ ] Settings → Pages still shows "Enforce HTTPS" checked