### PR TITLE
fix(cluster/repair): Merkle hashes partition content, plus diff primitives

### DIFF
--- a/ferrosa-cluster/src/lib.rs
+++ b/ferrosa-cluster/src/lib.rs
@@ -39,5 +39,10 @@ pub use ddl_path::DdlPath;
 pub use error::{ClusterError, Result};
 pub use mode::DeploymentMode;
 pub use pair::{PairCoordinator, PairNode, PairRole};
+pub use repair::{
+    InMemoryRepairStore, LocalRepairExecutor, RemoteRepairStore, RepairApplyHandler,
+    RepairCoordinator, RepairFetchHandler, RepairMerkleHandler, RepairStore, SessionExecutor,
+    SessionStats, StorageEngineRepairStore,
+};
 pub use state::{PairClusterState, RaftClusterState, SingleNodeClusterState};
 pub use write_path::WritePath;

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -1,0 +1,370 @@
+//! Anti-entropy repair scheduler — drives [`RepairSession`] runs across every
+//! `(table, owned-range, peer)` triple and reports per-session results.
+//!
+//! ## Design
+//!
+//! The coordinator is parameterised by a [`SessionExecutor`] trait so the
+//! scheduling logic can be unit-tested in isolation from the RPC + streaming
+//! machinery that actually runs a session against a remote peer.
+//!
+//! For a given (ring, local_node, rf, table):
+//!
+//! 1. Enumerate every token range the local node is a replica of, using the
+//!    ring's vnode topology.
+//! 2. For each range, look up the peer replicas via [`repair_participants`].
+//!    Skip self.
+//! 3. For each `(range, peer)` pair, invoke the executor. Cap concurrency
+//!    via a tokio semaphore.
+//! 4. Collect per-session results and return.
+//!
+//! The actual RPC + streaming impl of `SessionExecutor` lives in a follow-up
+//! PR alongside the wire-protocol additions.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use ferrosa_storage::TableId;
+
+use crate::ring::TokenRing;
+
+/// Statistics returned by a single repair session between two replicas.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionStats {
+    /// Partitions streamed from the remote peer to the local node.
+    pub partitions_streamed_in: u64,
+    /// Partitions streamed from the local node to the remote peer.
+    pub partitions_streamed_out: u64,
+    /// Partition keys with identical timestamps and divergent content —
+    /// surfaced to the operator, NOT auto-resolved.
+    pub timestamp_ties: u64,
+}
+
+/// A `(table, range, peer)` triple scheduled for repair plus the
+/// [`SessionStats`] (or error) the executor returned.
+#[derive(Debug)]
+pub struct SessionResult {
+    pub table: TableId,
+    pub range_start: i64,
+    pub range_end: i64,
+    pub peer: u64,
+    pub result: Result<SessionStats, String>,
+}
+
+/// Executes a single repair session between the local node and one peer
+/// over one token range of one table.
+///
+/// The production implementation runs the Merkle exchange + partition diff
+/// + streaming over the internode RPC channel. Tests inject mocks that
+/// record their inputs without actually doing any I/O.
+#[async_trait]
+pub trait SessionExecutor: Send + Sync {
+    async fn run_session(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+        peer: u64,
+    ) -> Result<SessionStats, String>;
+}
+
+/// Coordinator that fans repair sessions out across every (range, peer)
+/// pair for a given table.
+pub struct RepairCoordinator {
+    /// Max concurrent sessions in flight. Bounded so a node with many
+    /// vnodes × many peers doesn't open hundreds of simultaneous streams.
+    pub max_concurrent_sessions: usize,
+}
+
+impl Default for RepairCoordinator {
+    fn default() -> Self {
+        Self {
+            // Matches Cassandra's default per-node repair concurrency.
+            max_concurrent_sessions: 4,
+        }
+    }
+}
+
+impl RepairCoordinator {
+    /// Repair `table` across every owned token range against every peer
+    /// participant. Returns one [`SessionResult`] per `(range, peer)`
+    /// invocation, in arbitrary order.
+    pub async fn repair_table(
+        &self,
+        executor: Arc<dyn SessionExecutor>,
+        ring: &TokenRing,
+        local_node_id: u64,
+        rf: usize,
+        table: &TableId,
+    ) -> Vec<SessionResult> {
+        // Build the work list synchronously. For each (range, peer) we
+        // need: range bounds, peer id. Skip ranges this node doesn't
+        // replicate, and skip self when looking up peers.
+        let owned_ranges = owned_token_ranges(ring, local_node_id, rf);
+        let mut tasks: Vec<(i64, i64, u64)> = Vec::new();
+        for (range_start, range_end) in owned_ranges {
+            // Pick a representative token in the range to ask the ring
+            // who replicates it. All tokens in a single vnode range
+            // share the same replica set by construction.
+            let peers = super::repair_participants(ring, range_start, rf);
+            for peer in peers {
+                if peer == local_node_id {
+                    continue;
+                }
+                tasks.push((range_start, range_end, peer));
+            }
+        }
+
+        // Bound parallelism with a semaphore.
+        let sem = Arc::new(tokio::sync::Semaphore::new(self.max_concurrent_sessions));
+        let mut handles = Vec::with_capacity(tasks.len());
+        for (range_start, range_end, peer) in tasks {
+            let table = table.clone();
+            let executor = executor.clone();
+            let sem = sem.clone();
+            handles.push(tokio::spawn(async move {
+                // OwnedSemaphorePermit: held for the body of run_session,
+                // released on drop. Bound on the runtime queue, not on
+                // throughput of any single session.
+                let _permit = sem.acquire_owned().await.expect("semaphore not closed");
+                let result = executor
+                    .run_session(&table, range_start, range_end, peer)
+                    .await;
+                SessionResult {
+                    table,
+                    range_start,
+                    range_end,
+                    peer,
+                    result,
+                }
+            }));
+        }
+
+        let mut results = Vec::with_capacity(handles.len());
+        for h in handles {
+            // A panicking session is reported as an error rather than
+            // aborting the whole repair run.
+            match h.await {
+                Ok(r) => results.push(r),
+                Err(e) => {
+                    // We can't reconstruct the (range, peer) from a panic,
+                    // so use sentinel values. Tests treat this as
+                    // unexpected; production logs it.
+                    results.push(SessionResult {
+                        table: table.clone(),
+                        range_start: 0,
+                        range_end: 0,
+                        peer: 0,
+                        result: Err(format!("session task panicked: {e}")),
+                    });
+                }
+            }
+        }
+        results
+    }
+}
+
+/// Token ranges this node is a replica of, as `[start, end)` pairs over the
+/// vnode partitioning. Excludes ranges where the local node isn't in the
+/// replica set for `rf`. For the wrap-around segment (last token → first
+/// token via i64::MIN/MAX), we emit TWO ranges so callers don't have to
+/// special-case it.
+fn owned_token_ranges(ring: &TokenRing, local_node_id: u64, rf: usize) -> Vec<(i64, i64)> {
+    let mut all_tokens: Vec<i64> = ring
+        .node_ids()
+        .iter()
+        .flat_map(|&n| ring.tokens_for_node(n))
+        .collect();
+    all_tokens.sort_unstable();
+    all_tokens.dedup();
+    if all_tokens.is_empty() {
+        return vec![];
+    }
+
+    let mut ranges = Vec::new();
+    for (i, &start) in all_tokens.iter().enumerate() {
+        let end_token = all_tokens.get(i + 1).copied().unwrap_or(i64::MAX); // wrap segment continues to i64::MAX...
+                                                                            // A range belongs to the local node if local_node_id is in the
+                                                                            // replica set of the range's start token.
+        if ring.replicas(start, rf).contains(&local_node_id) {
+            ranges.push((start, end_token));
+        }
+    }
+    // ... and from i64::MIN to the smallest token, if that wrap segment's
+    // replicas include local.
+    let first = all_tokens[0];
+    if first != i64::MIN && ring.replicas(i64::MIN, rf).contains(&local_node_id) {
+        ranges.push((i64::MIN, first));
+    }
+    ranges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raft::{NodeInfo, NodeState};
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    fn node_with(addr: &str, state: NodeState) -> NodeInfo {
+        NodeInfo {
+            host_id: Uuid::new_v4(),
+            addr: addr.to_string(),
+            data_center: "dc1".to_string(),
+            rack: "rack1".to_string(),
+            state,
+            cql_broadcast: None,
+        }
+    }
+
+    /// Mock executor that records every invocation and returns the
+    /// configured stats. Lets tests assert on the (range, peer) work
+    /// the coordinator scheduled without doing any real I/O.
+    struct MockExecutor {
+        calls: Mutex<Vec<(TableId, i64, i64, u64)>>,
+        next_stats: SessionStats,
+    }
+
+    impl MockExecutor {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                next_stats: SessionStats::default(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SessionExecutor for MockExecutor {
+        async fn run_session(
+            &self,
+            table: &TableId,
+            range_start: i64,
+            range_end: i64,
+            peer: u64,
+        ) -> Result<SessionStats, String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((table.clone(), range_start, range_end, peer));
+            Ok(self.next_stats.clone())
+        }
+    }
+
+    fn three_node_ring() -> TokenRing {
+        let mut ring = TokenRing::new();
+        ring.add_node(1, node_with("10.0.0.1:7000", NodeState::Normal));
+        ring.add_node(2, node_with("10.0.0.2:7000", NodeState::Normal));
+        ring.add_node(3, node_with("10.0.0.3:7000", NodeState::Normal));
+        ring.assign_tokens(1, &[100, 400, 700]);
+        ring.assign_tokens(2, &[200, 500, 800]);
+        ring.assign_tokens(3, &[300, 600, 900]);
+        ring
+    }
+
+    #[tokio::test]
+    async fn repair_table_schedules_one_session_per_peer_per_owned_range() {
+        let ring = three_node_ring();
+        let table = TableId::new("ks", "tbl");
+        let exec = Arc::new(MockExecutor::new());
+        let coord = RepairCoordinator {
+            max_concurrent_sessions: 4,
+        };
+        // RF=3 on a 3-node ring: every range is replicated by all 3 nodes.
+        let results = coord.repair_table(exec.clone(), &ring, 1, 3, &table).await;
+        // Expect: 9 vnode ranges × 2 peers = 18 sessions (plus the wrap
+        // segment if local owns it — which it does at RF=3).
+        let calls = exec.calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            results.len(),
+            "every session must record exactly one mock call"
+        );
+        assert!(
+            results.iter().all(|r| r.result.is_ok()),
+            "mock executor returns Ok for every call"
+        );
+        // Every peer recorded is in {2, 3} — never the local node.
+        let peers: std::collections::BTreeSet<u64> = calls.iter().map(|(_, _, _, p)| *p).collect();
+        assert_eq!(peers, [2u64, 3].iter().copied().collect());
+        // At least one session per peer.
+        assert!(calls.iter().any(|(_, _, _, p)| *p == 2));
+        assert!(calls.iter().any(|(_, _, _, p)| *p == 3));
+    }
+
+    #[tokio::test]
+    async fn repair_table_skips_self() {
+        let ring = three_node_ring();
+        let table = TableId::new("ks", "tbl");
+        let exec = Arc::new(MockExecutor::new());
+        let coord = RepairCoordinator::default();
+        coord.repair_table(exec.clone(), &ring, 2, 3, &table).await;
+        let calls = exec.calls.lock().unwrap();
+        assert!(
+            !calls.iter().any(|(_, _, _, p)| *p == 2),
+            "local node 2 must never be its own peer"
+        );
+    }
+
+    #[tokio::test]
+    async fn repair_table_empty_ring_returns_no_results() {
+        let ring = TokenRing::new();
+        let table = TableId::new("ks", "tbl");
+        let exec = Arc::new(MockExecutor::new());
+        let coord = RepairCoordinator::default();
+        let results = coord.repair_table(exec.clone(), &ring, 1, 3, &table).await;
+        assert!(results.is_empty());
+        assert!(exec.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn repair_table_concurrency_cap_caps_in_flight() {
+        // Custom executor that holds the OwnedSemaphorePermit while sleeping,
+        // letting us observe that more than max_concurrent_sessions don't
+        // run simultaneously.
+        struct ConcurrencyTracker {
+            in_flight: Arc<std::sync::atomic::AtomicUsize>,
+            peak: Arc<std::sync::atomic::AtomicUsize>,
+        }
+        #[async_trait]
+        impl SessionExecutor for ConcurrencyTracker {
+            async fn run_session(
+                &self,
+                _table: &TableId,
+                _: i64,
+                _: i64,
+                _: u64,
+            ) -> Result<SessionStats, String> {
+                let n = self
+                    .in_flight
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                    + 1;
+                self.peak.fetch_max(n, std::sync::atomic::Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                self.in_flight
+                    .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(SessionStats::default())
+            }
+        }
+        let in_flight = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let peak = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let exec: Arc<dyn SessionExecutor> = Arc::new(ConcurrencyTracker {
+            in_flight: in_flight.clone(),
+            peak: peak.clone(),
+        });
+        let coord = RepairCoordinator {
+            max_concurrent_sessions: 2,
+        };
+        let ring = three_node_ring();
+        let table = TableId::new("ks", "tbl");
+        coord.repair_table(exec, &ring, 1, 3, &table).await;
+        let observed_peak = peak.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            observed_peak <= 2,
+            "peak concurrency was {observed_peak}, must be <= 2"
+        );
+        assert!(
+            observed_peak >= 2,
+            "with 18 sessions and cap=2 we should hit the cap at some point; saw peak={observed_peak}"
+        );
+    }
+}

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -102,20 +102,44 @@ impl RepairCoordinator {
         rf: usize,
         table: &TableId,
     ) -> Vec<SessionResult> {
-        // Build the work list synchronously. For each (range, peer) we
-        // need: range bounds, peer id. Skip ranges this node doesn't
-        // replicate, and skip self when looking up peers.
+        // Build the work list synchronously. We collapse adjacent
+        // owned vnode ranges that share the same replica set into a
+        // single session — every (range, peer) pair within such a
+        // group does identical work, so issuing N×peers wire calls
+        // when 1×peers would suffice is just amplifying load on the
+        // peer (and the local CQL listener, which has crashed in the
+        // past from a 1 536-session storm on RF=3 / 3-node).
         let owned_ranges = owned_token_ranges(ring, local_node_id, rf);
-        let mut tasks: Vec<(i64, i64, u64)> = Vec::new();
-        for (range_start, range_end) in owned_ranges {
-            // Pick a representative token in the range to ask the ring
-            // who replicates it. All tokens in a single vnode range
-            // share the same replica set by construction.
-            let peers = super::repair_participants(ring, range_start, rf);
-            for peer in peers {
-                if peer == local_node_id {
+        // (start, end, peers_excluding_self_sorted). Sort by start so
+        // the wrap segment `[i64::MIN, first_token)` — which
+        // `owned_token_ranges` emits last — sits before the body and
+        // can merge with it where the replica set agrees.
+        let mut owned_with_peers: Vec<(i64, i64, Vec<u64>)> = owned_ranges
+            .into_iter()
+            .map(|(s, e)| {
+                let mut peers: Vec<u64> = super::repair_participants(ring, s, rf)
+                    .into_iter()
+                    .filter(|p| *p != local_node_id)
+                    .collect();
+                peers.sort_unstable();
+                (s, e, peers)
+            })
+            .collect();
+        owned_with_peers.sort_by_key(|(s, _, _)| *s);
+        let mut merged: Vec<(i64, i64, Vec<u64>)> = Vec::new();
+        for (range_start, range_end, peers) in owned_with_peers {
+            if let Some(last) = merged.last_mut() {
+                if last.1 == range_start && last.2 == peers {
+                    // Same replica set AND contiguous in token order.
+                    last.1 = range_end;
                     continue;
                 }
+            }
+            merged.push((range_start, range_end, peers));
+        }
+        let mut tasks: Vec<(i64, i64, u64)> = Vec::new();
+        for (range_start, range_end, peers) in merged {
+            for peer in peers {
                 tasks.push((range_start, range_end, peer));
             }
         }
@@ -268,33 +292,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repair_table_schedules_one_session_per_peer_per_owned_range() {
+    async fn repair_table_merges_ranges_sharing_the_same_replica_set() {
         let ring = three_node_ring();
         let table = TableId::new("ks", "tbl");
         let exec = Arc::new(MockExecutor::new());
         let coord = RepairCoordinator {
             max_concurrent_sessions: 4,
         };
-        // RF=3 on a 3-node ring: every range is replicated by all 3 nodes.
+        // RF=3 on a 3-node ring: every range is replicated by ALL three
+        // nodes, so every (range, peer) pair is doing identical work as
+        // every other. The coordinator must collapse them: schedule
+        // exactly ONE session per non-self peer (covering the union of
+        // all owned ranges), not one per vnode × per peer. This is what
+        // turns repair on a 256-vnode default cluster from 1 536 wire
+        // calls per node into 2.
         let results = coord.repair_table(exec.clone(), &ring, 1, 3, &table).await;
-        // Expect: 9 vnode ranges × 2 peers = 18 sessions (plus the wrap
-        // segment if local owns it — which it does at RF=3).
         let calls = exec.calls.lock().unwrap();
         assert_eq!(
             calls.len(),
+            2,
+            "RF=3/3-node merges all owned ranges into one session per non-self peer"
+        );
+        assert_eq!(
             results.len(),
+            calls.len(),
             "every session must record exactly one mock call"
         );
-        assert!(
-            results.iter().all(|r| r.result.is_ok()),
-            "mock executor returns Ok for every call"
-        );
-        // Every peer recorded is in {2, 3} — never the local node.
+        assert!(results.iter().all(|r| r.result.is_ok()));
         let peers: std::collections::BTreeSet<u64> = calls.iter().map(|(_, _, _, p)| *p).collect();
         assert_eq!(peers, [2u64, 3].iter().copied().collect());
-        // At least one session per peer.
-        assert!(calls.iter().any(|(_, _, _, p)| *p == 2));
-        assert!(calls.iter().any(|(_, _, _, p)| *p == 3));
     }
 
     #[tokio::test]

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -369,7 +369,10 @@ mod tests {
             .filter_map(|(_, s, e, p)| if *p == 2 { Some((*s, *e)) } else { None })
             .collect();
         chunks_for_peer_2.sort();
-        assert_eq!(chunks_for_peer_2.len(), super::REPAIR_CHUNKS_PER_MERGED_RANGE);
+        assert_eq!(
+            chunks_for_peer_2.len(),
+            super::REPAIR_CHUNKS_PER_MERGED_RANGE
+        );
         assert_eq!(chunks_for_peer_2.first().unwrap().0, i64::MIN);
         assert_eq!(chunks_for_peer_2.last().unwrap().1, i64::MAX);
         for win in chunks_for_peer_2.windows(2) {

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -1,4 +1,4 @@
-//! Anti-entropy repair scheduler — drives [`RepairSession`] runs across every
+//! Anti-entropy repair scheduler — drives `RepairSession` runs across every
 //! `(table, owned-range, peer)` triple and reports per-session results.
 //!
 //! ## Design
@@ -11,7 +11,7 @@
 //!
 //! 1. Enumerate every token range the local node is a replica of, using the
 //!    ring's vnode topology.
-//! 2. For each range, look up the peer replicas via [`repair_participants`].
+//! 2. For each range, look up the peer replicas via [`super::repair_participants`].
 //!    Skip self.
 //! 3. For each `(range, peer)` pair, invoke the executor. Cap concurrency
 //!    via a tokio semaphore.

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -79,10 +79,19 @@ pub struct RepairCoordinator {
 /// many equal-token chunks before scheduling. Bounds per-session
 /// memory to roughly `table_size / K * 2` (local + remote) so a
 /// session never tries to materialise a multi-GB replica in one
-/// shot. 32 keeps the wire-call count modest (RF=3/3-node: 1 group
-/// × 32 chunks × 2 peers = 64 sessions per node vs. 1 536 without
-/// the merge) while bounding peak memory at ~table_size/32.
-pub const REPAIR_CHUNKS_PER_MERGED_RANGE: usize = 32;
+/// shot.
+///
+/// 256 is sized for fat-partition tables where average-case
+/// partition size hides outliers: on the fmem entity_store with
+/// ~10 k partitions and a 1.3 GB local replica, K=32 still let a
+/// skewed chunk push peak memory to ~1.9 GiB (well-distributed
+/// average × 4 concurrent + skew + apply accumulation) and OOM
+/// the 2 GiB container. At K=256 each chunk holds roughly 40
+/// partitions on average and worst-case skew stays under a few MB
+/// per chunk. Wire-call count is still bounded — RF=3/3-node:
+/// 1 group × 256 chunks × 2 peers = 512 sessions per node, vs.
+/// 1 536 without the merge.
+pub const REPAIR_CHUNKS_PER_MERGED_RANGE: usize = 256;
 
 impl Default for RepairCoordinator {
     fn default() -> Self {

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -78,8 +78,14 @@ pub struct RepairCoordinator {
 impl Default for RepairCoordinator {
     fn default() -> Self {
         Self {
-            // Matches Cassandra's default per-node repair concurrency.
-            max_concurrent_sessions: 4,
+            // Conservative default: 1 session at a time. Each session
+            // currently does a per-call full-table prefix scan (until a
+            // token-bounded scan API lands on StorageEngine), so running
+            // many in parallel multiplies the working-set memory by the
+            // concurrency factor. On a 2 GB container this OOMs almost
+            // immediately. Raise this once the read path is bounded by
+            // token range, not by an in-memory limit-then-filter.
+            max_concurrent_sessions: 1,
         }
     }
 }

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -78,14 +78,14 @@ pub struct RepairCoordinator {
 impl Default for RepairCoordinator {
     fn default() -> Self {
         Self {
-            // Conservative default: 1 session at a time. Each session
-            // currently does a per-call full-table prefix scan (until a
-            // token-bounded scan API lands on StorageEngine), so running
-            // many in parallel multiplies the working-set memory by the
-            // concurrency factor. On a 2 GB container this OOMs almost
-            // immediately. Raise this once the read path is bounded by
-            // token range, not by an in-memory limit-then-filter.
-            max_concurrent_sessions: 1,
+            // 4 matches Cassandra's per-node default. With the
+            // `read_token_range` primitive wiring (only materialises
+            // partitions in the requested token sub-range, not a full
+            // key-ordered prefix), the per-session working set is bounded
+            // by leaf cardinality — typically << 1 partition per leaf at
+            // TREE_DEPTH=15 — so 4 concurrent sessions fit comfortably in
+            // the 2 GB fmem container.
+            max_concurrent_sessions: 4,
         }
     }
 }

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -75,6 +75,15 @@ pub struct RepairCoordinator {
     pub max_concurrent_sessions: usize,
 }
 
+/// Each merged (replica-set, owned-range) group is split into this
+/// many equal-token chunks before scheduling. Bounds per-session
+/// memory to roughly `table_size / K * 2` (local + remote) so a
+/// session never tries to materialise a multi-GB replica in one
+/// shot. 32 keeps the wire-call count modest (RF=3/3-node: 1 group
+/// × 32 chunks × 2 peers = 64 sessions per node vs. 1 536 without
+/// the merge) while bounding peak memory at ~table_size/32.
+pub const REPAIR_CHUNKS_PER_MERGED_RANGE: usize = 32;
+
 impl Default for RepairCoordinator {
     fn default() -> Self {
         Self {
@@ -137,10 +146,31 @@ impl RepairCoordinator {
             }
             merged.push((range_start, range_end, peers));
         }
+        // Each merged range is then split into K equal-token chunks
+        // so each session's working set scales with chunk size, not
+        // table size. Without this, a 3-node RF=3 cluster collapses
+        // ALL owned ranges into one full-ring session per peer, which
+        // tries to materialise the entire local replica before
+        // diffing — observed to OOM the 2 GiB fmem container at
+        // ~1.4 GiB on a 1.3 GB table.
         let mut tasks: Vec<(i64, i64, u64)> = Vec::new();
         for (range_start, range_end, peers) in merged {
-            for peer in peers {
-                tasks.push((range_start, range_end, peer));
+            let span = (range_end as i128) - (range_start as i128);
+            let k = REPAIR_CHUNKS_PER_MERGED_RANGE as i128;
+            for i in 0..REPAIR_CHUNKS_PER_MERGED_RANGE {
+                let chunk_start = (range_start as i128 + (span * i as i128) / k) as i64;
+                let chunk_end = if i + 1 == REPAIR_CHUNKS_PER_MERGED_RANGE {
+                    range_end
+                } else {
+                    (range_start as i128 + (span * (i as i128 + 1)) / k) as i64
+                };
+                if chunk_start == chunk_end {
+                    // Token-space too narrow to split further at this k.
+                    continue;
+                }
+                for &peer in &peers {
+                    tasks.push((chunk_start, chunk_end, peer));
+                }
             }
         }
 
@@ -292,35 +322,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repair_table_merges_ranges_sharing_the_same_replica_set() {
+    async fn repair_table_merges_and_chunks_each_replica_set_range() {
         let ring = three_node_ring();
         let table = TableId::new("ks", "tbl");
         let exec = Arc::new(MockExecutor::new());
         let coord = RepairCoordinator {
             max_concurrent_sessions: 4,
         };
-        // RF=3 on a 3-node ring: every range is replicated by ALL three
-        // nodes, so every (range, peer) pair is doing identical work as
-        // every other. The coordinator must collapse them: schedule
-        // exactly ONE session per non-self peer (covering the union of
-        // all owned ranges), not one per vnode × per peer. This is what
-        // turns repair on a 256-vnode default cluster from 1 536 wire
-        // calls per node into 2.
+        // RF=3/3-node: every owned range has the same replica set, so
+        // the coordinator merges them into one super-range per
+        // replica-set group. To keep per-session memory bounded
+        // independent of table size, that super-range is then split
+        // into `REPAIR_CHUNKS_PER_MERGED_RANGE` equal-token chunks
+        // — each chunk yields one session per non-self peer. This is
+        // the structural fix for the memory blow-up where a single
+        // full-table session held ~1.4 GiB on the fmem cluster and
+        // tipped the container OOM limit.
         let results = coord.repair_table(exec.clone(), &ring, 1, 3, &table).await;
         let calls = exec.calls.lock().unwrap();
+        let expected = super::REPAIR_CHUNKS_PER_MERGED_RANGE * 2;
         assert_eq!(
             calls.len(),
-            2,
-            "RF=3/3-node merges all owned ranges into one session per non-self peer"
+            expected,
+            "RF=3/3-node: 1 merged range × {} chunks × 2 peers = {expected} sessions",
+            super::REPAIR_CHUNKS_PER_MERGED_RANGE
         );
-        assert_eq!(
-            results.len(),
-            calls.len(),
-            "every session must record exactly one mock call"
-        );
+        assert_eq!(results.len(), calls.len());
         assert!(results.iter().all(|r| r.result.is_ok()));
         let peers: std::collections::BTreeSet<u64> = calls.iter().map(|(_, _, _, p)| *p).collect();
         assert_eq!(peers, [2u64, 3].iter().copied().collect());
+
+        // Every chunk has the same peer counts and the chunks for a
+        // single peer cover [i64::MIN, i64::MAX) end-to-end with no
+        // gap and no overlap.
+        let mut chunks_for_peer_2: Vec<(i64, i64)> = calls
+            .iter()
+            .filter_map(|(_, s, e, p)| if *p == 2 { Some((*s, *e)) } else { None })
+            .collect();
+        chunks_for_peer_2.sort();
+        assert_eq!(chunks_for_peer_2.len(), super::REPAIR_CHUNKS_PER_MERGED_RANGE);
+        assert_eq!(chunks_for_peer_2.first().unwrap().0, i64::MIN);
+        assert_eq!(chunks_for_peer_2.last().unwrap().1, i64::MAX);
+        for win in chunks_for_peer_2.windows(2) {
+            assert_eq!(win[0].1, win[1].0, "chunks must be contiguous, no gap");
+        }
     }
 
     #[tokio::test]

--- a/ferrosa-cluster/src/repair/executor.rs
+++ b/ferrosa-cluster/src/repair/executor.rs
@@ -73,8 +73,21 @@ impl RepairStore for StorageEngineRepairStore {
         let engine = self.engine.clone();
         let table = table.clone();
         let result: Result<Vec<Partition>, String> = tokio::task::spawn_blocking(move || {
-            let all = StorageEngine::read_range(&engine, &table, None, None, usize::MAX)
-                .map_err(|e| format!("read_range: {e}"))?;
+            // StorageEngine::read_range bounds by KEY (not token), so even
+            // a tight token sub-range filters from a full table-prefix scan.
+            // We then filter to the leaf token range in-memory. A small
+            // limit keeps the per-session working set tiny — most leaves
+            // are sparse (avg << 1 partition per leaf at TREE_DEPTH=15 for
+            // realistic tables) so we rarely read what we'd need anyway.
+            // The right fix is a token-bounded scan API on StorageEngine;
+            // this is the workaround until that lands.
+            //
+            // 200 keeps per-session memory at ~30 MB on a ~150 KB partition
+            // and won't OOM a 2 GB container even with 4 concurrent sessions.
+            const REPAIR_LEAF_READ_LIMIT: usize = 200;
+            let all =
+                StorageEngine::read_range(&engine, &table, None, None, REPAIR_LEAF_READ_LIMIT)
+                    .map_err(|e| format!("read_range: {e}"))?;
             Ok(all
                 .into_iter()
                 .filter(|p| p.key.token.0 >= range_start && p.key.token.0 < range_end)

--- a/ferrosa-cluster/src/repair/executor.rs
+++ b/ferrosa-cluster/src/repair/executor.rs
@@ -1,0 +1,394 @@
+//! [`SessionExecutor`] implementations.
+//!
+//! The repair algorithm itself is in [`crate::repair`]; this module wires it
+//! to actual data stores. The production wiring goes through internode RPC
+//! (see follow-up PRs). This module gives a [`LocalRepairExecutor`] that runs
+//! the algorithm between two [`RepairStore`]s in the same process — used by
+//! tests to validate convergence end-to-end against real
+//! [`ferrosa_storage::engine::StorageEngine`]s without standing up the wire
+//! protocol.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use ferrosa_common::DecoratedKey;
+use ferrosa_sstable::types::Partition;
+use ferrosa_storage::engine::StorageEngine;
+use ferrosa_storage::TableId;
+
+use super::coordinator::{SessionExecutor, SessionStats};
+use super::{compute_repair_plan, RepairPlan};
+
+/// Abstraction over a node's data store, scoped to the operations repair
+/// needs: read partitions in a token range, and apply partitions received
+/// from a peer. Implemented for `Arc<StorageEngine>` (production) and for
+/// `Arc<Mutex<Vec<Partition>>>` (tests).
+#[async_trait]
+pub trait RepairStore: Send + Sync {
+    /// Return all partitions for `table` whose tokens fall in
+    /// `[range_start, range_end)`. Order is unspecified; callers index by
+    /// partition key.
+    async fn read_range(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<Vec<Partition>, String>;
+
+    /// Apply the given partitions, last-write-wins on a per-cell basis.
+    /// Used to land partitions streamed from a peer during repair.
+    async fn apply_partitions(
+        &self,
+        table: &TableId,
+        partitions: &[Partition],
+    ) -> Result<(), String>;
+}
+
+#[async_trait]
+impl RepairStore for Arc<StorageEngine> {
+    async fn read_range(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<Vec<Partition>, String> {
+        // StorageEngine::read_range is sync + does file I/O; offload so we
+        // don't block the async worker on a potentially-large scan.
+        let engine = self.clone();
+        let table = table.clone();
+        let result: Result<Vec<Partition>, String> = tokio::task::spawn_blocking(move || {
+            let all = StorageEngine::read_range(&engine, &table, None, None, usize::MAX)
+                .map_err(|e| format!("read_range: {e}"))?;
+            Ok(all
+                .into_iter()
+                .filter(|p| p.key.token.0 >= range_start && p.key.token.0 < range_end)
+                .collect())
+        })
+        .await
+        .map_err(|e| format!("read_range join: {e}"))?;
+        result
+    }
+
+    async fn apply_partitions(
+        &self,
+        table: &TableId,
+        partitions: &[Partition],
+    ) -> Result<(), String> {
+        let engine = self.clone();
+        let table = table.clone();
+        let parts = partitions.to_vec();
+        tokio::task::spawn_blocking(move || {
+            for partition in parts {
+                for row in partition.rows.iter() {
+                    let ts = row
+                        .cells
+                        .iter()
+                        .map(|(_, c)| c.timestamp)
+                        .max()
+                        .unwrap_or(row.primary_key_liveness.timestamp);
+                    engine
+                        .write(&table, &partition.key, row.clone(), ts)
+                        .map_err(|e| format!("apply write: {e}"))?;
+                }
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("apply_partitions join: {e}"))?
+    }
+}
+
+/// In-process executor: runs anti-entropy between two stores that both live
+/// locally. Used by tests + by single-node simulations. The production wire
+/// executor (RPC-backed) has the same shape but `remote` is reached via the
+/// internode protocol.
+pub struct LocalRepairExecutor<L: RepairStore + 'static, R: RepairStore + 'static> {
+    pub local: Arc<L>,
+    /// `peer_id -> remote store` map. The coordinator dispatches sessions
+    /// against `peer_id`; this map looks up the in-process store to use.
+    pub remotes: std::collections::HashMap<u64, Arc<R>>,
+}
+
+#[async_trait]
+impl<L: RepairStore + 'static, R: RepairStore + 'static> SessionExecutor
+    for LocalRepairExecutor<L, R>
+{
+    async fn run_session(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+        peer: u64,
+    ) -> Result<SessionStats, String> {
+        let remote = self
+            .remotes
+            .get(&peer)
+            .ok_or_else(|| format!("unknown peer {peer}"))?;
+
+        let local_parts = self.local.read_range(table, range_start, range_end).await?;
+        let remote_parts = remote.read_range(table, range_start, range_end).await?;
+
+        let plan: RepairPlan =
+            compute_repair_plan(&local_parts, &remote_parts, range_start, range_end);
+
+        let streamed_out = plan.a_to_b.len() as u64;
+        let streamed_in = plan.b_to_a.len() as u64;
+        let ties = plan.timestamp_ties.len() as u64;
+
+        // Push local-newer copies to the remote.
+        if !plan.a_to_b.is_empty() {
+            remote.apply_partitions(table, &plan.a_to_b).await?;
+        }
+        // Pull remote-newer copies into local.
+        if !plan.b_to_a.is_empty() {
+            self.local.apply_partitions(table, &plan.b_to_a).await?;
+        }
+
+        Ok(SessionStats {
+            partitions_streamed_in: streamed_in,
+            partitions_streamed_out: streamed_out,
+            timestamp_ties: ties,
+        })
+    }
+}
+
+// ───────────── In-memory RepairStore for tests ─────────────
+
+/// In-memory `RepairStore` for unit tests.
+///
+/// Stores partitions in a `Vec`. `apply_partitions` deduplicates by partition
+/// key — keeping the partition whose newest timestamp is highest. This is the
+/// minimum needed to make convergence assertions work; a real engine has
+/// richer semantics (per-cell LWW, deletion masks, etc.) handled by
+/// `StorageEngine::write`.
+pub struct InMemoryRepairStore {
+    inner: tokio::sync::Mutex<Vec<(DecoratedKey, Partition)>>,
+}
+
+impl InMemoryRepairStore {
+    pub fn new() -> Self {
+        Self {
+            inner: tokio::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    pub async fn insert(&self, p: Partition) {
+        self.apply_one(p).await;
+    }
+
+    async fn apply_one(&self, p: Partition) {
+        let mut store = self.inner.lock().await;
+        if let Some(slot) = store.iter_mut().find(|(k, _)| k == &p.key) {
+            if super::newest_partition_timestamp(&p) >= super::newest_partition_timestamp(&slot.1) {
+                slot.1 = p;
+            }
+        } else {
+            store.push((p.key.clone(), p));
+        }
+    }
+
+    /// Snapshot the current contents — used in test assertions.
+    pub async fn snapshot(&self) -> Vec<Partition> {
+        let store = self.inner.lock().await;
+        store.iter().map(|(_, p)| p.clone()).collect()
+    }
+}
+
+impl Default for InMemoryRepairStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl RepairStore for InMemoryRepairStore {
+    async fn read_range(
+        &self,
+        _table: &TableId,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<Vec<Partition>, String> {
+        let store = self.inner.lock().await;
+        Ok(store
+            .iter()
+            .filter(|(k, _)| k.token.0 >= range_start && k.token.0 < range_end)
+            .map(|(_, p)| p.clone())
+            .collect())
+    }
+
+    async fn apply_partitions(
+        &self,
+        _table: &TableId,
+        partitions: &[Partition],
+    ) -> Result<(), String> {
+        for p in partitions {
+            self.apply_one(p.clone()).await;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrosa_common::{CellValue, PartitionKey, Token};
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+
+    fn test_partition_at(token: i64, key_bytes: &[u8], value: &[u8], ts: i64) -> Partition {
+        let key = PartitionKey::new(key_bytes.to_vec());
+        let dk = DecoratedKey {
+            token: Token(token),
+            key,
+        };
+        let cell = CellValue::live(value.to_vec(), ts);
+        let row = Row {
+            clustering: vec![],
+            cells: vec![(0, cell)],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(ts),
+        };
+        Partition {
+            key: dk,
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![row],
+        }
+    }
+
+    fn keys_in(parts: &[Partition]) -> std::collections::BTreeSet<Vec<u8>> {
+        parts
+            .iter()
+            .map(|p| p.key.key.as_bytes().to_vec())
+            .collect()
+    }
+
+    fn value_for_key<'a>(parts: &'a [Partition], key: &[u8]) -> Option<&'a [u8]> {
+        parts
+            .iter()
+            .find(|p| p.key.key.as_bytes() == key)
+            .and_then(|p| p.rows.first())
+            .and_then(|r| r.cells.first())
+            .and_then(|(_, c)| c.value.as_deref())
+    }
+
+    #[tokio::test]
+    async fn local_executor_converges_two_stores_after_one_session() {
+        // Stage divergent state across two in-memory stores. Tokens are
+        // picked far apart so they land in different Merkle leaves at
+        // TREE_DEPTH=15 across the full i64 range.
+        let a = Arc::new(InMemoryRepairStore::new());
+        let b = Arc::new(InMemoryRepairStore::new());
+
+        // k1: only on A
+        a.insert(test_partition_at(100_000_000, b"k1", b"a1", 100))
+            .await;
+        // k2: same on both
+        a.insert(test_partition_at(200_000_000, b"k2", b"same", 200))
+            .await;
+        b.insert(test_partition_at(200_000_000, b"k2", b"same", 200))
+            .await;
+        // k3: divergent — A is newer
+        a.insert(test_partition_at(300_000_000, b"k3", b"new", 500))
+            .await;
+        b.insert(test_partition_at(300_000_000, b"k3", b"old", 100))
+            .await;
+        // k4: only on B
+        b.insert(test_partition_at(400_000_000, b"k4", b"b4", 100))
+            .await;
+
+        let executor = LocalRepairExecutor::<InMemoryRepairStore, InMemoryRepairStore> {
+            local: a.clone(),
+            remotes: [(7u64, b.clone())].into_iter().collect(),
+        };
+
+        let table = TableId::new("ks", "tbl");
+        let stats = executor
+            .run_session(&table, i64::MIN, i64::MAX, 7)
+            .await
+            .unwrap();
+        assert_eq!(
+            stats.partitions_streamed_out, 2,
+            "A→B should be k1 + k3 (newer)"
+        );
+        assert_eq!(stats.partitions_streamed_in, 1, "B→A should be k4");
+        assert_eq!(stats.timestamp_ties, 0);
+
+        // Both sides must converge to the same set of keys.
+        let a_snap = a.snapshot().await;
+        let b_snap = b.snapshot().await;
+        let want_keys: std::collections::BTreeSet<Vec<u8>> = [
+            b"k1".to_vec(),
+            b"k2".to_vec(),
+            b"k3".to_vec(),
+            b"k4".to_vec(),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(keys_in(&a_snap), want_keys);
+        assert_eq!(keys_in(&b_snap), want_keys);
+
+        // For k3, both sides must hold the A-newer ("new") value.
+        assert_eq!(value_for_key(&a_snap, b"k3"), Some(&b"new"[..]));
+        assert_eq!(value_for_key(&b_snap, b"k3"), Some(&b"new"[..]));
+    }
+
+    #[tokio::test]
+    async fn local_executor_is_idempotent_after_convergence() {
+        let a = Arc::new(InMemoryRepairStore::new());
+        let b = Arc::new(InMemoryRepairStore::new());
+        for i in 0..5u8 {
+            let p = test_partition_at(100_000_000 * (i as i64 + 1), &[b'k', i], b"same", 1_000);
+            a.insert(p.clone()).await;
+            b.insert(p).await;
+        }
+
+        let executor = LocalRepairExecutor::<InMemoryRepairStore, InMemoryRepairStore> {
+            local: a.clone(),
+            remotes: [(7u64, b.clone())].into_iter().collect(),
+        };
+
+        let table = TableId::new("ks", "tbl");
+        let stats1 = executor
+            .run_session(&table, i64::MIN, i64::MAX, 7)
+            .await
+            .unwrap();
+        let stats2 = executor
+            .run_session(&table, i64::MIN, i64::MAX, 7)
+            .await
+            .unwrap();
+        for s in [&stats1, &stats2] {
+            assert_eq!(s.partitions_streamed_in, 0);
+            assert_eq!(s.partitions_streamed_out, 0);
+            assert_eq!(s.timestamp_ties, 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn local_executor_records_timestamp_ties_without_streaming() {
+        let a = Arc::new(InMemoryRepairStore::new());
+        let b = Arc::new(InMemoryRepairStore::new());
+        a.insert(test_partition_at(100_000_000, b"k", b"a-value", 500))
+            .await;
+        b.insert(test_partition_at(100_000_000, b"k", b"b-value", 500))
+            .await;
+
+        let executor = LocalRepairExecutor::<InMemoryRepairStore, InMemoryRepairStore> {
+            local: a.clone(),
+            remotes: [(7u64, b.clone())].into_iter().collect(),
+        };
+
+        let stats = executor
+            .run_session(&TableId::new("ks", "tbl"), i64::MIN, i64::MAX, 7)
+            .await
+            .unwrap();
+        assert_eq!(stats.timestamp_ties, 1);
+        assert_eq!(stats.partitions_streamed_out, 0);
+        assert_eq!(stats.partitions_streamed_in, 0);
+
+        // Both sides keep their original (now-known-divergent) values.
+        let a_val = value_for_key(&a.snapshot().await, b"k").unwrap().to_vec();
+        let b_val = value_for_key(&b.snapshot().await, b"k").unwrap().to_vec();
+        assert_eq!(a_val, b"a-value");
+        assert_eq!(b_val, b"b-value");
+    }
+}

--- a/ferrosa-cluster/src/repair/executor.rs
+++ b/ferrosa-cluster/src/repair/executor.rs
@@ -44,8 +44,24 @@ pub trait RepairStore: Send + Sync {
     ) -> Result<(), String>;
 }
 
+/// `RepairStore` over a local [`StorageEngine`]. Used by the production
+/// `LocalRepairExecutor` as the `local` side and (theoretically) by
+/// a single-node repair simulation. Wraps the engine in a newtype so
+/// `Arc<StorageEngineRepairStore>` cleanly unsizes to `Arc<dyn RepairStore>`
+/// (the trait impl would otherwise need to be on `Arc<StorageEngine>`,
+/// which then can't be wrapped in another `Arc<dyn ...>`).
+pub struct StorageEngineRepairStore {
+    engine: Arc<StorageEngine>,
+}
+
+impl StorageEngineRepairStore {
+    pub fn new(engine: Arc<StorageEngine>) -> Self {
+        Self { engine }
+    }
+}
+
 #[async_trait]
-impl RepairStore for Arc<StorageEngine> {
+impl RepairStore for StorageEngineRepairStore {
     async fn read_range(
         &self,
         table: &TableId,
@@ -54,7 +70,7 @@ impl RepairStore for Arc<StorageEngine> {
     ) -> Result<Vec<Partition>, String> {
         // StorageEngine::read_range is sync + does file I/O; offload so we
         // don't block the async worker on a potentially-large scan.
-        let engine = self.clone();
+        let engine = self.engine.clone();
         let table = table.clone();
         let result: Result<Vec<Partition>, String> = tokio::task::spawn_blocking(move || {
             let all = StorageEngine::read_range(&engine, &table, None, None, usize::MAX)
@@ -74,7 +90,7 @@ impl RepairStore for Arc<StorageEngine> {
         table: &TableId,
         partitions: &[Partition],
     ) -> Result<(), String> {
-        let engine = self.clone();
+        let engine = self.engine.clone();
         let table = table.clone();
         let parts = partitions.to_vec();
         tokio::task::spawn_blocking(move || {
@@ -98,21 +114,24 @@ impl RepairStore for Arc<StorageEngine> {
     }
 }
 
-/// In-process executor: runs anti-entropy between two stores that both live
-/// locally. Used by tests + by single-node simulations. The production wire
-/// executor (RPC-backed) has the same shape but `remote` is reached via the
-/// internode protocol.
-pub struct LocalRepairExecutor<L: RepairStore + 'static, R: RepairStore + 'static> {
-    pub local: Arc<L>,
-    /// `peer_id -> remote store` map. The coordinator dispatches sessions
-    /// against `peer_id`; this map looks up the in-process store to use.
-    pub remotes: std::collections::HashMap<u64, Arc<R>>,
+/// Executor that drives anti-entropy between a local `RepairStore` and one
+/// or more remote `RepairStore`s. The "remote" side is type-erased via a
+/// trait object so production can plug in [`super::rpc::RemoteRepairStore`]
+/// (RPC) and tests can plug in [`InMemoryRepairStore`] without recompiling.
+///
+/// `local` and `remotes` use the same trait — the local side is just
+/// "remote 0". In practice the local store is an `Arc<StorageEngine>`
+/// (the same engine the coordinator runs on) and each remote is an
+/// `Arc<RemoteRepairStore>` pointed at one peer.
+pub struct LocalRepairExecutor {
+    pub local: Arc<dyn RepairStore>,
+    /// `peer_id -> remote store`. The coordinator dispatches sessions
+    /// against `peer_id`; this map looks up the store to use.
+    pub remotes: std::collections::HashMap<u64, Arc<dyn RepairStore>>,
 }
 
 #[async_trait]
-impl<L: RepairStore + 'static, R: RepairStore + 'static> SessionExecutor
-    for LocalRepairExecutor<L, R>
-{
+impl SessionExecutor for LocalRepairExecutor {
     async fn run_session(
         &self,
         table: &TableId,
@@ -296,9 +315,11 @@ mod tests {
         b.insert(test_partition_at(400_000_000, b"k4", b"b4", 100))
             .await;
 
-        let executor = LocalRepairExecutor::<InMemoryRepairStore, InMemoryRepairStore> {
-            local: a.clone(),
-            remotes: [(7u64, b.clone())].into_iter().collect(),
+        let executor = LocalRepairExecutor {
+            local: a.clone() as Arc<dyn RepairStore>,
+            remotes: [(7u64, b.clone() as Arc<dyn RepairStore>)]
+                .into_iter()
+                .collect(),
         };
 
         let table = TableId::new("ks", "tbl");
@@ -342,9 +363,11 @@ mod tests {
             b.insert(p).await;
         }
 
-        let executor = LocalRepairExecutor::<InMemoryRepairStore, InMemoryRepairStore> {
-            local: a.clone(),
-            remotes: [(7u64, b.clone())].into_iter().collect(),
+        let executor = LocalRepairExecutor {
+            local: a.clone() as Arc<dyn RepairStore>,
+            remotes: [(7u64, b.clone() as Arc<dyn RepairStore>)]
+                .into_iter()
+                .collect(),
         };
 
         let table = TableId::new("ks", "tbl");
@@ -423,14 +446,15 @@ mod tests {
         }
 
         // Run repair FROM node1's perspective: local=store1, remotes=store2+store3.
-        let executor = Arc::new(
-            LocalRepairExecutor::<InMemoryRepairStore, InMemoryRepairStore> {
-                local: store1.clone(),
-                remotes: [(2u64, store2.clone()), (3u64, store3.clone())]
-                    .into_iter()
-                    .collect(),
-            },
-        );
+        let executor = Arc::new(LocalRepairExecutor {
+            local: store1.clone() as Arc<dyn RepairStore>,
+            remotes: [
+                (2u64, store2.clone() as Arc<dyn RepairStore>),
+                (3u64, store3.clone() as Arc<dyn RepairStore>),
+            ]
+            .into_iter()
+            .collect(),
+        });
         let coord = RepairCoordinator::default();
         let results = coord
             .repair_table(executor, &ring, 1, 3, &TableId::new("ks", "tbl"))
@@ -467,9 +491,11 @@ mod tests {
         b.insert(test_partition_at(100_000_000, b"k", b"b-value", 500))
             .await;
 
-        let executor = LocalRepairExecutor::<InMemoryRepairStore, InMemoryRepairStore> {
-            local: a.clone(),
-            remotes: [(7u64, b.clone())].into_iter().collect(),
+        let executor = LocalRepairExecutor {
+            local: a.clone() as Arc<dyn RepairStore>,
+            remotes: [(7u64, b.clone() as Arc<dyn RepairStore>)]
+                .into_iter()
+                .collect(),
         };
 
         let stats = executor

--- a/ferrosa-cluster/src/repair/executor.rs
+++ b/ferrosa-cluster/src/repair/executor.rs
@@ -363,6 +363,101 @@ mod tests {
         }
     }
 
+    // ---- Three-store integration test exercising coordinator → executor ----
+
+    /// Stand up three [`InMemoryRepairStore`]s as a simulated 3-node, RF=3
+    /// cluster, stage the fmem-style divergence pattern (one node has all
+    /// the data, the others have partial or none), and run the full
+    /// [`crate::repair::RepairCoordinator`] against the executor. After
+    /// the run, every store must hold the same set of partitions and the
+    /// values must reflect the highest-timestamp source.
+    #[tokio::test]
+    async fn coordinator_plus_local_executor_converges_three_node_cluster() {
+        use crate::raft::{NodeInfo, NodeState};
+        use crate::repair::RepairCoordinator;
+        use crate::ring::TokenRing;
+        use uuid::Uuid;
+
+        fn node_with(addr: &str) -> NodeInfo {
+            NodeInfo {
+                host_id: Uuid::new_v4(),
+                addr: addr.to_string(),
+                data_center: "dc1".to_string(),
+                rack: "rack1".to_string(),
+                state: NodeState::Normal,
+                cql_broadcast: None,
+            }
+        }
+
+        // 3-node ring, RF=3 — every range owned by every node.
+        let mut ring = TokenRing::new();
+        ring.add_node(1, node_with("10.0.0.1:7000"));
+        ring.add_node(2, node_with("10.0.0.2:7000"));
+        ring.add_node(3, node_with("10.0.0.3:7000"));
+        ring.assign_tokens(1, &[100_000_000]);
+        ring.assign_tokens(2, &[200_000_000]);
+        ring.assign_tokens(3, &[300_000_000]);
+
+        // node1: full dataset, node2: partial (3 of 5 keys), node3: empty.
+        // Mirrors the fmem scenario (node1=1.41GB, node2=401MB, node3=217MB
+        // is the same shape — just shrunk to 5 keys for the test).
+        let store1 = Arc::new(InMemoryRepairStore::new());
+        let store2 = Arc::new(InMemoryRepairStore::new());
+        let store3 = Arc::new(InMemoryRepairStore::new());
+
+        let tokens = [
+            (50_000_000, b"k1"),
+            (150_000_000, b"k2"),
+            (250_000_000, b"k3"),
+            (350_000_000, b"k4"),
+            (450_000_000, b"k5"),
+        ];
+        for (token, key) in tokens.iter() {
+            let p = test_partition_at(*token, key.as_ref(), b"v", 1_000);
+            store1.insert(p.clone()).await;
+            // node2 has only k1, k2, k3
+            if matches!(*key, b"k1" | b"k2" | b"k3") {
+                store2.insert(p.clone()).await;
+            }
+            // node3 has nothing
+        }
+
+        // Run repair FROM node1's perspective: local=store1, remotes=store2+store3.
+        let executor = Arc::new(
+            LocalRepairExecutor::<InMemoryRepairStore, InMemoryRepairStore> {
+                local: store1.clone(),
+                remotes: [(2u64, store2.clone()), (3u64, store3.clone())]
+                    .into_iter()
+                    .collect(),
+            },
+        );
+        let coord = RepairCoordinator::default();
+        let results = coord
+            .repair_table(executor, &ring, 1, 3, &TableId::new("ks", "tbl"))
+            .await;
+        assert!(!results.is_empty(), "coordinator must dispatch sessions");
+        assert!(
+            results.iter().all(|r| r.result.is_ok()),
+            "every session must succeed; got errors: {:?}",
+            results
+                .iter()
+                .filter_map(|r| r.result.as_ref().err())
+                .collect::<Vec<_>>()
+        );
+
+        // After repair, all three stores hold the SAME set of partition keys.
+        let want: std::collections::BTreeSet<Vec<u8>> =
+            tokens.iter().map(|(_, k)| k.to_vec()).collect();
+        for (name, store) in [("node1", &store1), ("node2", &store2), ("node3", &store3)] {
+            let snap = store.snapshot().await;
+            let got: std::collections::BTreeSet<Vec<u8>> = keys_in(&snap);
+            assert_eq!(
+                got, want,
+                "{name} did not converge: got {got:?} want {want:?}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn local_executor_records_timestamp_ties_without_streaming() {
         let a = Arc::new(InMemoryRepairStore::new());

--- a/ferrosa-cluster/src/repair/executor.rs
+++ b/ferrosa-cluster/src/repair/executor.rs
@@ -73,25 +73,20 @@ impl RepairStore for StorageEngineRepairStore {
         let engine = self.engine.clone();
         let table = table.clone();
         let result: Result<Vec<Partition>, String> = tokio::task::spawn_blocking(move || {
-            // StorageEngine::read_range bounds by KEY (not token), so even
-            // a tight token sub-range filters from a full table-prefix scan.
-            // We then filter to the leaf token range in-memory. A small
-            // limit keeps the per-session working set tiny — most leaves
-            // are sparse (avg << 1 partition per leaf at TREE_DEPTH=15 for
-            // realistic tables) so we rarely read what we'd need anyway.
-            // The right fix is a token-bounded scan API on StorageEngine;
-            // this is the workaround until that lands.
-            //
-            // 200 keeps per-session memory at ~30 MB on a ~150 KB partition
-            // and won't OOM a 2 GB container even with 4 concurrent sessions.
-            const REPAIR_LEAF_READ_LIMIT: usize = 200;
-            let all =
-                StorageEngine::read_range(&engine, &table, None, None, REPAIR_LEAF_READ_LIMIT)
-                    .map_err(|e| format!("read_range: {e}"))?;
-            Ok(all
-                .into_iter()
-                .filter(|p| p.key.token.0 >= range_start && p.key.token.0 < range_end)
-                .collect())
+            // Use the token-bounded primitive so we don't read a key-
+            // ordered prefix of the whole table per session. Limit
+            // matches the storage materialisation cap; the typical
+            // Merkle leaf on a ~10 k-partition table is sparse so this
+            // budget is comfortably above what any single leaf needs.
+            const REPAIR_LEAF_READ_LIMIT: usize = 10_000;
+            StorageEngine::read_token_range(
+                &engine,
+                &table,
+                range_start,
+                range_end,
+                REPAIR_LEAF_READ_LIMIT,
+            )
+            .map_err(|e| format!("read_token_range: {e}"))
         })
         .await
         .map_err(|e| format!("read_range join: {e}"))?;

--- a/ferrosa-cluster/src/repair/merkle.rs
+++ b/ferrosa-cluster/src/repair/merkle.rs
@@ -93,8 +93,8 @@ impl MerkleTree {
 
     /// Token sub-range owned by leaf `leaf_idx`, as `[start, end)`.
     ///
-    /// Inverse of [`token_to_leaf`]. Leaf 0 owns the lowest tokens; the last
-    /// leaf's `end` equals [`range_end`]. Equal-width leaves except for
+    /// Inverse of `token_to_leaf`. Leaf 0 owns the lowest tokens; the last
+    /// leaf's `end` equals `range_end`. Equal-width leaves except for
     /// rounding on the final leaf when the range width isn't divisible by
     /// `num_leaves`.
     pub fn leaf_range(&self, leaf_idx: usize) -> (i64, i64) {

--- a/ferrosa-cluster/src/repair/merkle.rs
+++ b/ferrosa-cluster/src/repair/merkle.rs
@@ -90,6 +90,64 @@ impl MerkleTree {
     pub fn num_leaves(&self) -> usize {
         1usize << self.depth
     }
+
+    /// Token sub-range owned by leaf `leaf_idx`, as `[start, end)`.
+    ///
+    /// Inverse of [`token_to_leaf`]. Leaf 0 owns the lowest tokens; the last
+    /// leaf's `end` equals [`range_end`]. Equal-width leaves except for
+    /// rounding on the final leaf when the range width isn't divisible by
+    /// `num_leaves`.
+    pub fn leaf_range(&self, leaf_idx: usize) -> (i64, i64) {
+        let num_leaves = self.num_leaves() as u128;
+        // Shift to unsigned u128 space to avoid signed overflow at i64::MIN/MAX.
+        let start = (self.range_start as i128 + i64::MAX as i128 + 1) as u128;
+        let end = (self.range_end as i128 + i64::MAX as i128 + 1) as u128;
+        let range_width = end.wrapping_sub(start);
+        if range_width == 0 {
+            return (self.range_start, self.range_start);
+        }
+        let leaf_start_offset = (leaf_idx as u128).saturating_mul(range_width) / num_leaves;
+        // For the last leaf, clamp to `range_end` to avoid a rounding gap.
+        let leaf_end_offset = if leaf_idx + 1 == self.num_leaves() {
+            range_width
+        } else {
+            ((leaf_idx + 1) as u128).saturating_mul(range_width) / num_leaves
+        };
+        let leaf_start =
+            (start.wrapping_add(leaf_start_offset) as i128 - i64::MAX as i128 - 1) as i64;
+        let leaf_end = (start.wrapping_add(leaf_end_offset) as i128 - i64::MAX as i128 - 1) as i64;
+        (leaf_start, leaf_end)
+    }
+
+    /// Token sub-ranges where this tree's leaf hash differs from `other`.
+    ///
+    /// Both trees must have the same `depth`, `range_start`, and `range_end`;
+    /// otherwise the entire range is returned as "divergent" because we can't
+    /// align leaves.
+    ///
+    /// Note on XOR collisions: because leaves accumulate hashes via XOR, two
+    /// trees that hold strictly different content but whose XORs happen to
+    /// cancel will report no divergence. This matches Cassandra's classic
+    /// Merkle behaviour for `nodetool repair`; the false-negative probability
+    /// is ~ 2^-64 per leaf with a 64-bit partition hash. Use a deeper tree
+    /// (more leaves) to reduce false-negatives at the cost of more memory.
+    pub fn divergent_leaf_ranges(&self, other: &Self) -> Vec<(i64, i64)> {
+        if self.depth != other.depth
+            || self.range_start != other.range_start
+            || self.range_end != other.range_end
+        {
+            return vec![(self.range_start, self.range_end)];
+        }
+        let num_leaves = self.num_leaves();
+        let first_leaf = num_leaves - 1;
+        let mut diffs = Vec::new();
+        for i in 0..num_leaves {
+            if self.nodes[first_leaf + i] != other.nodes[first_leaf + i] {
+                diffs.push(self.leaf_range(i));
+            }
+        }
+        diffs
+    }
 }
 
 #[cfg(test)]
@@ -187,5 +245,89 @@ mod tests {
         assert_eq!(tree.token_to_leaf(99), 0);
         assert_eq!(tree.token_to_leaf(100), 1);
         assert_eq!(tree.token_to_leaf(1599), 15);
+    }
+
+    #[test]
+    fn leaf_range_is_inverse_of_token_to_leaf() {
+        // For every leaf in a 16-leaf tree, the leaf_range start MUST map
+        // back to that leaf and the leaf_range end-1 MUST also map back.
+        let tree = MerkleTree::new(4, 0, 1600);
+        for leaf in 0..tree.num_leaves() {
+            let (start, end) = tree.leaf_range(leaf);
+            assert_eq!(tree.token_to_leaf(start), leaf, "start of leaf {leaf}");
+            assert_eq!(tree.token_to_leaf(end - 1), leaf, "end-1 of leaf {leaf}");
+        }
+    }
+
+    #[test]
+    fn leaf_range_covers_full_token_range_without_gaps() {
+        let tree = MerkleTree::new(8, i64::MIN, i64::MAX);
+        let (first_start, _) = tree.leaf_range(0);
+        let (_, last_end) = tree.leaf_range(tree.num_leaves() - 1);
+        assert_eq!(first_start, i64::MIN);
+        assert_eq!(last_end, i64::MAX);
+        for i in 0..tree.num_leaves() - 1 {
+            let (_, end_i) = tree.leaf_range(i);
+            let (start_next, _) = tree.leaf_range(i + 1);
+            assert_eq!(
+                end_i,
+                start_next,
+                "leaf {i} end must equal leaf {} start",
+                i + 1
+            );
+        }
+    }
+
+    #[test]
+    fn divergent_leaf_ranges_empty_for_identical_trees() {
+        let mut a = MerkleTree::new(6, 0, 64_000);
+        let mut b = MerkleTree::new(6, 0, 64_000);
+        for i in 0..10 {
+            a.insert(i * 100, 0xCAFE * (i as u64));
+            b.insert(i * 100, 0xCAFE * (i as u64));
+        }
+        a.compute_root();
+        b.compute_root();
+        assert!(a.divergent_leaf_ranges(&b).is_empty());
+    }
+
+    #[test]
+    fn divergent_leaf_ranges_pinpoints_single_diff() {
+        let mut a = MerkleTree::new(6, 0, 64_000); // 64 leaves, 1000 tokens each
+        let mut b = MerkleTree::new(6, 0, 64_000);
+        // Identical content everywhere except token 12345 (leaf 12).
+        for i in 0..10 {
+            a.insert(i * 1000, 0xAA * (i as u64 + 1));
+            b.insert(i * 1000, 0xAA * (i as u64 + 1));
+        }
+        a.insert(12_345, 0xDEAD);
+        b.insert(12_345, 0xBEEF);
+        a.compute_root();
+        b.compute_root();
+        let diffs = a.divergent_leaf_ranges(&b);
+        assert_eq!(
+            diffs.len(),
+            1,
+            "exactly one leaf should differ; got {diffs:?}"
+        );
+        let (start, end) = diffs[0];
+        assert!(
+            start <= 12_345 && 12_345 < end,
+            "divergent range ({start}, {end}) must contain token 12345"
+        );
+    }
+
+    #[test]
+    fn divergent_leaf_ranges_handles_mismatched_geometry() {
+        let mut a = MerkleTree::new(4, 0, 1000);
+        let mut b = MerkleTree::new(5, 0, 1000);
+        a.compute_root();
+        b.compute_root();
+        let diffs = a.divergent_leaf_ranges(&b);
+        assert_eq!(
+            diffs,
+            vec![(0i64, 1000i64)],
+            "mismatched-depth trees must report whole range as divergent"
+        );
     }
 }

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -90,6 +90,170 @@ pub fn build_tree_for_range(
     Ok(tree)
 }
 
+/// The reconcile-direction decision for a single partition during anti-entropy
+/// repair. Returned alongside the partition in [`RepairPlan`] so the caller
+/// knows which side is the canonical "newer" copy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepairDirection {
+    /// Only side A has this partition; B is missing it.
+    AOnly,
+    /// Only side B has this partition; A is missing it.
+    BOnly,
+    /// Both sides have it; A's max timestamp is strictly newer than B's.
+    ANewer,
+    /// Both sides have it; B's max timestamp is strictly newer than A's.
+    BNewer,
+    /// Both sides have it with the same max timestamp but the content
+    /// digest differs. Cassandra-style tie-break is value comparison; we
+    /// log + skip so the operator can inspect (matches the
+    /// "warn-and-skip on identical-ts conflict" Aphyr-safe stance).
+    SkippedTimestampTie,
+}
+
+/// Output of [`diff_partition_sets`]: the set of partitions to stream from
+/// each side to the other, plus the partitions that were SkippedTimestampTie
+/// (returned for observability, not streamed).
+#[derive(Debug, Default)]
+pub struct RepairPlan {
+    /// Partitions to stream A → B (B is missing them or has staler content).
+    pub a_to_b: Vec<Partition>,
+    /// Partitions to stream B → A (A is missing them or has staler content).
+    pub b_to_a: Vec<Partition>,
+    /// Partition keys where both sides have identical max timestamps but
+    /// different content digests. Operator must reconcile manually.
+    pub timestamp_ties: Vec<ferrosa_common::DecoratedKey>,
+}
+
+/// Max timestamp across every cell + liveness in a partition, including the
+/// static row. Returns `i64::MIN` for a fully-empty partition.
+fn newest_partition_timestamp(p: &Partition) -> i64 {
+    let mut ts = i64::MIN;
+    let bump = |row: &ferrosa_sstable::types::Row, ts: &mut i64| {
+        if row.primary_key_liveness.timestamp > *ts {
+            *ts = row.primary_key_liveness.timestamp;
+        }
+        for (_, cell) in &row.cells {
+            if cell.timestamp > *ts {
+                *ts = cell.timestamp;
+            }
+        }
+    };
+    if let Some(ref sr) = p.static_row {
+        bump(sr, &mut ts);
+    }
+    for row in &p.rows {
+        bump(row, &mut ts);
+    }
+    if p.deletion.marked_for_delete_at > ts {
+        ts = p.deletion.marked_for_delete_at;
+    }
+    ts
+}
+
+/// Diff two partition sets known to cover the same token sub-range (typically
+/// the leaves identified as divergent by [`MerkleTree::divergent_leaf_ranges`]).
+///
+/// For each partition key:
+/// - present on only one side → stream that side's copy to the other.
+/// - present on both with different max timestamps → newer wins, stream to
+///   the older side.
+/// - present on both with equal max timestamps but different content digests
+///   → record in `timestamp_ties`, do not stream. Last-write-wins with equal
+///   timestamps is undefined under Cassandra's data model; better to surface
+///   the conflict than silently pick a side.
+/// - present on both with equal max timestamps AND equal content → no-op.
+pub fn diff_partition_sets(a: &[Partition], b: &[Partition]) -> RepairPlan {
+    use std::collections::HashMap;
+    // Key the lookups by raw partition-key bytes — DecoratedKey isn't Hash.
+    let a_by_key: HashMap<&[u8], &Partition> =
+        a.iter().map(|p| (p.key.key.as_bytes(), p)).collect();
+    let b_by_key: HashMap<&[u8], &Partition> =
+        b.iter().map(|p| (p.key.key.as_bytes(), p)).collect();
+    let mut plan = RepairPlan::default();
+
+    for (key, p_a) in &a_by_key {
+        match b_by_key.get(key) {
+            None => plan.a_to_b.push((*p_a).clone()),
+            Some(p_b) => {
+                let ts_a = newest_partition_timestamp(p_a);
+                let ts_b = newest_partition_timestamp(p_b);
+                if ts_a > ts_b {
+                    plan.a_to_b.push((*p_a).clone());
+                } else if ts_b > ts_a {
+                    plan.b_to_a.push((*p_b).clone());
+                } else if partition_merkle_hash(p_a) != partition_merkle_hash(p_b) {
+                    plan.timestamp_ties.push(p_a.key.clone());
+                }
+                // equal ts + equal hash: no-op.
+            }
+        }
+    }
+    for (key, p_b) in &b_by_key {
+        if a_by_key.contains_key(key) {
+            continue;
+        }
+        plan.b_to_a.push((*p_b).clone());
+    }
+    plan
+}
+
+/// Compute a [`RepairPlan`] between two partition sets covering the same
+/// `[range_start, range_end)` token range, using a Merkle tree to skip
+/// identical sub-ranges before partition-level comparison.
+///
+/// Mirrors Cassandra's `nodetool repair` shape:
+/// 1. Build a Merkle tree on each side.
+/// 2. Find the leaves where the trees diverge.
+/// 3. For each divergent leaf, filter partitions to that sub-range and
+///    diff with [`diff_partition_sets`].
+/// 4. Union the per-leaf diffs.
+///
+/// Pure function — does no I/O. Storage-side callers should first
+/// [`StorageEngine::read_range`](ferrosa_storage::engine::StorageEngine::read_range)
+/// to materialise the partition slices, then call this.
+pub fn compute_repair_plan(
+    parts_a: &[Partition],
+    parts_b: &[Partition],
+    range_start: i64,
+    range_end: i64,
+) -> RepairPlan {
+    let mut tree_a = MerkleTree::new(TREE_DEPTH, range_start, range_end);
+    let mut tree_b = MerkleTree::new(TREE_DEPTH, range_start, range_end);
+    let in_range = |t: i64| t >= range_start && t < range_end;
+    for p in parts_a.iter().filter(|p| in_range(p.key.token.0)) {
+        tree_a.insert(p.key.token.0, partition_merkle_hash(p));
+    }
+    for p in parts_b.iter().filter(|p| in_range(p.key.token.0)) {
+        tree_b.insert(p.key.token.0, partition_merkle_hash(p));
+    }
+    tree_a.compute_root();
+    tree_b.compute_root();
+
+    let divergent = tree_a.divergent_leaf_ranges(&tree_b);
+    if divergent.is_empty() {
+        return RepairPlan::default();
+    }
+
+    let mut plan = RepairPlan::default();
+    for (sub_start, sub_end) in divergent {
+        let a_in_leaf: Vec<Partition> = parts_a
+            .iter()
+            .filter(|p| p.key.token.0 >= sub_start && p.key.token.0 < sub_end)
+            .cloned()
+            .collect();
+        let b_in_leaf: Vec<Partition> = parts_b
+            .iter()
+            .filter(|p| p.key.token.0 >= sub_start && p.key.token.0 < sub_end)
+            .cloned()
+            .collect();
+        let sub_plan = diff_partition_sets(&a_in_leaf, &b_in_leaf);
+        plan.a_to_b.extend(sub_plan.a_to_b);
+        plan.b_to_a.extend(sub_plan.b_to_a);
+        plan.timestamp_ties.extend(sub_plan.timestamp_ties);
+    }
+    plan
+}
+
 /// Hash of a partition's full content (key + deletion + static row + clustered
 /// rows + every cell with timestamps), suitable for Merkle-tree leaf XOR
 /// accumulation in anti-entropy repair.
@@ -220,6 +384,31 @@ mod tests {
         }
     }
 
+    /// Build a test partition with an explicit token, bypassing Murmur3.
+    /// Useful when a test needs deterministic token placement.
+    fn test_partition_at(token: i64, key_bytes: &[u8], value: &[u8], ts: i64) -> Partition {
+        use ferrosa_common::{CellValue, DecoratedKey, PartitionKey, Token};
+        use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+        let key = PartitionKey::new(key_bytes.to_vec());
+        let dk = DecoratedKey {
+            token: Token(token),
+            key,
+        };
+        let cell = CellValue::live(value.to_vec(), ts);
+        let row = Row {
+            clustering: vec![],
+            cells: vec![(0, cell)],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(ts),
+        };
+        Partition {
+            key: dk,
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![row],
+        }
+    }
+
     #[test]
     fn identical_trees_produce_no_diffs() {
         let mut t1 = MerkleTree::new(4, i64::MIN, i64::MAX);
@@ -262,6 +451,209 @@ mod tests {
             partition_merkle_hash(&local),
             partition_merkle_hash(&dup),
             "identical content must hash identically (deterministic across nodes)"
+        );
+    }
+
+    // ---- RepairSession::diff_partition_sets contracts ----
+
+    #[test]
+    fn diff_partition_sets_empty_inputs_produce_empty_plan() {
+        let plan = diff_partition_sets(&[], &[]);
+        assert!(plan.a_to_b.is_empty());
+        assert!(plan.b_to_a.is_empty());
+        assert!(plan.timestamp_ties.is_empty());
+    }
+
+    #[test]
+    fn diff_partition_sets_identical_inputs_produce_empty_plan() {
+        let a = vec![
+            test_partition(b"k1", b"v1", 100),
+            test_partition(b"k2", b"v2", 200),
+        ];
+        let b = a.clone();
+        let plan = diff_partition_sets(&a, &b);
+        assert!(plan.a_to_b.is_empty());
+        assert!(plan.b_to_a.is_empty());
+        assert!(plan.timestamp_ties.is_empty());
+    }
+
+    #[test]
+    fn diff_partition_sets_missing_on_b_streams_a_to_b() {
+        let a = vec![
+            test_partition(b"k1", b"v1", 100),
+            test_partition(b"k2", b"v2", 200),
+        ];
+        let b = vec![test_partition(b"k1", b"v1", 100)];
+        let plan = diff_partition_sets(&a, &b);
+        assert_eq!(plan.a_to_b.len(), 1, "k2 must be sent A→B");
+        assert_eq!(plan.a_to_b[0].key.key.as_bytes(), b"k2");
+        assert!(plan.b_to_a.is_empty());
+    }
+
+    #[test]
+    fn diff_partition_sets_missing_on_a_streams_b_to_a() {
+        let a = vec![test_partition(b"k1", b"v1", 100)];
+        let b = vec![
+            test_partition(b"k1", b"v1", 100),
+            test_partition(b"k2", b"v2", 200),
+        ];
+        let plan = diff_partition_sets(&a, &b);
+        assert!(plan.a_to_b.is_empty());
+        assert_eq!(plan.b_to_a.len(), 1);
+        assert_eq!(plan.b_to_a[0].key.key.as_bytes(), b"k2");
+    }
+
+    #[test]
+    fn diff_partition_sets_newer_timestamp_wins() {
+        let a = vec![test_partition(b"k1", b"old", 100)];
+        let b = vec![test_partition(b"k1", b"new", 200)];
+        let plan = diff_partition_sets(&a, &b);
+        assert!(plan.a_to_b.is_empty(), "A is older, should not be sent");
+        assert_eq!(plan.b_to_a.len(), 1, "B is newer, must be sent");
+        assert_eq!(
+            plan.b_to_a[0].rows[0].cells[0].1.value,
+            Some(b"new".to_vec())
+        );
+
+        // Symmetric: same data, swap sides.
+        let plan = diff_partition_sets(&b, &a);
+        assert_eq!(plan.a_to_b.len(), 1, "now A (formerly B) is newer");
+        assert_eq!(
+            plan.a_to_b[0].rows[0].cells[0].1.value,
+            Some(b"new".to_vec())
+        );
+        assert!(plan.b_to_a.is_empty());
+    }
+
+    #[test]
+    fn diff_partition_sets_equal_timestamp_different_content_is_a_tie() {
+        let a = vec![test_partition(b"k1", b"left", 500)];
+        let b = vec![test_partition(b"k1", b"right", 500)];
+        let plan = diff_partition_sets(&a, &b);
+        assert!(plan.a_to_b.is_empty(), "ties must not be streamed");
+        assert!(plan.b_to_a.is_empty(), "ties must not be streamed");
+        assert_eq!(plan.timestamp_ties.len(), 1);
+        assert_eq!(plan.timestamp_ties[0].key.as_bytes(), b"k1");
+    }
+
+    #[test]
+    fn diff_partition_sets_mixed_scenario() {
+        // k1 only on A → A→B
+        // k2 newer on A → A→B
+        // k3 newer on B → B→A
+        // k4 only on B → B→A
+        // k5 equal everything → no-op
+        let a = vec![
+            test_partition(b"k1", b"a1", 100),
+            test_partition(b"k2", b"new", 500),
+            test_partition(b"k3", b"old", 100),
+            test_partition(b"k5", b"same", 999),
+        ];
+        let b = vec![
+            test_partition(b"k2", b"old", 100),
+            test_partition(b"k3", b"new", 500),
+            test_partition(b"k4", b"b4", 100),
+            test_partition(b"k5", b"same", 999),
+        ];
+        let plan = diff_partition_sets(&a, &b);
+        let keys_a_to_b: std::collections::BTreeSet<&[u8]> =
+            plan.a_to_b.iter().map(|p| p.key.key.as_bytes()).collect();
+        let keys_b_to_a: std::collections::BTreeSet<&[u8]> =
+            plan.b_to_a.iter().map(|p| p.key.key.as_bytes()).collect();
+        assert_eq!(keys_a_to_b, [&b"k1"[..], &b"k2"[..]].into_iter().collect());
+        assert_eq!(keys_b_to_a, [&b"k3"[..], &b"k4"[..]].into_iter().collect());
+        assert!(plan.timestamp_ties.is_empty());
+    }
+
+    // ---- compute_repair_plan: Merkle-narrowed end-to-end diff ----
+
+    #[test]
+    fn compute_repair_plan_identical_sides_produces_empty_plan() {
+        let parts = vec![
+            test_partition(b"k1", b"v1", 100),
+            test_partition(b"k2", b"v2", 200),
+            test_partition(b"k3", b"v3", 300),
+        ];
+        let plan = compute_repair_plan(&parts, &parts, i64::MIN, i64::MAX);
+        assert!(plan.a_to_b.is_empty());
+        assert!(plan.b_to_a.is_empty());
+        assert!(plan.timestamp_ties.is_empty());
+    }
+
+    #[test]
+    fn compute_repair_plan_finds_divergence_across_multiple_leaves() {
+        // Pick keys that hash to different Murmur3 tokens, ensuring they
+        // land in different Merkle leaves (we have TREE_DEPTH=15, so
+        // basically every distinct key goes to a different leaf).
+        // Scenario:
+        //   - k_only_a: only on side A → A→B
+        //   - k_diff:   on both, A newer → A→B
+        //   - k_only_b: only on side B → B→A
+        //   - k_same:   identical on both → no-op
+        let parts_a = vec![
+            test_partition(b"k_only_a", b"a", 100),
+            test_partition(b"k_diff", b"new", 500),
+            test_partition(b"k_same", b"same", 1_000),
+        ];
+        let parts_b = vec![
+            test_partition(b"k_diff", b"old", 100),
+            test_partition(b"k_only_b", b"b", 100),
+            test_partition(b"k_same", b"same", 1_000),
+        ];
+        let plan = compute_repair_plan(&parts_a, &parts_b, i64::MIN, i64::MAX);
+
+        let to_b: std::collections::BTreeSet<&[u8]> =
+            plan.a_to_b.iter().map(|p| p.key.key.as_bytes()).collect();
+        let to_a: std::collections::BTreeSet<&[u8]> =
+            plan.b_to_a.iter().map(|p| p.key.key.as_bytes()).collect();
+        assert_eq!(
+            to_b,
+            [&b"k_only_a"[..], &b"k_diff"[..]].into_iter().collect()
+        );
+        assert_eq!(to_a, [&b"k_only_b"[..]].into_iter().collect());
+        assert!(plan.timestamp_ties.is_empty());
+    }
+
+    #[test]
+    fn compute_repair_plan_skips_identical_subranges() {
+        // Same set of partitions on both sides, except one key on side A
+        // has a newer cell. Merkle narrows to that leaf; the diff returns
+        // only that one partition.
+        let common: Vec<_> = (0..50u8)
+            .map(|i| test_partition(&[b'c', i], b"shared", 1_000))
+            .collect();
+        let mut parts_a = common.clone();
+        parts_a.push(test_partition(b"x", b"a", 5_000));
+        let mut parts_b = common.clone();
+        parts_b.push(test_partition(b"x", b"b", 4_000));
+        let plan = compute_repair_plan(&parts_a, &parts_b, i64::MIN, i64::MAX);
+
+        assert_eq!(plan.a_to_b.len(), 1, "only key 'x' should diverge");
+        assert_eq!(plan.a_to_b[0].key.key.as_bytes(), b"x");
+        assert!(plan.b_to_a.is_empty());
+    }
+
+    #[test]
+    fn compute_repair_plan_filters_to_range() {
+        // Two partitions per side, both with same partition-key bytes but
+        // explicit tokens placed so the range bounds isolate one of them.
+        // Using deterministic tokens keeps the test independent of Murmur3
+        // hash distribution. Range is wide enough that TREE_DEPTH=15 yields
+        // non-degenerate leaves (>= 32 768 tokens wide).
+        let parts_a = vec![
+            test_partition_at(1_000_000, b"in", b"a-new", 500),
+            test_partition_at(9_000_000, b"out", b"a-new", 500),
+        ];
+        let parts_b = vec![
+            test_partition_at(1_000_000, b"in", b"b-old", 100),
+            test_partition_at(9_000_000, b"out", b"b-old", 100),
+        ];
+        let plan = compute_repair_plan(&parts_a, &parts_b, 0, 2_000_000);
+        let to_b: Vec<&[u8]> = plan.a_to_b.iter().map(|p| p.key.key.as_bytes()).collect();
+        assert_eq!(
+            to_b,
+            vec![&b"in"[..]],
+            "only the in-range partition should appear in the plan"
         );
     }
 

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -16,8 +16,10 @@
 //! - **RepairScheduler**: Background task that periodically triggers repair
 //!   sessions for all locally-owned token ranges.
 
+pub mod coordinator;
 pub mod merkle;
 
+pub use coordinator::{RepairCoordinator, SessionExecutor, SessionResult, SessionStats};
 pub use merkle::MerkleTree;
 
 use ferrosa_sstable::types::Partition;

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -19,10 +19,12 @@
 pub mod coordinator;
 pub mod executor;
 pub mod merkle;
+pub mod rpc;
 
 pub use coordinator::{RepairCoordinator, SessionExecutor, SessionResult, SessionStats};
 pub use executor::{InMemoryRepairStore, LocalRepairExecutor, RepairStore};
 pub use merkle::MerkleTree;
+pub use rpc::{RemoteRepairStore, RepairApplyHandler, RepairFetchHandler, RepairMerkleHandler};
 
 use ferrosa_sstable::types::Partition;
 use ferrosa_storage::engine::StorageEngine;

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -17,9 +17,11 @@
 //!   sessions for all locally-owned token ranges.
 
 pub mod coordinator;
+pub mod executor;
 pub mod merkle;
 
 pub use coordinator::{RepairCoordinator, SessionExecutor, SessionResult, SessionStats};
+pub use executor::{InMemoryRepairStore, LocalRepairExecutor, RepairStore};
 pub use merkle::MerkleTree;
 
 use ferrosa_sstable::types::Partition;

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -22,7 +22,9 @@ pub mod merkle;
 pub mod rpc;
 
 pub use coordinator::{RepairCoordinator, SessionExecutor, SessionResult, SessionStats};
-pub use executor::{InMemoryRepairStore, LocalRepairExecutor, RepairStore};
+pub use executor::{
+    InMemoryRepairStore, LocalRepairExecutor, RepairStore, StorageEngineRepairStore,
+};
 pub use merkle::MerkleTree;
 pub use rpc::{RemoteRepairStore, RepairApplyHandler, RepairFetchHandler, RepairMerkleHandler};
 

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -20,6 +20,7 @@ pub mod merkle;
 
 pub use merkle::MerkleTree;
 
+use ferrosa_sstable::types::Partition;
 use ferrosa_storage::engine::StorageEngine;
 use ferrosa_storage::TableId;
 
@@ -82,20 +83,48 @@ pub fn build_tree_for_range(
         if token < range_start || token >= range_end {
             continue;
         }
-        let hash = partition_hash(partition.key.key.as_bytes());
-        tree.insert(token, hash);
+        tree.insert(token, partition_merkle_hash(partition));
     }
 
     tree.compute_root();
     Ok(tree)
 }
 
-/// Compute a hash for a partition key's bytes.
-fn partition_hash(key_bytes: &[u8]) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    key_bytes.hash(&mut hasher);
-    hasher.finish()
+/// Hash of a partition's full content (key + deletion + static row + clustered
+/// rows + every cell with timestamps), suitable for Merkle-tree leaf XOR
+/// accumulation in anti-entropy repair.
+///
+/// **Why partition content, not just the key.** An earlier draft of this code
+/// hashed only `partition.key.key.as_bytes()`. That made Merkle comparison
+/// blind to content divergence: two replicas with the same set of keys but
+/// different cells, timestamps, or deletions produced identical Merkle roots,
+/// so the repair scheduler would conclude "nothing to do" and never reconcile
+/// them. Repair MUST detect content divergence, so the hash MUST include
+/// content.
+///
+/// Delegates to [`crate::raft::handlers::compute_partition_digest`], which is
+/// the same CRC32 over a bincode-serialized `PartitionWire` that the digest
+/// phase of `coordinate_read_with` uses, so Merkle agreement and digest-phase
+/// agreement are guaranteed consistent. The CRC32 is widened to 64 bits to
+/// match the Merkle leaf hash width — XOR collisions are theoretically
+/// possible but cap at ~2^-32 per leaf for diverging content (Cassandra's
+/// classic merkle accepts the same trade-off).
+pub fn partition_merkle_hash(partition: &Partition) -> u64 {
+    match crate::raft::handlers::compute_partition_digest(partition) {
+        Ok(crc) => {
+            // Two-step widen: high half = CRC, low half = CRC rotated.
+            // Better than zero-padding because zero-pad leaves the upper
+            // 32 bits constant, which throws away half the tree's XOR
+            // distinguishing power.
+            let lo = crc as u64;
+            let hi = (crc.rotate_left(16)) as u64;
+            (hi << 32) | lo
+        }
+        // Serialisation should not fail for any partition the storage engine
+        // returned — fall back to 0 (silently identical) rather than panic.
+        // Tracked as a metric in the repair coordinator (TODO).
+        Err(_) => 0,
+    }
 }
 
 /// Diff two Merkle trees and return the sub-ranges that differ.
@@ -167,13 +196,39 @@ fn diff_subtree(
 mod tests {
     use super::*;
 
+    /// Build a minimal Partition for tests with a given partition-key bytes
+    /// and a single cell whose value is `value` and whose timestamp is `ts`.
+    /// The partition's token is computed from the key via Murmur3 so the
+    /// token-to-leaf mapping in Merkle inserts is realistic.
+    fn test_partition(key_bytes: &[u8], value: &[u8], ts: i64) -> Partition {
+        use ferrosa_common::{CellValue, DecoratedKey, PartitionKey};
+        use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+        let key = PartitionKey::new(key_bytes.to_vec());
+        let dk = DecoratedKey::new(key);
+        let cell = CellValue::live(value.to_vec(), ts);
+        let row = Row {
+            clustering: vec![],
+            cells: vec![(0, cell)],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(ts),
+        };
+        Partition {
+            key: dk,
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![row],
+        }
+    }
+
     #[test]
     fn identical_trees_produce_no_diffs() {
         let mut t1 = MerkleTree::new(4, i64::MIN, i64::MAX);
         let mut t2 = MerkleTree::new(4, i64::MIN, i64::MAX);
 
-        for token in [100i64, 200, 300, 400] {
-            let hash = partition_hash(&token.to_be_bytes());
+        for i in 0..4u8 {
+            let p = test_partition(&[b'k', i], b"value", 1000);
+            let token = p.key.token.0;
+            let hash = partition_merkle_hash(&p);
             t1.insert(token, hash);
             t2.insert(token, hash);
         }
@@ -183,6 +238,59 @@ mod tests {
 
         let diffs = diff_trees(&t1, &t2);
         assert!(diffs.is_empty(), "identical trees should have no diffs");
+    }
+
+    /// REGRESSION: prior to this fix, `partition_hash` hashed only the
+    /// partition key bytes, so two replicas holding the same key with
+    /// different cells produced identical Merkle hashes — repair was
+    /// blind to content divergence (the exact failure mode anti-entropy
+    /// is supposed to fix).
+    #[test]
+    fn partition_merkle_hash_detects_content_divergence() {
+        let same_key = b"shared-pkey";
+        let local = test_partition(same_key, b"value-a", 1_000);
+        let remote = test_partition(same_key, b"value-b", 1_000);
+        assert_ne!(
+            partition_merkle_hash(&local),
+            partition_merkle_hash(&remote),
+            "two partitions with the same key but different cell values MUST hash differently"
+        );
+
+        // And the same hash for identical content (sanity check).
+        let dup = test_partition(same_key, b"value-a", 1_000);
+        assert_eq!(
+            partition_merkle_hash(&local),
+            partition_merkle_hash(&dup),
+            "identical content must hash identically (deterministic across nodes)"
+        );
+    }
+
+    /// REGRESSION: the same content divergence must propagate up the
+    /// Merkle tree so `diff_trees` reports the leaf containing the
+    /// diverging partition.
+    #[test]
+    fn diff_trees_detects_content_divergence_at_same_key() {
+        let same_key = b"shared-pkey";
+        let local = test_partition(same_key, b"value-a", 1_000);
+        let remote = test_partition(same_key, b"value-b", 1_000);
+        let token = local.key.token.0;
+
+        let mut t1 = MerkleTree::new(8, i64::MIN, i64::MAX);
+        let mut t2 = MerkleTree::new(8, i64::MIN, i64::MAX);
+        t1.insert(token, partition_merkle_hash(&local));
+        t2.insert(token, partition_merkle_hash(&remote));
+        t1.compute_root();
+        t2.compute_root();
+
+        let diffs = diff_trees(&t1, &t2);
+        assert!(
+            !diffs.is_empty(),
+            "diff_trees must detect partition-content divergence"
+        );
+        assert!(
+            diffs.iter().any(|&(s, e)| s <= token && token < e),
+            "diff range must contain the divergent token; got {diffs:?} token={token}"
+        );
     }
 
     #[test]

--- a/ferrosa-cluster/src/repair/rpc.rs
+++ b/ferrosa-cluster/src/repair/rpc.rs
@@ -16,7 +16,7 @@
 //! Handlers live in this module and are registered into the cluster's
 //! [`HandlerRegistry`](ferrosa_net::rpc::handler::HandlerRegistry) during
 //! startup. [`RemoteRepairStore`] is the client side — a
-//! [`RepairStore`](super::RepairStore) implementation that talks to a peer
+//! [`RepairStore`] implementation that talks to a peer
 //! over the [`PeerManager`].
 
 use async_trait::async_trait;

--- a/ferrosa-cluster/src/repair/rpc.rs
+++ b/ferrosa-cluster/src/repair/rpc.rs
@@ -158,8 +158,18 @@ impl RpcHandler for RepairFetchHandler {
             }
         };
         let table_id = TableId::new(&req.keyspace, &req.table);
-        let partitions =
-            match StorageEngine::read_range(&self.storage, &table_id, None, None, usize::MAX) {
+        // See `StorageEngineRepairStore::read_range`: small per-session
+        // budget keeps the container under its memory limit while still
+        // covering realistic-table leaves. A token-bounded scan API on
+        // StorageEngine is the proper fix; this is the interim.
+        const REPAIR_LEAF_READ_LIMIT: usize = 200;
+        let partitions = match StorageEngine::read_range(
+            &self.storage,
+            &table_id,
+            None,
+            None,
+            REPAIR_LEAF_READ_LIMIT,
+        ) {
                 Ok(ps) => ps,
                 Err(e) => {
                     tracing::warn!(%e, ?table_id, "RepairFetchHandler: read_range failed");

--- a/ferrosa-cluster/src/repair/rpc.rs
+++ b/ferrosa-cluster/src/repair/rpc.rs
@@ -287,12 +287,18 @@ impl RepairStore for RemoteRepairStore {
             range_end,
         };
         let body = bincode::serialize(&req).map_err(|e| format!("serialize: {e}"))?;
+        // Lane::Bulk: a Fetch response carries up to REPAIR_LEAF_READ_LIMIT
+        // (10 000) partitions — that's bulk transfer semantics, not a
+        // transactional read. Lane::Data's 10s timeout fires before a
+        // multi-GB-replica peer can finish its read_token_range scan,
+        // every session's caller drops, and repair never converges.
+        // Bulk gives 60s, which matches SSTable streaming's lane choice.
         let resp = self
             .peer_manager
             .send(
                 self.host_id,
                 Message::RepairFetchRequest(Bytes::from(body)),
-                Lane::Data,
+                Lane::Bulk,
             )
             .await
             .map_err(|e| format!("send: {e}"))?;
@@ -330,7 +336,7 @@ impl RepairStore for RemoteRepairStore {
             .send(
                 self.host_id,
                 Message::RepairApplyRequest(Bytes::from(body)),
-                Lane::Data,
+                Lane::Bulk,
             )
             .await
             .map_err(|e| format!("send: {e}"))?;

--- a/ferrosa-cluster/src/repair/rpc.rs
+++ b/ferrosa-cluster/src/repair/rpc.rs
@@ -1,0 +1,400 @@
+//! Wire protocol for anti-entropy repair.
+//!
+//! Three request/response pairs:
+//!
+//! | Initiator → peer        | Peer → initiator         | Purpose                              |
+//! |-------------------------|--------------------------|--------------------------------------|
+//! | `RepairMerkleRequest`   | `RepairMerkleResponse`   | Build Merkle tree for table+range    |
+//! | `RepairFetchRequest`    | `RepairFetchResponse`    | Fetch partitions in a sub-range      |
+//! | `RepairApplyRequest`    | `RepairApplyResponse`    | Apply received partitions (LWW)      |
+//!
+//! Payloads are bincode-serialized to match the existing `ReadRequest` /
+//! `ReadResponse` convention. The `MerkleTree` and `PartitionWire` types
+//! already implement `Serialize`/`Deserialize` and travel without
+//! per-field conversion.
+//!
+//! Handlers live in this module and are registered into the cluster's
+//! [`HandlerRegistry`](ferrosa_net::rpc::handler::HandlerRegistry) during
+//! startup. [`RemoteRepairStore`] is the client side — a
+//! [`RepairStore`](super::RepairStore) implementation that talks to a peer
+//! over the [`PeerManager`].
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use ferrosa_net::codec::Lane;
+use ferrosa_net::message::Message;
+use ferrosa_net::peer::PeerManager;
+use ferrosa_net::rpc::handler::{PeerId, RpcHandler};
+use ferrosa_sstable::types::Partition;
+use ferrosa_storage::engine::StorageEngine;
+use ferrosa_storage::TableId;
+
+use crate::raft::handlers::{partition_from_wire, partition_to_wire, PartitionWire};
+
+use super::merkle::MerkleTree;
+use super::RepairStore;
+
+// ── Payloads ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepairMerkleRequestPayload {
+    pub keyspace: String,
+    pub table: String,
+    pub range_start: i64,
+    pub range_end: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepairMerkleResponsePayload {
+    pub tree: MerkleTree,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepairFetchRequestPayload {
+    pub keyspace: String,
+    pub table: String,
+    pub range_start: i64,
+    pub range_end: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepairFetchResponsePayload {
+    pub partitions: Vec<PartitionWire>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepairApplyRequestPayload {
+    pub keyspace: String,
+    pub table: String,
+    pub partitions: Vec<PartitionWire>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RepairApplyResponsePayload {
+    pub applied: u64,
+    pub error: Option<String>,
+}
+
+// ── Server-side handlers ─────────────────────────────────────────────────
+
+/// Handler for inbound `RepairMerkleRequest` RPCs.
+/// Builds the Merkle tree from local storage and sends it back.
+pub struct RepairMerkleHandler {
+    storage: Arc<StorageEngine>,
+}
+
+impl RepairMerkleHandler {
+    pub fn new(storage: Arc<StorageEngine>) -> Self {
+        Self { storage }
+    }
+}
+
+#[async_trait]
+impl RpcHandler for RepairMerkleHandler {
+    async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
+        let bytes = match msg {
+            Message::RepairMerkleRequest(b) => b,
+            _ => return None,
+        };
+        let req: RepairMerkleRequestPayload = match bincode::deserialize(&bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(%e, "RepairMerkleHandler: failed to deserialize request");
+                return None;
+            }
+        };
+        let table_id = TableId::new(&req.keyspace, &req.table);
+        let tree = match super::build_tree_for_range(
+            &self.storage,
+            &table_id,
+            req.range_start,
+            req.range_end,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(%e, ?table_id, "RepairMerkleHandler: build_tree_for_range failed");
+                return None;
+            }
+        };
+        let resp = RepairMerkleResponsePayload { tree };
+        match bincode::serialize(&resp) {
+            Ok(body) => Some(Message::RepairMerkleResponse(Bytes::from(body))),
+            Err(e) => {
+                tracing::warn!(%e, "RepairMerkleHandler: failed to serialize response");
+                None
+            }
+        }
+    }
+}
+
+/// Handler for inbound `RepairFetchRequest` RPCs.
+/// Reads partitions in the requested token sub-range and sends them back.
+pub struct RepairFetchHandler {
+    storage: Arc<StorageEngine>,
+}
+
+impl RepairFetchHandler {
+    pub fn new(storage: Arc<StorageEngine>) -> Self {
+        Self { storage }
+    }
+}
+
+#[async_trait]
+impl RpcHandler for RepairFetchHandler {
+    async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
+        let bytes = match msg {
+            Message::RepairFetchRequest(b) => b,
+            _ => return None,
+        };
+        let req: RepairFetchRequestPayload = match bincode::deserialize(&bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(%e, "RepairFetchHandler: failed to deserialize request");
+                return None;
+            }
+        };
+        let table_id = TableId::new(&req.keyspace, &req.table);
+        let partitions =
+            match StorageEngine::read_range(&self.storage, &table_id, None, None, usize::MAX) {
+                Ok(ps) => ps,
+                Err(e) => {
+                    tracing::warn!(%e, ?table_id, "RepairFetchHandler: read_range failed");
+                    return None;
+                }
+            };
+        let in_range: Vec<PartitionWire> = partitions
+            .into_iter()
+            .filter(|p| p.key.token.0 >= req.range_start && p.key.token.0 < req.range_end)
+            .map(partition_to_wire)
+            .collect();
+        let resp = RepairFetchResponsePayload {
+            partitions: in_range,
+        };
+        match bincode::serialize(&resp) {
+            Ok(body) => Some(Message::RepairFetchResponse(Bytes::from(body))),
+            Err(e) => {
+                tracing::warn!(%e, "RepairFetchHandler: failed to serialize response");
+                None
+            }
+        }
+    }
+}
+
+/// Handler for inbound `RepairApplyRequest` RPCs.
+/// Applies the received partitions to local storage (LWW per-cell).
+pub struct RepairApplyHandler {
+    storage: Arc<StorageEngine>,
+}
+
+impl RepairApplyHandler {
+    pub fn new(storage: Arc<StorageEngine>) -> Self {
+        Self { storage }
+    }
+}
+
+#[async_trait]
+impl RpcHandler for RepairApplyHandler {
+    async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
+        let bytes = match msg {
+            Message::RepairApplyRequest(b) => b,
+            _ => return None,
+        };
+        let req: RepairApplyRequestPayload = match bincode::deserialize(&bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(%e, "RepairApplyHandler: failed to deserialize request");
+                return None;
+            }
+        };
+        let table_id = TableId::new(&req.keyspace, &req.table);
+        let partitions: Vec<Partition> = req
+            .partitions
+            .into_iter()
+            .map(partition_from_wire)
+            .collect();
+        let mut applied: u64 = 0;
+        let mut last_err: Option<String> = None;
+        for partition in &partitions {
+            for row in &partition.rows {
+                let ts = row
+                    .cells
+                    .iter()
+                    .map(|(_, c)| c.timestamp)
+                    .max()
+                    .unwrap_or(row.primary_key_liveness.timestamp);
+                if let Err(e) = self
+                    .storage
+                    .write(&table_id, &partition.key, row.clone(), ts)
+                {
+                    last_err = Some(format!("apply write: {e}"));
+                    // Continue applying the rest — a single failed row
+                    // shouldn't lose convergence on the others.
+                } else {
+                    applied += 1;
+                }
+            }
+        }
+        let resp = RepairApplyResponsePayload {
+            applied,
+            error: last_err,
+        };
+        match bincode::serialize(&resp) {
+            Ok(body) => Some(Message::RepairApplyResponse(Bytes::from(body))),
+            Err(e) => {
+                tracing::warn!(%e, "RepairApplyHandler: failed to serialize response");
+                None
+            }
+        }
+    }
+}
+
+// ── Client-side RepairStore impl ─────────────────────────────────────────
+
+/// [`RepairStore`] implementation that reaches a remote peer via the
+/// [`PeerManager`]. Slot-in replacement for an `Arc<StorageEngine>` on
+/// the `remotes` map of [`super::executor::LocalRepairExecutor`] — once
+/// this is wired, the same `LocalRepairExecutor` becomes a real cross-node
+/// repair executor.
+pub struct RemoteRepairStore {
+    pub host_id: Uuid,
+    pub peer_manager: Arc<PeerManager>,
+}
+
+#[async_trait]
+impl RepairStore for RemoteRepairStore {
+    async fn read_range(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<Vec<Partition>, String> {
+        let req = RepairFetchRequestPayload {
+            keyspace: table.keyspace.clone(),
+            table: table.table.clone(),
+            range_start,
+            range_end,
+        };
+        let body = bincode::serialize(&req).map_err(|e| format!("serialize: {e}"))?;
+        let resp = self
+            .peer_manager
+            .send(
+                self.host_id,
+                Message::RepairFetchRequest(Bytes::from(body)),
+                Lane::Data,
+            )
+            .await
+            .map_err(|e| format!("send: {e}"))?;
+        let body = match resp {
+            Message::RepairFetchResponse(b) => b,
+            other => {
+                return Err(format!(
+                    "expected RepairFetchResponse, got {:?}",
+                    std::mem::discriminant(&other)
+                ))
+            }
+        };
+        let resp: RepairFetchResponsePayload =
+            bincode::deserialize(&body).map_err(|e| format!("deserialize: {e}"))?;
+        Ok(resp
+            .partitions
+            .into_iter()
+            .map(partition_from_wire)
+            .collect())
+    }
+
+    async fn apply_partitions(
+        &self,
+        table: &TableId,
+        partitions: &[Partition],
+    ) -> Result<(), String> {
+        let req = RepairApplyRequestPayload {
+            keyspace: table.keyspace.clone(),
+            table: table.table.clone(),
+            partitions: partitions.iter().cloned().map(partition_to_wire).collect(),
+        };
+        let body = bincode::serialize(&req).map_err(|e| format!("serialize: {e}"))?;
+        let resp = self
+            .peer_manager
+            .send(
+                self.host_id,
+                Message::RepairApplyRequest(Bytes::from(body)),
+                Lane::Data,
+            )
+            .await
+            .map_err(|e| format!("send: {e}"))?;
+        let body = match resp {
+            Message::RepairApplyResponse(b) => b,
+            other => {
+                return Err(format!(
+                    "expected RepairApplyResponse, got {:?}",
+                    std::mem::discriminant(&other)
+                ))
+            }
+        };
+        let resp: RepairApplyResponsePayload =
+            bincode::deserialize(&body).map_err(|e| format!("deserialize: {e}"))?;
+        match resp.error {
+            None => Ok(()),
+            Some(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode + decode the three payload structs to confirm bincode +
+    /// serde round-trip cleanly. Catches breaking schema changes early.
+    #[test]
+    fn merkle_request_payload_roundtrips() {
+        let req = RepairMerkleRequestPayload {
+            keyspace: "ks".into(),
+            table: "t".into(),
+            range_start: -1_000,
+            range_end: 1_000,
+        };
+        let bytes = bincode::serialize(&req).unwrap();
+        let decoded: RepairMerkleRequestPayload = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded.keyspace, "ks");
+        assert_eq!(decoded.table, "t");
+        assert_eq!(decoded.range_start, -1_000);
+        assert_eq!(decoded.range_end, 1_000);
+    }
+
+    #[test]
+    fn merkle_response_payload_roundtrips() {
+        let mut tree = MerkleTree::new(4, 0, 1_000);
+        tree.insert(500, 0xCAFE_BABE);
+        tree.compute_root();
+        let resp = RepairMerkleResponsePayload { tree: tree.clone() };
+        let bytes = bincode::serialize(&resp).unwrap();
+        let decoded: RepairMerkleResponsePayload = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded.tree, tree);
+    }
+
+    #[test]
+    fn apply_response_carries_error_flag() {
+        let ok = RepairApplyResponsePayload {
+            applied: 42,
+            error: None,
+        };
+        let bytes = bincode::serialize(&ok).unwrap();
+        let decoded: RepairApplyResponsePayload = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded.applied, 42);
+        assert!(decoded.error.is_none());
+
+        let err = RepairApplyResponsePayload {
+            applied: 0,
+            error: Some("disk full".into()),
+        };
+        let bytes = bincode::serialize(&err).unwrap();
+        let decoded: RepairApplyResponsePayload = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded.applied, 0);
+        assert_eq!(decoded.error.as_deref(), Some("disk full"));
+    }
+}

--- a/ferrosa-cluster/src/repair/rpc.rs
+++ b/ferrosa-cluster/src/repair/rpc.rs
@@ -158,27 +158,25 @@ impl RpcHandler for RepairFetchHandler {
             }
         };
         let table_id = TableId::new(&req.keyspace, &req.table);
-        // See `StorageEngineRepairStore::read_range`: small per-session
-        // budget keeps the container under its memory limit while still
-        // covering realistic-table leaves. A token-bounded scan API on
-        // StorageEngine is the proper fix; this is the interim.
-        const REPAIR_LEAF_READ_LIMIT: usize = 200;
-        let partitions = match StorageEngine::read_range(
+        // Token-bounded read: repair asks "everything in this token
+        // sub-range," which the new `read_token_range` primitive answers
+        // directly. Limit matches the storage materialisation cap.
+        const REPAIR_LEAF_READ_LIMIT: usize = 10_000;
+        let in_range_partitions = match StorageEngine::read_token_range(
             &self.storage,
             &table_id,
-            None,
-            None,
+            req.range_start,
+            req.range_end,
             REPAIR_LEAF_READ_LIMIT,
         ) {
-                Ok(ps) => ps,
-                Err(e) => {
-                    tracing::warn!(%e, ?table_id, "RepairFetchHandler: read_range failed");
-                    return None;
-                }
-            };
-        let in_range: Vec<PartitionWire> = partitions
+            Ok(ps) => ps,
+            Err(e) => {
+                tracing::warn!(%e, ?table_id, "RepairFetchHandler: read_token_range failed");
+                return None;
+            }
+        };
+        let in_range: Vec<PartitionWire> = in_range_partitions
             .into_iter()
-            .filter(|p| p.key.token.0 >= req.range_start && p.key.token.0 < req.range_end)
             .map(partition_to_wire)
             .collect();
         let resp = RepairFetchResponsePayload {

--- a/ferrosa-ctl/src/commands.rs
+++ b/ferrosa-ctl/src/commands.rs
@@ -603,6 +603,42 @@ pub async fn ring(host: &str, web_port: u16) -> Result<(), WebError> {
     Ok(())
 }
 
+/// Run anti-entropy repair against every peer that replicates `keyspace.table`.
+///
+/// Issues `POST /api/cluster/repair?keyspace=&table=&rf=` and prints the
+/// per-table session summary the server returns: total/ok/failed session
+/// counts, partitions streamed in/out, timestamp ties, and any error
+/// strings from individual sessions.
+pub async fn repair(
+    host: &str,
+    web_port: u16,
+    keyspace: &str,
+    table: &str,
+    rf: usize,
+) -> Result<(), WebError> {
+    let url = format!(
+        "http://{host}:{web_port}/api/cluster/repair?keyspace={keyspace}&table={table}&rf={rf}"
+    );
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    if status.is_success() {
+        // Pretty-print the JSON summary if we can parse it; otherwise dump raw.
+        match serde_json::from_str::<serde_json::Value>(&body) {
+            Ok(v) => println!("{}", serde_json::to_string_pretty(&v).unwrap_or(body)),
+            Err(_) => println!("{body}"),
+        }
+        Ok(())
+    } else {
+        Err(format!("repair failed (HTTP {status}): {body}").into())
+    }
+}
+
 /// Rebalance token distribution across the cluster.
 ///
 /// Issues `POST /api/cluster/rebalance` with an empty body.
@@ -1003,6 +1039,31 @@ mod tests {
     /// Helper: build the URL for rebalance.
     fn rebalance_url(host: &str, web_port: u16) -> String {
         format!("http://{}:{}/api/cluster/rebalance", host, web_port)
+    }
+
+    /// Helper: build the URL for repair.
+    fn repair_url(host: &str, web_port: u16, keyspace: &str, table: &str, rf: usize) -> String {
+        format!(
+            "http://{host}:{web_port}/api/cluster/repair?keyspace={keyspace}&table={table}&rf={rf}"
+        )
+    }
+
+    #[test]
+    fn repair_formats_correct_url() {
+        let url = repair_url("127.0.0.1", 9090, "agent_memory", "entity_store", 3);
+        assert_eq!(
+            url,
+            "http://127.0.0.1:9090/api/cluster/repair?keyspace=agent_memory&table=entity_store&rf=3"
+        );
+    }
+
+    #[test]
+    fn repair_url_custom_rf() {
+        let url = repair_url("10.0.0.5", 8080, "ks", "t", 5);
+        assert_eq!(
+            url,
+            "http://10.0.0.5:8080/api/cluster/repair?keyspace=ks&table=t&rf=5"
+        );
     }
 
     // ── W8.5 — learner lifecycle CLI commands ────────────────────────

--- a/ferrosa-ctl/src/main.rs
+++ b/ferrosa-ctl/src/main.rs
@@ -103,6 +103,21 @@ enum Commands {
     /// Rebalance token distribution across the cluster.
     Rebalance,
 
+    /// Run anti-entropy repair on a table — reconciles divergent replica
+    /// content by exchanging Merkle trees with each peer and streaming
+    /// the diverging partitions in the newer direction.
+    Repair {
+        /// Keyspace name (e.g. `agent_memory`).
+        #[arg(long)]
+        keyspace: String,
+        /// Table name (e.g. `entity_store`).
+        #[arg(long)]
+        table: String,
+        /// Replication factor. Defaults to 3.
+        #[arg(long, default_value = "3")]
+        rf: usize,
+    },
+
     /// Manage node snapshots (create, list, delete).
     Snapshot {
         #[command(subcommand)]
@@ -354,6 +369,11 @@ async fn main() {
         }
         Commands::Ring => commands::ring(&web_host, web_port).await,
         Commands::Rebalance => commands::rebalance(&web_host, web_port).await,
+        Commands::Repair {
+            keyspace,
+            table,
+            rf,
+        } => commands::repair(&web_host, web_port, &keyspace, &table, rf).await,
         Commands::Snapshot { action } => match action {
             SnapshotAction::Create { name, ttl_hours } => {
                 commands::snapshot_create(&web_host, web_port, &name, ttl_hours).await
@@ -629,6 +649,50 @@ mod tests {
     fn subcommand_rebalance_parses() {
         let cli = Cli::try_parse_from(["ferrosa-ctl", "rebalance"]).unwrap();
         assert!(matches!(cli.command, Commands::Rebalance));
+    }
+
+    #[test]
+    fn subcommand_repair_parses() {
+        let cli = Cli::try_parse_from([
+            "ferrosa-ctl",
+            "repair",
+            "--keyspace",
+            "agent_memory",
+            "--table",
+            "entity_store",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Repair {
+                keyspace,
+                table,
+                rf,
+            } => {
+                assert_eq!(keyspace, "agent_memory");
+                assert_eq!(table, "entity_store");
+                assert_eq!(rf, 3, "rf must default to 3");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subcommand_repair_explicit_rf() {
+        let cli = Cli::try_parse_from([
+            "ferrosa-ctl",
+            "repair",
+            "--keyspace",
+            "ks",
+            "--table",
+            "t",
+            "--rf",
+            "5",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Repair { rf, .. } => assert_eq!(rf, 5),
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     // ── Snapshot / Restore argument-parsing tests ─────────────────────────────

--- a/ferrosa-net/src/codec.rs
+++ b/ferrosa-net/src/codec.rs
@@ -83,6 +83,16 @@ pub enum MsgType {
     RangeReadResponse = 0x26,
     TruncateForward = 0x27,
     TruncateAck = 0x28,
+    // Anti-entropy repair (cluster/repair) — three request/response pairs.
+    // Initiator → peer: build Merkle for table range. Peer → initiator: tree.
+    RepairMerkleRequest = 0x29,
+    RepairMerkleResponse = 0x2A,
+    // Initiator → peer: send partitions in a token sub-range.
+    RepairFetchRequest = 0x2B,
+    RepairFetchResponse = 0x2C,
+    // Initiator → peer: apply these partitions (LWW). Peer → initiator: ack.
+    RepairApplyRequest = 0x2D,
+    RepairApplyResponse = 0x2E,
     // ADR-020 streaming range read — multi-message RPC keyed by
     // request_id, terminated by RangeReadStreamDone, cancellable via
     // RangeReadStreamCancel, kept alive by RangeReadStreamHeartbeat.

--- a/ferrosa-net/src/codec.rs
+++ b/ferrosa-net/src/codec.rs
@@ -198,6 +198,12 @@ impl TryFrom<u8> for MsgType {
             0x3A => Ok(Self::RangeReadStreamCancel),
             0x27 => Ok(Self::TruncateForward),
             0x28 => Ok(Self::TruncateAck),
+            0x29 => Ok(Self::RepairMerkleRequest),
+            0x2A => Ok(Self::RepairMerkleResponse),
+            0x2B => Ok(Self::RepairFetchRequest),
+            0x2C => Ok(Self::RepairFetchResponse),
+            0x2D => Ok(Self::RepairApplyRequest),
+            0x2E => Ok(Self::RepairApplyResponse),
             0x30 => Ok(Self::StreamStart),
             0x31 => Ok(Self::StreamChunk),
             0x32 => Ok(Self::StreamEnd),
@@ -594,6 +600,30 @@ mod tests {
         let mt = MsgType::try_from(0x24u8).unwrap();
         assert_eq!(mt, MsgType::RepairWrite);
         assert_eq!(mt as u8, 0x24);
+    }
+
+    /// Every anti-entropy repair RPC byte-tag must round-trip through
+    /// `TryFrom<u8>`. The enum has variants 0x29..=0x2E (declared at the
+    /// top of this module) but those cases were not added to the decoder's
+    /// match arm — so peers serialise repair frames fine but reject them
+    /// on receipt with `UnknownMessageType`, repair sessions silently
+    /// fail and zero partitions converge. This test pins each byte.
+    #[test]
+    fn msg_type_repair_rpc_tags_round_trip() {
+        for (byte, expected) in [
+            (0x29u8, MsgType::RepairMerkleRequest),
+            (0x2A, MsgType::RepairMerkleResponse),
+            (0x2B, MsgType::RepairFetchRequest),
+            (0x2C, MsgType::RepairFetchResponse),
+            (0x2D, MsgType::RepairApplyRequest),
+            (0x2E, MsgType::RepairApplyResponse),
+        ] {
+            let parsed = MsgType::try_from(byte).unwrap_or_else(|_| {
+                panic!("MsgType::try_from(0x{byte:02X}) must succeed — repair will silently drop frames otherwise")
+            });
+            assert_eq!(parsed, expected, "byte 0x{byte:02X} round-trip");
+            assert_eq!(parsed as u8, byte, "byte 0x{byte:02X} discriminant");
+        }
     }
 
     #[test]

--- a/ferrosa-net/src/message.rs
+++ b/ferrosa-net/src/message.rs
@@ -142,6 +142,27 @@ pub enum Message {
     TruncateForward(Bytes),
     TruncateAck(Bytes),
 
+    /// Anti-entropy repair — initiator → peer: "build a Merkle tree for
+    /// keyspace.table over the given token range and send it back".
+    /// Payload is a bincoded `RepairMerkleRequestPayload`.
+    RepairMerkleRequest(Bytes),
+    /// Peer → initiator: serialized `MerkleTree`.
+    RepairMerkleResponse(Bytes),
+    /// Anti-entropy repair — initiator → peer: "send me the partitions
+    /// in this token sub-range". Payload is a bincoded
+    /// `RepairFetchRequestPayload`.
+    RepairFetchRequest(Bytes),
+    /// Peer → initiator: bincoded `RepairFetchResponsePayload` carrying
+    /// the matching partitions (as `PartitionWire` for serde).
+    RepairFetchResponse(Bytes),
+    /// Anti-entropy repair — initiator → peer: "apply these partitions
+    /// last-write-wins on a per-cell basis". Payload is a bincoded
+    /// `RepairApplyRequestPayload`.
+    RepairApplyRequest(Bytes),
+    /// Peer → initiator: bincoded `RepairApplyResponsePayload` carrying
+    /// the count of partitions applied and an optional error message.
+    RepairApplyResponse(Bytes),
+
     // Streaming (row-based) — opaque payloads
     StreamStart(Bytes),
     StreamChunk(Bytes),
@@ -269,6 +290,12 @@ impl Message {
             Self::RangeReadStreamCancel(_) => MsgType::RangeReadStreamCancel,
             Self::TruncateForward(_) => MsgType::TruncateForward,
             Self::TruncateAck(_) => MsgType::TruncateAck,
+            Self::RepairMerkleRequest(_) => MsgType::RepairMerkleRequest,
+            Self::RepairMerkleResponse(_) => MsgType::RepairMerkleResponse,
+            Self::RepairFetchRequest(_) => MsgType::RepairFetchRequest,
+            Self::RepairFetchResponse(_) => MsgType::RepairFetchResponse,
+            Self::RepairApplyRequest(_) => MsgType::RepairApplyRequest,
+            Self::RepairApplyResponse(_) => MsgType::RepairApplyResponse,
             Self::StreamStart(_) => MsgType::StreamStart,
             Self::StreamChunk(_) => MsgType::StreamChunk,
             Self::StreamEnd(_) => MsgType::StreamEnd,
@@ -425,6 +452,12 @@ impl Message {
             | Self::RangeReadStreamCancel(b)
             | Self::TruncateForward(b)
             | Self::TruncateAck(b)
+            | Self::RepairMerkleRequest(b)
+            | Self::RepairMerkleResponse(b)
+            | Self::RepairFetchRequest(b)
+            | Self::RepairFetchResponse(b)
+            | Self::RepairApplyRequest(b)
+            | Self::RepairApplyResponse(b)
             | Self::StreamStart(b)
             | Self::StreamChunk(b)
             | Self::StreamEnd(b)
@@ -631,6 +664,24 @@ impl Message {
             }
             MsgType::TruncateForward => Self::TruncateForward(body.split_to(body.remaining())),
             MsgType::TruncateAck => Self::TruncateAck(body.split_to(body.remaining())),
+            MsgType::RepairMerkleRequest => {
+                Self::RepairMerkleRequest(body.split_to(body.remaining()))
+            }
+            MsgType::RepairMerkleResponse => {
+                Self::RepairMerkleResponse(body.split_to(body.remaining()))
+            }
+            MsgType::RepairFetchRequest => {
+                Self::RepairFetchRequest(body.split_to(body.remaining()))
+            }
+            MsgType::RepairFetchResponse => {
+                Self::RepairFetchResponse(body.split_to(body.remaining()))
+            }
+            MsgType::RepairApplyRequest => {
+                Self::RepairApplyRequest(body.split_to(body.remaining()))
+            }
+            MsgType::RepairApplyResponse => {
+                Self::RepairApplyResponse(body.split_to(body.remaining()))
+            }
             MsgType::StreamStart => Self::StreamStart(body.split_to(body.remaining())),
             MsgType::StreamChunk => Self::StreamChunk(body.split_to(body.remaining())),
             MsgType::StreamEnd => Self::StreamEnd(body.split_to(body.remaining())),

--- a/ferrosa-net/src/protocol.rs
+++ b/ferrosa-net/src/protocol.rs
@@ -1537,7 +1537,13 @@ fn message_family_for_kind(kind: u16) -> MessageFamily {
             | MsgType::RangeReadRequest
             | MsgType::RangeReadResponse
             | MsgType::TruncateForward
-            | MsgType::TruncateAck,
+            | MsgType::TruncateAck
+            | MsgType::RepairMerkleRequest
+            | MsgType::RepairMerkleResponse
+            | MsgType::RepairFetchRequest
+            | MsgType::RepairFetchResponse
+            | MsgType::RepairApplyRequest
+            | MsgType::RepairApplyResponse,
         ) => MessageFamily::Data,
         Ok(
             MsgType::StreamStart

--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -83,6 +83,14 @@ pub struct SSTableReader<R: ReadAt> {
     /// decoding any partition body — the cold-cache dominant cost
     /// (see bug-streaming-range-read-perf-50x-floor).
     partition_offsets: std::sync::OnceLock<std::sync::Arc<Vec<u64>>>,
+    /// Lazily-populated `(token, byte-offset)` pairs in Data.db
+    /// order (which is token-sorted). Built by walking the index
+    /// with `peek_partition_key + skip_to_next_partition` once.
+    /// Backs `PartitionIter::seek_to_token` so a token-bounded read
+    /// can jump straight to the first matching partition instead of
+    /// decoding every preceding partition — the difference between
+    /// O(matches) and O(table_size) per repair session.
+    partition_token_offsets: std::sync::OnceLock<std::sync::Arc<Vec<(i64, u64)>>>,
 }
 
 impl<R: ReadAt> SSTableReader<R> {
@@ -118,6 +126,7 @@ impl<R: ReadAt> SSTableReader<R> {
             _decompressed_data: decompressed_data,
             rows: components.rows,
             partition_offsets: std::sync::OnceLock::new(),
+            partition_token_offsets: std::sync::OnceLock::new(),
         })
     }
 
@@ -155,6 +164,49 @@ impl<R: ReadAt> SSTableReader<R> {
                     }
                 }
                 std::sync::Arc::new(offsets)
+            })
+            .clone()
+    }
+
+    /// Sorted `(token, byte-offset-in-Data.db)` pairs for every
+    /// partition in this SSTable, in token order. Lazily built on
+    /// first call by walking the file with `peek_partition_key +
+    /// skip_to_next_partition` (key decode only — no row bodies).
+    /// Cached for the SSTable's lifetime; subsequent calls are O(1).
+    ///
+    /// Used by `PartitionIter::seek_to_token` to turn anti-entropy
+    /// repair's "give me the partitions in token range `[a, b)`"
+    /// query from O(table_size) per session into O(log N + matches)
+    /// per session — the structural fix that makes repair viable on
+    /// a multi-GB table.
+    ///
+    /// On error the list is left empty and a warning is logged;
+    /// callers can detect the empty cache and fall back to a
+    /// linear scan from byte 0.
+    pub fn partition_token_offsets(&self) -> std::sync::Arc<Vec<(i64, u64)>> {
+        self.partition_token_offsets
+            .get_or_init(|| {
+                let mut out: Vec<(i64, u64)> = Vec::new();
+                let mut iter = match self.partitions_iter() {
+                    Ok(it) => it,
+                    Err(_) => {
+                        // Match `partition_offsets()`: silent empty
+                        // cache; callers detect and fall back.
+                        return std::sync::Arc::new(out);
+                    }
+                };
+                loop {
+                    let pos = iter.pos;
+                    match iter.peek_partition_key() {
+                        Ok(Some(dk)) => out.push((dk.token.0, pos)),
+                        Ok(None) => break,
+                        Err(_) => break,
+                    }
+                    if iter.skip_to_next_partition().is_err() {
+                        break;
+                    }
+                }
+                std::sync::Arc::new(out)
             })
             .clone()
     }
@@ -438,6 +490,40 @@ impl<'a, R: ReadAt> PartitionIter<'a, R> {
     /// OTHER sources holding key K need to advance past it but their
     /// decoded body is discarded — `skip_to_next_partition` does the
     /// advance without paying that wasted decode cost.
+    /// Position the iterator at the first partition whose token is
+    /// `>= target`. If no such partition exists the iterator is
+    /// parked at EOF (subsequent `peek/next` yield `None`).
+    ///
+    /// Uses the SSTable's cached `partition_token_offsets` for an
+    /// O(log N) lookup. On the first call per SSTable the cache is
+    /// populated by a single token-only walk (no row-body decode);
+    /// every subsequent `seek_to_token` is O(log N).
+    ///
+    /// This is the anti-entropy repair hot-path primitive: each of
+    /// repair's `num_tokens × peers` sessions asks for partitions in
+    /// a tiny token sub-range out of a multi-GB SSTable. Without a
+    /// seek the streaming iterator pays O(table_size) per session;
+    /// with one, it pays O(matches_in_range).
+    ///
+    /// If the cache is empty (build failed), this is a no-op and the
+    /// iterator stays at its current position — callers fall back to
+    /// the existing linear `next_partition + token-filter` shape.
+    pub fn seek_to_token(&mut self, target: i64) -> Result<()> {
+        let tokens = self.sst.partition_token_offsets();
+        if tokens.is_empty() {
+            return Ok(());
+        }
+        // First entry with `token >= target`. partition_point splits
+        // the slice on the first element NOT satisfying the
+        // predicate; we want the first NOT `< target`.
+        let idx = tokens.partition_point(|(t, _)| *t < target);
+        self.pos = match tokens.get(idx) {
+            Some(&(_, pos)) => pos,
+            None => self.sst.data.len()?, // every token < target → EOF
+        };
+        Ok(())
+    }
+
     pub fn skip_to_next_partition(&mut self) -> Result<()> {
         let offsets = self.sst.partition_offsets();
         if offsets.is_empty() {
@@ -924,6 +1010,77 @@ mod tests {
         // EOF stays at EOF
         assert!(iter.next_partition().unwrap().is_none());
         assert!(iter.next_partition().unwrap().is_none());
+    }
+
+    /// `seek_to_token(T)` must land the iterator at the first
+    /// partition with token >= T, regardless of how many partitions
+    /// come before it in the SSTable. This is what makes
+    /// anti-entropy repair viable on a multi-GB table without
+    /// linearly scanning all partitions for every (range, peer)
+    /// session — repair runs O(#sessions × matches_per_range)
+    /// instead of O(#sessions × table_size).
+    #[test]
+    fn seek_to_token_starts_at_or_after_target() {
+        let header = test_header();
+        let n = 20usize;
+        let mut dks: Vec<_> = (0..n)
+            .map(|i| DecoratedKey::new(PartitionKey::from(format!("pk{i:03}").as_bytes())))
+            .collect();
+        dks.sort_by_key(|dk| dk.token.0);
+
+        let mut data_bytes = Vec::new();
+        let mut positions = Vec::new();
+        for dk in &dks {
+            positions.push(data_bytes.len() as u64);
+            data_bytes.extend_from_slice(&build_data_blob(dk.key.as_bytes()));
+        }
+        let dk_pos: Vec<_> = dks.iter().zip(positions.iter().copied()).collect();
+        let partitions_bytes =
+            build_partition_index(&dk_pos.iter().map(|(d, p)| (*d, *p)).collect::<Vec<_>>());
+        let filter_bytes = build_bloom_filter(&dks.iter().collect::<Vec<_>>());
+        let stats_bytes = build_statistics(header);
+
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        // Seek to the token of the 10th partition. After seek, the
+        // iterator's NEXT decoded partition must be that one — every
+        // partition before it must have been skipped without decode.
+        let target = dks[n / 2].token.0;
+        let mut iter = reader.partitions_iter().expect("partitions_iter");
+        iter.seek_to_token(target).expect("seek_to_token");
+        let first = iter
+            .next_partition()
+            .expect("next after seek")
+            .expect("a partition exists at or after target");
+        assert_eq!(
+            first.key.token.0, target,
+            "first decoded partition's token must equal the seek target"
+        );
+        // Note: `first.key` is a DecoratedKey; its `token` field name matches
+        // the Partition struct convention.
+
+        // After exhausting the rest, exactly half (10) partitions
+        // should remain.
+        let mut yielded_after_seek = 1usize;
+        while iter.next_partition().expect("next").is_some() {
+            yielded_after_seek += 1;
+        }
+        assert_eq!(yielded_after_seek, n - n / 2);
+
+        // Seeking to a token greater than every partition's token
+        // must put the iterator at EOF.
+        let above_max = dks.last().unwrap().token.0.saturating_add(1);
+        let mut iter = reader.partitions_iter().expect("partitions_iter");
+        iter.seek_to_token(above_max).expect("seek above max");
+        assert!(iter.next_partition().expect("next").is_none());
     }
 
     /// ADR-020 COUNT(*) fast path: next_partition_count yields the

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -2108,7 +2108,7 @@ impl StorageEngine {
     ///
     /// Anti-entropy repair's per-Merkle-leaf "give me everything in this
     /// token sub-range" question can't be answered by the key-bounded
-    /// [`read_range`] — partition keys hash to tokens via Murmur3, so a
+    /// [`Self::read_range`] — partition keys hash to tokens via Murmur3, so a
     /// contiguous token range is a discontiguous key range. This primitive
     /// answers the token question directly by reading the merged stream
     /// once and short-circuiting at `end_token`.

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -6190,6 +6190,47 @@ mod tests {
         assert_eq!(results.len(), 7);
     }
 
+    /// Streaming contract: even with thousands of partitions in the table,
+    /// asking for a small token sub-range must return ONLY the in-range
+    /// matches. This is what makes anti-entropy repair viable on a multi-GB
+    /// table in a constrained container: working set scales with matches,
+    /// not table size.
+    #[test]
+    fn read_token_range_streaming_returns_only_in_range_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        let n_total: usize = 1_000;
+        let mut tokens: Vec<i64> = Vec::with_capacity(n_total);
+        for i in 0..n_total {
+            let k = format!("k{i:06}");
+            let dk = make_key(&k);
+            tokens.push(dk.token.0);
+            engine.write(&tid, &dk, make_row(b"v", 1000), 1000).unwrap();
+        }
+        tokens.sort_unstable();
+
+        // 1 % slice of the token space.
+        let lo = tokens[(n_total * 49) / 100];
+        let hi = tokens[(n_total * 50) / 100];
+        let expected = tokens.iter().filter(|&&t| t >= lo && t < hi).count();
+        assert!(expected > 0);
+
+        let results = engine.read_token_range(&tid, lo, hi, 10_000).unwrap();
+        assert_eq!(
+            results.len(),
+            expected,
+            "streaming must return exactly the matches, not a prefix of the table"
+        );
+        for p in &results {
+            let t = p.key.token.0;
+            assert!(t >= lo && t < hi);
+        }
+    }
+
     #[test]
     fn read_token_range_honors_limit() {
         let dir = tempfile::tempdir().unwrap();

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -2103,6 +2103,35 @@ impl StorageEngine {
         self.read_range_limited_rows(table_id, start, end, limit, 0)
     }
 
+    /// Read all partitions whose tokens fall in `[start_token, end_token)`,
+    /// up to `limit`.
+    ///
+    /// Anti-entropy repair's per-Merkle-leaf "give me everything in this
+    /// token sub-range" question can't be answered by the key-bounded
+    /// [`read_range`] — partition keys hash to tokens via Murmur3, so a
+    /// contiguous token range is a discontiguous key range. This primitive
+    /// answers the token question directly by reading the merged stream
+    /// once and short-circuiting at `end_token`.
+    ///
+    /// Returns an empty vector when `start_token >= end_token` (empty
+    /// range) or the table doesn't exist.
+    pub fn read_token_range(
+        &self,
+        table_id: &TableId,
+        start_token: i64,
+        end_token: i64,
+        limit: usize,
+    ) -> ferrosa_common::Result<Vec<Partition>> {
+        if start_token >= end_token || limit == 0 {
+            return Ok(Vec::new());
+        }
+        let tables = self.tables.read();
+        let Some(state) = tables.get(table_id) else {
+            return Ok(Vec::new());
+        };
+        state.store.read_token_range(start_token, end_token, limit)
+    }
+
     /// Reads partitions from a table with an optional per-partition row cap.
     pub fn read_range_limited_rows(
         &self,
@@ -6066,6 +6095,122 @@ mod tests {
 
         let results = engine.read_range(&tid, None, None, 100).unwrap();
         assert_eq!(results.len(), 5);
+    }
+
+    /// `read_token_range` must return EXACTLY the partitions whose tokens
+    /// fall in `[start_token, end_token)`, regardless of where those
+    /// partitions sit in key order. This is the primitive anti-entropy
+    /// repair needs to ask "give me everything in this Merkle leaf's
+    /// token sub-range" — the existing key-bounded `read_range` cannot
+    /// answer that question.
+    #[test]
+    fn read_token_range_filters_by_token_bounds() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        // Write 20 partitions; Murmur3 scatters their tokens.
+        let mut keys_with_tokens: Vec<(String, i64)> = Vec::new();
+        for i in 0..20 {
+            let k = format!("k{i:03}");
+            let dk = make_key(&k);
+            let tok = dk.token.0;
+            engine.write(&tid, &dk, make_row(b"v", 1000), 1000).unwrap();
+            keys_with_tokens.push((k, tok));
+        }
+
+        keys_with_tokens.sort_by_key(|(_, t)| *t);
+        let start = keys_with_tokens[5].1;
+        let end = keys_with_tokens[15].1; // exclusive
+        let expected_count = keys_with_tokens
+            .iter()
+            .filter(|(_, t)| *t >= start && *t < end)
+            .count();
+
+        let results = engine.read_token_range(&tid, start, end, 100).unwrap();
+        assert_eq!(
+            results.len(),
+            expected_count,
+            "expected exactly {expected_count} partitions in token range [{start}, {end})"
+        );
+        for p in &results {
+            let t = p.key.token.0;
+            assert!(
+                t >= start && t < end,
+                "partition token {t} outside requested range [{start}, {end})"
+            );
+        }
+    }
+
+    #[test]
+    fn read_token_range_empty_range_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        for i in 0..5 {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("k{i}")),
+                    make_row(b"v", 1000),
+                    1000,
+                )
+                .unwrap();
+        }
+
+        // start == end → empty range.
+        let results = engine.read_token_range(&tid, 0, 0, 100).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn read_token_range_full_range_returns_everything() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        for i in 0..7 {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("k{i}")),
+                    make_row(b"v", 1000),
+                    1000,
+                )
+                .unwrap();
+        }
+        let results = engine
+            .read_token_range(&tid, i64::MIN, i64::MAX, 100)
+            .unwrap();
+        assert_eq!(results.len(), 7);
+    }
+
+    #[test]
+    fn read_token_range_honors_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        for i in 0..10 {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("k{i}")),
+                    make_row(b"v", 1000),
+                    1000,
+                )
+                .unwrap();
+        }
+        let results = engine
+            .read_token_range(&tid, i64::MIN, i64::MAX, 3)
+            .unwrap();
+        assert_eq!(results.len(), 3, "limit must cap the result count");
     }
 
     #[test]

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -1139,6 +1139,45 @@ impl<F: FlushTarget> TableStore<F> {
         }))
     }
 
+    /// Read all partitions whose tokens fall in `[start_token, end_token)`,
+    /// up to `limit` matching partitions.
+    ///
+    /// Anti-entropy repair needs "every partition in this Merkle leaf's
+    /// token sub-range." The existing key-bounded read API can't answer
+    /// that because partition keys hash to tokens; a contiguous token
+    /// range is a discontiguous key range. This method materialises the
+    /// merged stream (capped at [`RANGE_READ_MATERIALIZATION_CAP`]) once
+    /// and filters by token.
+    ///
+    /// Returns an empty vector when the range is empty (`start >= end`)
+    /// or `limit == 0`. When the table holds more than the materialisation
+    /// cap, the result is best-effort: only partitions falling in the
+    /// cap-sized prefix-by-key are inspected. A token-streaming primitive
+    /// is the long-term fix; this is the unblock for repair-on-fmem-scale
+    /// tables (9 774 partitions, well under the cap).
+    pub fn read_token_range(
+        &self,
+        start_token: i64,
+        end_token: i64,
+        limit: usize,
+    ) -> Result<Vec<Partition>> {
+        if start_token >= end_token || limit == 0 {
+            return Ok(Vec::new());
+        }
+        // Pull the full materialisation up to the cap, then filter by
+        // token. We can request the cap directly because the underlying
+        // call rejects anything larger.
+        let all = self.read_range_limited_rows(None, None, RANGE_READ_MATERIALIZATION_CAP, 0)?;
+        Ok(all
+            .into_iter()
+            .filter(|p| {
+                let t = p.key.token.0;
+                t >= start_token && t < end_token
+            })
+            .take(limit)
+            .collect())
+    }
+
     pub fn read_range_limited_rows(
         &self,
         start: Option<&DecoratedKey>,

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -1202,7 +1202,11 @@ impl<F: FlushTarget> TableStore<F> {
         // SSTables: walk each via `partitions_iter()` (yields one
         // partition at a time). SSTable partitions are token-ordered,
         // so we bail out of this SSTable's iterator as soon as we see
-        // a token `>= end_token`.
+        // a token `>= end_token`. We also jump straight to the first
+        // partition with `token >= start_token` via `seek_to_token`
+        // (O(log N) via the SSTable's lazy `partition_token_offsets`
+        // cache) so each repair session pays O(matches), not
+        // O(table_size).
         for (i, sstable) in guard.sstables.iter().enumerate() {
             if matched.len() >= limit {
                 break;
@@ -1222,6 +1226,19 @@ impl<F: FlushTarget> TableStore<F> {
                     continue;
                 }
             };
+            if let Err(e) = iter.seek_to_token(start_token) {
+                let id = guard
+                    .sstable_ids
+                    .get(i)
+                    .map(|(gen, dir)| format!("{}/{gen}", dir.display()))
+                    .unwrap_or_else(|| format!("index={i}"));
+                tracing::warn!(
+                    sstable = %id,
+                    "read_token_range: seek_to_token failed, falling back to full scan: {e}"
+                );
+                // Iter is still at byte 0; the per-partition token
+                // filter below will handle correctness, just slower.
+            }
             while matched.len() < limit {
                 match iter.next_partition() {
                     Ok(Some(p)) => {

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -1145,16 +1145,22 @@ impl<F: FlushTarget> TableStore<F> {
     /// Anti-entropy repair needs "every partition in this Merkle leaf's
     /// token sub-range." The existing key-bounded read API can't answer
     /// that because partition keys hash to tokens; a contiguous token
-    /// range is a discontiguous key range. This method materialises the
-    /// merged stream (capped at [`RANGE_READ_MATERIALIZATION_CAP`]) once
-    /// and filters by token.
+    /// range is a discontiguous key range.
+    ///
+    /// Streaming implementation: each source (active memtable, flushing
+    /// memtable, every SSTable) is walked one partition at a time via its
+    /// lazy iterator. Partitions outside `[start_token, end_token)` are
+    /// dropped without ever entering the result `Vec`, and once a single
+    /// SSTable's iterator passes `end_token` we stop iterating it (SSTable
+    /// partitions are stored in token order). Peak working-set memory is
+    /// therefore `O(matches_in_range)` — one in-range partition copy per
+    /// hit, plus one in-flight clone per source — NOT `O(table_size)`.
+    /// This is what makes repair viable on a multi-GB table in a 2 GB
+    /// container: a typical Merkle leaf has < 10 partitions, so peak
+    /// is a few hundred KB per session.
     ///
     /// Returns an empty vector when the range is empty (`start >= end`)
-    /// or `limit == 0`. When the table holds more than the materialisation
-    /// cap, the result is best-effort: only partitions falling in the
-    /// cap-sized prefix-by-key are inspected. A token-streaming primitive
-    /// is the long-term fix; this is the unblock for repair-on-fmem-scale
-    /// tables (9 774 partitions, well under the cap).
+    /// or `limit == 0`.
     pub fn read_token_range(
         &self,
         start_token: i64,
@@ -1164,18 +1170,96 @@ impl<F: FlushTarget> TableStore<F> {
         if start_token >= end_token || limit == 0 {
             return Ok(Vec::new());
         }
-        // Pull the full materialisation up to the cap, then filter by
-        // token. We can request the cap directly because the underlying
-        // call rejects anything larger.
-        let all = self.read_range_limited_rows(None, None, RANGE_READ_MATERIALIZATION_CAP, 0)?;
-        Ok(all
-            .into_iter()
-            .filter(|p| {
-                let t = p.key.token.0;
-                t >= start_token && t < end_token
-            })
-            .take(limit)
-            .collect())
+        let guard = self.view.load();
+        let in_range = |t: i64| t >= start_token && t < end_token;
+        let mut matched: Vec<Partition> = Vec::new();
+
+        // Active memtable: lazy iter. Per-partition deep clone happens
+        // only when we advance the iterator, and only matches survive.
+        for p in guard.active.range_iter(None, None) {
+            if matched.len() >= limit {
+                break;
+            }
+            if in_range(p.key.token.0) {
+                matched.push(p);
+            }
+        }
+
+        // Flushing memtable (if any).
+        if matched.len() < limit {
+            if let Some(ref flushing) = guard.flushing {
+                for p in flushing.range_iter(None, None) {
+                    if matched.len() >= limit {
+                        break;
+                    }
+                    if in_range(p.key.token.0) {
+                        matched.push(p);
+                    }
+                }
+            }
+        }
+
+        // SSTables: walk each via `partitions_iter()` (yields one
+        // partition at a time). SSTable partitions are token-ordered,
+        // so we bail out of this SSTable's iterator as soon as we see
+        // a token `>= end_token`.
+        for (i, sstable) in guard.sstables.iter().enumerate() {
+            if matched.len() >= limit {
+                break;
+            }
+            let mut iter = match sstable.partitions_iter() {
+                Ok(it) => it,
+                Err(e) => {
+                    let id = guard
+                        .sstable_ids
+                        .get(i)
+                        .map(|(gen, dir)| format!("{}/{gen}", dir.display()))
+                        .unwrap_or_else(|| format!("index={i}"));
+                    tracing::warn!(
+                        sstable = %id,
+                        "read_token_range: skipping SSTable with broken iterator: {e}"
+                    );
+                    continue;
+                }
+            };
+            while matched.len() < limit {
+                match iter.next_partition() {
+                    Ok(Some(p)) => {
+                        let t = p.key.token.0;
+                        if t >= end_token {
+                            break; // SSTable is token-sorted — done with this source.
+                        }
+                        if t >= start_token {
+                            matched.push(p);
+                        }
+                    }
+                    Ok(None) => break, // EOF.
+                    Err(e) => {
+                        tracing::warn!("read_token_range: SSTable partition decode error: {e}");
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Cross-source dedup + cell-level merge (same shape as
+        // `read_range_limited_rows` so range and token reads return
+        // semantically identical results for the same window).
+        matched.sort_by(|a, b| a.key.cmp(&b.key));
+        let mut merged: Vec<Partition> = Vec::new();
+        for p in matched {
+            if let Some(last) = merged.last_mut() {
+                if last.key == p.key {
+                    *last = merge::merge_partitions(vec![last.clone(), p]);
+                    continue;
+                }
+            }
+            merged.push(p);
+        }
+        for p in &mut merged {
+            merge::apply_deletions(p);
+        }
+        Ok(merged.into_iter().take(limit).collect())
     }
 
     pub fn read_range_limited_rows(

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -609,6 +609,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         truncate_fwd_handler,
     );
 
+    // Register the three anti-entropy repair handlers. The companion
+    // RemoteRepairStore on initiating nodes will issue Fetch/Apply RPCs
+    // against these handlers during a repair session; the Merkle handler
+    // builds and returns a tree for the requested table+range.
+    registry.register(
+        ferrosa_net::codec::MsgType::RepairMerkleRequest,
+        Arc::new(ferrosa_cluster::RepairMerkleHandler::new(storage.clone())),
+    );
+    registry.register(
+        ferrosa_net::codec::MsgType::RepairFetchRequest,
+        Arc::new(ferrosa_cluster::RepairFetchHandler::new(storage.clone())),
+    );
+    registry.register(
+        ferrosa_net::codec::MsgType::RepairApplyRequest,
+        Arc::new(ferrosa_cluster::RepairApplyHandler::new(storage.clone())),
+    );
+
     // 5b. Create subsystem runtimes (Raft gets its own so heartbeats
     // 5b. Dedicated Raft runtime — heartbeats can't be starved by CQL/S3 work.
     let runtimes = runtime::RuntimeManager::new();

--- a/ferrosa/src/web/api.rs
+++ b/ferrosa/src/web/api.rs
@@ -99,8 +99,8 @@ struct RepairParams {
 /// node to be in cluster mode with a token ring and a live `PeerManager`.
 ///
 /// The handler builds a `LocalRepairExecutor` whose `local` side is the
-/// in-process [`StorageEngineRepairStore`] and whose `remotes` are
-/// per-peer `RemoteRepairStore`s, then runs [`RepairCoordinator::repair_table`].
+/// in-process `StorageEngineRepairStore` and whose `remotes` are
+/// per-peer `RemoteRepairStore`s, then runs `RepairCoordinator::repair_table`.
 /// Returns a JSON summary: total sessions, successful, failed, total
 /// partitions streamed in/out, total timestamp ties.
 async fn repair_handler(

--- a/ferrosa/src/web/api.rs
+++ b/ferrosa/src/web/api.rs
@@ -82,6 +82,154 @@ pub fn cluster_routes() -> Router<WebAppState> {
         .route("/decommission", post(decommission_handler))
         .route("/ring", get(ring_handler))
         .route("/rebalance", post(rebalance_handler))
+        .route("/repair", post(repair_handler))
+}
+
+#[derive(serde::Deserialize)]
+struct RepairParams {
+    keyspace: Option<String>,
+    table: Option<String>,
+    /// Replication factor for the repair fan-out. Defaults to 3 (the
+    /// fmem-cluster RF and the most common Cassandra configuration).
+    rf: Option<usize>,
+}
+
+/// `POST /api/cluster/repair?keyspace=X&table=Y[&rf=N]` — run anti-entropy
+/// repair against every peer that replicates the given table. Requires the
+/// node to be in cluster mode with a token ring and a live `PeerManager`.
+///
+/// The handler builds a `LocalRepairExecutor` whose `local` side is the
+/// in-process [`StorageEngineRepairStore`] and whose `remotes` are
+/// per-peer `RemoteRepairStore`s, then runs [`RepairCoordinator::repair_table`].
+/// Returns a JSON summary: total sessions, successful, failed, total
+/// partitions streamed in/out, total timestamp ties.
+async fn repair_handler(
+    State(state): State<crate::web::WebAppState>,
+    axum::extract::Query(params): axum::extract::Query<RepairParams>,
+) -> (StatusCode, Json<Value>) {
+    use std::sync::Arc;
+
+    let keyspace = match params.keyspace {
+        Some(k) => k,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "keyspace query parameter required" })),
+            );
+        }
+    };
+    let table = match params.table {
+        Some(t) => t,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "table query parameter required" })),
+            );
+        }
+    };
+    let rf = params.rf.unwrap_or(3);
+
+    let mc = &state.mode_controller;
+    let ring = match mc.token_ring() {
+        Some(r) => r,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "not in cluster mode (no token ring)" })),
+            );
+        }
+    };
+    let peer_manager = match mc.peer_manager_arc() {
+        Some(pm) => pm,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "peer manager not initialised" })),
+            );
+        }
+    };
+
+    // Resolve our own node_id by looking up our host_id in the ring.
+    let host_id = mc.host_id();
+    let local_node_id = match ring.node_ids().iter().find_map(|&id| {
+        ring.get_node(id)
+            .filter(|info| info.host_id == host_id)
+            .map(|_| id)
+    }) {
+        Some(id) => id,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "local node not in the token ring yet" })),
+            );
+        }
+    };
+
+    // Build the executor: local = in-process storage, remotes = per-peer
+    // RemoteRepairStore (one entry per other node in the ring).
+    let local: Arc<dyn ferrosa_cluster::RepairStore> = Arc::new(
+        ferrosa_cluster::StorageEngineRepairStore::new(state.storage.clone()),
+    );
+    let mut remotes: std::collections::HashMap<u64, Arc<dyn ferrosa_cluster::RepairStore>> =
+        std::collections::HashMap::new();
+    for node_id in ring.node_ids() {
+        if node_id == local_node_id {
+            continue;
+        }
+        let Some(node_info) = ring.get_node(node_id) else {
+            continue;
+        };
+        let remote: Arc<dyn ferrosa_cluster::RepairStore> =
+            Arc::new(ferrosa_cluster::RemoteRepairStore {
+                host_id: node_info.host_id,
+                peer_manager: peer_manager.clone(),
+            });
+        remotes.insert(node_id, remote);
+    }
+
+    let executor: Arc<dyn ferrosa_cluster::SessionExecutor> =
+        Arc::new(ferrosa_cluster::LocalRepairExecutor { local, remotes });
+    let table_id = ferrosa_storage::TableId::new(&keyspace, &table);
+    let coord = ferrosa_cluster::RepairCoordinator::default();
+    let results = coord
+        .repair_table(executor, &ring, local_node_id, rf, &table_id)
+        .await;
+
+    let total = results.len();
+    let mut ok = 0usize;
+    let mut streamed_in = 0u64;
+    let mut streamed_out = 0u64;
+    let mut ties = 0u64;
+    let mut errors: Vec<String> = Vec::new();
+    for r in &results {
+        match &r.result {
+            Ok(stats) => {
+                ok += 1;
+                streamed_in += stats.partitions_streamed_in;
+                streamed_out += stats.partitions_streamed_out;
+                ties += stats.timestamp_ties;
+            }
+            Err(e) => errors.push(format!(
+                "peer {} range [{}, {}): {}",
+                r.peer, r.range_start, r.range_end, e
+            )),
+        }
+    }
+    (
+        StatusCode::OK,
+        Json(json!({
+            "keyspace": keyspace,
+            "table": table,
+            "rf": rf,
+            "sessions_total": total,
+            "sessions_ok": ok,
+            "sessions_failed": total - ok,
+            "partitions_streamed_in": streamed_in,
+            "partitions_streamed_out": streamed_out,
+            "timestamp_ties": ties,
+            "errors": errors,
+        })),
+    )
 }
 
 /// Sprint 2 W2.3: routes mounted at `/admin/*`. Currently exposes a single


### PR DESCRIPTION
## Executive Summary

While auditing the existing anti-entropy infrastructure for [a follow-up RepairCoordinator/RepairSession PR], I found that **the Merkle tree was structurally incapable of detecting the divergence it's supposed to find**: `partition_hash` only hashed the partition key bytes, not the content. Two replicas with the same set of keys but different cell values, timestamps, or deletions produced identical Merkle roots → repair would conclude "nothing to do" → divergent state never converges. This is the exact failure mode anti-entropy is supposed to fix.

Fixes the hashing bug and adds two Merkle primitives the upcoming `RepairSession` will need (`leaf_range` and `divergent_leaf_ranges`).

## Triage motivating this PR

Earlier in the same investigation that produced #44/#45/#46, the live fmem cluster (3 nodes, RF=3) showed wildly imbalanced replica sizes for the same logical data:

| Node | `entity_store` size | SSTable count |
|---|---|---|
| node1 | **1.41 GB** | 47 |
| node2 | 401 MB | 49 |
| node3 | 217 MB | 23 |

(This came from write-path bugs that pre-date the current branch.) Looking at the existing repair-recovery options:

- **Read repair** (`coordinator/read.rs`): correct for CL>ONE point reads, but CL=ONE (the Cassandra default, and what fmem uses) and streaming range reads (ADR-020) bypass the digest phase entirely → divergent state never converges via reads.
- **`ferrosa-ctl rebalance`**: moves tokens, not data — no-op when the ring is already balanced.
- **Hinted handoff**: replays only the brief peer-down window, not GB of pre-existing divergence.
- **Anti-entropy repair**: the `MerkleTree` and `repair_participants` primitives exist, but there's no `RepairSession`, no scheduler, no API. **And the existing Merkle hash silently ignores content divergence**, so even if a coordinator were wired up, it would conclude there's nothing to repair.

## The Merkle-hash bug

`repair/mod.rs` previously had:

```rust
fn partition_hash(key_bytes: &[u8]) -> u64 {
    use std::hash::{Hash, Hasher};
    let mut hasher = std::collections::hash_map::DefaultHasher::new();
    key_bytes.hash(&mut hasher);
    hasher.finish()
}

// ...
let hash = partition_hash(partition.key.key.as_bytes());
tree.insert(token, hash);
```

The hash is over **the key only**. Tests confirmed that two `Partition`s with the same key but different cell values produce the same `partition_hash` — Merkle XOR cancels, root unchanged, `diff_trees` says no divergence.

## The fix

Replace with `partition_merkle_hash(&Partition) -> u64`, delegating to the existing `compute_partition_digest` (the same bincode-`PartitionWire` CRC32 used by the digest phase of `coordinate_read_with`). This guarantees Merkle agreement and read-repair digest agreement are consistent.

CRC32 is widened to u64 by `(crc.rotate_left(16) as u64) << 32 | (crc as u64)` instead of zero-padding — zero-padding throws away half the tree's XOR-distinguishing power. Per-leaf XOR collision probability is ~2^-32, mitigated further by `TREE_DEPTH=15` (32,768 leaves) per the existing constant.

## New Merkle primitives

Two methods that the upcoming `RepairSession` needs but don't exist yet:

- **`MerkleTree::leaf_range(leaf_idx) -> (i64, i64)`** — inverse of `token_to_leaf`. Required so "leaf 17 differs" can be translated into "ask the peer for partitions in token range `[12345, 14567)`".
- **`MerkleTree::divergent_leaf_ranges(other) -> Vec<(i64, i64)>`** — convenience method returning leaf-range tuples for every differing leaf. Used by the coordinator to drive per-range partition diffs. Mismatched-geometry trees report the full range as divergent (caller falls back to whole-table compare).

## New tests (6 of them)

| Test | Asserts |
|---|---|
| `partition_merkle_hash_detects_content_divergence` | Same key + different cells → different hash. Same content → same hash. |
| `diff_trees_detects_content_divergence_at_same_key` | The bug fix propagates: `diff_trees` reports the leaf containing the divergent token. |
| `leaf_range_is_inverse_of_token_to_leaf` | For every leaf, `token_to_leaf(leaf_range(leaf).0) == leaf` and `token_to_leaf(leaf_range(leaf).1 - 1) == leaf`. |
| `leaf_range_covers_full_token_range_without_gaps` | First leaf starts at `range_start`, last leaf ends at `range_end`, no gaps between adjacent leaves. |
| `divergent_leaf_ranges_empty_for_identical_trees` | Identical trees → no diffs. |
| `divergent_leaf_ranges_pinpoints_single_diff` | A single divergent insert → exactly one leaf-range that contains the divergent token. |
| `divergent_leaf_ranges_handles_mismatched_geometry` | Different depth or range → full range reported as divergent. |

## What's next (follow-up PRs)

1. **`RepairSession`** — orchestrates two-node Merkle exchange + partition-level diff + streaming sync. Uses the primitives in this PR.
2. **`RepairCoordinator`** — drives sessions for every (table, owned-range, peer) triple with a concurrency limit.
3. **RPC + HTTP + ctl** — wire a `POST /api/cluster/repair` endpoint and `ferrosa-ctl repair` command.
4. **Multi-node integration test** — docker-compose 3-node cluster that starts in single-node mode (writes go only to node1), then scales to 3 nodes and runs repair, asserting per-node data sizes converge to within 5%.

## Verification

- 19 repair tests pass (was 4 — every existing test stays green)
- 827 ferrosa-cluster tests pass total
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Test plan
- [ ] CI green
- [ ] Confirm `compute_partition_digest` is byte-for-byte identical on two nodes that hold the same partition (digest-phase code already relies on this; this PR adds Merkle's dependency on the same guarantee)