### PR TITLE
fix(cluster): avoid stale peer address downgrade

### DIFF
--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -68,6 +68,52 @@ use crate::streaming::{
 };
 use crate::write_path::WritePath;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum InvitePeerConnectionPlan {
+    SkipSelf,
+    KeepLiveKnownPeer {
+        known_addr: String,
+        invite_addr: SocketAddr,
+    },
+    AlreadyConnected,
+    Connect {
+        reverse_addr: SocketAddr,
+        previous_addr: Option<String>,
+    },
+}
+
+pub(super) fn plan_invite_peer_connection(
+    local_host_id: Uuid,
+    peer_id: Uuid,
+    peer_addr: SocketAddr,
+    internode_port: u16,
+    known_addr: Option<&str>,
+    live: bool,
+) -> InvitePeerConnectionPlan {
+    if peer_id == local_host_id {
+        return InvitePeerConnectionPlan::SkipSelf;
+    }
+
+    let reverse_addr = SocketAddr::new(peer_addr.ip(), internode_port);
+    let invite_addr = reverse_addr.to_string();
+
+    if live {
+        return match known_addr {
+            Some(known) if known == invite_addr => InvitePeerConnectionPlan::AlreadyConnected,
+            Some(known) => InvitePeerConnectionPlan::KeepLiveKnownPeer {
+                known_addr: known.to_string(),
+                invite_addr: reverse_addr,
+            },
+            None => InvitePeerConnectionPlan::AlreadyConnected,
+        };
+    }
+
+    InvitePeerConnectionPlan::Connect {
+        reverse_addr,
+        previous_addr: known_addr.map(ToOwned::to_owned),
+    }
+}
+
 use super::{ClusterStateHolder, ModeController};
 
 pub(super) fn should_initialize_seed_membership(
@@ -2240,39 +2286,56 @@ impl RpcHandler for ClusterInviteHandler {
         let internode_port = self.net_config.bind_addr.port();
         let mut new_peers = Vec::new();
         for (peer_id, peer_addr) in &peers {
-            if *peer_id == self.local_host_id {
-                continue;
-            }
-            let expected_addr = SocketAddr::new(peer_addr.ip(), internode_port).to_string();
             let known_addr = self.peer_manager.peer_addr(*peer_id).await;
             let live = self.peer_manager.has_live_peer(*peer_id);
-            let addr_changed = known_addr.as_deref() != Some(expected_addr.as_str());
-            if live && !addr_changed {
-                continue;
+            match plan_invite_peer_connection(
+                self.local_host_id,
+                *peer_id,
+                *peer_addr,
+                internode_port,
+                known_addr.as_deref(),
+                live,
+            ) {
+                InvitePeerConnectionPlan::SkipSelf | InvitePeerConnectionPlan::AlreadyConnected => {
+                }
+                InvitePeerConnectionPlan::KeepLiveKnownPeer {
+                    known_addr,
+                    invite_addr,
+                } => {
+                    tracing::warn!(
+                        peer = %peer_id,
+                        %known_addr,
+                        %invite_addr,
+                        "cluster invite: ignoring conflicting address for live peer"
+                    );
+                }
+                InvitePeerConnectionPlan::Connect {
+                    reverse_addr,
+                    previous_addr,
+                } => {
+                    if previous_addr.as_deref() != Some(&reverse_addr.to_string()) {
+                        tracing::info!(
+                            peer = %peer_id,
+                            old_addr = ?previous_addr,
+                            new_addr = %reverse_addr,
+                            "cluster invite: peer address changed, refreshing reverse connection"
+                        );
+                    }
+                    new_peers.push((*peer_id, reverse_addr));
+                }
             }
-            if addr_changed {
-                tracing::info!(
-                    peer = %peer_id,
-                    old_addr = ?known_addr,
-                    new_addr = %expected_addr,
-                    "cluster invite: peer address changed, refreshing reverse connection"
-                );
-            }
-            new_peers.push((*peer_id, *peer_addr));
         }
 
         // Connect to unknown peers using a local JoinSet so we can await
         // completion before re-broadcasting (replaces raw tokio::spawn +
         // fixed 500ms sleep).
-        let internode_port = self.net_config.bind_addr.port();
         let mut connect_tasks = tokio::task::JoinSet::new();
-        for (peer_id, peer_addr) in &new_peers {
-            let reverse_addr = SocketAddr::new(peer_addr.ip(), internode_port);
+        for (peer_id, reverse_addr) in &new_peers {
             let pm = self.peer_manager.clone();
             let cfg = self.net_config.clone();
             let local_id = self.local_host_id;
             let uuid = *peer_id;
-            let addr = reverse_addr;
+            let addr = *reverse_addr;
 
             connect_tasks.spawn(async move {
                 match PriorityPool::connect(cfg, local_id, &addr.to_string(), None, None).await {

--- a/ferrosa-cluster/src/controller/peer_events.rs
+++ b/ferrosa-cluster/src/controller/peer_events.rs
@@ -12,6 +12,27 @@ use crate::mode::DeploymentMode;
 use super::peer_plan::{self, PeerConnectPlanInput, PeerEventAction, PeerRecoveredPlanInput};
 use super::ModeController;
 
+pub(super) fn track_connected_peer(
+    peers: &mut Vec<(uuid::Uuid, std::net::SocketAddr)>,
+    host_id: uuid::Uuid,
+    addr: std::net::SocketAddr,
+    capacity: usize,
+) {
+    if let Some((_, existing_addr)) = peers.iter_mut().find(|(id, _)| *id == host_id) {
+        *existing_addr = addr;
+        return;
+    }
+
+    if peers.len() >= capacity {
+        tracing::warn!(
+            cap = capacity,
+            "connected_peers at capacity — evicting oldest entry"
+        );
+        peers.remove(0);
+    }
+    peers.push((host_id, addr));
+}
+
 #[cfg(test)]
 pub(super) fn should_send_cluster_invite_after_join_trigger(
     join_enqueued: bool,
@@ -110,16 +131,7 @@ impl PeerEventListener for ModeController {
         // Track this peer
         {
             let mut peers = self.connected_peers.lock();
-            if !peers.iter().any(|(id, _)| *id == host_id) {
-                if peers.len() >= super::MAX_CONNECTED_PEERS {
-                    tracing::warn!(
-                        cap = super::MAX_CONNECTED_PEERS,
-                        "connected_peers at capacity — evicting oldest entry"
-                    );
-                    peers.remove(0);
-                }
-                peers.push((host_id, addr));
-            }
+            track_connected_peer(&mut peers, host_id, addr, super::MAX_CONNECTED_PEERS);
         }
 
         // Hold the transition guard across mode-check-and-transition to prevent
@@ -257,16 +269,12 @@ impl InboundPeerCallback for ModeController {
         // Track this peer
         {
             let mut peers = self.connected_peers.lock();
-            if !peers.iter().any(|(id, _)| *id == host_id) {
-                if peers.len() >= super::MAX_CONNECTED_PEERS {
-                    tracing::warn!(
-                        cap = super::MAX_CONNECTED_PEERS,
-                        "connected_peers at capacity — evicting oldest entry"
-                    );
-                    peers.remove(0);
-                }
-                peers.push((host_id, addr));
-            }
+            track_connected_peer(
+                &mut peers,
+                host_id,
+                reverse_addr,
+                super::MAX_CONNECTED_PEERS,
+            );
         }
 
         let _guard = self.transition_guard.lock();

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -594,6 +594,24 @@ fn reconnect_invite_plan_includes_self_and_excludes_recipient() {
 }
 
 #[test]
+fn connected_peer_tracking_updates_existing_peer_address() {
+    let peer = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+    let old_addr = "10.89.1.14:7000".parse().unwrap();
+    let new_addr = "10.89.1.17:7000".parse().unwrap();
+    let other = Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap();
+    let other_addr = "10.89.1.18:7000".parse().unwrap();
+    let mut peers = vec![(peer, old_addr), (other, other_addr)];
+
+    super::peer_events::track_connected_peer(&mut peers, peer, new_addr, 16);
+
+    assert_eq!(
+        peers,
+        vec![(peer, new_addr), (other, other_addr)],
+        "reconnects with a new container IP must update connected_peers; otherwise later ClusterInvite payloads re-advertise dead addresses"
+    );
+}
+
+#[test]
 fn reconnect_invite_plan_returns_none_when_no_peer_addresses_available() {
     let local = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
     let recipient = Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap();
@@ -609,6 +627,31 @@ fn reconnect_invite_plan_returns_none_when_no_peer_addresses_available() {
     assert!(
         plan.is_none(),
         "an invite with no reachable peers would only echo the recipient"
+    );
+}
+
+#[test]
+fn cluster_invite_keeps_live_peer_when_payload_advertises_older_address() {
+    let local = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let peer = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+    let stale_invite_addr = "10.89.1.14:9042".parse().unwrap();
+
+    let plan = super::cluster::plan_invite_peer_connection(
+        local,
+        peer,
+        stale_invite_addr,
+        7000,
+        Some("10.89.1.17:7000"),
+        true,
+    );
+
+    assert_eq!(
+        plan,
+        super::cluster::InvitePeerConnectionPlan::KeepLiveKnownPeer {
+            known_addr: "10.89.1.17:7000".to_string(),
+            invite_addr: "10.89.1.14:7000".parse().unwrap(),
+        },
+        "third-party ClusterInvite metadata must not downgrade an already-live peer to a dead address"
     );
 }
 

--- a/ferrosa-cluster/src/membership/mod.rs
+++ b/ferrosa-cluster/src/membership/mod.rs
@@ -413,6 +413,34 @@ impl<N: MembershipNetwork> MembershipChanger<N> {
         Duration::from_secs(10),
     ];
 
+    async fn transfer_leadership_away_from(
+        &self,
+        node_id: u64,
+        target: u64,
+        context: &str,
+    ) -> Result<Option<u64>, MembershipError> {
+        let transfer_result = self.raft.trigger().transfer_to(target).await;
+        let deadline =
+            std::time::Instant::now() + Duration::from_millis(Self::LEADERSHIP_TRANSFER_OBSERVE_MS);
+        loop {
+            let m = self.raft.metrics().borrow().clone();
+            if m.current_leader.is_some() && m.current_leader != Some(node_id) {
+                return Ok(m.current_leader);
+            }
+            if std::time::Instant::now() >= deadline {
+                return match transfer_result {
+                    Ok(()) => Err(MembershipError::RaftError(format!(
+                        "{context}: leadership transfer dispatched but new leader not observed"
+                    ))),
+                    Err(e) => Err(MembershipError::RaftError(format!(
+                        "{context}: transfer_to({target}) failed and no replacement leader was observed: {e}"
+                    ))),
+                };
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
     /// W7.8 / I-30 — Drain in-flight Accord transactions for a DC swap.
     ///
     /// Polls `drain` for transactions referencing any of `leaving_voters`
@@ -689,28 +717,12 @@ impl<N: MembershipNetwork> MembershipChanger<N> {
                     "demote_voter_to_learner: no eligible voter for leadership transfer".into(),
                 )
             })?;
-            self.raft
-                .trigger()
-                .transfer_to(target)
-                .await
-                .map_err(|e| MembershipError::RaftError(format!("transfer_to({target}): {e}")))?;
-            let deadline = std::time::Instant::now()
-                + Duration::from_millis(Self::LEADERSHIP_TRANSFER_OBSERVE_MS);
-            loop {
-                let m = self.raft.metrics().borrow().clone();
-                if m.current_leader.is_some() && m.current_leader != Some(node_id) {
-                    break;
-                }
-                if std::time::Instant::now() >= deadline {
-                    return Err(MembershipError::RaftError(
-                        "leadership transfer dispatched but new leader not observed".into(),
-                    ));
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
+            let new_leader = self
+                .transfer_leadership_away_from(node_id, target, "demote_voter_to_learner")
+                .await?;
             // Caller must re-issue the demote on the new leader.
             return Err(MembershipError::NotLeader {
-                leader_node_id: self.raft.metrics().borrow().current_leader,
+                leader_node_id: new_leader,
             });
         }
 
@@ -837,35 +849,15 @@ impl<N: MembershipNetwork> MembershipChanger<N> {
                         .into(),
                 )
             })?;
-            self.raft
-                .trigger()
-                .transfer_to(target)
-                .await
-                .map_err(|e| MembershipError::RaftError(format!("transfer_to({target}): {e}")))?;
-
-            // Wait until our metrics show we are no longer leader.
-            // openraft updates the watch synchronously inside the engine
-            // step that processes TimeoutNow; we observe via current_leader.
-            let deadline = std::time::Instant::now()
-                + Duration::from_millis(Self::LEADERSHIP_TRANSFER_OBSERVE_MS);
-            loop {
-                let m = self.raft.metrics().borrow().clone();
-                if m.current_leader.is_some() && m.current_leader != Some(node_id) {
-                    break;
-                }
-                if std::time::Instant::now() >= deadline {
-                    return Err(MembershipError::RaftError(
-                        "leadership transfer dispatched but new leader not observed".into(),
-                    ));
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
+            let new_leader = self
+                .transfer_leadership_away_from(node_id, target, "remove_voter")
+                .await?;
             // After transfer the local node is a follower and Steps
             // 2-4 below will surface ForwardToLeader.  Caller drives
             // the forward via Message::ClusterMembershipForward as
             // for any non-leader change.
             return Err(MembershipError::NotLeader {
-                leader_node_id: self.raft.metrics().borrow().current_leader,
+                leader_node_id: new_leader,
             });
         }
 

--- a/ferrosa-cluster/tests/common/raft_harness.rs
+++ b/ferrosa-cluster/tests/common/raft_harness.rs
@@ -655,6 +655,68 @@ impl TestCluster {
         }
     }
 
+    /// Wait until a strict majority of bootstrap voters report the same
+    /// current leader. This is stronger than `wait_for_leader`, which is
+    /// useful for tests that assert election convergence rather than first
+    /// leader discovery.
+    pub async fn wait_for_majority_leader(&self, timeout: Duration) -> Option<u64> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(leader_id) = self.majority_leader_id() {
+                return Some(leader_id);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Return a leader id only when a strict majority of bootstrap voters
+    /// agree on it.
+    pub fn majority_leader_id(&self) -> Option<u64> {
+        let quorum = (self.nodes.len() / 2) + 1;
+        let mut counts = BTreeMap::<u64, usize>::new();
+        for n in &self.nodes {
+            if let Some(leader_id) = n.raft.metrics().borrow().current_leader {
+                let count = counts.entry(leader_id).or_insert(0);
+                *count += 1;
+                if *count >= quorum {
+                    return Some(leader_id);
+                }
+            }
+        }
+        None
+    }
+
+    /// Wait until every bootstrap voter reports the same current leader.
+    pub async fn wait_for_all_voters_leader(&self, timeout: Duration) -> Option<u64> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(leader_id) = self.all_voters_leader_id() {
+                return Some(leader_id);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Return a leader id only when all bootstrap voters agree on it.
+    pub fn all_voters_leader_id(&self) -> Option<u64> {
+        let mut leader = None;
+        for n in &self.nodes {
+            let node_leader = n.raft.metrics().borrow().current_leader?;
+            match leader {
+                Some(existing) if existing != node_leader => return None,
+                Some(_) => {}
+                None => leader = Some(node_leader),
+            }
+        }
+        leader
+    }
+
     /// Locate the leader's `TestNode`. Panics if no leader is currently
     /// elected on any node — call `wait_for_leader` first.
     pub fn leader_node(&self) -> &TestNode {

--- a/ferrosa-cluster/tests/failure_mode_matrix.rs
+++ b/ferrosa-cluster/tests/failure_mode_matrix.rs
@@ -497,27 +497,17 @@ async fn s_16_leader_disappears_followers_elect() {
     // S-16: leader OOM mid-commit.  Harness equivalent: isolate the
     // leader; followers must elect a new one.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
-    let leader_id = cluster.leader_node().node_id;
+    let leader_id = cluster
+        .wait_for_majority_leader(Duration::from_secs(5))
+        .await
+        .expect("initial leader must converge before isolation");
     let leader_idx = cluster
         .nodes()
         .iter()
         .position(|n| n.node_id == leader_id)
         .unwrap();
     cluster.partition(leader_idx);
-    let pred = || {
-        for node in &cluster.nodes() {
-            if node.node_id == leader_id {
-                continue;
-            }
-            if let Some(lid) = node.metrics().current_leader {
-                if lid != leader_id {
-                    return true;
-                }
-            }
-        }
-        false
-    };
+    let pred = || matches!(cluster.majority_leader_id(), Some(lid) if lid != leader_id);
     let elected = wait_until(pred, Duration::from_secs(5)).await;
     cluster.heal();
     assert!(elected, "remaining voters must elect a new leader");
@@ -768,7 +758,7 @@ async fn s_31_two_simultaneous_elections_resolve_to_one_leader() {
     // S-31: even under a fresh start, exactly one leader emerges.
     let cluster = TestCluster::with_voters(3).await;
     let leader = cluster
-        .wait_for_leader(Duration::from_secs(5))
+        .wait_for_majority_leader(Duration::from_secs(5))
         .await
         .unwrap();
     // The second simultaneous candidate should have given up.

--- a/ferrosa-cluster/tests/learner_lifecycle.rs
+++ b/ferrosa-cluster/tests/learner_lifecycle.rs
@@ -338,7 +338,7 @@ async fn demote_voter_to_learner_transfers_leader_first_if_needed() {
     // target's `matched_idx` may still trail the leader's `last_log_index`.
     // openraft's `transfer_to` has an internal catch-up budget of
     // `election_timeout_max × 2` which can run short under contention
-    // (this was a CI flake before the explicit pre-wait — see Sprint 8
+    // (this exposed a leadership-transfer readiness bug before the explicit pre-wait — see Sprint 8
     // W8.3 follow-up). Block until either the indices align or 4s elapse.
     {
         let leader = cluster.leader_node();

--- a/ferrosa-cluster/tests/raft_harness_smoke.rs
+++ b/ferrosa-cluster/tests/raft_harness_smoke.rs
@@ -17,9 +17,9 @@ async fn harness_3_node_cluster_elects_leader_and_commits() {
 
     // Wait for leader election.
     let leader = cluster
-        .wait_for_leader(Duration::from_secs(10))
+        .wait_for_all_voters_leader(Duration::from_secs(10))
         .await
-        .expect("leader should elect within 10 s");
+        .expect("all voters should agree on a leader within 10 s");
 
     // The leader must be one of the three nodes.
     assert!(

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -616,6 +616,81 @@ fn normalize_consolidation_type(type_name: &str) -> String {
 }
 
 impl StorageEngine {
+    /// Remove stale local compaction staging files from previous processes.
+    ///
+    /// Compaction output is only live while an in-process compaction result is
+    /// waiting to be promoted. On startup there are no such in-memory results,
+    /// so any files under `compaction/` are disk-only debris. Durable SSTables
+    /// used for reads and pending S3 replay live under `sstables/`; replay drops
+    /// missing-file entries instead of treating staging files as authoritative.
+    fn cleanup_stale_compaction_staging(
+        config: &StorageEngineConfig,
+    ) -> ferrosa_common::Result<()> {
+        let output_dir = &config.compaction.output_dir;
+        if !output_dir.exists() {
+            std::fs::create_dir_all(output_dir).map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to create compaction staging dir {}: {e}",
+                    output_dir.display()
+                ))
+            })?;
+            return Ok(());
+        }
+
+        let removed_files = Self::count_regular_files(output_dir)?;
+        std::fs::remove_dir_all(output_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to remove stale compaction staging dir {}: {e}",
+                output_dir.display()
+            ))
+        })?;
+        std::fs::create_dir_all(output_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to recreate compaction staging dir {}: {e}",
+                output_dir.display()
+            ))
+        })?;
+
+        if removed_files > 0 {
+            tracing::info!(
+                removed_files,
+                path = %output_dir.display(),
+                "storage startup: cleaned stale compaction staging files"
+            );
+        }
+
+        Ok(())
+    }
+
+    fn count_regular_files(dir: &Path) -> ferrosa_common::Result<usize> {
+        let mut count = 0usize;
+        for entry in std::fs::read_dir(dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to read compaction staging dir {}: {e}",
+                dir.display()
+            ))
+        })? {
+            let entry = entry.map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to read compaction staging entry in {}: {e}",
+                    dir.display()
+                ))
+            })?;
+            let file_type = entry.file_type().map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to inspect compaction staging entry {}: {e}",
+                    entry.path().display()
+                ))
+            })?;
+            if file_type.is_file() {
+                count += 1;
+            } else if file_type.is_dir() {
+                count += Self::count_regular_files(&entry.path())?;
+            }
+        }
+        Ok(count)
+    }
+
     /// Creates a new storage engine. Initializes the commit log, compaction
     /// executor, and optional upload manager.
     pub fn new(
@@ -636,6 +711,7 @@ impl StorageEngine {
         std::fs::create_dir_all(&config.commit_log.log_dir).map_err(|e| {
             ferrosa_common::Error::InvalidFormat(format!("failed to create commitlog dir: {e}"))
         })?;
+        Self::cleanup_stale_compaction_staging(&config)?;
 
         let commit_log = CommitLog::new(config.commit_log.clone())?;
         let compaction_executor = CompactionExecutor::new();
@@ -734,6 +810,7 @@ impl StorageEngine {
         std::fs::create_dir_all(&config.commit_log.log_dir).map_err(|e| {
             ferrosa_common::Error::InvalidFormat(format!("failed to create commitlog dir: {e}"))
         })?;
+        Self::cleanup_stale_compaction_staging(&config)?;
 
         let mut commit_log = CommitLog::new(config.commit_log.clone())?;
         let compaction_executor = CompactionExecutor::new();
@@ -847,6 +924,7 @@ impl StorageEngine {
         std::fs::create_dir_all(&config.commit_log.log_dir).map_err(|e| {
             ferrosa_common::Error::InvalidFormat(format!("failed to create commitlog dir: {e}"))
         })?;
+        Self::cleanup_stale_compaction_staging(&config)?;
 
         let compaction_executor = CompactionExecutor::new();
 
@@ -1012,6 +1090,13 @@ impl StorageEngine {
                 sstable = sstable_id,
                 "pending upload: SSTable files not found on disk — cannot replay"
             );
+            if let Err(e) = pending_log.remove_entry(sstable_id) {
+                tracing::warn!(
+                    table = table_id_str,
+                    sstable = sstable_id,
+                    "pending upload: failed to remove missing-file entry from pending-uploads.log: {e}"
+                );
+            }
         }
 
         for (table_id_str, sstable_id, error) in &report.submit_failures {
@@ -5148,6 +5233,49 @@ mod tests {
         );
     }
 
+    #[test]
+    fn replay_pending_uploads_removes_entries_whose_files_are_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let table_id = "agent_memory.entity_store";
+
+        let pending_log =
+            crate::upload::PendingUploadsLog::open(&config.data_dir.join("pending-uploads.log"))
+                .unwrap();
+        pending_log.add_entry(table_id, "missing-101").unwrap();
+
+        let upload_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let store = Arc::new(object_store::memory::InMemory::new());
+        let engine = StorageEngine::new_with_upload_store_and_queue_depth(
+            config,
+            store,
+            "test-prefix".to_string(),
+            upload_runtime.handle(),
+            1,
+        )
+        .unwrap();
+
+        let replay_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        replay_runtime.block_on(engine.replay_pending_uploads());
+
+        let remaining = crate::upload::PendingUploadsLog::open(
+            &engine.config.data_dir.join("pending-uploads.log"),
+        )
+        .unwrap()
+        .pending_entries()
+        .unwrap();
+        assert!(
+            remaining.is_empty(),
+            "missing SSTable uploads cannot be retried and should be pruned from pending-uploads.log"
+        );
+    }
+
     /// Read the first and last raw partition key bytes from Partitions.db.
     ///
     /// Footer (last 24 bytes): key_bounds_offset (i64 BE) | key_count (i64 BE) | root_pos (i64 BE).
@@ -5331,6 +5459,83 @@ mod tests {
 
     fn table_id() -> TableId {
         TableId::new("test_ks", "test_table")
+    }
+
+    #[test]
+    fn storage_engine_new_removes_stale_compaction_staging_without_touching_sstables() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let table = table_id().to_string();
+        let compaction_table_dir = config.compaction.output_dir.join(&table);
+        let sstable_table_dir = config.data_dir.join("sstables").join(&table);
+        std::fs::create_dir_all(&compaction_table_dir).unwrap();
+        std::fs::create_dir_all(&sstable_table_dir).unwrap();
+
+        let stale_data = compaction_table_dir.join("101-Data.db");
+        let stale_toc = compaction_table_dir.join("101-TOC.txt");
+        let live_data = sstable_table_dir.join("99-Data.db");
+        std::fs::write(&stale_data, b"stale compaction output").unwrap();
+        std::fs::write(&stale_toc, b"TOC").unwrap();
+        std::fs::write(&live_data, b"live sstable output").unwrap();
+
+        let _engine = StorageEngine::new(config, None).unwrap();
+
+        assert!(
+            !stale_data.exists() && !stale_toc.exists(),
+            "startup must remove stale compaction staging files"
+        );
+        assert!(
+            live_data.exists(),
+            "startup cleanup must not remove normal SSTable files"
+        );
+    }
+
+    #[test]
+    fn storage_engine_open_removes_stale_compaction_staging_on_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let table = table_id().to_string();
+        let compaction_table_dir = config.compaction.output_dir.join(&table);
+        std::fs::create_dir_all(&compaction_table_dir).unwrap();
+
+        let stale_data = compaction_table_dir.join("202-Data.db");
+        std::fs::write(&stale_data, b"stale compaction output").unwrap();
+
+        let (_engine, _pending) = StorageEngine::open(config, None).unwrap();
+
+        assert!(
+            !stale_data.exists(),
+            "restart must remove stale compaction staging files"
+        );
+    }
+
+    #[test]
+    fn startup_removes_legacy_pending_upload_compaction_staging_without_sstable_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let table = table_id().to_string();
+        let compaction_table_dir = config.compaction.output_dir.join(&table);
+        std::fs::create_dir_all(&compaction_table_dir).unwrap();
+
+        let legacy_pending_data = compaction_table_dir.join("303-Data.db");
+        let stale_data = compaction_table_dir.join("404-Data.db");
+        std::fs::write(&legacy_pending_data, b"legacy pending upload output").unwrap();
+        std::fs::write(&stale_data, b"stale compaction output").unwrap();
+        crate::upload::PendingUploadsLog::open(&config.data_dir.join("pending-uploads.log"))
+            .unwrap()
+            .add_entry(&table, "303")
+            .unwrap();
+
+        let _engine = StorageEngine::new(config, None).unwrap();
+
+        assert!(
+            !legacy_pending_data.exists(),
+            "startup must remove legacy compaction-only pending upload staging files"
+        );
+        assert!(
+            !stale_data.exists(),
+            "startup must still remove unrelated stale staging files"
+        );
     }
 
     #[test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -3538,9 +3538,17 @@ impl StorageEngine {
                 .collect();
             let table_id = &result.task.table_id;
 
-            // Open the compacted output SSTable.
-            let gen = &result.output.id;
-            let dir = &result.output.path;
+            let output = match self.promote_compaction_output(table_id, &result.output) {
+                Ok(output) => output,
+                Err(e) => {
+                    tracing::error!(%e, %table_id, "compaction: failed to promote output SSTable");
+                    continue;
+                }
+            };
+
+            // Open the promoted compacted output SSTable.
+            let gen = &output.id;
+            let dir = &output.path;
             let reader = match Self::open_sstable_from_dir(dir, gen) {
                 Ok(r) => Arc::new(r),
                 Err(e) => {
@@ -3566,7 +3574,7 @@ impl StorageEngine {
                     if let Err(e) = state.store.swap_compacted_sstables(
                         &input_id_paths,
                         output_id,
-                        result.output.path.clone(),
+                        output.path.clone(),
                         reader,
                         std::collections::HashMap::new(),
                     ) {
@@ -3587,7 +3595,7 @@ impl StorageEngine {
                     if let Some(ref scheduler) = self.index_scheduler {
                         for (index_name, col_pos) in state.store.indexed_columns() {
                             let job = crate::index::IndexBuildJob {
-                                sstable_id: result.output.id.clone(),
+                                sstable_id: output.id.clone(),
                                 index_name: index_name.clone(),
                                 index_type: ferrosa_index::IndexType::BTree,
                                 table: (
@@ -3607,11 +3615,9 @@ impl StorageEngine {
             }
 
             // Register in local cache.
-            self.local_cache.register(
-                &result.output.id,
-                result.output.path.clone(),
-                result.output.size_bytes,
-            );
+            self.local_cache
+                .register(&output.id, output.path.clone(), output.size_bytes);
+            Self::evict_local_input_sstable_files(&result.task.inputs);
 
             // ── Skip S3 upload for pinned tables ────────────────────────────
             //
@@ -3622,8 +3628,8 @@ impl StorageEngine {
                 tables.get(table_id).is_some_and(|s| s.pin_config.is_some())
             };
             if is_compaction_pinned {
-                let size = result.output.size_bytes;
-                let sstable_id = result.output.id.clone();
+                let size = output.size_bytes;
+                let sstable_id = output.id.clone();
                 {
                     let mut tables = self.tables.write();
                     if let Some(state) = tables.get_mut(table_id) {
@@ -3659,7 +3665,7 @@ impl StorageEngine {
             };
 
             let table_id_str = table_id.to_string();
-            let sstable_id = result.output.id.clone();
+            let sstable_id = output.id.clone();
 
             // Parse the generation number — output id is always a decimal u64.
             let gen_u64: u64 = match sstable_id.parse() {
@@ -3670,8 +3676,8 @@ impl StorageEngine {
                 }
             };
 
-            // The compaction output lives in result.output.path.
-            let output_dir = result.output.path.clone();
+            // The compaction output has been promoted into the table SSTable directory.
+            let output_dir = output.path.clone();
 
             let files = Self::collect_sstable_files(&output_dir, gen_u64);
             if files.is_empty() {
@@ -3768,7 +3774,7 @@ impl StorageEngine {
             let manifest_plan = crate::compaction::finalize::plan_manifest_update(
                 &table_id_str,
                 &result.task.inputs,
-                &result.output,
+                &output,
                 total_size,
             );
             let input_ids = manifest_plan.remove_input_ids.clone();
@@ -3868,24 +3874,6 @@ impl StorageEngine {
                 if deletion_plan.fire_and_forget {
                     // Fire-and-forget: S3 deletions are best-effort.
                     drop(del_rx);
-                }
-            }
-
-            // Evict local input SSTable component files (best-effort).
-            // Each input carries its own path (flush dir or compaction dir).
-            for input in &result.task.inputs {
-                let standard_components = [
-                    "Data.db",
-                    "Partitions.db",
-                    "Rows.db",
-                    "Filter.db",
-                    "Statistics.db",
-                    "TOC.txt",
-                    "CompressionInfo.db",
-                ];
-                for component in &standard_components {
-                    let file_path = input.path.join(format!("{}-{component}", input.id));
-                    let _ = std::fs::remove_file(&file_path);
                 }
             }
         }
@@ -4574,6 +4562,112 @@ impl StorageEngine {
                 }
             })
             .collect()
+    }
+
+    fn promote_compaction_output(
+        &self,
+        table_id: &TableId,
+        output: &crate::compaction::metadata::SSTableMetadata,
+    ) -> ferrosa_common::Result<crate::compaction::metadata::SSTableMetadata> {
+        let source_dir = &output.path;
+        let target_dir = self
+            .config
+            .data_dir
+            .join("sstables")
+            .join(table_id.to_string());
+        std::fs::create_dir_all(&target_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to create promoted compaction directory: {e}"
+            ))
+        })?;
+
+        let output_gen = output.id.parse::<u64>().map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "compaction output SSTable id is not a u64: {e}"
+            ))
+        })?;
+        let table_max_gen = Self::scan_generations(&target_dir)
+            .into_iter()
+            .max()
+            .unwrap_or(0);
+        let promoted_gen = table_max_gen.max(output_gen).saturating_add(1);
+        let promoted_id = promoted_gen.to_string();
+        let old_prefix = format!("{}-", output.id);
+
+        let mut moves = Vec::new();
+        for entry in std::fs::read_dir(source_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to read compaction output directory: {e}"
+            ))
+        })? {
+            let entry = entry.map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to read compaction output entry: {e}"
+                ))
+            })?;
+            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some(component_suffix) = name.strip_prefix(&old_prefix) else {
+                continue;
+            };
+            let target = target_dir.join(format!("{promoted_id}-{component_suffix}"));
+            if target.exists() {
+                return Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "promoted compaction target already exists: {}",
+                    target.display()
+                )));
+            }
+            moves.push((entry.path(), target));
+        }
+
+        if moves.is_empty() {
+            return Err(ferrosa_common::Error::InvalidFormat(format!(
+                "compaction output has no component files in {}",
+                source_dir.display()
+            )));
+        }
+
+        for (source, target) in &moves {
+            std::fs::rename(source, target).map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to promote compaction component {} to {}: {e}",
+                    source.display(),
+                    target.display()
+                ))
+            })?;
+        }
+        let _ = std::fs::remove_dir(source_dir);
+
+        let size_bytes = moves
+            .iter()
+            .filter_map(|(_, target)| std::fs::metadata(target).ok().map(|m| m.len()))
+            .sum();
+
+        let mut promoted = output.clone();
+        promoted.id = promoted_id;
+        promoted.path = target_dir;
+        promoted.size_bytes = size_bytes;
+        Ok(promoted)
+    }
+
+    fn evict_local_input_sstable_files(inputs: &[crate::compaction::metadata::SSTableMetadata]) {
+        let standard_components = [
+            "Data.db",
+            "Partitions.db",
+            "Rows.db",
+            "Filter.db",
+            "Statistics.db",
+            "TOC.txt",
+            "CompressionInfo.db",
+        ];
+        for input in inputs {
+            for component in &standard_components {
+                let file_path = input.path.join(format!("{}-{component}", input.id));
+                let _ = std::fs::remove_file(&file_path);
+            }
+        }
     }
 
     /// Collect local component file paths for an SSTable generation.
@@ -9781,7 +9875,7 @@ mod tests {
 
         // Manually submit a compaction task.
         {
-            let compaction_output_dir = dir.path().join("compaction");
+            let compaction_output_dir = dir.path().join("compaction").join(tid.to_string());
             let tables = engine.tables.read();
             let state = tables.get(&tid).unwrap();
             let metadata = engine.collect_sstable_metadata(&tid, state);
@@ -10129,9 +10223,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compaction_inputs_evicted_locally() {
-        // After poll_compactions() the input SSTable component files must be deleted
-        // from the table directory, while the compaction output directory must still exist.
+    async fn compaction_outputs_are_promoted_and_compaction_dir_drained() {
+        // After poll_compactions(), input SSTable component files must be deleted
+        // from the table directory, the compacted output must be promoted into
+        // that same table directory, and the compaction staging directory must
+        // not retain orphaned output files.
         let dir = tempfile::tempdir().unwrap();
         let (engine, _store, _prefix, tid) = make_engine_with_pending_compaction(&dir).await;
 
@@ -10157,6 +10253,7 @@ mod tests {
         // Run compaction + local eviction. Retry until the channel result is
         // consumed: the compaction thread writes files before sending on the
         // channel, so a single poll may miss the result under parallel load.
+        let table_compaction_dir = dir.path().join("compaction").join(&tid_str);
         let mut data_files_after = vec![];
         for _ in 0..40 {
             engine.poll_compactions().await;
@@ -10166,26 +10263,57 @@ mod tests {
                 .map(|e| e.path())
                 .filter(|p| p.is_file() && p.extension().map(|e| e == "db").unwrap_or(false))
                 .collect();
-            if data_files_after.is_empty() {
+            let input_files_evicted = input_files_before.iter().all(|path| !path.exists());
+            let promoted_data_file_present = data_files_after.iter().any(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-Data.db"))
+            });
+            let staging_drained = table_compaction_dir
+                .read_dir()
+                .into_iter()
+                .flatten()
+                .next()
+                .is_none();
+            if input_files_evicted && promoted_data_file_present && staging_drained {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
 
-        // All input SSTable component files must have been evicted.
-        // The sstable_dir may be empty or contain only output-generation files
-        // (but the output goes into dir/compaction, not sstable_dir).
+        // The old input generations must be gone from the table directory.
         assert!(
-            data_files_after.is_empty(),
-            "input SSTable files should be evicted, remaining: {:?}",
+            input_files_before.iter().all(|path| !path.exists()),
+            "input SSTable files should be evicted, still present: {:?}",
+            input_files_before
+                .iter()
+                .filter(|path| path.exists())
+                .collect::<Vec<_>>()
+        );
+
+        // The compacted output must be durable in the normal SSTable directory.
+        assert!(
+            data_files_after.iter().any(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-Data.db"))
+            }),
+            "compacted output Data.db should be promoted into {:?}, got {:?}",
+            sstable_dir,
             data_files_after
         );
 
-        // The compaction output directory must still exist.
-        let output_dir = dir.path().join("compaction");
+        let staged_files: Vec<_> = table_compaction_dir
+            .read_dir()
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .collect();
         assert!(
-            output_dir.exists(),
-            "compaction output directory must still exist after poll_compactions"
+            staged_files.is_empty(),
+            "compaction staging dir should be drained after promotion, got {:?}",
+            staged_files
         );
     }
 

--- a/specs/implemented/bug-lane-reconnect-stale-ip-when-peer-restarts.md
+++ b/specs/implemented/bug-lane-reconnect-stale-ip-when-peer-restarts.md
@@ -2,10 +2,10 @@
 type: bug
 priority: P3
 reported-by: ferrosa-memory launch debugging
-implemented-by: ""
+implemented-by: "codex"
 verified-by: ""
 created: 2026-04-18
-updated: 2026-04-18
+updated: 2026-05-22
 ---
 
 # Lane reconnect may use stale IP when peer container restarts with new IP
@@ -37,3 +37,12 @@ to current hostname and update it when peers reconnect from new IPs.
 P3 — only affects container restarts with IP reassignment. The workaround
 is to restart the connecting node too, or use static IPs in the compose
 network.
+
+## Implementation Notes
+
+- Updated cluster peer tracking so reconnects replace an existing peer's
+  address instead of preserving the first observed container IP forever.
+- Added `ClusterInvite` connection planning that refuses to downgrade an
+  already-live peer to a conflicting stale address advertised by another node.
+- Added regression tests for stale `connected_peers` reuse and stale invite
+  address downgrades.


### PR DESCRIPTION
## Executive Summary
Fixes two recovery paths found while investigating replica divergence after a rolling restart:

- cluster reconnect tracking now updates a peer's stored address when the same host ID reconnects from a new container IP
- ClusterInvite handling no longer downgrades an already-live peer to a conflicting stale address advertised by another node
- storage startup cleanup removes stale compaction staging files and prunes unreplayable pending-upload entries without touching durable SSTables

## Root Cause
The controller preserved the first address in `connected_peers`, so later reconnect invites could continue advertising dead container IPs. Invite handling also treated conflicting third-party peer metadata as a reason to reconnect, even when the local peer manager already had a live connection to the current address.

## Validation
- `cargo fmt --check`
- `cargo test -p ferrosa-cluster connected_peer_tracking_updates_existing_peer_address -- --nocapture`
- `cargo test -p ferrosa-cluster cluster_invite_keeps_live_peer_when_payload_advertises_older_address -- --nocapture`
- `cargo test -p ferrosa-cluster reconnect -- --nocapture`
- `cargo test -p ferrosa-cluster existing_cluster_member -- --nocapture`
- `cargo test -p ferrosa-cluster cluster_invite -- --nocapture`
- Earlier storage checks for the compaction cleanup path passed on this branch.
