### PR TITLE
fix(jepsen): allow RustFS defaults in nightly compose

### DIFF
--- a/ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml
+++ b/ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml
@@ -56,6 +56,7 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_ACCESS_KEY: rustfsadmin
       RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
     volumes:
       - jepsen-t3-rustfs-data:/data
     healthcheck:

--- a/ferrosa-jepsen/tests/docker/jepsen-cluster.yml
+++ b/ferrosa-jepsen/tests/docker/jepsen-cluster.yml
@@ -44,6 +44,7 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_ACCESS_KEY: rustfsadmin
       RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
     volumes:
       - jepsen-rustfs-data:/data
     healthcheck:

--- a/ferrosa-jepsen/tests/rustfs_credentials.rs
+++ b/ferrosa-jepsen/tests/rustfs_credentials.rs
@@ -1,0 +1,55 @@
+//! Regression coverage for RustFS test credentials in Jepsen compose files.
+
+use std::path::{Path, PathBuf};
+
+fn compose_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+#[test]
+fn jepsen_compose_files_allow_rustfs_default_credentials() {
+    for relative in [
+        "tests/docker/jepsen-cluster.yml",
+        "tests/docker/jepsen-cluster-t3.yml",
+    ] {
+        assert_rustfs_default_credentials_are_explicitly_allowed(&compose_path(relative));
+    }
+}
+
+fn assert_rustfs_default_credentials_are_explicitly_allowed(path: &Path) {
+    let raw =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    let services = parsed
+        .get("services")
+        .and_then(|v| v.as_mapping())
+        .unwrap_or_else(|| panic!("{} missing services mapping", path.display()));
+    let rustfs = services
+        .get(serde_yaml::Value::String("rustfs".into()))
+        .unwrap_or_else(|| panic!("{} missing rustfs service", path.display()));
+    let env = rustfs
+        .get("environment")
+        .and_then(|v| v.as_mapping())
+        .unwrap_or_else(|| panic!("{} rustfs service missing environment", path.display()));
+
+    let access_key = env
+        .get(serde_yaml::Value::String("RUSTFS_ACCESS_KEY".into()))
+        .and_then(|v| v.as_str());
+    let secret_key = env
+        .get(serde_yaml::Value::String("RUSTFS_SECRET_KEY".into()))
+        .and_then(|v| v.as_str());
+
+    if access_key == Some("rustfsadmin") && secret_key == Some("rustfsadmin") {
+        assert_eq!(
+            env.get(serde_yaml::Value::String(
+                "RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS".into()
+            ))
+            .and_then(|v| v.as_str()),
+            Some("true"),
+            "{} uses RustFS default credentials and must set \
+             RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true",
+            path.display()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- allow RustFS insecure default credentials in the Jepsen single-DC and T3 compose files
- add a regression test for Jepsen compose files that use rustfsadmin/rustfsadmin

Closes #53

## Verification
- cargo test -p ferrosa-jepsen --test rustfs_credentials
- cargo test -p ferrosa-jepsen --test t3_topology t3_compose
- cargo test -p ferrosa-jepsen --test tier_multi_dc tier_multi_dc_resolves_to_t3
- cargo test -p ferrosa-jepsen --test tier_multi_dc dc_partition_plus_dc_slow_nemesis_registered
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' ferrosa-jepsen/tests/docker/jepsen-cluster.yml ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml\n- git diff --check\n\nNote: the full live tier_multi_dc_one_hour_bank_workload was not run locally because it requires FERROSA_TEST_CONTAINERS=1 and a Docker/Podman daemon.