### PR TITLE
docs: fix memory onboarding contract

### DIFF
--- a/docs/ferrosa-memory/getting-started.md
+++ b/docs/ferrosa-memory/getting-started.md
@@ -100,8 +100,8 @@ Nomic embeddings disabled; semantic/vector search is degraded.
 mkdir -p ~/src/ferrosa-suite
 cd ~/src/ferrosa-suite
 
-git clone https://github.com/bkearns/ferrosa.git ferrosa
-git clone https://github.com/bkearns/ferrosa-memory.git ferrosa-memory
+git clone https://github.com/ferrosadb/ferrosa.git ferrosa
+git clone https://github.com/ferrosadb/ferrosa-memory.git ferrosa-memory
 ```
 
 If you already have the repositories:
@@ -127,7 +127,11 @@ Use repository config examples or `setup-memory.sh`/`ONBOARDING.md` to choose po
 
 ## Full Compose development stack
 
-The Compose stack is for local cluster/operator testing. It expects a local Ferrosa node image named `ferrosa-memory-node:latest`.
+The Compose stack is for local cluster/operator testing. It expects a local Ferrosa node image named `ferrosa-memory-node:latest`, a local MCP binary staged in `target-podman-linux/`, and generated runtime config under `.runtime/`.
+
+The MCP service runs with `network_mode: host`, so the documented loopback HTTP smoke tests are valid for this compose deployment. Do not switch the MCP service to bridge networking without also changing the runtime config and smoke tests to TLS-aware `https://` checks.
+
+Before starting Compose, ensure `~/data/ferrosa-memory/` is writable and that your Docker/Podman engine can mount paths under `$HOME`. The compose file bind-mounts `~/data/ferrosa-memory/{minio,node1,node2,node3}` for persistent data.
 
 ```bash
 cd ~/src/ferrosa-suite/ferrosa
@@ -135,6 +139,8 @@ docker build -t ferrosa-memory-node:latest .
 # or: podman build -t ferrosa-memory-node:latest .
 
 cd ~/src/ferrosa-suite/ferrosa-memory
+scripts/init-runtime.sh
+make build-podman-binary
 docker compose up -d
 # or: podman compose up -d
 

--- a/docs/setup-memory.sh
+++ b/docs/setup-memory.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 # and optionally clones/updates repos. It never deletes data or volumes.
 
 FERROSA_SUITE_DIR="${FERROSA_SUITE_DIR:-$HOME/src/ferrosa-suite}"
-FERROSA_MEMORY_REPO="${FERROSA_MEMORY_REPO:-https://github.com/bkearns/ferrosa-memory.git}"
-FERROSA_REPO="${FERROSA_REPO:-https://github.com/bkearns/ferrosa.git}"
-ONBOARDING_URL="${ONBOARDING_URL:-https://raw.githubusercontent.com/bkearns/ferrosa-memory/main/ONBOARDING.md}"
+FERROSA_MEMORY_REPO="${FERROSA_MEMORY_REPO:-https://github.com/ferrosadb/ferrosa-memory.git}"
+FERROSA_REPO="${FERROSA_REPO:-https://github.com/ferrosadb/ferrosa.git}"
+ONBOARDING_URL="${ONBOARDING_URL:-https://raw.githubusercontent.com/ferrosadb/ferrosa-memory/main/ONBOARDING.md}"
 ONBOARDING_PATH="${ONBOARDING_PATH:-$FERROSA_SUITE_DIR/ferrosa-memory/ONBOARDING.md}"
 NOMIC_MODEL="${NOMIC_MODEL:-nomic-embed-text-v2-moe}"
 

--- a/tests/docs/test_ferrosa_memory_onboarding_contract.py
+++ b/tests/docs/test_ferrosa_memory_onboarding_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_SCRIPT = REPO_ROOT / "docs" / "setup-memory.sh"
+GETTING_STARTED = REPO_ROOT / "docs" / "ferrosa-memory" / "getting-started.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_setup_memory_defaults_use_canonical_ferrosadb_org_and_existing_onboarding_path():
+    script = read(SETUP_SCRIPT)
+    assert "https://github.com/ferrosadb/ferrosa-memory.git" in script
+    assert "https://github.com/ferrosadb/ferrosa.git" in script
+    assert (
+        "https://raw.githubusercontent.com/ferrosadb/ferrosa-memory/main/ONBOARDING.md"
+        in script
+    )
+    assert "github.com/bkearns/ferrosa" not in script
+    assert "raw.githubusercontent.com/bkearns/ferrosa-memory" not in script
+
+
+def test_getting_started_manual_clone_and_compose_steps_match_public_runtime_contract():
+    guide = read(GETTING_STARTED)
+    assert "git clone https://github.com/ferrosadb/ferrosa.git ferrosa" in guide
+    assert (
+        "git clone https://github.com/ferrosadb/ferrosa-memory.git ferrosa-memory"
+        in guide
+    )
+    assert "scripts/init-runtime.sh" in guide
+    assert "make build-podman-binary" in guide
+    assert "~/data/ferrosa-memory/" in guide
+    assert "curl -fsS http://127.0.0.1:18765/healthz/live" in guide
+
+
+def test_getting_started_does_not_mix_bridge_tls_guidance_with_host_network_smoke_test():
+    guide = read(GETTING_STARTED)
+    compose_section = guide.split("## Full Compose development stack", 1)[1]
+    assert "host-network" in compose_section or "network_mode: host" in compose_section
+    assert "loopback" in compose_section
+    assert "http://127.0.0.1:18765" in compose_section


### PR DESCRIPTION
## Summary
- Point the public memory setup script at the canonical `ferrosadb` repositories.
- Document the runtime initialization and podman-target binary build steps required by the compose deployment.
- Align the smoke-test guidance and host data-directory prerequisites with the documented deployment.
- Add static docs contract coverage for the setup script, onboarding URL, smoke-test protocol, and prerequisite text.

## Dependency
Blocked on ferrosadb/ferrosa-memory#6, which is stacked on ferrosadb/ferrosa-memory#5. Keep this draft until the memory-side onboarding artifact/runtime changes have landed.

## Test plan
- `python3 -m pytest tests/docs/test_ferrosa_memory_onboarding_contract.py -q`
