### PR TITLE
fix(cql): keep accept loop responsive under connection storms (F1+F2+F3)

### DIFF
--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -42,6 +42,26 @@ use futures::SinkExt;
 /// Idle timeout: drop connection if no complete frame arrives within this duration (M11).
 const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Authenticate on the blocking pool so bcrypt (`cost=12` ≈ 200 ms per call on
+/// commodity hardware) does not block the async worker that runs this
+/// connection's handler. Without offloading, a burst of concurrent auth
+/// attempts pins every async worker thread in CPU-bound `bcrypt::verify`
+/// for hundreds of milliseconds at a time, starving the accept loop and
+/// every other connection on the same runtime.
+///
+/// The `JoinError` path (task panicked) is mapped to `AuthenticationFailed`
+/// so panics in the auth path become auth failures rather than dropped
+/// futures.
+pub(crate) async fn authenticate_off_runtime(
+    schema: Arc<ferrosa_schema::Schema>,
+    username: String,
+    password: String,
+) -> ferrosa_schema::Result<ferrosa_schema::AuthContext> {
+    tokio::task::spawn_blocking(move || schema.authenticate(&username, &password))
+        .await
+        .unwrap_or(Err(ferrosa_schema::SchemaError::AuthenticationFailed))
+}
+
 /// Connection phase state machine (M7).
 #[derive(Debug)]
 enum ConnectionPhase {
@@ -834,7 +854,9 @@ async fn handle_frame(
             }
         },
         ConnectionPhase::Authenticating { .. } => match frame.header.opcode {
-            Opcode::AuthResponse => handle_auth_response(phase, auth_context, state, &frame.body),
+            Opcode::AuthResponse => {
+                handle_auth_response(phase, auth_context, state, &frame.body).await
+            }
             _ => {
                 // Any opcode other than AUTH_RESPONSE before authentication is
                 // complete is an unauthorized access attempt — return 0x2100, not
@@ -989,7 +1011,7 @@ fn handle_options() -> HandleResult {
 
 // ── AUTH_RESPONSE ─────────────────────────────────────────────────────────
 
-fn handle_auth_response(
+async fn handle_auth_response(
     phase: &mut ConnectionPhase,
     auth_context: &mut Option<AuthContext>,
     state: &SharedState,
@@ -1010,19 +1032,29 @@ fn handle_auth_response(
 
     let payload = &cursor[..payload_len as usize];
 
-    match parse_sasl_plain(payload) {
-        Ok((username, password)) => match state.schema.authenticate(username, password) {
-            Ok(ctx) => {
-                *auth_context = Some(ctx);
-                *phase = ConnectionPhase::Ready;
-                let body = BytesMut::from(&encode_auth_success()[..]);
-                HandleResult::Reply(Opcode::AuthSuccess, body)
-            }
-            Err(_) => {
-                let err = CqlError::BadCredentials;
-                increment_auth_attempts_and_reply(phase, err)
-            }
-        },
+    let (username, password) = match parse_sasl_plain(payload) {
+        Ok(creds) => creds,
+        Err(_) => {
+            let err = CqlError::BadCredentials;
+            return increment_auth_attempts_and_reply(phase, err);
+        }
+    };
+
+    // Offload bcrypt to the blocking pool — see `authenticate_off_runtime`.
+    let result = authenticate_off_runtime(
+        state.schema.clone(),
+        username.to_string(),
+        password.to_string(),
+    )
+    .await;
+
+    match result {
+        Ok(ctx) => {
+            *auth_context = Some(ctx);
+            *phase = ConnectionPhase::Ready;
+            let body = BytesMut::from(&encode_auth_success()[..]);
+            HandleResult::Reply(Opcode::AuthSuccess, body)
+        }
         Err(_) => {
             let err = CqlError::BadCredentials;
             increment_auth_attempts_and_reply(phase, err)
@@ -2083,6 +2115,66 @@ fn extract_keyspace_table(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn build_minimal_schema_for_test() -> Arc<ferrosa_schema::Schema> {
+        use ferrosa_schema::audit::TestAuditSink;
+        use ferrosa_schema::{
+            AuthMethod, DeploymentMode, EnvSecretsProvider, PasswordHasher, PasswordPolicy,
+            RateLimitConfig, Schema, SchemaConfig,
+        };
+        let schema = Schema::new(SchemaConfig {
+            hasher: PasswordHasher::Bcrypt { cost: 4 },
+            password_policy: PasswordPolicy::permissive(),
+            auth_method: AuthMethod::Password,
+            rate_limit: RateLimitConfig::default(),
+            audit_sink: Box::new(TestAuditSink::new()),
+            secrets: Box::new(EnvSecretsProvider),
+            mode: DeploymentMode::Development,
+        })
+        .unwrap();
+        Arc::new(schema)
+    }
+
+    #[tokio::test]
+    async fn authenticate_off_runtime_does_not_serialize_on_async_thread() {
+        // Pre-fix: `authenticate` ran synchronously on the async worker. On a
+        // single-threaded runtime (which `#[tokio::test]` uses), 10 concurrent
+        // cost-4 bcrypts serialise through the one worker thread (~50-100 ms
+        // total). Post-fix: `spawn_blocking` offloads each to the blocking
+        // pool; the 10 run in parallel (~5-15 ms total).
+        let schema = build_minimal_schema_for_test();
+        let start = std::time::Instant::now();
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let s = schema.clone();
+            handles.push(tokio::spawn(async move {
+                authenticate_off_runtime(s, "cassandra".into(), "cassandra".into()).await
+            }));
+        }
+        for h in handles {
+            let res = h.await.unwrap();
+            assert!(
+                res.is_ok(),
+                "auth should succeed against the default cassandra user: {res:?}"
+            );
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_millis(40),
+            "10 concurrent cost-4 auths took {elapsed:?} — auth is not offloaded to the blocking pool"
+        );
+    }
+
+    #[tokio::test]
+    async fn authenticate_off_runtime_returns_failure_for_bad_password() {
+        let schema = build_minimal_schema_for_test();
+        let result =
+            authenticate_off_runtime(schema, "cassandra".into(), "wrong-password".into()).await;
+        assert!(matches!(
+            result,
+            Err(ferrosa_schema::SchemaError::AuthenticationFailed)
+        ));
+    }
 
     #[test]
     fn connection_guard_deregisters_on_drop() {

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -96,13 +96,14 @@ impl Drop for ConnectionGuard {
 /// In-flight request limiting: a semaphore bounds the number of concurrent
 /// requests being processed. When the limit is reached, new requests receive
 /// ERROR(Overloaded) without consuming a permit.
-pub async fn handle_connection<S>(
+pub(crate) async fn handle_connection<S>(
     stream: S,
     peer: SocketAddr,
     max_frame_size: u32,
     max_in_flight: usize,
     auth_disabled: bool,
     state: Arc<SharedState>,
+    mut ip_slot: Option<crate::server::IpSlotGuard>,
 ) where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
 {
@@ -435,6 +436,15 @@ pub async fn handle_connection<S>(
                             if let Some(ctx) = auth_context.as_ref() {
                                 state.connection_tracker.update_username(&peer, &ctx.role);
                             }
+                            // F3: drop the per-IP rate-limit slot the instant
+                            // the connection reaches Ready. The per-IP cap is a
+                            // defence against unauthenticated connection storms;
+                            // once a client has completed the handshake (and auth,
+                            // if enabled), it should not be counted toward that
+                            // cap — otherwise a burst from one IP holds slots
+                            // for the full IDLE_TIMEOUT even after all clients
+                            // succeed, rejecting legitimate follow-up traffic.
+                            ip_slot.take();
                         }
                         if was_ready {
                             state.connection_tracker.increment_requests(&peer);

--- a/ferrosa-cql/src/server.rs
+++ b/ferrosa-cql/src/server.rs
@@ -156,6 +156,38 @@ impl Drop for IpSlotGuard {
     }
 }
 
+/// Send a single rejection frame to a newly-accepted stream in a spawned task.
+///
+/// The accept loop must NEVER await on a write to a peer it has just rejected:
+/// if that one write blocks (slow peer, full kernel buffer, TCP retransmit
+/// timeout after the peer disappears), every subsequent `listener.accept()`
+/// is also blocked, and the entire CQL listener becomes unresponsive. This
+/// is exactly the failure mode triaged in the connect-stall investigation
+/// (commit message of this PR).
+///
+/// By spawning the send into its own task, slow rejection-writes are
+/// quarantined to their own task. The accept loop returns to
+/// `listener.accept()` on the very next instruction.
+fn spawn_reject(stream: tokio::net::TcpStream, max_frame_size: u32, err: CqlError) {
+    tokio::spawn(async move {
+        let codec = CqlCodec::new(max_frame_size);
+        let mut framed = Framed::new(stream, codec);
+        let body = err.encode_body().freeze();
+        let frame = CqlFrame {
+            header: FrameHeader {
+                version: VERSION_RESPONSE,
+                flags: 0,
+                stream_id: -1,
+                opcode: Opcode::Error,
+                length: 0,
+            },
+            body,
+        };
+        let _ = framed.send(frame).await;
+        // Framed (and the underlying TcpStream) drop here, closing the socket.
+    });
+}
+
 /// CQL protocol server.
 pub struct CqlServer {
     config: ServerConfig,
@@ -249,21 +281,11 @@ impl CqlServer {
                         if current >= max_connections {
                             active.fetch_sub(1, Ordering::Relaxed);
                             warn!("connection limit reached, rejecting {peer}");
-                            let codec = CqlCodec::new(max_frame_size);
-                            let mut framed = Framed::new(stream, codec);
-                            let err = CqlError::Overloaded("connection limit reached".into());
-                            let body = err.encode_body().freeze();
-                            let frame = CqlFrame {
-                                header: FrameHeader {
-                                    version: VERSION_RESPONSE,
-                                    flags: 0,
-                                    stream_id: -1,
-                                    opcode: Opcode::Error,
-                                    length: 0,
-                                },
-                                body,
-                            };
-                            let _ = framed.send(frame).await;
+                            spawn_reject(
+                                stream,
+                                max_frame_size,
+                                CqlError::Overloaded("connection limit reached".into()),
+                            );
                             continue;
                         }
                         // In pair mode, only the primary accepts CQL connections.
@@ -273,24 +295,14 @@ impl CqlServer {
                             tracing::debug!(
                                 "rejecting CQL connection: node is pair-mode secondary"
                             );
-                            let codec = CqlCodec::new(max_frame_size);
-                            let mut framed = Framed::new(stream, codec);
-                            let err = CqlError::Overloaded(
-                                "writes disallowed on read replica; connect to the primary node"
-                                    .into(),
+                            spawn_reject(
+                                stream,
+                                max_frame_size,
+                                CqlError::Overloaded(
+                                    "writes disallowed on read replica; connect to the primary node"
+                                        .into(),
+                                ),
                             );
-                            let body = err.encode_body().freeze();
-                            let frame = CqlFrame {
-                                header: FrameHeader {
-                                    version: VERSION_RESPONSE,
-                                    flags: 0,
-                                    stream_id: -1,
-                                    opcode: Opcode::Error,
-                                    length: 0,
-                                },
-                                body,
-                            };
-                            let _ = framed.send(frame).await;
                             continue;
                         }
                         // Per-IP rate limiting
@@ -298,22 +310,11 @@ impl CqlServer {
                         if !ip_tracker.try_acquire(peer_ip, max_connections_per_ip) {
                             active.fetch_sub(1, Ordering::Relaxed);
                             warn!("per-IP limit reached for {peer_ip}, rejecting");
-                            let codec = CqlCodec::new(max_frame_size);
-                            let mut framed = Framed::new(stream, codec);
-                            let err =
-                                CqlError::Overloaded("per-IP connection limit reached".into());
-                            let body = err.encode_body().freeze();
-                            let frame = CqlFrame {
-                                header: FrameHeader {
-                                    version: VERSION_RESPONSE,
-                                    flags: 0,
-                                    stream_id: -1,
-                                    opcode: Opcode::Error,
-                                    length: 0,
-                                },
-                                body,
-                            };
-                            let _ = framed.send(frame).await;
+                            spawn_reject(
+                                stream,
+                                max_frame_size,
+                                CqlError::Overloaded("per-IP connection limit reached".into()),
+                            );
                             continue;
                         }
                         // Configure TCP keepalive to detect dead peers in ~60s
@@ -541,6 +542,60 @@ mod tests {
         assert_eq!(header.opcode, Opcode::Error);
         let error_code = i32::from_be_bytes(buf[HEADER_SIZE..HEADER_SIZE + 4].try_into().unwrap());
         assert_eq!(error_code, 0x1100);
+    }
+
+    /// Regression test for the CQL connect-stall: if rejection writes happen
+    /// inline in the accept loop, ONE slow rejection-peer freezes every
+    /// subsequent accept on the listener. With the fix, rejection writes
+    /// are quarantined to spawned tasks; the accept loop keeps draining the
+    /// SYN queue regardless of how slow individual rejection-peers are.
+    #[tokio::test]
+    async fn rejection_does_not_block_subsequent_accepts() {
+        let (state, _dir) = setup_state();
+        // Global cap=1, per-IP cap large so we test only the global path.
+        let server = CqlServer::new(test_config(1, 64), state);
+        let addr = server.start_background().await.unwrap();
+
+        // Open and HOLD the one allowed slot; never read from it.
+        let _hog = TcpStream::connect(addr).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // Open a rejected connection whose kernel recv buffer is set tiny
+        // and that NEVER reads. With the old inline-await design, the
+        // server's framed.send to this peer would saturate the kernel
+        // buffer and block the accept loop. (For a 50-byte Error frame
+        // this rarely happens in practice — but the structural fix is
+        // what protects us, not the kernel buffer luck.)
+        let slow_peer = TcpStream::connect(addr).await.unwrap();
+        {
+            let sref = socket2::SockRef::from(&slow_peer);
+            let _ = sref.set_recv_buffer_size(512);
+        }
+
+        // Now race a NEW client: in the buggy design the accept loop is
+        // wedged behind the slow_peer's rejection-send and this connect
+        // would have to wait. We assert it completes within a tight bound.
+        let race_start = std::time::Instant::now();
+        let mut race = TcpStream::connect(addr).await.unwrap();
+        let connect_elapsed = race_start.elapsed();
+
+        let mut buf = vec![0u8; 256];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(2), race.read(&mut buf))
+            .await
+            .expect("rejection frame read timed out")
+            .unwrap();
+        assert!(n >= HEADER_SIZE);
+        let header = FrameHeader::decode(&buf[..HEADER_SIZE]).unwrap();
+        assert_eq!(header.opcode, Opcode::Error);
+
+        assert!(
+            connect_elapsed < std::time::Duration::from_millis(500),
+            "race connect took {connect_elapsed:?} — accept loop appears blocked behind the slow rejection"
+        );
+
+        // Keep references alive so their sockets stay open during the test.
+        drop(_hog);
+        drop(slow_peer);
     }
 
     #[tokio::test]

--- a/ferrosa-cql/src/server.rs
+++ b/ferrosa-cql/src/server.rs
@@ -145,7 +145,16 @@ impl IpConnectionTracker {
 ///
 /// This ensures the slot is freed even if the handler task panics
 /// or is cancelled, preventing permanent connection slot leaks.
-struct IpSlotGuard {
+///
+/// The guard is handed off to `handle_connection`, which drops it
+/// as soon as the connection reaches the `Ready` phase — the per-IP
+/// limit only needs to defend against unauthenticated connection
+/// storms; once a client has completed the protocol handshake (and
+/// auth, if enabled), it is no longer counted toward the per-IP cap.
+/// If the handler never reaches `Ready` (e.g. the client disconnects
+/// before STARTUP, or fails MAX_AUTH_ATTEMPTS), the guard drops with
+/// the handler task and the slot is released anyway.
+pub(crate) struct IpSlotGuard {
     tracker: Arc<IpConnectionTracker>,
     ip: IpAddr,
 }
@@ -329,7 +338,9 @@ impl CqlServer {
 
                         // RAII guard: releases the IP slot on drop (including panics
                         // and task cancellation), preventing permanent slot leaks.
-                        let _ip_guard = IpSlotGuard {
+                        // Handed to the connection handler, which drops it the moment
+                        // the connection reaches Ready phase — see IpSlotGuard docs.
+                        let ip_guard = IpSlotGuard {
                             tracker: ip_tracker.clone(),
                             ip: peer_ip,
                         };
@@ -338,10 +349,6 @@ impl CqlServer {
                         let state = state.clone();
                         let tls_acceptor = tls_acceptor.clone();
                         tokio::spawn(async move {
-                            // Move the guard into the spawned task so its lifetime
-                            // is tied to the connection handler, not the accept loop.
-                            let _ip_guard = _ip_guard;
-
                             if let Some(acceptor) = tls_acceptor {
                                 // TLS handshake with 10s timeout
                                 match tokio::time::timeout(
@@ -358,10 +365,12 @@ impl CqlServer {
                                             max_in_flight,
                                             auth_disabled,
                                             state,
+                                            Some(ip_guard),
                                         )
                                         .await;
                                     }
                                     Ok(Err(e)) => {
+                                        // ip_guard drops here, releasing the slot.
                                         warn!("TLS handshake failed from {peer}: {e}");
                                     }
                                     Err(_) => {
@@ -376,10 +385,10 @@ impl CqlServer {
                                     max_in_flight,
                                     auth_disabled,
                                     state,
+                                    Some(ip_guard),
                                 )
                                 .await;
                             }
-                            // _ip_guard drops here, releasing the IP slot.
                             // active connection count is decremented explicitly.
                             active.fetch_sub(1, Ordering::Relaxed);
                         });
@@ -542,6 +551,83 @@ mod tests {
         assert_eq!(header.opcode, Opcode::Error);
         let error_code = i32::from_be_bytes(buf[HEADER_SIZE..HEADER_SIZE + 4].try_into().unwrap());
         assert_eq!(error_code, 0x1100);
+    }
+
+    /// Send a v4 STARTUP frame and read one response frame.
+    async fn startup_and_read_one_frame(stream: &mut TcpStream) -> FrameHeader {
+        use bytes::BufMut;
+        use tokio::io::AsyncWriteExt;
+        let mut body = bytes::BytesMut::new();
+        body.put_u16(1); // 1 entry in the string map
+        let key = b"CQL_VERSION";
+        body.put_u16(key.len() as u16);
+        body.put_slice(key);
+        let val = b"3.0.0";
+        body.put_u16(val.len() as u16);
+        body.put_slice(val);
+        let body_len = body.len() as u32;
+
+        let mut header = bytes::BytesMut::new();
+        header.put_u8(0x04); // version (request)
+        header.put_u8(0x00); // flags
+        header.put_i16(0); // stream id
+        header.put_u8(0x01); // STARTUP opcode
+        header.put_u32(body_len);
+        stream.write_all(&header).await.unwrap();
+        stream.write_all(&body).await.unwrap();
+
+        let mut buf = vec![0u8; HEADER_SIZE];
+        let mut read_total = 0;
+        while read_total < HEADER_SIZE {
+            let n = stream.read(&mut buf[read_total..]).await.unwrap();
+            if n == 0 {
+                panic!("EOF before response header");
+            }
+            read_total += n;
+        }
+        let h = FrameHeader::decode(&buf).unwrap();
+        // drain body so caller can reuse stream cleanly
+        if h.length > 0 {
+            let mut body = vec![0u8; h.length as usize];
+            let _ = stream.read_exact(&mut body).await;
+        }
+        h
+    }
+
+    /// F3 regression test: per-IP rate-limit slot must be released the moment
+    /// the connection reaches Ready phase. Otherwise a burst from one IP
+    /// holds every slot for the full IDLE_TIMEOUT after the clients finish,
+    /// rejecting legitimate follow-up traffic for minutes.
+    #[tokio::test]
+    async fn per_ip_slot_released_on_ready_transition() {
+        let (state, _dir) = setup_state();
+        let mut config = test_config(10, 1); // per-IP cap = 1
+        config.auth_disabled = true; // STARTUP transitions directly to Ready
+        let server = CqlServer::new(config, state);
+        let addr = server.start_background().await.unwrap();
+
+        // Connection 1 — complete handshake, reach Ready.
+        let mut c1 = TcpStream::connect(addr).await.unwrap();
+        let h1 = startup_and_read_one_frame(&mut c1).await;
+        assert_eq!(h1.opcode, Opcode::Ready);
+
+        // Give the server a brief window to drop the slot guard.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Connection 2 from SAME IP — pre-F3, c1 still holds the per-IP slot
+        // and this would be rejected with Overloaded. Post-F3, c1's slot was
+        // released when it reached Ready, so c2 acquires it and succeeds.
+        let mut c2 = TcpStream::connect(addr).await.unwrap();
+        let h2 = startup_and_read_one_frame(&mut c2).await;
+        assert_eq!(
+            h2.opcode,
+            Opcode::Ready,
+            "second connection from same IP should be accepted: c1 must release its per-IP slot on Ready transition"
+        );
+
+        // Keep c1 alive so we know its IDLE_TIMEOUT didn't release the slot.
+        drop(c1);
+        drop(c2);
     }
 
     /// Regression test for the CQL connect-stall: if rejection writes happen


### PR DESCRIPTION
## Executive Summary

Triage of a connect-stall observed in the wild: after a burst of ~60 rapid `cqlsh -e` invocations against `127.0.0.1:19042`, ferrosa stopped responding to new CQL connections for *hours* (TCP connect from inside the node's netns timed out at 10 s; no log activity on connect attempts; process otherwise healthy). Persisted across `docker compose restart`. Root cause was three independent bugs in the CQL accept path. Each is fixed below; on the live cluster the same 70-connection burst now succeeds 70/70 with no wedge.

## Bugs and fixes

### F1 — bcrypt blocks the async runtime

`Schema::authenticate` is synchronous and calls `bcrypt::verify` (cost=12 → ~100-300 ms per call). The CQL connection handler invoked it inline from an `async fn`, so every concurrent auth pinned a tokio async worker for the duration. With `worker_threads = num_cpus` (often 8) a burst of ~60 cqlsh connections saturated the worker pool with synchronous bcrypt work; **the accept-loop task scheduled on the same workers was starved and could not drain the kernel's SYN backlog** until the entire batch finished.

**Fix:** route `Schema::authenticate` through `tokio::task::spawn_blocking` in a new `authenticate_off_runtime` helper. Auth still runs on a CPU thread — just on the dedicated blocking pool — and async workers stay free.

### F2 — rejection writes inline in the accept loop

The accept loop performed `let _ = framed.send(error_frame).await;` for all three rejection paths (`max_connections`, pair-mode secondary, per-IP limit). The `.await` is on the accept-loop task itself: **one slow rejection write (slow peer, full kernel send buffer, retransmit timeout to a disappeared peer) is enough to wedge `listener.accept()` for every subsequent connection.**

**Fix:** new `spawn_reject` helper. Rejection-frame writes happen in their own spawned tasks; the accept loop returns to `listener.accept()` on the very next instruction.

### F3 — per-IP slot held for the full 300 s `IDLE_TIMEOUT`

`max_connections_per_ip` (default 64) is a defence against unauthenticated connection-storm DoS. The `IpSlotGuard` only releases when the handler task ends — typically the 300 s idle timeout. A burst of 60 cqlsh-from-one-IP **held 60 slots for 5 minutes after the clients finished**, rejecting follow-up traffic from the same IP with `Overloaded` for that window.

**Fix:** hand the `IpSlotGuard` from the accept loop into the connection handler; the handler drops it the moment the connection reaches `ConnectionPhase::Ready` (after STARTUP if auth is disabled, or after AUTH_RESPONSE if not). If the connection never reaches Ready (client disconnects pre-STARTUP, exhausts `MAX_AUTH_ATTEMPTS`, TLS handshake fails), the guard drops with the handler and the slot is released anyway.

## Tests (4 new contracts)

| Test | Asserts |
|---|---|
| `authenticate_off_runtime_does_not_serialize_on_async_thread` | 10 concurrent cost-4 auths on a single-thread runtime complete in <40 ms (pre-fix: ~50-100 ms serialised through one worker) |
| `authenticate_off_runtime_returns_failure_for_bad_password` | Panic / error mapping |
| `rejection_does_not_block_subsequent_accepts` | Fills global cap, parks a slow rejection-peer with a tiny `SO_RCVBUF`, then races a new connect — asserts <500 ms |
| `per_ip_slot_released_on_ready_transition` | max_per_ip=1; c1 completes STARTUP → Ready; c2 from same IP succeeds (pre-F3 it would be rejected with Overloaded) |

## Measured impact on the live fmem cluster

Same 70-connection cqlsh storm against `127.0.0.1:19042`:

| Metric | Pre-fix | F1+F2 only | **F1+F2+F3** |
|---|---|---|---|
| Cluster wedges after burst | **yes (hours)** | no | **no** |
| Storm connections succeed | n/a (wedged) | ~50% | **70 / 70** |
| Mid-storm probe latency | hangs | 3.3 s | 3.3 s |
| Post-storm probe latency | timeout | 0.4 s | 0.56 s |

## Verification

- 761 `ferrosa-cql` unit tests pass
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- End-to-end on the live 3-node fmem cluster (MinIO S3, RF=3): connection-storm regression no longer reproducible

## Test plan
- [ ] CI green
- [ ] Burn-in under the loadgen `resource_monitor` — confirm no per-IP slot leak after sustained traffic; FD count stays bounded
- [ ] If feasible, repeat the original burst on a staging cluster and confirm zero `Overloaded` rejections on follow-up traffic