### PR TITLE
fix(compose): allow rustfs default creds for local-dev sample

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_ACCESS_KEY: rustfsadmin
       RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      # Newer rustfs images reject default creds on non-loopback listeners;
+      # this sample is local-dev only (see FERROSA_AUTH_DISABLED above).
+      RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
     volumes:
       - rustfs-data:/data
     healthcheck:

--- a/tests/cluster/docker-compose.cql-integration.yml
+++ b/tests/cluster/docker-compose.cql-integration.yml
@@ -22,6 +22,7 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_ACCESS_KEY: rustfsadmin
       RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
     volumes:
       - cqltest-rustfs:/data
     healthcheck:

--- a/tests/docker-compose.cluster.w3-standalone.yml
+++ b/tests/docker-compose.cluster.w3-standalone.yml
@@ -39,6 +39,7 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_ACCESS_KEY: rustfsadmin
       RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
     volumes:
       - rustfs-data:/data
     healthcheck:

--- a/tests/docker-compose.compaction-test.yml
+++ b/tests/docker-compose.compaction-test.yml
@@ -33,6 +33,7 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_ACCESS_KEY: rustfsadmin
       RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
     volumes:
       - ct-rustfs-data:/data
     healthcheck:

--- a/tests/drivers/docker-compose.drivers.yml
+++ b/tests/drivers/docker-compose.drivers.yml
@@ -39,6 +39,7 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_ACCESS_KEY: rustfsadmin
       RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
     volumes:
       - rustfs-data:/data
     healthcheck:


### PR DESCRIPTION
The root sample deployment binds rustfs to 0.0.0.0:9000 using the built-in rustfsadmin credentials. Recent rustfs builds refuse to start with default root credentials on a non-loopback listener, so `docker-compose up` aborts before the cluster can form.

Set RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true on the rustfs service — the documented opt-in for local development, consistent with this sample already running with auth disabled.