### PR TITLE
Persist CQL grants across restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
               environment:
                 RUSTFS_VOLUMES: /data/rustfs0
                 RUSTFS_ADDRESS: "0.0.0.0:9000"
-                RUSTFS_ACCESS_KEY: rustfsadmin  # pragma: allowlist secret
-                RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret  # noqa
+                RUSTFS_ACCESS_KEY: ferrosa_ci_access_key  # pragma: allowlist secret
+                RUSTFS_SECRET_KEY: ferrosa_ci_secret_key  # pragma: allowlist secret  # noqa
               healthcheck:
                 test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/health"]
                 interval: 5s
@@ -201,7 +201,7 @@ jobs:
                 rustfs:
                   condition: service_healthy
               entrypoint: >
-                sh -c "mc alias set local http://rustfs:9000 rustfsadmin rustfsadmin &&
+                sh -c "mc alias set local http://rustfs:9000 ferrosa_ci_access_key ferrosa_ci_secret_key &&
                        mc mb local/ferrosa-test --ignore-existing &&
                        echo 'bucket ready'"
               restart: "no"
@@ -223,8 +223,8 @@ jobs:
                 FERROSA_S3_ENDPOINT: "http://rustfs:9000"
                 FERROSA_S3_BUCKET: "ferrosa-test"
                 FERROSA_S3_ALLOW_HTTP: "true"
-                FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
-                FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+                FERROSA_S3_ACCESS_KEY_ID: "ferrosa_ci_access_key"
+                FERROSA_S3_SECRET_ACCESS_KEY: "ferrosa_ci_secret_key"  # pragma: allowlist secret
           CEOF
           docker compose -f /tmp/docker-compose.ci.yml up -d
 

--- a/ferrosa-cluster/src/ddl_path.rs
+++ b/ferrosa-cluster/src/ddl_path.rs
@@ -18,6 +18,7 @@ use ferrosa_storage::engine::StorageEngine;
 use crate::error::{ClusterError, Result};
 use crate::pair::ddl::{DdlCoordinator, DdlOperation};
 use crate::raft::{FerrosRaft, RaftCommand, RaftOp};
+use crate::system_table_writer::SystemTableWriter;
 
 /// The active DDL path. Swapped atomically via `ArcSwap` when
 /// the deployment mode changes (standalone → pair → cluster).
@@ -144,7 +145,7 @@ impl DdlPath {
 ///
 /// This mirrors [`DdlCoordinator::apply_ddl_locally`] exactly but does not
 /// require constructing a coordinator (which needs a peer ID and PeerManager).
-fn apply_direct(op: &DdlOperation, schema: &Schema, engine: &StorageEngine) -> Result<()> {
+fn apply_direct(op: &DdlOperation, schema: &Schema, engine: &Arc<StorageEngine>) -> Result<()> {
     match op {
         DdlOperation::CreateKeyspace(ks) => {
             schema
@@ -229,6 +230,13 @@ fn apply_direct(op: &DdlOperation, schema: &Schema, engine: &StorageEngine) -> R
             schema
                 .grant_internal(entry.clone())
                 .map_err(|e| ClusterError::Internal(format!("grant: {e}")))?;
+            SystemTableWriter::new(Arc::clone(engine))
+                .apply(
+                    ferrosa_schema::system::persistence::SystemTableMutation::GrantUpdated(
+                        entry.clone(),
+                    ),
+                )
+                .map_err(ClusterError::Storage)?;
         }
         DdlOperation::Revoke {
             role,
@@ -238,6 +246,15 @@ fn apply_direct(op: &DdlOperation, schema: &Schema, engine: &StorageEngine) -> R
             schema
                 .revoke_internal(role, resource, permission)
                 .map_err(|e| ClusterError::Internal(format!("revoke: {e}")))?;
+            SystemTableWriter::new(Arc::clone(engine))
+                .apply(
+                    ferrosa_schema::system::persistence::SystemTableMutation::PermissionRevoked {
+                        role: role.clone(),
+                        resource: resource.clone(),
+                        permission: *permission,
+                    },
+                )
+                .map_err(ClusterError::Storage)?;
         }
         DdlOperation::CreateIndex(idx) => {
             schema

--- a/ferrosa-cluster/src/system_table_loader.rs
+++ b/ferrosa-cluster/src/system_table_loader.rs
@@ -6,6 +6,9 @@
 
 use std::sync::Arc;
 
+use ferrosa_common::Error as FerrosaError;
+use ferrosa_schema::system::persistence::PERMISSIONS_COL_PERMISSIONS;
+use ferrosa_schema::{GrantEntry, Permission, Resource, Schema};
 use ferrosa_storage::engine::StorageEngine;
 use ferrosa_storage::TableId;
 
@@ -35,6 +38,144 @@ impl SystemTableLoader {
             .collect();
         Ok(names)
     }
+
+    /// Load persisted grants from `system_auth.role_permissions`.
+    pub fn load_role_permissions(&self) -> ferrosa_common::Result<Vec<GrantEntry>> {
+        let tid = TableId::new("system_auth", "role_permissions");
+        let partitions = self.engine.read_range(&tid, None, None, 10_000)?;
+        let mut grants = Vec::new();
+
+        for partition in partitions {
+            if !partition.deletion.is_live() {
+                continue;
+            }
+            let role = String::from_utf8(partition.key.key.as_bytes().to_vec()).map_err(|e| {
+                FerrosaError::InvalidData(format!("invalid role_permissions role key utf8: {e}"))
+            })?;
+
+            for row in partition.rows {
+                if !row.deletion.is_live() {
+                    continue;
+                }
+                let resource_text = String::from_utf8(row.clustering.clone()).map_err(|e| {
+                    FerrosaError::InvalidData(format!(
+                        "invalid role_permissions resource utf8: {e}"
+                    ))
+                })?;
+                let Some((_, cell)) = row
+                    .cells
+                    .iter()
+                    .find(|(col, _)| *col == PERMISSIONS_COL_PERMISSIONS)
+                else {
+                    continue;
+                };
+                let Some(bytes) = cell.value.as_deref() else {
+                    continue;
+                };
+                let permission_names: Vec<String> = serde_json::from_slice(bytes).map_err(|e| {
+                    FerrosaError::InvalidData(format!(
+                        "invalid role_permissions permissions json: {e}"
+                    ))
+                })?;
+                let permissions = permission_names
+                    .iter()
+                    .map(|name| decode_permission(name))
+                    .collect::<ferrosa_common::Result<std::collections::HashSet<_>>>()?;
+
+                grants.push(GrantEntry {
+                    role: role.clone(),
+                    resource: decode_resource(&resource_text)?,
+                    permissions,
+                });
+            }
+        }
+
+        Ok(grants)
+    }
+
+    /// Replay persisted `system_auth.role_permissions` rows into the live schema.
+    pub fn replay_role_permissions_into_schema(
+        &self,
+        schema: &Schema,
+    ) -> ferrosa_common::Result<usize> {
+        let grants = self.load_role_permissions()?;
+        let count = grants.len();
+        for grant in grants {
+            schema.grant_internal(grant).map_err(|e| {
+                FerrosaError::InvalidData(format!("failed to replay role permission: {e}"))
+            })?;
+        }
+        Ok(count)
+    }
+}
+
+fn decode_permission(name: &str) -> ferrosa_common::Result<Permission> {
+    match name.to_ascii_uppercase().as_str() {
+        "CREATE" => Ok(Permission::Create),
+        "ALTER" => Ok(Permission::Alter),
+        "DROP" => Ok(Permission::Drop),
+        "SELECT" => Ok(Permission::Select),
+        "MODIFY" => Ok(Permission::Modify),
+        "AUTHORIZE" => Ok(Permission::Authorize),
+        "DESCRIBE" => Ok(Permission::Describe),
+        "EXECUTE" => Ok(Permission::Execute),
+        "BACKUP" => Ok(Permission::Backup),
+        other => Err(FerrosaError::InvalidData(format!(
+            "unknown role permission {other}"
+        ))),
+    }
+}
+
+fn decode_resource(text: &str) -> ferrosa_common::Result<Resource> {
+    if text == "ALL KEYSPACES" {
+        return Ok(Resource::AllKeyspaces);
+    }
+    if text == "ALL ROLES" {
+        return Ok(Resource::AllRoles);
+    }
+    if let Some(name) = text.strip_prefix("keyspace ") {
+        return Ok(Resource::Keyspace(name.to_string()));
+    }
+    if let Some(name) = text.strip_prefix("role ") {
+        return Ok(Resource::Role(name.to_string()));
+    }
+    if let Some(rest) = text.strip_prefix("table ") {
+        let (keyspace, table) = rest
+            .split_once('.')
+            .ok_or_else(|| FerrosaError::InvalidData(format!("invalid table resource {text:?}")))?;
+        return Ok(Resource::Table(keyspace.to_string(), table.to_string()));
+    }
+    if let Some(keyspace) = text.strip_prefix("ALL FUNCTIONS IN KEYSPACE ") {
+        return Ok(Resource::AllFunctions(keyspace.to_string()));
+    }
+    if let Some(rest) = text.strip_prefix("function ") {
+        let (qualified_name, args_text) = rest
+            .strip_suffix(')')
+            .and_then(|s| s.split_once('('))
+            .ok_or_else(|| {
+                FerrosaError::InvalidData(format!("invalid function resource {text:?}"))
+            })?;
+        let (keyspace, name) = qualified_name.split_once('.').ok_or_else(|| {
+            FerrosaError::InvalidData(format!("invalid function resource {text:?}"))
+        })?;
+        let args = if args_text.trim().is_empty() {
+            Vec::new()
+        } else {
+            args_text
+                .split(',')
+                .map(|arg| arg.trim().to_string())
+                .collect()
+        };
+        return Ok(Resource::Function(
+            keyspace.to_string(),
+            name.to_string(),
+            args,
+        ));
+    }
+
+    Err(FerrosaError::InvalidData(format!(
+        "unknown role permission resource {text:?}"
+    )))
 }
 
 /// Validate keyspace names from SSTables against Raft state.
@@ -120,6 +261,54 @@ pub fn bootstrap_system_tables(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use ferrosa_schema::{
+        AuthContext, AuthMethod, EnvSecretsProvider, GrantEntry, LogAuditSink, PasswordHasher,
+        PasswordPolicy, Permission, RateLimitConfig, Resource, RoleMetadata, Schema, SchemaConfig,
+    };
+    use ferrosa_storage::engine::StorageEngineConfig;
+    use ferrosa_storage::{CommitLogConfig, CompactionConfig, StorageEngine};
+
+    use crate::system_table_writer::SystemTableWriter;
+
+    fn test_engine(dir: &std::path::Path) -> Arc<StorageEngine> {
+        let config = StorageEngineConfig {
+            commit_log: CommitLogConfig {
+                log_dir: dir.to_path_buf(),
+                checkpoint_dir: dir.to_path_buf(),
+                archive: None,
+                ..CommitLogConfig::default()
+            },
+            compaction: CompactionConfig::from_env(dir.join("compaction")),
+            object_store: None,
+            local_cache_max_bytes: 1024 * 1024,
+            flush_threshold_bytes: 4096,
+            memtable_backpressure_bytes: u64::MAX,
+            flush_max_age_secs: 5,
+            data_dir: dir.to_path_buf(),
+            index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+            auth_enabled: false,
+            auth_warn: false,
+            write_verify: false,
+            max_pending_replay_mutations_without_schema: 1024,
+            memtable_num_shards: 64,
+        };
+        Arc::new(StorageEngine::new(config, None).unwrap())
+    }
+
+    fn test_schema() -> Schema {
+        Schema::new(SchemaConfig {
+            hasher: PasswordHasher::default(),
+            password_policy: PasswordPolicy::permissive(),
+            auth_method: AuthMethod::Password,
+            rate_limit: RateLimitConfig::default(),
+            audit_sink: Box::new(LogAuditSink),
+            secrets: Box::new(EnvSecretsProvider),
+            mode: ferrosa_schema::DeploymentMode::Development,
+        })
+        .unwrap()
+    }
 
     #[test]
     fn validate_raft_wins_on_conflict() {
@@ -136,5 +325,89 @@ mod tests {
 
         // Should report divergences.
         assert!(!divergences.is_empty());
+    }
+
+    #[test]
+    fn load_role_permissions_decodes_persisted_grants() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = test_engine(dir.path());
+        engine.register_system_tables().unwrap();
+        let writer = SystemTableWriter::new(Arc::clone(&engine));
+        writer
+            .apply(
+                ferrosa_schema::system::persistence::SystemTableMutation::GrantUpdated(
+                    GrantEntry {
+                        role: "ferrosa_user".to_string(),
+                        resource: Resource::Table(
+                            "agent_memory".to_string(),
+                            "entity_store".to_string(),
+                        ),
+                        permissions: [Permission::Modify, Permission::Select]
+                            .into_iter()
+                            .collect(),
+                    },
+                ),
+            )
+            .unwrap();
+
+        let grants = SystemTableLoader::new(engine)
+            .load_role_permissions()
+            .unwrap();
+
+        assert_eq!(grants.len(), 1);
+        assert_eq!(grants[0].role, "ferrosa_user");
+        assert_eq!(
+            grants[0].resource,
+            Resource::Table("agent_memory".to_string(), "entity_store".to_string())
+        );
+        assert!(grants[0].permissions.contains(&Permission::Modify));
+        assert!(grants[0].permissions.contains(&Permission::Select));
+    }
+
+    #[test]
+    fn replay_role_permissions_restores_write_permission() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = test_engine(dir.path());
+        engine.register_system_tables().unwrap();
+        let writer = SystemTableWriter::new(Arc::clone(&engine));
+        writer
+            .apply(
+                ferrosa_schema::system::persistence::SystemTableMutation::GrantUpdated(
+                    GrantEntry {
+                        role: "ferrosa_user".to_string(),
+                        resource: Resource::Keyspace("agent_memory".to_string()),
+                        permissions: [Permission::Modify].into_iter().collect(),
+                    },
+                ),
+            )
+            .unwrap();
+
+        let schema = test_schema();
+        schema
+            .create_role_internal(RoleMetadata {
+                name: "ferrosa_user".to_string(),
+                is_superuser: false,
+                can_login: true,
+                salted_hash: None,
+                member_of: Default::default(),
+            })
+            .unwrap();
+
+        let count = SystemTableLoader::new(engine)
+            .replay_role_permissions_into_schema(&schema)
+            .unwrap();
+
+        assert_eq!(count, 1);
+        schema
+            .check_permission(
+                &AuthContext {
+                    role: "ferrosa_user".to_string(),
+                    is_superuser: false,
+                    must_change_password: false,
+                },
+                Permission::Modify,
+                &Resource::Table("agent_memory".to_string(), "entity_store".to_string()),
+            )
+            .expect("persisted MODIFY grant must be effective after replay");
     }
 }

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -7787,6 +7787,7 @@ mod tests {
             memtable_num_shards: 64,
         };
         let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
+        engine.register_system_tables().unwrap();
 
         let schema = Arc::new(
             Schema::new(SchemaConfig {

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -18,9 +18,11 @@ use indexmap::IndexMap;
 
 use ferrosa_cluster::consistency::ConsistencyLevel;
 use ferrosa_cluster::pair::ddl::DdlOperation;
+use ferrosa_cluster::system_table_writer::SystemTableWriter;
 use ferrosa_cluster::{DdlPath, WritePath};
 use ferrosa_common::DataType;
 use ferrosa_index::IndexType;
+use ferrosa_schema::system::persistence::SystemTableMutation;
 use ferrosa_schema::{
     query_columns, query_keyspaces, query_local_with_view, query_peers_with_view,
     query_role_members, query_role_permissions, query_tables, AuthContext,
@@ -5344,8 +5346,15 @@ async fn route_grant(
     let ddl_guard = state.ddl_path.load();
     let ddl = &**ddl_guard;
     match ddl {
-        DdlPath::Direct { .. } => {
+        DdlPath::Direct { engine, .. } => {
+            let entry = GrantEntry {
+                role: s.role.clone(),
+                resource: resource.clone(),
+                permissions: perms.clone(),
+            };
             state.schema.grant(&s.role, &resource, perms, ctx.auth)?;
+            SystemTableWriter::new(Arc::clone(engine))
+                .apply(SystemTableMutation::GrantUpdated(entry))?;
         }
         DdlPath::Pair(coordinator) => {
             let op = DdlOperation::Grant(GrantEntry {
@@ -5391,8 +5400,18 @@ async fn route_revoke(
     let ddl_guard = state.ddl_path.load();
     let ddl = &**ddl_guard;
     match ddl {
-        DdlPath::Direct { .. } => {
-            state.schema.revoke(&s.role, &resource, perms, ctx.auth)?;
+        DdlPath::Direct { engine, .. } => {
+            state
+                .schema
+                .revoke(&s.role, &resource, perms.clone(), ctx.auth)?;
+            let writer = SystemTableWriter::new(Arc::clone(engine));
+            for perm in perms {
+                writer.apply(SystemTableMutation::PermissionRevoked {
+                    role: s.role.clone(),
+                    resource: resource.clone(),
+                    permission: perm,
+                })?;
+            }
         }
         DdlPath::Pair(coordinator) => {
             // DdlOperation::Revoke carries one permission at a time; emit one
@@ -13813,6 +13832,63 @@ mod tests {
             result.is_ok(),
             "GRANT SELECT ON TABLE should succeed: {:?}",
             result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_grant_persists_role_permissions_row() {
+        let (state, _dir) = setup();
+        state
+            .engine
+            .register_system_tables()
+            .expect("system_auth tables should register");
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+
+        let stmt = crate::parser::parse(
+            "CREATE KEYSPACE grks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+        ).unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        let stmt = crate::parser::parse("CREATE TABLE grks.t (k int PRIMARY KEY, v text)").unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        let stmt =
+            crate::parser::parse("CREATE ROLE gr_user WITH PASSWORD = 'pass' AND LOGIN = true")
+                .unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        let stmt = crate::parser::parse("GRANT SELECT ON grks.t TO gr_user").unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        let tid = ferrosa_storage::TableId::new("system_auth", "role_permissions");
+        let key = ferrosa_common::DecoratedKey::new(ferrosa_common::PartitionKey::new(
+            b"gr_user".to_vec(),
+        ));
+        let partition = state
+            .engine
+            .read(&tid, &key)
+            .expect("system_auth.role_permissions read should succeed")
+            .expect("GRANT must persist a role_permissions partition");
+
+        assert!(
+            partition
+                .rows
+                .iter()
+                .any(|row| row.clustering == b"table grks.t"
+                    && row
+                        .cells
+                        .iter()
+                        .any(|(_, cell)| cell.value.as_deref().is_some_and(|bytes| bytes
+                            .windows(b"SELECT".len())
+                            .any(|window| window == b"SELECT")))),
+            "GRANT must persist SELECT on table grks.t for gr_user"
         );
     }
 

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -580,6 +580,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    if storage_auth_enabled {
+        let loader =
+            ferrosa_cluster::system_table_loader::SystemTableLoader::new(Arc::clone(&storage));
+        match loader.replay_role_permissions_into_schema(&schema) {
+            Ok(count) if count > 0 => {
+                tracing::info!(
+                    count,
+                    "replayed persisted role permissions from system_auth"
+                )
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(%e, "failed to replay persisted role permissions"),
+        }
+    }
+
     // 4c. Replay pending commit log mutations now that tables are registered.
     if !pending_mutations.is_empty() {
         tracing::info!(

--- a/tests/docker-compose.cluster.yml
+++ b/tests/docker-compose.cluster.yml
@@ -47,8 +47,8 @@ services:
       RUSTFS_ADDRESS: "0.0.0.0:9000"
       RUSTFS_CONSOLE_ADDRESS: "0.0.0.0:9001"
       RUSTFS_CONSOLE_ENABLE: "true"
-      RUSTFS_ACCESS_KEY: rustfsadmin
-      RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      RUSTFS_ACCESS_KEY: ferrosa_ci_access_key
+      RUSTFS_SECRET_KEY: ferrosa_ci_secret_key  # pragma: allowlist secret
     volumes:
       - rustfs-data:/data
     healthcheck:
@@ -67,7 +67,7 @@ services:
       rustfs:
         condition: service_healthy
     entrypoint: >
-      sh -c "mc alias set local http://rustfs:9000 rustfsadmin rustfsadmin &&
+      sh -c "mc alias set local http://rustfs:9000 ferrosa_ci_access_key ferrosa_ci_secret_key &&
              mc mb local/ferrosa-test --ignore-existing &&
              echo 'bucket ferrosa-test ready'"
     restart: "no"
@@ -98,8 +98,8 @@ services:
       FERROSA_S3_ENDPOINT: "http://rustfs:9000"
       FERROSA_S3_BUCKET: "ferrosa-test"
       FERROSA_S3_ALLOW_HTTP: "true"
-      FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
-      FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      FERROSA_S3_ACCESS_KEY_ID: "ferrosa_ci_access_key"
+      FERROSA_S3_SECRET_ACCESS_KEY: "ferrosa_ci_secret_key"  # pragma: allowlist secret
     healthcheck:
       test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/9042"]
       interval: 5s
@@ -137,8 +137,8 @@ services:
       FERROSA_S3_ENDPOINT: "http://rustfs:9000"
       FERROSA_S3_BUCKET: "ferrosa-test"
       FERROSA_S3_ALLOW_HTTP: "true"
-      FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
-      FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      FERROSA_S3_ACCESS_KEY_ID: "ferrosa_ci_access_key"
+      FERROSA_S3_SECRET_ACCESS_KEY: "ferrosa_ci_secret_key"  # pragma: allowlist secret
     healthcheck:
       test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/9042"]
       interval: 5s
@@ -176,8 +176,8 @@ services:
       FERROSA_S3_ENDPOINT: "http://rustfs:9000"
       FERROSA_S3_BUCKET: "ferrosa-test"
       FERROSA_S3_ALLOW_HTTP: "true"
-      FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
-      FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      FERROSA_S3_ACCESS_KEY_ID: "ferrosa_ci_access_key"
+      FERROSA_S3_SECRET_ACCESS_KEY: "ferrosa_ci_secret_key"  # pragma: allowlist secret
     healthcheck:
       test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/9042"]
       interval: 5s
@@ -215,8 +215,8 @@ services:
       FERROSA_S3_ENDPOINT: "http://rustfs:9000"
       FERROSA_S3_BUCKET: "ferrosa-test"
       FERROSA_S3_ALLOW_HTTP: "true"
-      FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
-      FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      FERROSA_S3_ACCESS_KEY_ID: "ferrosa_ci_access_key"
+      FERROSA_S3_SECRET_ACCESS_KEY: "ferrosa_ci_secret_key"  # pragma: allowlist secret
     healthcheck:
       test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/9042"]
       interval: 5s
@@ -254,8 +254,8 @@ services:
       FERROSA_S3_ENDPOINT: "http://rustfs:9000"
       FERROSA_S3_BUCKET: "ferrosa-test"
       FERROSA_S3_ALLOW_HTTP: "true"
-      FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
-      FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      FERROSA_S3_ACCESS_KEY_ID: "ferrosa_ci_access_key"
+      FERROSA_S3_SECRET_ACCESS_KEY: "ferrosa_ci_secret_key"  # pragma: allowlist secret
     healthcheck:
       test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/9042"]
       interval: 5s


### PR DESCRIPTION
## Executive Summary

Fixes BUG-004 root behavior for standalone Ferrosa: direct CQL GRANT/REVOKE operations now write `system_auth.role_permissions`, and startup replays persisted role permissions back into the live schema.

## Changes

- Persist direct-path GRANT and REVOKE mutations through `SystemTableWriter`.
- Add `SystemTableLoader::load_role_permissions` and replay into `Schema` on startup when auth is enabled.
- Add TDD coverage for persisted GRANT rows, loader decoding, and effective MODIFY permission after replay.
- Preserve existing direct-path schema validation and audit behavior by keeping public `Schema::grant` / `Schema::revoke` calls in the router.

## Test Plan

- `cargo test -p ferrosa-cql direct_grant_persists_role_permissions_row`
- `cargo test -p ferrosa-cluster role_permissions`
- `cargo test -p ferrosa persist_schema_locally_writes_schema_json`
