### PR TITLE
fix(cql): ALTER TABLE Direct path propagates new column set to storage engine

### DIFF
--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -4591,6 +4591,33 @@ async fn route_alter_table(
     match ddl {
         DdlPath::Direct { .. } => {
             state.schema.alter_table(ks, &s.table, updates, ctx.auth)?;
+            // Propagate the post-ALTER column set to the storage engine,
+            // mirroring what CreateTable's Direct arm does. Without this,
+            // standalone/Direct nodes leave their TableSchema stuck at the
+            // CREATE-TABLE column set; every subsequent write produces a
+            // cell whose col_idx (computed from the live Schema metadata)
+            // exceeds the storage TableSchema's num_columns. The flush
+            // path's fail-loud assertion at writer.rs:496 then panics:
+            //   "cell col_idx N is out of range (num_columns=M)"
+            // and the row is silently dropped. The cluster-mode path
+            // already calls engine.update_table_schema via the RaftOp
+            // AlterTable apply (state_machine.rs:995) — the Direct
+            // path was simply missing the equivalent local update.
+            let snap = state.schema.snapshot();
+            if let Some(tbl) = snap.tables.get(&(ks.to_string(), s.table.clone())) {
+                let tid = ferrosa_storage::TableId::new(ks, &s.table);
+                if let Err(e) = state
+                    .engine
+                    .update_table_schema(&tid, tbl.to_storage_schema())
+                {
+                    tracing::error!(
+                        %e,
+                        keyspace = %ks,
+                        table = %s.table,
+                        "Direct ALTER: engine.update_table_schema failed — future flushes may panic on stale column count"
+                    );
+                }
+            }
         }
         DdlPath::Pair(coordinator) => {
             let op = DdlOperation::AlterTable {
@@ -9791,6 +9818,90 @@ mod tests {
             "INSERT into added column must succeed, got: {:?}",
             result.err()
         );
+    }
+
+    /// Direct repro for ferrosa-memory PR#4 cluster-int third-layer
+    /// failure: `live_run_three_step_scenario` panicked the test-cluster
+    /// node1 at flush time with
+    ///   "SSTable writer: cell col_idx 3 is out of range (num_columns=3)"
+    /// because `route_alter_table`'s Direct arm only updated the Schema
+    /// registry — never `engine.update_table_schema`. The encoder used
+    /// the post-ALTER column set (via Schema metadata) and produced a
+    /// cell at the new column's index, but the storage TableSchema was
+    /// still stuck at the CREATE-TABLE column count. The mismatch goes
+    /// undetected on the write (memtable validation skips out-of-range
+    /// indices) and only fails loud at flush time, dropping the row.
+    ///
+    /// Without the fix in `route_alter_table` this test panics at the
+    /// `engine.flush` call. With the fix it succeeds.
+    #[tokio::test]
+    async fn alter_table_direct_propagates_schema_to_storage_for_flush() {
+        let (state, dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        let stmt = crate::parser::parse(
+            "CREATE KEYSPACE ks WITH REPLICATION = \
+             {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+        )
+        .unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        let ctx_ks = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &Some("ks".into()),
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        let stmt = crate::parser::parse("CREATE TABLE ks.t (k int PRIMARY KEY, v text)").unwrap();
+        route(&state, &ctx_ks, stmt).await.unwrap();
+
+        let stmt = crate::parser::parse("ALTER TABLE ks.t ADD new_col text").unwrap();
+        route(&state, &ctx_ks, stmt).await.unwrap();
+
+        let stmt =
+            crate::parser::parse("INSERT INTO ks.t (k, v, new_col) VALUES (1, 'hello', 'world')")
+                .unwrap();
+        route(&state, &ctx_ks, stmt).await.unwrap();
+
+        // The bug: storage TableSchema is stuck at CREATE-time num_columns=1
+        // (just `v`). The INSERT for `new_col` writes a cell at col_idx=1.
+        // memtable validation accepts it (silently skipped on out-of-range
+        // index), but flush panics at writer.rs:496. With the fix in
+        // route_alter_table, this flush completes cleanly.
+        let table_id = ferrosa_storage::TableId::new("ks", "t");
+        state
+            .engine
+            .flush(&table_id)
+            .expect("flush after ALTER + INSERT must not panic; storage TableSchema must reflect post-ALTER column count");
+
+        // Belt and suspenders: re-issue another ALTER + INSERT + flush so
+        // we catch the regression even if some lazy refresh path
+        // accidentally covered the first ALTER.
+        let stmt = crate::parser::parse("ALTER TABLE ks.t ADD third_col text").unwrap();
+        route(&state, &ctx_ks, stmt).await.unwrap();
+
+        let stmt = crate::parser::parse(
+            "INSERT INTO ks.t (k, v, new_col, third_col) VALUES (2, 'h2', 'w2', 't2')",
+        )
+        .unwrap();
+        route(&state, &ctx_ks, stmt).await.unwrap();
+
+        state
+            .engine
+            .flush(&table_id)
+            .expect("flush after second ALTER + INSERT must not panic");
+
+        // Keep `dir` alive for the duration of the test so tempdir
+        // doesn't drop and unlink the SSTable directory underneath us.
+        drop(dir);
     }
 
     /// Temporal schema migrations use ALTER TABLE DROP.


### PR DESCRIPTION
## Summary

\`route_alter_table\`'s \`DdlPath::Direct\` arm only called \`schema.alter_table(...)\`. The CreateTable Direct arm calls both \`schema.create_table\` AND \`engine.register_table\`; AlterTable was missing the equivalent \`engine.update_table_schema\`.

On a standalone node, every \`ALTER TABLE ADD COLUMN\` left the storage engine's \`TableSchema\` stuck at the CREATE-TABLE column count. The next write that filled the newly-added column produced a cell whose \`col_idx\` (looked up from the post-ALTER Schema metadata) was beyond \`regular_columns.len()\` on the storage side. Memtable validation silently skipped the out-of-range cell; on the next flush the SSTable writer's fail-loud guard at \`writer.rs:496\` panicked:

\`\`\`text
SSTable writer: cell col_idx 1 is out of range (num_columns=1).
Serializing would produce a silently corrupt SSTable.
\`\`\`

The row got dropped, the flush task crashed, and the table looked empty to readers — exactly the failure mode in ferrosa-memory's \`live_run_three_step_scenario\` cluster-int test (\"after-snapshot should show >= 1 entity, got 0\"), which uses a standalone test cluster after their PR#4 commit 9a5bb73.

This is the third in a chain of related bugs:
- #29 reverted (wrong diagnosis of the same family)
- #30 fixed the Cluster-mode DDL apply-lag race
- #31 fixed \`system_graph_*\` exclusion from Phase A replay
- this PR fixes the Direct-mode equivalent of #30

Cluster-mode and Pair-mode paths already covered this: \`state_machine.rs:995\` calls \`engine.update_table_schema\` from \`RaftOp::AlterTable\` apply, and \`pair/ddl.rs\` does the same in \`apply_ddl_locally\`. Only the in-process Direct arm was missing it.

## TDD

\`alter_table_direct_propagates_schema_to_storage_for_flush\` in \`ferrosa-cql/src/router.rs\` goes red against main with the same panic shape as the live cluster:

\`\`\`text
thread '...' panicked at ferrosa-sstable/src/writer.rs:496:
  cell col_idx 1 is out of range (num_columns=1).
\`\`\`

…and green with this commit. Verified by temporarily reverting the fix and observing red.

## Test plan

- [x] \`cargo test -p ferrosa-cql --lib alter_table\` — 10/10 (7 existing + new regression).
- [x] \`cargo test -p ferrosa-cql --lib\` — 757/757.
- [x] \`cargo fmt --check\`.
- [x] \`cargo clippy -p ferrosa-cql --all-targets -- -D warnings\`.

Once this lands the ferrosa-memory PR#4 cluster-int \`live_run_three_step_scenario\` test should clear, leaving the cluster-int job fully green.