### PR TITLE
fix(cql-compat): system_schema.views honors SELECT projection

### DIFF
--- a/.github/workflows/driver-tests.yml
+++ b/.github/workflows/driver-tests.yml
@@ -8,6 +8,21 @@ name: Driver Smoke Tests
 #   CONTAINER_RUNTIME=podman ./tests/drivers/run-all.sh
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    # Path filter keeps cheap PRs (docs-only, specs-only) from spending
+    # ~15 min of CI on the multi-language driver matrix.
+    paths:
+      - 'ferrosa-cql/**'
+      - 'ferrosa-schema/**'
+      - 'ferrosa-net/**'
+      - 'ferrosa/**'
+      - 'tests/drivers/**'
+      - 'Dockerfile'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/driver-tests.yml'
   schedule:
     - cron: '30 3 * * *'  # 3:30 AM UTC daily (after nightly-fuzz at 3:00)
   workflow_dispatch:  # manual trigger

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1674,38 +1674,57 @@ async fn route_select(
             ))
         }
         // system_schema.views — empty (ferrosa does not implement
-        // materialized views) but the column metadata must match Cassandra
-        // 5.0 so the DataStax driver's `ViewParser` finds the boolean
-        // columns it expects (`cdc`, `include_all_columns`,
-        // `allow_auto_snapshot`, `incremental_backups`).  Without these in
-        // the column set, `getBoolean(...)` returns null during schema
-        // refresh and unboxing throws NPE.  See
-        // ferrosa-nosqlbench/docs/initial-gaps-found.md (Gap 7).
+        // materialized views).  Two driver shapes must work:
+        //   * DataStax Java 4.x / NoSQLBench `SELECT *` — needs the full
+        //     Cassandra-5.0 column set so `ViewParser.getBoolean(...)`
+        //     finds `cdc`, `include_all_columns`, `allow_auto_snapshot`,
+        //     `incremental_backups` (NPE otherwise — Gap 7).
+        //   * scylla 0.15 `SELECT keyspace_name, view_name, base_table_name`
+        //     — driver tuple type-check rejects extra columns
+        //     ("statement operates on 10 columns, but given rust types
+        //     contains 3" — p1-37 regression after Gap 7).
+        // Honor SELECT projection like aggregates/triggers does so both
+        // drivers see the column count they expect; type the canonical
+        // columns by name, fall back to text for unknown names.
         ("system_schema", "views") => {
-            let col_names = vec![
-                "keyspace_name".into(),
-                "view_name".into(),
-                "base_table_id".into(),
-                "base_table_name".into(),
-                "cdc".into(),
-                "include_all_columns".into(),
-                "allow_auto_snapshot".into(),
-                "incremental_backups".into(),
-                "id".into(),
-                "where_clause".into(),
+            let canonical: [(&str, CqlType); 10] = [
+                ("keyspace_name", CqlType::Varchar),
+                ("view_name", CqlType::Varchar),
+                ("base_table_id", CqlType::Uuid),
+                ("base_table_name", CqlType::Varchar),
+                ("cdc", CqlType::Boolean),
+                ("include_all_columns", CqlType::Boolean),
+                ("allow_auto_snapshot", CqlType::Boolean),
+                ("incremental_backups", CqlType::Boolean),
+                ("id", CqlType::Uuid),
+                ("where_clause", CqlType::Varchar),
             ];
-            let col_types = vec![
-                CqlType::Varchar,
-                CqlType::Varchar,
-                CqlType::Uuid,
-                CqlType::Varchar,
-                CqlType::Boolean,
-                CqlType::Boolean,
-                CqlType::Boolean,
-                CqlType::Boolean,
-                CqlType::Uuid,
-                CqlType::Varchar,
-            ];
+            let select_all = s.columns.is_empty()
+                || s.columns
+                    .iter()
+                    .any(|c| matches!(c, crate::ast::SelectColumn::Star));
+            let (col_names, col_types): (Vec<String>, Vec<CqlType>) = if select_all {
+                canonical
+                    .iter()
+                    .map(|(n, t)| (String::from(*n), t.clone()))
+                    .unzip()
+            } else {
+                s.columns
+                    .iter()
+                    .filter_map(|c| match c {
+                        crate::ast::SelectColumn::Column(name) => Some(name.clone()),
+                        _ => None,
+                    })
+                    .map(|name| {
+                        let ty = canonical
+                            .iter()
+                            .find(|(n, _)| *n == name)
+                            .map(|(_, t)| t.clone())
+                            .unwrap_or(CqlType::Varchar);
+                        (name, ty)
+                    })
+                    .unzip()
+            };
             Ok(result::encode_rows(
                 &col_names,
                 &col_types,
@@ -8361,6 +8380,58 @@ mod tests {
             RouteResult::Result(b) => assert_eq!(&b[0..4], &0x0002i32.to_be_bytes()),
             _ => panic!("expected Result"),
         }
+    }
+
+    /// Regression: PR#21 (Gap 7) hardcoded the 10-col Cassandra-5.0 shape
+    /// for system_schema.views to satisfy the DataStax driver's `ViewParser`
+    /// boolean lookups.  The scylla 0.15 driver issues
+    /// `SELECT keyspace_name, view_name, base_table_name FROM
+    /// system_schema.views` and tuple-type-checks the result; ferrosa was
+    /// returning 10 columns and the driver rejected metadata with
+    /// "statement operates on 10 columns, but given rust types contains 3".
+    ///
+    /// Post-fix the views arm honors SELECT projection (3 cols requested →
+    /// 3 cols back) while still returning the full canonical 10-col shape
+    /// for `SELECT *`.
+    #[tokio::test]
+    async fn select_system_schema_views_honors_projection() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+
+        // SELECT * → 10 columns (DataStax/NoSQLBench path).
+        let stmt = crate::parser::parse("SELECT * FROM system_schema.views").unwrap();
+        let RouteResult::Result(body) = route(&state, &ctx, stmt).await.unwrap() else {
+            panic!("expected Rows result for SELECT *");
+        };
+        assert_eq!(&body[0..4], &0x0002i32.to_be_bytes());
+        // [0..4]=kind, [4..8]=flags, [8..12]=col_count
+        let col_count = i32::from_be_bytes(body[8..12].try_into().unwrap());
+        assert_eq!(
+            col_count, 10,
+            "SELECT * must return all 10 canonical columns"
+        );
+
+        // SELECT specific cols → only those columns (scylla path).
+        let stmt = crate::parser::parse(
+            "SELECT keyspace_name, view_name, base_table_name FROM system_schema.views",
+        )
+        .unwrap();
+        let RouteResult::Result(body) = route(&state, &ctx, stmt).await.unwrap() else {
+            panic!("expected Rows result for SELECT-projected");
+        };
+        assert_eq!(&body[0..4], &0x0002i32.to_be_bytes());
+        let col_count = i32::from_be_bytes(body[8..12].try_into().unwrap());
+        assert_eq!(
+            col_count, 3,
+            "SELECT-projected must return only requested columns",
+        );
     }
 
     /// Gap 2 (ferrosa-nosqlbench/docs/initial-gaps-found.md): the DataStax

--- a/tests/drivers/rust/src/main.rs
+++ b/tests/drivers/rust/src/main.rs
@@ -108,6 +108,65 @@ async fn main() {
     })
     .await;
 
+    // Regression for the views-projection bug introduced by the NoSQLBench
+    // gap-closure work (PR #21 Gap 7).  scylla 0.15 issues this exact
+    // 3-column SELECT during its internal metadata fetch on every
+    // `SessionBuilder::build()` and after every schema-altering DDL.  When
+    // the router hardcoded the 10-column DataStax shape, the driver's
+    // tuple type-check rejected the result with
+    // `WrongColumnCount { rust_cols: 3, cql_cols: 10 }` and every DDL
+    // surfaced "Bad views metadata" at schema-agreement time.  This test
+    // pins both behaviours: a 3-column projection decodes as
+    // `(String, String, String)`, and `SELECT *` still returns the full
+    // Cassandra-5.0 shape that DataStax/NoSQLBench needs.
+    run_test("system_schema_views_projection_3col", || async {
+        let res = session
+            .query_unpaged(
+                "SELECT keyspace_name, view_name, base_table_name FROM system_schema.views",
+                &[],
+            )
+            .await?;
+        let rows_result = res.into_rows_result()?;
+        // Empty result is fine — type-check must still succeed.
+        let _rows: Vec<(String, String, String)> = rows_result
+            .rows::<(String, String, String)>()?
+            .collect::<Result<_, _>>()?;
+        Ok(())
+    })
+    .await;
+
+    run_test("system_schema_views_select_star_full_shape", || async {
+        let res = session
+            .query_unpaged("SELECT * FROM system_schema.views", &[])
+            .await?;
+        let rows_result = res.into_rows_result()?;
+        // Cassandra-5.0 columns required for DataStax Java Driver 4.x.
+        // The driver itself looks these up by name via
+        // `AdminRow.getBoolean(...)`, so the columns must be advertised in
+        // the metadata even when the result set is empty.
+        let col_specs = rows_result.column_specs();
+        let names: Vec<&str> = col_specs.iter().map(|c| c.name()).collect();
+        for expected in [
+            "keyspace_name",
+            "view_name",
+            "base_table_id",
+            "base_table_name",
+            "cdc",
+            "include_all_columns",
+            "allow_auto_snapshot",
+            "incremental_backups",
+            "id",
+            "where_clause",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "SELECT * must advertise `{expected}` column for Cassandra-5.0 driver compat (got {names:?})",
+            );
+        }
+        Ok(())
+    })
+    .await;
+
     // ---- DDL ----------------------------------------------------------------
 
     run_test("create_keyspace", || async {


### PR DESCRIPTION
## Summary
- Restore projection-honoring behavior on the `system_schema.views` router arm so scylla 0.15's 3-column `SELECT keyspace_name, view_name, base_table_name` metadata fetch decodes correctly, while preserving the full 10-column Cassandra-5.0 shape that PR #21 Gap 7 added for the DataStax Java Driver / NoSQLBench.
- Add a scylla-driver wire-protocol regression test alongside the in-process router unit test, so both the encoding contract and the on-the-wire type check are pinned.
- Trigger `driver-tests.yml` on push-to-main and PRs that touch driver-relevant code, so future driver-compat regressions surface pre-merge instead of overnight.

## Root cause

PR #21 (`fce7a13`) extended the `system_schema.views` stub to satisfy the DataStax driver's `ViewParser.getBoolean(...)` lookups for `cdc`, `include_all_columns`, `allow_auto_snapshot`, `incremental_backups`. The change correctly added the four boolean columns to the result-set advertisement, but reverted the SELECT-projection honoring that `076a244` ("fix(p1-37): scylla driver compat") added for `aggregates|triggers|functions|views`. Result:

- scylla 0.15's internal `SELECT keyspace_name, view_name, base_table_name FROM system_schema.views` got back 10 columns
- the driver's tuple type-check (`(String, String, String)` against 10 advertised cols) rejected with `WrongColumnCount { rust_cols: 3, cql_cols: 10 }`
- every DDL through the scylla driver failed at the post-DDL schema-agreement metadata fetch with `Bad views metadata`

This blocked ferrosa-memory PR#4's `Cluster integration tests` job (`Apply DDL + wait for schema propagation across all 3 nodes`).

## Fix

Mirror the existing `aggregates|triggers` arm pattern: define the canonical 10-column (name, type) list once. On `SELECT *` or empty projection, return the full canonical shape (DataStax/NoSQLBench happy). On a projected SELECT, return only the requested columns typed from the canonical list — unknown column names fall back to `text` since the result set is always empty.

## Tests

- `ferrosa-cql/src/router.rs::tests::select_system_schema_views_honors_projection` — in-process, asserts col_count==10 for `SELECT *` and col_count==3 for `SELECT keyspace_name, view_name, base_table_name`. Runs on every push/PR via `ci.yml`.
- `tests/drivers/rust/src/main.rs::system_schema_views_projection_3col` + `system_schema_views_select_star_full_shape` — wire-protocol, uses scylla 0.15 against a real ferrosa node. Catches the same regression at the type-check layer the driver enforces.
- `driver-tests.yml` now triggers on push-to-main and PRs touching `ferrosa-cql/**`, `ferrosa-schema/**`, `ferrosa-net/**`, `ferrosa/**`, `tests/drivers/**`, `Dockerfile`, `Cargo.{toml,lock}`, or the workflow itself.

## Test plan

- [x] `cargo test -p ferrosa-cql --lib router::tests` — 184/184 pass (new test included)
- [x] `cargo fmt --check -p ferrosa-cql`, `cargo clippy -p ferrosa-cql --all-targets -- -D warnings` — clean
- [x] Locally rebuilt `ferrosa-memory-node` image, redeployed ferrosa-memory dev cluster: mcp `/healthz/ready` → `ready`, schema migrations apply, scylla driver no longer trips on views metadata
- [ ] CI driver-tests workflow runs against this PR and passes
- [ ] ferrosa-memory PR#4's `Cluster integration tests` job re-runs green after this lands