### PR TITLE
feat(storage): read_token_range — anti-entropy's missing primitive

### DIFF
--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -2108,7 +2108,7 @@ impl StorageEngine {
     ///
     /// Anti-entropy repair's per-Merkle-leaf "give me everything in this
     /// token sub-range" question can't be answered by the key-bounded
-    /// [`read_range`] — partition keys hash to tokens via Murmur3, so a
+    /// [`Self::read_range`] — partition keys hash to tokens via Murmur3, so a
     /// contiguous token range is a discontiguous key range. This primitive
     /// answers the token question directly by reading the merged stream
     /// once and short-circuiting at `end_token`.

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -2103,6 +2103,35 @@ impl StorageEngine {
         self.read_range_limited_rows(table_id, start, end, limit, 0)
     }
 
+    /// Read all partitions whose tokens fall in `[start_token, end_token)`,
+    /// up to `limit`.
+    ///
+    /// Anti-entropy repair's per-Merkle-leaf "give me everything in this
+    /// token sub-range" question can't be answered by the key-bounded
+    /// [`read_range`] — partition keys hash to tokens via Murmur3, so a
+    /// contiguous token range is a discontiguous key range. This primitive
+    /// answers the token question directly by reading the merged stream
+    /// once and short-circuiting at `end_token`.
+    ///
+    /// Returns an empty vector when `start_token >= end_token` (empty
+    /// range) or the table doesn't exist.
+    pub fn read_token_range(
+        &self,
+        table_id: &TableId,
+        start_token: i64,
+        end_token: i64,
+        limit: usize,
+    ) -> ferrosa_common::Result<Vec<Partition>> {
+        if start_token >= end_token || limit == 0 {
+            return Ok(Vec::new());
+        }
+        let tables = self.tables.read();
+        let Some(state) = tables.get(table_id) else {
+            return Ok(Vec::new());
+        };
+        state.store.read_token_range(start_token, end_token, limit)
+    }
+
     /// Reads partitions from a table with an optional per-partition row cap.
     pub fn read_range_limited_rows(
         &self,
@@ -6066,6 +6095,122 @@ mod tests {
 
         let results = engine.read_range(&tid, None, None, 100).unwrap();
         assert_eq!(results.len(), 5);
+    }
+
+    /// `read_token_range` must return EXACTLY the partitions whose tokens
+    /// fall in `[start_token, end_token)`, regardless of where those
+    /// partitions sit in key order. This is the primitive anti-entropy
+    /// repair needs to ask "give me everything in this Merkle leaf's
+    /// token sub-range" — the existing key-bounded `read_range` cannot
+    /// answer that question.
+    #[test]
+    fn read_token_range_filters_by_token_bounds() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        // Write 20 partitions; Murmur3 scatters their tokens.
+        let mut keys_with_tokens: Vec<(String, i64)> = Vec::new();
+        for i in 0..20 {
+            let k = format!("k{i:03}");
+            let dk = make_key(&k);
+            let tok = dk.token.0;
+            engine.write(&tid, &dk, make_row(b"v", 1000), 1000).unwrap();
+            keys_with_tokens.push((k, tok));
+        }
+
+        keys_with_tokens.sort_by_key(|(_, t)| *t);
+        let start = keys_with_tokens[5].1;
+        let end = keys_with_tokens[15].1; // exclusive
+        let expected_count = keys_with_tokens
+            .iter()
+            .filter(|(_, t)| *t >= start && *t < end)
+            .count();
+
+        let results = engine.read_token_range(&tid, start, end, 100).unwrap();
+        assert_eq!(
+            results.len(),
+            expected_count,
+            "expected exactly {expected_count} partitions in token range [{start}, {end})"
+        );
+        for p in &results {
+            let t = p.key.token.0;
+            assert!(
+                t >= start && t < end,
+                "partition token {t} outside requested range [{start}, {end})"
+            );
+        }
+    }
+
+    #[test]
+    fn read_token_range_empty_range_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        for i in 0..5 {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("k{i}")),
+                    make_row(b"v", 1000),
+                    1000,
+                )
+                .unwrap();
+        }
+
+        // start == end → empty range.
+        let results = engine.read_token_range(&tid, 0, 0, 100).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn read_token_range_full_range_returns_everything() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        for i in 0..7 {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("k{i}")),
+                    make_row(b"v", 1000),
+                    1000,
+                )
+                .unwrap();
+        }
+        let results = engine
+            .read_token_range(&tid, i64::MIN, i64::MAX, 100)
+            .unwrap();
+        assert_eq!(results.len(), 7);
+    }
+
+    #[test]
+    fn read_token_range_honors_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        for i in 0..10 {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("k{i}")),
+                    make_row(b"v", 1000),
+                    1000,
+                )
+                .unwrap();
+        }
+        let results = engine
+            .read_token_range(&tid, i64::MIN, i64::MAX, 3)
+            .unwrap();
+        assert_eq!(results.len(), 3, "limit must cap the result count");
     }
 
     #[test]

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -1146,7 +1146,7 @@ impl<F: FlushTarget> TableStore<F> {
     /// token sub-range." The existing key-bounded read API can't answer
     /// that because partition keys hash to tokens; a contiguous token
     /// range is a discontiguous key range. This method materialises the
-    /// merged stream (capped at [`RANGE_READ_MATERIALIZATION_CAP`]) once
+    /// merged stream (capped at `RANGE_READ_MATERIALIZATION_CAP`) once
     /// and filters by token.
     ///
     /// Returns an empty vector when the range is empty (`start >= end`)

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -1139,6 +1139,45 @@ impl<F: FlushTarget> TableStore<F> {
         }))
     }
 
+    /// Read all partitions whose tokens fall in `[start_token, end_token)`,
+    /// up to `limit` matching partitions.
+    ///
+    /// Anti-entropy repair needs "every partition in this Merkle leaf's
+    /// token sub-range." The existing key-bounded read API can't answer
+    /// that because partition keys hash to tokens; a contiguous token
+    /// range is a discontiguous key range. This method materialises the
+    /// merged stream (capped at [`RANGE_READ_MATERIALIZATION_CAP`]) once
+    /// and filters by token.
+    ///
+    /// Returns an empty vector when the range is empty (`start >= end`)
+    /// or `limit == 0`. When the table holds more than the materialisation
+    /// cap, the result is best-effort: only partitions falling in the
+    /// cap-sized prefix-by-key are inspected. A token-streaming primitive
+    /// is the long-term fix; this is the unblock for repair-on-fmem-scale
+    /// tables (9 774 partitions, well under the cap).
+    pub fn read_token_range(
+        &self,
+        start_token: i64,
+        end_token: i64,
+        limit: usize,
+    ) -> Result<Vec<Partition>> {
+        if start_token >= end_token || limit == 0 {
+            return Ok(Vec::new());
+        }
+        // Pull the full materialisation up to the cap, then filter by
+        // token. We can request the cap directly because the underlying
+        // call rejects anything larger.
+        let all = self.read_range_limited_rows(None, None, RANGE_READ_MATERIALIZATION_CAP, 0)?;
+        Ok(all
+            .into_iter()
+            .filter(|p| {
+                let t = p.key.token.0;
+                t >= start_token && t < end_token
+            })
+            .take(limit)
+            .collect())
+    }
+
     pub fn read_range_limited_rows(
         &self,
         start: Option<&DecoratedKey>,


### PR DESCRIPTION
## Executive Summary

Adds `StorageEngine::read_token_range(table_id, start_token, end_token, limit)` — returns all partitions whose tokens fall in `[start, end)`, up to `limit`.

Anti-entropy repair (#47) needs to answer "give me everything in this Merkle leaf's token sub-range," but the existing `read_range` is **key-bounded**: partition keys hash to tokens via Murmur3, so a contiguous token range is a discontiguous key range. Without this primitive, repair sessions read the first N partitions by key, filter to a token sub-range, and almost always get zero hits → algorithm runs correctly on the wrong inputs → no convergence on the wire.

## Implementation

MVP that materialises the full table up to `RANGE_READ_MATERIALIZATION_CAP` (10 000 partitions), then filters by token. Correct for any table at or under the cap — which covers the fmem-scale validation target (entity_store has ~9.8k partitions).

```rust
pub fn read_token_range(
    &self,
    table_id: &TableId,
    start_token: i64,
    end_token: i64,
    limit: usize,
) -> ferrosa_common::Result<Vec<Partition>>
```

Returns empty for `start >= end`, `limit == 0`, or unknown table. Delegates to a new `TableStore::read_token_range` that internally reuses `read_range_limited_rows` with the cap as the underlying limit, then applies the token filter.

A follow-up commit will add a streaming variant that walks the merged-stream iterator and short-circuits at `>= end_token` — that's what real production scale (10M+ partitions per table) needs. This MVP unblocks end-to-end repair without that larger refactor.

## Tests (4 new)

| Test | Asserts |
|---|---|
| `read_token_range_filters_by_token_bounds` | 20 partitions written; assert exactly the partitions whose tokens fall in the chosen range are returned, none outside |
| `read_token_range_empty_range_returns_empty` | `start == end` → no partitions |
| `read_token_range_full_range_returns_everything` | `[i64::MIN, i64::MAX)` returns all written partitions |
| `read_token_range_honors_limit` | limit caps the result count |

## Verification

- 669 ferrosa-storage tests pass (was 665; +4 new)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Relationship to PR #47

Wire-up will happen in PR #47 (anti-entropy repair) — the repair-side code will switch from `read_range(None, None, N)` + filter to `read_token_range(start, end, N)`. That unblocks the fmem live-cluster validation.

## Test plan

- [ ] CI green
- [ ] Once #47 is rebased on top, run live `ferrosa-ctl repair --keyspace agent_memory --table entity_store` against the fmem cluster and verify per-node size convergence from 1346 / 383 / 207 MB toward roughly equal