### PR TITLE
fix: improve streaming graph and compaction reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sim"
-version = "0.8.8+8"
+version = "0.8.9"
 dependencies = [
  "proptest",
  "serde",

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -14,7 +14,7 @@ use ferrosa_cluster::ring::strategy::ReplicationStrategy;
 use ferrosa_cluster::write_path::WritePath;
 use ferrosa_common::{CellValue, DecoratedKey, PartitionKey};
 use ferrosa_schema::{Schema, VirtualTableRegistry};
-use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
 use ferrosa_storage::{Mutation, TableId};
 
 use crate::adjacency::observer::derive_adjacency_mutations;
@@ -702,53 +702,97 @@ async fn execute_expand(
         );
     }
 
-    let anchor_table_id = TableId::new(&anchor.table.keyspace, &anchor.table.table);
-    let anchor_meta = table_metadata_for(schema, &anchor.table.keyspace, &anchor.table.table);
-    let anchor_partitions = if let Some(meta) = anchor_meta.as_ref() {
-        if let Some((key, _clustering)) =
-            build_direct_lookup_shape(meta, &HashMap::new(), &anchor.props, &HashMap::new())?
-        {
-            let strategy = graph_replication_strategy(schema, &anchor.table.keyspace)?;
-            write_path
-                .pk_read(&anchor_table_id, &key, ConsistencyLevel::One, &strategy)
-                .await?
-                .into_iter()
-                .collect()
+    let (mut current_states, traversal_hops): (Vec<ExpandState>, &[Hop]) = if let Some(states) =
+        try_edge_anchored_initial_states(
+            write_path,
+            anchor,
+            hops,
+            optional_hops,
+            schema,
+            &mut stats,
+        )
+        .await?
+    {
+        check_timeout(start, config.query_timeout)?;
+        (states, &hops[1..])
+    } else {
+        let anchor_table_id = TableId::new(&anchor.table.keyspace, &anchor.table.table);
+        let anchor_meta = table_metadata_for(schema, &anchor.table.keyspace, &anchor.table.table);
+        let anchor_partitions = if let Some(meta) = anchor_meta.as_ref() {
+            if let Some((key, _clustering)) =
+                build_direct_lookup_shape(meta, &HashMap::new(), &anchor.props, &HashMap::new())?
+            {
+                let strategy = graph_replication_strategy(schema, &anchor.table.keyspace)?;
+                write_path
+                    .pk_read(&anchor_table_id, &key, ConsistencyLevel::One, &strategy)
+                    .await?
+                    .into_iter()
+                    .collect()
+            } else {
+                write_path.range_read(&anchor_table_id).await?
+            }
         } else {
             write_path.range_read(&anchor_table_id).await?
-        }
-    } else {
-        write_path.range_read(&anchor_table_id).await?
-    };
-    stats.vertices_read += anchor_partitions.len();
-    check_timeout(start, config.query_timeout)?;
+        };
+        stats.vertices_read += anchor_partitions.len();
+        check_timeout(start, config.query_timeout)?;
 
-    // Resolve column names from schema for property mapping.
-    let anchor_col_names =
-        column_names_for_table(schema, &anchor.table.keyspace, &anchor.table.table);
+        // Resolve column names from schema for property mapping.
+        let anchor_col_names =
+            column_names_for_table(schema, &anchor.table.keyspace, &anchor.table.table);
 
-    // Apply WHERE filters to anchor partitions using the expression evaluator.
-    // Skip partitions that are fully tombstoned (no live cells in any row
-    // and no live static row) — these represent deleted vertices whose
-    // tombstones have not yet been purged by compaction.
-    let anchor_var = anchor.var.as_deref().unwrap_or("_anon");
-    let mut current_states: Vec<ExpandState> = Vec::with_capacity(anchor_partitions.len());
-    for partition in &anchor_partitions {
-        if is_partition_dead(partition) {
-            continue;
-        }
+        // Apply WHERE filters to anchor partitions using the expression evaluator.
+        // Skip partitions that are fully tombstoned (no live cells in any row
+        // and no live static row) — these represent deleted vertices whose
+        // tombstones have not yet been purged by compaction.
+        let anchor_var = anchor.var.as_deref().unwrap_or("_anon");
+        let mut states: Vec<ExpandState> = Vec::with_capacity(anchor_partitions.len());
+        for partition in &anchor_partitions {
+            if is_partition_dead(partition) {
+                continue;
+            }
 
-        if let Some(meta) = anchor_meta.as_ref() {
-            for row in &partition.rows {
-                let row_json = row_to_json(meta, partition, row);
-                if !prop_map_passes(anchor_var, &anchor.props, &row_json)? {
-                    continue;
+            if let Some(meta) = anchor_meta.as_ref() {
+                for row in &partition.rows {
+                    let row_json = row_to_json(meta, partition, row);
+                    if !prop_map_passes(anchor_var, &anchor.props, &row_json)? {
+                        continue;
+                    }
+
+                    let mut bindings = HashMap::new();
+                    bindings.insert(anchor_var.to_string(), row_json);
+                    let current_key = graph_vertex_lookup_key(meta, partition, row, &anchor.props)
+                        .unwrap_or_else(|| partition.key.clone());
+
+                    let mut passes = true;
+                    for filter in &anchor.filters {
+                        if !graph_filter_passes(
+                            filter,
+                            write_path,
+                            keyspace,
+                            schema,
+                            &bindings,
+                            anchor_var,
+                            &current_key,
+                        )
+                        .await?
+                        {
+                            passes = false;
+                            break;
+                        }
+                    }
+                    if passes {
+                        states.push(ExpandState {
+                            current_key,
+                            bindings,
+                        });
+                    }
                 }
-
+            } else {
+                let hex_id = hex::encode(partition.key.key.as_bytes());
+                let row_json = eval::partition_to_json(partition, &hex_id, &anchor_col_names);
                 let mut bindings = HashMap::new();
                 bindings.insert(anchor_var.to_string(), row_json);
-                let current_key = graph_vertex_lookup_key(meta, partition, row, &anchor.props)
-                    .unwrap_or_else(|| partition.key.clone());
 
                 let mut passes = true;
                 for filter in &anchor.filters {
@@ -759,7 +803,7 @@ async fn execute_expand(
                         schema,
                         &bindings,
                         anchor_var,
-                        &current_key,
+                        &partition.key,
                     )
                     .await?
                     {
@@ -768,49 +812,21 @@ async fn execute_expand(
                     }
                 }
                 if passes {
-                    current_states.push(ExpandState {
-                        current_key,
+                    states.push(ExpandState {
+                        current_key: partition.key.clone(),
                         bindings,
                     });
                 }
             }
-        } else {
-            let hex_id = hex::encode(partition.key.key.as_bytes());
-            let row_json = eval::partition_to_json(partition, &hex_id, &anchor_col_names);
-            let mut bindings = HashMap::new();
-            bindings.insert(anchor_var.to_string(), row_json);
-
-            let mut passes = true;
-            for filter in &anchor.filters {
-                if !graph_filter_passes(
-                    filter,
-                    write_path,
-                    keyspace,
-                    schema,
-                    &bindings,
-                    anchor_var,
-                    &partition.key,
-                )
-                .await?
-                {
-                    passes = false;
-                    break;
-                }
-            }
-            if passes {
-                current_states.push(ExpandState {
-                    current_key: partition.key.clone(),
-                    bindings,
-                });
-            }
         }
-    }
+        (states, hops)
+    };
 
     // Step 2: For each hop, traverse adjacency index.
     let adj_ks = adjacency_keyspace_name(keyspace);
     let adj_table_id = TableId::new(&adj_ks, "adjacency");
 
-    for hop in hops {
+    for hop in traversal_hops {
         check_timeout(start, config.query_timeout)?;
 
         let mut next_states = Vec::new();
@@ -878,6 +894,9 @@ async fn execute_expand(
                             if let Some(value) = state.bindings.get(var_name) {
                                 target_bindings.insert(var_name.clone(), value.clone());
                             }
+                        }
+                        if let Some(edge_match) = edge_match.as_ref() {
+                            target_bindings.insert("_edge".to_string(), edge_match.json.clone());
                         }
 
                         let neighbor_json = if let (Some(vertex_tid), Some(meta)) = (
@@ -1221,6 +1240,9 @@ async fn execute_optional_hops(
                             target_bindings.insert(var_name.clone(), value.clone());
                         }
                     }
+                    if let Some(edge_match) = edge_match.as_ref() {
+                        target_bindings.insert("_edge".to_string(), edge_match.json.clone());
+                    }
                     let neighbor_json = if let (Some(vertex_tid), Some(meta)) = (
                         hop.vertex_table
                             .as_ref()
@@ -1303,6 +1325,192 @@ async fn execute_optional_hops(
     Ok(current_states)
 }
 
+#[allow(clippy::too_many_arguments)]
+async fn try_edge_anchored_initial_states(
+    write_path: &WritePath,
+    anchor: &Anchor,
+    hops: &[Hop],
+    optional_hops: &[Hop],
+    schema: Option<&Schema>,
+    stats: &mut QueryStats,
+) -> Result<Option<Vec<ExpandState>>> {
+    let Some(hop) = hops.first() else {
+        return Ok(None);
+    };
+    let Some(edge_table) = hop.edge_table.as_ref() else {
+        return Ok(None);
+    };
+    let Some(edge_meta) = table_metadata_for(schema, &edge_table.keyspace, &edge_table.table)
+    else {
+        return Ok(None);
+    };
+    let Some(source_col) = edge_meta.extensions.get("graph.source") else {
+        return Ok(None);
+    };
+    let Some(target_col) = edge_meta.extensions.get("graph.target") else {
+        return Ok(None);
+    };
+
+    // Keep this fast path deliberately narrow: it replaces the pathological
+    // unanchored vertex-table scan for `MATCH (a)-[r {prop}]->(b)` with a
+    // single relationship-table scan filtered by edge properties. Anchored
+    // node patterns and anchor WHERE filters still use the general executor.
+    if !anchor.props.is_empty()
+        || !anchor.filters.is_empty()
+        || hop.prop_filters.is_empty()
+        || matches!(hop.direction, Direction::Both)
+        || !optional_hops.is_empty()
+    {
+        return Ok(None);
+    }
+
+    let edge_tid = TableId::new(&edge_table.keyspace, &edge_table.table);
+    let strategy = graph_replication_strategy(schema, &edge_table.keyspace)?;
+    let edge_partitions: Vec<Partition> = if let Some((key, _clustering)) =
+        build_direct_lookup_shape(
+            &edge_meta,
+            &HashMap::new(),
+            &hop.prop_filters,
+            &HashMap::new(),
+        )? {
+        write_path
+            .pk_read(&edge_tid, &key, ConsistencyLevel::One, &strategy)
+            .await?
+            .into_iter()
+            .collect()
+    } else {
+        write_path.range_read(&edge_tid).await?
+    };
+    let source_vertex_tid = TableId::new(&anchor.table.keyspace, &anchor.table.table);
+    let source_vertex_meta =
+        table_metadata_for(schema, &anchor.table.keyspace, &anchor.table.table);
+    let target_vertex = hop.vertex_table.as_ref();
+    let target_vertex_tid = target_vertex.map(|vt| TableId::new(&vt.keyspace, &vt.table));
+    let target_vertex_meta =
+        target_vertex.and_then(|vt| table_metadata_for(schema, &vt.keyspace, &vt.table));
+
+    let mut states = Vec::new();
+    for partition in edge_partitions {
+        if is_partition_dead(&partition) {
+            continue;
+        }
+        stats.edges_read += partition.rows.len();
+        for row in &partition.rows {
+            let edge_json = row_to_json(&edge_meta, &partition, row);
+            let edge_match = MatchedTableRow {
+                key: partition.key.clone(),
+                clustering: row.clustering.clone(),
+                json: edge_json.clone(),
+            };
+            if !edge_row_passes_filters(Some(&edge_match), &hop.prop_filters) {
+                continue;
+            }
+
+            let Some(raw_source_id) = extract_column_bytes_from_row(
+                &edge_meta,
+                partition.key.key.as_bytes(),
+                row,
+                source_col,
+            ) else {
+                continue;
+            };
+            let Some(raw_target_id) = extract_column_bytes_from_row(
+                &edge_meta,
+                partition.key.key.as_bytes(),
+                row,
+                target_col,
+            ) else {
+                continue;
+            };
+            let (source_id, target_id) = match hop.direction {
+                Direction::Out => (raw_source_id, raw_target_id),
+                Direction::In => (raw_target_id, raw_source_id),
+                Direction::Both => unreachable!("Both is rejected above"),
+            };
+
+            let mut edge_bindings = HashMap::new();
+            edge_bindings.insert("_edge".to_string(), edge_json.clone());
+
+            let source_json = if let Some(meta) = source_vertex_meta.as_ref() {
+                find_vertex_match(
+                    write_path,
+                    &source_vertex_tid,
+                    meta,
+                    &edge_bindings,
+                    &source_id,
+                    anchor.props.as_slice(),
+                    anchor.var.as_deref().unwrap_or("_anchor"),
+                    schema,
+                )
+                .await?
+                .map(|matched| matched.json)
+            } else {
+                None
+            };
+            if source_vertex_meta.is_some() && source_json.is_none() {
+                continue;
+            }
+
+            let target_json = if let (Some(vertex_tid), Some(meta)) =
+                (target_vertex_tid.as_ref(), target_vertex_meta.as_ref())
+            {
+                find_vertex_match(
+                    write_path,
+                    vertex_tid,
+                    meta,
+                    &edge_bindings,
+                    &target_id,
+                    hop.target_props.as_slice(),
+                    hop.var.as_deref().unwrap_or("_hop"),
+                    schema,
+                )
+                .await?
+                .map(|matched| matched.json)
+            } else {
+                None
+            };
+            if target_vertex_meta.is_some() && target_json.is_none() {
+                continue;
+            }
+
+            let mut bindings = HashMap::new();
+            if let Some(anchor_var) = &anchor.var {
+                bindings.insert(
+                    anchor_var.clone(),
+                    source_json
+                        .unwrap_or_else(|| serde_json::Value::String(hex::encode(&source_id))),
+                );
+            }
+            if let Some(target_var) = &hop.var {
+                bindings.insert(
+                    target_var.clone(),
+                    target_json
+                        .unwrap_or_else(|| serde_json::Value::String(hex::encode(&target_id))),
+                );
+            }
+            if let Some(rel_var) = &hop.rel_var {
+                bindings.insert(
+                    rel_var.clone(),
+                    edge_binding_json(
+                        row,
+                        Some(&edge_match),
+                        hop.edge_label.as_deref(),
+                        &partition.key,
+                        &target_id,
+                    ),
+                );
+            }
+
+            states.push(ExpandState {
+                current_key: DecoratedKey::new(PartitionKey::new(target_id)),
+                bindings,
+            });
+        }
+    }
+
+    Ok(Some(states))
+}
+
 /// Check whether an edge row passes all property filters.
 ///
 /// Looks up the edge row in the given edge partition by matching the
@@ -1349,6 +1557,14 @@ fn edge_binding_json(
     }
 
     if let Some(edge_match) = edge_match {
+        map.insert(
+            "__ferrosa_key".to_string(),
+            serde_json::Value::String(hex::encode(edge_match.key.key.as_bytes())),
+        );
+        map.insert(
+            "__ferrosa_clustering".to_string(),
+            serde_json::Value::String(hex::encode(&edge_match.clustering)),
+        );
         if let serde_json::Value::Object(obj) = &edge_match.json {
             map.extend(obj.clone());
         }
@@ -1708,7 +1924,7 @@ async fn find_vertex_match(
     schema: Option<&Schema>,
 ) -> Result<Option<MatchedTableRow>> {
     if let Some((key, clustering)) =
-        build_direct_lookup_shape(meta, bindings, target_props, &HashMap::new())?
+        build_neighbor_vertex_lookup_shape(meta, bindings, target_props, neighbor_id)?
     {
         let strategy = graph_replication_strategy(schema, &table_id.keyspace)?;
         if let Some(partition) = write_path
@@ -1759,6 +1975,24 @@ async fn find_vertex_match(
     }
 
     Ok(None)
+}
+
+fn build_neighbor_vertex_lookup_shape(
+    meta: &ferrosa_schema::metadata::table::TableMetadata,
+    bindings: &HashMap<String, serde_json::Value>,
+    target_props: &[(String, Expr)],
+    neighbor_id: &[u8],
+) -> Result<Option<(DecoratedKey, Vec<u8>)>> {
+    let mut direct_components = HashMap::new();
+    if let Some((column_name, _)) = meta
+        .clustering_key
+        .iter()
+        .find(|(name, _)| name == "id" || name.ends_with("_id") || name.ends_with("_uuid"))
+    {
+        direct_components.insert(column_name.clone(), neighbor_id.to_vec());
+    }
+
+    build_direct_lookup_shape(meta, bindings, target_props, &direct_components)
 }
 
 fn build_direct_lookup_shape(
@@ -3197,15 +3431,45 @@ async fn execute_set(
             };
 
             if let Some(hex_id) = hex_id {
-                let key_bytes = hex::decode(hex_id)
-                    .map_err(|e| GraphError::Internal(format!("invalid hex vertex ID: {e}")))?;
-                let key = DecoratedKey::new(PartitionKey::new(key_bytes));
-
                 let table_name = variable_tables
                     .get(col_name)
                     .map(String::as_str)
                     .unwrap_or(col_name);
                 let table_id = TableId::new(keyspace, table_name);
+                let table_meta = table_metadata_for(schema, keyspace, table_name);
+                let is_edge_table = table_meta.as_ref().is_some_and(|meta| {
+                    meta.extensions
+                        .get("graph.type")
+                        .is_some_and(|graph_type| graph_type == "edge")
+                });
+                let key_hex = if is_edge_table {
+                    row_values
+                        .get(col_idx)
+                        .and_then(|value| value.as_object())
+                        .and_then(|map| map.get("__ferrosa_key"))
+                        .and_then(|value| value.as_str())
+                        .unwrap_or(hex_id)
+                } else {
+                    hex_id
+                };
+                let key_bytes = hex::decode(key_hex)
+                    .map_err(|e| GraphError::Internal(format!("invalid hex storage key: {e}")))?;
+                let key = DecoratedKey::new(PartitionKey::new(key_bytes));
+                let clustering = if is_edge_table {
+                    row_values
+                        .get(col_idx)
+                        .and_then(|value| value.as_object())
+                        .and_then(|map| map.get("__ferrosa_clustering"))
+                        .and_then(|value| value.as_str())
+                        .map(hex::decode)
+                        .transpose()
+                        .map_err(|e| {
+                            GraphError::Internal(format!("invalid hex storage clustering: {e}"))
+                        })?
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
 
                 let mut cells = Vec::with_capacity(matching_assignments.len());
                 for (_var, prop, val) in matching_assignments {
@@ -3236,7 +3500,7 @@ async fn execute_set(
                 }
 
                 let update_row = Row {
-                    clustering: vec![],
+                    clustering,
                     cells,
                     deletion: DeletionTime::LIVE,
                     primary_key_liveness: LivenessInfo::NONE,
@@ -3324,10 +3588,6 @@ async fn execute_delete(
             };
 
             if let Some(hex_id) = hex_id {
-                let key_bytes = hex::decode(&hex_id)
-                    .map_err(|e| GraphError::Internal(format!("invalid hex vertex ID: {e}")))?;
-                let key = DecoratedKey::new(PartitionKey::new(key_bytes));
-
                 // Use the resolved table name (e.g. "Person") rather than
                 // the Cypher variable name (e.g. "n") so the tombstone is
                 // written to the same table that the vertex lives in.
@@ -3336,10 +3596,44 @@ async fn execute_delete(
                     .map(String::as_str)
                     .unwrap_or(col_name);
                 let table_id = TableId::new(keyspace, table_name);
+                let table_meta = table_metadata_for(schema, keyspace, table_name);
+                let is_edge_table = table_meta.as_ref().is_some_and(|meta| {
+                    meta.extensions
+                        .get("graph.type")
+                        .is_some_and(|graph_type| graph_type == "edge")
+                });
+                let key_hex = if is_edge_table {
+                    row_values
+                        .get(col_idx)
+                        .and_then(|value| value.as_object())
+                        .and_then(|map| map.get("__ferrosa_key"))
+                        .and_then(|value| value.as_str())
+                        .unwrap_or(hex_id.as_str())
+                } else {
+                    hex_id.as_str()
+                };
+                let key_bytes = hex::decode(key_hex)
+                    .map_err(|e| GraphError::Internal(format!("invalid hex storage key: {e}")))?;
+                let key = DecoratedKey::new(PartitionKey::new(key_bytes));
+                let clustering = if is_edge_table {
+                    row_values
+                        .get(col_idx)
+                        .and_then(|value| value.as_object())
+                        .and_then(|map| map.get("__ferrosa_clustering"))
+                        .and_then(|value| value.as_str())
+                        .map(hex::decode)
+                        .transpose()
+                        .map_err(|e| {
+                            GraphError::Internal(format!("invalid hex storage clustering: {e}"))
+                        })?
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
 
                 // Write a row-level tombstone.
                 let tombstone_row = Row {
-                    clustering: vec![],
+                    clustering,
                     cells: vec![],
                     deletion: DeletionTime::new(timestamp, local_deletion_time),
                     primary_key_liveness: LivenessInfo::NONE,
@@ -4356,6 +4650,37 @@ mod tests {
             build_direct_lookup_shape(&meta, &bindings, &props, &HashMap::new())
                 .unwrap()
                 .expect("scoped bindings should produce a direct vertex lookup");
+
+        assert_eq!(
+            key.key.as_bytes(),
+            encode_partition_components(&[
+                tenant_id.as_bytes().to_vec(),
+                session_id.as_bytes().to_vec(),
+            ])
+        );
+        assert_eq!(clustering, entity_id.as_bytes().to_vec());
+    }
+
+    #[test]
+    fn build_neighbor_vertex_lookup_shape_uses_edge_scope_and_neighbor_id() {
+        let meta = scoped_entity_meta();
+        let tenant_id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let session_id = uuid::Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let entity_id = uuid::Uuid::parse_str("66666666-7777-8888-9999-aaaaaaaaaaaa").unwrap();
+
+        let mut bindings = HashMap::new();
+        bindings.insert(
+            "_edge".to_string(),
+            serde_json::json!({
+                "tenant_id": tenant_id.to_string(),
+                "session_id": session_id.to_string()
+            }),
+        );
+
+        let (key, clustering) =
+            build_neighbor_vertex_lookup_shape(&meta, &bindings, &[], entity_id.as_bytes())
+                .unwrap()
+                .expect("edge scope plus neighbor id should produce a direct vertex lookup");
 
         assert_eq!(
             key.key.as_bytes(),

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -3966,6 +3966,102 @@ async fn co_occurs_merge_on_tiny_agent_memory_graph_is_immediately_matchable() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0][0].as_str(), Some(src_id.to_string().as_str()));
     assert_eq!(rows[0][1].as_str(), Some(dst_id.to_string().as_str()));
+
+    let set_query = format!(
+        "MATCH (a:Entity)-[r:CO_OCCURS_WITH {{tenant_id: '{tenant_id}', entity_a: '{src_id}', entity_b: '{dst_id}'}}]->(b:Entity) \
+         SET r.strength = 0.25"
+    );
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": set_query,
+            "keyspace": "agent_memory"
+        })),
+    );
+    let resp = tokio::time::timeout(std::time::Duration::from_secs(1), app.oneshot(req))
+        .await
+        .expect("edge-keyed fmem CO_OCCURS SET must return immediately")
+        .unwrap();
+    let status = resp.status();
+    let body = response_json(resp).await;
+    assert_eq!(status, StatusCode::OK, "SET response body: {body:#}");
+
+    let match_query = format!(
+        "MATCH (a:Entity)-[r:CO_OCCURS_WITH {{tenant_id: '{tenant_id}'}}]->(b:Entity) \
+         RETURN a.entity_id AS src_id, b.entity_id AS dst_id, r.strength AS strength"
+    );
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": match_query,
+            "keyspace": "agent_memory"
+        })),
+    );
+    let resp = tokio::time::timeout(std::time::Duration::from_secs(1), app.oneshot(req))
+        .await
+        .expect("updated tiny fmem CO_OCCURS list MATCH must return immediately")
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"]
+        .as_array()
+        .expect("MATCH response must include rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_str(), Some(src_id.to_string().as_str()));
+    assert_eq!(rows[0][1].as_str(), Some(dst_id.to_string().as_str()));
+    assert_eq!(rows[0][2].as_f64(), Some(0.25));
+
+    let delete_query = format!(
+        "MATCH (a:Entity)-[r:CO_OCCURS_WITH {{tenant_id: '{tenant_id}', entity_a: '{src_id}', entity_b: '{dst_id}'}}]->(b:Entity) \
+         DELETE r"
+    );
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": delete_query,
+            "keyspace": "agent_memory"
+        })),
+    );
+    let resp = tokio::time::timeout(std::time::Duration::from_secs(1), app.oneshot(req))
+        .await
+        .expect("edge-keyed fmem CO_OCCURS DELETE must return immediately")
+        .unwrap();
+    let status = resp.status();
+    let body = response_json(resp).await;
+    assert_eq!(status, StatusCode::OK, "DELETE response body: {body:#}");
+
+    let match_query = format!(
+        "MATCH (a:Entity)-[r:CO_OCCURS_WITH {{tenant_id: '{tenant_id}'}}]->(b:Entity) \
+         RETURN a.entity_id AS src_id, b.entity_id AS dst_id, r.strength AS strength"
+    );
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": match_query,
+            "keyspace": "agent_memory"
+        })),
+    );
+    let resp = tokio::time::timeout(std::time::Duration::from_secs(1), app.oneshot(req))
+        .await
+        .expect("deleted tiny fmem CO_OCCURS list MATCH must return immediately")
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"]
+        .as_array()
+        .expect("MATCH response must include rows");
+    assert!(
+        rows.is_empty(),
+        "DELETE must remove the matched edge: {rows:#?}"
+    );
 }
 
 #[tokio::test]

--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -202,10 +202,30 @@ impl<R: ReadAt> SSTableReader<R> {
     /// Read all partitions from this SSTable in storage order.
     ///
     /// Scans the Data.db file sequentially from position 0, reading each
-    /// partition until EOF. Used by the compaction executor to merge
-    /// multiple SSTables.
+    /// partition until EOF. **Materializes the entire SSTable into memory.**
+    ///
+    /// Prefer [`Self::partitions_iter`] for compaction and other large-scan
+    /// callers — full materialization here was OOM-ing the compaction
+    /// executor on tombstone-heavy workloads (`cql_timeseries2`, IoT TTL
+    /// patterns).  See `specs/in-process/streaming-compaction.md`.
     pub fn read_all_partitions(&self) -> Result<Vec<crate::types::Partition>> {
         self.read_partitions_limited(usize::MAX)
+    }
+
+    /// Stream partitions from this SSTable in storage (token) order, one at
+    /// a time, without materializing the whole file into memory.
+    ///
+    /// The returned iterator borrows this `SSTableReader` for its lifetime
+    /// and decompresses the Data.db once up-front (for compressed
+    /// SSTables) or reads directly from the underlying [`ReadAt`] (for
+    /// uncompressed). Each call to [`PartitionIter::next_partition`] yields
+    /// at most one partition; the iterator returns `Ok(None)` at EOF.
+    ///
+    /// Memory: `O(decompressed_data_size)` for compressed SSTables (single
+    /// pre-decompressed buffer held for the iterator's lifetime), `O(1)`
+    /// for uncompressed.  Independent of partition count.
+    pub fn partitions_iter(&self) -> Result<PartitionIter<'_, R>> {
+        PartitionIter::new(self)
     }
 
     /// Scan partitions sequentially, stopping once `limit` partitions have
@@ -249,6 +269,55 @@ impl<R: ReadAt> SSTableReader<R> {
             }
         }
         Ok(partitions)
+    }
+}
+
+/// Streaming partition iterator over an SSTable.
+///
+/// Returned by [`SSTableReader::partitions_iter`]. Yields partitions in
+/// storage (token) order, one at a time. Decompression happens once at
+/// construction time for compressed SSTables; the decompressed buffer is
+/// held for the iterator's lifetime and freed on drop.
+///
+/// Memory cost is constant in the number of partitions — only the
+/// currently-yielded `Partition` is materialized.
+pub struct PartitionIter<'a, R: ReadAt> {
+    sst: &'a SSTableReader<R>,
+    pos: u64,
+    /// Decompressed Data.db for compressed SSTables. `None` for
+    /// uncompressed, where the iterator reads directly from `sst.data`.
+    decompressed: Option<Vec<u8>>,
+}
+
+impl<'a, R: ReadAt> PartitionIter<'a, R> {
+    fn new(sst: &'a SSTableReader<R>) -> Result<Self> {
+        let decompressed = match &sst.compression_info {
+            Some(ci) => Some(decompress_data(&sst.data, ci)?),
+            None => None,
+        };
+        Ok(Self {
+            sst,
+            pos: 0,
+            decompressed,
+        })
+    }
+
+    /// Yield the next partition in storage order. Returns `Ok(None)` when
+    /// the iterator has reached EOF.
+    pub fn next_partition(&mut self) -> Result<Option<crate::types::Partition>> {
+        let header = &self.sst.header;
+        if let Some(ref buf) = self.decompressed {
+            let slice: &[u8] = buf.as_slice();
+            let mut reader = crate::data::DataReader::new(&slice, header, self.pos);
+            let result = reader.read_partition()?;
+            self.pos = reader.position();
+            Ok(result)
+        } else {
+            let mut reader = crate::data::DataReader::new(&self.sst.data, header, self.pos);
+            let result = reader.read_partition()?;
+            self.pos = reader.position();
+            Ok(result)
+        }
     }
 }
 
@@ -615,5 +684,53 @@ mod tests {
 
         // Verify compression_info is None
         assert!(reader.compression_info().is_none());
+    }
+
+    /// Parity: streaming `partitions_iter()` yields the same sequence as
+    /// the materializing `read_all_partitions()`.  This is the regression
+    /// guard for the streaming-compaction refactor.
+    #[test]
+    fn partitions_iter_matches_read_all_partitions() {
+        let header = test_header();
+        let dks: Vec<_> = (0..7u32)
+            .map(|i| DecoratedKey::new(PartitionKey::from(format!("pk{i:02}").as_bytes())))
+            .collect();
+        let mut data_bytes = Vec::new();
+        let mut positions = Vec::new();
+        for dk in &dks {
+            positions.push(data_bytes.len() as u64);
+            data_bytes.extend_from_slice(&build_data_blob(dk.key.as_bytes()));
+        }
+        let dk_pos: Vec<_> = dks.iter().zip(positions.iter().copied()).collect();
+        let partitions_bytes =
+            build_partition_index(&dk_pos.iter().map(|(d, p)| (*d, *p)).collect::<Vec<_>>());
+        let filter_bytes = build_bloom_filter(&dks.iter().collect::<Vec<_>>());
+        let stats_bytes = build_statistics(header);
+
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        let materialized = reader.read_all_partitions().expect("read_all");
+        let mut streamed = Vec::new();
+        let mut iter = reader.partitions_iter().expect("partitions_iter");
+        while let Some(p) = iter.next_partition().expect("next") {
+            streamed.push(p);
+        }
+
+        assert_eq!(materialized.len(), streamed.len(), "same partition count");
+        for (m, s) in materialized.iter().zip(streamed.iter()) {
+            assert_eq!(m.key, s.key);
+            assert_eq!(m.rows.len(), s.rows.len());
+        }
+        // EOF stays at EOF
+        assert!(iter.next_partition().unwrap().is_none());
+        assert!(iter.next_partition().unwrap().is_none());
     }
 }

--- a/ferrosa-storage/src/compaction/executor.rs
+++ b/ferrosa-storage/src/compaction/executor.rs
@@ -108,33 +108,36 @@ impl Drop for CompactionExecutor {
 
 impl CompactionExecutor {
     /// Execute a single compaction task by merging input SSTables into one output.
+    ///
+    /// **Streaming compaction**: this function uses a k-way streaming merge
+    /// across the input SSTables instead of materializing them all into
+    /// `BTreeMap<key, Vec<Partition>>` + `Vec<merged>` (which OOM'd on
+    /// tombstone-heavy workloads with wide partitions — see
+    /// `cql_timeseries2` and IoT TTL patterns).
+    ///
+    /// Memory cost is now O(N_input_sstables × 1 partition) at any moment,
+    /// independent of the total dataset size. The output's serialization
+    /// header is built from the inputs' headers (bounded compute) rather
+    /// than from a full data scan.
     fn execute_task(task: &CompactionTask) -> std::result::Result<SSTableMetadata, String> {
-        use crate::flush::{self, FileFlushTarget, FlushTarget};
+        use crate::flush::{FileFlushTarget, FlushTarget};
         use crate::merge;
         use ferrosa_sstable::io::FileReadAt;
         use ferrosa_sstable::reader::{SSTableComponents, SSTableReader};
         use ferrosa_sstable::writer::SSTableWriter;
         use ferrosa_sstable::WriteOptions;
-        use std::collections::BTreeMap;
+        use std::collections::BinaryHeap;
 
         tracing::info!(
             table_id = %task.table_id,
             inputs = task.inputs.len(),
-            "compaction: starting task"
+            "compaction: starting streaming task"
         );
 
-        // 1. Read all partitions from each input SSTable.
-        //
-        // CRITICAL: If ANY input SSTable fails to read, the entire compaction
-        // must abort. Previously, unreadable SSTables were silently skipped
-        // while the task succeeded. This caused data loss because
-        // swap_compacted_sstables removes ALL input SSTables (including the
-        // skipped unreadable ones) and replaces them with the output — which
-        // only contains data from the successfully-read inputs.
-        let mut all_partitions: BTreeMap<Vec<u8>, Vec<ferrosa_sstable::types::Partition>> =
-            BTreeMap::new();
-        let mut total_input_rows: usize = 0;
-
+        // 1. Open every input SSTable.  ANY missing/corrupt input aborts the
+        //    whole compaction — silent skipping previously caused data loss
+        //    because swap_compacted_sstables removes all inputs.
+        let mut readers: Vec<SSTableReader<FileReadAt>> = Vec::with_capacity(task.inputs.len());
         for input in &task.inputs {
             let gen = &input.id;
             let dir = &input.path;
@@ -145,7 +148,7 @@ impl CompactionExecutor {
                 %gen,
                 data_file_size,
                 path = ?data_path,
-                "compaction: reading input SSTable"
+                "compaction: opening input SSTable"
             );
             match std::fs::metadata(&data_path) {
                 Ok(meta) if meta.len() == 0 => {
@@ -185,48 +188,164 @@ impl CompactionExecutor {
             })
             .map_err(|e| format!("aborting compaction: SSTable {gen} corrupt: {e}"))?;
 
-            let partitions = reader
-                .read_all_partitions()
-                .map_err(|e| format!("aborting compaction: SSTable {gen} read failed: {e}"))?;
+            readers.push(reader);
+        }
 
-            let input_row_count: usize = partitions.iter().map(|p| p.rows.len()).sum();
-            total_input_rows += input_row_count;
-            tracing::info!(
-                %gen,
-                partitions = partitions.len(),
-                rows = input_row_count,
-                "compaction: input SSTable stats"
+        if readers.is_empty() {
+            return Err("no input SSTables to compact".into());
+        }
+
+        // 2. Build the output serialization header by combining the inputs'
+        //    own headers.  Each input header records the min/max ts and
+        //    ldt observed in that SSTable; the union is correct for the
+        //    output (it's a strict superset of what's actually written
+        //    because deletions can drop cells, but conservative is fine —
+        //    drivers don't depend on it being tight).  Picking ferrosa's
+        //    column model from the schema mirrors the legacy
+        //    `flush::build_serialization_header` behaviour.
+        let header = combine_input_headers(&task.schema, &readers);
+        let header_min_ts = header.min_timestamp;
+        let header_max_ts = header.max_timestamp;
+        tracing::info!(
+            min_ts = header_min_ts,
+            max_ts = header_max_ts,
+            "compaction: combined output serialization header"
+        );
+
+        let options = WriteOptions {
+            compression: None,
+            ..WriteOptions::default()
+        };
+        let mut writer = SSTableWriter::new(options, header);
+
+        // 3. K-way streaming merge across the input partition iterators.
+        //
+        // Min-heap (custom `Ord` flips the comparison) yields the
+        // smallest partition key.  For each minimum key we drain every
+        // reader currently exposing that key (replenishing as we go),
+        // run `merge::merge_partitions`, write the result, and free it.
+        let mut iters: Vec<ferrosa_sstable::reader::PartitionIter<'_, FileReadAt>> =
+            Vec::with_capacity(readers.len());
+        for r in &readers {
+            iters.push(
+                r.partitions_iter()
+                    .map_err(|e| format!("partitions_iter: {e}"))?,
             );
+        }
 
-            for p in partitions {
-                all_partitions
-                    .entry(p.key.key.as_bytes().to_vec())
-                    .or_default()
-                    .push(p);
+        // Heap entry: the Partition is moved into the heap (no key
+        // clones), with a custom `Ord` that sorts by the partition's
+        // own DecoratedKey in token-comparable order.  This eliminates
+        // the O(N) key-allocation pressure the previous (key.clone(),
+        // idx) design caused.
+        struct HeapEntry {
+            partition: ferrosa_sstable::types::Partition,
+            reader_idx: usize,
+        }
+        impl PartialEq for HeapEntry {
+            fn eq(&self, other: &Self) -> bool {
+                self.partition.key == other.partition.key
+            }
+        }
+        impl Eq for HeapEntry {}
+        impl PartialOrd for HeapEntry {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+        impl Ord for HeapEntry {
+            // BinaryHeap is a max-heap; we want a min-heap, so flip the
+            // comparison (smaller DecoratedKey "wins" the pop).
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                other.partition.key.cmp(&self.partition.key)
             }
         }
 
+        let mut heap: BinaryHeap<HeapEntry> = BinaryHeap::with_capacity(iters.len());
+        for (idx, it) in iters.iter_mut().enumerate() {
+            if let Some(partition) = it.next_partition().map_err(|e| format!("iter init: {e}"))? {
+                heap.push(HeapEntry {
+                    partition,
+                    reader_idx: idx,
+                });
+            }
+        }
+
+        let mut total_input_rows: usize = 0;
+        let mut merged_partition_count: u64 = 0;
+        let mut merged_row_count: usize = 0;
+        // Track min/max token across all merged output partitions so the
+        // emitted SSTableMetadata can be filled without a second scan.
+        let mut min_token: i64 = i64::MAX;
+        let mut max_token: i64 = i64::MIN;
+
+        while let Some(top) = heap.pop() {
+            // Drain all heap entries that share this key (multiple inputs
+            // wrote the same partition).
+            let HeapEntry {
+                partition: first_partition,
+                reader_idx: first_idx,
+            } = top;
+            // We need to compare future heap tops against this key to
+            // collect duplicates. The partition itself moves into the
+            // group; cheap to compare via a reference into `group`
+            // afterward.
+            total_input_rows += first_partition.rows.len();
+            let mut group: Vec<ferrosa_sstable::types::Partition> = Vec::with_capacity(1);
+            group.push(first_partition);
+            // Advance reader first_idx.
+            if let Some(next) = iters[first_idx]
+                .next_partition()
+                .map_err(|e| format!("iter advance: {e}"))?
+            {
+                heap.push(HeapEntry {
+                    partition: next,
+                    reader_idx: first_idx,
+                });
+            }
+            // Drain other readers sitting at the same key.
+            while heap.peek().map(|h| h.partition.key == group[0].key) == Some(true) {
+                let HeapEntry {
+                    partition,
+                    reader_idx,
+                } = heap.pop().expect("peek implies pop");
+                total_input_rows += partition.rows.len();
+                group.push(partition);
+                if let Some(next) = iters[reader_idx]
+                    .next_partition()
+                    .map_err(|e| format!("iter advance: {e}"))?
+                {
+                    heap.push(HeapEntry {
+                        partition: next,
+                        reader_idx,
+                    });
+                }
+            }
+
+            let merged = merge::merge_partitions(group);
+            merged_row_count += merged.rows.len();
+            merged_partition_count += 1;
+            let token = merged.key.token.0;
+            if token < min_token {
+                min_token = token;
+            }
+            if token > max_token {
+                max_token = token;
+            }
+            writer
+                .add_partition(&merged)
+                .map_err(|e| format!("write partition: {e}"))?;
+        }
+
+        if merged_partition_count == 0 {
+            return Err("no partitions to compact".into());
+        }
+
         tracing::info!(
-            unique_keys = all_partitions.len(),
-            total_input_rows,
-            "compaction: total input summary"
-        );
-
-        // 2. Merge partitions with the same key.
-        let mut merged: Vec<ferrosa_sstable::types::Partition> = all_partitions
-            .into_values()
-            .map(merge::merge_partitions)
-            .collect();
-
-        // 3. Sort by key (SSTableWriter requires token order).
-        merged.sort_by(|a, b| a.key.cmp(&b.key));
-
-        let merged_row_count: usize = merged.iter().map(|p| p.rows.len()).sum();
-        tracing::info!(
-            partitions = merged.len(),
+            partitions = merged_partition_count,
             merged_row_count,
             total_input_rows,
-            "compaction: after merge"
+            "compaction: streaming merge complete"
         );
         if merged_row_count < total_input_rows {
             tracing::warn!(
@@ -237,70 +356,56 @@ impl CompactionExecutor {
             );
         }
 
-        if merged.is_empty() {
-            return Err("no partitions to compact".into());
-        }
-
-        // 4. Build serialization header and write output SSTable.
-        let header = flush::build_serialization_header(&task.schema, &merged);
-        tracing::info!(
-            min_ts = header.min_timestamp,
-            max_ts = header.max_timestamp,
-            "compaction: serialization header"
-        );
-        let header_min_ts = header.min_timestamp;
-        let header_max_ts = header.max_timestamp;
-        let options = WriteOptions {
-            compression: None,
-            ..WriteOptions::default()
-        };
-        let mut writer = SSTableWriter::new(options, header);
-        for p in &merged {
-            writer
-                .add_partition(p)
-                .map_err(|e| format!("write partition: {e}"))?;
-        }
         let output = writer.finish().map_err(|e| format!("finish: {e}"))?;
 
-        // 5. Write to output directory via FileFlushTarget.
+        // 4. Write to output directory via FileFlushTarget.
         let flush_target = FileFlushTarget::new_starting_at(task.output_dir.clone())
             .map_err(|e| format!("flush target: {e}"))?;
         let reader = flush_target
             .flush(output)
             .map_err(|e| format!("flush output: {e}"))?;
 
-        // Readback verification: immediately re-read the output to ensure
-        // the SSTable roundtrip is lossless.
-        let readback_partitions = reader
-            .read_all_partitions()
-            .map_err(|e| format!("CORRUPTION: output SSTable readback failed: {e}"))?;
-        let readback_row_count: usize = readback_partitions.iter().map(|p| p.rows.len()).sum();
-        if readback_partitions.len() != merged.len() || readback_row_count != merged_row_count {
+        // 5. Streaming readback verification — count partitions and rows
+        //    without materializing the output back into a Vec.  Catches
+        //    Data.db / Partitions.db inconsistencies that would corrupt
+        //    later reads.
+        let mut readback_partitions: u64 = 0;
+        let mut readback_rows: usize = 0;
+        {
+            let mut iter = reader
+                .partitions_iter()
+                .map_err(|e| format!("CORRUPTION: output partitions_iter failed: {e}"))?;
+            while let Some(p) = iter
+                .next_partition()
+                .map_err(|e| format!("CORRUPTION: output read failed: {e}"))?
+            {
+                readback_partitions += 1;
+                readback_rows += p.rows.len();
+            }
+        }
+        if readback_partitions != merged_partition_count || readback_rows != merged_row_count {
             tracing::error!(
-                written_partitions = merged.len(),
+                written_partitions = merged_partition_count,
                 written_rows = merged_row_count,
-                readback_partitions = readback_partitions.len(),
-                readback_rows = readback_row_count,
+                readback_partitions,
+                readback_rows,
                 "compaction: CORRUPTION DETECTED in output SSTable"
             );
             return Err(format!(
                 "compaction output SSTable is corrupt: expected {} partitions/{} rows, \
                  readback got {} partitions/{} rows",
-                merged.len(),
-                merged_row_count,
-                readback_partitions.len(),
-                readback_row_count
+                merged_partition_count, merged_row_count, readback_partitions, readback_rows
             ));
         }
         tracing::info!(
-            partitions = readback_partitions.len(),
-            rows = readback_row_count,
-            "compaction: output verified (matches merge)"
+            partitions = readback_partitions,
+            rows = readback_rows,
+            "compaction: output verified (streaming readback matches merge)"
         );
 
         let gen = flush_target.generation();
         let output_id = format!("{gen}");
-        let partition_count = merged.len() as u64;
+        let partition_count = merged_partition_count;
 
         let total_size: u64 = [
             format!("{gen}-Data.db"),
@@ -317,12 +422,12 @@ impl CompactionExecutor {
         })
         .sum();
 
-        let min_token = merged.first().map(|p| p.key.token.0).unwrap_or(0);
-        let max_token = merged.last().map(|p| p.key.token.0).unwrap_or(0);
+        // min/max token tracked inline during the streaming merge; if the
+        // merge produced zero partitions we'd have returned above.
 
-        // Use the actual header timestamps from the merged data, not the
-        // input metadata. Input metadata may have stale/incorrect values
-        // that propagate to future compactions.
+        // Use the combined-header timestamps (from input headers) for the
+        // output metadata. Input metadata may have stale/incorrect values
+        // that would propagate; the header values are authoritative.
         Ok(SSTableMetadata {
             id: output_id,
             path: task.output_dir.clone(),
@@ -333,6 +438,69 @@ impl CompactionExecutor {
             max_timestamp: header_max_ts,
             partition_count,
         })
+    }
+}
+
+/// Build an output `SerializationHeader` from the inputs' own headers
+/// plus the (current) table schema, in `O(N_inputs)` time and without
+/// scanning Data.db.
+///
+/// Each input header already records the timestamp / ldt / ttl ranges
+/// observed when that SSTable was written; the output is the union of
+/// those ranges. The column model (key type, clustering, statics,
+/// regular columns) comes from the schema — same convention as the
+/// flush path used to use via `flush::build_serialization_header`.
+fn combine_input_headers<R: ferrosa_sstable::io::ReadAt>(
+    schema: &ferrosa_common::schema::TableSchema,
+    readers: &[ferrosa_sstable::reader::SSTableReader<R>],
+) -> ferrosa_sstable::statistics::SerializationHeader {
+    use ferrosa_common::{NO_DELETION_TIME, NO_TIMESTAMP, NO_TTL};
+    use ferrosa_sstable::statistics::SerializationHeader;
+
+    // Use the first reader's column model as the template; the schema
+    // shape is identical across all inputs by definition (compaction
+    // never mixes SSTables from different tables).
+    let template = readers
+        .first()
+        .map(|r| r.header().clone())
+        .unwrap_or_else(|| crate::flush::build_serialization_header(schema, &[]));
+
+    let mut min_timestamp = NO_TIMESTAMP;
+    let mut max_timestamp = i64::MIN;
+    let mut min_local_deletion_time = NO_DELETION_TIME;
+    let mut min_ttl = NO_TTL;
+
+    for r in readers {
+        let h = r.header();
+        if h.min_timestamp != NO_TIMESTAMP
+            && (min_timestamp == NO_TIMESTAMP || h.min_timestamp < min_timestamp)
+        {
+            min_timestamp = h.min_timestamp;
+        }
+        if h.max_timestamp > max_timestamp {
+            max_timestamp = h.max_timestamp;
+        }
+        if h.min_local_deletion_time != NO_DELETION_TIME
+            && (min_local_deletion_time == NO_DELETION_TIME
+                || h.min_local_deletion_time < min_local_deletion_time)
+        {
+            min_local_deletion_time = h.min_local_deletion_time;
+        }
+        if h.min_ttl != NO_TTL && (min_ttl == NO_TTL || h.min_ttl < min_ttl) {
+            min_ttl = h.min_ttl;
+        }
+    }
+
+    if max_timestamp == i64::MIN {
+        max_timestamp = NO_TIMESTAMP;
+    }
+
+    SerializationHeader {
+        min_timestamp,
+        max_timestamp,
+        min_local_deletion_time,
+        min_ttl,
+        ..template
     }
 }
 


### PR DESCRIPTION
## Summary
- Stream graph expansion reads without materializing large intermediate result sets
- Add graph HTTP integration coverage for streamed traversal paths
- Improve compaction/SSTable read paths to avoid full in-memory accumulation

## Test plan
- cargo fmt --all -- --check

Companion branch for ferrosa-memory PR #4 cluster integration.