### PR TITLE
docs: specify S3 spill tier for HVQ vector indexes

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -40,7 +40,7 @@ specs/
 | [Secondary Index Pipeline](secondary-index-pipeline.md) | Query integration, sidecar persistence, vector indexes | Implemented |
 | [Full-Text Indexing](fulltext-index-architecture.md) | Inverted index sidecars, analyzer pipeline, BM25, fts_match() | Implemented |
 | [Remote Index Build Backend](remote-index-build-backend.md) | Standalone `ferrosa-index-builder` binary, engine backend modes (local/remote/off) | Draft |
-| [Hierarchical Vector Quantization](hierarchical-vector-quantization.md) | NVMe-resident tiered Q1/Q2/Q4/Q8/F32 vector search design for HNSW/IVFFlat | Draft |
+| [Hierarchical Vector Quantization](hierarchical-vector-quantization.md) | S3-durable, NVMe-cached tiered Q1/Q2/Q4/Q8/F32 vector search design for HNSW/IVFFlat | Draft |
 | [UCS Compaction](ucs-compaction-architecture.md) | Unified Compaction Strategy: density-based levels, fan factor, per-table DDL | New |
 | [Cluster Formation](cluster-formation-architecture.md) | Cluster formation state machine and protocol | Active |
 | [Observability](observability-architecture.md) | Metrics, tracing, telemetry pipeline | Active |
@@ -65,6 +65,7 @@ specs/
 | Spec | Scope |
 |------|-------|
 | [Cluster Formation](fmea-cluster-formation.md) | Formation protocol failure modes |
+| [HVQ S3 Spill Tier](fmea-hvq-s3-spill-tier.md) | Quantized vector artifact persistence, read-through cache, remote builder failures |
 | [Observability](observability-fmea.md) | Telemetry pipeline failure modes |
 
 ## DSM Analysis
@@ -80,6 +81,7 @@ specs/
 | Plan | Scope | Status |
 |------|-------|--------|
 | [Next Sprints](project-plan-next-sprints.md) | S1-S4: hazard fixes, NTS read, correctness, repair, Jepsen | Active |
+| [HVQ S3 Spill Tier](project-plan-hvq-s3-spill-tier.md) | S3-durable hierarchical vector quantization with bounded NVMe cache | Draft |
 | [UCS Compaction](project-plan-ucs-compaction.md) | 4 sprints: metadata, UCS strategy, integration, equivalence | New |
 | [Cluster Formation](project-plan-cluster-formation.md) | Formation state machine implementation | Active |
 | [Unified Roadmap](project-plan-unified.md) | Ferrosa ecosystem: core DB, memory, dbaas, Temporal | Active |

--- a/specs/components.md
+++ b/specs/components.md
@@ -88,7 +88,7 @@ graph BT
 - **Purpose**: Pluggable secondary index framework with multiple index type implementations
 - **Location**: `ferrosa-index/`
 - **Dependencies**: `ferrosa-common`, `serde`, `serde_json`, `rand`, `tracing`
-- **Status**: Implemented — 8 index types with build/read/factory trait system
+- **Status**: Implemented — 8 index types with build/read/factory trait system; HVQ S3 spill tier planned as additive vector artifact path
 - **Modules**:
   - `lib.rs` — Core types (`IndexType`, `IndexKey`, `RowPosition`, `IndexFiles`, `IndexConfig`, `IndexCapabilities`, `FilterPredicate`), traits (`IndexBuilder`, `IndexReader`, `IndexFactory`), error types
   - `btree.rs` — B-tree index (sorted key → row position, binary search lookup, range scan)
@@ -99,10 +99,27 @@ graph BT
   - `vector/mod.rs` — Distance functions (L2, cosine, inner product), dimension constants (4096 f32 / 8192 f16)
   - `vector/hnsw.rs` — HNSW graph index (multi-layer navigable small world, beam search)
   - `vector/ivfflat.rs` — IVFFlat index (k-means clustering, inverted list probing)
-- **Key interfaces**: Two trait APIs — secondary indexes use `IndexFactory`/`IndexBuilder`/`IndexReader` with partition/clustering key addressing; vector indexes use their own trait set in `vector::` module with byte-offset `RowPosition` and `nearest(query, k, ef_search)` for ANN queries. Storage-attached design — indexes are per-SSTable companion files built asynchronously after flush.
+  - `vector/quantized.rs` (planned) — `.qvec` page-addressable Q4/Q8/F32 tier codec and reader API for S3-backed HVQ
+- **Key interfaces**: Two trait APIs — secondary indexes use `IndexFactory`/`IndexBuilder`/`IndexReader` with partition/clustering key addressing; vector indexes use their own trait set in `vector::` module with byte-offset `RowPosition` and `nearest(query, k, ef_search)` for ANN queries. Storage-attached design — indexes are per-SSTable companion files built asynchronously after flush. HVQ will add an object-backed artifact reader whose row identity includes SSTable generation/build id so `.qvec` pages can be read from S3 without local full-file residency.
 - **Vector index type**: `IndexType::Vector` registered in the factory for `CREATE INDEX ... USING 'vector'` DDL.
 - **Phonetic encoder public API**: `PhoneticEncoder` trait and Double Metaphone algorithm are public, usable outside of index builds.
 - **Spec**: [Secondary Indexes Design](../superpowers/specs/2026-03-14-secondary-indexes-design.md)
+
+### ferrosa-index-builder
+
+- **Purpose**: Remote index construction service for scalar sidecars and planned
+  `.qvec` vector artifacts, keeping heavy build work off the serving node.
+- **Location**: `ferrosa-index-builder/`
+- **Dependencies**: `ferrosa-storage`, `ferrosa-sstable`, `ferrosa-index`,
+  `ferrosa-common`, `object_store`, HTTP server/runtime dependencies.
+- **Key interfaces**: `POST /internal/index/build`, pull-mode manifest watcher,
+  object-store upload contract.
+- **HVQ contract**: for `quantized_ivf_flat` and future `quantized_hnsw`, the
+  builder returns artifact manifest entries with object keys, sizes, checksums,
+  dimensions, metric, format version, tier summaries, and build id. It must
+  stream/range-read input and fail loud on scratch-budget exhaustion; it must
+  not make partial `.qvec` uploads visible.
+- **Spec**: [Remote Index Build Backend](remote-index-build-backend.md)
 
 ### ferrosa-udf
 

--- a/specs/data-flow.md
+++ b/specs/data-flow.md
@@ -61,6 +61,24 @@ When `pin_config.is_pinned()` returns true for a table, flushed SSTables remain 
 
 After an SSTable is written during flush, for each registered FullText index on the table, a `FullTextIndexBuilder` processes the flushed partitions and writes a sidecar file named `{generation}-FTI-{index_name}.db` alongside the SSTable. These sidecars follow the same locality rules as the parent SSTable (pinned or uploaded to S3).
 
+### HVQ Vector Artifact Publishing
+
+For `quantized_ivf_flat` and future `quantized_hnsw`, vector index build output
+is not a local-only sidecar. The flush path or remote builder writes immutable
+`.qvec` objects to S3-compatible storage, validates object size/checksum/page
+metadata, then publishes an index artifact manifest entry. A node may cache hot
+pages on NVMe, but manifest visibility is the durable source of truth.
+
+Publish order:
+
+1. Build from `f32` vectors so graph/list quality is not degraded by low-bit
+   edge selection.
+1. Write `.qvec` tier objects or pages to object storage.
+1. Validate every object key, size, checksum, dimension, metric, tier, and page
+   table entry.
+1. CAS-update the table/index manifest to make the artifact query-visible.
+1. Admit selected hot pages to the local NVMe cache.
+
 ## Read Path
 
 ```mermaid
@@ -120,6 +138,36 @@ sequenceDiagram
 **Sidecar files** are per-SSTable companion files written during flush. They contain sorted `(indexed_value, RowPosition)` entries with a CRC32-checksummed header. Missing sidecars trigger a fallback to full scan for that SSTable, with startup rebuild.
 
 **IndexIntersection**: When multiple indexed columns appear in WHERE, the planner collects RowPositions from each index and intersects them before row fetch, reducing I/O.
+
+### HVQ ANN Read-Through Flow
+
+ANN queries over `.qvec` artifacts use multi-fidelity read-through instead of
+whole-sidecar reads:
+
+```mermaid
+sequenceDiagram
+    participant P as Planner
+    participant M as Artifact Manifest
+    participant C as NVMe Page Cache
+    participant S3 as S3 Range GET
+    participant R as Quantized Reader
+
+    P->>M: Resolve index artifact for SSTable generations
+    P->>R: Start staged ANN search with page/byte budgets
+    R->>C: Read routing/page table pages
+    alt Cache miss
+        C->>S3: Range GET page
+        S3-->>C: Page bytes + etag
+        C->>C: Verify checksum/version/tier
+    end
+    R->>C: Read Q4/Q8 survivor pages
+    R->>C: Optionally read F32/residual rerank pages
+    R-->>P: Top-k VectorRowRef values
+```
+
+Low-bit tiers act like map tiles: they route to a smaller candidate set, then
+higher-bit tiers or exact `f32` pages refine survivors. A cache miss fetches a
+bounded byte range from S3; it must not trigger full artifact materialization.
 
 ## Accord Transaction Flow
 

--- a/specs/fmea-hvq-s3-spill-tier.md
+++ b/specs/fmea-hvq-s3-spill-tier.md
@@ -1,0 +1,116 @@
+# FMEA — HVQ S3 Spill Tier
+
+> Date: 2026-05-13
+> Scope: Hierarchical vector quantization artifacts, S3-durable vector index
+>        persistence, NVMe read-through cache, remote index builder, and
+>        multi-fidelity ANN query planning.
+> Method: RPN = Severity × Occurrence × Detection on a 1–10 scale. Action
+>        required for RPN >= 50. Every row with RPN >= 50 has a detection,
+>        exploitation, and recovery test.
+
+## Executive Summary
+
+The highest-risk failure modes are not codec math bugs; they are accidental
+local-residency seams that make a node require more disk or RAM than it owns.
+The HVQ implementation must make S3/object storage authoritative, publish
+artifacts only after checksum validation, and prove queries still work when the
+NVMe cache is smaller than the index.
+
+Top actions:
+
+1. Replace whole-sidecar `Vec<u8>` paths with page/range-readable index
+   artifacts before enabling production HVQ.
+1. Make remote-builder local fallback fail-loud for HVQ unless explicitly
+   configured with enough scratch space.
+1. Add MinIO integration tests that wipe local vector cache and prove query
+   correctness through S3 range reads.
+1. Add recall gates against an exact `f32` baseline before exposing Q1/Q2
+   routing to user traffic.
+
+## Scope
+
+In scope:
+
+- `.qvec` index artifact format and page table.
+- Q1/Q2/Q4/Q8/F32 or residual tier storage.
+- Object-store publish and manifest visibility.
+- Bounded NVMe page cache and S3 range reads.
+- Remote builder scratch-space and upload behavior.
+- Query planner staged narrowing and final rerank.
+
+Out of scope:
+
+- Scalar BTree/hash/full-text sidecar failures, except where their APIs would
+  be reused incorrectly by HVQ.
+- Cassandra compatibility behavior unrelated to vector indexes.
+
+## Scoring Criteria
+
+| Score | Severity | Occurrence | Detection |
+|-------|----------|------------|-----------|
+| 1     | No user-visible effect | Rare | Always caught by type/unit tests |
+| 2-3   | Minor latency or cost regression | Uncommon | Caught by focused integration tests |
+| 4-6   | Query degraded or stale until retry | Plausible under load | Metrics or integration tests catch it |
+| 7-8   | Incorrect ANN results or node instability | Likely at scale | Requires targeted tests/audits |
+| 9-10  | Silent corruption, unavailable index, or data loss | Chronic if seam exists | Only production symptoms catch it |
+
+## Top Risks
+
+| Rank | ID | Failure Mode | Status | RPN |
+|-----:|----|--------------|--------|----:|
+| 1 | HVQ-02 | Builder exhausts temp disk/RAM on production-size SSTables | open | 280 |
+| 2 | HVQ-03 | Whole-sidecar read path accidentally used for `.qvec` artifacts | open | 252 |
+| 3 | HVQ-04 | Partial upload or stale manifest exposes corrupt `.qvec` | open | 240 |
+| 4 | HVQ-08 | Remote builder writes artifacts that engine cannot discover/validate | open | 216 |
+| 5 | HVQ-01 | Q1/Q2 routing drops true neighbors too early | open | 180 |
+
+## Failure Modes
+
+| ID | Function | Failure Mode | Effect | S | Cause | O | Detection | D | RPN | Required Tests |
+|----|----------|--------------|--------|---|-------|---|-----------|---|-----|----------------|
+| HVQ-01 | Query planning | Q1/Q2 routing eliminates true neighbors too early | Fast but wrong ANN results; recall below SLO | 9 | Low-bit quantization used for graph/list pruning without enough candidates or rerank | 4 | Recall benchmark against exact `f32` baseline | 5 | 180 | Detection: recall@k gate by dimension/metric. Exploitation: adversarial close-vector corpus. Recovery: widen candidate multiplier and exact rerank restores recall. |
+| HVQ-02 | Index build | Builder exhausts temp disk/RAM on production-size SSTables | Build backlog, stale indexes, node instability | 8 | Current builder downloads full components and materializes partitions/indexes locally | 5 | Temp-disk watermark and build memory metrics | 7 | 280 | Detection: enforce `max_temp_bytes` before download. Exploitation: build with cache smaller than SSTable/index. Recovery: streaming/range build fails loud or completes bounded. |
+| HVQ-03 | Query read path | Whole-sidecar `Vec<u8>` path used for `.qvec` | Node tries to read entire index from S3/NVMe; OOM or disk exhaustion | 9 | Reusing legacy `read_vector_sidecar` instead of page reader | 4 | Metrics: bytes/query and range-get count; API type separation | 7 | 252 | Detection: test asserts bounded bytes read. Exploitation: `.qvec` larger than local cache. Recovery: range reader succeeds with fixed page budget. |
+| HVQ-04 | Publish | Partial upload or stale manifest exposes corrupt `.qvec` | Decode failures or wrong row references | 10 | Manifest visible before all pages/checksums are committed | 4 | Checksum/object-size validation before CAS publish | 6 | 240 | Detection: manifest validator rejects missing/short object. Exploitation: kill builder mid-upload. Recovery: old artifact remains live, new build is retried. |
+| HVQ-05 | Cache coherency | Stale cached pages used after compaction | Queries return candidates from obsolete SSTables | 9 | Cache key omits generation/build/checksum or liveness check | 3 | Cache key/version tests and manifest liveness checks | 6 | 162 | Detection: stale-page lookup rejected. Exploitation: compact, reuse object range/page id. Recovery: old cache invalidated, new artifact queried. |
+| HVQ-06 | S3 access | Range-read amplification / cold-page storm | High p99 latency and S3 cost | 7 | Poor page layout, no prefetch bounds, too many survivor pages | 5 | `s3_range_gets_per_query`, bytes/query, timeout metrics | 5 | 175 | Detection: cold-cache benchmark. Exploitation: scatter candidate pages. Recovery: page clustering, prefetch, query budget cutoff. |
+| HVQ-07 | Format validation | Codec/dimension/metric mismatch | Wrong scores or decode panics | 9 | Missing magic/version/codec/dim/metric validation | 3 | Header validation and property tests | 3 | 81 | Detection: malformed header tests. Exploitation: decode Q4 as Q8 or cosine as L2. Recovery: fail loud with typed error. |
+| HVQ-08 | Builder contract | Engine cannot discover or validate remote-builder `.qvec` | Index silently stale or ignored | 8 | Response only reports scalar sidecar path; no artifact manifest entry | 3 | Manifest reconciliation and builder response validation | 9 | 216 | Detection: missing artifact manifest alert. Exploitation: builder returns object key without checksum. Recovery: engine keeps old index/stale state and schedules rebuild. |
+| HVQ-09 | Fallback policy | Remote builder failure falls back to local full build | Compute node exhausts disk despite tiered design | 8 | Existing `RemoteBackend` local fallback reused for HVQ | 4 | Config test for fail-loud HVQ fallback policy | 6 | 192 | Detection: all builders down with HVQ job. Exploitation: local scratch smaller than input. Recovery: job queued/stale, node remains healthy. |
+| HVQ-10 | Row identity | Candidate positions collide across SSTable generations | Wrong row rerank or duplicate suppression | 8 | Legacy `RowPosition { offset }` lacks SSTable/object generation | 3 | Type-level `VectorRowRef` with generation/object key | 5 | 120 | Detection: two SSTables with identical offsets. Exploitation: merge candidates by offset only. Recovery: candidate identity includes generation/build id. |
+
+## Required Test Matrix
+
+| Layer | Test | Evidence |
+|-------|------|----------|
+| Unit | `.qvec` header/page-table validation rejects unknown versions, bad checksums, dimension mismatch, codec mismatch | Typed errors, no panic |
+| Property | Q8/Q4/Q2/Q1 encode/decode error bounds across dimensions and metrics | Regression seeds committed |
+| Integration | Build `.qvec`, upload to MinIO, publish manifest only after checksum validation | Object metadata and manifest CAS verified |
+| Integration | Delete local NVMe vector cache and query through S3 range reads | Non-empty results, bounded bytes/query |
+| Integration | Local cache smaller than total vector index still returns correct top-k after rerank | Recall gate passes |
+| Chaos | Kill remote builder mid-upload | No visible partial artifact; old index remains live |
+| Chaos | S3 short read, missing object, stale etag, and checksum mismatch | Fail-loud error and metric increment |
+| Compaction | Replacement `.qvec` published before old artifact GC; stale cached pages rejected | Old generation no longer returned |
+| Performance | Cold/warm p50/p95/p99, S3 range gets/query, bytes/query, cache hit ratio | Baseline stored for regression detection |
+
+## Mitigation Requirements
+
+1. Durable artifact visibility must be publish-after-validate:
+   object upload -> checksum/size validation -> manifest CAS -> query planner visibility.
+1. Reader APIs must distinguish local full-file sidecars from object-range HVQ
+   artifacts at the type level.
+1. Remote builder fallback policy must be explicit for HVQ:
+   `fail_loud`, `queue`, or `local_if_capacity_reserved`; never silent local
+   fallback by default.
+1. Cache keys must include object key, generation/build id, byte range/page id,
+   tier, checksum, and format version.
+1. Query planner must expose hard budgets for page reads, bytes read, survivor
+   count, and exact-rerank fanout.
+
+## Related Specs
+
+- [Hierarchical Vector Quantization](hierarchical-vector-quantization.md)
+- [Project Plan — HVQ S3 Spill Tier](project-plan-hvq-s3-spill-tier.md)
+- [Remote Index Build Backend](remote-index-build-backend.md)
+- [Storage Engine](storage.md)
+- [Testing Strategy](testing.md)

--- a/specs/hierarchical-vector-quantization.md
+++ b/specs/hierarchical-vector-quantization.md
@@ -1,13 +1,15 @@
-# Hierarchical Vector Quantization for NVMe-Resident ANN
+# Hierarchical Vector Quantization for S3-Durable, NVMe-Cached ANN
 
-> Last updated: 2026-05-12
+> Last updated: 2026-05-13
 > Status: Draft / design investigation
 
 ## Executive Summary
 
-Ferrosa currently stores flushed vector indexes as per-SSTable JSON sidecars that contain full `f32` vectors for HNSW and IVFFlat. That is correct for small sidecars, but it does not scale to a 100B-vector target: every searched sidecar must be read and decoded as full precision before it can narrow the candidate set.
+Ferrosa currently stores flushed vector indexes as per-SSTable JSON sidecars that contain full `f32` vectors for HNSW. `ferrosa-index` also has an IVFFlat implementation with the same whole-file/full-vector shape, but `ferrosa-storage`'s flushed vector sidecar path currently builds and searches HNSW only. That is correct for small sidecars, but it does not scale to a 100B-vector target: every searched sidecar must be read and decoded as full precision before it can narrow the candidate set.
 
-This spec proposes a hierarchical quantized vector index: store progressively more precise vector representations (`Q1 -> Q2 -> Q4 -> Q8 -> F32` or residual/PQ equivalents) in NVMe-resident sidecar pages, use coarse tiers to eliminate most candidates with bounded reads, then fetch finer tiers only for survivors. The first implementation should be an additive index method (`quantized_hnsw` or `hnsw_quantized`) rather than a rewrite of existing HNSW/IVFFlat.
+This spec proposes a hierarchical quantized vector index: store progressively more precise vector representations (`Q1 -> Q2 -> Q4 -> Q8 -> F32` or residual/PQ equivalents) in S3-durable, page-addressable `.qvec` objects, use bounded NVMe cache only for hot manifests/routing/pages, eliminate most candidates with bounded object-range reads, then fetch finer tiers only for survivors. The first implementation should be an additive index method (`quantized_ivf_flat` first, then `quantized_hnsw`) rather than a rewrite of existing HNSW/IVFFlat.
+
+Important invariant: local compute-node disk is not assumed to hold the full vector index. S3-compatible object storage is authoritative and durable; NVMe is a bounded, evictable cache.
 
 ## Current Codebase Findings
 
@@ -32,10 +34,8 @@ This spec proposes a hierarchical quantized vector index: store progressively mo
 ### Current flush/search path
 
 - `TableStore::flush()` drains each `VectorMemtableIndex` and writes one `{gen}-VEC-{index_name}.db` sidecar per SSTable generation.
-- Persistent vector sidecar method dispatch currently supports:
-  - `IndexMethod::Hnsw { m, ef_construction }`
-  - `IndexMethod::IvfFlat { lists }`
-- `TableStore::ann_search()` searches the active memtable, then loops all SSTable generation IDs, reads each vector sidecar with `flush_target.read_vector_sidecar(gen, index_name)`, dispatches to HNSW or IVFFlat decoder, merges by `position.offset`, sorts by score, and truncates to `k`.
+- Persistent vector sidecar dispatch in `ferrosa-storage` currently builds and searches HNSW sidecars only. `ferrosa-index` has IVFFlat code, but the storage flush/search path does not currently persist IVFFlat vector sidecars.
+- `TableStore::ann_search()` searches the active memtable, then loops all SSTable generation IDs, reads each vector sidecar with `flush_target.read_vector_sidecar(gen, index_name)`, dispatches to the HNSW decoder, merges by `position.offset`, sorts by score, and truncates to `k`. This is a correctness and scale seam: offsets can collide across generations, and the current file-backed `FlushTarget` writes vector sidecars but does not provide a matching remote/object-range read path.
 - `FlushTarget::write_vector_sidecar/read_vector_sidecar` currently treat the whole sidecar as one byte blob. File-based sidecars are named `{generation}-VEC-{index_name}.db`.
 
 ### Hotspots
@@ -59,25 +59,33 @@ At 100B vectors, full precision sidecars are untenable:
   - 100B x 1536 dims x 4 bytes = 614.4 TB before metadata.
 - JSON adds unacceptable overhead and decode CPU.
 - Existing `ann_search()` reads per-SSTable whole sidecars, which becomes an O(number-of-SSTables * sidecar-size) anti-pattern.
+- Data volume can exceed the local disk capacity of any compute node. A correct design cannot require all quantized sidecars, F32 rerank pages, or candidate tiers to be locally resident before query execution.
+- Existing storage architecture is S3-first/write-behind; vector index sidecars must follow the same durability model rather than becoming a local-only exception.
 - HNSW and IVFFlat both currently store full vectors at their leaf/candidate layer.
 
-The design goal is not merely smaller storage. It is fewer NVMe reads per query by matching representation precision to search phase.
+The design goal is not merely smaller storage. It is bounded bytes read per query across a two-tier storage model: S3/object storage as durable backing, NVMe as a bounded cache, and representation precision matched to search phase.
 
 ## Design Goals
 
 1. Keep all existing vector index methods working.
-1. Add a new method whose on-disk format is page-addressable, binary, and versioned.
+1. Add a new method whose durable format is page-addressable, binary, versioned, and S3/object-store addressable.
+1. Make every quantized index artifact S3-durable before it is advertised in table/index manifests.
+1. Support object-range reads for manifests, page tables, routing pages, quantized tiers, and optional F32/residual pages.
+1. Treat NVMe as an optional bounded cache, not a correctness requirement.
+1. Continue serving queries when total index data exceeds compute-node disk by fetching cold pages from S3 on demand.
+1. Define cache admission, eviction, rehydration, and fail-loud behavior for cache misses and S3 read failures.
 1. Store coarse quantized representations in upper/coarse routing nodes.
 1. Fetch more precise representations only after candidate narrowing.
 1. Keep exact `f32` vectors optional and cold; use them only for final rerank when configured.
 1. Make cost/recall tunable per query and per index.
-1. Avoid global in-memory graph requirements. The reader may cache manifests, routing summaries, and hot top-level pages, but not all vectors.
+1. Avoid global in-memory graph requirements. The reader may cache manifests, routing summaries, and hot top-level pages in NVMe/RAM, but must never require all vectors or all tier pages to fit locally.
 1. Preserve fail-loud behavior: unknown format, missing tier page, dimension mismatch, or corrupted checksum returns an error and records telemetry.
 
 ## Non-Goals for First Implementation
 
 - No mutation-in-place of an existing quantized sidecar. Build immutable sidecars during flush or remote index build.
-- No global 100B index across all SSTables in v1. The first cut remains per-SSTable sidecars, then adds a higher-level manifest/fanout layer later.
+- No global 100B index across all SSTables in v1. The first cut remains per-SSTable artifacts, then adds a higher-level manifest/fanout layer later.
+- No assumption that one node's NVMe can contain all sidecars for its assigned SSTables. Even v1 per-SSTable artifacts must be readable from S3 object ranges with local caching.
 - No GPU requirement.
 - No approximate delete handling beyond current SSTable/tombstone semantics.
 - No replacement of scalar secondary index machinery.
@@ -89,19 +97,26 @@ flowchart TD
     W[Writes] --> M[VectorMemtableIndex<br/>brute-force bounded RAM]
     M --> F[Flush / remote index build]
     F --> B[Quantized builder]
-    B --> MAN[manifest.qvec]
-    B --> T1[Q1/Q2 routing pages<br/>NVMe hot]
-    B --> T4[Q4 candidate pages<br/>NVMe warm]
-    B --> T8[Q8 refine pages<br/>NVMe cold]
-    B --> FP[F32 residual/final pages<br/>optional cold]
+    B --> S3MAN[S3 .qvec manifest/page table]
+    B --> S3T1[S3 Q1/Q2 routing pages]
+    B --> S3T4[S3 Q4 candidate pages]
+    B --> S3T8[S3 Q8 refine pages]
+    B --> S3FP[S3 F32/residual pages<br/>optional]
+
+    S3MAN --> CACHE[Bounded NVMe cache]
+    S3T1 --> CACHE
+    S3T4 --> CACHE
+    S3T8 --> CACHE
+    S3FP --> CACHE
 
     Q[ANN query] --> R[Quantized reader]
-    R --> MAN
-    R --> T1
-    R --> T4
-    R --> T8
-    R --> FP
-    R --> OUT[top-k RowPosition]
+    R --> CACHE
+    CACHE -->|miss: Range GET| S3MAN
+    CACHE -->|miss: Range GET| S3T1
+    CACHE -->|miss: Range GET| S3T4
+    CACHE -->|miss: Range GET| S3T8
+    CACHE -->|miss: Range GET| S3FP
+    R --> OUT[top-k VectorRowRef]
 ```
 
 ### Components
@@ -129,10 +144,20 @@ struct QuantizedVectorManifest {
     dimensions: u16,
     metric: DistanceMetric,
     method: QuantizedMethod,     // HNSW, IVFFlat, IVF_HNSW, future
+    storage: QuantizedStorageDescriptor,
     tiers: Vec<QuantizedTier>,
     routing_root: PageId,
     row_count: u64,
+    manifest_generation: u64,
     checksum: u32,
+}
+
+struct QuantizedStorageDescriptor {
+    durable_backend: DurableBackend, // S3-compatible object store in production
+    object_key: String,              // canonical .qvec object key
+    object_etag: Option<String>,
+    object_size: u64,
+    local_cache_policy: CachePolicyId,
 }
 
 struct QuantizedTier {
@@ -140,15 +165,88 @@ struct QuantizedTier {
     page_size: u32,              // e.g. 4 KiB, 16 KiB, 64 KiB
     page_count: u64,
     codec: CodecId,
+    object_key: String,
     byte_range: ByteRange,
+    page_index_range: Range<u64>,
+    checksum: u32,
 }
 ```
 
 #### `QuantizedPageStore`
 
-A page-addressable sidecar reader/writer abstraction. It should not require reading the entire sidecar into memory.
+A page-addressable reader/writer abstraction over durable object storage plus an optional local NVMe cache. It must not require reading the entire sidecar into memory or materializing the full sidecar on local disk.
 
-First version can wrap local files under the existing flush target directory. Later versions can map the same page API to S3 object ranges or an NVMe cache manager.
+Required backends:
+
+- `ObjectRangePageStore`: reads `.qvec` page byte ranges from S3-compatible object storage using ranged GETs.
+- `NvmeCachePageStore`: wraps the object-range store with bounded local cache admission and eviction.
+- `FilePageStore`: test/prototype backend only; implements the same range-read contract.
+
+Cache misses are normal. A miss should issue an object-range read, verify checksum, optionally admit the page to NVMe cache, and return the page. S3/object read failure, checksum mismatch, short read, wrong object generation, or missing page must fail loudly; never return partial or empty results as success.
+
+#### S3 durability and object layout
+
+S3-compatible object storage is the durable source of truth for `.qvec` artifacts. Local files and NVMe pages are cache entries only.
+
+Requirements:
+
+1. A quantized index is not visible to query planning until object upload completes, object checksum/metadata is recorded, and the table/index manifest publish succeeds.
+1. Upload must be atomic from the reader perspective: readers either see the old index generation or the fully uploaded new generation.
+1. `.qvec` objects must support HTTP/S3 Range GET for the manifest/header, page table, routing pages, tier pages, and optional F32/residual pages.
+1. Object metadata should include checksum, format version, table/index/generation identity, and build id.
+1. Compaction must publish replacement `.qvec` objects before removing old objects from the live manifest.
+1. Garbage collection of old quantized objects must follow the same manifest/liveness rules as SSTable components.
+
+The implementation should align with existing storage primitives:
+
+- `object_store::ObjectStore` for durable remote reads/writes.
+- `ferrosa-storage/src/upload/manager.rs` `UploadTask::IndexFiles` for uploading index artifacts.
+- `hex_prefix_for` and `sstable_object_key` path conventions for object distribution.
+- `ferrosa_sstable::io::ReadAt` for range-addressable data access.
+- `LocalCache` as cache bookkeeping to extend for vector artifacts.
+- `IndexBuildBackend`, `RemoteBackend`, and `IndexBuildResult::sidecar_written_to_s3` for remote builder integration.
+
+Suggested logical object key:
+
+```text
+{s3_prefix}/indexes/{table_id}/{sstable_generation}/{index_name}/{build_id}.qvec
+```
+
+#### NVMe cache and eviction requirements
+
+NVMe is a bounded cache, not durability.
+
+Requirements:
+
+1. Correctness must not depend on any page remaining cached.
+1. Cache keys must include object key, generation/build id, byte range/page id, tier, and checksum/version.
+1. Admission policy should prefer manifests/page tables, top-level routing pages, frequently hit Q2/Q4 pages, and only selectively admit Q8/F32 pages.
+1. Eviction policy must be deterministic and observable; LRU or TinyLFU is acceptable for v1.
+1. Rehydration must fetch the required byte range, not the whole object.
+1. Cache must expose metrics for hit/miss/eviction/fill bytes and S3 range-read latency.
+
+#### Index artifact manifest
+
+The existing SSTable manifest/discovery paths focus on SSTable components. Quantized vector artifacts need explicit manifest entries or an equivalent index-artifact manifest so remote-built sidecars are durable and discoverable without scanning local directories.
+
+Suggested fields:
+
+```rust
+struct IndexArtifactManifestEntry {
+    table_id: TableId,
+    sstable_generation: u64,
+    index_name: String,
+    artifact_kind: IndexArtifactKind, // vector_hnsw, hvq_qvec, fti, future
+    object_key: String,
+    format_version: u16,
+    object_size: u64,
+    checksum: u32,
+    build_id: BuildId,
+    build_epoch: u64,
+}
+```
+
+This manifest is the bridge that makes `sidecar_written_to_s3 = true` safe: the query path must be able to resolve and range-read the S3 artifact even when no local file exists.
 
 #### Query planner
 
@@ -213,7 +311,7 @@ This is the easier first target than HNSW because it minimizes graph traversal e
 
 ## Sidecar Layout
 
-Replace one JSON blob with a small manifest plus binary tier pages. One physical file is simplest for atomicity; multiple files are simpler for debugging. Suggested v1: one `.qvec` file with internal byte ranges.
+Replace one JSON blob with a small manifest plus binary tier pages. Suggested v1: one logical `.qvec` object per SSTable/index generation with internal byte ranges. The object may be cached partially or wholly on NVMe, but the canonical copy is S3-durable. Multiple physical objects per tier can be considered later if S3 range-read behavior, object size limits, or independent tier lifecycle justify it.
 
 ```text
 {gen}-VEC-{index_name}.qvec
@@ -230,6 +328,12 @@ Replace one JSON blob with a small manifest plus binary tier pages. One physical
 
 The existing `{gen}-VEC-{index_name}.db` can remain for JSON HNSW/IVFFlat. New method should use `.qvec` or a magic header so decode never guesses.
 
+Canonical object layout should be manifest-addressable rather than local-directory-scanned. A v1 path can use:
+
+```text
+{s3_prefix}/indexes/{table_id}/{sstable_generation}/{index_name}/{build_id}.qvec
+```
+
 ## Query Flow
 
 ```mermaid
@@ -237,18 +341,25 @@ sequenceDiagram
     participant CQL as CQL executor
     participant Store as TableStore::ann_search
     participant Reader as QuantizedReader
-    participant NVMe as NVMe/PageStore
+    participant Cache as NVMe Cache
+    participant S3 as S3 Object Store
 
     CQL->>Store: ANN query, k, ef_search
     Store->>Reader: nearest(query, budget)
-    Reader->>NVMe: read manifest + hot routing pages
+    Reader->>Cache: read manifest + hot routing pages
+    Cache->>S3: Range GET on cache miss
+    S3-->>Cache: page bytes + metadata
+    Cache->>Cache: verify checksum and admit/evict
     Reader->>Reader: coarse search with Q1/Q2
-    Reader->>NVMe: fetch Q4 pages for survivors
+    Reader->>Cache: fetch Q4 pages for survivors
+    Cache->>S3: Range GET on cache miss
     Reader->>Reader: prune candidate set
-    Reader->>NVMe: fetch Q8 pages
+    Reader->>Cache: fetch Q8 pages
+    Cache->>S3: Range GET on cache miss
     Reader->>Reader: refine candidates
     alt exact_rerank
-        Reader->>NVMe: fetch F32/residual pages
+        Reader->>Cache: fetch F32/residual pages
+        Cache->>S3: Range GET on cache miss
         Reader->>Reader: exact score top candidates
     end
     Reader-->>Store: top-k positions + scores
@@ -270,6 +381,10 @@ enum IndexMethod {
         m: Option<usize>,          // for HNSW
         ef_construction: Option<usize>,
         exact_rerank: bool,
+        storage: QuantizedStorageMode, // s3_backed | local_test_only
+        cache_policy: CachePolicy,
+        max_local_cache_bytes: Option<u64>,
+        max_object_range_bytes_per_query: Option<u64>,
     },
 }
 ```
@@ -284,7 +399,10 @@ CREATE INDEX idx_embed ON docs (embedding) USING 'vector'
         'metric': 'cosine',
         'tiers': 'q2,q4,q8,f32',
         'lists': '65536',
-        'exact_rerank': 'true'
+        'exact_rerank': 'true',
+        'storage': 's3_backed',
+        'cache_policy': 'routing_hot_lru',
+        'max_page_reads': '512'
     };
 ```
 
@@ -303,12 +421,13 @@ Questions before locking the public DDL:
 1. Establish recall@k and latency baselines for full precision.
 1. Add instrumentation for candidates scanned, sidecar bytes read, page reads, and rerank count.
 
-### Phase 1 — Binary Page Container
+### Phase 1 — S3-Durable Binary Page Container
 
-1. Implement a versioned binary `.qvec` container with manifest, page table, and checksums.
-1. Add `QuantizedPageStore` with file-backed read ranges.
-1. Add golden encode/decode tests and corruption tests.
-1. Add fail-loud errors for magic/version/checksum/dimension mismatch.
+1. Implement a versioned binary `.qvec` container with manifest, page table, object keys, byte ranges, and checksums.
+1. Add `QuantizedPageStore` with object-range reads, checksum verification, and a file-backed test backend using the same range-read contract.
+1. Add `NvmeCachePageStore` wrapper semantics for cache miss/fill/evict behavior.
+1. Add golden encode/decode tests, corruption tests, short-read tests, and missing-object tests.
+1. Add fail-loud errors for magic/version/checksum/dimension/object-generation mismatch.
 
 ### Phase 2 — Quantization Codecs
 
@@ -335,14 +454,18 @@ Questions before locking the public DDL:
 
 1. Extend `IndexMethod::from_options` for `quantized`.
 1. Add dispatch in `TableStore::flush()` and `ann_search()`.
-1. Update `FlushTarget` docs and file-backed range read support.
+1. Add vector artifact upload through `UploadTask::IndexFiles` and publish manifest entries only after durable upload verification.
+1. Add cache-backed object-range reads for quantized query path; keep whole-blob reads only for legacy JSON sidecars.
+1. Update `FlushTarget` docs to clarify it is local materialization, not S3 durability.
 1. Preserve old `.db` sidecars for existing HNSW/IVFFlat methods.
 
-### Phase 6 — Remote Index Builder / NVMe Cache
+### Phase 6 — Remote Index Builder / Production Tuning
 
 1. Move large quantized builds to `ferrosa-index-builder` for production-sized SSTables.
+1. Have the builder read SSTable/object artifacts from S3 and write `.qvec` artifacts back to S3 through the object-store/index-artifact path.
 1. Add page prefetch and admission policy for hot routing pages.
-1. Add compaction merge behavior: rebuild quantized sidecars for compacted SSTables.
+1. Add compaction merge behavior: publish replacement quantized sidecars for compacted SSTables before old-object GC.
+1. Tune page clustering and range-read budgets to control S3 latency and request amplification.
 
 ## Test Strategy
 
@@ -356,10 +479,14 @@ Questions before locking the public DDL:
   - staged search never returns more than `k`
   - exact rerank score ordering equals full `f32` scoring for survivor set
 - Integration tests:
-  - flush writes `.qvec` sidecar
-  - restart/read path opens sidecar without full decode
+  - flush/build uploads `.qvec` artifact to S3/MinIO before manifest publish
+  - restart/read path opens sidecar without full decode or full local materialization
+  - deleting local cache still allows query by S3 range reads
+  - cache size smaller than total index size still allows correct queries
+  - cache eviction during repeated queries does not change correctness
+  - missing S3 object, short range read, checksum mismatch, or stale object generation fails loudly
   - `ann_search()` merges active memtable + quantized SSTable results
-  - compaction removes/replaces old quantized sidecars
+  - compaction publishes replacement quantized sidecars and prevents stale cached pages from being used
 - Benchmarks:
   - bytes read/query
   - p50/p95 latency
@@ -374,9 +501,14 @@ Questions before locking the public DDL:
 | Low-bit traversal breaks HNSW recall | Bad results despite fast search | Start with IVFFlat; keep HNSW exact/rerank pages; benchmark recall before enabling by default |
 | JSON compatibility churn | Existing sidecars fail to decode | New magic/versioned `.qvec`; no change to old `.db` readers |
 | `RowPosition { offset }` insufficient | Cannot uniquely identify rows across SSTables/pages | Keep generation context at `TableStore` merge layer initially; consider future `VectorRowRef { generation, offset }` in quantized sidecar internals |
-| Whole-sidecar `read_vector_sidecar` API | Destroys NVMe page-read goal | Add page/range read API for quantized method; keep old blob API for old formats |
+| Whole-sidecar `read_vector_sidecar` API | Destroys object-range and cache-read goal | Add page/range read API for quantized method; keep old blob API only for legacy formats |
 | Large builder RAM use | Cannot build production-size indexes during flush | Use remote index builder and streaming/page-spilling builder before production use |
 | Quantization calibration drift | Poor recall on skewed embedding distributions | Store per-block/per-list scales; benchmark on real corpus embeddings |
+| Spec assumes local NVMe contains full index | Production cannot handle index volume > compute disk | Make S3 durable backing mandatory; test with cache smaller than index |
+| S3 range-read amplification | High latency/cost under scattered candidate pages | Page clustering, query read budgets, prefetch, tier-aware layout |
+| Cache eviction removes needed pages | Query failure/perf cliff if cache is treated as source of truth | Cache is non-authoritative; rehydrate from S3 by object range |
+| Stale cached pages after compaction | Wrong nearest-neighbor results | Cache key includes generation/build/checksum; manifest controls liveness |
+| Partial upload visible to readers | Corrupt/incomplete query results | Publish-after-upload CAS; checksum and object-size validation |
 
 
 ## Blueprint Expansion
@@ -391,8 +523,8 @@ Until the grill-me answers below are resolved, use these defaults for planning:
 |---|---|---|
 | First base algorithm | IVFFlat | IVFFlat has explicit centroid/list phases, so low-bit approximation is easier to bound than HNSW graph traversal error. |
 | HNSW scope | Research/prototype after IVFFlat | HNSW can still use tiered payload pages, but low-bit vectors can corrupt greedy routing decisions. |
-| First storage format | New `.qvec` container | Avoids changing existing JSON `.db` sidecars and makes version/magic/checksum checks fail loud. |
-| First durability model | Immutable per-SSTable sidecar | Matches current flush/compaction semantics and avoids mutable quantized trees. |
+| First storage format | New `.qvec` object | Avoids changing existing JSON `.db` sidecars and makes version/magic/checksum checks fail loud. |
+| First durability model | Immutable S3-durable per-SSTable object, NVMe cached | Matches current flush/compaction semantics, avoids mutable quantized trees, and supports data volume greater than compute-node disk. |
 | First precision ladder | Q2 -> Q4 -> Q8 -> optional F32 | Q1 should be benchmark-gated; it is attractive for routing but high-risk for recall. |
 | First query guarantee | Approximate narrow + exact survivor rerank | Keeps correctness understandable while storage and recall are measured. |
 | First build path | Local prototype builder, remote production builder later | Local keeps tests simple; remote builder is required before production-scale flushes. |
@@ -403,6 +535,8 @@ Until the grill-me answers below are resolved, use these defaults for planning:
 - Existing vector implementations are concentrated in `ferrosa-index/src/vector/{mod,hnsw,ivfflat}.rs`.
 - Existing persistence/search integration is concentrated in `ferrosa-storage/src/{store,flush}.rs` and `ferrosa-storage/src/memtable/vector_index.rs`.
 - `store.rs` is the main churn hotspot, so quantized search should add one dispatch seam there and keep page format/search logic inside `ferrosa-index`.
+- Existing sidecar upload/bootstrap paths handle standard SSTable components first; vector/FTI sidecars need explicit object-store artifact manifest/discovery.
+- `UploadTask::IndexFiles` and remote index-builder `sidecar_written_to_s3` are the right write-side seams, but the read-side resolver/materializer is missing.
 - `ferrosa-index-builder` is already the natural production path for large index construction; this design should not assume flush-time training at production scale.
 
 ### Phase 2 — Architecture Boundary
@@ -412,18 +546,18 @@ Split the work into five stable seams:
 | Seam | Owns | Should not own |
 |---|---|---|
 | Quantized codecs | Bit-packing, scale/zero-point metadata, distance kernels | SSTable generation, CQL parsing, compaction policy |
-| `.qvec` container | Manifest, page table, checksums, range reads | Search algorithm policy |
+| `.qvec` container | Manifest, object keys, page table, checksums, range reads | Search algorithm policy |
 | Quantized ANN reader/builder | IVFFlat/HNSW staged narrowing and rerank | Flush target implementation details |
-| Storage dispatch | Method selection, sidecar naming, per-generation merge | Codec internals |
+| Storage dispatch | Method selection, artifact manifest publish, per-generation merge | Codec internals |
 | Benchmark harness | Recall/latency/bytes-read gates | Production query execution |
 
 The critical dependency direction should be:
 
 ```text
-ferrosa-storage -> ferrosa-index::vector::quantized -> quantized codecs/container
+ferrosa-storage -> vector artifact resolver -> ferrosa-index::vector::quantized -> quantized codecs/container
 ```
 
-Do not let codec/container code depend back on storage, table schema, or CQL executor types. Pass plain row positions and byte-range abstractions.
+Do not let codec/container code depend back on storage, table schema, or CQL executor types. Pass durable vector row references and object-key/byte-range abstractions.
 
 ### Phase 3 — Threat / Data Integrity Model
 
@@ -470,7 +604,7 @@ RPN >= 180 items should be treated as gating work before any production/default 
 | S3 Quantized IVFFlat | Tiered list pages, staged narrowing, exact rerank | Recall@10 gate met against exact/f32 baseline on synthetic and real embeddings. |
 | S4 Storage integration | New index method dispatch in flush/search; old methods unchanged | Restart/read and memtable+SSTable merge tests pass. |
 | S5 HNSW research | Split adjacency/payload and quantized traversal prototype | Recall regression characterized before product decision. |
-| S6 Productionization | Remote builder, NVMe cache policy, compaction rebuild | Build memory bounded; bytes-read/query telemetry available. |
+| S6 Productionization | Remote builder, S3 artifact manifest, NVMe cache policy, compaction rebuild | Build memory bounded; S3 range-read/cache telemetry available. |
 
 ### Phase 7 — Test Specification
 
@@ -490,23 +624,32 @@ Add metrics before tuning:
 
 - `vector_quantized_page_reads_total{tier,index}`
 - `vector_quantized_bytes_read_total{tier,index}`
+- `vector_quantized_cache_hit_total{tier,index}`
+- `vector_quantized_cache_miss_total{tier,index}`
+- `vector_quantized_cache_evictions_total{tier,reason}`
+- `vector_quantized_cache_fill_bytes_total{tier,index}`
+- `vector_quantized_s3_range_reads_total{tier,index}`
+- `vector_quantized_s3_range_read_bytes_total{tier,index}`
+- `vector_quantized_s3_range_read_latency_seconds{tier,index}`
+- `vector_quantized_object_generation_mismatch_total`
+- `vector_quantized_cache_resident_bytes{tier,index}`
 - `vector_quantized_candidates_total{stage,index}`
 - `vector_quantized_exact_rerank_total{index}`
 - `vector_quantized_recall_benchmark{tier,corpus}` for offline benchmark output, not runtime production metrics
 - `vector_quantized_decode_errors_total{reason}`
 
-Operational rule: a decode/checksum/dimension failure should fail the query/index read loudly and emit telemetry. It should not fall back to a plausible empty result set.
+Operational rule: a decode/checksum/dimension/object-read failure should fail the query/index read loudly and emit telemetry. It should not fall back to a plausible empty result set.
 
 ### Phase 9 — Compiled Implementation DAG
 
-1. `container-types`: define manifest/page table structs and binary encoding.
-1. `container-reader-writer`: implement file-backed range reads/writes and checksum checks.
+1. `container-types`: define manifest/page table structs, object-key/byte-range fields, and binary encoding.
+1. `container-reader-writer`: implement object-range and file-backed test range reads/writes plus checksum checks.
 1. `codec-q8-q4`: implement and test higher-precision scalar codecs first.
 1. `codec-q2-q1`: add lower-bit codecs after Q8/Q4 gates are stable.
 1. `bench-baseline`: measure current f32 HNSW/IVFFlat before comparing new code.
 1. `ivf-builder`: write quantized inverted-list pages.
 1. `ivf-reader`: staged scan Q2/Q4/Q8/F32 survivor rerank.
-1. `storage-dispatch`: add `IndexMethod::Quantized` and sidecar naming/range-read API.
+1. `storage-dispatch`: add `IndexMethod::Quantized`, S3 artifact publish, artifact manifest entries, and cache-backed object-range API.
 1. `integration-tests`: flush/restart/search/compaction coverage.
 1. `hnsw-prototype`: only after IVFFlat gates pass.
 
@@ -530,8 +673,18 @@ These are the decisions that need owner input before implementation starts:
    - Recommended: expose precision tiers generically, benchmark scalar Q tiers and PQ before freezing the format.
 1. Exact rerank: Must final top-k be reranked against full `f32` vectors, or is approximate `Q8` final scoring acceptable?
    - Recommended: default exact rerank for correctness-sensitive workloads; allow approximate-only for cost-sensitive workloads.
-1. Storage target: Should cold `F32`/residual pages live on local NVMe only, S3 object ranges, or both?
-   - Recommended: manifest + routing pages hot on NVMe; cold full/residual pages recoverable from S3 or rebuilt by remote index builder.
+1. Storage invariant: Confirm that S3-compatible object storage is the durable source of truth and NVMe is only a bounded cache. Are there any deployments where `local_test_only` should be allowed outside unit/integration tests?
+   - Recommended: no; production index artifacts are S3-durable, and local-only is a test/prototype mode.
+1. Cache sizing: What max local cache fraction should benchmarks assume: 1%, 5%, or 10% of total vector index bytes?
+   - Recommended: test at 1% and 5% so the design proves it works with data larger than disk.
+1. S3 budget: What S3 range-read budget/latency SLO is acceptable per ANN query?
+   - Recommended: expose `max_page_reads` and `max_object_range_bytes_per_query`, then tune per corpus.
+1. F32/residual cache policy: Should F32/residual pages default to S3-only with cache admission disabled unless explicitly configured?
+   - Recommended: yes; route/cache coarse tiers first.
+1. Object layout: Is one `.qvec` object per SSTable/index generation acceptable for v1, or do we need multi-object tier layout now to reduce range-read scatter?
+   - Recommended: one object for v1, but keep tier `object_key` fields so multi-object layout is compatible.
+1. Remote builder upload path: Should the remote index builder upload `.qvec` directly to S3, or return artifacts to the engine for upload?
+   - Recommended: remote builder uploads directly and returns manifest metadata; engine publishes only after validation.
 1. Query contract: Should CQL continue using `ef_search`, or add explicit ANN budget knobs?
    - Recommended: keep `ef_search` for compatibility now; add internal budget mapping and later expose explicit options.
 1. Build path: Is synchronous flush-time build acceptable for v1 prototypes?

--- a/specs/hierarchical-vector-quantization.md
+++ b/specs/hierarchical-vector-quantization.md
@@ -38,6 +38,35 @@ Important invariant: local compute-node disk is not assumed to hold the full vec
 - `TableStore::ann_search()` searches the active memtable, then loops all SSTable generation IDs, reads each vector sidecar with `flush_target.read_vector_sidecar(gen, index_name)`, dispatches to the HNSW decoder, merges by `position.offset`, sorts by score, and truncates to `k`. This is a correctness and scale seam: offsets can collide across generations, and the current file-backed `FlushTarget` writes vector sidecars but does not provide a matching remote/object-range read path.
 - `FlushTarget::write_vector_sidecar/read_vector_sidecar` currently treat the whole sidecar as one byte blob. File-based sidecars are named `{generation}-VEC-{index_name}.db`.
 
+### Spill-safety review findings
+
+Parallel review of vector, storage, and remote-builder code found these seams
+that must be closed before production HVQ:
+
+- HNSW and IVFFlat both serialize monolithic JSON blobs containing graph/list
+  structures plus full `f32` vectors. Query code must not copy this pattern for
+  `.qvec`; it needs page-addressable graph/list/vector tiers.
+- `FileFlushTarget` writes vector sidecars locally, while the query seam is
+  `FlushTarget::read_vector_sidecar() -> Option<Vec<u8>>`. HVQ requires an
+  artifact resolver with S3 range reads and cache-backed page fetches instead
+  of whole-sidecar byte loading.
+- `LocalCache` tracks only local paths and sizes. It has no object key,
+  generation/build id, page id, checksum, range-fetch callback, or partial
+  residency state.
+- Engine bootstrap and `register_table()` currently discover SSTables and
+  sidecars through local directory scans. HVQ must make manifests/object refs
+  authoritative so a node can query before local full-file materialization.
+- `ferrosa-index-builder` currently downloads full SSTable components into temp
+  disk and uses local builder paths. HVQ builders must stream/range-read input,
+  reserve scratch before fetch, spill bounded work pages, and publish `.qvec`
+  manifest entries only after validation.
+- `RemoteBackend` local fallback is unsafe for HVQ-scale jobs. If builders are
+  down, the safe behavior is stale-index serving, queueing, or fail-loud status,
+  not unbounded local build.
+- Candidate identity must evolve from `RowPosition { offset }` to a row ref that
+  includes SSTable generation/object identity; offsets can collide across
+  generations.
+
 ### Hotspots
 
 Git churn over the last year for the vector-relevant paths:

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -27,6 +27,7 @@ graph TB
         Cluster[ferrosa-cluster<br/>Raft, Routing, CL]
         Accord[Accord Consensus<br/>Transactions, LWT]
         Index[ferrosa-index<br/>Secondary + Vector Indexes]
+        Builder[ferrosa-index-builder<br/>Remote Index Builder]
         UDF[ferrosa-udf<br/>WASM Sandbox]
         Storage[ferrosa-storage<br/>Memtable, Cache, Compaction, PITR]
         SST[ferrosa-sstable<br/>BTI Read + Write]
@@ -53,6 +54,8 @@ graph TB
     CQL --> Cluster
     CQL --> Accord
     CQL --> Index
+    Index --> Builder
+    Builder -.->|publish sidecars + .qvec artifacts| S3
     CQL --> UDF
     Graph --> Schema
     Graph --> Storage
@@ -74,7 +77,8 @@ graph TB
 
 ## Design Principles
 
-1. **S3 as source of truth** — nodes are ephemeral, SSTables live in object storage
+1. **S3 as source of truth** — nodes are ephemeral, SSTables and index artifacts live in object storage
+1. **Bounded NVMe cache** — local disk improves performance but must not be required to hold full table or vector-index volume
 1. **CQL compatibility** — existing drivers and tools work unchanged
 1. **Rust-native** — idiomatic Rust with clean ownership, not a Java transliteration
 1. **Cassandra's consistency model** — tunable CL (ONE, QUORUM, ALL) preserved

--- a/specs/project-plan-hvq-s3-spill-tier.md
+++ b/specs/project-plan-hvq-s3-spill-tier.md
@@ -1,0 +1,289 @@
+# Project Plan — HVQ S3 Spill Tier
+
+> Last updated: 2026-05-13
+> Status: Draft / ready for implementation decomposition
+> Source: [Hierarchical Vector Quantization](hierarchical-vector-quantization.md)
+
+## Executive Summary
+
+This plan turns hierarchical vector quantization into an S3-durable, bounded
+NVMe-cache implementation. The implementation order deliberately starts with
+measurement and artifact contracts before ANN algorithms so no code path can
+quietly require all vector tiers to fit on compute-node disk.
+
+Critical path:
+
+1. Define `.qvec` artifact metadata and page/range reader contracts.
+1. Prove S3 read-through with a cache smaller than the total vector index.
+1. Add Q8/Q4 and quantized IVFFlat first; defer quantized HNSW until recall and
+   storage contracts are stable.
+1. Extend remote builder to stream/spill and publish manifest entries, not just
+   scalar sidecar paths.
+1. Gate rollout on recall@k, bytes/query, range-get/query, and build scratch
+   watermarks.
+
+## Non-Negotiable Invariants
+
+1. S3-compatible object storage is authoritative for `.qvec` artifacts.
+1. NVMe is a bounded, evictable cache; correctness cannot depend on full local
+   residency.
+1. Build uses unquantized `f32` input for graph/list quality, then persists
+   quantized tiers for search.
+1. Low-bit tiers are routing maps, not proof of final nearest neighbors.
+1. The planner narrows with quantized tiers, then optionally loads higher-bit or
+   `f32` pages for rerank.
+1. Missing, corrupt, stale, or dimension-mismatched artifacts fail loud.
+1. Remote-builder failure must not silently fall back to local full-resident
+   builds for HVQ.
+
+## Current Seams to Remove
+
+| Seam | Evidence | Required Direction |
+|------|----------|--------------------|
+| Monolithic HNSW JSON | `ferrosa-index/src/vector/hnsw.rs` stores graph, positions, and `Vec<Vec<f32>>` in one JSON blob | New page-addressable `.qvec` format |
+| Monolithic IVFFlat JSON | `ferrosa-index/src/vector/ivfflat.rs` stores centroids/lists/full vectors in one JSON blob | Keep centroids hot; page list entries and vector codes |
+| Whole-sidecar API | `FlushTarget::read_vector_sidecar` returns `Option<Vec<u8>>` | Replace HVQ path with object-range reader |
+| File-backed vector read gap | `FileFlushTarget` writes vector sidecars but does not provide matching read-through path | Add vector artifact resolver keyed by manifest/object refs |
+| Local startup assumption | `register_table()` discovers SSTables/sidecars via local directory scans | Make manifest/object refs authoritative |
+| Builder scratch pressure | `ferrosa-index-builder` downloads whole components and uses local `LocalBackend` | Stream/range-read inputs and reserve scratch before download |
+| Remote fallback | `RemoteBackend` can call local fallback when builders are down | Fail-loud/queue by default for HVQ |
+| Row identity | `RowPosition { offset }` lacks generation/object identity | Introduce `VectorRowRef` with SSTable/artifact generation |
+
+## Work Streams
+
+### S0 — Baseline and Repro Cases
+
+Goal: quantify current behavior and lock in regression tests before designing
+around assumptions.
+
+Deliverables:
+
+- Current HNSW sidecar size and decode time by row count and dimension.
+- Current IVFFlat sidecar size and build/query profile.
+- Exact `f32` brute-force recall baseline for benchmark corpora.
+- Metrics skeleton for ANN bytes/query and candidates/query.
+- Repro test showing legacy whole-sidecar path fails or exceeds budget when the
+  index is larger than the cache budget.
+
+Acceptance criteria:
+
+- `cargo test -p ferrosa-index vector_baseline` or equivalent focused tests pass.
+- Benchmark output records sidecar bytes, decode ms, search ms, recall@k.
+- Test harness can run with an artificial local-cache cap smaller than index
+  artifact size.
+
+### S1 — `.qvec` Artifact Container and Manifest Contract
+
+Goal: define durable index artifacts before implementing new ANN logic.
+
+Deliverables:
+
+- Binary `.qvec` header: magic, format version, index method, dimensions,
+  metric, build id, SSTable generation, row count, tier set, checksum scheme.
+- Page table with object key, byte range, compressed length, uncompressed length,
+  checksum, tier, and logical page id.
+- `IndexArtifactManifestEntry` schema for storage/remote-builder handoff.
+- Fail-loud validation errors for missing, short, stale, or corrupt pages.
+
+Acceptance criteria:
+
+- Unit tests validate good and malformed headers/page tables.
+- Property tests cover page table bounds and checksum mismatch cases.
+- No query code can accept a `.qvec` without validated artifact metadata.
+
+### S2 — Cache-Backed Object Range Reader
+
+Goal: make object storage readable without local full-file staging.
+
+Deliverables:
+
+- `ObjectRangeReader` or equivalent trait with local-hit/S3-range-miss behavior.
+- NVMe page cache keys include object key, generation/build id, range/page id,
+  tier, checksum, and format version.
+- Cache admission and eviction policy with pinned-hot-metadata support that does
+  not make full artifacts unevictable.
+- Metrics: range gets/query, bytes/query, cache hit/miss/fill/evict bytes,
+  checksum failures, stale-page rejections.
+
+Acceptance criteria:
+
+- MinIO integration test queries an artifact after deleting local cache.
+- Test with cache cap < artifact size succeeds without full artifact download.
+- S3 unavailable or corrupt page returns a typed error and increments metrics.
+
+### S3 — Quantization Codecs
+
+Goal: persist compact tiers with bounded decode error.
+
+Deliverables:
+
+- Q8 and Q4 first; Q2/Q1 behind feature flags until recall is proven.
+- Per-block or per-list scale/zero-point metadata.
+- Optional residual or PQ extension point without changing container identity.
+- SIMD-friendly decode path where practical; scalar reference path for tests.
+
+Acceptance criteria:
+
+- Property tests cover encode/decode error bounds across dimensions and metrics.
+- Golden fixtures validate backwards-compatible decode by format version.
+- Codec mismatch and dimension mismatch fail loud.
+
+### S4 — Quantized IVFFlat v1
+
+Goal: ship the first production HVQ method on the simpler list-based ANN shape.
+
+Deliverables:
+
+- Build centroids/lists from `f32` input.
+- Persist list pages as quantized codes and row refs.
+- Query flow: centroid routing -> Q4/Q8 candidate pages -> optional `f32` or
+  residual rerank -> top-k.
+- Hard query budgets for pages read, bytes read, survivor count, and rerank
+  fanout.
+
+Acceptance criteria:
+
+- Recall@k meets configured SLO against exact `f32` baseline.
+- Cold-cache and warm-cache latency/bytes metrics are recorded.
+- Query still succeeds with total `.qvec` bytes > local cache cap.
+
+### S5 — Storage Engine Integration
+
+Goal: integrate `.qvec` artifacts as first-class storage objects.
+
+Deliverables:
+
+- Extend index metadata/options for `quantized_ivf_flat`.
+- Add vector artifact resolver that uses manifest/object refs rather than local
+  sidecar directory scans.
+- Ensure publish order: upload objects -> validate -> CAS manifest -> planner
+  visibility.
+- Preserve legacy HNSW/IVFFlat sidecar methods as compatible local/dev paths.
+
+Acceptance criteria:
+
+- `TableStore::ann_search` can route legacy sidecars and `.qvec` artifacts
+  through distinct readers.
+- Compaction replacement publishes new artifacts before old artifact GC.
+- Stale cache pages cannot be used after manifest generation changes.
+
+### S6 — Remote Builder and Spill-Safe Build Path
+
+Goal: offload large vector index builds without moving the disk-pressure problem
+onto the engine or builder.
+
+Deliverables:
+
+- Extend `POST /internal/index/build` request with vector method, tiers,
+  dimensions, metric, max temp bytes, max build memory bytes, and build id.
+- Extend response with artifact manifest entries, object keys, sizes, checksums,
+  row count, page/tier summary, and format version.
+- Stream/range-read SSTable input; do not download all components before work
+  starts.
+- Reserve scratch before fetch and fail loud if a build cannot fit configured
+  limits.
+- Disable silent local fallback for HVQ unless `local_if_capacity_reserved` is
+  explicitly configured and proven.
+
+Acceptance criteria:
+
+- Builder crash mid-build leaves no visible manifest entry.
+- Temp-disk limit exceeded returns a typed build failure and no partial publish.
+- Engine validates returned object metadata before marking index current.
+- `backend=off` pull mode discovers missing `.qvec` artifacts from manifest
+  state, not fixed sidecar paths.
+
+### S7 — Query Planner Multi-Fidelity Search
+
+Goal: make quantized indexes usable as map tiles that refine on demand.
+
+Deliverables:
+
+- Planner uses low-bit tiers for broad routing only.
+- Higher-bit pages are loaded for survivors according to query/index budget.
+- Optional exact `f32` rerank is default for high-recall profiles.
+- Query options expose recall/cost controls without leaking storage internals.
+
+Acceptance criteria:
+
+- Low-bit-only path is never the default for user-visible top-k unless recall
+  gate allows it.
+- Query plan explains selected tiers, budgets, and rerank policy.
+- Metrics distinguish coarse-routing misses from final-rerank misses.
+
+### S8 — Quantized HNSW Research Track
+
+Goal: adapt HNSW after the storage contract is proven on IVFFlat.
+
+Deliverables:
+
+- Split adjacency pages from vector payload pages.
+- Build graph edges from `f32` input, not low-bit approximations.
+- Test graph quality degradation across Q2/Q4/Q8 traversal policies.
+- Decide whether HNSW uses quantized traversal, quantized payload only, or stays
+  full-precision at upper layers.
+
+Acceptance criteria:
+
+- HNSW recall degradation is measured against legacy HNSW and exact baseline.
+- Graph traversal does not require all adjacency/vector pages locally resident.
+- If quality is unacceptable, HNSW remains a non-goal and IVFFlat remains the
+  production path.
+
+## Parallel Implementation Batches
+
+| Batch | Tasks | Dependencies | Suggested Agents |
+|-------|-------|--------------|------------------|
+| A | S0 baseline, exact recall harness, metric names | none | 2 agents |
+| B | S1 `.qvec` format, S2 range reader prototype | A | 2 agents |
+| C | S3 codecs, S4 quantized IVFFlat builder/query | B | 3 agents |
+| D | S5 storage manifest integration, S6 remote builder API | B | 3 agents |
+| E | S7 planner policies, MinIO integration tests, docs | C + D | 3 agents |
+| F | S8 HNSW research, performance tuning | E | 1-2 agents |
+
+## Verification Gates
+
+| Gate | Command or Evidence | Required Result |
+|------|---------------------|-----------------|
+| Format | `cargo fmt --all -- --check` | pass |
+| Rust lint | `cargo clippy --workspace --all-targets -- -D warnings` | pass |
+| Unit | `cargo test -p ferrosa-index -p ferrosa-storage` | pass |
+| Builder | `cargo test -p ferrosa-index-builder` | pass |
+| Integration | MinIO-backed HVQ cache-miss/read-through suite | pass |
+| Recall | exact baseline vs quantized top-k | meets configured SLO |
+| Capacity | local cache cap smaller than total `.qvec` bytes | query succeeds |
+| Failure | missing/corrupt/stale object | typed fail-loud error, no empty success |
+
+## Open Design Decisions
+
+| ID | Decision | Recommended Default | Owner Action |
+|----|----------|---------------------|--------------|
+| D1 | First production method | `quantized_ivf_flat`; defer HNSW | Confirm unless HNSW is must-ship first |
+| D2 | Q1 exposure | Planner-internal only; do not expose until recall gate passes | Confirm |
+| D3 | Exact rerank | Default on for high-recall profiles | Confirm target latency/recall tradeoff |
+| D4 | Artifact shape | One `.qvec` manifest per SSTable/index, with multiple objects allowed per tier | Confirm object count/cost preference |
+| D5 | Remote failure behavior | Queue/fail-loud for HVQ, no silent local fallback | Confirm operator preference |
+| D6 | Cache budgets | Per-node hard byte cap plus per-query bytes/range cap | Define initial defaults |
+
+## Documentation Updates Required
+
+- [x] `hierarchical-vector-quantization.md` — S3 durability and NVMe-cache
+  invariant.
+- [x] `fmea-hvq-s3-spill-tier.md` — scoped failure analysis.
+- [x] `project-plan-hvq-s3-spill-tier.md` — implementation plan.
+- [x] `overview.md` — add HVQ to system architecture summary.
+- [x] `components.md` — add `.qvec`, artifact resolver, range reader, remote
+  builder contract.
+- [x] `data-flow.md` — add query read-through flow and publish-after-validate.
+- [x] `storage.md` — add vector artifact manifest/cache semantics.
+- [x] `remote-index-build-backend.md` — add HVQ request/response and fallback
+  semantics.
+- [x] `testing.md` — add HVQ integration/performance test gates.
+
+## Related Artifacts
+
+- [Hierarchical Vector Quantization](hierarchical-vector-quantization.md)
+- [FMEA — HVQ S3 Spill Tier](fmea-hvq-s3-spill-tier.md)
+- [Remote Index Build Backend](remote-index-build-backend.md)
+- [Storage Engine](storage.md)
+- [Testing Strategy](testing.md)

--- a/specs/remote-index-build-backend.md
+++ b/specs/remote-index-build-backend.md
@@ -41,6 +41,13 @@ graph LR
 | `remote` | `RemoteBackend` sends jobs via HTTP to builder, circuit breaker fallback to local | Required — receives push jobs | Scale tier, mixed workloads |
 | `off` | `IndexBuildScheduler` not started, no worker threads, no `EagerIndexBuilder` hook | Required — pull mode, discovers work via manifest/S3 | Enterprise tier, dedicated hot-path serving |
 
+HVQ constraint: quantized vector jobs must not silently fall back to local
+full-resident builds when remote builders are unavailable. The allowed fallback
+policies are `fail_loud`, `queue`, or `local_if_capacity_reserved`; `local` is
+only valid when the engine has reserved enough scratch space for the declared
+input and output artifact budgets. The default for `quantized_ivf_flat` and
+future `quantized_hnsw` is `fail_loud` or stale-index serving, not local build.
+
 ---
 
 ## Architecture
@@ -158,6 +165,75 @@ Content-Type: application/json
   "elapsed_ms": 1200
 }
 ```
+
+### HVQ `.qvec` Build Contract
+
+Hierarchical vector quantization extends the scalar sidecar API because a single
+`sidecar_s3_path` is insufficient for page-addressable vector artifacts.
+
+Example request fields for HVQ jobs:
+
+```json
+{
+  "sstable_id": "gen-42",
+  "index_name": "idx_embedding",
+  "index_type": "quantized_ivf_flat",
+  "artifact_kind": "hvq_qvec",
+  "build_id": "gen-42-idx_embedding-0001",
+  "dimensions": 1536,
+  "metric": "cosine",
+  "tiers": ["q4", "q8", "f32_rerank"],
+  "exact_rerank": true,
+  "max_temp_bytes": 10737418240,
+  "max_build_memory_bytes": 4294967296,
+  "s3_prefix": "prod/a7/ks.users/gen-42"
+}
+```
+
+Example success response:
+
+```json
+{
+  "status": "completed",
+  "artifact_kind": "hvq_qvec",
+  "artifact_manifest_entry": {
+    "format_version": 1,
+    "build_id": "gen-42-idx_embedding-0001",
+    "index_name": "idx_embedding",
+    "index_type": "quantized_ivf_flat",
+    "row_count": 42000,
+    "dimensions": 1536,
+    "metric": "cosine",
+    "objects": [
+      {
+        "tier": "q4",
+        "object_key": "prod/a7/ks.users/gen-42/idx_embedding/q4.qvec",
+        "size_bytes": 8388608,
+        "checksum": "sha256:..."
+      },
+      {
+        "tier": "q8",
+        "object_key": "prod/a7/ks.users/gen-42/idx_embedding/q8.qvec",
+        "size_bytes": 16777216,
+        "checksum": "sha256:..."
+      }
+    ],
+    "page_table_checksum": "sha256:..."
+  },
+  "elapsed_ms": 1200
+}
+```
+
+Publish semantics:
+
+1. The builder may upload temporary objects, but the engine must not mark the
+   index current until every object key, size, checksum, tier, dimension, and
+   metric validates.
+1. A builder crash during upload leaves no visible manifest entry.
+1. Pull mode discovers missing `.qvec` artifact manifest entries, not fixed
+   `{sstable_id}-{index_name}.sidecar` paths.
+1. Temp-disk or memory-budget exhaustion is a typed build failure; it must not
+   degrade into an unbounded local build.
 
 **Response (failure)**:
 

--- a/specs/storage.md
+++ b/specs/storage.md
@@ -138,6 +138,31 @@ No versioned protocols between in-process modules — they share Rust types dire
 | Commit log segments | B | Segment header with descriptor (version, id, compression) | Implemented |
 | `manifest.json` (S3) | C | `"format_version": 1` field in JSON | Implemented |
 | `checkpoint.json` | B | `"format_version"` field in JSON | Implemented |
+| `.qvec` vector artifacts | D/HVQ | Binary magic + format version + page table + per-page checksum + manifest object refs | Planned |
+
+### HVQ S3 Spill-Tier Storage Contract
+
+Hierarchical vector quantization must not reuse the legacy local sidecar
+contract as its durable model. S3-compatible object storage is authoritative for
+`.qvec` artifacts; local NVMe is only a bounded, evictable page cache.
+
+Required storage semantics:
+
+1. `.qvec` artifacts are uploaded and checksum/object-size validated before
+   any table or index manifest advertises them.
+1. Reader discovery is manifest/object-ref driven, not local directory driven.
+1. Cache keys include object key, SSTable generation or build id, byte range or
+   page id, tier, checksum, and format version.
+1. Cache eviction removes only local copies after remote durability is proven.
+   Eviction must never delete the only copy of a vector artifact.
+1. Missing pages, short range reads, stale etags, dimension mismatch, codec
+   mismatch, and checksum failures return typed errors and increment telemetry.
+1. Query-time readers fetch cold pages through object-range reads and must not
+   require the full vector artifact to fit on the compute node.
+
+This contract deliberately differs from current `FlushTarget::read_vector_sidecar`
+behavior, which treats a vector sidecar as one `Vec<u8>` blob. The HVQ path
+requires a page/range-readable artifact resolver.
 
 ## Components
 

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -66,6 +66,25 @@ flowchart TD
 - p50, p99, p999 latency
 - S3 upload lag (Ferrosa-specific)
 - Cache hit ratio (Ferrosa-specific)
+- HVQ S3 range GETs per query, bytes read per query, vector cache hit/miss
+  bytes, checksum failures, and recall@k against exact `f32` baseline
+
+### HVQ S3 Spill-Tier Gates
+
+Hierarchical vector quantization adds test gates because vector indexes may be
+larger than any compute node's local disk. These gates are required before
+`quantized_ivf_flat` or `quantized_hnsw` can become production defaults.
+
+| Test | Validates | Method |
+|------|-----------|--------|
+| Exact baseline | Quantized recall is measured against truth | Brute-force `f32` top-k corpus |
+| Codec properties | Q8/Q4/Q2/Q1 decode error stays bounded | `proptest` generated vectors/dimensions |
+| S3 publish | `.qvec` manifest is visible only after checksum validation | MinIO integration, kill builder mid-upload |
+| Cold read-through | Query works with no local vector pages | Wipe NVMe cache, query via S3 Range GET |
+| Cache smaller than index | Correctness does not depend on full local residency | Set cache cap below `.qvec` size |
+| Corrupt remote page | Missing/short/stale/checksum-bad object fails loud | Inject object-store faults |
+| Compaction replacement | New `.qvec` is published before old artifact GC | Compact, query, reject stale cached pages |
+| Budget enforcement | Query and build stay within declared limits | Assert bytes/query, range gets/query, temp bytes |
 
 ## Suite 1: Data Integrity
 


### PR DESCRIPTION
## Summary
- Reworks the HVQ spec so quantized vector artifacts are S3-durable and NVMe is only a bounded page cache.
- Adds artifact manifest, .qvec page/tier layout, read-through Range GET semantics, publish-after-validate rules, and f32-build/quantized-search quality guardrails.
- Adds scoped FMEA and implementation project plan for the HVQ S3 spill tier.
- Updates overview/components/data-flow/storage/remote-builder/testing docs and specs index.

## Verification
- Validated updated Mermaid diagrams with forge mermaid validator.
- Checked newly added local markdown links resolve.
- Ran secret scan over all changed/new spec files; no findings in changed files.

## Notes
- Existing repo-wide spec secret scan still reports pre-existing example password-assignment snippets in specs/decisions/design-cql-role-auth-rollout.md; this PR did not touch that file.