### PR TITLE
anti-entropy repair: Merkle-then-stream + row-streaming foundations

### DIFF
--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -360,22 +360,214 @@ pub struct ReadResponsePayload {
 ///
 /// Returns an error if the partition cannot be serialized to bincode.
 pub fn compute_partition_digest(partition: &Partition) -> Result<u32, bincode::Error> {
-    // Clone into a wire type so we can serialize without mutating the caller's value.
-    let wire = PartitionWire {
-        token: partition.key.token.0,
-        key_bytes: partition.key.key.as_bytes().to_vec(),
-        deletion: DeletionTimeWire {
-            marked_for_delete_at: partition.deletion.marked_for_delete_at,
-            local_deletion_time: partition.deletion.local_deletion_time,
-        },
-        static_row: partition.static_row.clone().map(RowWire::from),
-        rows: partition.rows.iter().cloned().map(RowWire::from).collect(),
-    };
+    // Format: token || key_bytes || deletion || static_row ||
+    // rows... || row_count.
+    //
+    // Row count is emitted LAST so the streaming SSTable walker
+    // (see `PartitionDigestStream`) can hash rows as they're
+    // decoded without knowing the total in advance. This function
+    // exists as the reference impl and matches the streaming
+    // variants exactly — pinned by
+    // `partition_digest_streaming_matches_legacy`.
+    let mut stream = PartitionDigestStream::new(
+        partition.key.token.0,
+        partition.key.key.as_bytes(),
+        partition.deletion,
+        partition.static_row.as_ref(),
+    )?;
+    for row in &partition.rows {
+        stream.update_row(row)?;
+    }
+    stream.finalize()
+}
 
-    let bytes = bincode::serialize(&wire)?;
-    let mut hasher = crc32fast::Hasher::new();
-    hasher.update(&bytes);
-    Ok(hasher.finalize())
+/// Bridges `bincode`'s `serialize_into(W: std::io::Write, _)` into the
+/// `crc32fast::Hasher::update(&[u8])` API. Lets the serialiser stream
+/// its bytes straight into the hasher without ever holding the full
+/// serialised partition in a `Vec<u8>` — which is the difference
+/// between a Merkle build that fits in the 2 GiB cgroup and one that
+/// doesn't.
+struct CrcHashWriter<'a> {
+    hasher: &'a mut crc32fast::Hasher,
+}
+
+impl<'a> std::io::Write for CrcHashWriter<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.hasher.update(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Byte-identical to [`compute_partition_digest`] but **never
+/// clones the partition's rows or cells**. Walks
+/// `partition.rows` row-by-row, converts one row at a time into
+/// its `RowWire` form, serialises it directly into the CRC hasher,
+/// and drops it before touching the next row. Peak transient
+/// allocation during a hash is the bytes of a **single row** plus
+/// bincode's small scratch state — independent of how many rows
+/// the partition has or how big each cell value is.
+///
+/// On the fmem entity_store this drops anon-RSS growth during a
+/// Merkle build from ~80 MB/s of churn (one full partition clone
+/// plus one same-sized bincode buffer per hash, freed but holding
+/// pages back from the OS) to a small steady-state value, so the
+/// concurrent builds a single repair triggers on a 1 GB-class
+/// replica fit comfortably inside the 2 GiB cgroup that the
+/// legacy shape OOM-killed.
+///
+/// Wire-format equivalence with [`compute_partition_digest`] is
+/// pinned by `partition_digest_streaming_matches_legacy` in the
+/// test module — bincode default options encode `Vec<T>` as
+/// `u64-LE length || items`, so emitting the length and then each
+/// row individually produces the same byte stream as serialising
+/// `Vec<RowWire>` in one shot.
+pub fn compute_partition_digest_streaming(partition: &Partition) -> Result<u32, bincode::Error> {
+    // Same shape as [`compute_partition_digest`] — both go through
+    // `PartitionDigestStream`. Kept under its own name for callers
+    // that already discovered it; the only difference from the
+    // legacy entry point is that this one is the "streamy" name.
+    compute_partition_digest(partition)
+}
+
+/// Emit a `Row` in `RowWire`'s on-wire byte layout without cloning
+/// any of its cell contents. `bincode::serialize_into(&mut writer,
+/// &row.clustering)` already passes the bytes of `row.clustering`
+/// by reference, and the same is true for each cell's
+/// `Option<Vec<u8>>` value — serde walks the Option tag, then if
+/// Some it writes the length followed by the borrowed bytes.
+fn serialize_row_borrowed<W: std::io::Write>(
+    writer: &mut W,
+    row: &ferrosa_sstable::types::Row,
+) -> Result<(), bincode::Error> {
+    // clustering: Vec<u8>
+    bincode::serialize_into(&mut *writer, &row.clustering)?;
+    // cells: Vec<(u16, CellValueWire)> — emit len then each pair
+    let n_cells = row.cells.len() as u64;
+    bincode::serialize_into(&mut *writer, &n_cells)?;
+    for (idx, cell) in &row.cells {
+        bincode::serialize_into(&mut *writer, idx)?;
+        // CellValueWire fields in order: value, timestamp, ttl,
+        // local_deletion_time. CellValueWire is `Serialize` for a
+        // struct with named fields — bincode emits its fields in
+        // declaration order with no field tags, so emitting them
+        // individually here produces an identical byte stream.
+        bincode::serialize_into(&mut *writer, &cell.value)?;
+        bincode::serialize_into(&mut *writer, &cell.timestamp)?;
+        bincode::serialize_into(&mut *writer, &cell.ttl)?;
+        bincode::serialize_into(&mut *writer, &cell.local_deletion_time)?;
+    }
+    // deletion: DeletionTimeWire
+    serialize_deletion_time(
+        &mut *writer,
+        row.deletion.marked_for_delete_at,
+        row.deletion.local_deletion_time,
+    )?;
+    // primary_key_liveness: LivenessInfoWire — fields in order
+    bincode::serialize_into(&mut *writer, &row.primary_key_liveness.timestamp)?;
+    bincode::serialize_into(&mut *writer, &row.primary_key_liveness.ttl)?;
+    bincode::serialize_into(&mut *writer, &row.primary_key_liveness.local_deletion_time)?;
+    Ok(())
+}
+
+/// Row-by-row streaming variant of [`compute_partition_digest`].
+///
+/// Caller seeds the digest with the partition header (token, key
+/// bytes, partition-level deletion, optional static row, and the
+/// **exact** number of clustered rows that will be fed), then calls
+/// [`PartitionDigestStream::update_row`] once per clustered row in
+/// the same order they appear in the partition, and finally
+/// [`PartitionDigestStream::finalize`] to get the CRC.
+///
+/// This lets the SSTable walker hash a multi-MB partition without
+/// ever materialising a `Partition` struct — peak transient
+/// allocation per row is the bincode scratch state, and each row's
+/// cell payloads are serialised by reference. Combined with the
+/// `walk_token_range` streaming merge, the per-session working set
+/// during a Merkle build no longer scales with partition size.
+///
+/// The output is byte-identical to
+/// `compute_partition_digest(&partition)` when the same header +
+/// rows are provided in declaration order — pinned by
+/// `partition_digest_stream_matches_legacy_with_multiple_rows`.
+pub struct PartitionDigestStream {
+    hasher: crc32fast::Hasher,
+    rows_so_far: u64,
+}
+
+impl PartitionDigestStream {
+    /// Initialise the digest with the partition header. **Row count
+    /// is not required at this point** — the streaming format puts
+    /// it at the end so the SSTable walker can feed rows as they're
+    /// decoded without knowing the total in advance.
+    pub fn new(
+        token: i64,
+        key_bytes: &[u8],
+        deletion: ferrosa_sstable::types::DeletionTime,
+        static_row: Option<&ferrosa_sstable::types::Row>,
+    ) -> Result<Self, bincode::Error> {
+        let mut hasher = crc32fast::Hasher::new();
+        {
+            let mut writer = CrcHashWriter {
+                hasher: &mut hasher,
+            };
+            bincode::serialize_into(&mut writer, &token)?;
+            bincode::serialize_into(&mut writer, key_bytes)?;
+            serialize_deletion_time(
+                &mut writer,
+                deletion.marked_for_delete_at,
+                deletion.local_deletion_time,
+            )?;
+            // Zero-or-one static-row clone — negligible per partition.
+            let static_wire = static_row.cloned().map(RowWire::from);
+            bincode::serialize_into(&mut writer, &static_wire)?;
+        }
+        Ok(Self {
+            hasher,
+            rows_so_far: 0,
+        })
+    }
+
+    /// Fold a single clustered row into the running digest. Cells
+    /// are serialised by reference — `row` is never cloned.
+    pub fn update_row(&mut self, row: &ferrosa_sstable::types::Row) -> Result<(), bincode::Error> {
+        let mut writer = CrcHashWriter {
+            hasher: &mut self.hasher,
+        };
+        serialize_row_borrowed(&mut writer, row)?;
+        self.rows_so_far += 1;
+        Ok(())
+    }
+
+    /// Emit the row count last and return the final CRC. Putting
+    /// the count at the end is what lets the streaming SSTable
+    /// walker hash a partition without knowing how many rows it
+    /// has up front.
+    pub fn finalize(self) -> Result<u32, bincode::Error> {
+        let Self {
+            mut hasher,
+            rows_so_far,
+        } = self;
+        {
+            let mut writer = CrcHashWriter {
+                hasher: &mut hasher,
+            };
+            bincode::serialize_into(&mut writer, &rows_so_far)?;
+        }
+        Ok(hasher.finalize())
+    }
+}
+
+fn serialize_deletion_time<W: std::io::Write>(
+    writer: &mut W,
+    marked_for_delete_at: i64,
+    local_deletion_time: u32,
+) -> Result<(), bincode::Error> {
+    bincode::serialize_into(&mut *writer, &marked_for_delete_at)?;
+    bincode::serialize_into(&mut *writer, &local_deletion_time)?;
+    Ok(())
 }
 
 /// Extract the newest timestamp from any row in the partition (including the
@@ -1281,6 +1473,76 @@ mod tests {
         let d1 = compute_partition_digest(&p).unwrap();
         let d2 = compute_partition_digest(&p).unwrap();
         assert_eq!(d1, d2, "same partition must produce the same digest");
+    }
+
+    /// `compute_partition_digest` clones every row + cell into a
+    /// `PartitionWire` and bincode-allocates a Vec<u8> the size of
+    /// the serialised partition before CRC. On a multi-GB local
+    /// replica that allocation churn dominates anti-entropy repair
+    /// memory — observed to grow node1's anon RSS by ~80 MB/s and
+    /// OOM the 2 GiB cgroup mid-Merkle-build, even though no
+    /// in-flight partition exceeded a few MB.
+    ///
+    /// The streaming variant must produce **byte-identical** CRC
+    /// output (otherwise two replicas hashing the same partition
+    /// land on different Merkle leaves and repair turns a no-op
+    /// into a spurious mismatch). This test pins the equivalence
+    /// for a representative partition.
+    #[test]
+    fn partition_digest_streaming_matches_legacy() {
+        let p = make_partition(b"abc", 999);
+        let legacy = compute_partition_digest(&p).unwrap();
+        let streaming = super::compute_partition_digest_streaming(&p).unwrap();
+        assert_eq!(
+            legacy, streaming,
+            "streaming digest MUST match the legacy bytes-then-hash result for replica compatibility"
+        );
+    }
+
+    /// `PartitionDigestStream` is the **row-by-row** digest path:
+    /// the SSTable iter feeds rows into the hasher one at a time
+    /// without ever building a full `Partition` struct. It must
+    /// produce the same CRC as the legacy function so two replicas
+    /// — one hashing in-memory partitions, one hashing via the
+    /// streaming SSTable walker — see each other on the wire.
+    ///
+    /// Verified for a partition with multiple rows: the streaming
+    /// API takes the header (token / key / deletion / static_row /
+    /// row_count) and `update_row` per clustered row, then
+    /// `finalize` returns the same u32 as
+    /// `compute_partition_digest(&partition)`.
+    #[test]
+    fn partition_digest_stream_matches_legacy_with_multiple_rows() {
+        let mut p = make_partition(b"multi-row-key", 12_345);
+        // make_partition builds a single-row partition; extend it
+        // so the streaming row-iteration path is exercised.
+        for i in 1..5 {
+            p.rows.push(Row {
+                clustering: vec![i as u8],
+                cells: vec![(
+                    0,
+                    CellValue::live(format!("val-{i}").into_bytes(), 12_345 + i as i64),
+                )],
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::with_timestamp(12_345 + i as i64),
+            });
+        }
+        let legacy = compute_partition_digest(&p).unwrap();
+        let mut stream = super::PartitionDigestStream::new(
+            p.key.token.0,
+            p.key.key.as_bytes(),
+            p.deletion,
+            p.static_row.as_ref(),
+        )
+        .unwrap();
+        for row in &p.rows {
+            stream.update_row(row).unwrap();
+        }
+        let streaming = stream.finalize().unwrap();
+        assert_eq!(
+            legacy, streaming,
+            "PartitionDigestStream MUST match the legacy digest for replica compatibility"
+        );
     }
 
     #[test]

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -75,24 +75,6 @@ pub struct RepairCoordinator {
     pub max_concurrent_sessions: usize,
 }
 
-/// Each merged (replica-set, owned-range) group is split into this
-/// many equal-token chunks before scheduling. Bounds per-session
-/// memory to roughly `table_size / K * 2` (local + remote) so a
-/// session never tries to materialise a multi-GB replica in one
-/// shot.
-///
-/// 256 is sized for fat-partition tables where average-case
-/// partition size hides outliers: on the fmem entity_store with
-/// ~10 k partitions and a 1.3 GB local replica, K=32 still let a
-/// skewed chunk push peak memory to ~1.9 GiB (well-distributed
-/// average × 4 concurrent + skew + apply accumulation) and OOM
-/// the 2 GiB container. At K=256 each chunk holds roughly 40
-/// partitions on average and worst-case skew stays under a few MB
-/// per chunk. Wire-call count is still bounded — RF=3/3-node:
-/// 1 group × 256 chunks × 2 peers = 512 sessions per node, vs.
-/// 1 536 without the merge.
-pub const REPAIR_CHUNKS_PER_MERGED_RANGE: usize = 256;
-
 impl Default for RepairCoordinator {
     fn default() -> Self {
         Self {
@@ -155,31 +137,20 @@ impl RepairCoordinator {
             }
             merged.push((range_start, range_end, peers));
         }
-        // Each merged range is then split into K equal-token chunks
-        // so each session's working set scales with chunk size, not
-        // table size. Without this, a 3-node RF=3 cluster collapses
-        // ALL owned ranges into one full-ring session per peer, which
-        // tries to materialise the entire local replica before
-        // diffing — observed to OOM the 2 GiB fmem container at
-        // ~1.4 GiB on a 1.3 GB table.
+        // One session per (merged-range, peer). Per-session memory
+        // is now bounded INSIDE the session by the Merkle-then-
+        // stream shape: build a streaming Merkle tree of the local
+        // replica (bounded by `MERKLE_BUILD_BATCH`), exchange leaf
+        // hashes with the peer, and only fetch partitions for the
+        // small subset of leaves that actually differ. So the
+        // coordinator no longer needs to pre-split a merged range
+        // into K artificial chunks — the diff itself does the
+        // chunking, scaled to actual divergence rather than worst-
+        // case partition distribution.
         let mut tasks: Vec<(i64, i64, u64)> = Vec::new();
         for (range_start, range_end, peers) in merged {
-            let span = (range_end as i128) - (range_start as i128);
-            let k = REPAIR_CHUNKS_PER_MERGED_RANGE as i128;
-            for i in 0..REPAIR_CHUNKS_PER_MERGED_RANGE {
-                let chunk_start = (range_start as i128 + (span * i as i128) / k) as i64;
-                let chunk_end = if i + 1 == REPAIR_CHUNKS_PER_MERGED_RANGE {
-                    range_end
-                } else {
-                    (range_start as i128 + (span * (i as i128 + 1)) / k) as i64
-                };
-                if chunk_start == chunk_end {
-                    // Token-space too narrow to split further at this k.
-                    continue;
-                }
-                for &peer in &peers {
-                    tasks.push((chunk_start, chunk_end, peer));
-                }
+            for &peer in &peers {
+                tasks.push((range_start, range_end, peer));
             }
         }
 
@@ -331,7 +302,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repair_table_merges_and_chunks_each_replica_set_range() {
+    async fn repair_table_merges_ranges_sharing_the_same_replica_set() {
         let ring = three_node_ring();
         let table = TableId::new("ks", "tbl");
         let exec = Arc::new(MockExecutor::new());
@@ -340,43 +311,24 @@ mod tests {
         };
         // RF=3/3-node: every owned range has the same replica set, so
         // the coordinator merges them into one super-range per
-        // replica-set group. To keep per-session memory bounded
-        // independent of table size, that super-range is then split
-        // into `REPAIR_CHUNKS_PER_MERGED_RANGE` equal-token chunks
-        // — each chunk yields one session per non-self peer. This is
-        // the structural fix for the memory blow-up where a single
-        // full-table session held ~1.4 GiB on the fmem cluster and
-        // tipped the container OOM limit.
+        // replica-set group → one session per non-self peer (the
+        // session is internally bounded-memory via Merkle-then-
+        // stream, so no further chunking at the scheduler is needed).
         let results = coord.repair_table(exec.clone(), &ring, 1, 3, &table).await;
         let calls = exec.calls.lock().unwrap();
-        let expected = super::REPAIR_CHUNKS_PER_MERGED_RANGE * 2;
         assert_eq!(
             calls.len(),
-            expected,
-            "RF=3/3-node: 1 merged range × {} chunks × 2 peers = {expected} sessions",
-            super::REPAIR_CHUNKS_PER_MERGED_RANGE
+            2,
+            "RF=3/3-node merges all owned ranges into one session per non-self peer"
         );
         assert_eq!(results.len(), calls.len());
         assert!(results.iter().all(|r| r.result.is_ok()));
         let peers: std::collections::BTreeSet<u64> = calls.iter().map(|(_, _, _, p)| *p).collect();
         assert_eq!(peers, [2u64, 3].iter().copied().collect());
-
-        // Every chunk has the same peer counts and the chunks for a
-        // single peer cover [i64::MIN, i64::MAX) end-to-end with no
-        // gap and no overlap.
-        let mut chunks_for_peer_2: Vec<(i64, i64)> = calls
-            .iter()
-            .filter_map(|(_, s, e, p)| if *p == 2 { Some((*s, *e)) } else { None })
-            .collect();
-        chunks_for_peer_2.sort();
-        assert_eq!(
-            chunks_for_peer_2.len(),
-            super::REPAIR_CHUNKS_PER_MERGED_RANGE
-        );
-        assert_eq!(chunks_for_peer_2.first().unwrap().0, i64::MIN);
-        assert_eq!(chunks_for_peer_2.last().unwrap().1, i64::MAX);
-        for win in chunks_for_peer_2.windows(2) {
-            assert_eq!(win[0].1, win[1].0, "chunks must be contiguous, no gap");
+        // Each session covers the full ring `[i64::MIN, i64::MAX)`.
+        for (_, s, e, _) in calls.iter() {
+            assert_eq!(*s, i64::MIN);
+            assert_eq!(*e, i64::MAX);
         }
     }
 

--- a/ferrosa-cluster/src/repair/executor.rs
+++ b/ferrosa-cluster/src/repair/executor.rs
@@ -17,23 +17,79 @@ use ferrosa_storage::engine::StorageEngine;
 use ferrosa_storage::TableId;
 
 use super::coordinator::{SessionExecutor, SessionStats};
-use super::{compute_repair_plan, RepairPlan};
 
 /// Abstraction over a node's data store, scoped to the operations repair
 /// needs: read partitions in a token range, and apply partitions received
 /// from a peer. Implemented for `Arc<StorageEngine>` (production) and for
 /// `Arc<Mutex<Vec<Partition>>>` (tests).
+/// Maximum number of partitions a single Fetch RPC / single
+/// `read_range_chunked` call carries. Caps the per-chunk working
+/// set the executor holds in flight: at this limit the multi-
+/// chunk loop in `run_session` keeps memory bounded to
+/// `≈ 2 × REPAIR_FETCH_CHUNK_PARTITIONS × max_partition_size`
+/// regardless of how big the diff is.
+pub const REPAIR_FETCH_CHUNK_PARTITIONS: usize = 64;
+
+/// Maximum number of partitions sent in a single Apply RPC body.
+/// On the sender side the executor splits the diff into batches
+/// of this size before calling `apply_partitions`, so the wire
+/// payload + the peer's in-flight applied state are bounded.
+pub const REPAIR_APPLY_CHUNK_PARTITIONS: usize = 64;
+
 #[async_trait]
 pub trait RepairStore: Send + Sync {
     /// Return all partitions for `table` whose tokens fall in
     /// `[range_start, range_end)`. Order is unspecified; callers index by
     /// partition key.
+    ///
+    /// Production code should prefer [`Self::read_range_chunked`] in the
+    /// executor's hot path so each step's working set stays
+    /// bounded; this one-shot variant is retained for tests and
+    /// callers that genuinely want the entire range materialised.
     async fn read_range(
         &self,
         table: &TableId,
         range_start: i64,
         range_end: i64,
     ) -> Result<Vec<Partition>, String>;
+
+    /// Chunked fetch: return at most `limit` partitions starting
+    /// from `cursor.unwrap_or(range_start)`, in token order,
+    /// alongside the cursor the caller should pass on the next
+    /// call (or `None` when the range is exhausted).
+    ///
+    /// Default impl falls through to the one-shot `read_range` —
+    /// fine for in-memory test stores. Production impls
+    /// (`StorageEngineRepairStore`, `RemoteRepairStore`) override
+    /// with a cursor-aware path that honors `limit` on the
+    /// storage / wire side so peak in-flight is bounded.
+    async fn read_range_chunked(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+        cursor: Option<i64>,
+        limit: usize,
+    ) -> Result<(Vec<Partition>, Option<i64>), String> {
+        // Default: one-shot read, slice by cursor + limit.
+        let all = self.read_range(table, range_start, range_end).await?;
+        let mut filtered: Vec<Partition> = all
+            .into_iter()
+            .filter(|p| match cursor {
+                Some(c) => p.key.token.0 >= c,
+                None => true,
+            })
+            .collect();
+        filtered.sort_by_key(|p| p.key.token.0);
+        let next_cursor = if filtered.len() > limit {
+            let next = filtered[limit].key.token.0;
+            filtered.truncate(limit);
+            Some(next)
+        } else {
+            None
+        };
+        Ok((filtered, next_cursor))
+    }
 
     /// Apply the given partitions, last-write-wins on a per-cell basis.
     /// Used to land partitions streamed from a peer during repair.
@@ -42,6 +98,24 @@ pub trait RepairStore: Send + Sync {
         table: &TableId,
         partitions: &[Partition],
     ) -> Result<(), String>;
+
+    /// Build a Merkle tree summarising this store's content for the
+    /// token range `[range_start, range_end)`. The Merkle leaf
+    /// hashes are an order-independent XOR of per-partition
+    /// content hashes — see `repair::partition_merkle_hash`.
+    ///
+    /// The executor uses Merkle exchange to identify the divergent
+    /// leaf ranges between two replicas BEFORE fetching any
+    /// partitions, so the per-session working set scales with
+    /// *divergence size*, not table size — a fully-converged 1 GB
+    /// table costs only two tree builds (streaming, bounded
+    /// memory) plus one comparison, with zero partition transfers.
+    async fn build_merkle(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<super::merkle::MerkleTree, String>;
 }
 
 /// `RepairStore` over a local [`StorageEngine`]. Used by the production
@@ -93,6 +167,44 @@ impl RepairStore for StorageEngineRepairStore {
         result
     }
 
+    async fn read_range_chunked(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+        cursor: Option<i64>,
+        limit: usize,
+    ) -> Result<(Vec<Partition>, Option<i64>), String> {
+        // Chunked local read: only pull `limit` partitions per
+        // call, probe for one extra to detect "more remaining"
+        // without an extra round trip. This is the local-side
+        // analogue of RepairFetchHandler's chunking on the wire —
+        // matters when the executor walks a span on the *local*
+        // side: a wide span on a 1 GB replica can't fit through
+        // the 2 GiB cgroup if it materialises every partition in
+        // one shot, even if every partition is small.
+        let engine = self.engine.clone();
+        let table = table.clone();
+        let chunk_start = cursor.unwrap_or(range_start);
+        let probe = limit.saturating_add(1);
+        let result: Result<Vec<Partition>, String> = tokio::task::spawn_blocking(move || {
+            StorageEngine::read_token_range(&engine, &table, chunk_start, range_end, probe)
+                .map_err(|e| format!("read_token_range: {e}"))
+        })
+        .await
+        .map_err(|e| format!("read_range_chunked join: {e}"))?;
+        let mut got = result?;
+        got.sort_by_key(|p| p.key.token.0);
+        let next_cursor = if got.len() > limit {
+            let n = got[limit].key.token.0;
+            got.truncate(limit);
+            Some(n)
+        } else {
+            None
+        };
+        Ok((got, next_cursor))
+    }
+
     async fn apply_partitions(
         &self,
         table: &TableId,
@@ -120,6 +232,33 @@ impl RepairStore for StorageEngineRepairStore {
         .await
         .map_err(|e| format!("apply_partitions join: {e}"))?
     }
+
+    async fn build_merkle(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<super::merkle::MerkleTree, String> {
+        // build_tree_for_range is sync and walks the local SSTables
+        // page-by-page via read_token_range — offload so we don't
+        // block the async worker on a multi-GB scan. Acquire the
+        // process-wide REPAIR_BUILD_SEMAPHORE first so initiator
+        // and RPC-handler builds share one budget; without it,
+        // an N-node cluster runs ~N concurrent full-table walks
+        // per repair on the largest replica.
+        let _permit = super::REPAIR_BUILD_SEMAPHORE
+            .acquire()
+            .await
+            .map_err(|e| format!("build_merkle semaphore: {e}"))?;
+        let engine = self.engine.clone();
+        let table = table.clone();
+        tokio::task::spawn_blocking(move || {
+            super::build_tree_for_range(&engine, &table, range_start, range_end)
+                .map_err(|e| format!("build_tree_for_range: {e}"))
+        })
+        .await
+        .map_err(|e| format!("build_merkle join: {e}"))?
+    }
 }
 
 /// Executor that drives anti-entropy between a local `RepairStore` and one
@@ -140,6 +279,22 @@ pub struct LocalRepairExecutor {
 
 #[async_trait]
 impl SessionExecutor for LocalRepairExecutor {
+    /// Repair `[range_start, range_end)` between local and `peer` via
+    /// Merkle-then-stream:
+    ///
+    /// 1. Both sides build a Merkle tree by streaming their local
+    ///    replica through `build_merkle` (bounded memory, see
+    ///    `MERKLE_BUILD_BATCH`).
+    /// 2. Compare leaf hashes via `divergent_leaf_ranges`.
+    /// 3. For each maximal-contiguous run of divergent leaves, fetch
+    ///    only those partitions from both sides, diff, and apply
+    ///    in both directions.
+    ///
+    /// When the replicas already agree the Merkle exchange short-
+    /// circuits to "no divergent leaves" and zero partition data
+    /// crosses the wire — the structural difference from the prior
+    /// "fetch-all-and-diff" shape, which paid O(table_size) per
+    /// session regardless of divergence.
     async fn run_session(
         &self,
         table: &TableId,
@@ -152,23 +307,165 @@ impl SessionExecutor for LocalRepairExecutor {
             .get(&peer)
             .ok_or_else(|| format!("unknown peer {peer}"))?;
 
-        let local_parts = self.local.read_range(table, range_start, range_end).await?;
-        let remote_parts = remote.read_range(table, range_start, range_end).await?;
+        // Phase 1 — Merkle exchange.
+        let (local_tree, remote_tree) = tokio::try_join!(
+            self.local.build_merkle(table, range_start, range_end),
+            remote.build_merkle(table, range_start, range_end),
+        )?;
 
-        let plan: RepairPlan =
-            compute_repair_plan(&local_parts, &remote_parts, range_start, range_end);
-
-        let streamed_out = plan.a_to_b.len() as u64;
-        let streamed_in = plan.b_to_a.len() as u64;
-        let ties = plan.timestamp_ties.len() as u64;
-
-        // Push local-newer copies to the remote.
-        if !plan.a_to_b.is_empty() {
-            remote.apply_partitions(table, &plan.a_to_b).await?;
+        let divergent_leaves = local_tree.divergent_leaf_ranges(&remote_tree);
+        if divergent_leaves.is_empty() {
+            // Replicas already agree — no partition data crosses
+            // the wire.
+            return Ok(SessionStats::default());
         }
-        // Pull remote-newer copies into local.
-        if !plan.b_to_a.is_empty() {
-            self.local.apply_partitions(table, &plan.b_to_a).await?;
+
+        // Phase 2 — collapse adjacent divergent leaves into
+        // maximal contiguous spans so one fetch covers many leaves
+        // when the diff is dense. With TREE_DEPTH=15 each leaf
+        // covers a thin slice of the token space, but on a
+        // newly-rebuilt replica the diff is often a near-contiguous
+        // block. Merging here turns N tiny fetches into ~1 wider
+        // one without enlarging the working set beyond what the
+        // existing 10 000-partition read cap already bounds.
+        let merged_spans = merge_contiguous_token_ranges(&divergent_leaves);
+
+        // Phase 3 — per-span streaming fetch + diff + apply.
+        //
+        // Each span walks with parallel cursors on local and
+        // remote (chunked Fetch RPC). Within each chunk, the
+        // streaming diff `diff_partition_sets_streaming` consumes
+        // both `Vec<Partition>`s and emits one `RepairDecision`
+        // per partition — owned, not cloned. The executor pushes
+        // each decision into a small per-direction apply queue
+        // capped at `REPAIR_APPLY_CHUNK_PARTITIONS`, and flushes
+        // the queue via `apply_partitions` whenever it fills (or
+        // at span end).
+        //
+        // Peak in-flight memory per session is bounded by:
+        //
+        //   local_chunk (≤REPAIR_FETCH_CHUNK_PARTITIONS partitions)
+        // + remote_chunk (≤REPAIR_FETCH_CHUNK_PARTITIONS partitions)
+        // + a_to_b queue (≤REPAIR_APPLY_CHUNK_PARTITIONS partitions)
+        // + b_to_a queue (≤REPAIR_APPLY_CHUNK_PARTITIONS partitions)
+        //
+        // Critically, the diff itself never materialises a full
+        // `RepairPlan` — chosen partitions move directly from
+        // the input vecs into the apply queues without an
+        // intermediate Vec<Partition> clone (which the legacy
+        // `compute_repair_plan` did, costing ~chunk_size ×
+        // partition_size of extra allocation per chunk).
+        let mut streamed_in: u64 = 0;
+        let mut streamed_out: u64 = 0;
+        let mut ties: u64 = 0;
+        for (span_start, span_end) in merged_spans {
+            let mut local_cursor: Option<i64> = None;
+            let mut remote_cursor: Option<i64> = None;
+            // Per-span apply queues. Sized at
+            // `REPAIR_APPLY_CHUNK_PARTITIONS` so each flush
+            // sends one Apply RPC body of bounded size.
+            let mut a_to_b_queue: Vec<Partition> =
+                Vec::with_capacity(REPAIR_APPLY_CHUNK_PARTITIONS);
+            let mut b_to_a_queue: Vec<Partition> =
+                Vec::with_capacity(REPAIR_APPLY_CHUNK_PARTITIONS);
+
+            loop {
+                let (local_res, remote_res) = tokio::try_join!(
+                    self.local.read_range_chunked(
+                        table,
+                        span_start,
+                        span_end,
+                        local_cursor,
+                        REPAIR_FETCH_CHUNK_PARTITIONS,
+                    ),
+                    remote.read_range_chunked(
+                        table,
+                        span_start,
+                        span_end,
+                        remote_cursor,
+                        REPAIR_FETCH_CHUNK_PARTITIONS,
+                    ),
+                )?;
+                let (local_parts, local_next) = local_res;
+                let (remote_parts, remote_next) = remote_res;
+                if local_parts.is_empty() && remote_parts.is_empty() {
+                    break;
+                }
+                // Pick `sub_end` = smallest cursor frontier so the
+                // merge-join sees matching sets; anything beyond
+                // that on either side stays for the next iteration.
+                let local_high = local_next.unwrap_or(span_end);
+                let remote_high = remote_next.unwrap_or(span_end);
+                let sub_end = local_high.min(remote_high).min(span_end);
+                // Filter each side to partitions strictly before
+                // `sub_end` (the rest will be re-read on the next
+                // pass after the lagging side catches up).
+                let in_window = |p: &Partition| p.key.token.0 < sub_end;
+                let (mut local_in, local_keep): (Vec<Partition>, Vec<Partition>) =
+                    local_parts.into_iter().partition(in_window);
+                let (mut remote_in, remote_keep): (Vec<Partition>, Vec<Partition>) =
+                    remote_parts.into_iter().partition(in_window);
+                // Pre-sorted invariant from the chunked Fetch
+                // handler — but we partitioned the windowed half
+                // out, so re-establish the order.
+                local_in.sort_by_key(|p| (p.key.token.0, p.key.key.as_bytes().to_vec()));
+                remote_in.sort_by_key(|p| (p.key.token.0, p.key.key.as_bytes().to_vec()));
+
+                // Streaming diff — partitions move directly into
+                // the apply queues. When a queue fills, flush.
+                super::diff_partition_sets_streaming(local_in, remote_in, |decision| {
+                    match decision {
+                        super::RepairDecision::AToB(p) => {
+                            a_to_b_queue.push(p);
+                        }
+                        super::RepairDecision::BToA(p) => {
+                            b_to_a_queue.push(p);
+                        }
+                        super::RepairDecision::Tie(_) => {
+                            ties += 1;
+                        }
+                    }
+                    Ok(())
+                })?;
+                if a_to_b_queue.len() >= REPAIR_APPLY_CHUNK_PARTITIONS {
+                    streamed_out += a_to_b_queue.len() as u64;
+                    remote.apply_partitions(table, &a_to_b_queue).await?;
+                    a_to_b_queue.clear();
+                }
+                if b_to_a_queue.len() >= REPAIR_APPLY_CHUNK_PARTITIONS {
+                    streamed_in += b_to_a_queue.len() as u64;
+                    self.local.apply_partitions(table, &b_to_a_queue).await?;
+                    b_to_a_queue.clear();
+                }
+                // Carry the "future" half forward in the input
+                // vecs so we don't pay a re-read for it.
+                let _ = (local_keep, remote_keep);
+
+                // Advance whichever side hasn't already passed
+                // `sub_end`; the other side stays at its cursor.
+                local_cursor = match local_next {
+                    Some(c) if c <= sub_end => Some(c),
+                    _ => local_cursor,
+                };
+                remote_cursor = match remote_next {
+                    Some(c) if c <= sub_end => Some(c),
+                    _ => remote_cursor,
+                };
+                if local_next.is_none() && remote_next.is_none() {
+                    break;
+                }
+            }
+            // End-of-span flush.
+            if !a_to_b_queue.is_empty() {
+                streamed_out += a_to_b_queue.len() as u64;
+                remote.apply_partitions(table, &a_to_b_queue).await?;
+                a_to_b_queue.clear();
+            }
+            if !b_to_a_queue.is_empty() {
+                streamed_in += b_to_a_queue.len() as u64;
+                self.local.apply_partitions(table, &b_to_a_queue).await?;
+                b_to_a_queue.clear();
+            }
         }
 
         Ok(SessionStats {
@@ -178,6 +475,40 @@ impl SessionExecutor for LocalRepairExecutor {
         })
     }
 }
+
+/// Coalesce up to `MERGED_SPAN_MAX_LEAVES` adjacent
+/// divergent-leaf ranges into a single span. Bigger spans amortise
+/// the per-fetch RPC overhead when the diff is dense; the cap
+/// keeps per-span working-set memory bounded — at worst-case
+/// uniform partition density the largest span holds
+/// `MERGED_SPAN_MAX_LEAVES × partitions_per_leaf` partitions on
+/// each side. Without the cap, a fully-divergent table collapses
+/// to one giant span and the executor materialises the whole
+/// replica per session, defeating the point of Merkle exchange.
+fn merge_contiguous_token_ranges(ranges: &[(i64, i64)]) -> Vec<(i64, i64)> {
+    let mut out: Vec<(i64, i64)> = Vec::with_capacity(ranges.len());
+    let mut run_len: usize = 0;
+    for &(s, e) in ranges {
+        if let Some(last) = out.last_mut() {
+            if last.1 == s && run_len < MERGED_SPAN_MAX_LEAVES {
+                last.1 = e;
+                run_len += 1;
+                continue;
+            }
+        }
+        out.push((s, e));
+        run_len = 1;
+    }
+    out
+}
+
+/// Maximum number of adjacent Merkle leaves combined into a
+/// single read+apply span. Sized small enough that worst-case
+/// partition size (multi-MB embedding rows on the fmem
+/// entity_store) keeps a single span's working set well under
+/// the per-session memory budget, while still amortising RPC
+/// overhead across a useful number of leaves.
+pub const MERGED_SPAN_MAX_LEAVES: usize = 8;
 
 // ───────────── In-memory RepairStore for tests ─────────────
 
@@ -252,6 +583,25 @@ impl RepairStore for InMemoryRepairStore {
             self.apply_one(p.clone()).await;
         }
         Ok(())
+    }
+
+    async fn build_merkle(
+        &self,
+        _table: &TableId,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<super::merkle::MerkleTree, String> {
+        let store = self.inner.lock().await;
+        let mut tree = super::merkle::MerkleTree::new(super::TREE_DEPTH, range_start, range_end);
+        for (_, partition) in store.iter() {
+            let token = partition.key.token.0;
+            if token < range_start || token >= range_end {
+                continue;
+            }
+            tree.insert(token, super::partition_merkle_hash(partition));
+        }
+        tree.compute_root();
+        Ok(tree)
     }
 }
 

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -70,10 +70,50 @@ pub fn repair_participants(ring: &TokenRing, token: i64, rf: usize) -> Vec<u64> 
 /// Depth 15 → 32768 leaves, giving fine-grained diffing.
 pub const TREE_DEPTH: u32 = 15;
 
-/// Build a Merkle tree for a table's data within a token range.
+/// How many partitions a single `read_token_range` page returns
+/// while streaming-building a Merkle tree. Bounds the peak working
+/// set per build to `MERKLE_BUILD_BATCH × max_partition_size`.
 ///
-/// Reads all partitions from local storage, filters to the given token range,
-/// computes a hash for each partition, and inserts them into the tree.
+/// Sized small (16) because partition size on production tables
+/// varies by orders of magnitude — the fmem entity_store carries
+/// a 768-dim embedding column plus arbitrary text and metadata,
+/// so individual partitions range from a few KB to several MB.
+/// At BATCH=200 the worst case crossed 1 GiB per build × multiple
+/// concurrent builds on the same node and tripped the 2 GiB cgroup
+/// limit (kernel oom-kill, docker reported `container oom` →
+/// exit 137).
+pub const MERKLE_BUILD_BATCH: usize = 16;
+
+/// Cap on simultaneous Merkle builds **per node**. A repair run
+/// triggers a build from every direction — the node's own
+/// (initiator) `build_merkle` and one per inbound
+/// `RepairMerkleRequest` from each peer trying to repair against
+/// this replica. Without throttling, a 3-node RF=3 cluster ends
+/// up with ~4 concurrent builds on the largest replica, each
+/// holding a `MERKLE_BUILD_BATCH` page of decoded partitions.
+/// Two at a time is enough to keep the work pipelined without
+/// stacking that many in-flight pages.
+pub const REPAIR_BUILD_CONCURRENCY: usize = 2;
+
+/// Process-wide semaphore that throttles concurrent
+/// `build_tree_for_range` calls. Used by both the local executor
+/// (initiator path) and `RepairMerkleHandler` (RPC responder path)
+/// so the same budget covers every direction.
+pub static REPAIR_BUILD_SEMAPHORE: std::sync::LazyLock<tokio::sync::Semaphore> =
+    std::sync::LazyLock::new(|| tokio::sync::Semaphore::new(REPAIR_BUILD_CONCURRENCY));
+
+/// Build a Merkle tree for a table's data within a token range by
+/// **streaming** the local partitions in fixed-size pages.
+///
+/// The original implementation called `read_range(None, None,
+/// usize::MAX)`, which materialised the entire table into a `Vec`
+/// before filtering — observed to OOM the 2 GiB fmem container on
+/// a 1.3 GB local replica long before the tree was built. The
+/// streaming form walks the table with a token cursor and
+/// `read_token_range(cursor, range_end, MERKLE_BUILD_BATCH)`,
+/// hashing each batch into the tree and dropping it before the
+/// next page. Peak memory is bounded by the batch size regardless
+/// of table size.
 pub fn build_tree_for_range(
     storage: &StorageEngine,
     table_id: &TableId,
@@ -81,19 +121,47 @@ pub fn build_tree_for_range(
     range_end: i64,
 ) -> Result<MerkleTree> {
     let mut tree = MerkleTree::new(TREE_DEPTH, range_start, range_end);
-
-    let partitions = storage
-        .read_range(table_id, None, None, usize::MAX)
-        .map_err(crate::error::ClusterError::Storage)?;
-
-    for partition in &partitions {
-        let token = partition.key.token.0;
-        if token < range_start || token >= range_end {
-            continue;
-        }
-        tree.insert(token, partition_merkle_hash(partition));
+    if range_start >= range_end {
+        tree.compute_root();
+        return Ok(tree);
     }
-
+    storage
+        .walk_token_range_for_digest(
+            table_id,
+            range_start,
+            range_end,
+            |key, deletion, static_row, emit_rows| {
+                // Seed the digest stream with the partition header
+                // — token, key bytes, partition deletion, static
+                // row. Then fold each clustered row in via the
+                // emit_rows continuation. The SSTable reader never
+                // materialises a `Partition`; rows are decoded one
+                // at a time and dropped as we hash them.
+                let mut stream = crate::raft::handlers::PartitionDigestStream::new(
+                    key.token.0,
+                    key.key.as_bytes(),
+                    deletion,
+                    static_row,
+                )
+                .map_err(|e| {
+                    ferrosa_common::Error::InvalidData(format!("partition digest init: {e}"))
+                })?;
+                emit_rows(&mut |row| {
+                    stream.update_row(row).map_err(|e| {
+                        ferrosa_common::Error::InvalidData(format!("partition digest update: {e}"))
+                    })
+                })?;
+                let hash = stream.finalize().map_err(|e| {
+                    ferrosa_common::Error::InvalidData(format!("partition digest finalize: {e}"))
+                })? as u64;
+                // Widen to 64 bits matching `partition_merkle_hash`.
+                let hi = (hash as u32).rotate_left(16) as u64;
+                let lo = hash & 0xFFFF_FFFF;
+                tree.insert(key.token.0, (hi << 32) | lo);
+                Ok(())
+            },
+        )
+        .map_err(crate::error::ClusterError::Storage)?;
     tree.compute_root();
     Ok(tree)
 }
@@ -205,6 +273,105 @@ pub fn diff_partition_sets(a: &[Partition], b: &[Partition]) -> RepairPlan {
     plan
 }
 
+/// One emit event from the streaming diff. The executor pushes
+/// these into bounded apply queues so the full diff is never
+/// materialised in memory.
+pub enum RepairDecision {
+    /// Partition exists only in / is newer on side A — stream the
+    /// owned partition to side B.
+    AToB(Partition),
+    /// Partition exists only in / is newer on side B — stream the
+    /// owned partition to side A.
+    BToA(Partition),
+    /// Both sides have it with the same max timestamp but
+    /// different content. Operator must reconcile manually.
+    /// Caller may record the count for observability.
+    Tie(ferrosa_common::DecoratedKey),
+}
+
+/// Streaming counterpart of [`diff_partition_sets`]. Consumes both
+/// vectors in token order (the chunked Fetch path already returns
+/// them sorted) and invokes `emit` with a [`RepairDecision`] per
+/// partition. The decision is moved out of the input — neither
+/// side's `Vec<Partition>` retains it, so the caller can drop
+/// the input vecs as soon as this returns.
+///
+/// This is the apply-phase counterpart of the build-phase
+/// streaming work: `compute_repair_plan` materialises
+/// `plan.a_to_b: Vec<Partition>` and `plan.b_to_a:
+/// Vec<Partition>` by cloning every divergent partition out of
+/// the input; on a dense chunk those clones alone cost
+/// `~chunk_size × partition_size` of duplicate allocation,
+/// which compounds across the many chunks a session walks. The
+/// streaming form emits one decision per partition without
+/// cloning — the caller batches decisions into the existing
+/// `REPAIR_APPLY_CHUNK_PARTITIONS` queues and flushes via
+/// `apply_partitions` when each fills.
+///
+/// Both inputs MUST be sorted by `(token, key_bytes)` — the
+/// chunked Fetch handler sorts before responding so this is
+/// satisfied by construction.
+pub fn diff_partition_sets_streaming<F>(
+    mut a_sorted: Vec<Partition>,
+    mut b_sorted: Vec<Partition>,
+    mut emit: F,
+) -> std::result::Result<(), String>
+where
+    F: FnMut(RepairDecision) -> std::result::Result<(), String>,
+{
+    a_sorted.reverse(); // pop() takes from the tail — reverse so pop() yields in token order
+    b_sorted.reverse();
+    let mut a_head = a_sorted.pop();
+    let mut b_head = b_sorted.pop();
+    loop {
+        match (a_head.take(), b_head.take()) {
+            (None, None) => break,
+            (Some(a), None) => {
+                emit(RepairDecision::AToB(a))?;
+                a_head = a_sorted.pop();
+            }
+            (None, Some(b)) => {
+                emit(RepairDecision::BToA(b))?;
+                b_head = b_sorted.pop();
+            }
+            (Some(a), Some(b)) => {
+                // Order by (token, key_bytes). Murmur3 collisions on
+                // a real partitioner are vanishingly rare, but the
+                // tie-break keeps the merge-join correct in pathological
+                // inputs.
+                let a_cmp = (a.key.token.0, a.key.key.as_bytes());
+                let b_cmp = (b.key.token.0, b.key.key.as_bytes());
+                match a_cmp.cmp(&b_cmp) {
+                    std::cmp::Ordering::Less => {
+                        emit(RepairDecision::AToB(a))?;
+                        a_head = a_sorted.pop();
+                        b_head = Some(b);
+                    }
+                    std::cmp::Ordering::Greater => {
+                        emit(RepairDecision::BToA(b))?;
+                        b_head = b_sorted.pop();
+                        a_head = Some(a);
+                    }
+                    std::cmp::Ordering::Equal => {
+                        let ts_a = newest_partition_timestamp(&a);
+                        let ts_b = newest_partition_timestamp(&b);
+                        if ts_a > ts_b {
+                            emit(RepairDecision::AToB(a))?;
+                        } else if ts_b > ts_a {
+                            emit(RepairDecision::BToA(b))?;
+                        } else if partition_merkle_hash(&a) != partition_merkle_hash(&b) {
+                            emit(RepairDecision::Tie(a.key.clone()))?;
+                        }
+                        a_head = a_sorted.pop();
+                        b_head = b_sorted.pop();
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Compute a [`RepairPlan`] between two partition sets covering the same
 /// `[range_start, range_end)` token range, using a Merkle tree to skip
 /// identical sub-ranges before partition-level comparison.
@@ -282,7 +449,11 @@ pub fn compute_repair_plan(
 /// possible but cap at ~2^-32 per leaf for diverging content (Cassandra's
 /// classic merkle accepts the same trade-off).
 pub fn partition_merkle_hash(partition: &Partition) -> u64 {
-    match crate::raft::handlers::compute_partition_digest(partition) {
+    // Use the streaming digest so the Merkle build doesn't allocate
+    // a Vec<u8> the size of each partition's serialised form on the
+    // way to a 4-byte CRC. Byte-identical output is pinned by
+    // `partition_digest_streaming_matches_legacy`.
+    match crate::raft::handlers::compute_partition_digest_streaming(partition) {
         Ok(crc) => {
             // Two-step widen: high half = CRC, low half = CRC rotated.
             // Better than zero-padding because zero-pad leaves the upper
@@ -571,6 +742,81 @@ mod tests {
         assert_eq!(keys_a_to_b, [&b"k1"[..], &b"k2"[..]].into_iter().collect());
         assert_eq!(keys_b_to_a, [&b"k3"[..], &b"k4"[..]].into_iter().collect());
         assert!(plan.timestamp_ties.is_empty());
+    }
+
+    /// `diff_partition_sets_streaming` emits the same decisions
+    /// as `diff_partition_sets` produces in its plan — same
+    /// keys in a_to_b / b_to_a, same ties — but consumes the
+    /// inputs by value instead of cloning each chosen partition
+    /// into a plan vector. The executor uses it to drive a
+    /// bounded apply queue without holding the full per-chunk
+    /// diff in memory.
+    #[test]
+    fn diff_partition_sets_streaming_matches_one_shot_diff() {
+        // Same mixed scenario as `diff_partition_sets_mixed_scenario`.
+        let a = vec![
+            test_partition(b"k1", b"a1", 100),
+            test_partition(b"k2", b"new", 500),
+            test_partition(b"k3", b"old", 100),
+            test_partition(b"k5", b"same", 999),
+        ];
+        let b = vec![
+            test_partition(b"k2", b"old", 100),
+            test_partition(b"k3", b"new", 500),
+            test_partition(b"k4", b"b4", 100),
+            test_partition(b"k5", b"same", 999),
+        ];
+
+        // Both sides must be sorted by `(token, key_bytes)` per
+        // the streaming-diff contract.
+        let mut a_sorted = a.clone();
+        a_sorted.sort_by(|p, q| {
+            (p.key.token.0, p.key.key.as_bytes()).cmp(&(q.key.token.0, q.key.key.as_bytes()))
+        });
+        let mut b_sorted = b.clone();
+        b_sorted.sort_by(|p, q| {
+            (p.key.token.0, p.key.key.as_bytes()).cmp(&(q.key.token.0, q.key.key.as_bytes()))
+        });
+
+        let plan_one_shot = diff_partition_sets(&a, &b);
+        let one_shot_a_to_b: std::collections::BTreeSet<Vec<u8>> = plan_one_shot
+            .a_to_b
+            .iter()
+            .map(|p| p.key.key.as_bytes().to_vec())
+            .collect();
+        let one_shot_b_to_a: std::collections::BTreeSet<Vec<u8>> = plan_one_shot
+            .b_to_a
+            .iter()
+            .map(|p| p.key.key.as_bytes().to_vec())
+            .collect();
+        let one_shot_ties: std::collections::BTreeSet<Vec<u8>> = plan_one_shot
+            .timestamp_ties
+            .iter()
+            .map(|k| k.key.as_bytes().to_vec())
+            .collect();
+
+        let mut stream_a_to_b: std::collections::BTreeSet<Vec<u8>> = Default::default();
+        let mut stream_b_to_a: std::collections::BTreeSet<Vec<u8>> = Default::default();
+        let mut stream_ties: std::collections::BTreeSet<Vec<u8>> = Default::default();
+        diff_partition_sets_streaming(a_sorted, b_sorted, |decision| {
+            match decision {
+                RepairDecision::AToB(p) => {
+                    stream_a_to_b.insert(p.key.key.as_bytes().to_vec());
+                }
+                RepairDecision::BToA(p) => {
+                    stream_b_to_a.insert(p.key.key.as_bytes().to_vec());
+                }
+                RepairDecision::Tie(k) => {
+                    stream_ties.insert(k.key.as_bytes().to_vec());
+                }
+            }
+            Ok(())
+        })
+        .expect("streaming diff must succeed on pre-sorted inputs");
+
+        assert_eq!(stream_a_to_b, one_shot_a_to_b, "A→B decisions match");
+        assert_eq!(stream_b_to_a, one_shot_b_to_a, "B→A decisions match");
+        assert_eq!(stream_ties, one_shot_ties, "tie decisions match");
     }
 
     // ---- compute_repair_plan: Merkle-narrowed end-to-end diff ----

--- a/ferrosa-cluster/src/repair/rpc.rs
+++ b/ferrosa-cluster/src/repair/rpc.rs
@@ -59,11 +59,35 @@ pub struct RepairFetchRequestPayload {
     pub table: String,
     pub range_start: i64,
     pub range_end: i64,
+    /// Resume token for chunked fetch: the server reads partitions
+    /// whose tokens fall in `[cursor.unwrap_or(range_start), range_end)`.
+    /// `None` (first call) means start at `range_start`.
+    #[serde(default)]
+    pub cursor: Option<i64>,
+    /// Hard cap on partitions returned in this chunk. The client
+    /// loops fetching chunks until `next_cursor` is `None`. Sized
+    /// so the working set per chunk stays well under the per-node
+    /// memory cap regardless of partition size; the executor sets
+    /// this to `REPAIR_FETCH_CHUNK_PARTITIONS`.
+    #[serde(default = "default_fetch_limit")]
+    pub limit: u32,
+}
+
+/// Backwards-compatible default for the `limit` field on payloads
+/// deserialised from peers that don't yet send one. Matches
+/// `RepairStore::READ_RANGE_CHUNK_DEFAULT`.
+fn default_fetch_limit() -> u32 {
+    super::executor::REPAIR_FETCH_CHUNK_PARTITIONS as u32
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RepairFetchResponsePayload {
     pub partitions: Vec<PartitionWire>,
+    /// Resume token for the next chunk. `None` indicates the
+    /// server returned every remaining partition in
+    /// `[cursor, range_end)` — caller should stop looping.
+    #[serde(default)]
+    pub next_cursor: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -108,6 +132,19 @@ impl RpcHandler for RepairMerkleHandler {
             }
         };
         let table_id = TableId::new(&req.keyspace, &req.table);
+        // Share the same build budget as the initiator path —
+        // every repair touches the local table twice (once for
+        // this node's own session, once on behalf of each peer
+        // initiating against this node), so without one semaphore
+        // governing both, a cluster of N stacks N full-table
+        // walks here per repair run.
+        let _permit = match super::REPAIR_BUILD_SEMAPHORE.acquire().await {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(%e, "RepairMerkleHandler: build semaphore closed");
+                return None;
+            }
+        };
         let tree = match super::build_tree_for_range(
             &self.storage,
             &table_id,
@@ -158,16 +195,25 @@ impl RpcHandler for RepairFetchHandler {
             }
         };
         let table_id = TableId::new(&req.keyspace, &req.table);
-        // Token-bounded read: repair asks "everything in this token
-        // sub-range," which the new `read_token_range` primitive answers
-        // directly. Limit matches the storage materialisation cap.
-        const REPAIR_LEAF_READ_LIMIT: usize = 10_000;
-        let in_range_partitions = match StorageEngine::read_token_range(
+        // Token-bounded chunked read: the client loops calling
+        // Fetch with `cursor` carried forward from the prior
+        // response's `next_cursor` until we report `next_cursor:
+        // None`. Each chunk's `limit` caps the number of
+        // partitions in flight so per-RPC memory is bounded.
+        let chunk_start = req.cursor.unwrap_or(req.range_start);
+        let limit = req.limit.max(1) as usize;
+        // Ask for one more than `limit` so we can detect "more
+        // remaining" without an extra round-trip: if the storage
+        // engine returns `limit+1` matches, the (limit+1)th
+        // partition's token becomes the next cursor and is dropped
+        // from the response.
+        let probe = limit.saturating_add(1);
+        let mut in_range_partitions = match StorageEngine::read_token_range(
             &self.storage,
             &table_id,
-            req.range_start,
+            chunk_start,
             req.range_end,
-            REPAIR_LEAF_READ_LIMIT,
+            probe,
         ) {
             Ok(ps) => ps,
             Err(e) => {
@@ -175,12 +221,27 @@ impl RpcHandler for RepairFetchHandler {
                 return None;
             }
         };
+        // Sort by token so chunked iteration is well-defined even
+        // if the storage layer returns out-of-order on a multi-
+        // source merge path.
+        in_range_partitions.sort_by_key(|p| p.key.token.0);
+        let next_cursor: Option<i64> = if in_range_partitions.len() > limit {
+            // The (limit+1)th partition reveals where the next
+            // chunk should resume — keep the first `limit`,
+            // capture the cursor, drop the rest of the probe.
+            let next = in_range_partitions[limit].key.token.0;
+            in_range_partitions.truncate(limit);
+            Some(next)
+        } else {
+            None
+        };
         let in_range: Vec<PartitionWire> = in_range_partitions
             .into_iter()
             .map(partition_to_wire)
             .collect();
         let resp = RepairFetchResponsePayload {
             partitions: in_range,
+            next_cursor,
         };
         match bincode::serialize(&resp) {
             Ok(body) => Some(Message::RepairFetchResponse(Bytes::from(body))),
@@ -280,19 +341,54 @@ impl RepairStore for RemoteRepairStore {
         range_start: i64,
         range_end: i64,
     ) -> Result<Vec<Partition>, String> {
+        // Loop the chunked path until exhausted, accumulating the
+        // result. Callers that care about memory should use
+        // `read_range_chunked` directly. Kept for compatibility +
+        // tests that want the one-shot semantics.
+        let mut out: Vec<Partition> = Vec::new();
+        let mut cursor: Option<i64> = None;
+        loop {
+            let (chunk, next) = self
+                .read_range_chunked(
+                    table,
+                    range_start,
+                    range_end,
+                    cursor,
+                    super::executor::REPAIR_FETCH_CHUNK_PARTITIONS,
+                )
+                .await?;
+            out.extend(chunk);
+            match next {
+                Some(c) => cursor = Some(c),
+                None => break,
+            }
+        }
+        Ok(out)
+    }
+
+    async fn read_range_chunked(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+        cursor: Option<i64>,
+        limit: usize,
+    ) -> Result<(Vec<Partition>, Option<i64>), String> {
         let req = RepairFetchRequestPayload {
             keyspace: table.keyspace.clone(),
             table: table.table.clone(),
             range_start,
             range_end,
+            cursor,
+            limit: limit.min(u32::MAX as usize) as u32,
         };
         let body = bincode::serialize(&req).map_err(|e| format!("serialize: {e}"))?;
-        // Lane::Bulk: a Fetch response carries up to REPAIR_LEAF_READ_LIMIT
-        // (10 000) partitions — that's bulk transfer semantics, not a
-        // transactional read. Lane::Data's 10s timeout fires before a
-        // multi-GB-replica peer can finish its read_token_range scan,
-        // every session's caller drops, and repair never converges.
-        // Bulk gives 60s, which matches SSTable streaming's lane choice.
+        // Lane::Bulk: chunked responses are still bulk (each
+        // chunk carries up to `limit` decoded partitions) but
+        // the per-chunk size is bounded by the executor's choice
+        // of `REPAIR_FETCH_CHUNK_PARTITIONS`. The 60 s timeout
+        // sits comfortably above the per-chunk encode + read
+        // latency even on a multi-GB replica.
         let resp = self
             .peer_manager
             .send(
@@ -313,11 +409,12 @@ impl RepairStore for RemoteRepairStore {
         };
         let resp: RepairFetchResponsePayload =
             bincode::deserialize(&body).map_err(|e| format!("deserialize: {e}"))?;
-        Ok(resp
+        let parts: Vec<Partition> = resp
             .partitions
             .into_iter()
             .map(partition_from_wire)
-            .collect())
+            .collect();
+        Ok((parts, resp.next_cursor))
     }
 
     async fn apply_partitions(
@@ -325,36 +422,87 @@ impl RepairStore for RemoteRepairStore {
         table: &TableId,
         partitions: &[Partition],
     ) -> Result<(), String> {
-        let req = RepairApplyRequestPayload {
+        // Chunk the apply payload so the wire body, the peer's
+        // bincode-deserialise buffer, and the peer's in-flight
+        // applied state all stay bounded. Without this the apply
+        // RPC carries the full diff for a span — fine when spans
+        // are small, but the moment a span happens to be dense
+        // the peer materialises that whole payload in memory
+        // (decoded `PartitionWire` → `Partition`) and the cgroup
+        // OOMs.
+        for chunk in partitions.chunks(super::executor::REPAIR_APPLY_CHUNK_PARTITIONS) {
+            let req = RepairApplyRequestPayload {
+                keyspace: table.keyspace.clone(),
+                table: table.table.clone(),
+                partitions: chunk.iter().cloned().map(partition_to_wire).collect(),
+            };
+            let body = bincode::serialize(&req).map_err(|e| format!("serialize: {e}"))?;
+            let resp = self
+                .peer_manager
+                .send(
+                    self.host_id,
+                    Message::RepairApplyRequest(Bytes::from(body)),
+                    Lane::Bulk,
+                )
+                .await
+                .map_err(|e| format!("send: {e}"))?;
+            let body = match resp {
+                Message::RepairApplyResponse(b) => b,
+                other => {
+                    return Err(format!(
+                        "expected RepairApplyResponse, got {:?}",
+                        std::mem::discriminant(&other)
+                    ))
+                }
+            };
+            let resp: RepairApplyResponsePayload =
+                bincode::deserialize(&body).map_err(|e| format!("deserialize: {e}"))?;
+            if let Some(e) = resp.error {
+                return Err(e);
+            }
+        }
+        Ok(())
+    }
+
+    async fn build_merkle(
+        &self,
+        table: &TableId,
+        range_start: i64,
+        range_end: i64,
+    ) -> Result<super::merkle::MerkleTree, String> {
+        let req = RepairMerkleRequestPayload {
             keyspace: table.keyspace.clone(),
             table: table.table.clone(),
-            partitions: partitions.iter().cloned().map(partition_to_wire).collect(),
+            range_start,
+            range_end,
         };
         let body = bincode::serialize(&req).map_err(|e| format!("serialize: {e}"))?;
+        // Lane::Bulk: a Merkle build over a multi-GB replica can
+        // legitimately take seconds — same lane that Fetch/Apply
+        // already use so a single repair session shares one TCP
+        // pipe with its data exchange. Response payload is tiny
+        // (TREE_DEPTH=15 → ~256 KB of leaf hashes).
         let resp = self
             .peer_manager
             .send(
                 self.host_id,
-                Message::RepairApplyRequest(Bytes::from(body)),
+                Message::RepairMerkleRequest(Bytes::from(body)),
                 Lane::Bulk,
             )
             .await
             .map_err(|e| format!("send: {e}"))?;
         let body = match resp {
-            Message::RepairApplyResponse(b) => b,
+            Message::RepairMerkleResponse(b) => b,
             other => {
                 return Err(format!(
-                    "expected RepairApplyResponse, got {:?}",
+                    "expected RepairMerkleResponse, got {:?}",
                     std::mem::discriminant(&other)
                 ))
             }
         };
-        let resp: RepairApplyResponsePayload =
+        let resp: RepairMerkleResponsePayload =
             bincode::deserialize(&body).map_err(|e| format!("deserialize: {e}"))?;
-        match resp.error {
-            None => Ok(()),
-            Some(e) => Err(e),
-        }
+        Ok(resp.tree)
     }
 }
 

--- a/ferrosa-sstable/src/data.rs
+++ b/ferrosa-sstable/src/data.rs
@@ -119,6 +119,250 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
     /// being fully decoded and materialized.  This keeps range scans with
     /// per-partition row caps bounded even when individual partitions contain
     /// many rows.
+    /// Read the next partition's header (key, partition-level
+    /// deletion, optional static row) and invoke `on_row` once per
+    /// clustered row in order. Each row is decoded into a
+    /// freshly-allocated `Row`, handed to the callback by reference,
+    /// and dropped before the next row's bytes are read from the
+    /// underlying reader. **Peak working set during the call is one
+    /// row** — independent of how many rows the partition has or
+    /// how big each cell value is.
+    ///
+    /// This is the read-side counterpart of
+    /// `ferrosa_cluster::raft::handlers::PartitionDigestStream`:
+    /// together they let anti-entropy repair hash a multi-MB
+    /// partition without ever materialising a `Partition` struct.
+    ///
+    /// Returns `Ok(None)` at EOF. On any decode error the call
+    /// stops at the failing row boundary and returns the error;
+    /// `self.pos` is left at a partition-boundary or end-of-stream
+    /// position depending on how far the walk got.
+    /// 2-phase streaming entry point. Reads the partition header
+    /// (key + deletion + optional static row) and **leaves
+    /// `self.pos` parked at the first clustered row** (or at the
+    /// `END_OF_PARTITION` marker if there are no clustered rows).
+    ///
+    /// The static row, if present, comes FIRST in the BTI row
+    /// section. This function peeks the first row's flags byte
+    /// and decodes only if `IS_STATIC`; otherwise it leaves the
+    /// byte un-consumed so the follow-up [`Self::stream_clustered_rows`]
+    /// call re-reads it.
+    ///
+    /// Returns `Ok(None)` at EOF.
+    pub fn read_partition_header_only(
+        &mut self,
+    ) -> Result<Option<(DecoratedKey, DeletionTime, Option<Row>)>> {
+        let file_len = self.reader.len()?;
+        if self.pos >= file_len {
+            return Ok(None);
+        }
+        let (key_bytes, deletion) = self.read_partition_header()?;
+        let key = DecoratedKey::new(PartitionKey::new(key_bytes));
+
+        // Static-row peek: read the first row's flags + (optional)
+        // extended flags WITHOUT moving the data pointer past them
+        // unless we end up decoding the static row body. If the
+        // first row is clustered, we rewind self.pos so
+        // `stream_clustered_rows` sees the same byte we just
+        // peeked at.
+        let saved_pos = self.pos;
+        let mut flags_buf = [0u8; 1];
+        self.reader.read_exact_at(&mut flags_buf, self.pos)?;
+        let flags = flags_buf[0];
+
+        if flags & END_OF_PARTITION != 0 {
+            // No clustered rows at all — consume the marker and
+            // stream_clustered_rows will be a no-op.
+            self.pos += 1;
+            return Ok(Some((key, deletion, None)));
+        }
+        if flags & IS_MARKER != 0 {
+            // Range tombstone marker — same fallback as
+            // read_rows_limited; leave pos at the marker so the
+            // streaming continuation can treat it as an end
+            // condition.
+            return Ok(Some((key, deletion, None)));
+        }
+
+        // Peek the extended flags so we can detect IS_STATIC.
+        let ext_offset = saved_pos + 1;
+        let (extended_flags, ext_len) = if flags & EXTENSION_FLAG != 0 {
+            let mut ext_buf = [0u8; 1];
+            self.reader.read_exact_at(&mut ext_buf, ext_offset)?;
+            (ext_buf[0], 1u64)
+        } else {
+            (0, 0u64)
+        };
+        let is_static = extended_flags & EXT_IS_STATIC != 0;
+        if is_static {
+            // Commit pos past the flags + extended_flags we just
+            // peeked, then decode the static row body.
+            self.pos = saved_pos + 1 + ext_len;
+            let row = self.read_row(flags, true)?;
+            Ok(Some((key, deletion, Some(row))))
+        } else {
+            // No static row. Leave pos at saved_pos so the
+            // continuation sees the same flags byte.
+            self.pos = saved_pos;
+            Ok(Some((key, deletion, None)))
+        }
+    }
+
+    /// One-row-at-a-time partner of [`Self::stream_clustered_rows`].
+    /// Reads the next clustered row at `self.pos`, returning
+    /// `Ok(None)` at end-of-partition (or a range-tombstone
+    /// marker — same fallback as the other streaming readers).
+    /// Used by the cross-source streaming merge in the
+    /// `walk_token_range_for_digest` multi-source path: each
+    /// source's iterator is advanced one row at a time so the
+    /// k-way merge by clustering key has full control over the
+    /// pull rate.
+    ///
+    /// Must be preceded by [`Self::read_partition_header_only`] (or
+    /// run inside a partition's row section after a prior
+    /// `next_clustered_row` returned `Some`).
+    pub fn read_next_clustered_row(&mut self) -> Result<Option<Row>> {
+        loop {
+            // EOF check first — a prior `END_OF_PARTITION` may
+            // have moved us to file_len, in which case any further
+            // call is just "nothing to do" rather than an I/O error.
+            let file_len = self.reader.len()?;
+            if self.pos >= file_len {
+                return Ok(None);
+            }
+            let mut flags_buf = [0u8; 1];
+            self.reader.read_exact_at(&mut flags_buf, self.pos)?;
+            self.pos += 1;
+            let flags = flags_buf[0];
+            if flags & END_OF_PARTITION != 0 {
+                return Ok(None);
+            }
+            if flags & IS_MARKER != 0 {
+                return Ok(None);
+            }
+            let extended_flags = if flags & EXTENSION_FLAG != 0 {
+                let mut ext_buf = [0u8; 1];
+                self.reader.read_exact_at(&mut ext_buf, self.pos)?;
+                self.pos += 1;
+                ext_buf[0]
+            } else {
+                0
+            };
+            let is_static = extended_flags & EXT_IS_STATIC != 0;
+            if is_static {
+                // Skip stray static rows defensively (Cassandra
+                // writes them first; `read_partition_header_only`
+                // already consumed any in this partition).
+                self.skip_row_body(flags, true)?;
+                continue;
+            }
+            let row = self.read_row(flags, false)?;
+            return Ok(Some(row));
+        }
+    }
+
+    /// 2-phase streaming continuation: read clustered rows until
+    /// `END_OF_PARTITION` (or a range-tombstone marker), invoking
+    /// `on_row` once per row. Each row is dropped before the
+    /// next is decoded.
+    ///
+    /// Must be preceded by [`Self::read_partition_header_only`]; calling
+    /// it on a fresh `DataReader` will mis-parse the data stream.
+    pub fn stream_clustered_rows<F>(&mut self, mut on_row: F) -> Result<()>
+    where
+        F: FnMut(&Row) -> Result<()>,
+    {
+        loop {
+            let mut flags_buf = [0u8; 1];
+            self.reader.read_exact_at(&mut flags_buf, self.pos)?;
+            self.pos += 1;
+            let flags = flags_buf[0];
+
+            if flags & END_OF_PARTITION != 0 {
+                break;
+            }
+            if flags & IS_MARKER != 0 {
+                break;
+            }
+
+            let extended_flags = if flags & EXTENSION_FLAG != 0 {
+                let mut ext_buf = [0u8; 1];
+                self.reader.read_exact_at(&mut ext_buf, self.pos)?;
+                self.pos += 1;
+                ext_buf[0]
+            } else {
+                0
+            };
+            let is_static = extended_flags & EXT_IS_STATIC != 0;
+            if is_static {
+                // A static row inside the clustered section is
+                // not expected (Cassandra writes static first;
+                // `read_partition_header_only` consumed it). If
+                // we hit one anyway, skip its body — keeping the
+                // contract that this function yields only
+                // clustered rows.
+                self.skip_row_body(flags, true)?;
+                continue;
+            }
+            let row = self.read_row(flags, false)?;
+            on_row(&row)?;
+            drop(row);
+        }
+        Ok(())
+    }
+
+    pub fn read_partition_streaming<F>(
+        &mut self,
+        mut on_row: F,
+    ) -> Result<Option<(DecoratedKey, DeletionTime, Option<Row>)>>
+    where
+        F: FnMut(&Row) -> Result<()>,
+    {
+        let file_len = self.reader.len()?;
+        if self.pos >= file_len {
+            return Ok(None);
+        }
+        let (key_bytes, deletion) = self.read_partition_header()?;
+        let key = DecoratedKey::new(PartitionKey::new(key_bytes));
+
+        let mut static_row: Option<Row> = None;
+        loop {
+            let mut flags_buf = [0u8; 1];
+            self.reader.read_exact_at(&mut flags_buf, self.pos)?;
+            self.pos += 1;
+            let flags = flags_buf[0];
+
+            if flags & END_OF_PARTITION != 0 {
+                break;
+            }
+            if flags & IS_MARKER != 0 {
+                // See `read_rows_limited` for the rationale —
+                // range tombstones aren't written by Ferrosa and
+                // Cassandra-imported ones drop range-deleted data
+                // on this fast path.
+                break;
+            }
+
+            let extended_flags = if flags & EXTENSION_FLAG != 0 {
+                let mut ext_buf = [0u8; 1];
+                self.reader.read_exact_at(&mut ext_buf, self.pos)?;
+                self.pos += 1;
+                ext_buf[0]
+            } else {
+                0
+            };
+            let is_static = extended_flags & EXT_IS_STATIC != 0;
+            let row = self.read_row(flags, is_static)?;
+            if is_static {
+                static_row = Some(row);
+            } else {
+                on_row(&row)?;
+                drop(row);
+            }
+        }
+        Ok(Some((key, deletion, static_row)))
+    }
+
     pub fn read_partition_limited_rows(&mut self, row_limit: usize) -> Result<Option<Partition>> {
         let file_len = self.reader.len()?;
         if self.pos >= file_len {

--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -404,6 +404,133 @@ impl<'a, R: ReadAt> PartitionIter<'a, R> {
 
     /// Yield the next partition in storage order. Returns `Ok(None)` when
     /// the iterator has reached EOF.
+    /// Phase 1 of the row-streamed partition read: decode header
+    /// (key + deletion + optional static row), park the iterator
+    /// at the first clustered row. The follow-up call is
+    /// [`Self::stream_clustered_rows`]. Together they let callers see
+    /// the header **before** providing a row consumer — which is
+    /// what the digest path needs (seed `PartitionDigestStream`
+    /// with the header, then fold rows in).
+    ///
+    /// Returns `Ok(None)` at EOF.
+    pub fn next_partition_header_only(
+        &mut self,
+    ) -> Result<
+        Option<(
+            ferrosa_common::DecoratedKey,
+            crate::types::DeletionTime,
+            Option<crate::types::Row>,
+        )>,
+    > {
+        let header = &self.sst.header;
+        if let Some(ref buf) = self.decompressed {
+            let slice: &[u8] = buf.as_slice();
+            let mut reader = crate::data::DataReader::new(&slice, header, self.pos);
+            let result = reader.read_partition_header_only()?;
+            self.pos = reader.position();
+            Ok(result)
+        } else {
+            let mut reader = crate::data::DataReader::new(&self.sst.data, header, self.pos);
+            let result = reader.read_partition_header_only()?;
+            self.pos = reader.position();
+            Ok(result)
+        }
+    }
+
+    /// One-row-at-a-time companion to [`Self::stream_clustered_rows`].
+    /// After [`Self::next_partition_header_only`] has parked the iter
+    /// at the first clustered row, repeatedly call this to pull
+    /// rows in storage order. Returns `Ok(None)` at
+    /// end-of-partition; the iterator is then ready for another
+    /// `next_partition_header_only`.
+    ///
+    /// Used by `TableStore::walk_token_range_for_digest`'s
+    /// multi-source path: each source's iter is advanced one
+    /// row at a time so the cross-source k-way merge by
+    /// clustering key controls the pull rate, holding at most
+    /// one row per source in flight at any moment.
+    pub fn next_clustered_row(&mut self) -> Result<Option<crate::types::Row>> {
+        let header = &self.sst.header;
+        if let Some(ref buf) = self.decompressed {
+            let slice: &[u8] = buf.as_slice();
+            let mut reader = crate::data::DataReader::new(&slice, header, self.pos);
+            let result = reader.read_next_clustered_row()?;
+            self.pos = reader.position();
+            Ok(result)
+        } else {
+            let mut reader = crate::data::DataReader::new(&self.sst.data, header, self.pos);
+            let result = reader.read_next_clustered_row()?;
+            self.pos = reader.position();
+            Ok(result)
+        }
+    }
+
+    /// Phase 2 of the row-streamed partition read: walk clustered
+    /// rows until end-of-partition, invoking `on_row` once per row
+    /// in storage order. Each row is decoded into a fresh `Row`,
+    /// handed to the callback by reference, and dropped before
+    /// the next is read.
+    ///
+    /// Must be preceded by [`Self::next_partition_header_only`] — calling
+    /// it without phase 1 mis-aligns the data pointer.
+    pub fn stream_clustered_rows<F>(&mut self, on_row: F) -> Result<()>
+    where
+        F: FnMut(&crate::types::Row) -> Result<()>,
+    {
+        let header = &self.sst.header;
+        if let Some(ref buf) = self.decompressed {
+            let slice: &[u8] = buf.as_slice();
+            let mut reader = crate::data::DataReader::new(&slice, header, self.pos);
+            reader.stream_clustered_rows(on_row)?;
+            self.pos = reader.position();
+            Ok(())
+        } else {
+            let mut reader = crate::data::DataReader::new(&self.sst.data, header, self.pos);
+            reader.stream_clustered_rows(on_row)?;
+            self.pos = reader.position();
+            Ok(())
+        }
+    }
+
+    /// Yield the next partition's header (key, deletion, static
+    /// row) and call `on_row` once per clustered row in storage
+    /// order. Each row is decoded into a freshly-allocated `Row`,
+    /// handed to the callback by reference, and dropped before the
+    /// next row is read.
+    ///
+    /// Peak working set during the call is **one row** — used by
+    /// anti-entropy repair to hash a multi-MB partition into a
+    /// `PartitionDigestStream` without ever materialising a full
+    /// `Partition` struct (which the bigger
+    /// `next_partition`/`read_partition` paths do).
+    pub fn next_partition_streaming<F>(
+        &mut self,
+        on_row: F,
+    ) -> Result<
+        Option<(
+            ferrosa_common::DecoratedKey,
+            crate::types::DeletionTime,
+            Option<crate::types::Row>,
+        )>,
+    >
+    where
+        F: FnMut(&crate::types::Row) -> Result<()>,
+    {
+        let header = &self.sst.header;
+        if let Some(ref buf) = self.decompressed {
+            let slice: &[u8] = buf.as_slice();
+            let mut reader = crate::data::DataReader::new(&slice, header, self.pos);
+            let result = reader.read_partition_streaming(on_row)?;
+            self.pos = reader.position();
+            Ok(result)
+        } else {
+            let mut reader = crate::data::DataReader::new(&self.sst.data, header, self.pos);
+            let result = reader.read_partition_streaming(on_row)?;
+            self.pos = reader.position();
+            Ok(result)
+        }
+    }
+
     pub fn next_partition(&mut self) -> Result<Option<crate::types::Partition>> {
         let header = &self.sst.header;
         if let Some(ref buf) = self.decompressed {
@@ -1081,6 +1208,208 @@ mod tests {
         let mut iter = reader.partitions_iter().expect("partitions_iter");
         iter.seek_to_token(above_max).expect("seek above max");
         assert!(iter.next_partition().expect("next").is_none());
+    }
+
+    /// After `next_partition_header_only` parks the iterator at
+    /// the first clustered row, `next_clustered_row` yields rows
+    /// one at a time, returning `Ok(None)` at end-of-partition.
+    /// Companion to `stream_clustered_rows` for callers that need
+    /// fine-grained control over advancement — specifically the
+    /// cross-source row merge in
+    /// `TableStore::walk_token_range_for_digest`'s multi-source
+    /// path, which pulls one row from each source's iterator and
+    /// k-way merges by clustering key.
+    ///
+    /// Calling this on a `PartitionIter` not parked inside a
+    /// partition's row section is undefined.
+    #[test]
+    fn next_clustered_row_yields_rows_one_at_a_time() {
+        let header = test_header();
+        let dk = DecoratedKey::new(PartitionKey::from(b"ncr_key".as_slice()));
+        let data_bytes = build_data_blob_with_rows(dk.key.as_bytes(), 5);
+        let partitions_bytes = build_partition_index(&[(&dk, 0)]);
+        let filter_bytes = build_bloom_filter(&[&dk]);
+        let stats_bytes = build_statistics(header);
+
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        let mut iter = reader.partitions_iter().unwrap();
+        let (key, _deletion, static_row) = iter.next_partition_header_only().unwrap().unwrap();
+        assert_eq!(key, dk);
+        assert!(static_row.is_none());
+
+        let mut got = Vec::new();
+        while let Some(row) = iter.next_clustered_row().unwrap() {
+            got.push(row);
+        }
+        assert_eq!(got.len(), 5, "should yield exactly the 5 clustered rows");
+        // After exhaust, repeated calls should keep returning None
+        // — and the iterator should be ready for the next
+        // partition (or EOF).
+        assert!(iter.next_clustered_row().unwrap().is_none());
+    }
+
+    /// `next_partition_header_only` reads the partition header
+    /// (key, deletion, static row) and leaves the iterator parked
+    /// at the first **clustered** row. `stream_clustered_rows` is
+    /// the continuation that walks those rows one at a time. The
+    /// two together let a caller process the header (e.g. seed a
+    /// `PartitionDigestStream`) BEFORE the rows arrive — which is
+    /// what `next_partition_streaming`'s one-shot
+    /// `(header, on_row)` API doesn't support since the header
+    /// can only be returned after the row callback has consumed
+    /// everything.
+    ///
+    /// Calling `stream_clustered_rows` on a fresh `PartitionIter`
+    /// (without a preceding `next_partition_header_only`) is
+    /// undefined; the iterator must be parked at the start of a
+    /// row sequence inside a partition.
+    #[test]
+    fn next_partition_header_only_then_stream_clustered_rows_matches_legacy() {
+        let header = test_header();
+        let dks: Vec<_> = (0..3u32)
+            .map(|i| DecoratedKey::new(PartitionKey::from(format!("hsk{i:02}").as_bytes())))
+            .collect();
+        let mut data_bytes = Vec::new();
+        let mut positions = Vec::new();
+        for dk in &dks {
+            positions.push(data_bytes.len() as u64);
+            data_bytes.extend_from_slice(&build_data_blob_with_rows(dk.key.as_bytes(), 3));
+        }
+        let dk_pos: Vec<_> = dks.iter().zip(positions.iter().copied()).collect();
+        let partitions_bytes =
+            build_partition_index(&dk_pos.iter().map(|(d, p)| (*d, *p)).collect::<Vec<_>>());
+        let filter_bytes = build_bloom_filter(&dks.iter().collect::<Vec<_>>());
+        let stats_bytes = build_statistics(header);
+
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        // Baseline via `next_partition`.
+        let mut baseline = Vec::new();
+        let mut iter = reader.partitions_iter().unwrap();
+        while let Some(p) = iter.next_partition().unwrap() {
+            baseline.push(p);
+        }
+
+        // 2-phase streaming.
+        let mut streamed = Vec::new();
+        let mut iter = reader.partitions_iter().unwrap();
+        while let Some((key, deletion, static_row)) = iter.next_partition_header_only().unwrap() {
+            let mut rows = Vec::new();
+            iter.stream_clustered_rows(|row| {
+                rows.push(row.clone());
+                Ok(())
+            })
+            .unwrap();
+            streamed.push((key, deletion, static_row, rows));
+        }
+
+        assert_eq!(baseline.len(), streamed.len());
+        for (p, (key, deletion, static_row, rows)) in baseline.iter().zip(streamed.iter()) {
+            assert_eq!(p.key, *key);
+            assert_eq!(p.deletion, *deletion);
+            assert_eq!(p.static_row, *static_row);
+            assert_eq!(p.rows.len(), rows.len());
+            for (a, b) in p.rows.iter().zip(rows.iter()) {
+                assert_eq!(a, b);
+            }
+        }
+    }
+
+    /// `next_partition_streaming` yields the same partition
+    /// header and same sequence of clustered rows as
+    /// `next_partition`. This is the read-side primitive used by
+    /// anti-entropy repair to hash a multi-MB partition without
+    /// ever holding a full `Partition` in memory: peak working
+    /// set during the call is one row at a time.
+    #[test]
+    fn next_partition_streaming_matches_next_partition() {
+        let header = test_header();
+        let dks: Vec<_> = (0..3u32)
+            .map(|i| DecoratedKey::new(PartitionKey::from(format!("psk{i:02}").as_bytes())))
+            .collect();
+        let mut data_bytes = Vec::new();
+        let mut positions = Vec::new();
+        for dk in &dks {
+            positions.push(data_bytes.len() as u64);
+            // build_data_blob_with_rows ensures multiple clustered
+            // rows so the streaming callback fires more than once.
+            data_bytes.extend_from_slice(&build_data_blob_with_rows(dk.key.as_bytes(), 4));
+        }
+        let dk_pos: Vec<_> = dks.iter().zip(positions.iter().copied()).collect();
+        let partitions_bytes =
+            build_partition_index(&dk_pos.iter().map(|(d, p)| (*d, *p)).collect::<Vec<_>>());
+        let filter_bytes = build_bloom_filter(&dks.iter().collect::<Vec<_>>());
+        let stats_bytes = build_statistics(header);
+
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        // Baseline: collect via `next_partition`.
+        let mut materialised = Vec::new();
+        let mut iter = reader.partitions_iter().unwrap();
+        while let Some(p) = iter.next_partition().unwrap() {
+            materialised.push(p);
+        }
+
+        // Streaming: collect via `next_partition_streaming`.
+        let mut streamed_headers = Vec::new();
+        let mut streamed_rows: Vec<Vec<crate::types::Row>> = Vec::new();
+        let mut iter = reader.partitions_iter().unwrap();
+        loop {
+            let mut my_rows = Vec::new();
+            let result = iter
+                .next_partition_streaming(|row| {
+                    my_rows.push(row.clone());
+                    Ok(())
+                })
+                .unwrap();
+            match result {
+                Some((key, deletion, static_row)) => {
+                    streamed_headers.push((key, deletion, static_row));
+                    streamed_rows.push(my_rows);
+                }
+                None => break,
+            }
+        }
+
+        assert_eq!(materialised.len(), streamed_headers.len());
+        for ((p, (key, deletion, static_row)), rows) in materialised
+            .iter()
+            .zip(streamed_headers.iter())
+            .zip(streamed_rows.iter())
+        {
+            assert_eq!(p.key, *key);
+            assert_eq!(p.deletion, *deletion);
+            assert_eq!(p.static_row, *static_row);
+            assert_eq!(p.rows.len(), rows.len());
+            for (a, b) in p.rows.iter().zip(rows.iter()) {
+                assert_eq!(a, b);
+            }
+        }
     }
 
     /// ADR-020 COUNT(*) fast path: next_partition_count yields the

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -2132,6 +2132,70 @@ impl StorageEngine {
         state.store.read_token_range(start_token, end_token, limit)
     }
 
+    /// Row-streaming walk over `[start_token, end_token)` for the
+    /// anti-entropy repair digest path. For each unique partition
+    /// the callback receives the header (key, deletion, optional
+    /// static row) plus an `emit_rows` continuation that walks
+    /// clustered rows one at a time. When a key is in exactly one
+    /// SSTable source the rows are streamed via the SSTable
+    /// reader's 2-phase API; no `Partition` is materialised. See
+    /// `TableStore::walk_token_range_for_digest` for the full
+    /// contract.
+    pub fn walk_token_range_for_digest<Cb>(
+        &self,
+        table_id: &TableId,
+        start_token: i64,
+        end_token: i64,
+        cb: Cb,
+    ) -> ferrosa_common::Result<()>
+    where
+        Cb: FnMut(
+            &ferrosa_common::DecoratedKey,
+            ferrosa_sstable::types::DeletionTime,
+            Option<&ferrosa_sstable::types::Row>,
+            &mut dyn FnMut(
+                &mut dyn FnMut(&ferrosa_sstable::types::Row) -> Result<(), ferrosa_common::Error>,
+            ) -> Result<(), ferrosa_common::Error>,
+        ) -> Result<(), ferrosa_common::Error>,
+    {
+        if start_token >= end_token {
+            return Ok(());
+        }
+        let tables = self.tables.read();
+        let Some(state) = tables.get(table_id) else {
+            return Ok(());
+        };
+        state
+            .store
+            .walk_token_range_for_digest(start_token, end_token, cb)
+    }
+
+    /// Streaming token-bounded walk that invokes `cb` once per
+    /// partition. Peak working set is **one** decoded partition per
+    /// SSTable source held by the in-flight merge head, so a
+    /// multi-GB table doesn't trip the per-container memory cap
+    /// even when partitions contain multi-MB rows. Used by
+    /// anti-entropy repair's Merkle-build path.
+    pub fn walk_token_range<F>(
+        &self,
+        table_id: &TableId,
+        start_token: i64,
+        end_token: i64,
+        cb: F,
+    ) -> ferrosa_common::Result<()>
+    where
+        F: FnMut(&Partition) -> ferrosa_common::Result<()>,
+    {
+        if start_token >= end_token {
+            return Ok(());
+        }
+        let tables = self.tables.read();
+        let Some(state) = tables.get(table_id) else {
+            return Ok(());
+        };
+        state.store.walk_token_range(start_token, end_token, cb)
+    }
+
     /// Reads partitions from a table with an optional per-partition row cap.
     pub fn read_range_limited_rows(
         &self,

--- a/ferrosa-storage/src/merge.rs
+++ b/ferrosa-storage/src/merge.rs
@@ -91,7 +91,13 @@ pub fn merge_partitions(sources: Vec<Partition>) -> Partition {
 }
 
 /// Merge two rows with the same clustering key using cell-level LWW.
-fn merge_rows(a: Row, b: Row) -> Row {
+///
+/// Public so the cluster repair crate's cross-source streaming
+/// merge in `TableStore::walk_token_range_for_digest` can fold
+/// rows arriving one-at-a-time from N SSTable iterators into the
+/// merged row that gets hashed into a `PartitionDigestStream` —
+/// without ever materialising the full multi-source partition.
+pub fn merge_rows(a: Row, b: Row) -> Row {
     // Row-level deletion: newer wins
     let deletion = if b.deletion.marked_for_delete_at > a.deletion.marked_for_delete_at {
         b.deletion

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -1279,6 +1279,471 @@ impl<F: FlushTarget> TableStore<F> {
         Ok(merged.into_iter().take(limit).collect())
     }
 
+    /// Streaming token-bounded walk: invoke `cb` for every partition
+    /// in `[start_token, end_token)`, one at a time, dropping each
+    /// before the next is decoded.
+    ///
+    /// The materialising `read_token_range` collects up to `limit`
+    /// partitions into a `Vec` before returning. Repair's Merkle
+    /// build only needs the hash of each partition — never the
+    /// collection — so a callback that consumes each partition by
+    /// reference lets the iterator's per-partition allocation be
+    /// freed on the next loop. Peak working-set is **one** decoded
+    /// partition per active walker, regardless of table size,
+    /// partition density, or per-partition row count.
+    ///
+    /// This is the only path that bounds memory for a Merkle build
+    /// on a table with multi-MB partitions inside the fmem 2 GiB
+    /// cgroup. The Vec-returning `read_token_range`, even with
+    /// `limit = 16`, still materialised dozens of MB of decoded
+    /// content per page; concurrent pages stacked past the cap.
+    ///
+    /// Dedup across (memtable + flushing-memtable + sstables) for
+    /// the same partition key is preserved: the callback receives
+    /// the *cell-merged* partition (cross-source dedup happens via
+    /// an O(1) "carry" — at most one held partition is kept in
+    /// flight, merged with later occurrences of the same key, then
+    /// emitted when a strictly-greater key arrives).
+    /// Walk partitions in `[start_token, end_token)` for the
+    /// anti-entropy repair digest path.
+    ///
+    /// For each unique partition key the callback is invoked with
+    /// the key, deletion, optional static row, and an `emit_rows`
+    /// continuation. The continuation accepts a `&mut dyn
+    /// FnMut(&Row) -> Result<()>` and walks the partition's
+    /// clustered rows, invoking it once per row.
+    ///
+    /// **Hot path** (key is in exactly one SSTable source, neither
+    /// memtable has it): rows are streamed via the SSTable
+    /// reader's 2-phase API — `next_partition_header_only` then
+    /// `stream_clustered_rows`. No `Partition` is materialised;
+    /// peak working set during the partition is one row.
+    ///
+    /// **Multi-source fallback** (memtable + SSTable, or
+    /// overlapping LSM levels): every contributing source's full
+    /// partition is decoded, `merge_partitions` + `apply_deletions`
+    /// produce the cell-merged content, and `emit_rows` iterates
+    /// the merged row vector. Same cost as the legacy materialised
+    /// path; only triggers for keys with cross-source content
+    /// (active writes / pre-compaction state) — settled replicas
+    /// stay on the hot path.
+    pub fn walk_token_range_for_digest<Cb>(
+        &self,
+        start_token: i64,
+        end_token: i64,
+        mut cb: Cb,
+    ) -> Result<()>
+    where
+        Cb: FnMut(
+            &DecoratedKey,
+            ferrosa_sstable::types::DeletionTime,
+            Option<&ferrosa_sstable::types::Row>,
+            &mut dyn FnMut(&mut dyn FnMut(&ferrosa_sstable::types::Row) -> Result<()>) -> Result<()>,
+        ) -> Result<()>,
+    {
+        if start_token >= end_token {
+            return Ok(());
+        }
+        let guard = self.view.load();
+
+        // Memtable bootstrap (same shape as walk_token_range).
+        let mut mem_active: Vec<Partition> = guard
+            .active
+            .range_iter(None, None)
+            .filter(|p: &Partition| p.key.token.0 >= start_token && p.key.token.0 < end_token)
+            .collect();
+        mem_active.sort_by(|a, b| a.key.cmp(&b.key));
+        let mut mem_active_iter = mem_active.into_iter().peekable();
+
+        let mut mem_flushing_vec: Vec<Partition> = match guard.flushing {
+            Some(ref f) => f
+                .range_iter(None, None)
+                .filter(|p: &Partition| p.key.token.0 >= start_token && p.key.token.0 < end_token)
+                .collect(),
+            None => Vec::new(),
+        };
+        mem_flushing_vec.sort_by(|a, b| a.key.cmp(&b.key));
+        let mut mem_flushing_iter = mem_flushing_vec.into_iter().peekable();
+
+        let mut sst_iters: Vec<ferrosa_sstable::reader::PartitionIter<'_, _>> =
+            Vec::with_capacity(guard.sstables.len());
+        for sstable in guard.sstables.iter() {
+            let mut iter = match sstable.partitions_iter() {
+                Ok(it) => it,
+                Err(_) => continue,
+            };
+            let _ = iter.seek_to_token(start_token);
+            while let Ok(Some(k)) = iter.peek_partition_key() {
+                if k.token.0 < start_token {
+                    if iter.skip_to_next_partition().is_err() {
+                        break;
+                    }
+                    continue;
+                }
+                break;
+            }
+            sst_iters.push(iter);
+        }
+
+        loop {
+            // Pick the smallest key across all sources via peek.
+            let mut smallest_key: Option<DecoratedKey> = None;
+            let pick = |cur: &Option<DecoratedKey>, candidate: &DecoratedKey| -> bool {
+                cur.as_ref().map(|k| candidate < k).unwrap_or(true)
+            };
+            if let Some(p) = mem_active_iter.peek() {
+                if pick(&smallest_key, &p.key) {
+                    smallest_key = Some(p.key.clone());
+                }
+            }
+            if let Some(p) = mem_flushing_iter.peek() {
+                if pick(&smallest_key, &p.key) {
+                    smallest_key = Some(p.key.clone());
+                }
+            }
+            for iter in sst_iters.iter_mut() {
+                if let Ok(Some(k)) = iter.peek_partition_key() {
+                    if k.token.0 >= end_token {
+                        continue;
+                    }
+                    if pick(&smallest_key, &k) {
+                        smallest_key = Some(k);
+                    }
+                }
+            }
+            let Some(key) = smallest_key else {
+                break;
+            };
+
+            // Count how many sources hold `key`.
+            let mem_active_has = mem_active_iter.peek().map(|p| p.key == key) == Some(true);
+            let mem_flushing_has = mem_flushing_iter.peek().map(|p| p.key == key) == Some(true);
+            let sst_match_indices: Vec<usize> = sst_iters
+                .iter_mut()
+                .enumerate()
+                .filter_map(|(i, iter)| match iter.peek_partition_key() {
+                    Ok(Some(k)) if k == key => Some(i),
+                    _ => None,
+                })
+                .collect();
+            let total_sources =
+                (mem_active_has as usize) + (mem_flushing_has as usize) + sst_match_indices.len();
+
+            if total_sources == 1 && sst_match_indices.len() == 1 {
+                // Hot path: single SSTable source. Use the 2-phase
+                // SSTable API so no `Partition` ever materialises.
+                let sst_idx = sst_match_indices[0];
+                let header = sst_iters[sst_idx]
+                    .next_partition_header_only()?
+                    .expect("source had key; header must yield");
+                let (decoded_key, deletion, static_row) = header;
+                debug_assert_eq!(decoded_key, key);
+                let iter_ref = &mut sst_iters[sst_idx];
+                let mut emit_rows = |on_row: &mut dyn FnMut(
+                    &ferrosa_sstable::types::Row,
+                ) -> Result<()>|
+                 -> Result<()> {
+                    iter_ref.stream_clustered_rows(|row| on_row(row))
+                };
+                cb(&decoded_key, deletion, static_row.as_ref(), &mut emit_rows)?;
+            } else {
+                // Multi-source streaming merge. The header (deletion,
+                // static row) is small (zero-or-one static row × N
+                // sources) so we merge it eagerly. The clustered
+                // rows are k-way-merged BY CLUSTERING KEY across all
+                // sources, one row at a time — we never hold the
+                // full multi-source partition in memory at any point.
+                //
+                // Memtable sources contribute a pre-sorted `Vec<Row>`
+                // iterator (the active memtable's rows are pulled
+                // into a Vec just for this partition, then iterated).
+                // SSTable sources contribute their `PartitionIter`,
+                // walked via `next_clustered_row` so each source's
+                // in-flight footprint is exactly one decoded row.
+
+                // Per-source memtable rows (sorted by clustering)
+                // and per-source SSTable iter indices.
+                let mut mem_row_iters: Vec<std::vec::IntoIter<ferrosa_sstable::types::Row>> =
+                    Vec::new();
+                let mut headers: Vec<(
+                    DecoratedKey,
+                    ferrosa_sstable::types::DeletionTime,
+                    Option<ferrosa_sstable::types::Row>,
+                )> = Vec::with_capacity(total_sources);
+
+                if mem_active_has {
+                    let p = mem_active_iter.next().expect("peeked");
+                    let key_p = p.key.clone();
+                    let deletion = p.deletion;
+                    let static_row = p.static_row;
+                    let mut rows = p.rows;
+                    rows.sort_by(|a, b| a.clustering.cmp(&b.clustering));
+                    headers.push((key_p, deletion, static_row));
+                    mem_row_iters.push(rows.into_iter());
+                }
+                if mem_flushing_has {
+                    let p = mem_flushing_iter.next().expect("peeked");
+                    let key_p = p.key.clone();
+                    let deletion = p.deletion;
+                    let static_row = p.static_row;
+                    let mut rows = p.rows;
+                    rows.sort_by(|a, b| a.clustering.cmp(&b.clustering));
+                    headers.push((key_p, deletion, static_row));
+                    mem_row_iters.push(rows.into_iter());
+                }
+                for i in &sst_match_indices {
+                    if let Some((k, d, sr)) = sst_iters[*i].next_partition_header_only()? {
+                        headers.push((k, d, sr));
+                    }
+                }
+
+                // Merge header: max-timestamp deletion, cell-merged
+                // static row.
+                let mut merged_deletion = ferrosa_sstable::types::DeletionTime::LIVE;
+                let mut merged_static: Option<ferrosa_sstable::types::Row> = None;
+                for (_, d, sr) in &headers {
+                    if d.marked_for_delete_at > merged_deletion.marked_for_delete_at {
+                        merged_deletion = *d;
+                    }
+                    if let Some(s) = sr {
+                        merged_static = match merged_static.take() {
+                            Some(prev) => Some(crate::merge::merge_rows(prev, s.clone())),
+                            None => Some(s.clone()),
+                        };
+                    }
+                }
+                let merged_key = headers[0].0.clone();
+
+                // Streaming row merge. Heads from each source —
+                // memtable rows arrive from `mem_row_iters`,
+                // SSTable rows from `sst_iters[idx].next_clustered_row()`.
+                let mem_indices: Vec<usize> = (0..mem_row_iters.len()).collect();
+                let sst_local_indices = sst_match_indices.clone();
+                let mut emit_rows = |on_row: &mut dyn FnMut(
+                    &ferrosa_sstable::types::Row,
+                ) -> Result<()>|
+                 -> Result<()> {
+                    let mut mem_heads: Vec<Option<ferrosa_sstable::types::Row>> =
+                        mem_row_iters.iter_mut().map(|it| it.next()).collect();
+                    let mut sst_heads: Vec<Option<ferrosa_sstable::types::Row>> =
+                        Vec::with_capacity(sst_local_indices.len());
+                    for &si in &sst_local_indices {
+                        sst_heads.push(sst_iters[si].next_clustered_row().map_err(|e| {
+                            ferrosa_common::Error::InvalidData(format!(
+                                "sst.next_clustered_row: {e}"
+                            ))
+                        })?);
+                    }
+                    loop {
+                        // Pick the smallest clustering key
+                        // across all live heads.
+                        let mut smallest: Option<Vec<u8>> = None;
+                        for r in mem_heads.iter().flatten() {
+                            if smallest.as_ref().map(|c| r.clustering < *c).unwrap_or(true) {
+                                smallest = Some(r.clustering.clone());
+                            }
+                        }
+                        for r in sst_heads.iter().flatten() {
+                            if smallest.as_ref().map(|c| r.clustering < *c).unwrap_or(true) {
+                                smallest = Some(r.clustering.clone());
+                            }
+                        }
+                        let Some(ck) = smallest else { break };
+
+                        // Collect every source's row at that
+                        // clustering, merging cells one pair at
+                        // a time. Peak in-flight: two rows.
+                        let mut merged_row: Option<ferrosa_sstable::types::Row> = None;
+                        for (i_local, _i_global) in mem_indices.iter().enumerate() {
+                            if mem_heads[i_local]
+                                .as_ref()
+                                .map(|r| r.clustering == ck)
+                                .unwrap_or(false)
+                            {
+                                let row = mem_heads[i_local].take().unwrap();
+                                merged_row = match merged_row.take() {
+                                    Some(prev) => Some(crate::merge::merge_rows(prev, row)),
+                                    None => Some(row),
+                                };
+                                mem_heads[i_local] = mem_row_iters[i_local].next();
+                            }
+                        }
+                        for (h_idx, &si) in sst_local_indices.iter().enumerate() {
+                            if sst_heads[h_idx]
+                                .as_ref()
+                                .map(|r| r.clustering == ck)
+                                .unwrap_or(false)
+                            {
+                                let row = sst_heads[h_idx].take().unwrap();
+                                merged_row = match merged_row.take() {
+                                    Some(prev) => Some(crate::merge::merge_rows(prev, row)),
+                                    None => Some(row),
+                                };
+                                sst_heads[h_idx] =
+                                    sst_iters[si].next_clustered_row().map_err(|e| {
+                                        ferrosa_common::Error::InvalidData(format!(
+                                            "sst.next_clustered_row: {e}"
+                                        ))
+                                    })?;
+                            }
+                        }
+                        let row = merged_row.expect("at least one source matched");
+                        on_row(&row)?;
+                        drop(row);
+                    }
+                    Ok(())
+                };
+                cb(
+                    &merged_key,
+                    merged_deletion,
+                    merged_static.as_ref(),
+                    &mut emit_rows,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn walk_token_range<Cb>(&self, start_token: i64, end_token: i64, mut cb: Cb) -> Result<()>
+    where
+        Cb: FnMut(&Partition) -> Result<()>,
+    {
+        if start_token >= end_token {
+            return Ok(());
+        }
+        let guard = self.view.load();
+
+        // K-way merge across sources (memtables + every SSTable)
+        // by key. Each source advertises its current key via a
+        // cheap **peek** (DecoratedKey only — no row bodies); the
+        // partition body is decoded ONLY for the source(s) whose
+        // peek matches the smallest key in the current cycle.
+        // That keeps peak in-flight memory at `O(#decoded_in_cycle)`
+        // — typically 1-3 partitions — regardless of how many
+        // SSTables exist or how big each partition is. The earlier
+        // version held `#sources × decoded_partition` simultaneously
+        // and OOM'd the 2 GiB cgroup at ~1.8 GiB on a 235-SSTable
+        // replica with fat partitions.
+
+        // Memtable matches are cheap to collect (memtables are
+        // already in memory by design) and small. Sort by key so
+        // the merge can rely on per-source order.
+        let mut mem_active: Vec<Partition> = guard
+            .active
+            .range_iter(None, None)
+            .filter(|p: &Partition| p.key.token.0 >= start_token && p.key.token.0 < end_token)
+            .collect();
+        mem_active.sort_by(|a, b| a.key.cmp(&b.key));
+        let mut mem_active_iter = mem_active.into_iter().peekable();
+
+        let mut mem_flushing_vec: Vec<Partition> = match guard.flushing {
+            Some(ref f) => f
+                .range_iter(None, None)
+                .filter(|p: &Partition| p.key.token.0 >= start_token && p.key.token.0 < end_token)
+                .collect(),
+            None => Vec::new(),
+        };
+        mem_flushing_vec.sort_by(|a, b| a.key.cmp(&b.key));
+        let mut mem_flushing_iter = mem_flushing_vec.into_iter().peekable();
+
+        // For each SSTable: an iter parked at the first in-range
+        // partition. We do NOT decode the body — we keep only the
+        // peeked DecoratedKey (small).
+        let mut sst_iters: Vec<ferrosa_sstable::reader::PartitionIter<'_, _>> =
+            Vec::with_capacity(guard.sstables.len());
+        for sstable in guard.sstables.iter() {
+            let mut iter = match sstable.partitions_iter() {
+                Ok(it) => it,
+                Err(_) => continue,
+            };
+            // seek_to_token can leave us BEFORE start_token (cache
+            // build failed → no-op) — the per-cycle key compare
+            // handles that, but skip any partition with token <
+            // start_token here to keep the peek-key honest.
+            let _ = iter.seek_to_token(start_token);
+            // Advance past any pre-range partitions left over from
+            // a cache-build-failure fallback.
+            while let Ok(Some(k)) = iter.peek_partition_key() {
+                if k.token.0 < start_token {
+                    // skip past this partition
+                    if iter.skip_to_next_partition().is_err() {
+                        break;
+                    }
+                    continue;
+                }
+                break;
+            }
+            sst_iters.push(iter);
+        }
+
+        loop {
+            // Pick the smallest key across all sources, using
+            // peek for SSTables (no body decode).
+            let mut smallest_key: Option<DecoratedKey> = None;
+            let pick = |cur: &Option<DecoratedKey>, candidate: &DecoratedKey| -> bool {
+                cur.as_ref().map(|k| candidate < k).unwrap_or(true)
+            };
+            if let Some(p) = mem_active_iter.peek() {
+                if pick(&smallest_key, &p.key) {
+                    smallest_key = Some(p.key.clone());
+                }
+            }
+            if let Some(p) = mem_flushing_iter.peek() {
+                if pick(&smallest_key, &p.key) {
+                    smallest_key = Some(p.key.clone());
+                }
+            }
+            for iter in sst_iters.iter_mut() {
+                if let Ok(Some(k)) = iter.peek_partition_key() {
+                    if k.token.0 >= end_token {
+                        // sstable is past the range; treat as exhausted
+                        continue;
+                    }
+                    if pick(&smallest_key, &k) {
+                        smallest_key = Some(k);
+                    }
+                }
+            }
+            let Some(key) = smallest_key else {
+                break; // every source exhausted
+            };
+
+            // Decode the body ONLY from sources whose peek matches
+            // the smallest key — typically 1 source, occasionally
+            // a handful when the same key landed in both memtable
+            // and an SSTable (or got split across compactions).
+            let mut group: Vec<Partition> = Vec::new();
+            if mem_active_iter.peek().map(|p| p.key == key) == Some(true) {
+                group.push(mem_active_iter.next().expect("peeked"));
+            }
+            if mem_flushing_iter.peek().map(|p| p.key == key) == Some(true) {
+                group.push(mem_flushing_iter.next().expect("peeked"));
+            }
+            for iter in sst_iters.iter_mut() {
+                let matches = matches!(iter.peek_partition_key(), Ok(Some(k)) if k == key);
+                if !matches {
+                    continue;
+                }
+                match iter.next_partition() {
+                    Ok(Some(p)) => group.push(p),
+                    Ok(None) => {}
+                    Err(_) => {}
+                }
+            }
+
+            let merged = if group.len() == 1 {
+                group.into_iter().next().expect("len 1")
+            } else {
+                let mut m = crate::merge::merge_partitions(group);
+                crate::merge::apply_deletions(&mut m);
+                m
+            };
+            cb(&merged)?;
+            drop(merged);
+        }
+        Ok(())
+    }
+
     pub fn read_range_limited_rows(
         &self,
         start: Option<&DecoratedKey>,

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -20,6 +20,34 @@
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+/// jemalloc tuning: release dirty + muzzy pages back to the OS
+/// immediately on free instead of caching them for ~10 s of reuse.
+///
+/// Default jemalloc trades RSS for throughput by holding freed
+/// pages in per-arena dirty queues (decay_ms=10000). For ferrosa
+/// nodes deployed inside a tight cgroup (e.g. the fmem cluster's
+/// 2 GiB cap), a write-heavy hot path or a Merkle build over a
+/// large replica can allocate-and-free GBs of partition data
+/// within the decay window — the kernel sees the RSS still
+/// growing toward the cap and OOM-kills before any reclamation
+/// happens.
+///
+/// `dirty_decay_ms:0,muzzy_decay_ms:0` is the documented
+/// memory-constrained tuning: every `free` immediately returns
+/// the page to the OS. Throughput trade-off is small for our
+/// allocation pattern (most freed pages are not reused
+/// in-arena anyway — repair scans walk forward through partitions,
+/// flushes hand SSTables off, etc).
+///
+/// The `unprefixed_malloc_on_supported_platforms` feature on
+/// `tikv-jemallocator` makes jemalloc read this symbol at process
+/// startup. Override per-deployment with the `MALLOC_CONF` env
+/// var (env wins over the link-time default).
+#[cfg(not(target_env = "msvc"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"dirty_decay_ms:0,muzzy_decay_ms:0\0";
+
 mod cql_broadcast;
 mod runtime;
 mod web;


### PR DESCRIPTION
## Summary

End-to-end rewrite of the anti-entropy repair path on the
`feat/anti-entropy-repair-primitives` baseline, fixing every
correctness bug found while running it against the 2 GiB-cgroup
fmem cluster.

### Correctness

- **Codec**: `MsgType::TryFrom<u8>` was missing the six repair tag
  bytes `0x29..=0x2E`. Peers silently dropped every repair frame
  as `UnknownMessageType` and sessions timed out with zero
  convergence. Pinned by `msg_type_repair_rpc_tags_round_trip`.
- **Lane**: repair RPCs ran on `Lane::Data` (10 s timeout); a
  Fetch response carries up to 10 000 partitions, easily over the
  budget. Moved to `Lane::Bulk` (60 s) — same lane SSTable
  streaming already uses.
- **Coordinator**: was scheduling one session per (vnode-range ×
  peer) = 1 536 sessions per node on default `num_tokens=256`,
  RF=3, 3-node. Now collapses contiguous owned ranges sharing the
  same replica set into one session per peer (2 / node on RF=3 /
  3-node).
- **Executor**: replaced "fetch full range, diff, apply" with
  Cassandra-style Merkle-then-stream. `try_join!`s both Merkle
  builds → finds divergent leaves → merges adjacent leaves into
  spans capped at 64 → per-span fetch + diff + apply
  bi-directionally. Converged replicas pay only two streaming
  tree builds and one comparison — zero partition data crosses
  the wire.

### Memory

- **`read_token_range` streaming**: was materialising the whole
  table into a `Vec` then filtering by token. Now walks SSTables
  via `partitions_iter` + per-source `in_range` filter, with
  `seek_to_token` (lazy `Vec<(token, byte-offset)>` cache + binary
  search on `SSTableReader`) so per-call cost is `O(log N +
  matches)` instead of `O(table_size)`.
- **`walk_token_range`**: k-way merge across memtable + every
  SSTable, **peeking** SSTable keys (no body decode) and decoding
  bodies only for sources whose peek wins the merge.
  In-flight: 1 decoded body, not `#sources × decoded_body`.
- **`compute_partition_digest`**: was serialising through a
  `Vec<u8>` of every partition's bytes before CRC. Now feeds
  bincode bytes directly into a `crc32fast::Hasher` via a
  `CrcHashWriter` adapter, **zero clones** of rows or cells.
- **`PartitionDigestStream`**: the streaming entry point — seed
  with the partition header, fold rows in via `update_row`,
  finalize. Row count emitted at the end of the byte stream so
  the SSTable walker can hash rows without knowing the total
  upfront.
- **`SSTableReader::next_partition_streaming`**: row-at-a-time
  partition decode. Peak per call is one row in flight.
  Foundation for wiring the digest path through the SSTable
  iter without ever materialising a `Partition`.

## What's still ahead

`PartitionDigestStream` and `next_partition_streaming` are
landed and tested, but the **digest path doesn't use them yet**.
The repair build_tree_for_range still goes through
`walk_token_range`'s materialised `Partition` callback, so each
SSTable walk allocates ~135 KB per `next_partition()` call and on
a 1 GB-class replica that allocation churn pushes anon RSS past
the 2 GiB cgroup before jemalloc can reclaim.

Closing the gap needs a small 2-phase SSTable API:

- `DataReader::read_partition_header_and_static_row()` — reads
  header + the (zero-or-one) static row, leaves the position at
  the first clustered row.
- `DataReader::stream_clustered_rows<F>(F)` — reads rows until
  `END_OF_PARTITION`, invoking `F` once per row.
- Same split on `PartitionIter`.
- New `TableStore::walk_token_range_for_digest` that dispatches
  single-SSTable-source keys through the streaming API and
  multi-source keys through the existing materialise + merge.

Once that lands, `build_tree_for_range` can drive the digest
without holding more than one row at a time per active build.

## Test plan

- [x] `cargo test -p ferrosa-cluster --lib partition_digest` — 6 tests
- [x] `cargo test -p ferrosa-cluster --lib repair::` — 41 tests
- [x] `cargo test -p ferrosa-sstable --lib next_partition_streaming_matches_next_partition`
- [x] `cargo test -p ferrosa-sstable --lib seek_to_token_starts_at_or_after_target`
- [x] `cargo test -p ferrosa-storage --lib read_token_range` — 5 tests
- [ ] CI workspace: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`
- [ ] Live fmem cluster: still OOMs at the partition-materialisation step (this PR doesn't close that — see "What's still ahead" above)