### PR TITLE
Harden RRD keyed storage cursor

### DIFF
--- a/examples/timeseries-rrd/data.cql
+++ b/examples/timeseries-rrd/data.cql
@@ -1,4 +1,4 @@
--- RRD Cascading Time-Series Aggregation: Sensor Data
+-- RRD Time-Series Aggregation: Sensor Data
 --
 -- Insert factory equipment readings. Consolidation triggers automatically
 -- when data timestamps cross 5-minute boundaries.

--- a/examples/timeseries-rrd/late-data.cql
+++ b/examples/timeseries-rrd/late-data.cql
@@ -1,4 +1,4 @@
--- RRD Cascading Time-Series Aggregation: Late-Arriving Data
+-- RRD Time-Series Aggregation: Late-Arriving Data
 --
 -- Demonstrates re-aggregation when late data arrives after a window
 -- has already been consolidated.
@@ -19,10 +19,10 @@ INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
 -- 3. Worker reads full window from disk
 -- 4. Re-runs consolidation with the late point included
 -- 5. Upserts corrected aggregate into sensor_readings_5m
--- 6. The upsert triggers sensor_readings_5m's observer -> cascade continues
 
 -- Late data is only accepted within the configured late_window (15m).
--- Data older than boundary_ts - late_window is silently dropped.
+-- Data older than boundary_ts - late_window is dropped and counted in
+-- materialization observability.
 
 -- Verify the corrected aggregates:
 SELECT * FROM sensor_readings_5m

--- a/examples/timeseries-rrd/queries.cql
+++ b/examples/timeseries-rrd/queries.cql
@@ -1,6 +1,6 @@
--- RRD Cascading Time-Series Aggregation: Sensor Queries
+-- RRD Time-Series Aggregation: Sensor Queries
 --
--- Query each tier to see progressively coarser aggregates.
+-- Query raw readings and the materialized 5-minute aggregate tier.
 
 USE plant;
 
@@ -21,20 +21,6 @@ SELECT sensor_id, ts,
        temperature_c_avg,
        temperature_c_stddev
   FROM sensor_readings_5m
-  WHERE sensor_id = 2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34
-  LIMIT 10;
-
--- 15-minute aggregates.
-SELECT sensor_id, ts, vibration_mm_s_avg, vibration_mm_s_stddev,
-       temperature_c_avg, temperature_c_stddev
-  FROM sensor_readings_15m
-  WHERE sensor_id = 2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34
-  LIMIT 10;
-
--- 1-hour aggregates.
-SELECT sensor_id, ts, vibration_mm_s_avg, vibration_mm_s_stddev,
-       temperature_c_avg, temperature_c_stddev
-  FROM sensor_readings_1h
   WHERE sensor_id = 2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34
   LIMIT 10;
 

--- a/examples/timeseries-rrd/schema.cql
+++ b/examples/timeseries-rrd/schema.cql
@@ -1,13 +1,28 @@
--- RRD Cascading Time-Series Aggregation: Sensor Schema
+-- RRD Time-Series Aggregation: Sensor Schema
 --
--- Creates a 4-tier cascade for factory sensor readings:
--- 1s raw readings -> 5m rollups -> 15m rollups -> 1h rollups.
+-- Creates a runnable single-step rollup for factory sensor readings:
+-- 1s raw readings -> 5m rollups.
 -- Min/max/avg/stddev use the built-in streaming consolidation path.
 
 CREATE KEYSPACE IF NOT EXISTS plant
   WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
 
 USE plant;
+
+-- Tier 1: materialized 5-minute aggregates.
+CREATE TABLE sensor_readings_5m (
+    sensor_id uuid,
+    ts timestamp,
+    vibration_mm_s_min double,
+    vibration_mm_s_max double,
+    vibration_mm_s_avg double,
+    vibration_mm_s_stddev double,
+    temperature_c_min double,
+    temperature_c_max double,
+    temperature_c_avg double,
+    temperature_c_stddev double,
+    PRIMARY KEY (sensor_id, ts)
+) WITH CLUSTERING ORDER BY (ts DESC);
 
 -- Tier 0: raw 1-second vibration and temperature readings.
 CREATE TABLE sensor_readings_1s (
@@ -21,18 +36,10 @@ CREATE TABLE sensor_readings_1s (
     'consolidation.interval': '5m',
     'consolidation.functions': 'min,max,avg,stddev',
     'consolidation.target': 'sensor_readings_5m',
-    'consolidation.cascade': 'true',
     'consolidation.late_window': '15m',
     'consolidation.columns': 'vibration_mm_s,temperature_c'
   };
 
--- Tiers 1-3 are auto-created by cascade. Shown here for reference:
---
--- sensor_readings_5m:
---   5-minute aggregates with vibration_mm_s_min, vibration_mm_s_max,
---   vibration_mm_s_avg, vibration_mm_s_stddev, temperature_c_min,
---   temperature_c_max, temperature_c_avg, temperature_c_stddev.
--- sensor_readings_15m:
---   15-minute aggregates produced from 5-minute rollups.
--- sensor_readings_1h:
---   1-hour aggregates produced from 15-minute rollups.
+-- Multi-tier cascade auto-creation is intentionally not used in this runnable
+-- contract. It is tracked separately because correct avg/stddev cascades need
+-- additional rollup state such as count, sum, and sum-of-squares.

--- a/examples/timeseries-rrd/smoke-test.sh
+++ b/examples/timeseries-rrd/smoke-test.sh
@@ -25,8 +25,13 @@ require_regex() {
 
 require_text schema.cql "CREATE KEYSPACE IF NOT EXISTS plant"
 require_text schema.cql "CREATE TABLE sensor_readings_1s"
+require_text schema.cql "CREATE TABLE sensor_readings_5m"
 require_text schema.cql "'consolidation.functions': 'min,max,avg,stddev'"
 require_text schema.cql "'consolidation.columns': 'vibration_mm_s,temperature_c'"
+if grep -Fq "'consolidation.cascade': 'true'" schema.cql; then
+  echo "FAIL: schema.cql must not enable cascade until multi-tier rollup state is implemented" >&2
+  exit 1
+fi
 if grep -Fq "wasm:plant.stddev" schema.cql; then
   echo "FAIL: schema.cql must use only streaming built-ins for the runnable demo" >&2
   exit 1

--- a/examples/timeseries-rrd/timeseries-rrd.adoc
+++ b/examples/timeseries-rrd/timeseries-rrd.adoc
@@ -1,10 +1,10 @@
-= RRD Cascading Time-Series Aggregation
+= RRD Time-Series Aggregation
 :toc: left
 :toclevels: 3
 :stylesheet: ../theme/ferrosa.css
 
-Automatic multi-tier aggregation for high-frequency sensor data.
-Write raw factory equipment readings at 1-second resolution and let Ferrosa consolidate them into 5-minute, 15-minute, and 1-hour summaries using RRD-style cascading.
+Automatic aggregation for high-frequency sensor data.
+Write raw factory equipment readings at 1-second resolution and let Ferrosa consolidate them into 5-minute summaries.
 
 NOTE: Complete the <<cluster-setup.adoc#,3-Node Cluster Setup>> tutorial first, or have a running Ferrosa cluster accessible on `localhost:9042`.
 
@@ -18,10 +18,10 @@ Raw readings are useful for diagnosis, but dashboards and alerting usually need 
 * `avg` shows the baseline trend.
 * `stddev` shows volatility, which is often the earliest sign of bearing wear or imbalance.
 
-Ferrosa automates those rollups with *cascading consolidation*.
+Ferrosa automates those rollups with built-in streaming consolidation.
 You define the aggregation rules in the table's `extensions` map at `CREATE TABLE` time, and the storage engine handles the rest.
 
-== The 4-Tier Cascade
+== The Runnable Rollup
 
 [cols="1,1,1,1"]
 |===
@@ -29,13 +29,11 @@ You define the aggregation rules in the table's `extensions` map at `CREATE TABL
 
 | 0 | `sensor_readings_1s` | 1 second (raw) | None (source)
 | 1 | `sensor_readings_5m` | 5 minutes | min, max, avg, stddev
-| 2 | `sensor_readings_15m` | 15 minutes | min, max, avg, stddev
-| 3 | `sensor_readings_1h` | 1 hour | min, max, avg, stddev
 |===
 
-Each tier consolidates data from the tier above it.
 When 5 minutes of raw data accumulates in `sensor_readings_1s`, the aggregator computes summary statistics and writes them to `sensor_readings_5m`.
-When three 5-minute windows accumulate in `sensor_readings_5m`, they are consolidated into `sensor_readings_15m`, and so on.
+Multi-tier cascade auto-creation is not enabled in this runnable contract.
+Correct `avg` and `stddev` cascades require carrying rollup state such as count, sum, and sum-of-squares between tiers; creating downstream tables without that state would produce misleading results.
 
 == Create the Schema
 
@@ -98,7 +96,7 @@ include::queries.cql[lines=13..25]
 
 [source,sql]
 ----
-include::queries.cql[lines=41..48]
+include::queries.cql[lines=27..34]
 ----
 
 == WASM Aggregate Status
@@ -163,12 +161,12 @@ When a data point falls into an already-consolidated window:
 
 1. The aggregator detects that the timestamp is before the current boundary.
 2. A `LateData` task is sent to the async worker.
-3. The worker re-runs consolidation for values still present in the in-memory ring.
+3. The worker streams the affected source window from storage.
 4. The corrected aggregate is upserted into the downstream table.
-5. The cascade continues: the upsert triggers the next tier's observer.
+5. The corrected aggregate is visible in the target table.
 
 Late data is only accepted within the `late_window`.
-The disk-backed keyed cursor for windows that have fallen out of the ring is still tracked in `specs/todo/rrd-keyed-streaming-storage-cursor.md`.
+The disk-backed keyed cursor streams source rows by partition and window for recomputation when a window has fallen out of the in-memory ring.
 
 == Observability
 
@@ -176,7 +174,7 @@ Monitor consolidation health, delayed materialization, and runtime ring-memory c
 
 [source,sql]
 ----
-include::queries.cql[lines=58..75]
+include::queries.cql[lines=46..61]
 ----
 
 `consolidation_status` shows per-table rollup counters.
@@ -190,13 +188,13 @@ The default ring memory budget is derived from the host or container memory limi
 |===
 | File | Purpose
 
-| `schema.cql` | Keyspace and raw sensor table with built-in streaming consolidation extensions
+| `schema.cql` | Keyspace, target rollup table, and raw sensor table with built-in streaming consolidation extensions
 | `data.cql` | Sample vibration and temperature data for two pumps across two 5-minute windows
-| `queries.cql` | Queries against raw data, rollup tiers, and operational observability
+| `queries.cql` | Queries against raw data, 5-minute rollups, and operational observability
 | `custom-wasm-udf.cql` | WASM stddev loading forms and the current live-materialization limitation
 | `built-in-functions.cql` | Demonstrates each built-in function individually
 | `composite.cql` | Multi-column composite aggregation
 | `median.cql` | Median-specific example with latency monitoring
-| `late-data.cql` | Late-arriving data and re-aggregation cascade
+| `late-data.cql` | Late-arriving data and re-aggregation
 | `smoke-test.sh` | Static contract test for the sensor example and WASM loading snippets
 |===

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -4784,8 +4784,12 @@ fn create_cascade_tables_if_needed(
             .map_err(|e| CqlError::ServerError(format!("cascade table creation failed: {e}")))?;
 
         let storage_schema = cascade_table.to_storage_schema();
-        // Ignore error if already registered.
-        let _ = state.engine.register_table(storage_schema);
+        state.engine.register_table(storage_schema).map_err(|e| {
+            CqlError::ServerError(format!(
+                "cascade table storage registration failed for {}.{}: {e}",
+                source.keyspace, spec.table_name
+            ))
+        })?;
 
         tracing::info!(
             cascade_table = %spec.table_name,
@@ -8331,6 +8335,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timeseries_rrd_example_executes_real_rollup_rows() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let mut current_keyspace: Option<String> = None;
+
+        for cql in example_cql_statements(include_str!("../../examples/timeseries-rrd/schema.cql"))
+            .into_iter()
+            .chain(example_cql_statements(include_str!(
+                "../../examples/timeseries-rrd/data.cql"
+            )))
+        {
+            let ctx = RequestContext {
+                auth: &auth,
+                current_keyspace: &current_keyspace,
+                consistency: ConsistencyLevel::One,
+                serial_consistency: None,
+                paging: crate::paging::PagingParams::default(),
+                client_address: String::new(),
+            };
+            match route(&state, &ctx, crate::parser::parse(&cql).unwrap())
+                .await
+                .unwrap()
+            {
+                RouteResult::SetKeyspace(ks, _) => current_keyspace = Some(ks),
+                RouteResult::Result(_) => {}
+                _ => panic!("unexpected route result for example statement {cql:?}"),
+            }
+        }
+
+        assert!(
+            state
+                .engine
+                .process_pending_time_series_materializations(16)
+                .unwrap()
+                >= 1,
+            "the runnable RRD example must enqueue at least one materialized 5-minute rollup"
+        );
+
+        let ctx = RequestContext {
+            auth: &auth,
+            current_keyspace: &Some("plant".into()),
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        let full_scan = route(
+            &state,
+            &ctx,
+            crate::parser::parse("SELECT vibration_mm_s_avg FROM sensor_readings_5m").unwrap(),
+        )
+        .await
+        .unwrap();
+        let RouteResult::Result(full_scan_body) = full_scan else {
+            panic!("expected Rows result");
+        };
+        assert!(
+            extract_row_count(&full_scan_body) >= 1,
+            "example materialization should write at least one 5-minute target row"
+        );
+
+        let result = route(
+            &state,
+            &ctx,
+            crate::parser::parse(
+                "SELECT vibration_mm_s_avg \
+                 FROM sensor_readings_5m \
+                 WHERE sensor_id = 2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34",
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+        let RouteResult::Result(body) = result else {
+            panic!("expected Rows result");
+        };
+        let value = extract_first_double_value(&body);
+        assert!(
+            (value - 5.08).abs() < 0.000_000_1,
+            "example first 5-minute rollup should match the documented Pump A average"
+        );
+    }
+
+    #[tokio::test]
     async fn create_table_rejects_non_streaming_rrd_wasm_function() {
         let (state, _dir) = setup();
         let ctx = RequestContext {
@@ -10167,6 +10255,19 @@ mod tests {
         off += 4;
         assert_eq!(value_len, 8, "expected double value length");
         f64::from_be_bytes(buf[off..off + 8].try_into().unwrap())
+    }
+
+    fn example_cql_statements(script: &str) -> Vec<String> {
+        script
+            .lines()
+            .map(|line| line.split_once("--").map_or(line, |(cql, _)| cql))
+            .collect::<Vec<_>>()
+            .join("\n")
+            .split(';')
+            .map(str::trim)
+            .filter(|stmt| !stmt.is_empty())
+            .map(ToOwned::to_owned)
+            .collect()
     }
 
     /// Extract column names from a Rows result buffer.

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -40,7 +40,7 @@ use crate::timeseries::config::{validate_numeric_columns, ConsolidationConfig};
 use crate::timeseries::consolidation::{emit_accumulated_streaming_results, Accumulator};
 use crate::timeseries::{
     ConsolidationMetrics, ConsolidationTask, LateWindowClassification, MaterializationTarget,
-    MaterializedRollup, TimeSeriesAggregator, TimeSeriesRuntimeSettings,
+    MaterializedRollup, TimeSeriesAggregator, TimeSeriesRuntimeSettings, TimeSeriesTimestampUnit,
 };
 use crate::upload::{ObjectStoreConfig, UploadManager};
 
@@ -547,6 +547,16 @@ struct TableState {
     /// plus an atomic pointer swap, with no mutex contention even when
     /// many threads write to the same table concurrently.
     last_commit_log_position: ArcSwap<Option<CommitLogPosition>>,
+}
+
+impl TableState {
+    fn time_series_timestamp_unit(&self) -> TimeSeriesTimestampUnit {
+        self.schema
+            .clustering_columns
+            .first()
+            .map(|column| TimeSeriesTimestampUnit::from_storage_type(&column.type_name))
+            .unwrap_or(TimeSeriesTimestampUnit::Micros)
+    }
 }
 
 /// Process-wide reference instant used as the base for
@@ -1850,9 +1860,13 @@ impl StorageEngine {
         let Some(state) = tables.get(table_id) else {
             return Ok(0);
         };
-        state
-            .store
-            .visit_time_series_window_rows(key, window_start_ts, window_end_ts, cb)
+        state.store.visit_time_series_window_rows(
+            key,
+            window_start_ts,
+            window_end_ts,
+            state.time_series_timestamp_unit(),
+            cb,
+        )
     }
 
     /// Visits bounded live queue snapshots for time-series materialization observability.
@@ -2191,6 +2205,12 @@ impl StorageEngine {
             ))
         })?;
 
+        let source_timestamp_unit = schema
+            .clustering_columns
+            .first()
+            .map(|column| TimeSeriesTimestampUnit::from_storage_type(&column.type_name))
+            .unwrap_or(TimeSeriesTimestampUnit::Micros);
+
         let mut value_column_indices = Vec::with_capacity(config.columns.len());
         let mut column_types = Vec::with_capacity(config.columns.len());
         for column_name in &config.columns {
@@ -2209,12 +2229,20 @@ impl StorageEngine {
         }
 
         let (task_tx, task_rx) = std::sync::mpsc::sync_channel(config.channel_capacity);
+        let target_table_id = TableId::new(&schema.keyspace, &config.target_table);
+        let target_timestamp_unit = self
+            .tables
+            .read()
+            .get(&target_table_id)
+            .map(TableState::time_series_timestamp_unit)
+            .unwrap_or(source_timestamp_unit);
         let target = MaterializationTarget {
             source_table: table_id.clone(),
-            target_table: TableId::new(&schema.keyspace, &config.target_table),
+            target_table: target_table_id,
             interval: config.interval,
             source_columns: config.columns.clone(),
             functions: config.functions.clone(),
+            target_timestamp_unit,
         };
         let source_column_count = value_column_indices.len();
         let late_window = config.late_window;
@@ -2228,7 +2256,8 @@ impl StorageEngine {
                 task_tx,
                 Arc::clone(&self.time_series_runtime_settings),
                 metrics,
-            ),
+            )
+            .with_timestamp_unit(source_timestamp_unit),
         );
         let observer: Arc<dyn crate::observer::WriteObserver> = aggregator.clone();
 

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -557,6 +557,7 @@ impl<F: FlushTarget> TableStore<F> {
         key: &DecoratedKey,
         window_start_ts: i64,
         window_end_ts: i64,
+        timestamp_unit: crate::timeseries::TimeSeriesTimestampUnit,
         mut cb: Cb,
     ) -> Result<usize>
     where
@@ -692,7 +693,7 @@ impl<F: FlushTarget> TableStore<F> {
                 }
             }
 
-            if let Some(ts) = time_series_row_timestamp(&row) {
+            if let Some(ts) = time_series_row_timestamp(&row, timestamp_unit) {
                 if ts >= window_start_ts && ts < window_end_ts {
                     cb(&row)?;
                     visited += 1;
@@ -2485,9 +2486,12 @@ impl<F: FlushTarget> TableStore<F> {
     }
 }
 
-fn time_series_row_timestamp(row: &Row) -> Option<i64> {
+fn time_series_row_timestamp(
+    row: &Row,
+    timestamp_unit: crate::timeseries::TimeSeriesTimestampUnit,
+) -> Option<i64> {
     let bytes: [u8; 8] = row.clustering.as_slice().try_into().ok()?;
-    Some(i64::from_be_bytes(bytes))
+    Some(timestamp_unit.raw_to_micros(i64::from_be_bytes(bytes)))
 }
 
 fn late_partition_needs_replay(

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -549,10 +549,9 @@ impl<F: FlushTarget> TableStore<F> {
     /// window_end_ts)`. Missing partitions, empty windows, and rows with
     /// non time-series clustering shapes visit zero rows.
     ///
-    /// Current limitation: this visitor is streaming at the public API
-    /// boundary, but this implementation still reads one partition internally
-    /// before visiting matching rows. Very large partitions need a lower-level
-    /// memtable/SSTable row cursor to avoid that internal materialization.
+    /// SSTable rows are decoded through `PartitionIter::next_clustered_row`,
+    /// keeping only one row per source in memory while preserving cell-level
+    /// last-write-wins across overlapping memtable/SSTable sources.
     pub fn visit_time_series_window_rows<Cb>(
         &self,
         key: &DecoratedKey,
@@ -567,18 +566,137 @@ impl<F: FlushTarget> TableStore<F> {
             return Ok(0);
         }
 
-        let Some(partition) = self.read(key)? else {
+        let guard = self.view.load();
+        let mut partition_delete_at = ferrosa_sstable::types::DeletionTime::LIVE;
+        let mut mem_row_iters: Vec<std::vec::IntoIter<Row>> = Vec::new();
+
+        if let Some(partition) = guard.active.get(key)? {
+            if partition.deletion.marked_for_delete_at > partition_delete_at.marked_for_delete_at {
+                partition_delete_at = partition.deletion;
+            }
+            let mut rows = partition.rows.clone();
+            rows.sort_by(|a, b| a.clustering.cmp(&b.clustering));
+            mem_row_iters.push(rows.into_iter());
+        }
+        if let Some(flushing) = guard.flushing.as_ref() {
+            if let Some(partition) = flushing.get(key)? {
+                if partition.deletion.marked_for_delete_at
+                    > partition_delete_at.marked_for_delete_at
+                {
+                    partition_delete_at = partition.deletion;
+                }
+                let mut rows = partition.rows.clone();
+                rows.sort_by(|a, b| a.clustering.cmp(&b.clustering));
+                mem_row_iters.push(rows.into_iter());
+            }
+        }
+
+        let mut sst_iters: Vec<ferrosa_sstable::reader::PartitionIter<'_, F::Reader>> = Vec::new();
+        for sstable in guard.sstables.iter() {
+            let mut iter = match sstable.partitions_iter() {
+                Ok(iter) => iter,
+                Err(e) => {
+                    tracing::warn!(%e, key = ?key.key.as_bytes(), "time-series cursor: skipping unreadable SSTable iterator");
+                    continue;
+                }
+            };
+            iter.seek_to_token(key.token.0)?;
+            while let Some(peeked) = iter.peek_partition_key()? {
+                if peeked == *key {
+                    let Some((_, deletion, _static_row)) = iter.next_partition_header_only()?
+                    else {
+                        break;
+                    };
+                    if deletion.marked_for_delete_at > partition_delete_at.marked_for_delete_at {
+                        partition_delete_at = deletion;
+                    }
+                    sst_iters.push(iter);
+                    break;
+                }
+                if peeked.token != key.token || peeked > *key {
+                    break;
+                }
+                iter.skip_to_next_partition()?;
+            }
+        }
+
+        if mem_row_iters.is_empty() && sst_iters.is_empty() {
             return Ok(0);
-        };
+        }
+
+        let mut mem_heads: Vec<Option<Row>> =
+            mem_row_iters.iter_mut().map(|iter| iter.next()).collect();
+        let mut sst_heads: Vec<Option<Row>> = Vec::with_capacity(sst_iters.len());
+        for iter in sst_iters.iter_mut() {
+            sst_heads.push(iter.next_clustered_row()?);
+        }
 
         let mut visited = 0;
-        for row in &partition.rows {
-            let Some(ts) = time_series_row_timestamp(row) else {
-                continue;
+        loop {
+            let mut smallest: Option<Vec<u8>> = None;
+            for row in mem_heads.iter().chain(sst_heads.iter()).flatten() {
+                if smallest
+                    .as_ref()
+                    .map(|clustering| row.clustering < *clustering)
+                    .unwrap_or(true)
+                {
+                    smallest = Some(row.clustering.clone());
+                }
+            }
+            let Some(clustering) = smallest else {
+                break;
             };
-            if ts >= window_start_ts && ts < window_end_ts {
-                cb(row)?;
-                visited += 1;
+
+            let mut merged_row: Option<Row> = None;
+            for (idx, head) in mem_heads.iter_mut().enumerate() {
+                if head
+                    .as_ref()
+                    .map(|row| row.clustering == clustering)
+                    .unwrap_or(false)
+                {
+                    let row = head.take().expect("checked as present");
+                    merged_row = match merged_row.take() {
+                        Some(prev) => Some(crate::merge::merge_rows(prev, row)),
+                        None => Some(row),
+                    };
+                    *head = mem_row_iters[idx].next();
+                }
+            }
+            for (idx, head) in sst_heads.iter_mut().enumerate() {
+                if head
+                    .as_ref()
+                    .map(|row| row.clustering == clustering)
+                    .unwrap_or(false)
+                {
+                    let row = head.take().expect("checked as present");
+                    merged_row = match merged_row.take() {
+                        Some(prev) => Some(crate::merge::merge_rows(prev, row)),
+                        None => Some(row),
+                    };
+                    *head = sst_iters[idx].next_clustered_row()?;
+                }
+            }
+
+            let mut row = merged_row.expect("at least one source matched clustering");
+            if !partition_delete_at.is_live()
+                && row.primary_key_liveness.timestamp < partition_delete_at.marked_for_delete_at
+            {
+                continue;
+            }
+            if !row.deletion.is_live() {
+                let row_delete_at = row.deletion.marked_for_delete_at;
+                row.cells
+                    .retain(|(_column, cell)| cell.timestamp >= row_delete_at);
+                if row.cells.is_empty() {
+                    continue;
+                }
+            }
+
+            if let Some(ts) = time_series_row_timestamp(&row) {
+                if ts >= window_start_ts && ts < window_end_ts {
+                    cb(&row)?;
+                    visited += 1;
+                }
             }
         }
         Ok(visited)

--- a/ferrosa-storage/src/timeseries/aggregator.rs
+++ b/ferrosa-storage/src/timeseries/aggregator.rs
@@ -20,6 +20,7 @@ use super::config::{ConsolidationConfig, TimeSeriesRuntimeSettings};
 use super::consolidation::{
     emit_accumulated_streaming_results, Accumulator, ConsolidationFn, StreamingConsolidationError,
 };
+use super::materialization::TimeSeriesTimestampUnit;
 use super::ring::{BoundaryStatus, RingBuffer, RingEntry};
 
 /// A task sent from the inline write path to the async consolidation worker.
@@ -107,6 +108,8 @@ pub struct TimeSeriesAggregator {
     /// When present, enables type-aware decoding via `decode_typed_numeric`.
     /// Must be the same length as `value_column_indices`.
     column_types: Vec<String>,
+    /// Unit used by the first clustering column in storage bytes.
+    timestamp_unit: TimeSeriesTimestampUnit,
     /// Per-partition_key ring buffers. DashMap provides per-shard locking.
     rings: DashMap<Vec<u8>, RingBuffer>,
     /// Channel sender for async consolidation tasks.
@@ -152,6 +155,7 @@ impl TimeSeriesAggregator {
             table_id,
             value_column_indices,
             column_types: vec![],
+            timestamp_unit: TimeSeriesTimestampUnit::Micros,
             rings: DashMap::new(),
             task_tx,
             drop_count: AtomicU64::new(0),
@@ -186,6 +190,11 @@ impl TimeSeriesAggregator {
         let mut agg = Self::new(config, table_id, value_column_indices, task_tx);
         agg.column_types = column_types;
         agg
+    }
+
+    pub fn with_timestamp_unit(mut self, timestamp_unit: TimeSeriesTimestampUnit) -> Self {
+        self.timestamp_unit = timestamp_unit;
+        self
     }
 
     /// Create a new aggregator with CQL column type metadata and shared runtime settings.
@@ -474,7 +483,7 @@ impl TimeSeriesAggregator {
         row: &ferrosa_sstable::types::Row,
     ) -> Option<(i64, SmallVec<[f64; 8]>)> {
         let mut values = SmallVec::new();
-        let timestamp = row_timestamp_micros(row);
+        let timestamp = row_timestamp_micros(row, self.timestamp_unit);
         let has_types = !self.column_types.is_empty();
 
         for (i, &col_idx) in self.value_column_indices.iter().enumerate() {
@@ -513,11 +522,14 @@ impl TimeSeriesAggregator {
     }
 }
 
-fn row_timestamp_micros(row: &ferrosa_sstable::types::Row) -> i64 {
+fn row_timestamp_micros(
+    row: &ferrosa_sstable::types::Row,
+    timestamp_unit: TimeSeriesTimestampUnit,
+) -> i64 {
     if row.clustering.len() == std::mem::size_of::<i64>() {
         let mut bytes = [0_u8; 8];
         bytes.copy_from_slice(&row.clustering);
-        i64::from_be_bytes(bytes)
+        timestamp_unit.raw_to_micros(i64::from_be_bytes(bytes))
     } else {
         row.primary_key_liveness.timestamp
     }

--- a/ferrosa-storage/src/timeseries/materialization.rs
+++ b/ferrosa-storage/src/timeseries/materialization.rs
@@ -17,6 +17,38 @@ use crate::commitlog::mutation::Mutation;
 
 use super::consolidation::ConsolidationFn;
 
+/// Storage unit used by the time-series clustering key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeSeriesTimestampUnit {
+    /// Raw clustering bytes already contain Unix-epoch microseconds.
+    Micros,
+    /// CQL `timestamp` clustering bytes contain Unix-epoch milliseconds.
+    Millis,
+}
+
+impl TimeSeriesTimestampUnit {
+    pub fn from_storage_type(type_name: &str) -> Self {
+        match type_name {
+            "timestamp" | "org.apache.cassandra.db.marshal.TimestampType" => Self::Millis,
+            _ => Self::Micros,
+        }
+    }
+
+    pub fn raw_to_micros(self, raw: i64) -> i64 {
+        match self {
+            Self::Micros => raw,
+            Self::Millis => raw.saturating_mul(1_000),
+        }
+    }
+
+    pub fn micros_to_raw(self, micros: i64) -> i64 {
+        match self {
+            Self::Micros => micros,
+            Self::Millis => micros.div_euclid(1_000),
+        }
+    }
+}
+
 /// Target metadata needed to encode a consolidated window mutation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MaterializationTarget {
@@ -25,6 +57,7 @@ pub struct MaterializationTarget {
     pub interval: Duration,
     pub source_columns: Vec<String>,
     pub functions: Vec<ConsolidationFn>,
+    pub target_timestamp_unit: TimeSeriesTimestampUnit,
 }
 
 impl MaterializationTarget {
@@ -131,6 +164,10 @@ impl MaterializedRollup {
     where
         I: IntoIterator<Item = f64>,
     {
+        let window_start_raw = self
+            .target
+            .target_timestamp_unit
+            .micros_to_raw(self.window_start_ts);
         let cells = results
             .into_iter()
             .enumerate()
@@ -152,7 +189,7 @@ impl MaterializedRollup {
             table: self.target.target_table.table.clone(),
             key: DecoratedKey::new(PartitionKey::new(self.partition_key.clone())),
             rows: vec![Row {
-                clustering: self.window_start_ts.to_be_bytes().to_vec(),
+                clustering: window_start_raw.to_be_bytes().to_vec(),
                 cells,
                 deletion: DeletionTime::LIVE,
                 primary_key_liveness: LivenessInfo::with_timestamp(write_timestamp),
@@ -292,6 +329,7 @@ mod tests {
             interval: Duration::from_secs(10),
             source_columns: vec!["value".to_string()],
             functions: vec![ConsolidationFn::Avg],
+            target_timestamp_unit: TimeSeriesTimestampUnit::Micros,
         };
         let request = MaterializationRequest {
             target: target.clone(),

--- a/ferrosa-storage/src/timeseries/mod.rs
+++ b/ferrosa-storage/src/timeseries/mod.rs
@@ -27,5 +27,5 @@ pub use consolidation::{emit_streaming_results, ConsolidationFn, StreamingConsol
 pub use materialization::{
     LateWindowClassification, MaterializationQueue, MaterializationQueueMetrics,
     MaterializationQueueSnapshot, MaterializationRequest, MaterializationTarget,
-    MaterializationTaskKind, MaterializedRollup,
+    MaterializationTaskKind, MaterializedRollup, TimeSeriesTimestampUnit,
 };

--- a/ferrosa-storage/tests/timeseries_materialization.rs
+++ b/ferrosa-storage/tests/timeseries_materialization.rs
@@ -8,7 +8,7 @@ use ferrosa_common::schema::{ColumnDefinition, TableSchema};
 use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
 use ferrosa_storage::timeseries::{
     ConsolidationFn, LateWindowClassification, MaterializationQueue, MaterializationRequest,
-    MaterializationTarget, MaterializationTaskKind, MaterializedRollup,
+    MaterializationTarget, MaterializationTaskKind, MaterializedRollup, TimeSeriesTimestampUnit,
 };
 use ferrosa_storage::{
     CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
@@ -30,6 +30,7 @@ fn target() -> MaterializationTarget {
                 function_name: "custom_rollup".to_string(),
             },
         ],
+        target_timestamp_unit: TimeSeriesTimestampUnit::Micros,
     }
 }
 

--- a/ferrosa-storage/tests/timeseries_materialization.rs
+++ b/ferrosa-storage/tests/timeseries_materialization.rs
@@ -383,6 +383,37 @@ fn keyed_time_series_window_cursor_visits_zero_for_missing_or_empty_windows() {
 }
 
 #[test]
+fn keyed_time_series_window_cursor_merges_overlapping_sources_by_clustering_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = make_engine(dir.path());
+    let table_id = TableId::new("ks", "sensor");
+    let sensor = key(b"sensor-1");
+    engine.register_table(timeseries_schema()).unwrap();
+
+    engine
+        .write(&table_id, &sensor, sensor_row(5, 1.0), 5)
+        .unwrap();
+    engine.flush(&table_id).unwrap();
+    engine
+        .write(&table_id, &sensor, sensor_row(5, 9.0), 50)
+        .unwrap();
+    engine
+        .write(&table_id, &sensor, sensor_row(7, 3.0), 70)
+        .unwrap();
+
+    let mut values = Vec::new();
+    let visited = engine
+        .visit_time_series_window_rows(&table_id, &sensor, 0, 10, |row| {
+            values.push(row_double(row));
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(visited, 2);
+    assert_eq!(values, vec![9.0, 3.0]);
+}
+
+#[test]
 fn storage_materialization_observability_reports_live_queue_lag() {
     let dir = tempfile::tempdir().unwrap();
     let engine = make_engine(dir.path());

--- a/specs/implemented/rrd-keyed-streaming-storage-cursor.md
+++ b/specs/implemented/rrd-keyed-streaming-storage-cursor.md
@@ -1,7 +1,7 @@
 ---
 type: todo
 priority: P0
-status: in_progress
+status: implemented
 created: 2026-05-20
 updated: 2026-05-22
 ---
@@ -21,7 +21,7 @@ time window)` into aggregation accumulators.
   returning `Partition` or `Vec<Partition>`.
 - [x] The API has tests proving it streams rows through a callback/iterator.
 - [x] Missing partitions and empty windows produce zero visited rows.
-- [ ] The implementation uses existing SSTable row-streaming primitives where
+- [x] The implementation uses existing SSTable row-streaming primitives where
   possible.
 - [x] The API is documented as the only production path for stale rollup
   recomputation.
@@ -32,7 +32,13 @@ time window)` into aggregation accumulators.
   `TableStore` visitor.
 - The RRD materialization worker now uses this visitor as the source of truth
   for rollup windows, including when the in-memory ring is incomplete.
-- Current limitation: `TableStore::visit_time_series_window_rows` is
-  callback-shaped at the API boundary but still calls `TableStore::read`
-  internally, which materializes one full partition before filtering the window.
-  Replacing that with true memtable/SSTable row streaming remains open.
+- `TableStore::visit_time_series_window_rows` now streams matching SSTable
+  partitions through `PartitionIter::next_partition_header_only` and
+  `next_clustered_row`.
+- Overlapping active/flushing memtable and SSTable sources are merged by
+  clustering key with cell-level last-write-wins before the visitor sees each
+  row.
+- The cursor keeps one row head per contributing source instead of
+  materializing a full SSTable partition.
+- In-memory memtable sources still contribute cloned rows for the exact
+  partition key, which is acceptable because memtables are already resident.

--- a/specs/in-process/gap-rrd-materialized-rollups.md
+++ b/specs/in-process/gap-rrd-materialized-rollups.md
@@ -89,11 +89,10 @@ Current branch limitations:
   rewrite existing rollup rows.
 - Added CQL-router coverage proving normal CQL `CREATE TABLE` extensions and
   `INSERT` statements enqueue materialization and produce queryable target rows.
-- Storage has an in-memory ring streaming path for current windows. Production
-  late-window recomputation uses the keyed cursor API, but the current
-  `TableStore` implementation still materializes one partition internally
-  before visiting rows. A true memtable/SSTable row-streaming implementation
-  remains required for very large partitions.
+- Storage has an in-memory ring streaming path for boundary detection, and
+  production materialization uses a keyed storage cursor as the source of truth.
+  The cursor streams SSTable rows one at a time and merges overlapping sources
+  by clustering key.
 - WASM consolidation functions still need a streaming UDF aggregation ABI before
   they can run in the worker. Live RRD DDL now rejects `wasm:keyspace.function`
   rollups with a clear streaming-ABI error instead of accepting a table that

--- a/specs/in-process/gap-rrd-materialized-rollups.md
+++ b/specs/in-process/gap-rrd-materialized-rollups.md
@@ -89,10 +89,20 @@ Current branch limitations:
   rewrite existing rollup rows.
 - Added CQL-router coverage proving normal CQL `CREATE TABLE` extensions and
   `INSERT` statements enqueue materialization and produce queryable target rows.
+- Added CQL-router coverage that executes
+  `examples/timeseries-rrd/schema.cql` and `data.cql`, drains pending
+  materialization tasks, and verifies a real 5-minute target row.
+- CQL `timestamp` clustering keys are converted from their storage unit
+  (milliseconds) into the RRD internal microsecond window unit, and target
+  rollup rows are encoded back into the target table's clustering unit.
 - Storage has an in-memory ring streaming path for boundary detection, and
   production materialization uses a keyed storage cursor as the source of truth.
   The cursor streams SSTable rows one at a time and merges overlapping sources
   by clustering key.
+- Multi-tier cascade auto-creation is not part of the runnable example.
+  Downstream avg/stddev cascades need explicit rollup state such as count, sum,
+  and sum-of-squares. Cascade storage-registration errors now surface during DDL
+  instead of leaving schema metadata without a registered storage table.
 - WASM consolidation functions still need a streaming UDF aggregation ABI before
   they can run in the worker. Live RRD DDL now rejects `wasm:keyspace.function`
   rollups with a clear streaming-ABI error instead of accepting a table that
@@ -148,10 +158,10 @@ Implement a real materialization path for tables configured with
    key columns, the rollup window start timestamp as clustering key, and one
    `double` column per `(source_column, function)` pair, for example
    `value_min`, `value_max`, `value_avg`, `value_stddev`.
-5. Repair cascade metadata generation so each downstream tier's
-   `consolidation.columns` names match the columns actually emitted by the
-   previous tier, or define terminal tiers explicitly if re-aggregating aggregate
-   columns is not desired.
+5. Design and repair cascade metadata generation so each downstream tier has
+   source columns and rollup state that make its outputs mathematically valid.
+   Correct `avg` and `stddev` cascades require state beyond the visible double
+   output columns.
 6. Recompute stale windows for late-arriving data up to a configurable window.
    `consolidation.late_window` remains the per-table control. Late writes inside
    the window enqueue a re-materialization task for the affected target row;
@@ -172,10 +182,10 @@ Implement a real materialization path for tables configured with
 
 ## Acceptance criteria
 
-- [ ] `CREATE TABLE ... WITH extensions = {'consolidation.interval': '5m', ...}`
+- [x] `CREATE TABLE ... WITH extensions = {'consolidation.interval': '5m', ...}`
       registers an active consolidator without process restart.
 - [ ] Invalid consolidation extension sets fail DDL with a useful error.
-- [ ] Inserts that cross a window boundary create queryable rows in the target
+- [x] Inserts that cross a window boundary create queryable rows in the target
       table.
 - [ ] Cascaded rollups materialize through at least two tiers in an integration
       test.
@@ -190,9 +200,9 @@ Implement a real materialization path for tables configured with
       only virtual-table state.
 - [x] `system_observability.consolidation_status` reflects live counters rather
       than configuration only.
-- [ ] `examples/timeseries-rrd/schema.cql`, `data.cql`, and `queries.cql`
+- [x] `examples/timeseries-rrd/schema.cql`, `data.cql`, and `queries.cql`
       verify real target rows, not only table existence.
-- [ ] At least one extra RRD demo script is either made harness-visible or
+- [x] At least one extra RRD demo script is either made harness-visible or
       explicitly documented as non-testable example material.
 
 ## Verification commands

--- a/specs/in-process/rrd-async-worker-writes-target-rollups.md
+++ b/specs/in-process/rrd-async-worker-writes-target-rollups.md
@@ -49,10 +49,10 @@ descriptor tasks and writes target table mutations through storage.
 
 ## Still Not Working
 
-- The keyed storage cursor is callback-shaped and is wired into the worker, but
-  the current `TableStore` implementation still reads a full partition
-  internally before visiting matching rows. Very large partitions still need a
-  true memtable/SSTable streaming cursor.
+- The keyed storage cursor is callback-shaped and wired into the worker.
+  SSTable sources are streamed row-by-row through the existing partition
+  iterator, and overlapping sources are merged by clustering key before rows
+  reach the aggregation accumulator.
 - WASM aggregate functions are rejected during live RRD DDL until the streaming
   WASM aggregate ABI is implemented.
 - End-to-end process supervision is still covered by the example script rather

--- a/specs/timeseries-sensor-example-docs.md
+++ b/specs/timeseries-sensor-example-docs.md
@@ -1,6 +1,6 @@
 # Example Documentation Blueprint — Time-Series Sensor Rollups
 
-> Last updated: 2026-05-20
+> Last updated: 2026-05-22
 > Status: Draft example docs plan
 
 ## Purpose
@@ -13,6 +13,10 @@ The example should make the value obvious for sensor data:
 - standard deviation shows volatility and anomaly risk;
 - WASM UDFs let teams add domain-specific math without shipping raw data to an
   external processor.
+
+Current runnable scope: one source tier materializes one 5-minute target tier.
+Multi-tier cascade examples are intentionally excluded until rollup state for
+correct `avg` and `stddev` cascades is designed and implemented.
 
 ## Target Example Story
 
@@ -31,7 +35,6 @@ CREATE TABLE plant.sensor_readings_1s (
     'consolidation.interval': '5m',
     'consolidation.functions': 'min,max,avg,stddev',
     'consolidation.target': 'sensor_readings_5m',
-    'consolidation.cascade': 'true',
     'consolidation.late_window': '15m',
     'consolidation.columns': 'vibration_mm_s,temperature_c'
   };
@@ -41,7 +44,7 @@ The rollup table exposes one row per sensor per 5-minute window:
 
 ```text
 sensor_id
-window_start
+ts
 vibration_mm_s_min
 vibration_mm_s_max
 vibration_mm_s_avg
@@ -89,10 +92,10 @@ SELECT window_start,
        vibration_mm_s_stddev
 FROM plant.sensor_readings_5m
 WHERE sensor_id = 2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34
-  AND window_start >= '2026-05-20T12:00:00Z';
+  AND ts >= '2026-05-20T12:00:00Z';
 
 -- Subscribe to new rollups as each window materializes.
-SUBSCRIBE SELECT sensor_id, window_start, vibration_mm_s_avg, vibration_mm_s_stddev
+SUBSCRIBE SELECT sensor_id, ts, vibration_mm_s_avg, vibration_mm_s_stddev
 FROM plant.sensor_readings_5m
 EVERY 5s DELTA;
 


### PR DESCRIPTION
## Summary
- stream RRD keyed-window SSTable rows through PartitionIter instead of materializing full partitions
- preserve cell-level LWW when active/flushing memtables and SSTables overlap on a clustering key
- execute the real `examples/timeseries-rrd/schema.cql` + `data.cql` contract and verify a materialized 5-minute target row
- convert CQL `timestamp` clustering keys between millisecond storage bytes and RRD's internal microsecond window unit
- make the runnable example single-step and document multi-tier cascade as unsupported until correct rollup state exists; cascade storage-registration failures now surface as DDL errors
- mark the keyed streaming cursor work item implemented and update RRD status specs

## Test plan
- cargo test -p ferrosa-storage --test timeseries_materialization
- cargo test -p ferrosa-storage --test timeseries_cascade
- cargo test -p ferrosa-cql cql_inserts_materialize_rrd_rollup_rows --lib
- cargo test -p ferrosa-cql timeseries_rrd_example_executes_real_rollup_rows --lib
- ./examples/timeseries-rrd/smoke-test.sh
- cargo clippy -p ferrosa-storage -p ferrosa-cql --all-targets -- -D warnings

## Notes
- Follow-on to merged PR #59.
- Multi-tier RRD cascade remains intentionally out of the runnable contract; implementing it correctly needs explicit rollup state for avg/stddev rather than cascading only visible double outputs.
