### PR TITLE
docs: ADR-020 streaming internode range read + bug spec timing baseline

### DIFF
--- a/specs/decisions/020-streaming-internode-range-read.md
+++ b/specs/decisions/020-streaming-internode-range-read.md
@@ -1,0 +1,298 @@
+# ADR-020: Streaming internode range read with idle-timeout watchdog
+
+> Date: 2026-05-16
+> Status: Proposed
+> Scope: `ferrosa-cluster::coordinator::read` (range / index reads),
+> `ferrosa-cluster::raft::handlers::{RangeReadHandler, IndexReadHandler}`,
+> `ferrosa-net` (multi-message RPC over the `Bulk` lane), and the
+> `ferrosa-storage` range iterator surface.
+> Non-goal: changing the CQL-client paging protocol; replacing
+> single-partition reads (`coordinate_read`) — those stay request-response.
+
+## Context
+
+Cross-node range and index reads currently route through a single
+request-response RPC on the `Bulk` lane:
+
+- `RangeReadRequest { keyspace, table, limit, row_limit }` →
+- `RangeReadResponse { partitions: Vec<PartitionWire>, truncated: bool }`
+
+Three magic-number caps and timeouts make this architecturally
+unscalable, and they all couple together to surface the same symptom:
+
+1. **Wire payload is fully materialized.** The receiver collects every
+   matching partition into a `Vec<Partition>`, serializes the whole
+   thing with `bincode`, then sends it as one
+   `Message::RangeReadResponse` blob. Memory is `O(table_window)` on
+   both sides; first byte to the coordinator arrives only after the
+   last byte was produced by the handler.
+2. **Storage layer enforces a 10 000-partition cap.**
+   `RANGE_READ_MATERIALIZATION_CAP = 10_000` in
+   `ferrosa-storage/src/store.rs` errors with
+   `"range read limit … exceeds materialization cap …; use a paged/streaming read path"`
+   — but no such paged/streaming read path exists at the internode
+   layer today.
+3. **Coordinator deadline is a wall-clock timeout.**
+   `BULK_READ_TIMEOUT` (currently 3 s, proposed 8 s in PR #41) is a
+   single deadline for the entire RPC. There is no notion of "the
+   peer is still streaming, just slowly" — either the full vec is on
+   the wire within the deadline or the coordinator gives up.
+
+### Empirical baseline (2026-05-16, ferrosa-memory cluster)
+
+Three back-to-back `SELECT COUNT(*) FROM agent_memory.entity_store`
+runs (9 774 partitions, 3 nodes, RF=3, no concurrent load):
+
+| Run | Wall-clock |
+|-----|------------|
+| 1   | 7.28 s     |
+| 2   | 37.15 s    |
+| 3   | 7.32 s     |
+
+A bounded `SELECT … LIMIT 5` against the same table completes in
+0.65 s. The same query that returns 5 rows in <1 s takes 7-37 s when
+the LIMIT is removed — confirming that materializing the full vec on
+both ends is what's slow, not the underlying reads.
+
+PB-scale tables make this categorically impossible: a 1 TB table
+serialized through a 10 Gbps link is 800+ seconds on the network
+alone, before storage, serialization, or deserialization.
+
+### What the user is observing
+
+> "what if the tables were PB in size … should the read timeout … be
+> a monitor that allows for streaming recovery? … there should not be
+> magic number caps that is an antipattern"
+
+Both observations are correct. The wall-clock timeout and the
+10 000-partition cap are independent symptoms of the same architectural
+gap — there is no chunked, observable, back-pressured streaming path
+between the coordinator and the storage-owning node.
+
+## Decision
+
+Replace the single-RPC range read with a **multi-message streaming
+RPC**, gated by an **idle-timeout watchdog** instead of a wall-clock
+deadline, with the storage layer producing partitions through a lazy
+iterator. No hardcoded partition cap; no hardcoded total-wall-clock
+timeout.
+
+```
+                Coordinator                        Storage-owning node
+        ┌─────────────────────────┐               ┌──────────────────────────┐
+        │  range_read_stream(...) │ ── Request ──▶│  storage.range_iter(...) │
+        │                         │               │                          │
+        │  ┌──────────────────┐   │  Chunk(0..N) │  for batch in iter {     │
+        │  │ idle_deadline    │ ◀─────────────────│      send(Chunk(batch)); │
+        │  │   = NOW + IDLE   │   │   Heartbeat   │      if slow:            │
+        │  │  reset on chunk  │ ◀─────────────────│         send(Hb);        │
+        │  │  reset on hb     │   │     Done      │  }                       │
+        │  └──────────────────┘ ◀─────────────────│  send(Done(total))       │
+        │                         │               │                          │
+        │  yield partitions       │               │                          │
+        └─────────────────────────┘               └──────────────────────────┘
+```
+
+### Required pieces
+
+1. **Storage layer: lazy range iterator.**
+   Replace
+   ```
+   fn read_range_limited_rows(...) -> Result<Vec<Partition>>
+   ```
+   with (additionally; the old call site keeps working for single-node
+   use):
+   ```
+   fn range_iter(start, end) -> impl Iterator<Item = Result<Partition>>
+   ```
+   The iterator merges memtable + flushing memtable + SSTables in
+   token order, applies deletions on the fly, and yields one partition
+   at a time. No vec materialization, no `RANGE_READ_MATERIALIZATION_CAP`.
+
+2. **Wire protocol: chunked response messages.**
+   Replace the single response with three message variants on the
+   Bulk lane:
+   ```
+   Message::RangeReadChunk {
+       request_id: u32,
+       seq: u32,
+       partitions: Vec<PartitionWire>, // small batch, ~64-256 partitions
+   }
+   Message::RangeReadHeartbeat { request_id: u32, seq: u32 } // sent when a chunk takes >IDLE/2 to produce
+   Message::RangeReadDone {
+       request_id: u32,
+       total_chunks: u32,
+       truncated: bool,
+   }
+   ```
+   `request_id` correlates a stream; `seq` lets the coordinator
+   detect gaps and reorders (Bulk lane is TCP, so reorders are
+   excluded, but `seq` is cheap insurance against future lane
+   changes). The chunk size is **a configurable target**, not a
+   hardcoded constant — exposed via `NetConfig` and chosen at runtime
+   to fit the MTU/buffer budget.
+
+3. **Bulk lane: multi-message RPC support.**
+   The existing `dispatch_send` in `ferrosa-net::lane_actor` is
+   request-response — one Message in, one Message out, then drop.
+   Adding streaming responses needs the existing bootstrap-streaming
+   machinery (`ferrosa-cluster::streaming`) generalized so any RPC on
+   the Bulk lane can return a stream of frames keyed by `request_id`.
+   The sender API becomes:
+   ```
+   pool.send_stream(msg, Lane::Bulk) -> impl Stream<Item = Result<Message>>
+   ```
+   That stream completes when a `Done` frame arrives, errors on idle
+   timeout, or errors on explicit `Error` frame.
+
+4. **Coordinator: idle-timeout watchdog, not wall-clock deadline.**
+   Drop `BULK_READ_TIMEOUT` entirely. Introduce:
+   ```
+   NetConfig {
+       bulk_stream_idle_timeout: Duration,   // default: 10s, no chunk = abort
+       bulk_stream_heartbeat_interval: Duration, // default: 4s, sender pings
+   }
+   ```
+   The coordinator's stream consumer resets its watchdog every time a
+   `RangeReadChunk` *or* `RangeReadHeartbeat` arrives. If the gap
+   between any two messages exceeds `bulk_stream_idle_timeout`, the
+   coordinator cancels the stream (sends `CancelStream { request_id }`,
+   peer aborts the iteration). Total wall-clock can be hours for a PB
+   scan; the watchdog only fires when the peer is actually stuck.
+
+5. **Heartbeat policy on the sender.**
+   The handler iterates the storage iterator and batches partitions.
+   It maintains its own `last_send_at` timestamp; if more than
+   `heartbeat_interval` elapses while waiting for the next batch
+   (e.g. S3 fetch, compaction back-pressure, large partition decode),
+   it sends a `RangeReadHeartbeat` and continues iterating. The
+   coordinator treats heartbeats as activity but discards them from
+   the result set.
+
+6. **Cancellation path.**
+   `CancelStream { request_id }` lets the coordinator stop the
+   handler when the CQL client disconnects, when read-quorum is
+   already satisfied by other replicas, or when the user issues
+   `KILL`. The handler must check a cancellation flag between batches
+   so a runaway scan can be stopped cheaply.
+
+7. **No magic-number partition cap.**
+   `RANGE_READ_MATERIALIZATION_CAP` and `DEFAULT_RANGE_READ_LIMIT`
+   are removed from the internode path. Limits flow from the CQL
+   layer (the client's `PAGE_SIZE` and `LIMIT` clauses) down through
+   the coordinator into the storage iterator, which simply stops
+   pulling partitions when the upstream consumer stops asking. The
+   storage iterator itself bounds memory by definition — one
+   partition at a time.
+
+## Consequences
+
+### Wins
+
+- **Scales to PB-sized tables.** Memory is `O(chunk_size)` regardless
+  of table size. First chunk reaches the coordinator in tens of
+  milliseconds.
+- **No spurious timeouts.** A slow scan that produces a chunk every
+  few seconds runs to completion. Only genuine stalls (peer crash,
+  network partition) abort the stream.
+- **Back-pressure is natural.** TCP flow control on the Bulk lane
+  paces the sender; the storage iterator stops decoding ahead of the
+  consumer.
+- **Removes two existing antipatterns** — the 3 s/8 s wall-clock
+  timeout magic number and the 10 000-partition materialization cap.
+
+### Costs
+
+- **Three new message variants** on the Bulk lane and matching
+  CapnProto schemas if the framing gate (ADR-019) is on. Each variant
+  carries a `request_id` correlation field.
+- **Bulk lane RPC machinery needs a multi-message mode.** Today it's
+  strict request-response. Adding streams touches `lane_actor`,
+  `rpc::client`, and `rpc::server`. The bootstrap streaming code path
+  is the right reference — its frame correlation, completion, and
+  cancellation primitives should be generalized rather than
+  duplicated.
+- **Backwards compatibility.** Mixed-version clusters during rolling
+  upgrade: a v0.10.0 coordinator talking to a v0.11.0 handler (or
+  vice versa) must negotiate. Two options:
+  1. Add the new RPC under a new `MsgType` (`RangeReadStreamRequest`,
+     `RangeReadStreamChunk`, …) and fall back to the legacy
+     `RangeReadRequest` when the peer's announced protocol version is
+     older. This is the safer path — old path keeps working until all
+     nodes are upgraded.
+  2. Replace in place behind a config flag.
+  Choose (1).
+- **Coordinator code complexity.** Today a range read is one
+  `send_remote_with_reconnect_timeout` per peer plus a join. The new
+  path is a stream consumer with per-peer state machines (chunk
+  reassembly, dedup-on-the-fly, cancellation). The complexity is
+  intrinsic to the problem, but it lands somewhere new in the
+  coordinator codebase.
+- **Tests need stream-aware fixtures.** Existing
+  `DelayedRangeReadHandler` test pattern verifies a 1 s delay
+  succeeds inside the 3 s timeout. New tests need:
+  - A slow-but-steady producer (chunks every 1 s for 30 s) succeeding
+    with idle_timeout=10 s.
+  - A genuinely-stuck producer (heartbeats stop) aborting via the
+    watchdog.
+  - A cancellation case where the coordinator drops the stream
+    mid-flight and the handler observes the cancel within one
+    batch boundary.
+
+## Migration plan
+
+This is a multi-PR change; each PR lands behind a feature flag and is
+independently testable.
+
+1. **ADR + design lock-in** (this doc).
+2. **Storage iterator.** Add `range_iter` returning
+   `impl Iterator<Item = Result<Partition>>`. Existing
+   `read_range_limited_rows` stays as a thin wrapper that collects N
+   items. Unit tests cover memtable + flushing + SSTable interleaving
+   without materialization.
+3. **Bulk lane stream primitive.** Generalize the bootstrap streaming
+   correlation/completion machinery into a `pool.send_stream` API.
+   Tests cover happy-path stream, idle-timeout fires, cancellation
+   propagates.
+4. **New range-read RPC** with the chunk / heartbeat / done frames,
+   gated by a `bulk_streaming_range_read = false` config flag.
+   Coordinator probes peer protocol version; falls back to the
+   existing `RangeReadRequest` when the peer is older or the flag is
+   off.
+5. **Enable by default** once a release cycle of bake-time confirms
+   no regressions. Remove the legacy
+   `RangeReadRequest`/`RangeReadResponse` path and
+   `BULK_READ_TIMEOUT` constant in the release after that.
+6. **Remove `RANGE_READ_MATERIALIZATION_CAP`** when the legacy path
+   is gone — the cap is only there because the legacy path
+   materializes.
+
+The same shape generalizes to `IndexReadRequest` (also currently a
+single-response RPC) and `RangeWriteRequest` (the inverse direction
+for bulk imports). Those follow as separate ADRs once this one lands.
+
+## Alternatives considered
+
+- **Just bump the timeout** (PR #41). Stopgap: hides the symptom at
+  small scale, fails at any scale.
+- **Bump the partition cap.** Same problem, larger blast radius —
+  10K → 100K means O(table_size) memory pressure grows 10× before
+  failing.
+- **Force every client to page via CQL `PAGE_SIZE`.** Pushes the
+  problem onto every caller and breaks `SELECT COUNT(*)` /
+  full-table aggregates which inherently need a fan-out.
+- **Stream over a side channel** (e.g. HTTP/2 separate from the
+  Bulk lane). Introduces a new transport and credential path; the
+  Bulk lane already has the right framing and TLS — just needs
+  multi-frame correlation.
+
+## Related
+
+- [[bug-bulk-lane-send-timeouts-on-coordinated-reads]] — the symptom
+  this design addresses.
+- [[019-capnproto-internode-protocol]] — the envelope work that makes
+  adding new typed message variants safe.
+- `ferrosa-cluster::streaming::*` — the bootstrap-streaming primitives
+  to generalize.
+- `ferrosa-cql` paging — the existing client-side paging model whose
+  shape this internode design mirrors.

--- a/specs/in-process/bug-bulk-lane-send-timeouts-on-coordinated-reads.md
+++ b/specs/in-process/bug-bulk-lane-send-timeouts-on-coordinated-reads.md
@@ -101,6 +101,48 @@ $ cqlsh 127.0.0.1 19042 -u ferrosa_admin -p ferrosa_admin
 Same query against node2 (19043) returns 9774; node3 (19044) returns
 10800 (replica skew, likely separate).
 
+## Performance baseline (2026-05-16)
+
+Three back-to-back `SELECT COUNT(*) FROM agent_memory.entity_store` runs
+on the live cluster (9 774 partitions, RF=3, 3 nodes, no concurrent
+load) under the v0.10.0 image:
+
+| Run | Wall-clock | Notes                                          |
+|-----|-----------|------------------------------------------------|
+| 1   | 7.28 s    | survives because cqlsh `--request-timeout=60`  |
+| 2   | 37.15 s   | same query — variance is intrinsic, not noise  |
+| 3   | 7.32 s    | reproducible                                   |
+
+A bounded `SELECT … LIMIT 5` against the same table returns in 0.65 s
+because the coordinator does not need to fan out a full range scan.
+
+On-disk size: `~/data/ferrosa-memory/minio/` is 3.6 GB; node1's
+`/var/lib/ferrosa` working set is 6.1 GB.
+
+## Why tweaking the timeout is the wrong axis
+
+- The current `BULK_READ_TIMEOUT = 3 s` already fires; the proposed bump
+  to 8 s (PR #41) still loses Run 2 (37 s). No fixed wall-clock value is
+  correct for both the steady-state (~7 s) and the outlier (~37 s)
+  observed *today* at 9 K partitions, let alone for production-scale
+  tables with millions or billions of partitions.
+- Magic-number caps are antipatterns. The existing
+  `RANGE_READ_MATERIALIZATION_CAP = 10_000` in `ferrosa-storage` is a
+  declared antipattern — its own error message says
+  `"use a paged/streaming read path"`. Adding a hardcoded 8 s timeout
+  alongside it compounds the problem.
+- The Bulk lane already has a 60 s envelope timeout
+  (`Lane::Bulk.timeout()` in `ferrosa-net/src/codec.rs`); the
+  coordinator's 3 s/8 s wall-clock cap on top of that is the
+  contradiction — Bulk lane is sized for high-throughput
+  latency-tolerant transfers, but the coordinator denies it the time
+  to actually transfer.
+
+The correct architecture replaces the single-shot RPC with a streaming
+response gated by an **idle-timeout watchdog** that resets every time a
+chunk or heartbeat arrives. See
+[[020-streaming-internode-range-read]] for the design.
+
 ## Suspected scope
 
 - `ferrosa_cluster::coordinator::read::coordinate_range_read` and

--- a/specs/in-process/bug-bulk-lane-send-timeouts-on-coordinated-reads.md
+++ b/specs/in-process/bug-bulk-lane-send-timeouts-on-coordinated-reads.md
@@ -1,0 +1,152 @@
+---
+type: todo
+priority: P1
+status: draft
+created: 2026-05-16
+updated: 2026-05-16
+affected-versions: ferrosa v0.10.0 and earlier (pre-existing; v0.10.0 timeouts are smaller/different but still present)
+---
+
+# Bug: Cross-node coordinated reads time out on the Bulk lane
+
+## Why this is a Ferrosa bug
+
+Ferrosa advertises CQL wire-protocol compatibility and a 3-node clustered
+deployment. CQL range reads, secondary-index reads, and the
+`/workbench/api/summary` endpoint all coordinate across replicas via the
+`Bulk` internode lane. Every coordinated read in the 3-node
+`ferrosa-memory` cluster fails with `net: timeout: Bulk lane send timeout`
+on at least one peer — bidirectionally, across all pairs — even when:
+
+- TCP peer connections are established (`peer connected` events fire
+  promptly at startup).
+- Reverse connections are established.
+- ClusterInvites flow across the same lane set.
+- Raft eventually elects a leader (after a ~3min cold-start settle).
+- Local CQL reads on each node work fine.
+
+Clients that only execute single-partition reads against the
+local coordinator (e.g. `cqlsh ... SELECT COUNT(*) FROM <local-replica
+table>`) succeed. Clients that issue range scans, multi-replica reads, or
+hit `workbench/api/*` see partial-result warnings or 500-level failures.
+
+Observed both on the v0.9.0 image (user-reported pre-existing timeouts)
+and the v0.10.0 image rebuilt 2026-05-16. v0.10.0 appears better than
+v0.9.0 in this user's testing — fewer queries time out overall — but the
+underlying coordinator timeout still reproduces deterministically on
+range reads.
+
+## Observed on
+
+- Ferrosa: `ferrosa-memory-node:v0.10.0` (image sha
+  `badbc54253b0`), built from main HEAD at commit `b7eb20c`
+  (`chore: release v0.10.0 (#40)`).
+- Cluster: `ferrosa-memory/docker-compose.yml` (3 nodes + ferrosa-memory-mcp
+  + MinIO). Auth enabled. `host_id` 11111111-…, 22222222-…, 33333333-….
+- Bridge network `172.20.0.0/16`, internode 7000/tcp.
+- Date: 2026-05-16.
+
+## Symptom
+
+After the cluster comes up healthy (all 5 containers
+`docker compose ps` healthy, Raft leader elected on node3, schema visible
+on every node), curl the workbench summary endpoint:
+
+```
+$ curl -sS -u ferrosa_user:ferrosa_user http://127.0.0.1:18765/workbench/api/summary
+{
+  "derived_fact_count": 1924,
+  "edge_count": 0,
+  "error": "Database returned an error: Internal server error. ...
+            Error message: server error: cluster error: internal:
+            index read from node 1229782938247303441 (11111111-1111-1111-1111-111111111111)
+            via 172.20.0.3:7000: net: timeout: Bulk lane send timeout",
+  "node_count": 0,
+  "rule_count": 0,
+  "status": "not_ready"
+}
+```
+
+Node-side logs show the timeout on every cross-replica read:
+
+```
+ERROR cql.request{cql.opcode=Query client.address=172.20.0.1:49730}:
+  ferrosa_cluster::coordinator::read:
+  coordinate_range_read: internal: range read from node 3689348814741910323
+  (33333333-3333-3333-3333-333333333333) via 172.20.0.5:7000:
+  net: timeout: Bulk lane send timeout
+
+WARN  cql.request{...}:
+  coordinate_range_read: 2 node(s) failed, returning partial results
+  from 1 node(s) failed_nodes=2 partitions_received=34
+```
+
+Raft replication is also affected:
+
+```
+WARN  openraft::replication: error replication to target=1229782938247303441
+  error=timeout after 600ms when AppendEntries 3689348814741910323->1229782938247303441
+```
+
+Local single-replica CQL queries succeed:
+
+```
+$ cqlsh 127.0.0.1 19042 -u ferrosa_admin -p ferrosa_admin
+  -e "SELECT COUNT(*) FROM agent_memory.entity_store;"
+ count
+-------
+  9774
+```
+
+Same query against node2 (19043) returns 9774; node3 (19044) returns
+10800 (replica skew, likely separate).
+
+## Suspected scope
+
+- `ferrosa_cluster::coordinator::read::coordinate_range_read` and
+  `coordinate_index_read` push work over the `Bulk` lane defined in
+  `ferrosa-net`.
+- Symptom is `Bulk lane send timeout` — the send side gives up before
+  the receiver responds. The new envelope framing gate in PR #39
+  (`Add CapnProto internode envelope framing gate`,
+  `Add CapnProto cluster recovery adapters`) touched lane dispatch.
+  Worth checking whether `Bulk` lane handler is still wired up the same
+  way after the gate landed, and whether the gate's default state
+  exposes a bug in the legacy path.
+- Worth also checking: per-lane queue depth limits, the
+  reconnect/backoff loop when one peer goes down briefly during cluster
+  bring-up, and whether the openraft 0.9 `loosen-follower-log-revert`
+  feature interacts.
+
+## Repro
+
+1. `cd ferrosa-suite/ferrosa-memory`
+2. `docker compose down && docker compose up -d`
+3. Wait ~3min for Raft to converge.
+4. `curl -sS -u ferrosa_user:ferrosa_user http://127.0.0.1:18765/workbench/api/summary | jq .`
+   → `status: not_ready`, error contains `Bulk lane send timeout`.
+5. `cqlsh 127.0.0.1 19042 -u ferrosa_admin -p ferrosa_admin -e "SELECT * FROM agent_memory.entity_store LIMIT 10;"`
+   → succeeds (local-replica, no coordinator fan-out).
+
+## Why it's load-bearing
+
+The `not_ready` summary status is the gate `smoke-18765.sh` checks before
+declaring the cluster healthy. Without coordinated reads, the
+workbench/MCP "knowledge graph console" cannot present aggregate stats;
+clients that query across partitions degrade to partial results; and
+Raft heartbeats time out at 600ms — within tolerance for leader stability
+but indicative that the same lane path that breaks reads also slows
+consensus.
+
+## Validation steps before declaring fixed
+
+- `smoke-18765.sh` runs to completion (passes `summary status is ready`).
+- `cqlsh -e "SELECT COUNT(*) FROM agent_memory.<table>"` against any
+  table where ownership crosses nodes succeeds without
+  `partial results from N node(s)` warnings.
+- 60s sample of node logs after a cold restart contains zero
+  `Bulk lane send timeout` lines.
+- Raft `AppendEntries` heartbeats stay under the 600ms timeout.
+
+Related: [[refactor-cluster-recovery-storage-oom-seams]],
+[[019-capnproto-internode-protocol]].

--- a/specs/in-process/bug-slow-raft-cold-start-after-graceful-shutdown.md
+++ b/specs/in-process/bug-slow-raft-cold-start-after-graceful-shutdown.md
@@ -1,0 +1,86 @@
+---
+type: todo
+priority: P3
+status: draft
+created: 2026-05-16
+updated: 2026-05-16
+affected-versions: ferrosa v0.10.0 (and likely earlier)
+---
+
+# Bug: Raft cold-start takes ~3 minutes to elect a leader after `docker compose down`/`up`
+
+## Why this is a Ferrosa bug
+
+A 3-node ferrosa cluster shut down cleanly via `docker compose down`
+(no data loss, MinIO bind-mount preserved, per-node volumes preserved)
+should re-converge to a Raft leader in seconds when brought back up
+with `docker compose up -d`. Observed convergence on 2026-05-16 was
+~3 minutes:
+
+- 18:59:28 — all 3 ferrosa nodes bound their listeners and emitted
+  `cluster: pair/cluster connections established`.
+- 18:59:41 — `openraft startup begin` on node1 (server_state=Learner,
+  is_voter=true, last_committed=7870, last_membership voter_ids set).
+- 19:01:58 onward — node1 enters a repeating loop:
+  `pre-vote round did not reach quorum; staying follower (no term advance)`,
+  one round every ~450ms.
+- 19:02:55 — leader elected (node3, `term: 1, node_id: 3689348814741910323`)
+  and `raft leader elected, swapping DDL path to Cluster` fires on node1.
+
+That's ~3 minutes of pre-vote churn after pair/cluster connectivity was
+already established. During this window, every coordinator read fails
+with `Bulk lane send timeout` (see
+[[bug-bulk-lane-send-timeouts-on-coordinated-reads]]); recovery only
+begins once a leader exists.
+
+## Observed on
+
+- Cluster: `ferrosa-memory-node:v0.10.0` (sha `badbc54253b0`), built
+  from main HEAD `b7eb20c`.
+- Bring-up via `docker compose down && docker compose up -d`.
+- 5 containers reach `healthy` in seconds (docker health check is a
+  TCP probe). The "healthy" signal arrives long before Raft converges.
+
+## Suspected scope
+
+- Pre-vote logic may be too conservative when followers come up before
+  a leader; quorum check fails on transient lane-not-yet-ready, then
+  backs off with a 450ms tick. Cumulative effect: many rounds before
+  the system happens to land all three nodes in vote-ready state.
+- `openraft 0.9.x` with `loosen-follower-log-revert` may need tuning
+  for fast restart with non-empty logs (last_committed=7870).
+- The `Bulk lane send timeout` bug above probably feeds back: vote
+  RPCs are not on Bulk lane (Raft has its own lane), but bring-up of
+  Bulk lane reconnect attempts may starve the Raft thread on send-side
+  contention.
+- Could also be that `docker compose down` does not deliver SIGTERM
+  with enough grace for a clean leader handoff, so the next start has
+  to re-elect from scratch with stale `vote` UTime entries.
+
+## Repro
+
+1. `cd ferrosa-suite/ferrosa-memory`
+2. Cluster up and healthy.
+3. `docker compose down` (waits ~35s for stop_grace_period).
+4. `docker compose up -d`.
+5. Tail logs: `docker logs -f ferrosa-memory-node1-1 | grep -E "pre-vote|leader"`.
+6. Time-from-start until `raft leader elected` log line — ~3min in observed run.
+
+## Why it's load-bearing
+
+The docker health check returns `healthy` once TCP listeners bind,
+which is before Raft converges. Smoke scripts and operators who wait
+for "all containers healthy" then immediately probe the cluster will
+see `not_ready` summaries / timed-out reads for several minutes.
+
+## Fix shape (speculative)
+
+- Add a separate readiness probe that gates on "Raft leader present"
+  rather than TCP bind.
+- Document the expected cold-start time so smoke scripts can wait
+  appropriately (or add a `wait-for-leader` helper).
+- Investigate whether a faster pre-vote schedule (smaller tick or
+  immediate retry on quorum miss) is safe with the
+  `loosen-follower-log-revert` feature.
+
+Related: [[bug-bulk-lane-send-timeouts-on-coordinated-reads]].

--- a/specs/in-process/bug-smoke-18765-tls-cert-path-mismatch.md
+++ b/specs/in-process/bug-smoke-18765-tls-cert-path-mismatch.md
@@ -1,0 +1,62 @@
+---
+type: todo
+priority: P3
+status: draft
+created: 2026-05-16
+updated: 2026-05-16
+affected-versions: ferrosa-memory main as of 2026-05-16
+---
+
+# Bug: `smoke-18765.sh` defaults to a TLS cert path that does not exist
+
+## Why this is a Ferrosa bug
+
+`ferrosa-memory/scripts/smoke-18765.sh` is the project's primary
+"is the cluster healthy" smoke test. Out of the box it fails on a fresh
+clone before reaching any actual probe:
+
+```
+$ bash scripts/smoke-18765.sh
+FAIL: TLS cert not readable: /home/bkearns/src/ferrosa-suite/ferrosa-memory/.runtime/tls.crt
+```
+
+The cert pair actually lives at `.runtime/tls/mcp.crt` and
+`.runtime/tls/mcp.key`. The smoke script's default
+`FERROSA_MEMORY_TLS_CACERT="${REPO_ROOT}/.runtime/tls.crt"` is stale.
+
+## Observed on
+
+- `ferrosa-memory` repo at `~/src/ferrosa-suite/ferrosa-memory/`, 2026-05-16.
+- `scripts/smoke-18765.sh` lines 18-19.
+
+## Suspected scope
+
+The smoke script was written when the cert lived at the .runtime root.
+At some point the cert pair was moved into `.runtime/tls/` (likely
+when both `mcp.crt` and `mcp.key` were generated as a pair — the
+filename also changed from `tls.crt` to `mcp.crt`).
+
+## Fix shape
+
+One of:
+
+1. Update the default in the smoke script:
+   `FERROSA_MEMORY_TLS_CACERT="${REPO_ROOT}/.runtime/tls/mcp.crt"`.
+2. Symlink `.runtime/tls.crt` → `.runtime/tls/mcp.crt` for backwards
+   compatibility, and update the script default in the next release.
+3. Add a fallback chain in the script: try `.runtime/tls/mcp.crt` first,
+   then `.runtime/tls.crt`, then fail with a clear message listing
+   both paths checked.
+
+Option 1 is cleanest if no other tooling depends on the old path.
+
+## Secondary issue: TLS scheme assumption
+
+The script also defaults `BASE_URL=https://127.0.0.1:18765`, but the
+in-tree `ferrosa-memory-http-podman.toml` runtime config sets
+`transport = "http"` and `require_tls = false`, so the MCP server
+listens with plain HTTP on 18765. Smoke users must override with
+`FERROSA_MEMORY_BASE_URL=http://127.0.0.1:18765` AND
+`FERROSA_MEMORY_TLS_CACERT=insecure` to get past the TLS handshake.
+Consider matching the script default to the in-tree compose config, or
+adding a guard that detects the scheme from the running endpoint.


### PR DESCRIPTION
## Summary

Architecture decision + concrete data to replace the single-shot range-read RPC with a streaming, idle-timeout-gated path.

## Why now

| `SELECT COUNT(*) FROM agent_memory.entity_store` | Wall-clock |
|---|---|
| Run 1 | 7.28 s |
| Run 2 | **37.15 s** |
| Run 3 | 7.32 s |

9,774 partitions. 3-node RF=3 cluster. No concurrent load. Even 8s loses Run 2; no fixed wall-clock value can be correct at *this* scale, let alone PB.

Both the timeout *and* the `RANGE_READ_MATERIALIZATION_CAP = 10_000` partition cap are magic-number antipatterns — and the storage layer's own error message at the cap literally says `"use a paged/streaming read path"` that doesn't exist.

## What this PR adds

- `specs/decisions/020-streaming-internode-range-read.md` — the design:
  - Storage layer exposes a lazy `range_iter` returning `impl Iterator<Item = Result<Partition>>`. No materialization, no cap.
  - Wire protocol gains `RangeReadChunk { request_id, seq, partitions }`, `RangeReadHeartbeat { request_id, seq }`, `RangeReadDone { request_id, total_chunks, truncated }`.
  - Bulk-lane RPC machinery generalizes to multi-message responses keyed by `request_id` (re-using the bootstrap-streaming primitives).
  - Coordinator runs an idle-timeout watchdog that resets on each chunk or heartbeat. Total wall-clock is unbounded; only genuine stalls abort.
  - Cancel + back-pressure fall out naturally.
  - Staged migration behind a feature flag with the legacy single-RPC path retained for mixed-version clusters; cap and constant removed in the release after.
- Bug spec `bug-bulk-lane-send-timeouts-on-coordinated-reads.md` updated with the wall-clock baseline + the "why tweaking the timeout is wrong" section pointing at this ADR.
- Merges in the other two smoke-validation bug specs from `docs/v0.10.0-smoke-bugs` so the three docs land together.


## Test plan

- [ ] Architecture review on the ADR — particularly the framing/correlation choice (extend bootstrap-streaming primitives vs. new transport).
- [ ] Decide: close PR #41 or keep it as a temporary stopgap with a "supersedes by ADR-020" note?
- [ ] Schedule the iterator + stream primitive work as separate PRs against this ADR.