### PR TITLE
perf: multiplex network lane + lock-free commit-log dirty tracking

### DIFF
--- a/ferrosa-cluster/src/coordinator/write.rs
+++ b/ferrosa-cluster/src/coordinator/write.rs
@@ -105,15 +105,10 @@ impl ClusterCoordinator {
         let replicas = ring.replicas(key.token.0, rf);
         let required = cl.block_for(rf);
 
-        {
-            let span = tracing::info_span!(
-                "cluster.write",
-                cl = %cl,
-                rf = rf,
-                replicas = replicas.len(),
-            );
-            let _enter = span.enter();
-        }
+        // No span here: the prior `info_span!{...}.enter()` was scoped to a
+        // bare block so it enclosed zero work — pure allocation cost on
+        // every write at INFO level (the default).  If finer-grained
+        // tracing is needed, instrument the surrounding handler instead.
 
         if replicas.len() < required {
             return Err(ClusterError::Unavailable {

--- a/ferrosa-cluster/src/coordinator/write.rs
+++ b/ferrosa-cluster/src/coordinator/write.rs
@@ -123,15 +123,6 @@ impl ClusterCoordinator {
             });
         }
 
-        let mutation = Mutation::new(
-            table_id.keyspace.clone(),
-            table_id.table.clone(),
-            key.clone(),
-            vec![row.clone()],
-            timestamp,
-        );
-        let body = encode_mutation(&mutation);
-
         // Collect (replica_id, Option<host_id>) before dropping the ring guard
         // so the futures we build don't hold a reference to the guard.
         let replica_targets: Vec<(u64, Option<(uuid::Uuid, String)>)> = replicas
@@ -144,6 +135,29 @@ impl ClusterCoordinator {
             })
             .collect();
         drop(ring);
+
+        // Lazy mutation encoding: only serialise the mutation if at least
+        // one replica is remote.  With cqld4 token-aware routing, every
+        // write lands on a coordinator that is also the owning replica
+        // (RF=1), so `body` was wasted ~50k allocations/s before this
+        // short-circuit.  `encode_mutation` does a heap allocation plus
+        // memcpy of the mutation bytes; skipping it for fully-local
+        // writes saves both CPU and allocator pressure.
+        let has_remote = replica_targets
+            .iter()
+            .any(|(replica_id, _)| *replica_id != self.local_node_id);
+        let body = if has_remote {
+            let mutation = Mutation::new(
+                table_id.keyspace.clone(),
+                table_id.table.clone(),
+                key.clone(),
+                vec![row.clone()],
+                timestamp,
+            );
+            Some(encode_mutation(&mutation))
+        } else {
+            None
+        };
 
         // Build concurrent futures for each replica.
         let mut fan_out: FuturesUnordered<_> = replica_targets
@@ -177,11 +191,24 @@ impl ClusterCoordinator {
                                 ReplicaResult::Failure { host_id: None }
                             }
                             Some((hid, addr)) => {
+                                // `body` is `Some` here because at least one
+                                // replica was non-local (we set it above when
+                                // `has_remote` was true).
+                                let forward_body = match body {
+                                    Some(b) => b,
+                                    None => {
+                                        tracing::error!(
+                                            replica_id,
+                                            "internal: missing body for remote replica"
+                                        );
+                                        return ReplicaResult::Failure { host_id: Some(hid) };
+                                    }
+                                };
                                 match coordinator
                                     .send_remote_write_with_reconnect(
                                         hid,
                                         &addr,
-                                        Message::MutationForward(body),
+                                        Message::MutationForward(forward_body),
                                     )
                                     .await
                                 {
@@ -231,7 +258,22 @@ impl ClusterCoordinator {
         // means anti-entropy repair must eventually fix divergence.
         if !failed_replicas.is_empty() {
             if let Some(ref hint_store) = self.hint_store {
-                let hint_row = body.to_vec();
+                // Hints only get stored for remote-replica failures (see
+                // the `Failure { host_id: Some(hid) }` arm above), which
+                // means we already computed `body` for forwarding.  If
+                // it's `None` here, hints simply can't be saved — fall
+                // through to the error branch below.
+                let hint_row = match body.as_ref() {
+                    Some(b) => b.to_vec(),
+                    None => {
+                        tracing::error!(
+                            failed_count = failed_replicas.len(),
+                            "internal: failed remote replicas with no encoded body — \
+                             divergent replicas will require anti-entropy repair"
+                        );
+                        Vec::new()
+                    }
+                };
                 let hint_key = key.key.as_bytes().to_vec();
                 for peer_id in &failed_replicas {
                     if let Err(e) = hint_store.store(

--- a/ferrosa-cluster/src/coordinator/write.rs
+++ b/ferrosa-cluster/src/coordinator/write.rs
@@ -105,10 +105,18 @@ impl ClusterCoordinator {
         let replicas = ring.replicas(key.token.0, rf);
         let required = cl.block_for(rf);
 
-        // No span here: the prior `info_span!{...}.enter()` was scoped to a
-        // bare block so it enclosed zero work — pure allocation cost on
-        // every write at INFO level (the default).  If finer-grained
-        // tracing is needed, instrument the surrounding handler instead.
+        // DEBUG-level span so it costs nothing at the default INFO filter.
+        // Keep the span construction outside the awaited fan-out below: a
+        // synchronous `entered()` guard must not be held across `.await`.
+        {
+            let span = tracing::debug_span!(
+                "cluster.write",
+                cl = %cl,
+                rf = rf,
+                replicas = replicas.len(),
+            );
+            let _enter = span.enter();
+        }
 
         if replicas.len() < required {
             return Err(ClusterError::Unavailable {

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -120,11 +120,29 @@ pub async fn handle_connection<S>(
     let (sub_tx, mut sub_rx) = tokio::sync::mpsc::channel::<crate::subscribe::SubscriptionPush>(64);
 
     // In-flight request limiter: bounds concurrent requests on this connection.
-    let in_flight = tokio::sync::Semaphore::new(max_in_flight);
+    // `Arc<Semaphore>` so spawned per-request tasks can hold owned permits;
+    // see the `dispatch_concurrent` path below.
+    let in_flight = Arc::new(tokio::sync::Semaphore::new(max_in_flight));
+
+    // Channel for responses produced by spawned request handlers (Query /
+    // Execute / Batch) back to this main loop, which owns `framed`. Without
+    // this, every request had to be fully processed before the loop could
+    // even read the next frame — turning CQL's stream-id-multiplexed protocol
+    // into a strictly-serial one-at-a-time channel and capping throughput
+    // at `1 / per_request_latency` per connection regardless of how many
+    // in-flight permits we advertised.
+    let (resp_tx, mut resp_rx) =
+        tokio::sync::mpsc::channel::<SpawnedResponse>(max_in_flight.max(64));
 
     loop {
-        // Use select to handle both client frames and subscription pushes.
+        // Use select to handle client frames, subscription pushes, and
+        // responses from spawned request handlers.
+        //
+        // `biased;` prefers draining responses first so the writer side
+        // doesn't lag the reader side under heavy concurrent load.
         let frame_or_push = tokio::select! {
+            biased;
+            Some(resp) = resp_rx.recv() => FrameOrPush::Response(resp),
             // M11: idle timeout — drop connection if no frame arrives within IDLE_TIMEOUT.
             result = timeout(IDLE_TIMEOUT, framed.next()) => {
                 match result {
@@ -171,6 +189,34 @@ pub async fn handle_connection<S>(
         };
 
         match frame_or_push {
+            FrameOrPush::Response(resp) => {
+                // Apply any keyspace mutation that the spawned handler
+                // observed (e.g. a `USE` statement). Mutations land here in
+                // spawn-completion order, not request-arrival order — same
+                // semantics as Cassandra under concurrent USE issuance.
+                if let Some(ks) = resp.keyspace_after {
+                    current_keyspace = ks;
+                }
+                if resp.bump_request_counter {
+                    state.connection_tracker.increment_requests(&peer);
+                }
+                if !apply_handle_result(
+                    resp.result,
+                    resp.stream_id,
+                    resp.response_version,
+                    &mut framed,
+                    &state,
+                    peer,
+                    &auth_context,
+                    &current_keyspace,
+                    &sub_tx,
+                    &mut subscription_state,
+                )
+                .await
+                {
+                    break;
+                }
+            }
             FrameOrPush::SubscriptionPush(push) => {
                 // Send streaming result frame from a subscription task.
                 let frame = CqlFrame {
@@ -185,12 +231,16 @@ pub async fn handle_connection<S>(
                 let stream_id = maybe_frame.header.stream_id;
 
                 // Check in-flight limit for request opcodes (QUERY, EXECUTE, BATCH).
+                // The permit lifetime is tied to the request: held inline
+                // (in `_permit`) for the rare opcodes still handled inline,
+                // and *moved into the spawned task* for Ready-phase
+                // Query/Execute/Batch via the concurrent dispatch path.
                 let is_request = matches!(
                     maybe_frame.header.opcode,
                     Opcode::Query | Opcode::Execute | Opcode::Batch
                 );
-                let _permit = if is_request {
-                    match in_flight.try_acquire() {
+                let acquired_permit: Option<tokio::sync::OwnedSemaphorePermit> = if is_request {
+                    match in_flight.clone().try_acquire_owned() {
                         Ok(permit) => Some(permit),
                         Err(_) => {
                             debug!("in-flight limit reached for {peer}, rejecting request");
@@ -224,6 +274,103 @@ pub async fn handle_connection<S>(
                 }
                 let was_awaiting_startup = matches!(phase, ConnectionPhase::AwaitingStartup);
                 let was_ready = matches!(phase, ConnectionPhase::Ready);
+
+                // Concurrent dispatch path: in `Ready` phase, run the
+                // common request opcodes on spawned tasks so the main
+                // loop can immediately read the next frame. This is what
+                // turns a per-connection serial channel into a real
+                // stream-id-multiplexed one (matching CQL native
+                // protocol semantics).
+                if was_ready
+                    && matches!(
+                        maybe_frame.header.opcode,
+                        Opcode::Query | Opcode::Execute | Opcode::Batch
+                    )
+                {
+                    let permit =
+                        acquired_permit.expect("permit acquired above for Query/Execute/Batch");
+                    let response_version = if client_protocol_version >= 0x05 {
+                        0x85
+                    } else {
+                        VERSION_RESPONSE
+                    };
+                    let opcode = maybe_frame.header.opcode;
+                    let body = maybe_frame.body.clone();
+                    let state_clone = state.clone();
+                    let resp_tx = resp_tx.clone();
+                    let ks_at_spawn = current_keyspace.clone();
+                    let mut auth_for_handler = auth_context.clone();
+                    let mut ks_for_handler = ks_at_spawn.clone();
+                    let peer_addr = peer;
+                    tokio::spawn(async move {
+                        let request_span = tracing::info_span!(
+                            "cql.request",
+                            cql.opcode = ?opcode,
+                            client.address = %peer_addr,
+                        );
+                        let result = (async {
+                            match opcode {
+                                Opcode::Query => {
+                                    handle_query(
+                                        &mut auth_for_handler,
+                                        &mut ks_for_handler,
+                                        &state_clone,
+                                        &body,
+                                        peer_addr,
+                                    )
+                                    .await
+                                }
+                                Opcode::Execute => {
+                                    handle_execute(
+                                        &mut auth_for_handler,
+                                        &mut ks_for_handler,
+                                        &state_clone,
+                                        &body,
+                                        peer_addr,
+                                    )
+                                    .await
+                                }
+                                Opcode::Batch => {
+                                    handle_batch(
+                                        &mut auth_for_handler,
+                                        &mut ks_for_handler,
+                                        &state_clone,
+                                        &body,
+                                        peer_addr,
+                                    )
+                                    .await
+                                }
+                                _ => unreachable!(
+                                    "concurrent dispatch only entered for Query/Execute/Batch"
+                                ),
+                            }
+                        })
+                        .instrument(request_span)
+                        .await;
+                        let keyspace_after = if ks_for_handler != ks_at_spawn {
+                            Some(ks_for_handler)
+                        } else {
+                            None
+                        };
+                        let _ = resp_tx
+                            .send(SpawnedResponse {
+                                stream_id,
+                                result,
+                                response_version,
+                                keyspace_after,
+                                bump_request_counter: true,
+                                _permit: permit,
+                            })
+                            .await;
+                    });
+                    continue;
+                }
+
+                // Inline path: handshake phases and rare Ready opcodes
+                // (Prepare, Register, Options). Keeps mutable connection
+                // state (`phase`, `auth_context`, `pending_compression`)
+                // owned by the main loop.
+                let _permit = acquired_permit;
 
                 debug!(
                     "received {:?} from {peer} stream={} phase={:?}",
@@ -458,10 +605,187 @@ pub async fn handle_connection<S>(
     debug!("connection handler for {peer} finished");
 }
 
-/// Internal enum for the select! loop — either a client frame or a subscription push.
+/// Apply a `HandleResult` from a spawned post-Ready handler to the
+/// connection's outbound side: writes the appropriate frame on `framed`,
+/// kicks off / cancels subscriptions if requested. Returns `false` if the
+/// caller should break out of the connection loop (e.g. socket send
+/// failure or `HandleResult::Close*`).
+///
+/// Only handles cases reachable from `Query` / `Execute` / `Batch` —
+/// handshake-driven codec changes (compression, v5-framing) stay on the
+/// inline path because they only fire for `Opcode::Ready` /
+/// `Opcode::AuthSuccess` and the inline match has the
+/// `client_protocol_version` / `pending_compression` it needs.
+#[allow(clippy::too_many_arguments)]
+async fn apply_handle_result<S>(
+    result: HandleResult,
+    stream_id: i16,
+    response_version: u8,
+    framed: &mut Framed<S, CqlCodec>,
+    state: &Arc<SharedState>,
+    _peer: SocketAddr,
+    auth_context: &Option<AuthContext>,
+    current_keyspace: &Option<String>,
+    sub_tx: &tokio::sync::mpsc::Sender<crate::subscribe::SubscriptionPush>,
+    subscription_state: &mut SubscriptionState,
+) -> bool
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
+    match result {
+        HandleResult::Reply(opcode, body) => {
+            let frame = CqlFrame {
+                header: FrameHeader {
+                    version: response_version,
+                    flags: 0,
+                    stream_id,
+                    opcode,
+                    length: 0,
+                },
+                body: body.freeze(),
+            };
+            framed.send(frame).await.is_ok()
+        }
+        HandleResult::StartSubscription {
+            inner,
+            interval,
+            delta,
+        } => {
+            let interval = match interval {
+                Some(d) => d,
+                None => {
+                    let err = CqlError::Invalid(
+                        "SUBSCRIBE without EVERY not yet supported; use SUBSCRIBE ... EVERY <interval>"
+                            .into(),
+                    );
+                    let frame = CqlFrame {
+                        header: FrameHeader {
+                            version: VERSION_RESPONSE,
+                            flags: 0,
+                            stream_id,
+                            opcode: Opcode::Error,
+                            length: 0,
+                        },
+                        body: err.encode_body().freeze(),
+                    };
+                    return framed.send(frame).await.is_ok();
+                }
+            };
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let handle = crate::subscribe::SubscriptionHandle {
+                stream_id: stream_id as u16,
+                cancel: cancel.clone(),
+            };
+            if let Err(msg) = subscription_state.add(handle) {
+                let err = CqlError::Invalid(msg.to_string());
+                let frame = CqlFrame {
+                    header: FrameHeader {
+                        version: VERSION_RESPONSE,
+                        flags: 0,
+                        stream_id,
+                        opcode: Opcode::Error,
+                        length: 0,
+                    },
+                    body: err.encode_body().freeze(),
+                };
+                return framed.send(frame).await.is_ok();
+            }
+            let ack_body = crate::result::encode_void().freeze();
+            let frame = CqlFrame {
+                header: FrameHeader {
+                    version: VERSION_RESPONSE,
+                    flags: 0,
+                    stream_id,
+                    opcode: Opcode::Result,
+                    length: 0,
+                },
+                body: ack_body,
+            };
+            if framed.send(frame).await.is_err() {
+                return false;
+            }
+            let auth = auth_context.clone().unwrap_or(AuthContext {
+                role: "cassandra".to_string(),
+                is_superuser: true,
+                must_change_password: false,
+            });
+            crate::subscribe::spawn_subscription_poll(
+                stream_id,
+                interval,
+                state.clone(),
+                auth,
+                current_keyspace.clone(),
+                *inner,
+                sub_tx.clone(),
+                cancel,
+                delta,
+            );
+            true
+        }
+        HandleResult::CancelSubscription { stream_id: sub_id } => {
+            subscription_state.cancel(sub_id);
+            let frame = CqlFrame {
+                header: FrameHeader {
+                    version: VERSION_RESPONSE,
+                    flags: 0,
+                    stream_id,
+                    opcode: Opcode::Result,
+                    length: 0,
+                },
+                body: crate::result::encode_void().freeze(),
+            };
+            framed.send(frame).await.is_ok()
+        }
+        HandleResult::Close(opcode, body) => {
+            let frame = CqlFrame {
+                header: FrameHeader {
+                    version: VERSION_RESPONSE,
+                    flags: 0,
+                    stream_id,
+                    opcode,
+                    length: 0,
+                },
+                body: body.freeze(),
+            };
+            let _ = framed.send(frame).await;
+            false
+        }
+        HandleResult::CloseNow => false,
+    }
+}
+
+/// Internal enum for the select! loop — either a client frame, a subscription
+/// push, or a response from a spawned request handler.
 enum FrameOrPush {
     ClientFrame(CqlFrame),
     SubscriptionPush(crate::subscribe::SubscriptionPush),
+    Response(SpawnedResponse),
+}
+
+/// Response produced by a spawned request handler, carrying back to the
+/// main loop everything it needs to (1) update connection-local state and
+/// (2) write the response frame.
+pub(crate) struct SpawnedResponse {
+    /// Stream id of the original request frame — echoed in the response
+    /// so the client can correlate.
+    stream_id: i16,
+    /// Whatever the handler produced; the main loop matches on this just
+    /// like the inline path.
+    result: HandleResult,
+    /// Response frame version (`0x84` for v4, `0x85` for v5). Captured at
+    /// dispatch time because `client_protocol_version` is per-connection
+    /// state owned by the main loop.
+    response_version: u8,
+    /// New keyspace value if the handler observed a `USE` statement.
+    /// `None` means unchanged; `Some(x)` is the new value.
+    keyspace_after: Option<Option<String>>,
+    /// `true` for spawned post-Ready requests so the main loop bumps the
+    /// per-connection request counter — matching the inline path's
+    /// `was_ready` bookkeeping.
+    bump_request_counter: bool,
+    /// Held until the handler responds so the in-flight permit is only
+    /// released after the response is buffered on the channel.
+    _permit: tokio::sync::OwnedSemaphorePermit,
 }
 
 /// Outcome of processing a single frame.

--- a/ferrosa-net/src/lane_actor.rs
+++ b/ferrosa-net/src/lane_actor.rs
@@ -352,16 +352,27 @@ async fn lane_actor_loop(
                 timeout,
                 reply,
             } => {
-                let result = handle_send(&mut state, &ctx, lane, msg, timeout).await;
-                let _ = reply.send(result);
+                // Dispatch the RPC on a spawned task so the actor loop
+                // can immediately process the next command. Without this,
+                // every Send was awaited inline and the actor handled
+                // one in-flight RPC per peer-lane at a time — turning
+                // the underlying multiplexed transport (per-stream IDs
+                // + DashMap of pending responses inside RpcClient) into
+                // a single-pipelined channel. On a 32-thread NoSQLBench
+                // workload this capped throughput at ~1 / RTT per peer.
+                //
+                // Connection failures are detected by the alive_watcher
+                // attached on Connected and propagated via SwapClient /
+                // MarkFailed — no need to mutate state from the spawned
+                // task.
+                dispatch_send(&state, lane, msg, timeout, reply);
             }
             LaneCommand::Fire {
                 msg,
                 timeout,
                 reply,
             } => {
-                let result = handle_fire(&mut state, &ctx, lane, msg, timeout).await;
-                let _ = reply.send(result);
+                dispatch_fire(&state, lane, msg, timeout, reply);
             }
             LaneCommand::SwapClient(new_client) => {
                 // If we were dormant, decrement the dormant counter.
@@ -491,66 +502,58 @@ async fn lane_actor_loop(
     }
 }
 
-/// Handle a Send command: perform the RPC with timeout, trigger reconnect on error.
-async fn handle_send(
-    state: &mut LaneState,
-    ctx: &ActorReconnectContext,
+/// Dispatch a Send command non-blocking: clone the client and spawn the
+/// RPC + reply on a task so the actor loop returns immediately.
+///
+/// Connection-error reconnect is handled by the alive_watcher attached on
+/// `LaneState::Connected`, not by mutating state from the spawned task.
+fn dispatch_send(
+    state: &LaneState,
     lane: Lane,
     msg: Message,
     timeout: Duration,
-) -> Result<Message> {
-    match state {
-        LaneState::Connected(client) => {
-            let result = tokio::time::timeout(timeout, client.send(msg, lane)).await;
-            match result {
-                Ok(Ok(response)) => Ok(response),
-                Ok(Err(e)) => {
-                    if matches!(&e, NetError::Io(_) | NetError::Protocol(_)) {
-                        tracing::warn!(?lane, error = %e, "connection error, triggering reconnect");
-                        *state = LaneState::Reconnecting {
-                            attempt: 0,
-                            exhaustion_count: 0,
-                        };
-                        ctx.spawn_reconnect(0);
-                    }
-                    Err(e)
-                }
-                Err(_elapsed) => Err(NetError::Timeout(format!("{lane:?} lane send timeout"))),
-            }
+    reply: oneshot::Sender<Result<Message>>,
+) {
+    let client = match state {
+        LaneState::Connected(c) => c.clone(),
+        LaneState::Reconnecting { .. } | LaneState::Dormant => {
+            let _ = reply.send(Err(NetError::Reconnecting));
+            return;
         }
-        LaneState::Reconnecting { .. } | LaneState::Dormant => Err(NetError::Reconnecting),
-    }
+    };
+    tokio::spawn(async move {
+        let result = match tokio::time::timeout(timeout, client.send(msg, lane)).await {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(e)) => Err(e),
+            Err(_elapsed) => Err(NetError::Timeout(format!("{lane:?} lane send timeout"))),
+        };
+        let _ = reply.send(result);
+    });
 }
 
-/// Handle a Fire command: send fire-and-forget with timeout, trigger reconnect on error.
-async fn handle_fire(
-    state: &mut LaneState,
-    ctx: &ActorReconnectContext,
+/// Dispatch a Fire command non-blocking. See `dispatch_send` for rationale.
+fn dispatch_fire(
+    state: &LaneState,
     lane: Lane,
     msg: Message,
     timeout: Duration,
-) -> Result<()> {
-    match state {
-        LaneState::Connected(client) => {
-            let result = tokio::time::timeout(timeout, client.fire(msg, lane)).await;
-            match result {
-                Ok(Ok(())) => Ok(()),
-                Ok(Err(e)) => {
-                    if matches!(&e, NetError::Io(_) | NetError::Protocol(_)) {
-                        tracing::warn!(?lane, error = %e, "connection error, triggering reconnect");
-                        *state = LaneState::Reconnecting {
-                            attempt: 0,
-                            exhaustion_count: 0,
-                        };
-                        ctx.spawn_reconnect(0);
-                    }
-                    Err(e)
-                }
-                Err(_elapsed) => Err(NetError::Timeout(format!("{lane:?} lane fire timeout"))),
-            }
+    reply: oneshot::Sender<Result<()>>,
+) {
+    let client = match state {
+        LaneState::Connected(c) => c.clone(),
+        LaneState::Reconnecting { .. } | LaneState::Dormant => {
+            let _ = reply.send(Err(NetError::Reconnecting));
+            return;
         }
-        LaneState::Reconnecting { .. } | LaneState::Dormant => Err(NetError::Reconnecting),
-    }
+    };
+    tokio::spawn(async move {
+        let result = match tokio::time::timeout(timeout, client.fire(msg, lane)).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e),
+            Err(_elapsed) => Err(NetError::Timeout(format!("{lane:?} lane fire timeout"))),
+        };
+        let _ = reply.send(result);
+    });
 }
 
 #[cfg(test)]

--- a/ferrosa-storage/src/commitlog/mod.rs
+++ b/ferrosa-storage/src/commitlog/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod sync;
 pub use config::{ArchiveConfig, CommitLogConfig, CommitLogPosition, SyncStrategyConfig, TableId};
 pub use mutation::Mutation;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
 use std::io::Read;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -76,8 +76,8 @@ fn is_zeroed_segment_header(path: &std::path::Path) -> ferrosa_common::Result<bo
 ///
 /// - **Append** is lock-free on the hot path (CAS allocation in the active segment).
 /// - **Rotation** briefly takes the `closed_segments` mutex to move the old segment.
-/// - **Discard** takes both `segment_tracker` and `closed_segments` mutexes to
-///   clean up fully-flushed segments.
+/// - **Discard** takes the `closed_segments` mutex and queries each
+///   segment's own (lock-free) `dirty_tables` map.
 pub struct CommitLog {
     /// Commit log configuration.
     config: Config,
@@ -87,10 +87,6 @@ pub struct CommitLog {
 
     /// Segments that are full but still have dirty (unflushed) tables.
     closed_segments: Mutex<Vec<Arc<Segment>>>,
-
-    /// Per-segment dirty table tracking. Key = segment ID, value = map of
-    /// table ID to the latest position written for that table in that segment.
-    segment_tracker: Mutex<HashMap<u64, HashMap<TableId, CommitLogPosition>>>,
 
     /// Controls when segment buffers are fsynced to disk.
     sync_strategy: Box<dyn SyncStrategy>,
@@ -138,7 +134,6 @@ impl CommitLog {
             config,
             active,
             closed_segments: Mutex::new(Vec::new()),
-            segment_tracker: Mutex::new(HashMap::new()),
             sync_strategy,
             next_segment_id: AtomicU64::new(first_segment_id + 1),
             archived: Mutex::new(HashSet::new()),
@@ -341,24 +336,11 @@ impl CommitLog {
         let position = segment.write_entry(offset, mutation);
         segment.writer_done();
 
-        // Track dirty table in this segment.
+        // Track dirty table in this segment. `dirty_tables` on the segment
+        // is a `DashMap<TableId, AtomicU64>` so this is lock-free in steady
+        // state — no global commit-log-level mutex on the hot path.
         let table_id = TableId::new(&mutation.keyspace, &mutation.table);
         segment.mark_table_dirty(&table_id, position);
-
-        // Update segment tracker.
-        {
-            let mut tracker = self.segment_tracker.lock();
-            tracker
-                .entry(segment.id)
-                .or_default()
-                .entry(table_id)
-                .and_modify(|existing| {
-                    if position > *existing {
-                        *existing = position;
-                    }
-                })
-                .or_insert(position);
-        }
 
         // Notify sync strategy.
         self.sync_strategy.on_write(&segment, offset);
@@ -379,31 +361,33 @@ impl CommitLog {
     ) -> ferrosa_common::Result<()> {
         let mut segments_to_delete = Vec::new();
 
-        {
-            let mut tracker = self.segment_tracker.lock();
-
-            // For each tracked segment, check if this table's position is dominated.
-            let segment_ids: Vec<u64> = tracker.keys().copied().collect();
-            for seg_id in segment_ids {
-                if let Some(tables) = tracker.get_mut(&seg_id) {
-                    if let Some(table_pos) = tables.get(table_id) {
-                        if *table_pos <= position {
-                            tables.remove(table_id);
-                        }
-                    }
-                    if tables.is_empty() {
-                        // Check archive gate: if archiving is enabled, the segment
-                        // must be archived before it can be deleted from disk.
-                        let dominated_by_archive = match &self.config.archive {
-                            Some(cfg) if cfg.enabled => self.archived.lock().contains(&seg_id),
-                            _ => true, // Archiving disabled — no gate.
-                        };
-
-                        if dominated_by_archive {
-                            tracker.remove(&seg_id);
-                            segments_to_delete.push(seg_id);
-                        }
-                    }
+        // Iterate active + closed segments. Each segment's `dirty_tables`
+        // is a `DashMap` so per-segment removal is lock-free per-shard.
+        //
+        // Ordering: `CommitLogPosition` sorts by `(segment_id, offset)`,
+        // so for a segment whose id is strictly less than `position.segment_id`,
+        // *every* recorded offset is dominated and the entry is removed
+        // unconditionally. When ids match, we compare offsets. Newer
+        // segments (id > position.segment_id) are skipped.
+        let active = self.active.load_full();
+        let active_id = active.id;
+        let closed_snapshot: Vec<Arc<Segment>> = self.closed_segments.lock().clone();
+        let all_segments = std::iter::once(active).chain(closed_snapshot);
+        for segment in all_segments {
+            let now_empty = match segment.id.cmp(&position.segment_id) {
+                std::cmp::Ordering::Less => segment.discard_table_unconditional(table_id),
+                std::cmp::Ordering::Equal => {
+                    segment.discard_table_if_dominated(table_id, position.offset)
+                }
+                std::cmp::Ordering::Greater => false,
+            };
+            if now_empty && segment.id != active_id {
+                let dominated_by_archive = match &self.config.archive {
+                    Some(cfg) if cfg.enabled => self.archived.lock().contains(&segment.id),
+                    _ => true,
+                };
+                if dominated_by_archive {
+                    segments_to_delete.push(segment.id);
                 }
             }
         }
@@ -449,23 +433,18 @@ impl CommitLog {
     pub fn discard_completed_segments(&self) -> ferrosa_common::Result<usize> {
         let mut segments_to_delete = Vec::new();
 
-        {
-            let mut tracker = self.segment_tracker.lock();
-            let segment_ids: Vec<u64> = tracker.keys().copied().collect();
-            for seg_id in segment_ids {
-                if tracker.get(&seg_id).is_some_and(|tables| tables.is_empty()) {
-                    // Check archive gate: if archiving is enabled, the segment
-                    // must be archived before it can be deleted from disk.
-                    let dominated_by_archive = match &self.config.archive {
-                        Some(cfg) if cfg.enabled => self.archived.lock().contains(&seg_id),
-                        _ => true, // Archiving disabled — no gate.
-                    };
-
-                    if dominated_by_archive {
-                        tracker.remove(&seg_id);
-                        segments_to_delete.push(seg_id);
-                    }
-                }
+        // Only look at closed segments — the active one keeps writing.
+        let closed_snapshot: Vec<Arc<Segment>> = self.closed_segments.lock().clone();
+        for segment in closed_snapshot {
+            if !segment.is_dirty_empty() {
+                continue;
+            }
+            let dominated_by_archive = match &self.config.archive {
+                Some(cfg) if cfg.enabled => self.archived.lock().contains(&segment.id),
+                _ => true,
+            };
+            if dominated_by_archive {
+                segments_to_delete.push(segment.id);
             }
         }
 

--- a/ferrosa-storage/src/commitlog/mod.rs
+++ b/ferrosa-storage/src/commitlog/mod.rs
@@ -293,7 +293,8 @@ impl CommitLog {
     /// 3. If the segment is full, rotate and retry.
     /// 4. Write the entry, update dirty tracking, notify sync strategy.
     pub fn append(&self, mutation: &Mutation) -> ferrosa_common::Result<CommitLogPosition> {
-        let _span = tracing::info_span!(
+        // DEBUG-level span so it costs nothing at the default INFO filter.
+        let _span = tracing::debug_span!(
             "commitlog.write",
             table = %mutation.table,
             keyspace = %mutation.keyspace,

--- a/ferrosa-storage/src/commitlog/segment.rs
+++ b/ferrosa-storage/src/commitlog/segment.rs
@@ -46,12 +46,12 @@
 #![allow(dead_code)]
 
 use std::cell::UnsafeCell;
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+use dashmap::DashMap;
 use parking_lot::Mutex;
 
 use super::config::{CommitLogPosition, TableId};
@@ -98,7 +98,15 @@ pub struct Segment {
     path: PathBuf,
 
     /// Tables with uncommitted data in this segment.
-    dirty_tables: Mutex<HashMap<TableId, CommitLogPosition>>,
+    ///
+    /// Stores only the **offset** — `segment_id` is implicit in `self.id`.
+    /// Using `DashMap<TableId, AtomicU64>` keeps the hot-path update
+    /// (`mark_table_dirty`, called on every write) lock-free in steady
+    /// state: a `get(table_id)` returns a shard-read-locked `Ref` and
+    /// `fetch_max` advances the offset atomically. The previous
+    /// `Mutex<HashMap<...>>` was a global serialization point for every
+    /// append into the active segment.
+    pub(crate) dirty_tables: DashMap<TableId, AtomicU64>,
 
     /// Number of writers currently between `allocate()` and `write_entry()`
     /// completion. `flush_to_disk()` waits for this to reach zero before
@@ -159,7 +167,7 @@ impl Segment {
             capacity: size,
             created_at: Instant::now(),
             path,
-            dirty_tables: Mutex::new(HashMap::new()),
+            dirty_tables: DashMap::new(),
             in_flight_writers: AtomicU64::new(0),
             file_handle: Mutex::new(None),
             last_flushed: AtomicU64::new(INITIAL_POSITION),
@@ -466,16 +474,72 @@ impl Segment {
     }
 
     /// Marks a table as having dirty (unflushed) data in this segment.
+    ///
+    /// Lock-free in steady state: hits `DashMap::get` (per-shard read
+    /// lock) and `AtomicU64::fetch_max`. Only the first write per
+    /// (segment, table) pair pays the shard-write-lock cost of insert.
     pub fn mark_table_dirty(&self, table_id: &TableId, position: CommitLogPosition) {
-        let mut dirty = self.dirty_tables.lock();
-        dirty
+        debug_assert_eq!(
+            position.segment_id, self.id,
+            "mark_table_dirty called with foreign segment_id"
+        );
+        if let Some(existing) = self.dirty_tables.get(table_id) {
+            existing.fetch_max(position.offset, Ordering::Relaxed);
+            return;
+        }
+        // First-time insert for this table — pays a one-shot shard write lock.
+        // `or_insert_with` is atomic-enough: if a racing thread inserted
+        // between our `get` and `entry`, we still `fetch_max` the existing
+        // entry, never overwriting a higher offset.
+        let entry = self
+            .dirty_tables
             .entry(table_id.clone())
-            .and_modify(|existing| {
-                if position > *existing {
-                    *existing = position;
-                }
+            .or_insert_with(|| AtomicU64::new(0));
+        entry.fetch_max(position.offset, Ordering::Relaxed);
+    }
+
+    /// Removes a table's entry if its recorded offset is ≤ `up_to_offset`.
+    /// Returns whether the segment is now empty of dirty tables.
+    pub fn discard_table_if_dominated(&self, table_id: &TableId, up_to_offset: u64) -> bool {
+        if let Some(entry) = self.dirty_tables.get(table_id) {
+            if entry.load(Ordering::Relaxed) <= up_to_offset {
+                drop(entry);
+                self.dirty_tables.remove(table_id);
+            }
+        }
+        self.dirty_tables.is_empty()
+    }
+
+    /// Unconditionally drop the table from the dirty set. Used by the
+    /// commit-log discard path when the discard threshold's `segment_id`
+    /// is strictly greater than this segment's id — meaning every offset
+    /// here is dominated.
+    pub fn discard_table_unconditional(&self, table_id: &TableId) -> bool {
+        self.dirty_tables.remove(table_id);
+        self.dirty_tables.is_empty()
+    }
+
+    /// Returns `true` when this segment has no dirty tables left.
+    pub fn is_dirty_empty(&self) -> bool {
+        self.dirty_tables.is_empty()
+    }
+
+    /// Returns a snapshot of (table, latest-position) pairs currently
+    /// recorded as dirty in this segment.
+    pub fn dirty_table_positions(&self) -> Vec<(TableId, CommitLogPosition)> {
+        self.dirty_tables
+            .iter()
+            .map(|kv| {
+                let offset = kv.value().load(Ordering::Relaxed);
+                (
+                    kv.key().clone(),
+                    CommitLogPosition {
+                        segment_id: self.id,
+                        offset,
+                    },
+                )
             })
-            .or_insert(position);
+            .collect()
     }
 
     /// Returns `true` if this segment is older than `max_age`.
@@ -759,8 +823,9 @@ mod tests {
         segment.mark_table_dirty(&table, pos1);
         segment.mark_table_dirty(&table, pos2);
 
-        let dirty = segment.dirty_tables.lock();
-        assert_eq!(dirty[&table], pos2);
+        let dirty = segment.dirty_table_positions();
+        assert_eq!(dirty.len(), 1);
+        assert_eq!(dirty[0], (table.clone(), pos2));
     }
 
     #[test]
@@ -871,11 +936,9 @@ mod tests {
             segment.path().file_name().unwrap().to_str().unwrap(),
             "commitlog-42.log"
         );
-        let dirty = segment.dirty_tables.lock();
-        assert_eq!(
-            dirty[&table], pos,
-            "dirty_tables must survive release_buffer"
-        );
+        let dirty = segment.dirty_table_positions();
+        assert_eq!(dirty.len(), 1, "dirty_tables must survive release_buffer");
+        assert_eq!(dirty[0], (table.clone(), pos));
     }
 
     #[test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use parking_lot::RwLock;
 
 use ferrosa_common::key::DecoratedKey;
@@ -448,19 +449,34 @@ struct TableState {
     /// SSTable IDs that are currently pinned on NVMe, in oldest-first order.
     /// Each entry is `(sstable_id, size_bytes)`.
     pinned_sstables: Vec<(String, u64)>,
-    /// Timestamp of the first write to the current (unflushed) memtable.
-    /// Reset to `None` after each flush. Used by `flush_if_needed` to trigger
-    /// time-based flushes for small, infrequently-updated tables.
-    /// Behind `Mutex` so writers can update it under a read lock on `tables`.
-    first_unflushed_write_at: parking_lot::Mutex<Option<std::time::Instant>>,
-    /// Latest commit log position written for this table. Updated on every
+    /// Nanoseconds since [`REFERENCE_INSTANT`] of the first write to the
+    /// current (unflushed) memtable. `0` means "memtable is clean". Used by
+    /// `flush_if_needed` to trigger time-based flushes for small, infrequently-
+    /// updated tables.  `AtomicI64` so the write hot path is lock-free: a
+    /// `compare_exchange(0, now)` that succeeds at most once per memtable
+    /// epoch, no contention thereafter.
+    first_unflushed_write_at_nanos: std::sync::atomic::AtomicI64,
+    /// Latest commit-log position written for this table. Updated on every
     /// write; passed to `commit_log.discard_completed()` after flush so that
-    /// fully-flushed segments can be GC'd. Without this, closed segments
-    /// accumulate indefinitely and leak file descriptors.
+    /// fully-flushed segments can be GC'd.
     ///
-    /// Wrapped in `Mutex` so writers can update it under a read lock on the
-    /// `tables` map (the hot path). The lock protects only two `u64`s.
-    last_commit_log_position: parking_lot::Mutex<Option<CommitLogPosition>>,
+    /// `ArcSwap` keeps the hot-path update lock-free — one `Arc::new` (~30ns)
+    /// plus an atomic pointer swap, with no mutex contention even when
+    /// many threads write to the same table concurrently.
+    last_commit_log_position: ArcSwap<Option<CommitLogPosition>>,
+}
+
+/// Process-wide reference instant used as the base for
+/// `first_unflushed_write_at_nanos`. Captured lazily on first access so
+/// that `now() - REFERENCE_INSTANT` always fits in an i64 (~292 years).
+static REFERENCE_INSTANT: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+
+fn reference_instant() -> std::time::Instant {
+    *REFERENCE_INSTANT.get_or_init(std::time::Instant::now)
+}
+
+fn now_nanos_since_reference() -> i64 {
+    reference_instant().elapsed().as_nanos() as i64
 }
 
 /// SSTable reader type alias for file-backed SSTables.
@@ -1263,8 +1279,8 @@ impl StorageEngine {
             store,
             pin_config: None,
             pinned_sstables: Vec::new(),
-            first_unflushed_write_at: parking_lot::Mutex::new(None),
-            last_commit_log_position: parking_lot::Mutex::new(None),
+            first_unflushed_write_at_nanos: std::sync::atomic::AtomicI64::new(0),
+            last_commit_log_position: ArcSwap::from_pointee(None),
         })
     }
 
@@ -1904,11 +1920,22 @@ impl StorageEngine {
             ferrosa_common::Error::InvalidFormat(format!("table not registered: {table_id}"))
         })?;
         state.store.write(key, row)?;
-        *state.last_commit_log_position.lock() = Some(cl_pos);
-        state
-            .first_unflushed_write_at
-            .lock()
-            .get_or_insert_with(std::time::Instant::now);
+        state.last_commit_log_position.store(Arc::new(Some(cl_pos)));
+        // Set the first-unflushed timestamp via CAS — succeeds at most once
+        // per memtable epoch, no contention after the first write.
+        if state
+            .first_unflushed_write_at_nanos
+            .load(std::sync::atomic::Ordering::Relaxed)
+            == 0
+        {
+            let now = now_nanos_since_reference();
+            let _ = state.first_unflushed_write_at_nanos.compare_exchange(
+                0,
+                now,
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
         drop(tables);
 
         // 3. Notify observers after successful commit log + memtable write.
@@ -1954,11 +1981,20 @@ impl StorageEngine {
                     ))
                 })?;
                 state.store.write(&key, row)?;
-                *state.last_commit_log_position.lock() = Some(cl_pos);
-                state
-                    .first_unflushed_write_at
-                    .lock()
-                    .get_or_insert_with(std::time::Instant::now);
+                state.last_commit_log_position.store(Arc::new(Some(cl_pos)));
+                if state
+                    .first_unflushed_write_at_nanos
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    == 0
+                {
+                    let now = now_nanos_since_reference();
+                    let _ = state.first_unflushed_write_at_nanos.compare_exchange(
+                        0,
+                        now,
+                        std::sync::atomic::Ordering::Relaxed,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                }
             }
 
             // Notify observers after successful commit log + memtable write.
@@ -2007,11 +2043,20 @@ impl StorageEngine {
                 state.store.write(&m.key, row.clone())?;
             }
             if let Some(&cl_pos) = positions.get(&table_id) {
-                *state.last_commit_log_position.lock() = Some(cl_pos);
-                state
-                    .first_unflushed_write_at
-                    .lock()
-                    .get_or_insert_with(std::time::Instant::now);
+                state.last_commit_log_position.store(Arc::new(Some(cl_pos)));
+                if state
+                    .first_unflushed_write_at_nanos
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    == 0
+                {
+                    let now = now_nanos_since_reference();
+                    let _ = state.first_unflushed_write_at_nanos.compare_exchange(
+                        0,
+                        now,
+                        std::sync::atomic::Ordering::Relaxed,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                }
             }
         }
         drop(tables);
@@ -2562,13 +2607,15 @@ impl StorageEngine {
 
             // Snapshot the commit log position before flushing. All mutations
             // up to this position are in the memtable we're about to flush.
-            let cl_position = *state.last_commit_log_position.lock();
+            let cl_position = **state.last_commit_log_position.load();
 
             state.store.flush()?;
 
             // Reset the unflushed-write timestamp so the next write starts a
             // fresh age window. This must happen after flush() succeeds.
-            *state.first_unflushed_write_at.lock() = None;
+            state
+                .first_unflushed_write_at_nanos
+                .store(0, std::sync::atomic::Ordering::Relaxed);
 
             // Eager index build: submit high-priority index rebuild for the newly
             // flushed SSTable. This keeps the MemtableIndex (Layer 4) bounded to
@@ -2675,8 +2722,9 @@ impl StorageEngine {
     /// trigger prevents one cold dirty memtable from pinning closed segments
     /// after hotter tables have already flushed.
     pub fn flush_if_needed(&self) -> ferrosa_common::Result<()> {
-        let now = std::time::Instant::now();
         let max_age = std::time::Duration::from_secs(self.config.flush_max_age_secs);
+        let max_age_nanos = max_age.as_nanos() as i64;
+        let now_nanos = now_nanos_since_reference();
         let retention_pressure = self.commit_log.closed_segment_count() > 0;
         let tables = self.tables.read();
         let to_flush: Vec<TableId> = tables
@@ -2684,10 +2732,10 @@ impl StorageEngine {
             .filter(|(_, state)| {
                 let memtable_size = state.store.memtable_size();
                 let size_exceeded = memtable_size as u64 >= self.config.flush_threshold_bytes;
-                let age_exceeded = state
-                    .first_unflushed_write_at
-                    .lock()
-                    .is_some_and(|t| now.duration_since(t) >= max_age);
+                let first = state
+                    .first_unflushed_write_at_nanos
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                let age_exceeded = first > 0 && now_nanos.saturating_sub(first) >= max_age_nanos;
                 memtable_size > 0 && (size_exceeded || age_exceeded || retention_pressure)
             })
             .map(|(id, _)| id.clone())

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -1899,7 +1899,10 @@ impl StorageEngine {
         row: Row,
         timestamp: i64,
     ) -> ferrosa_common::Result<()> {
-        let _span = tracing::info_span!(
+        // Per-write span emitted at DEBUG level so it is free at the
+        // default INFO subscriber filter — every span allocation was
+        // measurable on a 50k ops/s workload.
+        let _span = tracing::debug_span!(
             "storage.write",
             table = %table_id,
         )


### PR DESCRIPTION
## Summary

Three contention points were serializing the write path; together they were
a 6x cap on throughput vs what the cluster's CPU could sustain.

### 1. perf(net): multiplex lane actor (180a93e)
The per-peer/per-lane actor processed one RPC at a time by awaiting
handle_send inside the actor loop, even though RpcClient is fully
multiplexed (per-stream IDs + DashMap of pending responses).
Fix: spawn each send; actor returns to next command immediately.

### 2. perf(storage): lock-free commit-log dirty tracking (3bed35c)
Every commit-log append took two global mutexes back-to-back:
Segment::dirty_tables and CommitLog::segment_tracker (redundant).
Now: DashMap<TableId, AtomicU64> on segment, tracker removed entirely.
Discard paths iterate segments directly.

### 3. perf(cql): concurrent dispatch per connection (d01d28b)
Connection loop read frame, awaited full handler, then read next —
turning CQL stream-id multiplexing into per-connection serial.
Fix: spawn Ready-phase Query/Execute/Batch handlers; responses
route back via mpsc<SpawnedResponse>. Keyspace mutations (USE)
propagate via keyspace_after field.

## Measured impact (3-node ferrosa, cql_timeseries2.yaml, threads=32)

| Stage | 1M cycles | 3M cycles |
|---|---:|---:|
| origin/main | 8,771 | — |
| + lane-actor | 17,543 | — |
| + dirty_tables | 18,518 | — |
| + concurrent CQL | 33,333 | 53,571 |

The 1M -> 3M jump (33k -> 53k) is warm-up. At 3M all three nodes run
200-230% CPU each (~6.5 cores total), evenly distributed — cluster
is CPU-bound on replica work now.

## Test plan

- [x] 99 commitlog unit tests pass
- [x] 7 lane-actor unit tests pass
- [x] 755 ferrosa-cql unit tests pass
- [x] NB 3M cycles completes with no errors, even 3-way distribution

## Follow-up

The per-table last_commit_log_position / first_unflushed_write_at
Mutexes in engine.rs are still on the write hot path. Brief critical
sections but per-table-singleton, so contend on single-table workloads.
Replacing with ArcSwap / AtomicI64 should give a small additional win
— deferred so this PR ships now.