### PR TITLE
cql-compat: NoSQLBench gap closure (ongoing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sim"
-version = "0.8.8+8"
+version = "0.8.9"
 dependencies = [
  "proptest",
  "serde",

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -1422,6 +1422,58 @@ impl ModeController {
                         // races with leader election and yields
                         // "has to forward request to: None, None" on the seed.
                         let seed_num_tokens = config_for_promotion.num_tokens as usize;
+
+                        // Propose JoinNode + AssignTokens for the seed
+                        // itself, so the seed's identity replicates to every
+                        // follower's `state.members` / `state.token_map`.
+                        // Without this, follower state machines only learn
+                        // about *peers* and never about the seed — meaning
+                        // their `system.peers` view reports zero tokens for
+                        // the seed and writes coordinated through followers
+                        // never land on the seed's token range.  Cassandra
+                        // load tests then see roughly N-1 owners instead of
+                        // N, and the "diabolical" single-owner pattern
+                        // persists from the follower side.
+                        let local_node_info = crate::raft::NodeInfo {
+                            host_id: local_host_id_for_refresh,
+                            addr: local_addr_for_refresh.clone(),
+                            data_center: config_for_promotion.data_center.clone(),
+                            rack: config_for_promotion.rack.clone(),
+                            state: crate::raft::NodeState::Normal,
+                            cql_broadcast: local_cql_broadcast_for_refresh.clone(),
+                        };
+                        let self_join_cmd = crate::raft::RaftCommand {
+                            op: crate::raft::RaftOp::JoinNode(local_node_info),
+                            schema_version: Uuid::new_v4(),
+                        };
+                        if let Err(e) = raft_arc.client_write(self_join_cmd).await {
+                            tracing::warn!(
+                                local = local_node_id,
+                                leader = lid,
+                                %e,
+                                "seed: JoinNode for self failed after leader election"
+                            );
+                        }
+                        let self_tokens = crate::controller::token::deterministic_tokens_for_node(
+                            local_node_id,
+                            seed_num_tokens,
+                        );
+                        let self_assign_cmd = crate::raft::RaftCommand {
+                            op: crate::raft::RaftOp::AssignTokens {
+                                node_id: local_node_id,
+                                tokens: self_tokens,
+                            },
+                            schema_version: Uuid::new_v4(),
+                        };
+                        if let Err(e) = raft_arc.client_write(self_assign_cmd).await {
+                            tracing::warn!(
+                                local = local_node_id,
+                                leader = lid,
+                                %e,
+                                "seed: AssignTokens for self failed after leader election"
+                            );
+                        }
+
                         for (peer_uuid, addr) in &peers {
                             let peer_node_id = uuid_to_node_id(*peer_uuid);
                             let node_info = crate::raft::NodeInfo {

--- a/ferrosa-cluster/src/controller/mod.rs
+++ b/ferrosa-cluster/src/controller/mod.rs
@@ -26,7 +26,7 @@ pub use cluster_rejoin::{
     CLUSTER_REJOIN_FAILURES_TOTAL,
 };
 
-pub(crate) use token::deterministic_tokens_for_node;
+pub use token::deterministic_tokens_for_node;
 #[cfg(test)]
 pub(crate) use token::generate_deterministic_token;
 

--- a/ferrosa-cluster/src/controller/token.rs
+++ b/ferrosa-cluster/src/controller/token.rs
@@ -64,7 +64,7 @@ pub(crate) fn generate_deterministic_token(node_id: u64, index: usize) -> i64 {
 /// each other.
 ///
 /// See `specs/in-process/bug-token-ring-inconsistency-causes-data-scatter.md`.
-pub(crate) fn deterministic_tokens_for_node(node_id: u64, num_tokens: usize) -> Vec<i64> {
+pub fn deterministic_tokens_for_node(node_id: u64, num_tokens: usize) -> Vec<i64> {
     (0..num_tokens)
         .map(|i| generate_deterministic_token(node_id, i))
         .collect()

--- a/ferrosa-cluster/src/raft/state_machine.rs
+++ b/ferrosa-cluster/src/raft/state_machine.rs
@@ -1280,6 +1280,26 @@ impl FerrosStateMachine {
                 } else {
                     let node_id = super::uuid_to_node_id(node_info.host_id);
                     self.state.members.insert(node_id, node_info);
+                    // Auto-assign deterministic tokens so a late-joining node
+                    // (e.g. the rejoin path via `ClusterDdlForwardHandler`,
+                    // which only proposes `RaftOp::JoinNode` and not
+                    // `RaftOp::AssignTokens`) still appears as a token-owning
+                    // peer in `system.peers`. Without this, the node lands in
+                    // `state.members` but `state.token_map` has no entries for
+                    // it, so `RaftClusterState::peers().tokens` is empty and
+                    // CQL drivers route every key to the seed.
+                    // Use `or_insert` so we never steal a token already owned
+                    // by another node — deterministic generation makes
+                    // collisions astronomically unlikely, but this preserves
+                    // the existing owner if one occurs.
+                    let num_tokens = self.state.config.num_tokens as usize;
+                    if num_tokens > 0 {
+                        for tok in
+                            crate::controller::deterministic_tokens_for_node(node_id, num_tokens)
+                        {
+                            self.state.token_map.entry(tok).or_insert(node_id);
+                        }
+                    }
                     self.sync_ring();
                     // Mark the new node as Building for all existing indexes.
                     for statuses in self.state.index_state_map.values_mut() {
@@ -1962,6 +1982,122 @@ mod tests {
         assert_eq!(sm.state().members[&node_id].addr, "10.0.0.1:7000");
     }
 
+    /// Regression test for the system.peers empty-tokens bug:
+    /// the rejoin / late-join path goes through `ClusterDdlForwardHandler`,
+    /// which proposes `RaftOp::JoinNode` but **not** a follow-up
+    /// `RaftOp::AssignTokens`.  Without auto-assignment inside the
+    /// state machine, the new node lands in `state.members` with no
+    /// entry in `state.token_map`, so `system.peers` reports it with
+    /// empty tokens and cdrs-tokio's `is_peer_row_valid` filter drops
+    /// the row — making the cluster behave as single-owner.
+    #[tokio::test]
+    async fn apply_join_node_auto_assigns_deterministic_tokens() {
+        let mut sm = FerrosStateMachine::new();
+        // Seed a non-zero num_tokens so the assignment is observable.
+        let cfg = ClusterConfig {
+            num_tokens: 8,
+            ..ClusterConfig::default()
+        };
+        sm.apply(vec![make_entry(1, 1, RaftOp::UpdateConfig(cfg))])
+            .await
+            .unwrap();
+
+        let host_id = Uuid::new_v4();
+        let node = NodeInfo {
+            host_id,
+            addr: "10.0.0.1:7000".to_string(),
+            data_center: "dc1".to_string(),
+            rack: "rack1".to_string(),
+            state: NodeState::Normal,
+            cql_broadcast: None,
+        };
+        let node_id = super::super::uuid_to_node_id(host_id);
+
+        sm.apply(vec![make_entry(1, 2, RaftOp::JoinNode(node))])
+            .await
+            .unwrap();
+
+        assert!(sm.state().members.contains_key(&node_id));
+        let owned_tokens: Vec<i64> = sm
+            .state()
+            .token_map
+            .iter()
+            .filter_map(|(&t, &n)| (n == node_id).then_some(t))
+            .collect();
+        assert_eq!(
+            owned_tokens.len(),
+            8,
+            "JoinNode must auto-assign num_tokens deterministic tokens \
+             so the late-joining node is a visible owner in system.peers; \
+             got {} tokens",
+            owned_tokens.len()
+        );
+        // The auto-assigned set must match the deterministic generator.
+        let expected = crate::controller::deterministic_tokens_for_node(node_id, 8);
+        let mut expected_sorted = expected.clone();
+        expected_sorted.sort();
+        let mut got_sorted = owned_tokens.clone();
+        got_sorted.sort();
+        assert_eq!(
+            got_sorted, expected_sorted,
+            "auto-assigned tokens must match deterministic_tokens_for_node"
+        );
+    }
+
+    /// A follow-up explicit `AssignTokens` with the same deterministic
+    /// token set must be idempotent — the seed-init and
+    /// `MembershipManager::join_node` paths still issue it explicitly,
+    /// so re-application must not break the auto-assigned state.
+    #[tokio::test]
+    async fn apply_join_node_then_explicit_assign_tokens_is_idempotent() {
+        let mut sm = FerrosStateMachine::new();
+        let cfg = ClusterConfig {
+            num_tokens: 4,
+            ..ClusterConfig::default()
+        };
+        sm.apply(vec![make_entry(1, 1, RaftOp::UpdateConfig(cfg))])
+            .await
+            .unwrap();
+
+        let host_id = Uuid::new_v4();
+        let node = NodeInfo {
+            host_id,
+            addr: "10.0.0.2:7000".to_string(),
+            data_center: "dc1".to_string(),
+            rack: "rack1".to_string(),
+            state: NodeState::Normal,
+            cql_broadcast: None,
+        };
+        let node_id = super::super::uuid_to_node_id(host_id);
+        let tokens = crate::controller::deterministic_tokens_for_node(node_id, 4);
+
+        sm.apply(vec![
+            make_entry(1, 2, RaftOp::JoinNode(node)),
+            make_entry(
+                1,
+                3,
+                RaftOp::AssignTokens {
+                    node_id,
+                    tokens: tokens.clone(),
+                },
+            ),
+        ])
+        .await
+        .unwrap();
+
+        // After both ops, the node still owns exactly the deterministic set.
+        let owned: Vec<i64> = sm
+            .state()
+            .token_map
+            .iter()
+            .filter_map(|(&t, &n)| (n == node_id).then_some(t))
+            .collect();
+        assert_eq!(owned.len(), 4);
+        for t in &tokens {
+            assert_eq!(sm.state().token_map.get(t), Some(&node_id));
+        }
+    }
+
     #[tokio::test]
     async fn apply_assign_tokens() {
         let mut sm = FerrosStateMachine::new();
@@ -2130,7 +2266,15 @@ mod tests {
         let snapshot_path = dir.path().join("state-machine.snapshot.bin");
 
         let mut sm = FerrosStateMachine::with_snapshot_path(snapshot_path.clone());
+        // Disable auto-token-assignment so the explicit `AssignTokens` is
+        // the sole source of tokens — this test exercises snapshot
+        // round-trip, not the auto-assignment policy.
+        let cfg = ClusterConfig {
+            num_tokens: 0,
+            ..ClusterConfig::default()
+        };
         let entries = vec![
+            make_entry(1, 0, RaftOp::UpdateConfig(cfg)),
             make_entry(1, 1, RaftOp::CreateKeyspace(simple_keyspace("ks1"))),
             make_entry(
                 1,
@@ -2903,7 +3047,15 @@ mod tests {
             cql_broadcast: None,
         };
 
+        // Disable auto-token-assignment so the explicit `AssignTokens`
+        // entry is the sole source of tokens — this test exercises
+        // ring-sync, not the auto-assignment policy.
+        let cfg = ClusterConfig {
+            num_tokens: 0,
+            ..ClusterConfig::default()
+        };
         let entries = vec![
+            make_entry(1, 0, RaftOp::UpdateConfig(cfg)),
             make_entry(1, 1, RaftOp::JoinNode(node)),
             make_entry(
                 1,
@@ -3686,6 +3838,19 @@ mod tests {
         let mut sm = FerrosStateMachine::new();
         let host_id = Uuid::new_v4();
         let node_id = crate::raft::uuid_to_node_id(host_id);
+
+        // Disable auto-token-assignment so the explicit `AssignTokens`
+        // entry is the sole source of tokens — this test exercises that
+        // UpdateNodeInfo refreshes metadata without touching tokens,
+        // orthogonal to the auto-assignment policy.
+        let cfg = ClusterConfig {
+            num_tokens: 0,
+            ..ClusterConfig::default()
+        };
+        sm.apply_command(RaftCommand {
+            op: RaftOp::UpdateConfig(cfg),
+            schema_version: Uuid::new_v4(),
+        });
 
         sm.apply_command(RaftCommand {
             op: RaftOp::JoinNode(NodeInfo {

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -259,8 +259,13 @@ pub struct InsertStatement {
     pub columns: Vec<String>,
     pub values: Vec<Term>,
     pub if_not_exists: bool,
-    pub using_timestamp: Option<i64>,
-    pub using_ttl: Option<i32>,
+    /// `USING TIMESTAMP <term>` — term is either a literal int or a bind marker.
+    /// Gap 10 in ferrosa-nosqlbench/docs/initial-gaps-found.md: prior shape
+    /// `Option<i64>` silently dropped bind markers, breaking
+    /// `INSERT ... USING TIMESTAMP ?` from NoSQLBench's cql_timeseries2.
+    pub using_timestamp: Option<Term>,
+    /// `USING TTL <term>` — same shape as `using_timestamp`.
+    pub using_ttl: Option<Term>,
 }
 
 /// An assignment in an UPDATE SET clause.
@@ -309,8 +314,13 @@ pub struct UpdateStatement {
     pub where_clauses: Vec<WhereClause>,
     pub if_exists: bool,
     pub if_conditions: Vec<IfCondition>,
-    pub using_timestamp: Option<i64>,
-    pub using_ttl: Option<i32>,
+    /// `USING TIMESTAMP <term>` — term is either a literal int or a bind marker.
+    /// Gap 10 in ferrosa-nosqlbench/docs/initial-gaps-found.md: prior shape
+    /// `Option<i64>` silently dropped bind markers, breaking
+    /// `INSERT ... USING TIMESTAMP ?` from NoSQLBench's cql_timeseries2.
+    pub using_timestamp: Option<Term>,
+    /// `USING TTL <term>` — same shape as `using_timestamp`.
+    pub using_ttl: Option<Term>,
 }
 
 /// A column target in a DELETE statement — either a whole column or a map element.
@@ -340,7 +350,7 @@ pub struct DeleteStatement {
     pub where_clauses: Vec<WhereClause>,
     pub if_exists: bool,
     pub if_conditions: Vec<IfCondition>,
-    pub using_timestamp: Option<i64>,
+    pub using_timestamp: Option<Term>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -354,7 +364,7 @@ pub enum BatchType {
 pub struct BatchStatement {
     pub batch_type: BatchType,
     pub statements: Vec<Statement>,
-    pub using_timestamp: Option<i64>,
+    pub using_timestamp: Option<Term>,
 }
 
 /// CQL type name as written in CREATE TABLE.

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -303,14 +303,24 @@ pub async fn handle_connection<S>(
                                 );
                                 framed.codec_mut().set_compression(compression);
                             }
-                            // CQL v5 framing (CRC24/CRC32 envelopes) is only
-                            // enabled when the client sets USE_BETA (0x10) in
-                            // the STARTUP flags, matching Cassandra's behavior.
-                            // Clients that negotiate v5 without USE_BETA (e.g.,
-                            // Python cassandra-driver) use v5 semantics over
-                            // v4 unframed transport.
-                            if client_protocol_version >= 0x05 && client_use_beta {
-                                debug!("enabling v5 framing for {peer} (USE_BETA set)");
+                            // CQL v5 framing (CRC24/CRC32 envelopes) is the
+                            // wire format for v5 once negotiated — the
+                            // USE_BETA flag was a transitional opt-in while
+                            // v5 was beta in Cassandra 4.0 and is no longer
+                            // required by Cassandra 5.0 / DataStax Java Driver
+                            // 4.x / Python cassandra-driver 3.25+, all of
+                            // which send envelopes without USE_BETA.  Gating
+                            // on USE_BETA caused ferrosa to keep parsing the
+                            // driver's envelope flag byte (e.g. 0xA1) as a v4
+                            // opcode and close the connection.
+                            // See ferrosa-nosqlbench/docs/initial-gaps-found.md
+                            // (Gap 5).
+                            //
+                            // `_client_use_beta` is retained for future
+                            // gating of beta-only opcodes inside v5.
+                            let _ = client_use_beta;
+                            if client_protocol_version >= 0x05 {
+                                debug!("enabling v5 framing for {peer}");
                                 framed.codec_mut().enable_v5_framing();
                             }
                         }

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -303,24 +303,14 @@ pub async fn handle_connection<S>(
                                 );
                                 framed.codec_mut().set_compression(compression);
                             }
-                            // CQL v5 framing (CRC24/CRC32 envelopes) is the
-                            // wire format for v5 once negotiated — the
-                            // USE_BETA flag was a transitional opt-in while
-                            // v5 was beta in Cassandra 4.0 and is no longer
-                            // required by Cassandra 5.0 / DataStax Java Driver
-                            // 4.x / Python cassandra-driver 3.25+, all of
-                            // which send envelopes without USE_BETA.  Gating
-                            // on USE_BETA caused ferrosa to keep parsing the
-                            // driver's envelope flag byte (e.g. 0xA1) as a v4
-                            // opcode and close the connection.
-                            // See ferrosa-nosqlbench/docs/initial-gaps-found.md
-                            // (Gap 5).
-                            //
-                            // `_client_use_beta` is retained for future
-                            // gating of beta-only opcodes inside v5.
-                            let _ = client_use_beta;
-                            if client_protocol_version >= 0x05 {
-                                debug!("enabling v5 framing for {peer}");
+                            // CQL v5 framing (CRC24/CRC32 envelopes) is only
+                            // enabled when the client sets USE_BETA (0x10) in
+                            // the STARTUP flags, matching Cassandra's behavior.
+                            // Clients that negotiate v5 without USE_BETA (e.g.,
+                            // Python cassandra-driver) use v5 semantics over
+                            // v4 unframed transport.
+                            if client_protocol_version >= 0x05 && client_use_beta {
+                                debug!("enabling v5 framing for {peer} (USE_BETA set)");
                                 framed.codec_mut().enable_v5_framing();
                             }
                         }

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -1226,8 +1226,23 @@ fn analyze_prepared_columns(
                     }
                 }
             }
+            // USING TIMESTAMP ? / USING TTL ?  — Gap 10.  CQL syntactic
+            // order: VALUES first, then USING.
+            if matches!(i.using_timestamp, Some(Term::BindMarker(_))) {
+                bound_columns.push(("[timestamp]".into(), CqlType::Bigint));
+            }
+            if matches!(i.using_ttl, Some(Term::BindMarker(_))) {
+                bound_columns.push(("[ttl]".into(), CqlType::Int));
+            }
         }
         Statement::Update(u) => {
+            // UPDATE syntactic order: USING TIMESTAMP/TTL, then SET, then WHERE, then IF.
+            if matches!(u.using_timestamp, Some(Term::BindMarker(_))) {
+                bound_columns.push(("[timestamp]".into(), CqlType::Bigint));
+            }
+            if matches!(u.using_ttl, Some(Term::BindMarker(_))) {
+                bound_columns.push(("[ttl]".into(), CqlType::Int));
+            }
             // Bind markers in SET assignments
             for assignment in &u.assignments {
                 match assignment {
@@ -1276,6 +1291,10 @@ fn analyze_prepared_columns(
             }
         }
         Statement::Delete(d) => {
+            // DELETE syntactic order: USING TIMESTAMP, then WHERE, then IF.
+            if matches!(d.using_timestamp, Some(Term::BindMarker(_))) {
+                bound_columns.push(("[timestamp]".into(), CqlType::Bigint));
+            }
             // Bind markers in WHERE clauses
             for wc in &d.where_clauses {
                 if matches!(wc.value, Term::BindMarker(_)) {
@@ -1351,8 +1370,24 @@ fn count_bind_markers(stmt: &Statement) -> usize {
             };
             where_count + ann_count + limit_count
         }
-        Statement::Insert(i) => i.values.iter().filter(|v| is_bind(v)).count(),
+        Statement::Insert(i) => {
+            let values = i.values.iter().filter(|v| is_bind(v)).count();
+            let ts = i
+                .using_timestamp
+                .as_ref()
+                .filter(|t| is_bind(t))
+                .map_or(0, |_| 1);
+            let ttl = i.using_ttl.as_ref().filter(|t| is_bind(t)).map_or(0, |_| 1);
+            values + ts + ttl
+        }
         Statement::Update(u) => {
+            // UPDATE syntactic order: USING TIMESTAMP/TTL, then SET, then WHERE, then IF.
+            let ts = u
+                .using_timestamp
+                .as_ref()
+                .filter(|t| is_bind(t))
+                .map_or(0, |_| 1);
+            let ttl = u.using_ttl.as_ref().filter(|t| is_bind(t)).map_or(0, |_| 1);
             let set_count = u
                 .assignments
                 .iter()
@@ -1369,13 +1404,23 @@ fn count_bind_markers(stmt: &Statement) -> usize {
                 .filter(|wc| is_bind(&wc.value))
                 .count();
             let if_count = u.if_conditions.iter().filter(|c| is_bind(&c.value)).count();
-            set_count + where_count + if_count
+            ts + ttl + set_count + where_count + if_count
         }
-        Statement::Delete(d) => d
-            .where_clauses
-            .iter()
-            .filter(|wc| is_bind(&wc.value))
-            .count(),
+        Statement::Delete(d) => {
+            // DELETE syntactic order: USING TIMESTAMP, then WHERE, then IF.
+            let ts = d
+                .using_timestamp
+                .as_ref()
+                .filter(|t| is_bind(t))
+                .map_or(0, |_| 1);
+            let where_count = d
+                .where_clauses
+                .iter()
+                .filter(|wc| is_bind(&wc.value))
+                .count();
+            let if_count = d.if_conditions.iter().filter(|c| is_bind(&c.value)).count();
+            ts + where_count + if_count
+        }
         _ => 0,
     }
 }
@@ -1590,13 +1635,28 @@ fn substitute_in_statement(stmt: &Statement, terms: &[Term], idx: &mut usize) ->
         }
         Statement::Insert(i) => {
             let mut i = i.clone();
+            // VALUES first, then USING TIMESTAMP/TTL — must match
+            // `count_bind_markers` and `analyze_prepared_columns` order.
             for val in &mut i.values {
                 substitute_in_term(val, terms, idx);
+            }
+            if let Some(t) = i.using_timestamp.as_mut() {
+                substitute_in_term(t, terms, idx);
+            }
+            if let Some(t) = i.using_ttl.as_mut() {
+                substitute_in_term(t, terms, idx);
             }
             Statement::Insert(i)
         }
         Statement::Update(u) => {
             let mut u = u.clone();
+            // UPDATE syntactic order: USING TIMESTAMP/TTL, then SET, then WHERE, then IF.
+            if let Some(t) = u.using_timestamp.as_mut() {
+                substitute_in_term(t, terms, idx);
+            }
+            if let Some(t) = u.using_ttl.as_mut() {
+                substitute_in_term(t, terms, idx);
+            }
             for assignment in &mut u.assignments {
                 match assignment {
                     Assignment::Simple { value, .. } => substitute_in_term(value, terms, idx),
@@ -1611,12 +1671,22 @@ fn substitute_in_statement(stmt: &Statement, terms: &[Term], idx: &mut usize) ->
             for wc in &mut u.where_clauses {
                 substitute_in_term(&mut wc.value, terms, idx);
             }
+            for cond in &mut u.if_conditions {
+                substitute_in_term(&mut cond.value, terms, idx);
+            }
             Statement::Update(u)
         }
         Statement::Delete(d) => {
             let mut d = d.clone();
+            // DELETE syntactic order: USING TIMESTAMP, then WHERE, then IF.
+            if let Some(t) = d.using_timestamp.as_mut() {
+                substitute_in_term(t, terms, idx);
+            }
             for wc in &mut d.where_clauses {
                 substitute_in_term(&mut wc.value, terms, idx);
+            }
+            for cond in &mut d.if_conditions {
+                substitute_in_term(&mut cond.value, terms, idx);
             }
             Statement::Delete(d)
         }
@@ -2430,6 +2500,52 @@ mod tests {
             count_bind_markers(&stmt),
             8,
             "INSERT with 8 ? placeholders must count as 8"
+        );
+    }
+
+    /// Gap 10: `INSERT ... USING TIMESTAMP ?` must register the timestamp
+    /// placeholder so the driver and server agree on bind count.  Without
+    /// this fix, ferrosa silently dropped the `USING TIMESTAMP ?` marker
+    /// and the DataStax driver got `Too many variables (expected N, got
+    /// N+1)` at execute time — see
+    /// `ferrosa-nosqlbench/docs/initial-gaps-found.md`.
+    #[test]
+    fn count_bind_markers_insert_with_using_timestamp_bind() {
+        let stmt = crate::parser::parse(
+            "INSERT INTO ks.iot (machine_id, sensor_name, time, sensor_value, station_id, data) \
+             VALUES (?, ?, ?, ?, ?, ?) USING TIMESTAMP ?",
+        )
+        .unwrap();
+        assert_eq!(
+            count_bind_markers(&stmt),
+            7,
+            "6 value markers + 1 USING TIMESTAMP marker = 7"
+        );
+    }
+
+    #[test]
+    fn count_bind_markers_insert_with_using_timestamp_and_ttl_bind() {
+        let stmt = crate::parser::parse(
+            "INSERT INTO ks.t (a, b) VALUES (?, ?) USING TIMESTAMP ? AND TTL ?",
+        )
+        .unwrap();
+        assert_eq!(
+            count_bind_markers(&stmt),
+            4,
+            "2 value markers + USING TIMESTAMP ? + USING TTL ? = 4"
+        );
+    }
+
+    #[test]
+    fn count_bind_markers_insert_with_literal_using_does_not_add_placeholder() {
+        let stmt = crate::parser::parse(
+            "INSERT INTO ks.t (a, b) VALUES (?, ?) USING TIMESTAMP 12345 AND TTL 60",
+        )
+        .unwrap();
+        assert_eq!(
+            count_bind_markers(&stmt),
+            2,
+            "literal USING clauses must NOT count as placeholders"
         );
     }
 

--- a/ferrosa-cql/src/lexer.rs
+++ b/ferrosa-cql/src/lexer.rs
@@ -427,6 +427,24 @@ impl<'input> Lexer<'input> {
                 continue;
             }
 
+            // Line comment: `//` to end of line (Cassandra accepts both
+            // `--` and `//`; NoSQLBench workload templates such as
+            // `cql_timeseries2.yaml` use `//` to annotate columns inside
+            // `CREATE TABLE`, e.g. `machine_id UUID,     // source machine`.
+            // Without this arm the parser rejects the schema phase with
+            // `unexpected character '/' at position N`.  Gap 9 in
+            // ferrosa-nosqlbench/docs/initial-gaps-found.md.
+            if self.pos + 1 < self.bytes.len()
+                && self.bytes[self.pos] == b'/'
+                && self.bytes[self.pos + 1] == b'/'
+            {
+                self.pos += 2;
+                while self.pos < self.bytes.len() && self.bytes[self.pos] != b'\n' {
+                    self.pos += 1;
+                }
+                continue;
+            }
+
             // Block comment: /* ... */
             if self.pos + 1 < self.bytes.len()
                 && self.bytes[self.pos] == b'/'
@@ -1116,6 +1134,29 @@ mod tests {
     fn lex_block_comment() {
         let tokens = lex_all("/* comment */SELECT");
         assert_eq!(tokens, vec![TokenKind::Keyword(Keyword::Select)]);
+    }
+
+    /// `//` line comments are accepted by Cassandra; NoSQLBench bundled
+    /// workloads (e.g. `cql_timeseries2.yaml`) use them inline inside
+    /// `CREATE TABLE` to annotate columns.  See gap 9 in
+    /// `ferrosa-nosqlbench/docs/initial-gaps-found.md`.
+    #[test]
+    fn lex_double_slash_line_comment() {
+        let tokens = lex_all("// comment\nSELECT");
+        assert_eq!(tokens, vec![TokenKind::Keyword(Keyword::Select)]);
+    }
+
+    #[test]
+    fn lex_double_slash_inline_in_create_table_columns() {
+        // Mirrors the failing fragment from cql_timeseries2.yaml:
+        //   machine_id UUID,     // source machine
+        // The token stream should be: id, comma, then SELECT after the
+        // EOL terminating the comment.
+        let tokens = lex_all("machine_id UUID,     // source machine\nSELECT");
+        assert!(
+            matches!(tokens.last(), Some(TokenKind::Keyword(Keyword::Select))),
+            "expected SELECT after `//` comment, got: {tokens:?}"
+        );
     }
 
     #[test]

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -2275,7 +2275,7 @@ impl<'input> Parser<'input> {
     // USING clause
     // ---------------------------------------------------------------
 
-    fn parse_using_clause(&mut self) -> Result<(Option<i64>, Option<i32>), CqlError> {
+    fn parse_using_clause(&mut self) -> Result<(Option<Term>, Option<Term>), CqlError> {
         if self.lexer.eat(&TokenKind::Keyword(Keyword::Using))? {
             self.parse_using_clause_body()
         } else {
@@ -2283,9 +2283,13 @@ impl<'input> Parser<'input> {
         }
     }
 
-    fn parse_using_clause_body(&mut self) -> Result<(Option<i64>, Option<i32>), CqlError> {
-        let mut timestamp = None;
-        let mut ttl = None;
+    /// Parse the body of a `USING` clause. Each value is captured as a
+    /// `Term` (literal or bind marker) so the prepare path can register
+    /// `USING TIMESTAMP ?` / `USING TTL ?` placeholders correctly
+    /// (Gap 10 in `ferrosa-nosqlbench/docs/initial-gaps-found.md`).
+    fn parse_using_clause_body(&mut self) -> Result<(Option<Term>, Option<Term>), CqlError> {
+        let mut timestamp: Option<Term> = None;
+        let mut ttl: Option<Term> = None;
         loop {
             let tok = self.lexer.peek()?;
             match &tok.kind {
@@ -2293,14 +2297,15 @@ impl<'input> Parser<'input> {
                     self.lexer.next_token()?;
                     let val_tok = self.lexer.next_token()?;
                     match val_tok.kind {
-                        TokenKind::IntegerLiteral(n) => timestamp = Some(n),
-                        // Bind marker: USING TIMESTAMP ? — treat as 0 (resolved at execute time)
-                        TokenKind::QuestionMark | TokenKind::NamedBind(_) => {
-                            timestamp = Some(0);
+                        TokenKind::IntegerLiteral(n) => timestamp = Some(Term::IntegerLiteral(n)),
+                        TokenKind::QuestionMark => timestamp = Some(Term::BindMarker(None)),
+                        TokenKind::NamedBind(name) => {
+                            timestamp = Some(Term::BindMarker(Some(name.to_string())))
                         }
                         _ => {
                             return Err(CqlError::SyntaxError(format!(
-                                "expected integer after TIMESTAMP, got {:?} at position {}",
+                                "expected integer or bind marker after TIMESTAMP, \
+                                 got {:?} at position {}",
                                 val_tok.kind, val_tok.pos
                             )))
                         }
@@ -2310,19 +2315,15 @@ impl<'input> Parser<'input> {
                     self.lexer.next_token()?;
                     let val_tok = self.lexer.next_token()?;
                     match val_tok.kind {
-                        TokenKind::IntegerLiteral(n) => {
-                            let n = i32::try_from(n).map_err(|_| {
-                                CqlError::SyntaxError(format!("TTL value out of range: {n}"))
-                            })?;
-                            ttl = Some(n);
-                        }
-                        // Bind marker: USING TTL ? — treat as 0 (resolved at execute time)
-                        TokenKind::QuestionMark | TokenKind::NamedBind(_) => {
-                            ttl = Some(0);
+                        TokenKind::IntegerLiteral(n) => ttl = Some(Term::IntegerLiteral(n)),
+                        TokenKind::QuestionMark => ttl = Some(Term::BindMarker(None)),
+                        TokenKind::NamedBind(name) => {
+                            ttl = Some(Term::BindMarker(Some(name.to_string())))
                         }
                         _ => {
                             return Err(CqlError::SyntaxError(format!(
-                                "expected integer after TTL, got {:?} at position {}",
+                                "expected integer or bind marker after TTL, \
+                                 got {:?} at position {}",
                                 val_tok.kind, val_tok.pos
                             )))
                         }
@@ -2733,8 +2734,8 @@ mod tests {
             .unwrap();
         match stmt {
             Statement::Insert(s) => {
-                assert_eq!(s.using_timestamp, Some(12345));
-                assert_eq!(s.using_ttl, Some(3600));
+                assert_eq!(s.using_timestamp, Some(Term::IntegerLiteral(12345)));
+                assert_eq!(s.using_ttl, Some(Term::IntegerLiteral(3600)));
             }
             other => panic!("expected Insert, got {:?}", other),
         }
@@ -3678,8 +3679,8 @@ mod tests {
             parse("UPDATE t USING TIMESTAMP 1234 AND TTL 60 SET v = 'x' WHERE k = 1").unwrap();
         match stmt {
             Statement::Update(s) => {
-                assert_eq!(s.using_timestamp, Some(1234));
-                assert_eq!(s.using_ttl, Some(60));
+                assert_eq!(s.using_timestamp, Some(Term::IntegerLiteral(1234)));
+                assert_eq!(s.using_ttl, Some(Term::IntegerLiteral(60)));
             }
             other => panic!("expected Update, got {:?}", other),
         }

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1572,6 +1572,73 @@ async fn route_select(
                 &rows,
             ))
         }
+        // Cassandra 5.0 `system_virtual_schema` keyspace — describes the
+        // virtual tables a node exposes.  DataStax Java Driver 4.x queries
+        // all three of these during connection initialization; returning
+        // ERROR(table not found) leaves the driver's host pool empty and
+        // every subsequent query fails with "No node was available".
+        // See ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 2).
+        //
+        // We currently return well-typed empty result sets — Cassandra's
+        // driver tolerates an empty system_virtual_schema and proceeds to
+        // schema refresh of user keyspaces.  When ferrosa grows a
+        // first-class introspection surface for its virtual tables
+        // (system_observability.*, etc.) we populate these rows.
+        ("system_virtual_schema", "keyspaces") => {
+            let col_names = vec!["keyspace_name".to_string()];
+            let col_types = vec![CqlType::Varchar];
+            Ok(result::encode_rows(
+                &col_names,
+                &col_types,
+                "system_virtual_schema",
+                "keyspaces",
+                &[],
+            ))
+        }
+        ("system_virtual_schema", "tables") => {
+            let col_names = vec![
+                "keyspace_name".to_string(),
+                "table_name".to_string(),
+                "comment".to_string(),
+            ];
+            let col_types = vec![CqlType::Varchar, CqlType::Varchar, CqlType::Varchar];
+            Ok(result::encode_rows(
+                &col_names,
+                &col_types,
+                "system_virtual_schema",
+                "tables",
+                &[],
+            ))
+        }
+        ("system_virtual_schema", "columns") => {
+            let col_names = vec![
+                "keyspace_name".to_string(),
+                "table_name".to_string(),
+                "column_name".to_string(),
+                "clustering_order".to_string(),
+                "column_name_bytes".to_string(),
+                "kind".to_string(),
+                "position".to_string(),
+                "type".to_string(),
+            ];
+            let col_types = vec![
+                CqlType::Varchar,
+                CqlType::Varchar,
+                CqlType::Varchar,
+                CqlType::Varchar,
+                CqlType::Blob,
+                CqlType::Varchar,
+                CqlType::Int,
+                CqlType::Varchar,
+            ];
+            Ok(result::encode_rows(
+                &col_names,
+                &col_types,
+                "system_virtual_schema",
+                "columns",
+                &[],
+            ))
+        }
         // cqlsh queries these system_schema tables during startup introspection.
         // Return empty results for tables we don't populate yet.
         ("system_schema", "functions" | "aggregates" | "triggers" | "views") => {
@@ -8127,6 +8194,40 @@ mod tests {
         match &result {
             RouteResult::Result(b) => assert_eq!(&b[0..4], &0x0002i32.to_be_bytes()),
             _ => panic!("expected Result"),
+        }
+    }
+
+    /// Gap 2 (ferrosa-nosqlbench/docs/initial-gaps-found.md): the DataStax
+    /// Java Driver 4.x queries all three system_virtual_schema tables
+    /// during connection bring-up.  Pre-fix, ferrosa returned
+    /// "table not found" and the driver gave up on every host; post-fix
+    /// each query must succeed with an empty-but-typed result.
+    #[tokio::test]
+    async fn select_system_virtual_schema_keyspaces_returns_empty_ok() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        for table in ["keyspaces", "tables", "columns"] {
+            let q = format!("SELECT * FROM system_virtual_schema.{table}");
+            let stmt = crate::parser::parse(&q).unwrap();
+            let result = route(&state, &ctx, stmt)
+                .await
+                .unwrap_or_else(|e| panic!("system_virtual_schema.{table} returned error: {e:?}"));
+            match &result {
+                // Rows kind (0x0002) — schema-typed empty result.
+                RouteResult::Result(b) => assert_eq!(
+                    &b[0..4],
+                    &0x0002i32.to_be_bytes(),
+                    "system_virtual_schema.{table} should return Rows result",
+                ),
+                _ => panic!("expected RouteResult::Result for system_virtual_schema.{table}"),
+            }
         }
     }
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -2890,6 +2890,43 @@ fn route_explain(
     ))
 }
 
+// ── USING TIMESTAMP / TTL helpers (Gap 10) ───────────────────────────────
+//
+// `using_timestamp` and `using_ttl` are now `Option<Term>` so the prepare
+// path can register bind markers (`USING TIMESTAMP ?`).  By the time the
+// router executes, `substitute_in_statement` has replaced any
+// `Term::BindMarker` with the bound literal.  These helpers extract the
+// integer with a clear error if substitution was missed or the literal is
+// out of range.
+
+fn using_timestamp_as_i64(t: &Option<Term>) -> Result<Option<i64>, CqlError> {
+    match t {
+        None => Ok(None),
+        Some(Term::IntegerLiteral(n)) => Ok(Some(*n)),
+        Some(Term::BindMarker(_)) => Err(CqlError::Protocol(
+            "USING TIMESTAMP bind marker was not substituted before execution".into(),
+        )),
+        Some(other) => Err(CqlError::Invalid(format!(
+            "USING TIMESTAMP must be an integer literal or bind marker, got {other:?}"
+        ))),
+    }
+}
+
+fn using_ttl_as_i32(t: &Option<Term>) -> Result<Option<i32>, CqlError> {
+    match t {
+        None => Ok(None),
+        Some(Term::IntegerLiteral(n)) => i32::try_from(*n)
+            .map(Some)
+            .map_err(|_| CqlError::Invalid(format!("USING TTL value {n} out of i32 range"))),
+        Some(Term::BindMarker(_)) => Err(CqlError::Protocol(
+            "USING TTL bind marker was not substituted before execution".into(),
+        )),
+        Some(other) => Err(CqlError::Invalid(format!(
+            "USING TTL must be an integer literal or bind marker, got {other:?}"
+        ))),
+    }
+}
+
 // ── INSERT ───────────────────────────────────────────────────────────────
 
 async fn route_insert(
@@ -2917,7 +2954,7 @@ async fn route_insert(
     let mut pk_vals: Vec<(i32, CqlValue)> = Vec::new();
     let mut ck_vals: Vec<(i32, CqlValue)> = Vec::new();
     let mut regular_cells: Vec<(u16, CqlValue)> = Vec::new();
-    let timestamp = match s.using_timestamp {
+    let timestamp = match using_timestamp_as_i64(&s.using_timestamp)? {
         Some(ts) => ts,
         None => std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -2957,7 +2994,12 @@ async fn route_insert(
         .collect::<Result<Vec<_>, _>>()?;
 
     let decorated_key = bridge::build_decorated_key(&pk_values, &pk_types)?;
-    let row = bridge::build_row(&regular_cells, &ck_values, timestamp, s.using_ttl);
+    let row = bridge::build_row(
+        &regular_cells,
+        &ck_values,
+        timestamp,
+        using_ttl_as_i32(&s.using_ttl)?,
+    );
     let table_id = TableId::new(ks, &s.table);
     let strategy = keyspace_strategy(&state.schema, ks);
 
@@ -3101,7 +3143,7 @@ async fn route_update(
         .get(&(ks.to_string(), s.table.clone()))
         .ok_or_else(|| CqlError::Invalid(format!("table {}.{} not found", ks, s.table)))?;
 
-    let timestamp = match s.using_timestamp {
+    let timestamp = match using_timestamp_as_i64(&s.using_timestamp)? {
         Some(ts) => ts,
         None => std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -3350,7 +3392,12 @@ async fn route_update(
         regular_cells.push((col_idx, value));
     }
 
-    let row = bridge::build_row(&regular_cells, &ck_values, timestamp, s.using_ttl);
+    let row = bridge::build_row(
+        &regular_cells,
+        &ck_values,
+        timestamp,
+        using_ttl_as_i32(&s.using_ttl)?,
+    );
     let strategy = keyspace_strategy(&state.schema, ks);
 
     state
@@ -3475,7 +3522,7 @@ async fn route_delete(
         .get(&(ks.to_string(), s.table.clone()))
         .ok_or_else(|| CqlError::Invalid(format!("table {}.{} not found", ks, s.table)))?;
 
-    let timestamp = match s.using_timestamp {
+    let timestamp = match using_timestamp_as_i64(&s.using_timestamp)? {
         Some(ts) => ts,
         None => std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -3615,7 +3662,7 @@ async fn route_logged_batch(
 ) -> Result<BytesMut, CqlError> {
     use ferrosa_storage::Mutation;
 
-    let batch_timestamp = b.using_timestamp.unwrap_or_else(|| {
+    let batch_timestamp = using_timestamp_as_i64(&b.using_timestamp)?.unwrap_or_else(|| {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -3711,7 +3758,7 @@ fn materialize_insert(
         .get(&(ks.to_string(), s.table.clone()))
         .ok_or_else(|| CqlError::Invalid(format!("table {}.{} not found", ks, s.table)))?;
 
-    let timestamp = s.using_timestamp.unwrap_or(batch_timestamp);
+    let timestamp = using_timestamp_as_i64(&s.using_timestamp)?.unwrap_or(batch_timestamp);
 
     let mut pk_vals: Vec<(i32, CqlValue)> = Vec::new();
     let mut ck_vals: Vec<(i32, CqlValue)> = Vec::new();
@@ -3748,7 +3795,12 @@ fn materialize_insert(
         .collect::<Result<Vec<_>, _>>()?;
 
     let decorated_key = bridge::build_decorated_key(&pk_values, &pk_types)?;
-    let row = bridge::build_row(&regular_cells, &ck_values, timestamp, s.using_ttl);
+    let row = bridge::build_row(
+        &regular_cells,
+        &ck_values,
+        timestamp,
+        using_ttl_as_i32(&s.using_ttl)?,
+    );
     let table_id = TableId::new(ks, &s.table);
 
     Ok((table_id, decorated_key, row, timestamp))
@@ -3784,7 +3836,7 @@ fn materialize_update(
         .get(&(ks.to_string(), s.table.clone()))
         .ok_or_else(|| CqlError::Invalid(format!("table {}.{} not found", ks, s.table)))?;
 
-    let timestamp = s.using_timestamp.unwrap_or(batch_timestamp);
+    let timestamp = using_timestamp_as_i64(&s.using_timestamp)?.unwrap_or(batch_timestamp);
 
     let pk_values = extract_pk_values(
         &s.where_clauses,
@@ -3842,7 +3894,12 @@ fn materialize_update(
     }
 
     let decorated_key = bridge::build_decorated_key(&pk_values, &pk_types)?;
-    let row = bridge::build_row(&regular_cells, &ck_values, timestamp, s.using_ttl);
+    let row = bridge::build_row(
+        &regular_cells,
+        &ck_values,
+        timestamp,
+        using_ttl_as_i32(&s.using_ttl)?,
+    );
     let table_id = TableId::new(ks, &s.table);
 
     Ok((table_id, decorated_key, row, timestamp))
@@ -3878,7 +3935,7 @@ fn materialize_delete(
         .get(&(ks.to_string(), s.table.clone()))
         .ok_or_else(|| CqlError::Invalid(format!("table {}.{} not found", ks, s.table)))?;
 
-    let timestamp = s.using_timestamp.unwrap_or(batch_timestamp);
+    let timestamp = using_timestamp_as_i64(&s.using_timestamp)?.unwrap_or(batch_timestamp);
 
     let pk_values = extract_pk_values(
         &s.where_clauses,

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1215,8 +1215,38 @@ async fn route_select(
         ("system_schema", "tables") => {
             let snap = state.schema.snapshot();
             let table_rows = query_tables(&snap);
-            let col_names = vec!["keyspace_name".into(), "table_name".into(), "id".into()];
-            let col_types = vec![CqlType::Varchar, CqlType::Varchar, CqlType::Uuid];
+            // Cassandra 5.0 `system_schema.tables` has 20 columns; ferrosa
+            // currently advertises four: the three keys the existing schema
+            // introspection paths use (`keyspace_name`, `table_name`, `id`)
+            // plus `cdc` (boolean, default `false`). The DataStax Java
+            // Driver 4.x `TableParser.parseRow` calls
+            // `row.getBoolean("cdc")` unconditionally; without the column
+            // present, `getBoolean` returns null and unboxing throws NPE
+            // during the post-DDL schema refresh.  See
+            // ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 7).
+            // Boolean columns the DataStax driver reads unconditionally
+            // during schema refresh:
+            //   - cdc                 (driver default-ok via ifPresentAndNonNull)
+            //   - allow_auto_snapshot (driver requires column present)
+            //   - incremental_backups (driver requires column present)
+            // Cassandra returns NULL for the latter two on most rows — we do
+            // the same so the column metadata exists but values stay null.
+            let col_names = vec![
+                "keyspace_name".into(),
+                "table_name".into(),
+                "id".into(),
+                "cdc".into(),
+                "allow_auto_snapshot".into(),
+                "incremental_backups".into(),
+            ];
+            let col_types = vec![
+                CqlType::Varchar,
+                CqlType::Varchar,
+                CqlType::Uuid,
+                CqlType::Boolean,
+                CqlType::Boolean,
+                CqlType::Boolean,
+            ];
             // Apply WHERE equality filters.
             let filtered: Vec<_> = table_rows
                 .iter()
@@ -1244,6 +1274,10 @@ async fn route_select(
                         Some(CqlValue::Text(t.keyspace_name.clone())),
                         Some(CqlValue::Text(t.table_name.clone())),
                         Some(CqlValue::Uuid(t.id)),
+                        Some(CqlValue::Boolean(t.cdc)),
+                        // Cassandra returns NULL for these on most tables — match.
+                        None,
+                        None,
                     ]
                 })
                 .collect();
@@ -1639,9 +1673,84 @@ async fn route_select(
                 &[],
             ))
         }
+        // system_schema.views — empty (ferrosa does not implement
+        // materialized views) but the column metadata must match Cassandra
+        // 5.0 so the DataStax driver's `ViewParser` finds the boolean
+        // columns it expects (`cdc`, `include_all_columns`,
+        // `allow_auto_snapshot`, `incremental_backups`).  Without these in
+        // the column set, `getBoolean(...)` returns null during schema
+        // refresh and unboxing throws NPE.  See
+        // ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 7).
+        ("system_schema", "views") => {
+            let col_names = vec![
+                "keyspace_name".into(),
+                "view_name".into(),
+                "base_table_id".into(),
+                "base_table_name".into(),
+                "cdc".into(),
+                "include_all_columns".into(),
+                "allow_auto_snapshot".into(),
+                "incremental_backups".into(),
+                "id".into(),
+                "where_clause".into(),
+            ];
+            let col_types = vec![
+                CqlType::Varchar,
+                CqlType::Varchar,
+                CqlType::Uuid,
+                CqlType::Varchar,
+                CqlType::Boolean,
+                CqlType::Boolean,
+                CqlType::Boolean,
+                CqlType::Boolean,
+                CqlType::Uuid,
+                CqlType::Varchar,
+            ];
+            Ok(result::encode_rows(
+                &col_names,
+                &col_types,
+                "system_schema",
+                "views",
+                &[],
+            ))
+        }
+        // system_schema.functions — empty, but column metadata mirrors
+        // Cassandra so the Java driver's `FunctionParser` finds the
+        // boolean `called_on_null_input` it expects.  See gap 7 in
+        // ferrosa-nosqlbench/docs/initial-gaps-found.md.
+        ("system_schema", "functions") => {
+            let col_names = vec![
+                "keyspace_name".into(),
+                "function_name".into(),
+                "argument_types".into(),
+                "argument_names".into(),
+                "body".into(),
+                "called_on_null_input".into(),
+                "language".into(),
+                "return_type".into(),
+            ];
+            let list_text = CqlType::List(Box::new(CqlType::Varchar));
+            let col_types = vec![
+                CqlType::Varchar,
+                CqlType::Varchar,
+                list_text.clone(),
+                list_text,
+                CqlType::Varchar,
+                CqlType::Boolean,
+                CqlType::Varchar,
+                CqlType::Varchar,
+            ];
+            Ok(result::encode_rows(
+                &col_names,
+                &col_types,
+                "system_schema",
+                "functions",
+                &[],
+            ))
+        }
         // cqlsh queries these system_schema tables during startup introspection.
         // Return empty results for tables we don't populate yet.
-        ("system_schema", "functions" | "aggregates" | "triggers" | "views") => {
+        ("system_schema", "aggregates" | "triggers") => {
             // p1-37: Stub these tables until they have first-class
             // implementations. Honor the SELECT projection so col_specs
             // match driver-requested shape — every column is advertised

--- a/ferrosa-cql/src/server.rs
+++ b/ferrosa-cql/src/server.rs
@@ -59,6 +59,51 @@ impl Default for ServerConfig {
     }
 }
 
+/// Resolve the CQL server's `auth_disabled` flag from the storage-side
+/// `auth_enabled` flag, with an optional explicit override.
+///
+/// Cassandra has a single `authenticator:` setting; ferrosa historically
+/// had two (`FERROSA_AUTH_ENABLED` for storage, `FERROSA_AUTH_DISABLED`
+/// for the CQL server) which could drift out of sync — and did, in the
+/// default case: storage said "auth off, accepts everything" while the
+/// CQL server still sent `AUTHENTICATE`, breaking standard drivers
+/// (DataStax Java Driver, NoSQLBench).  See
+/// ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 1).
+///
+/// New contract: `storage_auth_enabled` is the single source of truth.
+/// `FERROSA_AUTH_DISABLED` (or the equivalent file-config key) is a
+/// **deprecated override**: when set, it wins, and main logs a
+/// deprecation warning pointing at this function.
+///
+/// # Returns
+///
+/// - `Some(override_value)` if explicit_override is set (deprecated path).
+/// - `!storage_auth_enabled` otherwise.
+pub fn resolve_auth_disabled(storage_auth_enabled: bool, explicit_override: Option<bool>) -> bool {
+    explicit_override.unwrap_or(!storage_auth_enabled)
+}
+
+#[cfg(test)]
+mod resolve_auth_disabled_tests {
+    use super::resolve_auth_disabled;
+
+    #[test]
+    fn defaults_to_inverse_of_storage_auth_enabled() {
+        // Storage auth off → CQL server sends READY (auth_disabled=true).
+        assert!(resolve_auth_disabled(false, None));
+        // Storage auth on → CQL server sends AUTHENTICATE (auth_disabled=false).
+        assert!(!resolve_auth_disabled(true, None));
+    }
+
+    #[test]
+    fn explicit_override_wins() {
+        // Explicit override beats storage flag in both directions (deprecated
+        // but supported for one release to ease migration).
+        assert!(resolve_auth_disabled(true, Some(true)));
+        assert!(!resolve_auth_disabled(false, Some(false)));
+    }
+}
+
 /// Tracks per-IP connection counts for rate limiting.
 #[derive(Debug, Default)]
 struct IpConnectionTracker {

--- a/ferrosa-jepsen/tests/cluster_topology_invariants.rs
+++ b/ferrosa-jepsen/tests/cluster_topology_invariants.rs
@@ -1,0 +1,223 @@
+//! Gap 11 — 3-node cluster topology invariants.
+//!
+//! A correctly-formed ferrosa cluster must satisfy three observable
+//! invariants visible to any CQL driver:
+//!
+//! 1. **Distinct host_ids** — every node has its own UUID.
+//! 2. **Distinct broadcast addresses** — drivers must be able to tell
+//!    nodes apart for connection pooling and load balancing.
+//! 3. **Distinct token sets that cover the ring** — under
+//!    `SimpleStrategy` with `replication_factor=1`, every key is owned
+//!    by exactly one node and the union of all tokens covers the entire
+//!    `i64` range so the partitioner can route every key.
+//!
+//! These invariants are what NoSQLBench (and any cassandra-driver
+//! client) relies on to spread load. Without them the cluster behaves
+//! like single-node + standbys — which is what the diabolical 3-node
+//! benchmark caught (one node held 1.4 GiB of memtable, two were
+//! effectively empty).  See
+//! `ferrosa-nosqlbench/docs/initial-gaps-found.md`.
+//!
+//! The test is gated on `FERROSA_TEST_CONTAINERS=1` per the project's
+//! test policy; without containers it panics with setup instructions
+//! instead of silently passing.
+//!
+//! ## Running locally
+//!
+//! ```bash
+//! # bring up the 3-node cluster
+//! ../scripts/test-cluster-up-ci.sh
+//!
+//! # run the test
+//! FERROSA_TEST_CONTAINERS=1 \
+//!   cargo test -p ferrosa-jepsen --test cluster_topology_invariants \
+//!   -- --nocapture
+//! ```
+
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+/// Hosts the test cluster's CQL endpoints listen on (mirrors
+/// `scripts/test-cluster-up-ci.sh`).
+const CLUSTER_HOSTS: &[&str] = &["127.0.0.1:9042", "127.0.0.1:9043", "127.0.0.1:9044"];
+
+/// Helper: spawn `cqlsh` against `host:port` and capture `key=value`
+/// pairs from a single-row `SELECT host_id, broadcast_address, tokens
+/// FROM system.local`.  Returns `None` if cqlsh isn't installed or the
+/// node is unreachable — callers panic with a setup hint.
+fn query_local(host: SocketAddr) -> Option<NodeIdentity> {
+    let output = std::process::Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--network",
+            "host",
+            "cassandra:5.0",
+            "cqlsh",
+            "--no-color",
+            &host.ip().to_string(),
+            &host.port().to_string(),
+            "-e",
+            "SELECT host_id, broadcast_address, tokens FROM system.local;",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_cqlsh_local_row(&stdout)
+}
+
+#[derive(Debug)]
+struct NodeIdentity {
+    host_id: String,
+    broadcast_address: String,
+    tokens: Vec<String>,
+}
+
+fn parse_cqlsh_local_row(stdout: &str) -> Option<NodeIdentity> {
+    // cqlsh emits a 4-line table:
+    //  host_id | broadcast_address | tokens
+    // --------+-------------------+--------
+    //  <uuid> | <inet>            | {...}
+    let mut data = None;
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('-') || trimmed.contains("host_id") {
+            continue;
+        }
+        if trimmed.contains('|') {
+            data = Some(trimmed.to_string());
+            break;
+        }
+    }
+    let row = data?;
+    let cells: Vec<&str> = row.split('|').map(|s| s.trim()).collect();
+    if cells.len() < 3 {
+        return None;
+    }
+    let tokens_raw = cells[2]
+        .trim_start_matches('{')
+        .trim_end_matches('}')
+        .trim();
+    let tokens: Vec<String> = if tokens_raw.is_empty() {
+        Vec::new()
+    } else {
+        tokens_raw
+            .split(',')
+            .map(|t| t.trim().trim_matches('\'').to_string())
+            .collect()
+    };
+    Some(NodeIdentity {
+        host_id: cells[0].to_string(),
+        broadcast_address: cells[1].to_string(),
+        tokens,
+    })
+}
+
+fn require_containers(test_name: &str) {
+    if std::env::var("FERROSA_TEST_CONTAINERS").is_err() {
+        panic!(
+            "FERROSA_TEST_CONTAINERS not set — bring the test cluster up first:\n\
+             \n\
+             scripts/test-cluster-up-ci.sh\n\
+             FERROSA_TEST_CONTAINERS=1 cargo test -p ferrosa-jepsen \\\n\
+                 --test cluster_topology_invariants {test_name} -- --nocapture\n"
+        );
+    }
+}
+
+/// Gap 11.1: each node in a 3-node cluster must report a distinct
+/// `host_id` in `system.local`.  Pre-fix, two of three nodes shared
+/// `11111111-1111-1111-1111-111111111111`, masking them as the same
+/// physical node to the driver.
+#[test]
+fn three_node_cluster_reports_three_distinct_host_ids() {
+    require_containers("three_node_cluster_reports_three_distinct_host_ids");
+    std::thread::sleep(Duration::from_secs(2));
+    let identities: Vec<NodeIdentity> = CLUSTER_HOSTS
+        .iter()
+        .map(|h| {
+            let addr: SocketAddr = h.parse().expect("parse cluster host");
+            query_local(addr)
+                .unwrap_or_else(|| panic!("could not query {h} system.local — is the cluster up?"))
+        })
+        .collect();
+    let unique: HashSet<&str> = identities.iter().map(|i| i.host_id.as_str()).collect();
+    assert_eq!(
+        unique.len(),
+        3,
+        "expected 3 distinct host_ids across the cluster, got {unique:?} from {identities:?}"
+    );
+}
+
+/// Gap 11.2: each node must report a distinct `broadcast_address`.
+/// Pre-fix, all three reported `127.0.0.1`, making the driver unable to
+/// distinguish them for load-balancing.
+#[test]
+fn three_node_cluster_reports_three_distinct_broadcast_addresses() {
+    require_containers("three_node_cluster_reports_three_distinct_broadcast_addresses");
+    std::thread::sleep(Duration::from_secs(2));
+    let identities: Vec<NodeIdentity> = CLUSTER_HOSTS
+        .iter()
+        .map(|h| {
+            let addr: SocketAddr = h.parse().expect("parse cluster host");
+            query_local(addr)
+                .unwrap_or_else(|| panic!("could not query {h} system.local — is the cluster up?"))
+        })
+        .collect();
+    let unique: HashSet<&str> = identities
+        .iter()
+        .map(|i| i.broadcast_address.as_str())
+        .collect();
+    assert_eq!(
+        unique.len(),
+        3,
+        "expected 3 distinct broadcast_addresses, got {unique:?} from {identities:?}"
+    );
+}
+
+/// Gap 11.3: tokens across the 3 nodes must form a distinct, non-empty
+/// set that covers the full i64 ring.  Pre-fix every node reported
+/// `tokens=['0']`, so all data hashed to one owner.
+#[test]
+fn three_node_cluster_tokens_are_distinct_and_cover_ring() {
+    require_containers("three_node_cluster_tokens_are_distinct_and_cover_ring");
+    std::thread::sleep(Duration::from_secs(2));
+    let identities: Vec<NodeIdentity> = CLUSTER_HOSTS
+        .iter()
+        .map(|h| {
+            let addr: SocketAddr = h.parse().expect("parse cluster host");
+            query_local(addr)
+                .unwrap_or_else(|| panic!("could not query {h} system.local — is the cluster up?"))
+        })
+        .collect();
+    let all_tokens: Vec<&str> = identities
+        .iter()
+        .flat_map(|i| i.tokens.iter().map(String::as_str))
+        .collect();
+    let unique: HashSet<&str> = all_tokens.iter().copied().collect();
+    assert!(
+        all_tokens.len() >= 3,
+        "expected at least 3 tokens total across the cluster, got {all_tokens:?}"
+    );
+    assert_eq!(
+        unique.len(),
+        all_tokens.len(),
+        "expected every token to be unique across nodes, but {all_tokens:?} \
+         has duplicates → cluster behaves as single-owner. (full identities: {identities:?})"
+    );
+    // The union of token ranges must reach both ends of the i64 ring.
+    // Cassandra's Murmur3Partitioner range is i64::MIN..=i64::MAX; with
+    // vnodes set, several tokens per node distribute coverage.  With a
+    // single-token-per-node config, three tokens divide the ring into
+    // three arcs and that's still a valid cover.
+    let parsed: Result<Vec<i64>, _> = all_tokens.iter().map(|t| t.parse::<i64>()).collect();
+    let parsed = parsed.expect("tokens must parse as i64");
+    assert!(
+        parsed.iter().any(|t| *t < 0) && parsed.iter().any(|t| *t > 0),
+        "tokens must span negative and positive halves of the i64 ring, got {parsed:?}"
+    );
+}

--- a/ferrosa-schema/src/registry.rs
+++ b/ferrosa-schema/src/registry.rs
@@ -3565,7 +3565,7 @@ mod tests {
         );
         assert_eq!(
             auth_rows[0].replication.get("class"),
-            Some(&"NetworkTopologyStrategy".to_string()),
+            Some(&"org.apache.cassandra.locator.NetworkTopologyStrategy".to_string()),
             "cqlsh-facing view of system_auth must advertise \
              NetworkTopologyStrategy"
         );

--- a/ferrosa-schema/src/system/local.rs
+++ b/ferrosa-schema/src/system/local.rs
@@ -45,7 +45,9 @@ impl Default for NodeConfig {
     fn default() -> Self {
         Self {
             cluster_name: "ferrosa".to_string(),
-            data_center: "dc1".to_string(),
+            // Cassandra 5.0 / DataStax driver convention.  See
+            // ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 3).
+            data_center: "datacenter1".to_string(),
             rack: "rack1".to_string(),
             rpc_port: 9042,
             host_id: Uuid::new_v4(),
@@ -176,7 +178,11 @@ mod tests {
     fn node_config_defaults() {
         let config = NodeConfig::default();
         assert_eq!(config.cluster_name, "ferrosa");
-        assert_eq!(config.data_center, "dc1");
+        // Cassandra 5.0 / DSE / DataStax driver convention.  Drivers default
+        // `localdc=datacenter1`; reporting anything else makes the driver's
+        // topology probe reject every contact point.  See
+        // ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 3).
+        assert_eq!(config.data_center, "datacenter1");
         assert_eq!(config.rack, "rack1");
         assert_eq!(config.rpc_port, 9042);
     }

--- a/ferrosa-schema/src/system/schema_tables.rs
+++ b/ferrosa-schema/src/system/schema_tables.rs
@@ -30,6 +30,12 @@ pub struct TableRow {
     pub table_name: String,
     /// Unique table identifier.
     pub id: Uuid,
+    /// Change-data-capture enabled (Cassandra 3.8+). The DataStax Java
+    /// Driver 4.x `TableParser` calls `row.getBoolean("cdc")` unconditionally,
+    /// so this column must be present and non-null even if ferrosa does not
+    /// implement CDC.  Default `false`.
+    /// See ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 7).
+    pub cdc: bool,
 }
 
 /// A row from `system_schema.columns`.
@@ -69,7 +75,10 @@ pub fn query_keyspaces(snap: &SchemaSnapshot) -> Vec<KeyspaceRow> {
         .values()
         .map(|ks| {
             let mut replication = ks.replication.options.clone();
-            replication.insert("class".to_string(), ks.replication.strategy.clone());
+            replication.insert(
+                "class".to_string(),
+                fully_qualify_strategy(&ks.replication.strategy),
+            );
             KeyspaceRow {
                 keyspace_name: ks.name.clone(),
                 durable_writes: ks.durable_writes,
@@ -92,11 +101,70 @@ pub fn query_keyspaces(snap: &SchemaSnapshot) -> Vec<KeyspaceRow> {
 
 fn system_keyspace_row(name: &str) -> KeyspaceRow {
     let mut replication = HashMap::new();
-    replication.insert("class".to_string(), "LocalStrategy".to_string());
+    replication.insert("class".to_string(), fully_qualify_strategy("LocalStrategy"));
     KeyspaceRow {
         keyspace_name: name.to_string(),
         durable_writes: true,
         replication,
+    }
+}
+
+/// Normalize a replication strategy class name to the fully-qualified
+/// `org.apache.cassandra.locator.*` form that the DataStax Java Driver
+/// 4.x recognises.  Unqualified names like `"SimpleStrategy"` cause the
+/// driver's `DefaultMetadata` token-map refresh to log a warning and skip
+/// the topology, breaking driver-aware routing.  See
+/// ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 8).
+fn fully_qualify_strategy(name: &str) -> String {
+    if name.starts_with("org.apache.cassandra.locator.") {
+        return name.to_string();
+    }
+    match name {
+        "SimpleStrategy" => "org.apache.cassandra.locator.SimpleStrategy".to_string(),
+        "NetworkTopologyStrategy" => {
+            "org.apache.cassandra.locator.NetworkTopologyStrategy".to_string()
+        }
+        "LocalStrategy" => "org.apache.cassandra.locator.LocalStrategy".to_string(),
+        // Unknown strategies pass through — operator may be using a custom
+        // strategy class that they already wrote fully qualified.
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod fully_qualify_strategy_tests {
+    use super::fully_qualify_strategy;
+
+    #[test]
+    fn shortname_becomes_fully_qualified() {
+        assert_eq!(
+            fully_qualify_strategy("SimpleStrategy"),
+            "org.apache.cassandra.locator.SimpleStrategy"
+        );
+        assert_eq!(
+            fully_qualify_strategy("NetworkTopologyStrategy"),
+            "org.apache.cassandra.locator.NetworkTopologyStrategy"
+        );
+        assert_eq!(
+            fully_qualify_strategy("LocalStrategy"),
+            "org.apache.cassandra.locator.LocalStrategy"
+        );
+    }
+
+    #[test]
+    fn already_qualified_passes_through() {
+        assert_eq!(
+            fully_qualify_strategy("org.apache.cassandra.locator.SimpleStrategy"),
+            "org.apache.cassandra.locator.SimpleStrategy"
+        );
+    }
+
+    #[test]
+    fn unknown_strategy_passes_through() {
+        assert_eq!(
+            fully_qualify_strategy("MyCustomStrategy"),
+            "MyCustomStrategy"
+        );
     }
 }
 
@@ -110,6 +178,7 @@ pub fn query_tables(snap: &SchemaSnapshot) -> Vec<TableRow> {
         keyspace_name: t.keyspace.clone(),
         table_name: t.name.clone(),
         id: t.id,
+        cdc: false,
     }));
     rows
 }
@@ -188,6 +257,7 @@ fn system_table_rows() -> Vec<TableRow> {
             keyspace_name: ks.to_string(),
             table_name: tbl.to_string(),
             id: Uuid::new_v4(),
+            cdc: false,
         })
         .collect()
 }
@@ -516,7 +586,7 @@ mod tests {
         assert!(user_rows[0].durable_writes);
         assert_eq!(
             user_rows[0].replication.get("class"),
-            Some(&"SimpleStrategy".to_string())
+            Some(&"org.apache.cassandra.locator.SimpleStrategy".to_string())
         );
     }
 

--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -202,10 +202,30 @@ impl<R: ReadAt> SSTableReader<R> {
     /// Read all partitions from this SSTable in storage order.
     ///
     /// Scans the Data.db file sequentially from position 0, reading each
-    /// partition until EOF. Used by the compaction executor to merge
-    /// multiple SSTables.
+    /// partition until EOF. **Materializes the entire SSTable into memory.**
+    ///
+    /// Prefer [`Self::partitions_iter`] for compaction and other large-scan
+    /// callers — full materialization here was OOM-ing the compaction
+    /// executor on tombstone-heavy workloads (`cql_timeseries2`, IoT TTL
+    /// patterns).  See `specs/in-process/streaming-compaction.md`.
     pub fn read_all_partitions(&self) -> Result<Vec<crate::types::Partition>> {
         self.read_partitions_limited(usize::MAX)
+    }
+
+    /// Stream partitions from this SSTable in storage (token) order, one at
+    /// a time, without materializing the whole file into memory.
+    ///
+    /// The returned iterator borrows this `SSTableReader` for its lifetime
+    /// and decompresses the Data.db once up-front (for compressed
+    /// SSTables) or reads directly from the underlying [`ReadAt`] (for
+    /// uncompressed). Each call to [`PartitionIter::next_partition`] yields
+    /// at most one partition; the iterator returns `Ok(None)` at EOF.
+    ///
+    /// Memory: `O(decompressed_data_size)` for compressed SSTables (single
+    /// pre-decompressed buffer held for the iterator's lifetime), `O(1)`
+    /// for uncompressed.  Independent of partition count.
+    pub fn partitions_iter(&self) -> Result<PartitionIter<'_, R>> {
+        PartitionIter::new(self)
     }
 
     /// Scan partitions sequentially, stopping once `limit` partitions have
@@ -249,6 +269,55 @@ impl<R: ReadAt> SSTableReader<R> {
             }
         }
         Ok(partitions)
+    }
+}
+
+/// Streaming partition iterator over an SSTable.
+///
+/// Returned by [`SSTableReader::partitions_iter`]. Yields partitions in
+/// storage (token) order, one at a time. Decompression happens once at
+/// construction time for compressed SSTables; the decompressed buffer is
+/// held for the iterator's lifetime and freed on drop.
+///
+/// Memory cost is constant in the number of partitions — only the
+/// currently-yielded `Partition` is materialized.
+pub struct PartitionIter<'a, R: ReadAt> {
+    sst: &'a SSTableReader<R>,
+    pos: u64,
+    /// Decompressed Data.db for compressed SSTables. `None` for
+    /// uncompressed, where the iterator reads directly from `sst.data`.
+    decompressed: Option<Vec<u8>>,
+}
+
+impl<'a, R: ReadAt> PartitionIter<'a, R> {
+    fn new(sst: &'a SSTableReader<R>) -> Result<Self> {
+        let decompressed = match &sst.compression_info {
+            Some(ci) => Some(decompress_data(&sst.data, ci)?),
+            None => None,
+        };
+        Ok(Self {
+            sst,
+            pos: 0,
+            decompressed,
+        })
+    }
+
+    /// Yield the next partition in storage order. Returns `Ok(None)` when
+    /// the iterator has reached EOF.
+    pub fn next_partition(&mut self) -> Result<Option<crate::types::Partition>> {
+        let header = &self.sst.header;
+        if let Some(ref buf) = self.decompressed {
+            let slice: &[u8] = buf.as_slice();
+            let mut reader = crate::data::DataReader::new(&slice, header, self.pos);
+            let result = reader.read_partition()?;
+            self.pos = reader.position();
+            Ok(result)
+        } else {
+            let mut reader = crate::data::DataReader::new(&self.sst.data, header, self.pos);
+            let result = reader.read_partition()?;
+            self.pos = reader.position();
+            Ok(result)
+        }
     }
 }
 
@@ -615,5 +684,53 @@ mod tests {
 
         // Verify compression_info is None
         assert!(reader.compression_info().is_none());
+    }
+
+    /// Parity: streaming `partitions_iter()` yields the same sequence as
+    /// the materializing `read_all_partitions()`.  This is the regression
+    /// guard for the streaming-compaction refactor.
+    #[test]
+    fn partitions_iter_matches_read_all_partitions() {
+        let header = test_header();
+        let dks: Vec<_> = (0..7u32)
+            .map(|i| DecoratedKey::new(PartitionKey::from(format!("pk{i:02}").as_bytes())))
+            .collect();
+        let mut data_bytes = Vec::new();
+        let mut positions = Vec::new();
+        for dk in &dks {
+            positions.push(data_bytes.len() as u64);
+            data_bytes.extend_from_slice(&build_data_blob(dk.key.as_bytes()));
+        }
+        let dk_pos: Vec<_> = dks.iter().zip(positions.iter().copied()).collect();
+        let partitions_bytes =
+            build_partition_index(&dk_pos.iter().map(|(d, p)| (*d, *p)).collect::<Vec<_>>());
+        let filter_bytes = build_bloom_filter(&dks.iter().collect::<Vec<_>>());
+        let stats_bytes = build_statistics(header);
+
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        let materialized = reader.read_all_partitions().expect("read_all");
+        let mut streamed = Vec::new();
+        let mut iter = reader.partitions_iter().expect("partitions_iter");
+        while let Some(p) = iter.next_partition().expect("next") {
+            streamed.push(p);
+        }
+
+        assert_eq!(materialized.len(), streamed.len(), "same partition count");
+        for (m, s) in materialized.iter().zip(streamed.iter()) {
+            assert_eq!(m.key, s.key);
+            assert_eq!(m.rows.len(), s.rows.len());
+        }
+        // EOF stays at EOF
+        assert!(iter.next_partition().unwrap().is_none());
+        assert!(iter.next_partition().unwrap().is_none());
     }
 }

--- a/ferrosa-storage/src/compaction/executor.rs
+++ b/ferrosa-storage/src/compaction/executor.rs
@@ -108,33 +108,36 @@ impl Drop for CompactionExecutor {
 
 impl CompactionExecutor {
     /// Execute a single compaction task by merging input SSTables into one output.
+    ///
+    /// **Streaming compaction**: this function uses a k-way streaming merge
+    /// across the input SSTables instead of materializing them all into
+    /// `BTreeMap<key, Vec<Partition>>` + `Vec<merged>` (which OOM'd on
+    /// tombstone-heavy workloads with wide partitions — see
+    /// `cql_timeseries2` and IoT TTL patterns).
+    ///
+    /// Memory cost is now O(N_input_sstables × 1 partition) at any moment,
+    /// independent of the total dataset size. The output's serialization
+    /// header is built from the inputs' headers (bounded compute) rather
+    /// than from a full data scan.
     fn execute_task(task: &CompactionTask) -> std::result::Result<SSTableMetadata, String> {
-        use crate::flush::{self, FileFlushTarget, FlushTarget};
+        use crate::flush::{FileFlushTarget, FlushTarget};
         use crate::merge;
         use ferrosa_sstable::io::FileReadAt;
         use ferrosa_sstable::reader::{SSTableComponents, SSTableReader};
         use ferrosa_sstable::writer::SSTableWriter;
         use ferrosa_sstable::WriteOptions;
-        use std::collections::BTreeMap;
+        use std::collections::BinaryHeap;
 
         tracing::info!(
             table_id = %task.table_id,
             inputs = task.inputs.len(),
-            "compaction: starting task"
+            "compaction: starting streaming task"
         );
 
-        // 1. Read all partitions from each input SSTable.
-        //
-        // CRITICAL: If ANY input SSTable fails to read, the entire compaction
-        // must abort. Previously, unreadable SSTables were silently skipped
-        // while the task succeeded. This caused data loss because
-        // swap_compacted_sstables removes ALL input SSTables (including the
-        // skipped unreadable ones) and replaces them with the output — which
-        // only contains data from the successfully-read inputs.
-        let mut all_partitions: BTreeMap<Vec<u8>, Vec<ferrosa_sstable::types::Partition>> =
-            BTreeMap::new();
-        let mut total_input_rows: usize = 0;
-
+        // 1. Open every input SSTable.  ANY missing/corrupt input aborts the
+        //    whole compaction — silent skipping previously caused data loss
+        //    because swap_compacted_sstables removes all inputs.
+        let mut readers: Vec<SSTableReader<FileReadAt>> = Vec::with_capacity(task.inputs.len());
         for input in &task.inputs {
             let gen = &input.id;
             let dir = &input.path;
@@ -145,7 +148,7 @@ impl CompactionExecutor {
                 %gen,
                 data_file_size,
                 path = ?data_path,
-                "compaction: reading input SSTable"
+                "compaction: opening input SSTable"
             );
             match std::fs::metadata(&data_path) {
                 Ok(meta) if meta.len() == 0 => {
@@ -185,48 +188,164 @@ impl CompactionExecutor {
             })
             .map_err(|e| format!("aborting compaction: SSTable {gen} corrupt: {e}"))?;
 
-            let partitions = reader
-                .read_all_partitions()
-                .map_err(|e| format!("aborting compaction: SSTable {gen} read failed: {e}"))?;
+            readers.push(reader);
+        }
 
-            let input_row_count: usize = partitions.iter().map(|p| p.rows.len()).sum();
-            total_input_rows += input_row_count;
-            tracing::info!(
-                %gen,
-                partitions = partitions.len(),
-                rows = input_row_count,
-                "compaction: input SSTable stats"
+        if readers.is_empty() {
+            return Err("no input SSTables to compact".into());
+        }
+
+        // 2. Build the output serialization header by combining the inputs'
+        //    own headers.  Each input header records the min/max ts and
+        //    ldt observed in that SSTable; the union is correct for the
+        //    output (it's a strict superset of what's actually written
+        //    because deletions can drop cells, but conservative is fine —
+        //    drivers don't depend on it being tight).  Picking ferrosa's
+        //    column model from the schema mirrors the legacy
+        //    `flush::build_serialization_header` behaviour.
+        let header = combine_input_headers(&task.schema, &readers);
+        let header_min_ts = header.min_timestamp;
+        let header_max_ts = header.max_timestamp;
+        tracing::info!(
+            min_ts = header_min_ts,
+            max_ts = header_max_ts,
+            "compaction: combined output serialization header"
+        );
+
+        let options = WriteOptions {
+            compression: None,
+            ..WriteOptions::default()
+        };
+        let mut writer = SSTableWriter::new(options, header);
+
+        // 3. K-way streaming merge across the input partition iterators.
+        //
+        // Min-heap (custom `Ord` flips the comparison) yields the
+        // smallest partition key.  For each minimum key we drain every
+        // reader currently exposing that key (replenishing as we go),
+        // run `merge::merge_partitions`, write the result, and free it.
+        let mut iters: Vec<ferrosa_sstable::reader::PartitionIter<'_, FileReadAt>> =
+            Vec::with_capacity(readers.len());
+        for r in &readers {
+            iters.push(
+                r.partitions_iter()
+                    .map_err(|e| format!("partitions_iter: {e}"))?,
             );
+        }
 
-            for p in partitions {
-                all_partitions
-                    .entry(p.key.key.as_bytes().to_vec())
-                    .or_default()
-                    .push(p);
+        // Heap entry: the Partition is moved into the heap (no key
+        // clones), with a custom `Ord` that sorts by the partition's
+        // own DecoratedKey in token-comparable order.  This eliminates
+        // the O(N) key-allocation pressure the previous (key.clone(),
+        // idx) design caused.
+        struct HeapEntry {
+            partition: ferrosa_sstable::types::Partition,
+            reader_idx: usize,
+        }
+        impl PartialEq for HeapEntry {
+            fn eq(&self, other: &Self) -> bool {
+                self.partition.key == other.partition.key
+            }
+        }
+        impl Eq for HeapEntry {}
+        impl PartialOrd for HeapEntry {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+        impl Ord for HeapEntry {
+            // BinaryHeap is a max-heap; we want a min-heap, so flip the
+            // comparison (smaller DecoratedKey "wins" the pop).
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                other.partition.key.cmp(&self.partition.key)
             }
         }
 
+        let mut heap: BinaryHeap<HeapEntry> = BinaryHeap::with_capacity(iters.len());
+        for (idx, it) in iters.iter_mut().enumerate() {
+            if let Some(partition) = it.next_partition().map_err(|e| format!("iter init: {e}"))? {
+                heap.push(HeapEntry {
+                    partition,
+                    reader_idx: idx,
+                });
+            }
+        }
+
+        let mut total_input_rows: usize = 0;
+        let mut merged_partition_count: u64 = 0;
+        let mut merged_row_count: usize = 0;
+        // Track min/max token across all merged output partitions so the
+        // emitted SSTableMetadata can be filled without a second scan.
+        let mut min_token: i64 = i64::MAX;
+        let mut max_token: i64 = i64::MIN;
+
+        while let Some(top) = heap.pop() {
+            // Drain all heap entries that share this key (multiple inputs
+            // wrote the same partition).
+            let HeapEntry {
+                partition: first_partition,
+                reader_idx: first_idx,
+            } = top;
+            // We need to compare future heap tops against this key to
+            // collect duplicates. The partition itself moves into the
+            // group; cheap to compare via a reference into `group`
+            // afterward.
+            total_input_rows += first_partition.rows.len();
+            let mut group: Vec<ferrosa_sstable::types::Partition> = Vec::with_capacity(1);
+            group.push(first_partition);
+            // Advance reader first_idx.
+            if let Some(next) = iters[first_idx]
+                .next_partition()
+                .map_err(|e| format!("iter advance: {e}"))?
+            {
+                heap.push(HeapEntry {
+                    partition: next,
+                    reader_idx: first_idx,
+                });
+            }
+            // Drain other readers sitting at the same key.
+            while heap.peek().map(|h| h.partition.key == group[0].key) == Some(true) {
+                let HeapEntry {
+                    partition,
+                    reader_idx,
+                } = heap.pop().expect("peek implies pop");
+                total_input_rows += partition.rows.len();
+                group.push(partition);
+                if let Some(next) = iters[reader_idx]
+                    .next_partition()
+                    .map_err(|e| format!("iter advance: {e}"))?
+                {
+                    heap.push(HeapEntry {
+                        partition: next,
+                        reader_idx,
+                    });
+                }
+            }
+
+            let merged = merge::merge_partitions(group);
+            merged_row_count += merged.rows.len();
+            merged_partition_count += 1;
+            let token = merged.key.token.0;
+            if token < min_token {
+                min_token = token;
+            }
+            if token > max_token {
+                max_token = token;
+            }
+            writer
+                .add_partition(&merged)
+                .map_err(|e| format!("write partition: {e}"))?;
+        }
+
+        if merged_partition_count == 0 {
+            return Err("no partitions to compact".into());
+        }
+
         tracing::info!(
-            unique_keys = all_partitions.len(),
-            total_input_rows,
-            "compaction: total input summary"
-        );
-
-        // 2. Merge partitions with the same key.
-        let mut merged: Vec<ferrosa_sstable::types::Partition> = all_partitions
-            .into_values()
-            .map(merge::merge_partitions)
-            .collect();
-
-        // 3. Sort by key (SSTableWriter requires token order).
-        merged.sort_by(|a, b| a.key.cmp(&b.key));
-
-        let merged_row_count: usize = merged.iter().map(|p| p.rows.len()).sum();
-        tracing::info!(
-            partitions = merged.len(),
+            partitions = merged_partition_count,
             merged_row_count,
             total_input_rows,
-            "compaction: after merge"
+            "compaction: streaming merge complete"
         );
         if merged_row_count < total_input_rows {
             tracing::warn!(
@@ -237,70 +356,56 @@ impl CompactionExecutor {
             );
         }
 
-        if merged.is_empty() {
-            return Err("no partitions to compact".into());
-        }
-
-        // 4. Build serialization header and write output SSTable.
-        let header = flush::build_serialization_header(&task.schema, &merged);
-        tracing::info!(
-            min_ts = header.min_timestamp,
-            max_ts = header.max_timestamp,
-            "compaction: serialization header"
-        );
-        let header_min_ts = header.min_timestamp;
-        let header_max_ts = header.max_timestamp;
-        let options = WriteOptions {
-            compression: None,
-            ..WriteOptions::default()
-        };
-        let mut writer = SSTableWriter::new(options, header);
-        for p in &merged {
-            writer
-                .add_partition(p)
-                .map_err(|e| format!("write partition: {e}"))?;
-        }
         let output = writer.finish().map_err(|e| format!("finish: {e}"))?;
 
-        // 5. Write to output directory via FileFlushTarget.
+        // 4. Write to output directory via FileFlushTarget.
         let flush_target = FileFlushTarget::new_starting_at(task.output_dir.clone())
             .map_err(|e| format!("flush target: {e}"))?;
         let reader = flush_target
             .flush(output)
             .map_err(|e| format!("flush output: {e}"))?;
 
-        // Readback verification: immediately re-read the output to ensure
-        // the SSTable roundtrip is lossless.
-        let readback_partitions = reader
-            .read_all_partitions()
-            .map_err(|e| format!("CORRUPTION: output SSTable readback failed: {e}"))?;
-        let readback_row_count: usize = readback_partitions.iter().map(|p| p.rows.len()).sum();
-        if readback_partitions.len() != merged.len() || readback_row_count != merged_row_count {
+        // 5. Streaming readback verification — count partitions and rows
+        //    without materializing the output back into a Vec.  Catches
+        //    Data.db / Partitions.db inconsistencies that would corrupt
+        //    later reads.
+        let mut readback_partitions: u64 = 0;
+        let mut readback_rows: usize = 0;
+        {
+            let mut iter = reader
+                .partitions_iter()
+                .map_err(|e| format!("CORRUPTION: output partitions_iter failed: {e}"))?;
+            while let Some(p) = iter
+                .next_partition()
+                .map_err(|e| format!("CORRUPTION: output read failed: {e}"))?
+            {
+                readback_partitions += 1;
+                readback_rows += p.rows.len();
+            }
+        }
+        if readback_partitions != merged_partition_count || readback_rows != merged_row_count {
             tracing::error!(
-                written_partitions = merged.len(),
+                written_partitions = merged_partition_count,
                 written_rows = merged_row_count,
-                readback_partitions = readback_partitions.len(),
-                readback_rows = readback_row_count,
+                readback_partitions,
+                readback_rows,
                 "compaction: CORRUPTION DETECTED in output SSTable"
             );
             return Err(format!(
                 "compaction output SSTable is corrupt: expected {} partitions/{} rows, \
                  readback got {} partitions/{} rows",
-                merged.len(),
-                merged_row_count,
-                readback_partitions.len(),
-                readback_row_count
+                merged_partition_count, merged_row_count, readback_partitions, readback_rows
             ));
         }
         tracing::info!(
-            partitions = readback_partitions.len(),
-            rows = readback_row_count,
-            "compaction: output verified (matches merge)"
+            partitions = readback_partitions,
+            rows = readback_rows,
+            "compaction: output verified (streaming readback matches merge)"
         );
 
         let gen = flush_target.generation();
         let output_id = format!("{gen}");
-        let partition_count = merged.len() as u64;
+        let partition_count = merged_partition_count;
 
         let total_size: u64 = [
             format!("{gen}-Data.db"),
@@ -317,12 +422,12 @@ impl CompactionExecutor {
         })
         .sum();
 
-        let min_token = merged.first().map(|p| p.key.token.0).unwrap_or(0);
-        let max_token = merged.last().map(|p| p.key.token.0).unwrap_or(0);
+        // min/max token tracked inline during the streaming merge; if the
+        // merge produced zero partitions we'd have returned above.
 
-        // Use the actual header timestamps from the merged data, not the
-        // input metadata. Input metadata may have stale/incorrect values
-        // that propagate to future compactions.
+        // Use the combined-header timestamps (from input headers) for the
+        // output metadata. Input metadata may have stale/incorrect values
+        // that would propagate; the header values are authoritative.
         Ok(SSTableMetadata {
             id: output_id,
             path: task.output_dir.clone(),
@@ -333,6 +438,69 @@ impl CompactionExecutor {
             max_timestamp: header_max_ts,
             partition_count,
         })
+    }
+}
+
+/// Build an output `SerializationHeader` from the inputs' own headers
+/// plus the (current) table schema, in `O(N_inputs)` time and without
+/// scanning Data.db.
+///
+/// Each input header already records the timestamp / ldt / ttl ranges
+/// observed when that SSTable was written; the output is the union of
+/// those ranges. The column model (key type, clustering, statics,
+/// regular columns) comes from the schema — same convention as the
+/// flush path used to use via `flush::build_serialization_header`.
+fn combine_input_headers<R: ferrosa_sstable::io::ReadAt>(
+    schema: &ferrosa_common::schema::TableSchema,
+    readers: &[ferrosa_sstable::reader::SSTableReader<R>],
+) -> ferrosa_sstable::statistics::SerializationHeader {
+    use ferrosa_common::{NO_DELETION_TIME, NO_TIMESTAMP, NO_TTL};
+    use ferrosa_sstable::statistics::SerializationHeader;
+
+    // Use the first reader's column model as the template; the schema
+    // shape is identical across all inputs by definition (compaction
+    // never mixes SSTables from different tables).
+    let template = readers
+        .first()
+        .map(|r| r.header().clone())
+        .unwrap_or_else(|| crate::flush::build_serialization_header(schema, &[]));
+
+    let mut min_timestamp = NO_TIMESTAMP;
+    let mut max_timestamp = i64::MIN;
+    let mut min_local_deletion_time = NO_DELETION_TIME;
+    let mut min_ttl = NO_TTL;
+
+    for r in readers {
+        let h = r.header();
+        if h.min_timestamp != NO_TIMESTAMP
+            && (min_timestamp == NO_TIMESTAMP || h.min_timestamp < min_timestamp)
+        {
+            min_timestamp = h.min_timestamp;
+        }
+        if h.max_timestamp > max_timestamp {
+            max_timestamp = h.max_timestamp;
+        }
+        if h.min_local_deletion_time != NO_DELETION_TIME
+            && (min_local_deletion_time == NO_DELETION_TIME
+                || h.min_local_deletion_time < min_local_deletion_time)
+        {
+            min_local_deletion_time = h.min_local_deletion_time;
+        }
+        if h.min_ttl != NO_TTL && (min_ttl == NO_TTL || h.min_ttl < min_ttl) {
+            min_ttl = h.min_ttl;
+        }
+    }
+
+    if max_timestamp == i64::MIN {
+        max_timestamp = NO_TIMESTAMP;
+    }
+
+    SerializationHeader {
+        min_timestamp,
+        max_timestamp,
+        min_local_deletion_time,
+        min_ttl,
+        ..template
     }
 }
 

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -46,6 +46,20 @@ fn config_val(
     })
 }
 
+/// Like `config_val` but returns `None` when neither the env var nor the
+/// config file set the key.  Needed to distinguish "operator did not say"
+/// from "operator wrote `false`" for the deprecated `FERROSA_AUTH_DISABLED`
+/// override path.
+fn config_val_opt(env_key: &str, config: &toml::Value, section: &str, key: &str) -> Option<String> {
+    if let Ok(v) = std::env::var(env_key) {
+        return Some(v);
+    }
+    config
+        .get(section)
+        .and_then(|s| s.get(key))
+        .and_then(|v| v.as_str().map(String::from).or_else(|| Some(v.to_string())))
+}
+
 /// Load TOML configuration from disk. Returns an empty table if the file does not exist.
 fn load_config(path: &str) -> Result<toml::Value, Box<dyn std::error::Error>> {
     if std::path::Path::new(path).exists() {
@@ -601,13 +615,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "0.0.0.0:9042",
     )
     .parse()?;
-    let auth_disabled_str = config_val(
+    // Deprecated direct override: prefer driving auth from FERROSA_AUTH_ENABLED.
+    // Set to None when neither env nor file specifies; resolver below
+    // defaults to `!storage_auth_enabled` in that case.
+    let auth_disabled_override: Option<bool> = config_val_opt(
         "FERROSA_AUTH_DISABLED",
         &file_config,
         "cql",
         "auth_disabled",
-        "false",
-    );
+    )
+    .map(|s| {
+        tracing::warn!(
+            "FERROSA_AUTH_DISABLED (or [cql].auth_disabled in config file) is \
+                 deprecated; use FERROSA_AUTH_ENABLED as the single source of truth. \
+                 Honoring the override for this release."
+        );
+        s == "true" || s == "1"
+    });
     let cql_tls_cert = config_val("FERROSA_CQL_TLS_CERT", &file_config, "cql", "tls_cert", "");
     let cql_tls_key = config_val("FERROSA_CQL_TLS_KEY", &file_config, "cql", "tls_key", "");
     let cql_require_tls = config_val(
@@ -635,7 +659,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .parse()?;
     let cql_config = ferrosa_cql::server::ServerConfig {
         bind_addr: cql_bind,
-        auth_disabled: auth_disabled_str == "true" || auth_disabled_str == "1",
+        auth_disabled: ferrosa_cql::server::resolve_auth_disabled(
+            storage_auth_enabled,
+            auth_disabled_override,
+        ),
         max_connections: cql_max_connections,
         max_connections_per_ip: cql_max_connections_per_ip,
         tls_cert_path: if cql_tls_cert.is_empty() {
@@ -1217,6 +1244,56 @@ mod tests {
 
     fn empty_config() -> toml::Value {
         toml::Value::Table(toml::map::Map::new())
+    }
+
+    /// Gap 1: with no auth env vars set and the storage default
+    /// (`auth_enabled=false`), the CQL server must NOT advertise an
+    /// authenticator — otherwise DataStax-style drivers refuse to connect.
+    /// See ferrosa-nosqlbench/docs/initial-gaps-found.md.
+    #[test]
+    fn config_val_opt_returns_none_when_unset() {
+        let key = "FERROSA_TEST_CFG_OPT_e7c1";
+        std::env::remove_var(key);
+        let result = config_val_opt(key, &empty_config(), "cql", "auth_disabled");
+        assert!(result.is_none(), "expected None for unset, got {result:?}");
+    }
+
+    #[test]
+    fn config_val_opt_reads_env_when_set() {
+        let key = "FERROSA_TEST_CFG_OPT_b2f4";
+        std::env::set_var(key, "true");
+        let result = config_val_opt(key, &empty_config(), "cql", "auth_disabled");
+        std::env::remove_var(key);
+        assert_eq!(result.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn config_val_opt_reads_file_when_env_unset() {
+        let key = "FERROSA_TEST_CFG_OPT_f9a3";
+        std::env::remove_var(key);
+        let cfg: toml::Value = toml::from_str("[cql]\nauth_disabled = true\n").unwrap();
+        let result = config_val_opt(key, &cfg, "cql", "auth_disabled");
+        assert_eq!(result.as_deref(), Some("true"));
+    }
+
+    /// End-to-end of the Gap 1 resolution chain: storage default is
+    /// `auth_enabled=false`, no explicit override → resolver returns
+    /// `auth_disabled=true` (CQL server sends READY, not AUTHENTICATE).
+    #[test]
+    fn auth_disabled_default_chain_matches_storage_default() {
+        // Storage default for `auth_enabled` is `false` (see
+        // StorageEngineConfig::default in ferrosa-storage); no override set.
+        let storage_default_auth_enabled = false;
+        let override_unset = None;
+        let auth_disabled = ferrosa_cql::server::resolve_auth_disabled(
+            storage_default_auth_enabled,
+            override_unset,
+        );
+        assert!(
+            auth_disabled,
+            "with storage auth_enabled=false (default) and no explicit override, \
+             CQL server must send READY (auth_disabled=true) so drivers connect"
+        );
     }
 
     fn sample_config() -> toml::Value {

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -535,6 +535,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::env::var("FERROSA_HINTED_HANDOFF_DIR").ok().as_deref(),
     );
     let cluster_config = Arc::new(cluster_config);
+    // Capture num_tokens locally before cluster_config is consumed by
+    // ModeController — needed downstream when populating system.local.tokens.
+    let num_tokens = cluster_config.num_tokens as usize;
     let net_config = Arc::new(ferrosa_net::config::NetConfig::from_env());
 
     // Build handler registry — shared between RPC server and ModeController.
@@ -686,8 +689,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (cql_broadcast_addr, cql_broadcast_port) = match std::env::var("FERROSA_CQL_BROADCAST") {
         Ok(addr_str) => cql_broadcast::parse_cql_broadcast(&addr_str, cql_bind.port()),
         Err(_) => {
+            // Gap 11: when CQL bind is 0.0.0.0 (the normal containerised
+            // case), the broadcast address must be the externally reachable
+            // IP so cluster peers and drivers can distinguish nodes.  Fall
+            // back to the internode-broadcast IP (which the operator already
+            // set to a reachable hostname/IP for gossip), not localhost —
+            // localhost made every node in a docker-compose cluster report
+            // `127.0.0.1` and load balancers / drivers couldn't tell them
+            // apart.  See ferrosa-nosqlbench/docs/initial-gaps-found.md.
             let ip = if cql_bind.ip().is_unspecified() {
-                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+                net_config.broadcast_addr.ip()
             } else {
                 cql_bind.ip()
             };
@@ -718,13 +729,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "CQL topology view policy: matching clients receive internal addresses"
         );
     }
+    // Gap 11: populate system.local with this node's actual tokens and
+    // gossip broadcast address.  Pre-fix, every node reported
+    // `tokens=['0']` (the NodeConfig::default sentinel) and
+    // `broadcast_address=127.0.0.1`, so a 3-node docker cluster looked
+    // to drivers like a single host with two duplicates — driving the
+    // 5x throughput gap NoSQLBench observed against Cassandra.
+    let local_node_id = ferrosa_cluster::raft::uuid_to_node_id(host_id);
+    let tokens: Vec<String> =
+        ferrosa_cluster::controller::deterministic_tokens_for_node(local_node_id, num_tokens)
+            .into_iter()
+            .map(|t| t.to_string())
+            .collect();
     let node_config = Arc::new(ferrosa_schema::NodeConfig {
         rpc_address: cql_broadcast_addr,
         rpc_port: cql_broadcast_port,
         internal_rpc_address: net_config.broadcast_addr.ip(),
         internal_rpc_port: cql_bind.port(),
         host_id,
+        broadcast_address: net_config.broadcast_addr.ip(),
+        broadcast_port: net_config.broadcast_addr.port(),
+        listen_address: net_config.broadcast_addr.ip(),
         listen_port: internode_addr.port(),
+        tokens,
         ..ferrosa_schema::NodeConfig::default()
     });
     let connection_tracker =

--- a/scripts/test-cluster-up-ci.sh
+++ b/scripts/test-cluster-up-ci.sh
@@ -40,7 +40,7 @@ docker build \
 
 # ── Bring up cluster (no --build; uses the pre-built image via image: tag) ──
 echo "Starting Ferrosa CI test cluster (profile: ${PROFILE}, project: ${PROJECT_NAME})..." >&2
-echo "Ports: CQL 9042/9043/9044, RustFS 9000/9001" >&2
+echo "Ports: CQL 9042/9043/9044 on host (RustFS is internal-only on the compose network)" >&2
 
 docker compose \
     -f "${COMPOSE_BASE}" \

--- a/tests/docker-compose.cluster.yml
+++ b/tests/docker-compose.cluster.yml
@@ -36,9 +36,12 @@ services:
     depends_on:
       volume-permissions:
         condition: service_completed_successfully
-    ports:
-      - "9000:9000"
-      - "9001:9001"
+    # No host port mappings — ferrosa nodes reach rustfs via the
+    # compose-internal docker network only.  Host 9000/9001 may be in use
+    # by other dev tools (e.g. local minio).
+    expose:
+      - "9000"
+      - "9001"
     environment:
       RUSTFS_VOLUMES: /data/rustfs0
       RUSTFS_ADDRESS: "0.0.0.0:9000"


### PR DESCRIPTION
## Summary

Umbrella PR for closing the CQL-compatibility gaps surfaced by running NoSQLBench (DataStax Java Driver 4.x) against ferrosa. Each gap is its own commit; we accumulate them here as the TDD loop walks through them.

The harness lives at `ferrosa-suite/ferrosa-nosqlbench/`. Flow per gap: run an NB workload → observe failure → write a failing unit test → implement → re-run NB → next gap surfaces.

## Gaps closed in this PR

| # | Gap | Commit | Status |
|---|---|---|---|
| 1 | CQL server advertised PasswordAuthenticator even when FERROSA_AUTH_ENABLED=false | 271ef3be | done |
| 2 | system_virtual_schema.{keyspaces,tables,columns} returned table not found | 271ef3be | done |
| 3 | NodeConfig.data_center default was dc1 not datacenter1 | 271ef3be | done |
| 4 | "No node was available" cascade | implicit on 1-3 | done |
| 5 | v5 envelope framing gated on USE_BETA flag (modern drivers do not set it) | 70b2efbf | done |
| 6 | v5 envelope header CRC24 mismatch (expected 0x000700, got 0xEF4FE1) | pending | next |

## Verification

End-to-end against a freshly-built docker image:
- Pre-fix: NB fails at STARTUP with AuthenticationException
- After 1-3: driver advances, fails at v5 framing with "unknown opcode 0xA1"
- After 5: driver speaks v5 envelopes, fails at CRC24 validation
- After 6 (pending): driver should reach the schema-creation cycles

## Test plan

- ferrosa-schema lib: 322 pass
- ferrosa-cql lib: 750 pass (7 new unit tests for gaps 1-5)
- ferrosa bin: 231 pass
- fmt, clippy -D warnings, rustdoc -D warnings: clean
- Local CI gates: green
- CI on this PR: monitoring
- NB schema phase zero-error: pending gap 6

## Followups (not in this PR)

- Populate system_virtual_schema rows with real virtual tables (introspection surface)
- Remove deprecated FERROSA_AUTH_DISABLED env var after one release
- Full bundled-workload sweep + commit baselines under ferrosa-nosqlbench/baselines/
- Cassandra 5.0 comparison harness