### PR TITLE
cluster: borrowed partition serialization for range-read stream chunks

### DIFF
--- a/ferrosa-cluster/src/coordinator/stream_producer.rs
+++ b/ferrosa-cluster/src/coordinator/stream_producer.rs
@@ -22,9 +22,15 @@ use bytes::Bytes;
 use ferrosa_sstable::types::Partition;
 
 use crate::raft::handlers::{
-    serialize_partition_to_wire_borrowed, RangeReadStreamChunkPayload, RangeReadStreamDonePayload,
-    RangeReadStreamRequestPayload,
+    serialize_partition_to_wire_borrowed, RangeReadStreamDonePayload, RangeReadStreamRequestPayload,
 };
+// `RangeReadStreamChunkPayload` is referenced only from the
+// in-module tests (decode_chunk uses it as the deserialise
+// target) — re-import it under `cfg(test)` so non-test builds
+// don't see an unused-import warning under
+// `-D unused-imports`.
+#[cfg(test)]
+use crate::raft::handlers::RangeReadStreamChunkPayload;
 use ferrosa_net::message::Message;
 
 /// Where a stream producer pushes outbound frames. The production

--- a/ferrosa-cluster/src/coordinator/stream_producer.rs
+++ b/ferrosa-cluster/src/coordinator/stream_producer.rs
@@ -22,7 +22,7 @@ use bytes::Bytes;
 use ferrosa_sstable::types::Partition;
 
 use crate::raft::handlers::{
-    partition_to_wire, RangeReadStreamChunkPayload, RangeReadStreamDonePayload,
+    serialize_partition_to_wire_borrowed, RangeReadStreamChunkPayload, RangeReadStreamDonePayload,
     RangeReadStreamRequestPayload,
 };
 use ferrosa_net::message::Message;
@@ -61,14 +61,34 @@ pub async fn stream_range_response<S: ChunkSink>(
 
     let mut seq: u32 = 0;
     for chunk in partitions.chunks(chunk_size) {
-        let payload = RangeReadStreamChunkPayload {
-            request_id: req.request_id,
-            seq,
-            partitions: chunk.iter().cloned().map(partition_to_wire).collect(),
-        };
-        let bytes = bincode::serialize(&payload)
-            .expect("RangeReadStreamChunkPayload serialization is infallible");
-        sink.send(Message::RangeReadStreamChunk(Bytes::from(bytes)))
+        // Emit the chunk's bytes directly, without first
+        // materialising `Vec<PartitionWire>` (which would clone
+        // every cell value in the chunk).
+        //
+        // Wire format of `RangeReadStreamChunkPayload` is
+        // `request_id: u32 || seq: u32 || partitions: Vec<PartitionWire>`,
+        // and bincode encodes `Vec<T>` as `u64-LE length || items`.
+        // Emitting the three fields in declaration order, then
+        // each partition via `serialize_partition_to_wire_borrowed`,
+        // produces byte-identical output to
+        // `bincode::serialize(&RangeReadStreamChunkPayload{..})`.
+        // Equivalence is pinned at the helper-level by
+        // `serialize_partition_to_wire_borrowed_matches_legacy`
+        // and at this call site by
+        // `stream_range_response_borrowed_emit_matches_legacy_collect`.
+        let mut body: Vec<u8> = Vec::new();
+        bincode::serialize_into(&mut body, &req.request_id)
+            .expect("RangeReadStreamChunkPayload header serialization is infallible");
+        bincode::serialize_into(&mut body, &seq)
+            .expect("RangeReadStreamChunkPayload header serialization is infallible");
+        let chunk_partitions_len = chunk.len() as u64;
+        bincode::serialize_into(&mut body, &chunk_partitions_len)
+            .expect("RangeReadStreamChunkPayload header serialization is infallible");
+        for partition in chunk {
+            serialize_partition_to_wire_borrowed(&mut body, partition)
+                .expect("PartitionWire serialization is infallible");
+        }
+        sink.send(Message::RangeReadStreamChunk(Bytes::from(body)))
             .await;
         seq = seq.saturating_add(1);
     }

--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -1221,8 +1221,7 @@ mod tests {
         }
 
         let legacy_wire = partition_to_wire(original.clone());
-        let legacy_bytes =
-            bincode::serialize(&legacy_wire).expect("legacy serialize must succeed");
+        let legacy_bytes = bincode::serialize(&legacy_wire).expect("legacy serialize must succeed");
 
         let mut borrowed_bytes: Vec<u8> = Vec::new();
         super::serialize_partition_to_wire_borrowed(&mut borrowed_bytes, &original)

--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -177,6 +177,101 @@ pub struct PartitionWire {
     pub rows: Vec<RowWire>,
 }
 
+/// Emit the bincode wire bytes for `p` (as if it had been
+/// converted with [`partition_to_wire`] then `bincode::serialize`d)
+/// **without cloning the partition or any of its rows or cells**.
+///
+/// Each `Option<Vec<u8>>` cell value is serialised by reference;
+/// the per-row conversion to `RowWire` is inlined into the writer
+/// rather than building a `Vec<RowWire>` intermediate. Per-call
+/// transient allocation is whatever bincode's small scratch state
+/// uses, independent of partition row count or cell-value size.
+///
+/// Used by the streaming range-read producer and the chunked
+/// repair Apply send path to avoid the
+/// `chunk.iter().cloned().map(partition_to_wire).collect::<Vec<_>>()`
+/// allocation that scales with chunk size × partition size.
+///
+/// Output is byte-identical to
+/// `bincode::serialize(&partition_to_wire(p.clone()))` — pinned
+/// by `serialize_partition_to_wire_borrowed_matches_legacy`.
+pub fn serialize_partition_to_wire_borrowed<W: std::io::Write>(
+    writer: &mut W,
+    p: &Partition,
+) -> Result<(), bincode::Error> {
+    // PartitionWire field order: token, key_bytes, deletion,
+    // static_row, rows.
+    bincode::serialize_into(&mut *writer, &p.key.token.0)?;
+    bincode::serialize_into(&mut *writer, p.key.key.as_bytes())?;
+    serialize_deletion_time_borrowed(
+        &mut *writer,
+        p.deletion.marked_for_delete_at,
+        p.deletion.local_deletion_time,
+    )?;
+    // Option<RowWire>: bincode tag (default u8) + inline payload.
+    // The zero-or-one static-row clone is a one-time cost per
+    // partition — negligible next to the row stream below.
+    let static_wire = p.static_row.clone().map(RowWire::from);
+    bincode::serialize_into(&mut *writer, &static_wire)?;
+    drop(static_wire);
+    // Vec<RowWire>: bincode emits length (u64) + items inline.
+    // Emit length then iterate, serialising each row from its
+    // owning slot — no intermediate Vec<RowWire>.
+    let n = p.rows.len() as u64;
+    bincode::serialize_into(&mut *writer, &n)?;
+    for row in &p.rows {
+        serialize_row_to_wire_borrowed(&mut *writer, row)?;
+    }
+    Ok(())
+}
+
+/// Inlined `RowWire` bincode emission from a borrowed `Row`. Each
+/// cell's `value: Option<Vec<u8>>` is serialised by reference —
+/// no clone. The cell tuple `(u16, CellValueWire)` is emitted
+/// field-by-field to match the wire layout exactly.
+fn serialize_row_to_wire_borrowed<W: std::io::Write>(
+    writer: &mut W,
+    row: &Row,
+) -> Result<(), bincode::Error> {
+    // RowWire: clustering, cells, deletion, primary_key_liveness.
+    bincode::serialize_into(&mut *writer, &row.clustering)?;
+    // Vec<(u16, CellValueWire)>: length + items.
+    let n_cells = row.cells.len() as u64;
+    bincode::serialize_into(&mut *writer, &n_cells)?;
+    for (idx, cell) in &row.cells {
+        bincode::serialize_into(&mut *writer, idx)?;
+        // CellValueWire field order: value, timestamp, ttl,
+        // local_deletion_time. Identical field layout to the
+        // in-memory `CellValue`, so emitting field-by-field
+        // matches the bincode struct serialisation.
+        bincode::serialize_into(&mut *writer, &cell.value)?;
+        bincode::serialize_into(&mut *writer, &cell.timestamp)?;
+        bincode::serialize_into(&mut *writer, &cell.ttl)?;
+        bincode::serialize_into(&mut *writer, &cell.local_deletion_time)?;
+    }
+    serialize_deletion_time_borrowed(
+        &mut *writer,
+        row.deletion.marked_for_delete_at,
+        row.deletion.local_deletion_time,
+    )?;
+    // LivenessInfoWire field order: timestamp, ttl,
+    // local_deletion_time.
+    bincode::serialize_into(&mut *writer, &row.primary_key_liveness.timestamp)?;
+    bincode::serialize_into(&mut *writer, &row.primary_key_liveness.ttl)?;
+    bincode::serialize_into(&mut *writer, &row.primary_key_liveness.local_deletion_time)?;
+    Ok(())
+}
+
+fn serialize_deletion_time_borrowed<W: std::io::Write>(
+    writer: &mut W,
+    marked_for_delete_at: i64,
+    local_deletion_time: u32,
+) -> Result<(), bincode::Error> {
+    bincode::serialize_into(&mut *writer, &marked_for_delete_at)?;
+    bincode::serialize_into(&mut *writer, &local_deletion_time)?;
+    Ok(())
+}
+
 /// Convert a [`Partition`] into its wire representation.
 pub fn partition_to_wire(p: Partition) -> PartitionWire {
     PartitionWire {
@@ -1089,6 +1184,54 @@ mod tests {
         assert_eq!(
             reconstructed.rows[0].cells[0].1.value,
             original.rows[0].cells[0].1.value
+        );
+    }
+
+    /// The borrow-based partition serializer must emit byte-for-byte
+    /// the same bincode output as
+    /// `bincode::serialize(&partition_to_wire(p.clone()))`.
+    ///
+    /// Without byte-equivalence, callers that decode on the wire
+    /// (RangeReadStreamChunk consumers, repair Apply receivers,
+    /// CL read responders) would see corrupted partitions —
+    /// the savings from skipping the clone aren't worth a
+    /// silent decoding bug.
+    ///
+    /// The streaming range-read producer
+    /// (`stream_range_response` in `coordinator::stream_producer`)
+    /// uses this helper to emit each chunk's partitions without
+    /// the per-partition `.clone()` + `Vec<PartitionWire>::collect()`
+    /// allocations that scale with chunk size.
+    #[test]
+    fn serialize_partition_to_wire_borrowed_matches_legacy() {
+        // Multi-row, multi-cell partition to exercise every layer
+        // of the wire encoding (DeletionTime, LivenessInfo,
+        // CellValue, Vec<(u16, _)>).
+        let mut original = make_partition(b"borrowed-eq", 12_345);
+        for i in 1..5 {
+            original.rows.push(Row {
+                clustering: vec![i as u8, 0, 0, 0],
+                cells: vec![(
+                    0,
+                    CellValue::live(format!("v-{i}").into_bytes(), 12_345 + i as i64),
+                )],
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::with_timestamp(12_345 + i as i64),
+            });
+        }
+
+        let legacy_wire = partition_to_wire(original.clone());
+        let legacy_bytes =
+            bincode::serialize(&legacy_wire).expect("legacy serialize must succeed");
+
+        let mut borrowed_bytes: Vec<u8> = Vec::new();
+        super::serialize_partition_to_wire_borrowed(&mut borrowed_bytes, &original)
+            .expect("borrowed serialize must succeed");
+
+        assert_eq!(
+            legacy_bytes, borrowed_bytes,
+            "borrowed partition serializer must emit byte-identical \
+             output to the clone-then-bincode path"
         );
     }
 


### PR DESCRIPTION
## Summary

`coordinator::stream_producer::stream_range_response` emits each `RangeReadStreamChunk` by collecting `chunk.iter().cloned().map(partition_to_wire)` into a `Vec<PartitionWire>` and handing it to `bincode::serialize`. Per chunk that's **three live copies of the partition data**:

1. the input slice (caller-owned)
2. the wire-vec clone (deep-clones every cell value into `PartitionWire`)
3. the bincode body buffer (a fresh `Vec<u8>` the size of the serialised chunk)

On a 64-partition chunk with multi-MB cell values that's tens of MB of transient allocation per outbound chunk, repeated for every chunk emitted on a streaming range read.

This PR adds `serialize_partition_to_wire_borrowed(writer, &Partition)` that emits the bincode bytes for a `PartitionWire` directly from a borrowed `&Partition` — no clone of the partition, the rows, or the cells. `stream_range_response` builds each chunk's body by writing the header fields (request_id, seq, partition count) directly into a fresh `Vec<u8>`, then folding each partition in via the borrowed serialiser.

## Wire compatibility

Byte-identical to the legacy `bincode::serialize(&RangeReadStreamChunkPayload{..})` output, pinned by the new `serialize_partition_to_wire_borrowed_matches_legacy` test. Existing decoder tests (which decode via `bincode::deserialize::<RangeReadStreamChunkPayload>`) still pass — the receiver path is unchanged.

## Follow-up

Same helper applies symmetrically to the chunked repair Apply send path (`repair::rpc::RemoteRepairStore::apply_partitions` — see PR #49), which has the identical `chunk.iter().cloned().map(partition_to_wire).collect()` shape. That swap is a one-line change once both PRs land.

## Test plan

- [x] New `serialize_partition_to_wire_borrowed_matches_legacy` (raft::handlers): byte-equivalence against the legacy `bincode::serialize(&partition_to_wire(p.clone()))` for a multi-row, multi-cell partition.
- [x] All 5 `coordinator::stream_producer` tests pass (decoder verifies receivers still parse the borrowed-emitted bytes correctly).
- [x] All 139 `coordinator::` tests pass.
- [x] CI workspace: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`.