### PR TITLE
Fix compaction promotion and leadership convergence

### DIFF
--- a/ferrosa-cluster/src/membership/mod.rs
+++ b/ferrosa-cluster/src/membership/mod.rs
@@ -413,6 +413,34 @@ impl<N: MembershipNetwork> MembershipChanger<N> {
         Duration::from_secs(10),
     ];
 
+    async fn transfer_leadership_away_from(
+        &self,
+        node_id: u64,
+        target: u64,
+        context: &str,
+    ) -> Result<Option<u64>, MembershipError> {
+        let transfer_result = self.raft.trigger().transfer_to(target).await;
+        let deadline =
+            std::time::Instant::now() + Duration::from_millis(Self::LEADERSHIP_TRANSFER_OBSERVE_MS);
+        loop {
+            let m = self.raft.metrics().borrow().clone();
+            if m.current_leader.is_some() && m.current_leader != Some(node_id) {
+                return Ok(m.current_leader);
+            }
+            if std::time::Instant::now() >= deadline {
+                return match transfer_result {
+                    Ok(()) => Err(MembershipError::RaftError(format!(
+                        "{context}: leadership transfer dispatched but new leader not observed"
+                    ))),
+                    Err(e) => Err(MembershipError::RaftError(format!(
+                        "{context}: transfer_to({target}) failed and no replacement leader was observed: {e}"
+                    ))),
+                };
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
     /// W7.8 / I-30 — Drain in-flight Accord transactions for a DC swap.
     ///
     /// Polls `drain` for transactions referencing any of `leaving_voters`
@@ -689,28 +717,12 @@ impl<N: MembershipNetwork> MembershipChanger<N> {
                     "demote_voter_to_learner: no eligible voter for leadership transfer".into(),
                 )
             })?;
-            self.raft
-                .trigger()
-                .transfer_to(target)
-                .await
-                .map_err(|e| MembershipError::RaftError(format!("transfer_to({target}): {e}")))?;
-            let deadline = std::time::Instant::now()
-                + Duration::from_millis(Self::LEADERSHIP_TRANSFER_OBSERVE_MS);
-            loop {
-                let m = self.raft.metrics().borrow().clone();
-                if m.current_leader.is_some() && m.current_leader != Some(node_id) {
-                    break;
-                }
-                if std::time::Instant::now() >= deadline {
-                    return Err(MembershipError::RaftError(
-                        "leadership transfer dispatched but new leader not observed".into(),
-                    ));
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
+            let new_leader = self
+                .transfer_leadership_away_from(node_id, target, "demote_voter_to_learner")
+                .await?;
             // Caller must re-issue the demote on the new leader.
             return Err(MembershipError::NotLeader {
-                leader_node_id: self.raft.metrics().borrow().current_leader,
+                leader_node_id: new_leader,
             });
         }
 
@@ -837,35 +849,15 @@ impl<N: MembershipNetwork> MembershipChanger<N> {
                         .into(),
                 )
             })?;
-            self.raft
-                .trigger()
-                .transfer_to(target)
-                .await
-                .map_err(|e| MembershipError::RaftError(format!("transfer_to({target}): {e}")))?;
-
-            // Wait until our metrics show we are no longer leader.
-            // openraft updates the watch synchronously inside the engine
-            // step that processes TimeoutNow; we observe via current_leader.
-            let deadline = std::time::Instant::now()
-                + Duration::from_millis(Self::LEADERSHIP_TRANSFER_OBSERVE_MS);
-            loop {
-                let m = self.raft.metrics().borrow().clone();
-                if m.current_leader.is_some() && m.current_leader != Some(node_id) {
-                    break;
-                }
-                if std::time::Instant::now() >= deadline {
-                    return Err(MembershipError::RaftError(
-                        "leadership transfer dispatched but new leader not observed".into(),
-                    ));
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
+            let new_leader = self
+                .transfer_leadership_away_from(node_id, target, "remove_voter")
+                .await?;
             // After transfer the local node is a follower and Steps
             // 2-4 below will surface ForwardToLeader.  Caller drives
             // the forward via Message::ClusterMembershipForward as
             // for any non-leader change.
             return Err(MembershipError::NotLeader {
-                leader_node_id: self.raft.metrics().borrow().current_leader,
+                leader_node_id: new_leader,
             });
         }
 

--- a/ferrosa-cluster/tests/common/raft_harness.rs
+++ b/ferrosa-cluster/tests/common/raft_harness.rs
@@ -655,6 +655,68 @@ impl TestCluster {
         }
     }
 
+    /// Wait until a strict majority of bootstrap voters report the same
+    /// current leader. This is stronger than `wait_for_leader`, which is
+    /// useful for tests that assert election convergence rather than first
+    /// leader discovery.
+    pub async fn wait_for_majority_leader(&self, timeout: Duration) -> Option<u64> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(leader_id) = self.majority_leader_id() {
+                return Some(leader_id);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Return a leader id only when a strict majority of bootstrap voters
+    /// agree on it.
+    pub fn majority_leader_id(&self) -> Option<u64> {
+        let quorum = (self.nodes.len() / 2) + 1;
+        let mut counts = BTreeMap::<u64, usize>::new();
+        for n in &self.nodes {
+            if let Some(leader_id) = n.raft.metrics().borrow().current_leader {
+                let count = counts.entry(leader_id).or_insert(0);
+                *count += 1;
+                if *count >= quorum {
+                    return Some(leader_id);
+                }
+            }
+        }
+        None
+    }
+
+    /// Wait until every bootstrap voter reports the same current leader.
+    pub async fn wait_for_all_voters_leader(&self, timeout: Duration) -> Option<u64> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(leader_id) = self.all_voters_leader_id() {
+                return Some(leader_id);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Return a leader id only when all bootstrap voters agree on it.
+    pub fn all_voters_leader_id(&self) -> Option<u64> {
+        let mut leader = None;
+        for n in &self.nodes {
+            let node_leader = n.raft.metrics().borrow().current_leader?;
+            match leader {
+                Some(existing) if existing != node_leader => return None,
+                Some(_) => {}
+                None => leader = Some(node_leader),
+            }
+        }
+        leader
+    }
+
     /// Locate the leader's `TestNode`. Panics if no leader is currently
     /// elected on any node — call `wait_for_leader` first.
     pub fn leader_node(&self) -> &TestNode {

--- a/ferrosa-cluster/tests/failure_mode_matrix.rs
+++ b/ferrosa-cluster/tests/failure_mode_matrix.rs
@@ -497,27 +497,17 @@ async fn s_16_leader_disappears_followers_elect() {
     // S-16: leader OOM mid-commit.  Harness equivalent: isolate the
     // leader; followers must elect a new one.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
-    let leader_id = cluster.leader_node().node_id;
+    let leader_id = cluster
+        .wait_for_majority_leader(Duration::from_secs(5))
+        .await
+        .expect("initial leader must converge before isolation");
     let leader_idx = cluster
         .nodes()
         .iter()
         .position(|n| n.node_id == leader_id)
         .unwrap();
     cluster.partition(leader_idx);
-    let pred = || {
-        for node in &cluster.nodes() {
-            if node.node_id == leader_id {
-                continue;
-            }
-            if let Some(lid) = node.metrics().current_leader {
-                if lid != leader_id {
-                    return true;
-                }
-            }
-        }
-        false
-    };
+    let pred = || matches!(cluster.majority_leader_id(), Some(lid) if lid != leader_id);
     let elected = wait_until(pred, Duration::from_secs(5)).await;
     cluster.heal();
     assert!(elected, "remaining voters must elect a new leader");
@@ -768,7 +758,7 @@ async fn s_31_two_simultaneous_elections_resolve_to_one_leader() {
     // S-31: even under a fresh start, exactly one leader emerges.
     let cluster = TestCluster::with_voters(3).await;
     let leader = cluster
-        .wait_for_leader(Duration::from_secs(5))
+        .wait_for_majority_leader(Duration::from_secs(5))
         .await
         .unwrap();
     // The second simultaneous candidate should have given up.

--- a/ferrosa-cluster/tests/learner_lifecycle.rs
+++ b/ferrosa-cluster/tests/learner_lifecycle.rs
@@ -338,7 +338,7 @@ async fn demote_voter_to_learner_transfers_leader_first_if_needed() {
     // target's `matched_idx` may still trail the leader's `last_log_index`.
     // openraft's `transfer_to` has an internal catch-up budget of
     // `election_timeout_max × 2` which can run short under contention
-    // (this was a CI flake before the explicit pre-wait — see Sprint 8
+    // (this exposed a leadership-transfer readiness bug before the explicit pre-wait — see Sprint 8
     // W8.3 follow-up). Block until either the indices align or 4s elapse.
     {
         let leader = cluster.leader_node();

--- a/ferrosa-cluster/tests/raft_harness_smoke.rs
+++ b/ferrosa-cluster/tests/raft_harness_smoke.rs
@@ -17,9 +17,9 @@ async fn harness_3_node_cluster_elects_leader_and_commits() {
 
     // Wait for leader election.
     let leader = cluster
-        .wait_for_leader(Duration::from_secs(10))
+        .wait_for_all_voters_leader(Duration::from_secs(10))
         .await
-        .expect("leader should elect within 10 s");
+        .expect("all voters should agree on a leader within 10 s");
 
     // The leader must be one of the three nodes.
     assert!(

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -3538,9 +3538,17 @@ impl StorageEngine {
                 .collect();
             let table_id = &result.task.table_id;
 
-            // Open the compacted output SSTable.
-            let gen = &result.output.id;
-            let dir = &result.output.path;
+            let output = match self.promote_compaction_output(table_id, &result.output) {
+                Ok(output) => output,
+                Err(e) => {
+                    tracing::error!(%e, %table_id, "compaction: failed to promote output SSTable");
+                    continue;
+                }
+            };
+
+            // Open the promoted compacted output SSTable.
+            let gen = &output.id;
+            let dir = &output.path;
             let reader = match Self::open_sstable_from_dir(dir, gen) {
                 Ok(r) => Arc::new(r),
                 Err(e) => {
@@ -3566,7 +3574,7 @@ impl StorageEngine {
                     if let Err(e) = state.store.swap_compacted_sstables(
                         &input_id_paths,
                         output_id,
-                        result.output.path.clone(),
+                        output.path.clone(),
                         reader,
                         std::collections::HashMap::new(),
                     ) {
@@ -3587,7 +3595,7 @@ impl StorageEngine {
                     if let Some(ref scheduler) = self.index_scheduler {
                         for (index_name, col_pos) in state.store.indexed_columns() {
                             let job = crate::index::IndexBuildJob {
-                                sstable_id: result.output.id.clone(),
+                                sstable_id: output.id.clone(),
                                 index_name: index_name.clone(),
                                 index_type: ferrosa_index::IndexType::BTree,
                                 table: (
@@ -3607,11 +3615,9 @@ impl StorageEngine {
             }
 
             // Register in local cache.
-            self.local_cache.register(
-                &result.output.id,
-                result.output.path.clone(),
-                result.output.size_bytes,
-            );
+            self.local_cache
+                .register(&output.id, output.path.clone(), output.size_bytes);
+            Self::evict_local_input_sstable_files(&result.task.inputs);
 
             // ── Skip S3 upload for pinned tables ────────────────────────────
             //
@@ -3622,8 +3628,8 @@ impl StorageEngine {
                 tables.get(table_id).is_some_and(|s| s.pin_config.is_some())
             };
             if is_compaction_pinned {
-                let size = result.output.size_bytes;
-                let sstable_id = result.output.id.clone();
+                let size = output.size_bytes;
+                let sstable_id = output.id.clone();
                 {
                     let mut tables = self.tables.write();
                     if let Some(state) = tables.get_mut(table_id) {
@@ -3659,7 +3665,7 @@ impl StorageEngine {
             };
 
             let table_id_str = table_id.to_string();
-            let sstable_id = result.output.id.clone();
+            let sstable_id = output.id.clone();
 
             // Parse the generation number — output id is always a decimal u64.
             let gen_u64: u64 = match sstable_id.parse() {
@@ -3670,8 +3676,8 @@ impl StorageEngine {
                 }
             };
 
-            // The compaction output lives in result.output.path.
-            let output_dir = result.output.path.clone();
+            // The compaction output has been promoted into the table SSTable directory.
+            let output_dir = output.path.clone();
 
             let files = Self::collect_sstable_files(&output_dir, gen_u64);
             if files.is_empty() {
@@ -3768,7 +3774,7 @@ impl StorageEngine {
             let manifest_plan = crate::compaction::finalize::plan_manifest_update(
                 &table_id_str,
                 &result.task.inputs,
-                &result.output,
+                &output,
                 total_size,
             );
             let input_ids = manifest_plan.remove_input_ids.clone();
@@ -3868,24 +3874,6 @@ impl StorageEngine {
                 if deletion_plan.fire_and_forget {
                     // Fire-and-forget: S3 deletions are best-effort.
                     drop(del_rx);
-                }
-            }
-
-            // Evict local input SSTable component files (best-effort).
-            // Each input carries its own path (flush dir or compaction dir).
-            for input in &result.task.inputs {
-                let standard_components = [
-                    "Data.db",
-                    "Partitions.db",
-                    "Rows.db",
-                    "Filter.db",
-                    "Statistics.db",
-                    "TOC.txt",
-                    "CompressionInfo.db",
-                ];
-                for component in &standard_components {
-                    let file_path = input.path.join(format!("{}-{component}", input.id));
-                    let _ = std::fs::remove_file(&file_path);
                 }
             }
         }
@@ -4574,6 +4562,112 @@ impl StorageEngine {
                 }
             })
             .collect()
+    }
+
+    fn promote_compaction_output(
+        &self,
+        table_id: &TableId,
+        output: &crate::compaction::metadata::SSTableMetadata,
+    ) -> ferrosa_common::Result<crate::compaction::metadata::SSTableMetadata> {
+        let source_dir = &output.path;
+        let target_dir = self
+            .config
+            .data_dir
+            .join("sstables")
+            .join(table_id.to_string());
+        std::fs::create_dir_all(&target_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to create promoted compaction directory: {e}"
+            ))
+        })?;
+
+        let output_gen = output.id.parse::<u64>().map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "compaction output SSTable id is not a u64: {e}"
+            ))
+        })?;
+        let table_max_gen = Self::scan_generations(&target_dir)
+            .into_iter()
+            .max()
+            .unwrap_or(0);
+        let promoted_gen = table_max_gen.max(output_gen).saturating_add(1);
+        let promoted_id = promoted_gen.to_string();
+        let old_prefix = format!("{}-", output.id);
+
+        let mut moves = Vec::new();
+        for entry in std::fs::read_dir(source_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to read compaction output directory: {e}"
+            ))
+        })? {
+            let entry = entry.map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to read compaction output entry: {e}"
+                ))
+            })?;
+            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some(component_suffix) = name.strip_prefix(&old_prefix) else {
+                continue;
+            };
+            let target = target_dir.join(format!("{promoted_id}-{component_suffix}"));
+            if target.exists() {
+                return Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "promoted compaction target already exists: {}",
+                    target.display()
+                )));
+            }
+            moves.push((entry.path(), target));
+        }
+
+        if moves.is_empty() {
+            return Err(ferrosa_common::Error::InvalidFormat(format!(
+                "compaction output has no component files in {}",
+                source_dir.display()
+            )));
+        }
+
+        for (source, target) in &moves {
+            std::fs::rename(source, target).map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to promote compaction component {} to {}: {e}",
+                    source.display(),
+                    target.display()
+                ))
+            })?;
+        }
+        let _ = std::fs::remove_dir(source_dir);
+
+        let size_bytes = moves
+            .iter()
+            .filter_map(|(_, target)| std::fs::metadata(target).ok().map(|m| m.len()))
+            .sum();
+
+        let mut promoted = output.clone();
+        promoted.id = promoted_id;
+        promoted.path = target_dir;
+        promoted.size_bytes = size_bytes;
+        Ok(promoted)
+    }
+
+    fn evict_local_input_sstable_files(inputs: &[crate::compaction::metadata::SSTableMetadata]) {
+        let standard_components = [
+            "Data.db",
+            "Partitions.db",
+            "Rows.db",
+            "Filter.db",
+            "Statistics.db",
+            "TOC.txt",
+            "CompressionInfo.db",
+        ];
+        for input in inputs {
+            for component in &standard_components {
+                let file_path = input.path.join(format!("{}-{component}", input.id));
+                let _ = std::fs::remove_file(&file_path);
+            }
+        }
     }
 
     /// Collect local component file paths for an SSTable generation.
@@ -9781,7 +9875,7 @@ mod tests {
 
         // Manually submit a compaction task.
         {
-            let compaction_output_dir = dir.path().join("compaction");
+            let compaction_output_dir = dir.path().join("compaction").join(tid.to_string());
             let tables = engine.tables.read();
             let state = tables.get(&tid).unwrap();
             let metadata = engine.collect_sstable_metadata(&tid, state);
@@ -10129,9 +10223,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compaction_inputs_evicted_locally() {
-        // After poll_compactions() the input SSTable component files must be deleted
-        // from the table directory, while the compaction output directory must still exist.
+    async fn compaction_outputs_are_promoted_and_compaction_dir_drained() {
+        // After poll_compactions(), input SSTable component files must be deleted
+        // from the table directory, the compacted output must be promoted into
+        // that same table directory, and the compaction staging directory must
+        // not retain orphaned output files.
         let dir = tempfile::tempdir().unwrap();
         let (engine, _store, _prefix, tid) = make_engine_with_pending_compaction(&dir).await;
 
@@ -10157,6 +10253,7 @@ mod tests {
         // Run compaction + local eviction. Retry until the channel result is
         // consumed: the compaction thread writes files before sending on the
         // channel, so a single poll may miss the result under parallel load.
+        let table_compaction_dir = dir.path().join("compaction").join(&tid_str);
         let mut data_files_after = vec![];
         for _ in 0..40 {
             engine.poll_compactions().await;
@@ -10166,26 +10263,57 @@ mod tests {
                 .map(|e| e.path())
                 .filter(|p| p.is_file() && p.extension().map(|e| e == "db").unwrap_or(false))
                 .collect();
-            if data_files_after.is_empty() {
+            let input_files_evicted = input_files_before.iter().all(|path| !path.exists());
+            let promoted_data_file_present = data_files_after.iter().any(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-Data.db"))
+            });
+            let staging_drained = table_compaction_dir
+                .read_dir()
+                .into_iter()
+                .flatten()
+                .next()
+                .is_none();
+            if input_files_evicted && promoted_data_file_present && staging_drained {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
 
-        // All input SSTable component files must have been evicted.
-        // The sstable_dir may be empty or contain only output-generation files
-        // (but the output goes into dir/compaction, not sstable_dir).
+        // The old input generations must be gone from the table directory.
         assert!(
-            data_files_after.is_empty(),
-            "input SSTable files should be evicted, remaining: {:?}",
+            input_files_before.iter().all(|path| !path.exists()),
+            "input SSTable files should be evicted, still present: {:?}",
+            input_files_before
+                .iter()
+                .filter(|path| path.exists())
+                .collect::<Vec<_>>()
+        );
+
+        // The compacted output must be durable in the normal SSTable directory.
+        assert!(
+            data_files_after.iter().any(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-Data.db"))
+            }),
+            "compacted output Data.db should be promoted into {:?}, got {:?}",
+            sstable_dir,
             data_files_after
         );
 
-        // The compaction output directory must still exist.
-        let output_dir = dir.path().join("compaction");
+        let staged_files: Vec<_> = table_compaction_dir
+            .read_dir()
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .collect();
         assert!(
-            output_dir.exists(),
-            "compaction output directory must still exist after poll_compactions"
+            staged_files.is_empty(),
+            "compaction staging dir should be drained after promotion, got {:?}",
+            staged_files
         );
     }
 


### PR DESCRIPTION
## Summary
- promote compaction outputs from compaction staging into the table SSTable directory before swapping readers/manifests
- delete local compacted input SSTable component files after a successful local swap so no-S3 deployments do not leak files
- add majority/all-voter leader convergence waits to the Raft harness where tests assert converged leadership
- make leader self-transfer observe replacement leadership before returning `NotLeader`, including post-timeout convergence

## Tests
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p ferrosa-storage compaction_outputs_are_promoted_and_compaction_dir_drained --lib`
- `cargo test -p ferrosa-storage poll_compactions_swap_happens_without_upload_manager --lib`
- `cargo test -p ferrosa-storage poll_compactions_does_not_re_process_already_swapped_result --lib`
- `cargo test -p ferrosa-storage compaction_output_uploaded_to_s3 --lib`
- `cargo test -p ferrosa-storage manifest_updated_after_compaction --lib`
- `cargo test -p ferrosa-storage compaction_s3_metrics_accurate --lib`
- `cargo test -p ferrosa-cluster --test failure_mode_matrix s_16_leader_disappears_followers_elect -- --exact`
- `cargo test -p ferrosa-cluster --test failure_mode_matrix s_31_two_simultaneous_elections_resolve_to_one_leader -- --exact`
- `cargo test -p ferrosa-cluster --test raft_harness_smoke harness_3_node_cluster_elects_leader_and_commits -- --exact`
- `cargo test -p ferrosa-cluster --test learner_lifecycle demote_voter_to_learner_transfers_leader_first_if_needed -- --exact`
- `cargo test --all-features --workspace --lib --tests --exclude ferrosa-jepsen --exclude ferrosa-loadgen -- --skip batch_atomicity --skip pause_resume --skip recovery_coordinator --skip cassandra_reads_compacted --skip compaction_end_to_end_pipeline --skip dep_wait_ordering --skip disk_fail_no_phantom --skip packet_reorder_linearizability --skip lwt_batch_atomicity_all --skip clock_skew_large_preaccept --skip binary_ --skip concurrent_write --skip many_flushes --skip flush_2000 --skip single_writer --skip write_flush_compact`