### PR TITLE
Fix streaming audit storage regressions

### DIFF
--- a/ferrosa-cluster/src/raft/log_store.rs
+++ b/ferrosa-cluster/src/raft/log_store.rs
@@ -12,8 +12,10 @@
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::fs;
 use std::ops::RangeBounds;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use openraft::storage::LogFlushed;
 use openraft::{
@@ -280,12 +282,17 @@ pub struct SledLogStore {
 }
 
 /// Counts of entries cleared by [`SledLogStore::reset`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResetCounts {
-    /// Entries removed from the `log` tree.
-    pub log_entries: u64,
-    /// Keys removed from the `meta` tree (vote / committed / last_purged).
-    pub meta_keys: u64,
+    /// Entries removed from the `log` tree, when counted.
+    ///
+    /// Atomic directory replacement does not open sled, so normal reset
+    /// reports `None` here rather than taking sled's exclusive directory lock.
+    pub log_entries: Option<u64>,
+    /// Keys removed from the `meta` tree (vote / committed / last_purged), when counted.
+    pub meta_keys: Option<u64>,
+    /// Previous raft directory retained for rollback/debugging.
+    pub backup_path: Option<PathBuf>,
 }
 
 #[allow(clippy::result_large_err)] // StorageIOError is 224 bytes — dictated by openraft
@@ -331,62 +338,63 @@ impl SledLogStore {
         Ok(())
     }
 
-    /// Wipe a node's persisted Raft state at `path`.
+    /// Wipe a stopped node's persisted Raft state at `path`.
     ///
-    /// Clears the `log` and `meta` trees so the node rejoins the cluster as
-    /// an empty learner: no persisted vote/term, no log entries, no purge
-    /// marker. The leader's `InstallSnapshot` / `AppendEntries` will replay
-    /// committed history onto the reset node.
-    ///
-    /// # When to use
-    ///
-    /// Recovery for the disruptor-partition failure mode (see
-    /// `specs/in-process/bug-raft-stale-candidate-runaway-term-no-prevote.md`):
-    /// a node whose term has run away past the live quorum and whose log is
-    /// behind cannot self-recover, because peers reject its votes (its log
-    /// is too short) AND it rejects the leader's heartbeats (its term is too
-    /// high). Wiping local Raft state and rejoining is the only escape.
-    ///
-    /// # Lock contention
-    ///
-    /// Sled holds an exclusive lock on the database directory. If a Ferrosa
-    /// process is still using `path`, this call returns
-    /// `sled::Error::Io(...)` from `flock(2)`. Stop the node before reset.
+    /// Atomically renames the existing raft directory aside, recreates an
+    /// empty directory at the original path, and returns the backup path. This
+    /// deliberately does not open sled, so reset itself does not acquire sled's
+    /// exclusive database lock and callers can immediately reopen a fresh store.
     ///
     /// # Safety
+    ///
+    /// The node must be stopped before reset. Do not run this against a live
+    /// process: POSIX filesystems may allow renaming a directory that another
+    /// process still has open.
     ///
     /// Only uncommitted writes — those Raft never replicated to a quorum —
     /// can be lost. By Raft's durability guarantee, committed writes survive
     /// on the remaining majority and are replayed back to this node.
     pub fn reset(path: &Path) -> Result<ResetCounts, sled::Error> {
-        let db = sled::open(path)?;
-        let log = db.open_tree("log")?;
-        let meta = db.open_tree("meta")?;
-
-        let log_entries = log.len() as u64;
-        let meta_keys = meta.len() as u64;
-
-        log.clear()?;
-        meta.clear()?;
-        log.flush()?;
-        meta.flush()?;
-        db.flush()?;
-
-        // Release sled's exclusive directory lock before reporting reset
-        // success. CI immediately reopens the same log-store path to prove
-        // the reset result, and returning while tree/db handles are still
-        // alive can race with sled's lock release on slower runners.
-        drop(log);
-        drop(meta);
-        drop(db);
+        let backup_path = if path.exists() {
+            let backup = Self::unique_reset_backup_path(path);
+            fs::rename(path, &backup).map_err(sled::Error::Io)?;
+            if let Err(err) = fs::create_dir_all(path) {
+                let _ = fs::rename(&backup, path);
+                return Err(sled::Error::Io(err));
+            }
+            Some(backup)
+        } else {
+            fs::create_dir_all(path).map_err(sled::Error::Io)?;
+            None
+        };
 
         Ok(ResetCounts {
-            log_entries,
-            meta_keys,
+            log_entries: None,
+            meta_keys: None,
+            backup_path,
         })
     }
 
     // -- helpers ----------------------------------------------------------
+
+    fn unique_reset_backup_path(path: &Path) -> PathBuf {
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("raft");
+        let pid = std::process::id();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        for attempt in 0..u32::MAX {
+            let candidate = parent.join(format!("{name}.reset-{pid}-{nanos}-{attempt}"));
+            if !candidate.exists() {
+                return candidate;
+            }
+        }
+
+        parent.join(format!("{name}.reset-{pid}-{nanos}"))
+    }
 
     fn index_key(index: u64) -> [u8; 8] {
         index.to_be_bytes()
@@ -1307,7 +1315,7 @@ mod tests {
     // -- reset ------------------------------------------------------------
 
     #[tokio::test]
-    async fn reset_clears_log_and_meta_and_counts_what_was_removed() {
+    async fn reset_replaces_log_and_meta_with_empty_store() {
         let dir = tempfile::tempdir().unwrap();
 
         // Pre-populate: 3 log entries + a vote + a committed marker.
@@ -1340,10 +1348,11 @@ mod tests {
         } // drop releases sled lock
 
         let counts = SledLogStore::reset(dir.path()).expect("reset must succeed on a free dir");
-        assert_eq!(counts.log_entries, 3, "all 3 log entries should be cleared");
-        assert_eq!(
-            counts.meta_keys, 2,
-            "vote + committed keys should be cleared"
+        assert_eq!(counts.log_entries, None);
+        assert_eq!(counts.meta_keys, None);
+        assert!(
+            counts.backup_path.as_ref().is_some_and(|p| p.exists()),
+            "reset must retain the previous raft dir as a backup"
         );
 
         // Reopen and confirm trees are empty.
@@ -1360,14 +1369,47 @@ mod tests {
     }
 
     #[test]
-    fn reset_on_empty_store_is_a_noop_with_zero_counts() {
+    fn reset_replaces_raft_dir_and_leaves_fresh_dir_immediately_openable() {
+        let dir = tempfile::tempdir().unwrap();
+        let original_path = dir.path().to_path_buf();
+        let marker = original_path.join("operator-note.txt");
+        std::fs::write(&marker, b"kept with reset backup").unwrap();
+
+        {
+            let db = sled::open(&original_path).unwrap();
+            let log = db.open_tree("log").unwrap();
+            log.insert(1u64.to_be_bytes(), b"entry".to_vec()).unwrap();
+            db.flush().unwrap();
+        }
+
+        let summary = SledLogStore::reset(&original_path).expect("reset must replace raft dir");
+        let backup = summary
+            .backup_path
+            .expect("reset must report the retained backup path");
+
+        assert!(original_path.exists(), "reset must recreate the raft dir");
+        assert!(backup.exists(), "previous raft dir must be retained");
+        assert!(
+            backup.join("operator-note.txt").exists(),
+            "backup must contain the previous directory contents"
+        );
+
+        let fresh = SledLogStore::new(&original_path)
+            .expect("fresh raft dir must be immediately openable without sled lock race");
+        assert_eq!(fresh.log.len(), 0, "fresh log tree must be empty");
+        assert_eq!(fresh.meta.len(), 0, "fresh meta tree must be empty");
+    }
+
+    #[test]
+    fn reset_on_empty_store_replaces_dir_and_reports_backup() {
         let dir = tempfile::tempdir().unwrap();
         // Touch a store so the on-disk layout exists, then drop.
         let _ = SledLogStore::new(dir.path()).unwrap();
 
         let counts = SledLogStore::reset(dir.path()).expect("reset on empty store must succeed");
-        assert_eq!(counts.log_entries, 0);
-        assert_eq!(counts.meta_keys, 0);
+        assert_eq!(counts.log_entries, None);
+        assert_eq!(counts.meta_keys, None);
+        assert!(counts.backup_path.as_ref().is_some_and(|p| p.exists()));
     }
 
     /// W1.19b: save_committed must flush the meta tree so the committed
@@ -1471,17 +1513,15 @@ mod tests {
     }
 
     #[test]
-    fn reset_fails_if_sled_lock_is_held() {
+    fn reset_missing_dir_creates_fresh_dir_without_backup() {
         let dir = tempfile::tempdir().unwrap();
-        // Hold an open store: this keeps sled's flock on the dir.
-        let _live = SledLogStore::new(dir.path()).unwrap();
+        let missing = dir.path().join("raft");
 
-        let err = SledLogStore::reset(dir.path())
-            .expect_err("reset must refuse while a Ferrosa node still holds the sled lock");
-        let msg = format!("{err}");
-        assert!(
-            msg.to_lowercase().contains("lock") || msg.to_lowercase().contains("io"),
-            "expected lock/io error, got: {msg}"
-        );
+        let counts = SledLogStore::reset(&missing).expect("reset must create missing raft dir");
+
+        assert!(missing.is_dir());
+        assert_eq!(counts.log_entries, None);
+        assert_eq!(counts.meta_keys, None);
+        assert_eq!(counts.backup_path, None);
     }
 }

--- a/ferrosa-cluster/src/streaming/receiver.rs
+++ b/ferrosa-cluster/src/streaming/receiver.rs
@@ -1,4 +1,4 @@
-//! Inbound streaming: accumulates chunks and applies mutations to storage.
+//! Inbound streaming: stages chunks and applies mutations to storage.
 //!
 //! # Protocol
 //!
@@ -7,12 +7,12 @@
 //! 1. The caller passes a decoded `StreamStartPayload` to `StreamReceiver::begin`.
 //! 2. Each decoded `StreamChunkPayload` is passed to `session.apply_chunk`.
 //! 3. The decoded `StreamEndPayload` is passed to `session.finish`, which
-//!    validates the CRC32 and applies all accumulated mutations to storage.
+//!    validates the CRC32 and replays staged mutations to storage.
 //!
 //! # Checksum validation
 //!
-//! The receiver recomputes the CRC32 over accumulated mutations and compares
-//! against the value in `StreamEnd`. A mismatch returns
+//! The receiver recomputes the CRC32 as chunks arrive and compares against the
+//! value in `StreamEnd`. A mismatch returns
 //! `ClusterError::Internal` and mutations are **not** applied.
 //!
 //! # Apply strategy
@@ -21,7 +21,26 @@
 //! normal writes. This means the commit log and memtable both receive each
 //! mutation, providing the same durability guarantees.
 
-use std::path::PathBuf;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+const DEFAULT_STREAM_MAX_MUTATIONS: u64 = 50_000;
+const DEFAULT_STREAM_MAX_BYTES: u64 = 128 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StreamSessionLimits {
+    max_mutations: u64,
+    max_bytes: u64,
+}
+
+impl Default for StreamSessionLimits {
+    fn default() -> Self {
+        Self {
+            max_mutations: DEFAULT_STREAM_MAX_MUTATIONS,
+            max_bytes: DEFAULT_STREAM_MAX_BYTES,
+        }
+    }
+}
 
 use ferrosa_common::key::DecoratedKey;
 use ferrosa_common::{PartitionKey, Token};
@@ -31,9 +50,9 @@ use ferrosa_storage::TableId;
 use crate::error::{ClusterError, Result};
 
 use super::{
-    compute_checksum, sstable_transfer::SSTableAssembler, SstableStreamChunkPayload,
-    SstableStreamEndPayload, SstableStreamStartPayload, StreamChunkPayload, StreamEndPayload,
-    StreamStartPayload, StreamedMutation,
+    sstable_transfer::SSTableAssembler, SstableStreamChunkPayload, SstableStreamEndPayload,
+    SstableStreamStartPayload, StreamChunkPayload, StreamEndPayload, StreamStartPayload,
+    StreamedMutation,
 };
 
 // ---------------------------------------------------------------------------
@@ -52,29 +71,91 @@ pub struct StreamResult {
 // StreamSession — mutable per-session state
 // ---------------------------------------------------------------------------
 
-/// In-progress streaming session accumulating mutations from chunks.
+/// In-progress streaming session staging mutations from chunks.
 pub struct StreamSession {
     pub(crate) start: StreamStartPayload,
-    pub(crate) mutations: Vec<StreamedMutation>,
+    pub(crate) staging_path: PathBuf,
+    pub(crate) staging_file: Option<std::fs::File>,
+    pub(crate) staging_error: Option<String>,
+    pub(crate) checksum: crc32fast::Hasher,
+    pub(crate) received_mutations: u64,
+    pub(crate) received_bytes: u64,
+    pub(crate) limits: StreamSessionLimits,
 }
 
 impl StreamSession {
     /// Accept the mutations from one `StreamChunk`.
     pub fn apply_chunk(&mut self, chunk: StreamChunkPayload) -> Result<()> {
+        if let Some(error) = self.staging_error.as_deref() {
+            return Err(ClusterError::Internal(format!(
+                "stream: staging unavailable: {error}"
+            )));
+        }
+
         if chunk.session_id != self.start.session_id {
             return Err(ClusterError::Internal(format!(
                 "stream: session_id mismatch in chunk: expected {}, got {}",
                 self.start.session_id, chunk.session_id
             )));
         }
-        self.mutations.extend(chunk.mutations);
+
+        if self.received_mutations + chunk.mutations.len() as u64 > self.limits.max_mutations {
+            return Err(ClusterError::Internal(format!(
+                "stream: mutation budget exceeded: limit {}, received {}",
+                self.limits.max_mutations,
+                self.received_mutations + chunk.mutations.len() as u64
+            )));
+        }
+
+        let Some(file) = self.staging_file.as_mut() else {
+            return Err(ClusterError::Internal(
+                "stream: staging file is not open".to_string(),
+            ));
+        };
+        for mutation in &chunk.mutations {
+            let encoded = bincode::serialize(mutation).map_err(|e| {
+                ClusterError::Internal(format!("stream: failed to serialize mutation: {e}"))
+            })?;
+            let len = encoded.len() as u64;
+            if self.received_bytes + len > self.limits.max_bytes {
+                self.staging_error = Some(format!(
+                    "byte budget exceeded: limit {}, received {}",
+                    self.limits.max_bytes,
+                    self.received_bytes + len
+                ));
+                return Err(ClusterError::Internal(format!(
+                    "stream: byte budget exceeded: limit {}, received {}",
+                    self.limits.max_bytes,
+                    self.received_bytes + len
+                )));
+            }
+            self.checksum.update(&encoded);
+            file.write_all(&len.to_le_bytes()).map_err(|e| {
+                ClusterError::Internal(format!("stream: failed to write mutation length: {e}"))
+            })?;
+            file.write_all(&encoded).map_err(|e| {
+                ClusterError::Internal(format!("stream: failed to write staged mutation: {e}"))
+            })?;
+            self.received_mutations += 1;
+            self.received_bytes += len;
+        }
         Ok(())
     }
 
     /// Validate `StreamEnd` and apply all accumulated mutations to `storage`.
     ///
     /// On checksum failure the mutations are discarded and an error is returned.
-    pub fn finish(self, end: StreamEndPayload, storage: &StorageEngine) -> Result<StreamResult> {
+    pub fn finish(
+        mut self,
+        end: StreamEndPayload,
+        storage: &StorageEngine,
+    ) -> Result<StreamResult> {
+        if let Some(error) = self.staging_error.as_deref() {
+            return Err(ClusterError::Internal(format!(
+                "stream: staging unavailable: {error}"
+            )));
+        }
+
         if end.session_id != self.start.session_id {
             return Err(ClusterError::Internal(format!(
                 "stream: session_id mismatch in StreamEnd: expected {}, got {}",
@@ -83,11 +164,58 @@ impl StreamSession {
         }
 
         // Validate checksum before touching storage.
-        StreamReceiver::validate_end(&self.mutations, &end)?;
+        if self.received_mutations != end.total_mutations {
+            return Err(ClusterError::Internal(format!(
+                "stream: mutation count mismatch: accumulated {}, StreamEnd says {}",
+                self.received_mutations, end.total_mutations
+            )));
+        }
 
-        // Apply mutations to storage.
+        let computed_checksum = self.checksum.clone().finalize();
+        if computed_checksum != end.checksum {
+            return Err(ClusterError::Internal(format!(
+                "stream: checksum mismatch: computed {:#010x}, StreamEnd says {:#010x}",
+                computed_checksum, end.checksum
+            )));
+        }
+
+        if let Some(mut file) = self.staging_file.take() {
+            file.flush().map_err(|e| {
+                ClusterError::Internal(format!("stream: failed to flush staged mutations: {e}"))
+            })?;
+            file.sync_all().map_err(|e| {
+                ClusterError::Internal(format!("stream: failed to sync staged mutations: {e}"))
+            })?;
+        }
+
         let mut applied = 0u64;
-        for mutation in &self.mutations {
+        let mut staged = std::fs::File::open(&self.staging_path).map_err(|e| {
+            ClusterError::Internal(format!(
+                "stream: failed to open staged mutations {}: {e}",
+                self.staging_path.display()
+            ))
+        })?;
+        while applied < self.received_mutations {
+            let mut len_buf = [0u8; 8];
+            staged.read_exact(&mut len_buf).map_err(|e| {
+                ClusterError::Internal(format!(
+                    "stream: failed to read staged mutation length: {e}"
+                ))
+            })?;
+            let len = u64::from_le_bytes(len_buf);
+            if len > self.limits.max_bytes {
+                return Err(ClusterError::Internal(format!(
+                    "stream: staged mutation length {len} exceeds session byte limit {}",
+                    self.limits.max_bytes
+                )));
+            }
+            let mut encoded = vec![0u8; len as usize];
+            staged.read_exact(&mut encoded).map_err(|e| {
+                ClusterError::Internal(format!("stream: failed to read staged mutation: {e}"))
+            })?;
+            let mutation: StreamedMutation = bincode::deserialize(&encoded).map_err(|e| {
+                ClusterError::Internal(format!("stream: failed to decode staged mutation: {e}"))
+            })?;
             let table_id = TableId::new(&mutation.keyspace, &mutation.table);
             // Reconstruct a minimal DecoratedKey from the raw key bytes.
             // We use Token(0) as a placeholder — the storage engine uses the
@@ -144,6 +272,17 @@ impl StreamSession {
     }
 }
 
+impl Drop for StreamSession {
+    fn drop(&mut self) {
+        if let Some(mut file) = self.staging_file.take() {
+            let _ = file.flush();
+        }
+        if self.staging_path.exists() {
+            let _ = std::fs::remove_file(&self.staging_path);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // StreamReceiver — stateless namespace + helpers
 // ---------------------------------------------------------------------------
@@ -162,9 +301,30 @@ impl StreamReceiver {
             estimated_bytes = start.estimated_bytes,
             "stream: session started"
         );
+        let staging_path = std::env::temp_dir().join(format!(
+            "ferrosa-row-stream-{}-{}-{}.bin",
+            std::process::id(),
+            start.source_node,
+            start.session_id
+        ));
+        let _ = std::fs::remove_file(&staging_path);
+        let (staging_file, staging_error) = match std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&staging_path)
+        {
+            Ok(file) => (Some(file), None),
+            Err(error) => (None, Some(error.to_string())),
+        };
         StreamSession {
             start,
-            mutations: Vec::new(),
+            checksum: crc32fast::Hasher::new(),
+            staging_path,
+            staging_file,
+            staging_error,
+            received_mutations: 0,
+            received_bytes: 0,
+            limits: StreamSessionLimits::default(),
         }
     }
 
@@ -191,6 +351,7 @@ impl StreamReceiver {
     /// Returns `ClusterError::Internal` if the checksum or count does not match.
     ///
     /// This is `pub(crate)` so that `mod.rs` tests can call it directly.
+    #[cfg(test)]
     pub(crate) fn validate_end(
         mutations: &[StreamedMutation],
         end: &StreamEndPayload,
@@ -205,7 +366,7 @@ impl StreamReceiver {
         }
 
         // Checksum check.
-        let computed = compute_checksum(mutations);
+        let computed = super::compute_checksum(mutations);
         if computed != end.checksum {
             return Err(ClusterError::Internal(format!(
                 "stream: checksum mismatch: computed {:#010x}, StreamEnd says {:#010x}",
@@ -235,10 +396,25 @@ pub struct SstableStreamResult {
 pub struct SstableStreamSession {
     pub(crate) start: SstableStreamStartPayload,
     pub(crate) assembler: SSTableAssembler,
+    /// Staging directory used while bytes are being received.
+    /// Files are moved to `final_dir` only after checksum/size verification.
+    pub(crate) staging_dir: PathBuf,
+    pub(crate) final_dir: PathBuf,
     /// Running CRC32 hasher — fed chunk data in receive order.
     pub(crate) hasher: crc32fast::Hasher,
     /// Running count of bytes received.
     pub(crate) bytes_received: u64,
+}
+
+fn staging_dir_for_session(dest_dir: &Path, source_node: u64, session_id: u64) -> PathBuf {
+    let final_name = dest_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("sstable");
+    let parent = dest_dir.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!(
+        ".{final_name}.node-{source_node}.session-{session_id}.staging"
+    ))
 }
 
 impl SstableStreamSession {
@@ -276,39 +452,106 @@ impl SstableStreamSession {
 
         // Validate total bytes.
         if self.bytes_received != end.total_bytes {
-            return Err(ClusterError::Internal(format!(
+            let err = ClusterError::Internal(format!(
                 "sstable_stream: byte count mismatch: received {}, end says {}",
                 self.bytes_received, end.total_bytes
-            )));
+            ));
+            self.cleanup_staging()?;
+            return Err(err);
         }
 
         // Validate checksum.
-        let computed = self.hasher.finalize();
+        let computed = self.hasher.clone().finalize();
         if computed != end.checksum {
-            return Err(ClusterError::Internal(format!(
+            let err = ClusterError::Internal(format!(
                 "sstable_stream: checksum mismatch: computed {:#010x}, end says {:#010x}",
                 computed, end.checksum
-            )));
+            ));
+            self.cleanup_staging()?;
+            return Err(err);
         }
 
-        // Write files to disk.
+        // Write files to staging, then promote atomically.
         let written_files = self
             .assembler
             .write_all()
             .map_err(|e| ClusterError::Internal(format!("sstable_stream: write files: {e}")))?;
+        let promoted_files = self.promote_staged(written_files)?;
 
         tracing::info!(
             session_id = self.start.session_id,
-            files = written_files.len(),
+            files = promoted_files.len(),
             bytes = self.bytes_received,
-            "sstable_stream: session written to disk"
+            "sstable_stream: session promoted to live SSTable directory"
         );
 
         Ok(SstableStreamResult {
             session_id: self.start.session_id,
-            written_files,
+            written_files: promoted_files,
             total_bytes: self.bytes_received,
         })
+    }
+
+    fn promote_staged(&self, written_files: Vec<PathBuf>) -> Result<Vec<PathBuf>> {
+        if let Some(parent) = self.final_dir.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ClusterError::Internal(format!(
+                    "sstable_stream: create final parent {} failed: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+
+        if self.final_dir.exists() {
+            self.cleanup_staging()?;
+            return Err(ClusterError::Internal(format!(
+                "sstable_stream: destination already exists: {}",
+                self.final_dir.display()
+            )));
+        }
+
+        std::fs::rename(&self.staging_dir, &self.final_dir).map_err(|e| {
+            let _ = self.cleanup_staging();
+            ClusterError::Internal(format!(
+                "sstable_stream: promote staging directory {} -> {} failed: {e}",
+                self.staging_dir.display(),
+                self.final_dir.display()
+            ))
+        })?;
+
+        let mut promoted_files = Vec::with_capacity(written_files.len());
+        for file in written_files {
+            let component_name = file.file_name().ok_or_else(|| {
+                ClusterError::Internal(
+                    "sstable_stream: staged component missing file name".to_string(),
+                )
+            })?;
+            promoted_files.push(self.final_dir.join(component_name));
+        }
+
+        Ok(promoted_files)
+    }
+
+    fn cleanup_staging(&self) -> Result<()> {
+        if self.staging_dir.exists() {
+            std::fs::remove_dir_all(&self.staging_dir).map_err(|e| {
+                ClusterError::Internal(format!(
+                    "sstable_stream: cleanup {} failed: {e}",
+                    self.staging_dir.display()
+                ))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SstableStreamSession {
+    fn drop(&mut self) {
+        if self.staging_dir.exists() {
+            if let Err(e) = self.cleanup_staging() {
+                tracing::warn!("sstable_stream: failed to cleanup staging directory: {e}");
+            }
+        }
     }
 }
 
@@ -321,6 +564,7 @@ impl SstableStreamReceiver {
     /// `dest_dir` is the directory where SSTable component files will be
     /// written. Typically `{data_dir}/sstables/{keyspace}.{table}/{sstable_id}`.
     pub fn begin(start: SstableStreamStartPayload, dest_dir: PathBuf) -> SstableStreamSession {
+        let staging_dir = staging_dir_for_session(&dest_dir, start.source_node, start.session_id);
         tracing::info!(
             session_id = start.session_id,
             source_node = start.source_node,
@@ -333,13 +577,15 @@ impl SstableStreamReceiver {
         );
         SstableStreamSession {
             start,
-            assembler: SSTableAssembler::new(dest_dir),
+            assembler: SSTableAssembler::new(staging_dir.clone()),
+            staging_dir: staging_dir.clone(),
+            final_dir: dest_dir,
             hasher: crc32fast::Hasher::new(),
             bytes_received: 0,
         }
     }
 
-    /// Convenience: accumulate all chunks and finish in one call.
+    /// Convenience: accumulate all chunks, verify integrity, and promote on success.
     pub fn receive_and_write(
         start: SstableStreamStartPayload,
         chunks: Vec<SstableStreamChunkPayload>,
@@ -591,6 +837,127 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.applied, 9);
+    }
+
+    // -----------------------------------------------------------------------
+    // 4b. Exceeding limits is rejected before unbounded growth
+    // -----------------------------------------------------------------------
+    #[test]
+    fn apply_chunk_rejects_when_limits_are_exceeded() {
+        let row = vec![0u8; 1024];
+        let start = StreamStartPayload {
+            session_id: 5,
+            source_node: 10,
+            token_range_start: 0,
+            token_range_end: 100,
+            estimated_bytes: 0,
+        };
+
+        let mut session = StreamReceiver::begin(start);
+        session.limits = StreamSessionLimits {
+            max_mutations: 2,
+            max_bytes: 2048,
+        };
+
+        let first_chunk = StreamChunkPayload {
+            session_id: 5,
+            mutations: vec![StreamedMutation {
+                keyspace: "ks".to_string(),
+                table: "tbl".to_string(),
+                key: vec![0],
+                row: row.clone(),
+                timestamp: 0,
+            }],
+        };
+        assert!(session.apply_chunk(first_chunk).is_ok());
+
+        let second_chunk = StreamChunkPayload {
+            session_id: 5,
+            mutations: vec![
+                StreamedMutation {
+                    keyspace: "ks".to_string(),
+                    table: "tbl".to_string(),
+                    key: vec![1],
+                    row: row.clone(),
+                    timestamp: 1,
+                },
+                StreamedMutation {
+                    keyspace: "ks".to_string(),
+                    table: "tbl".to_string(),
+                    key: vec![2],
+                    row,
+                    timestamp: 2,
+                },
+            ],
+        };
+
+        let result = session.apply_chunk(second_chunk);
+        assert!(
+            matches!(result, Err(ClusterError::Internal(_))),
+            "mutations and bytes over limit should be rejected"
+        );
+    }
+
+    #[test]
+    fn apply_chunk_rejects_when_byte_limit_is_exceeded() {
+        let start = StreamStartPayload {
+            session_id: 6,
+            source_node: 10,
+            token_range_start: 0,
+            token_range_end: 100,
+            estimated_bytes: 0,
+        };
+
+        let mut session = StreamReceiver::begin(start);
+        session.limits = StreamSessionLimits {
+            max_mutations: 10,
+            max_bytes: 64,
+        };
+
+        let big_row = vec![0u8; 128];
+        let chunk = StreamChunkPayload {
+            session_id: 6,
+            mutations: vec![StreamedMutation {
+                keyspace: "ks".to_string(),
+                table: "tbl".to_string(),
+                key: vec![0],
+                row: big_row,
+                timestamp: 0,
+            }],
+        };
+
+        let result = session.apply_chunk(chunk);
+        assert!(matches!(result, Err(ClusterError::Internal(_))));
+    }
+
+    #[test]
+    fn row_stream_session_does_not_materialize_all_mutations() {
+        let source = include_str!("receiver.rs");
+        let session_start = source
+            .find("pub struct StreamSession")
+            .expect("StreamSession must exist");
+        let session_tail = &source[session_start..];
+        let session_end = session_tail
+            .find("// ---------------------------------------------------------------------------\n// StreamReceiver")
+            .unwrap_or(session_tail.len());
+        let session_source = &session_tail[..session_end];
+
+        assert!(
+            !session_source.contains("Vec<StreamedMutation>"),
+            "row streaming sessions must stage and replay mutations instead of accumulating them in memory"
+        );
+        assert!(
+            !session_source.contains("self.mutations"),
+            "row streaming sessions must not append chunks to a session-wide mutation Vec"
+        );
+        assert!(
+            session_source.contains("staging_path") && session_source.contains("staging_file"),
+            "row streaming sessions should use a staging file between chunks and storage replay"
+        );
+        assert!(
+            !session_source.contains("Vec::with_capacity(chunk.mutations.len())"),
+            "row streaming must not duplicate a whole chunk into an encoded Vec before staging"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -871,6 +1238,129 @@ mod tests {
         assert!(
             matches!(result, Err(ClusterError::Internal(ref msg)) if msg.contains("checksum")),
             "bad checksum must produce ClusterError::Internal with checksum message"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 9b. Bad checksum leaves no live/staged SSTable files
+    // -----------------------------------------------------------------------
+    #[test]
+    fn sstable_stream_bad_checksum_cleans_staging_and_does_not_promote() {
+        use super::{
+            SstableStreamChunkPayload, SstableStreamEndPayload, SstableStreamStartPayload,
+        };
+        use crate::streaming::sstable_transfer::SSTableComponent;
+
+        let dst_dir = tempfile::tempdir().unwrap();
+        let dest_path = dst_dir.path().join("bad-checksum-cleanup");
+
+        let start = SstableStreamStartPayload {
+            session_id: 201,
+            source_node: 7,
+            keyspace: "ks".to_string(),
+            table: "tbl".to_string(),
+            sstable_id: "mc-002".to_string(),
+            components: vec![SSTableComponent {
+                name: "Data.db".to_string(),
+                size: 4,
+            }],
+            total_bytes: 4,
+        };
+
+        let mut session = SstableStreamReceiver::begin(start.clone(), dest_path.clone());
+        let staging_path = session.staging_dir.clone();
+
+        let chunks = vec![SstableStreamChunkPayload {
+            session_id: 201,
+            component: "Data.db".to_string(),
+            offset: 0,
+            data: vec![1, 2, 3, 4],
+        }];
+        for chunk in chunks {
+            session.apply_chunk(chunk).unwrap();
+        }
+
+        let end = SstableStreamEndPayload {
+            session_id: 201,
+            total_bytes: 4,
+            checksum: 0xBAD_BEEF, // intentionally wrong
+        };
+
+        let result = session.finish(end);
+        assert!(
+            matches!(result, Err(ClusterError::Internal(ref msg)) if msg.contains("checksum")),
+            "bad checksum must produce ClusterError::Internal with checksum message"
+        );
+        assert!(
+            !dest_path.join("Data.db").exists(),
+            "bad checksum should not promote component files into final location"
+        );
+        assert!(
+            !staging_path.exists(),
+            "bad checksum should remove staging directory"
+        );
+    }
+
+    #[test]
+    fn sstable_stream_existing_destination_is_not_deleted() {
+        use super::{
+            SstableStreamChunkPayload, SstableStreamEndPayload, SstableStreamStartPayload,
+        };
+        use crate::streaming::sstable_transfer::SSTableComponent;
+
+        let dst_dir = tempfile::tempdir().unwrap();
+        let dest_path = dst_dir.path().join("existing-sstable");
+        std::fs::create_dir_all(&dest_path).unwrap();
+        let existing_component = dest_path.join("Data.db");
+        std::fs::write(&existing_component, b"live").unwrap();
+
+        let start = SstableStreamStartPayload {
+            session_id: 202,
+            source_node: 7,
+            keyspace: "ks".to_string(),
+            table: "tbl".to_string(),
+            sstable_id: "mc-003".to_string(),
+            components: vec![SSTableComponent {
+                name: "Data.db".to_string(),
+                size: 4,
+            }],
+            total_bytes: 4,
+        };
+
+        let mut session = SstableStreamReceiver::begin(start, dest_path.clone());
+        let staging_path = session.staging_dir.clone();
+        session
+            .apply_chunk(SstableStreamChunkPayload {
+                session_id: 202,
+                component: "Data.db".to_string(),
+                offset: 0,
+                data: b"new!".to_vec(),
+            })
+            .unwrap();
+
+        let checksum = {
+            let mut hasher = crc32fast::Hasher::new();
+            hasher.update(b"new!");
+            hasher.finalize()
+        };
+        let result = session.finish(SstableStreamEndPayload {
+            session_id: 202,
+            total_bytes: 4,
+            checksum,
+        });
+
+        assert!(
+            matches!(result, Err(ClusterError::Internal(ref msg)) if msg.contains("destination already exists")),
+            "existing destinations should fail closed instead of being replaced"
+        );
+        assert_eq!(
+            std::fs::read(&existing_component).unwrap(),
+            b"live",
+            "failed stream promotion must not delete or replace existing live data"
+        );
+        assert!(
+            !staging_path.exists(),
+            "failed stream promotion should remove staging"
         );
     }
 

--- a/ferrosa-cluster/tests/failure_mode_matrix.rs
+++ b/ferrosa-cluster/tests/failure_mode_matrix.rs
@@ -850,7 +850,10 @@ async fn s_28_transfer_to_lagging_target_catches_up_first() {
     // S-28: `transfer_to` catches up the target before sending
     // TimeoutNow.  Engine-level test in the openraft fork
     // (`raft/trigger.rs::transfer_to`); here we smoke a transfer to
-    // confirm the catch-up branch is reachable.
+    // confirm the catch-up branch is reachable.  The smoke must not
+    // dispatch before the leader has populated replication metrics for the
+    // target: in that state openraft fails loud with `matched=None`, which
+    // proves the harness raced readiness rather than the catch-up path.
     let cluster = TestCluster::with_voters(3).await;
     let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
     let leader_id = cluster.leader_node().node_id;
@@ -859,13 +862,54 @@ async fn s_28_transfer_to_lagging_target_catches_up_first() {
         let voters: Vec<u64> = m.membership_config.membership().voter_ids().collect();
         voters.into_iter().find(|&v| v != leader_id).unwrap()
     };
-    cluster
-        .leader_node()
-        .raft
-        .trigger()
-        .transfer_to(target)
-        .await
-        .unwrap();
+
+    let replication_ready = || {
+        let m = cluster.leader_node().metrics();
+        m.last_log_index.is_some()
+            && m.replication
+                .as_ref()
+                .and_then(|r| r.get(&target))
+                .is_some()
+    };
+    assert!(
+        wait_until(replication_ready, Duration::from_secs(5)).await,
+        "leader must expose replication progress for target before transfer_to(target={target})"
+    );
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut last_error = None;
+    while tokio::time::Instant::now() < deadline {
+        let source = cluster
+            .current_leader_id()
+            .and_then(|leader_id| cluster.raft_for_node_id(leader_id))
+            .unwrap_or_else(|| cluster.leader_node().raft.clone());
+        match source.trigger().transfer_to(target).await {
+            Ok(()) => break,
+            Err(e) => {
+                last_error = Some(format!("{e:?}"));
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+        if cluster
+            .nodes()
+            .iter()
+            .any(|n| n.metrics().current_leader == Some(target))
+        {
+            break;
+        }
+    }
+
+    let target_is_leader = || {
+        cluster.leader_node().metrics().current_leader == Some(target)
+            || cluster
+                .nodes()
+                .iter()
+                .any(|n| n.metrics().current_leader == Some(target))
+    };
+    assert!(
+        wait_until(target_is_leader, Duration::from_secs(10)).await,
+        "target must become leader after transfer_to(target={target}); last transfer error: {last_error:?}"
+    );
     cluster.shutdown().await;
 }
 

--- a/ferrosa-common/src/schema.rs
+++ b/ferrosa-common/src/schema.rs
@@ -252,6 +252,57 @@ impl TableSchema {
         }
         None
     }
+
+    /// Returns a startup warning for schemas whose stored static/regular
+    /// column order does not match Cassandra's column-name comparator.
+    ///
+    /// Ferrosa preserves the stored schema order when reading existing
+    /// SSTables, because reordering the schema without remapping row-cell
+    /// ordinals would corrupt old data. New schema creation should use the
+    /// canonical order so exported/imported SSTables match Cassandra.
+    pub fn legacy_storage_column_order_warning(&self) -> Option<String> {
+        fn names(cols: &[ColumnDefinition]) -> Vec<&str> {
+            cols.iter().map(|c| c.name.as_str()).collect()
+        }
+
+        fn sorted_names(cols: &[ColumnDefinition]) -> Vec<&str> {
+            let mut sorted = names(cols);
+            sorted.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+            sorted
+        }
+
+        let mut mismatches = Vec::new();
+        let static_names = names(&self.static_columns);
+        let sorted_static_names = sorted_names(&self.static_columns);
+        if static_names != sorted_static_names {
+            mismatches.push(format!(
+                "static_columns stored=[{}] canonical=[{}]",
+                static_names.join(","),
+                sorted_static_names.join(",")
+            ));
+        }
+
+        let regular_names = names(&self.regular_columns);
+        let sorted_regular_names = sorted_names(&self.regular_columns);
+        if regular_names != sorted_regular_names {
+            mismatches.push(format!(
+                "regular_columns stored=[{}] canonical=[{}]",
+                regular_names.join(","),
+                sorted_regular_names.join(",")
+            ));
+        }
+
+        if mismatches.is_empty() {
+            None
+        } else {
+            Some(format!(
+                "table {}.{} has legacy non-canonical storage column order: {}; existing SSTables may not be Cassandra-import compatible. Do not reorder this schema without remapping row cell ordinals.",
+                self.keyspace,
+                self.table,
+                mismatches.join("; ")
+            ))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -528,5 +579,59 @@ mod tests {
         };
         assert_eq!(schema.column_index("a"), Some(0));
         assert_eq!(schema.column_index("b"), Some(1));
+    }
+
+    #[test]
+    fn warns_when_storage_columns_are_not_cassandra_name_ordered() {
+        let schema = TableSchema {
+            keyspace: "ks".to_string(),
+            table: "legacy".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![
+                ColumnDefinition {
+                    name: "v_text".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+                },
+                ColumnDefinition {
+                    name: "v_int".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+                },
+            ],
+            extensions: Default::default(),
+        };
+
+        let warning = schema
+            .legacy_storage_column_order_warning()
+            .expect("declaration-order v_text/v_int should be detected as legacy");
+        assert!(warning.contains("ks.legacy"));
+        assert!(warning.contains("regular_columns"));
+        assert!(warning.contains("v_text,v_int"));
+        assert!(warning.contains("v_int,v_text"));
+    }
+
+    #[test]
+    fn no_warning_when_storage_columns_are_cassandra_name_ordered() {
+        let schema = TableSchema {
+            keyspace: "ks".to_string(),
+            table: "canonical".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![
+                ColumnDefinition {
+                    name: "v_int".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+                },
+                ColumnDefinition {
+                    name: "v_text".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+                },
+            ],
+            extensions: Default::default(),
+        };
+
+        assert!(schema.legacy_storage_column_order_warning().is_none());
     }
 }

--- a/ferrosa-cql/src/bridge.rs
+++ b/ferrosa-cql/src/bridge.rs
@@ -1058,17 +1058,34 @@ pub fn partition_to_rows(
     pk_columns: &[usize],
     ck_columns: &[usize],
 ) -> Vec<Vec<Option<CqlValue>>> {
-    let mut result = Vec::new();
-
-    // Build mapping from storage column index (0-based within static+regular
-    // columns) to full-table column index.  Storage columns are every column
-    // that is NOT a partition key or clustering key, in their original table
-    // order.
     let pk_set: std::collections::HashSet<usize> = pk_columns.iter().copied().collect();
     let ck_set: std::collections::HashSet<usize> = ck_columns.iter().copied().collect();
     let storage_to_table: Vec<usize> = (0..column_names.len())
         .filter(|i| !pk_set.contains(i) && !ck_set.contains(i))
         .collect();
+
+    partition_to_rows_with_storage_mapping(
+        partition,
+        column_names,
+        column_types,
+        pk_columns,
+        ck_columns,
+        &storage_to_table,
+    )
+}
+
+/// Convert a storage `Partition` using an explicit storage-index to table-index
+/// map. New schemas use Cassandra column-name order for storage cells, which can
+/// differ from original CQL declaration order.
+pub fn partition_to_rows_with_storage_mapping(
+    partition: &ferrosa_sstable::types::Partition,
+    column_names: &[String],
+    column_types: &[CqlType],
+    pk_columns: &[usize],
+    ck_columns: &[usize],
+    storage_to_table: &[usize],
+) -> Vec<Vec<Option<CqlValue>>> {
+    let mut result = Vec::new();
 
     // Pre-decode PK values from the partition key
     let pk_values = decode_pk(&partition.key, pk_columns.len());
@@ -1175,14 +1192,32 @@ pub fn partition_to_rows_with_metadata(
     pk_columns: &[usize],
     ck_columns: &[usize],
 ) -> (Vec<Vec<Option<CqlValue>>>, Vec<Vec<CellMeta>>) {
-    let mut result = Vec::new();
-    let mut meta_result = Vec::new();
-
     let pk_set: std::collections::HashSet<usize> = pk_columns.iter().copied().collect();
     let ck_set: std::collections::HashSet<usize> = ck_columns.iter().copied().collect();
     let storage_to_table: Vec<usize> = (0..column_names.len())
         .filter(|i| !pk_set.contains(i) && !ck_set.contains(i))
         .collect();
+
+    partition_to_rows_with_metadata_storage_mapping(
+        partition,
+        column_names,
+        column_types,
+        pk_columns,
+        ck_columns,
+        &storage_to_table,
+    )
+}
+
+pub fn partition_to_rows_with_metadata_storage_mapping(
+    partition: &ferrosa_sstable::types::Partition,
+    column_names: &[String],
+    column_types: &[CqlType],
+    pk_columns: &[usize],
+    ck_columns: &[usize],
+    storage_to_table: &[usize],
+) -> (Vec<Vec<Option<CqlValue>>>, Vec<Vec<CellMeta>>) {
+    let mut result = Vec::new();
+    let mut meta_result = Vec::new();
 
     let pk_values = decode_pk(&partition.key, pk_columns.len());
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -347,6 +347,7 @@ struct PartitionRowContext<'a> {
     all_col_types: &'a [CqlType],
     pk_indices: &'a [usize],
     ck_indices: &'a [usize],
+    storage_to_table: &'a [usize],
 }
 
 struct SelectPredicateContext<'a> {
@@ -363,12 +364,13 @@ async fn count_rows_from_partitions(
 ) -> Result<i64, CqlError> {
     let mut count = 0_i64;
     for (idx, partition) in partitions.iter().enumerate() {
-        for row in bridge::partition_to_rows(
+        for row in bridge::partition_to_rows_with_storage_mapping(
             partition,
             row_context.all_col_names,
             row_context.all_col_types,
             row_context.pk_indices,
             row_context.ck_indices,
+            row_context.storage_to_table,
         ) {
             if row_matches_select_predicates(
                 &row,
@@ -423,20 +425,37 @@ async fn extend_rows_from_partitions(
     all_col_types: &[CqlType],
     pk_indices: &[usize],
     ck_indices: &[usize],
+    storage_to_table: &[usize],
 ) {
     for (idx, partition) in partitions.iter().enumerate() {
-        let mut prows = bridge::partition_to_rows(
+        let mut prows = bridge::partition_to_rows_with_storage_mapping(
             partition,
             all_col_names,
             all_col_types,
             pk_indices,
             ck_indices,
+            storage_to_table,
         );
         all_rows.append(&mut prows);
         if should_yield_during_partition_scan(idx + 1, cooperative_scan_yield_every_partitions()) {
             tokio::task::yield_now().await;
         }
     }
+}
+
+fn storage_to_table_indices(table_meta: &TableMetadata) -> Vec<usize> {
+    let mut pairs: Vec<(u16, usize)> = table_meta
+        .columns
+        .iter()
+        .filter(|(_, col)| matches!(col.kind, ColumnKind::Regular | ColumnKind::Static))
+        .filter_map(|(name, _)| {
+            let storage_idx = table_meta.storage_column_index(name)?;
+            let table_idx = table_meta.columns.get_index_of(name)?;
+            Some((storage_idx, table_idx))
+        })
+        .collect();
+    pairs.sort_by_key(|(storage_idx, _)| *storage_idx);
+    pairs.into_iter().map(|(_, table_idx)| table_idx).collect()
 }
 
 fn should_yield_during_partition_scan(processed_partitions: usize, yield_every: usize) -> bool {
@@ -2051,6 +2070,7 @@ async fn route_select_user_table(
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
+    let storage_to_table = storage_to_table_indices(table_meta);
     let table_id = TableId::new(&table_meta.keyspace, &table_meta.name);
 
     // ── fts_match(): full-text index search ───────────────────────────────────
@@ -2096,12 +2116,13 @@ async fn route_select_user_table(
                 .await
                 .map_err(|e| CqlError::ServerError(format!("{e}")))?
             {
-                let mut prows = bridge::partition_to_rows(
+                let mut prows = bridge::partition_to_rows_with_storage_mapping(
                     &partition,
                     &all_col_names,
                     &all_col_types,
                     &pk_indices,
                     &ck_indices,
+                    &storage_to_table,
                 );
                 // Post-filter: apply remaining (non-fts_match) WHERE predicates.
                 filter_rows_by_select_predicates(
@@ -2187,12 +2208,13 @@ async fn route_select_user_table(
             .pk_read(&table_id, &decorated_key, ctx.consistency, &read_strategy)
             .await?
         {
-            Some(partition) => bridge::partition_to_rows(
+            Some(partition) => bridge::partition_to_rows_with_storage_mapping(
                 &partition,
                 &all_col_names,
                 &all_col_types,
                 &pk_indices,
                 &ck_indices,
+                &storage_to_table,
             ),
             None => vec![],
         };
@@ -2218,6 +2240,7 @@ async fn route_select_user_table(
         &all_col_types,
         &pk_indices,
         &ck_indices,
+        &storage_to_table,
     )? {
         // PK IN (...) — multi-partition lookup.
         // Apply clustering key and other non-PK WHERE predicates.
@@ -2262,6 +2285,7 @@ async fn route_select_user_table(
                             all_col_types: &all_col_types,
                             pk_indices: &pk_indices,
                             ck_indices: &ck_indices,
+                            storage_to_table: &storage_to_table,
                         },
                         SelectPredicateContext {
                             statement: s,
@@ -2288,6 +2312,7 @@ async fn route_select_user_table(
                     &all_col_types,
                     &pk_indices,
                     &ck_indices,
+                    &storage_to_table,
                 )
                 .await;
                 filter_rows_by_select_predicates(
@@ -2366,6 +2391,7 @@ async fn route_select_user_table(
                             all_col_types: &all_col_types,
                             pk_indices: &pk_indices,
                             ck_indices: &ck_indices,
+                            storage_to_table: &storage_to_table,
                         },
                         SelectPredicateContext {
                             statement: s,
@@ -2393,6 +2419,7 @@ async fn route_select_user_table(
                     &all_col_types,
                     &pk_indices,
                     &ck_indices,
+                    &storage_to_table,
                 )
                 .await;
 
@@ -2453,6 +2480,7 @@ async fn route_select_user_table(
                             all_col_types: &all_col_types,
                             pk_indices: &pk_indices,
                             ck_indices: &ck_indices,
+                            storage_to_table: &storage_to_table,
                         },
                         SelectPredicateContext {
                             statement: s,
@@ -2480,6 +2508,7 @@ async fn route_select_user_table(
                     &all_col_types,
                     &pk_indices,
                     &ck_indices,
+                    &storage_to_table,
                 )
                 .await;
                 filter_rows_by_select_predicates(
@@ -2626,6 +2655,7 @@ async fn route_select_user_table(
                             all_col_types: &all_col_types,
                             pk_indices: &pk_indices,
                             ck_indices: &ck_indices,
+                            storage_to_table: &storage_to_table,
                         },
                         SelectPredicateContext {
                             statement: s,
@@ -2652,6 +2682,7 @@ async fn route_select_user_table(
                     &all_col_types,
                     &pk_indices,
                     &ck_indices,
+                    &storage_to_table,
                 )
                 .await;
                 filter_rows_by_select_predicates(
@@ -3249,12 +3280,14 @@ async fn route_insert(
                 .iter()
                 .filter_map(|(name, _)| table_meta.columns.get_index_of(name))
                 .collect();
-            let rows = bridge::partition_to_rows(
+            let storage_to_table = storage_to_table_indices(table_meta);
+            let rows = bridge::partition_to_rows_with_storage_mapping(
                 &partition,
                 &all_col_names,
                 &all_col_types,
                 &pk_indices,
                 &ck_indices,
+                &storage_to_table,
             );
             let matching = if ck_values.is_empty() {
                 rows.into_iter().next()
@@ -3524,6 +3557,7 @@ async fn route_update(
             .iter()
             .filter_map(|(name, _)| table_meta.columns.get_index_of(name))
             .collect();
+        let storage_to_table = storage_to_table_indices(table_meta);
 
         if let Some(partition) = state
             .write_path
@@ -3532,12 +3566,13 @@ async fn route_update(
             .await
             .map_err(|e| CqlError::ServerError(format!("{e}")))?
         {
-            let rows = bridge::partition_to_rows(
+            let rows = bridge::partition_to_rows_with_storage_mapping(
                 &partition,
                 &all_col_names,
                 &all_col_types,
                 &pk_indices,
                 &ck_indices,
+                &storage_to_table,
             );
             // Find the row matching our CK values
             if ck_values.is_empty() {
@@ -5862,6 +5897,7 @@ fn try_pk_in_lookup(
     all_col_types: &[CqlType],
     pk_indices: &[usize],
     ck_indices: &[usize],
+    storage_to_table: &[usize],
 ) -> Result<Option<Vec<Vec<Option<CqlValue>>>>, CqlError> {
     let pk_names = &table_meta.partition_key;
 
@@ -5947,12 +5983,13 @@ fn try_pk_in_lookup(
 
         let decorated_key = bridge::build_decorated_key(&pk_values, &pk_types)?;
         if let Some(partition) = engine.read(table_id, &decorated_key)? {
-            let mut prows = bridge::partition_to_rows(
+            let mut prows = bridge::partition_to_rows_with_storage_mapping(
                 &partition,
                 all_col_names,
                 all_col_types,
                 pk_indices,
                 ck_indices,
+                storage_to_table,
             );
             all_rows.append(&mut prows);
         }
@@ -8520,11 +8557,19 @@ mod tests {
             .unwrap()
             .expect("feedback_outcomes partition should exist");
         let row = partition.rows.first().expect("insert should write one row");
+        let snap = state.schema.snapshot();
+        let table_meta = snap
+            .tables
+            .get(&("agent_memory".to_string(), "feedback_outcomes".to_string()))
+            .expect("feedback_outcomes schema exists");
+        let succeeded_storage_idx = table_meta
+            .storage_column_index("succeeded")
+            .expect("succeeded has storage column index");
         let succeeded = row
             .cells
             .iter()
-            .find(|(idx, _)| *idx == 4)
-            .expect("succeeded should be storage column index 4")
+            .find(|(idx, _)| *idx == succeeded_storage_idx)
+            .expect("succeeded should be present at its schema storage column index")
             .1
             .value
             .as_deref();

--- a/ferrosa-ctl/src/commands.rs
+++ b/ferrosa-ctl/src/commands.rs
@@ -755,15 +755,14 @@ pub async fn restore(
 
 // ── Raft administration (offline) ─────────────────────────────────────────────
 
-/// W1.11: wipe a stopped node's persisted Raft state (sled `log` and
-/// `meta` trees). The node must be stopped before this runs — sled
-/// holds an exclusive flock(2) on the data directory and reset will
-/// fail if a Ferrosa process is still using it.
+/// Wipe a stopped node's persisted Raft state by atomically replacing
+/// the raft directory.
 ///
-/// On `dry_run = true`, the function opens the trees just to count
-/// what *would* be cleared, prints the counts, and returns without
-/// mutating. (sled does open the trees here, which acquires the lock
-/// briefly, so even dry-run requires the node to be stopped.)
+/// The node must be stopped before this runs. Reset deliberately does
+/// not open the sled database, so it does not take sled's exclusive
+/// directory lock and the next startup can immediately open a fresh store.
+/// On `dry_run = true`, the function reports the planned replacement
+/// without opening or mutating the database.
 pub fn raft_reset(
     data_dir: &std::path::Path,
     dry_run: bool,
@@ -771,34 +770,30 @@ pub fn raft_reset(
     use ferrosa_cluster::raft::log_store::SledLogStore;
 
     if dry_run {
-        // Open read-only-ish: we just want to enumerate counts. The
-        // ResetCounts type isn't accessible without calling reset(),
-        // so for dry-run we open and inspect the trees directly.
-        let db = sled::open(data_dir)?;
-        let log = db.open_tree("log")?;
-        let meta = db.open_tree("meta")?;
         println!(
             "ferrosa-ctl raft reset --dry-run\n\
-             would clear: log entries = {}, meta keys = {}\n\
-             path: {}",
-            log.len(),
-            meta.len(),
+             would replace raft directory at: {}\n\
+             note: exact log/meta counts are not reported because dry-run does not open sled",
             data_dir.display()
         );
-        // Drop is enough — sled flushes on drop.
         return Ok(());
     }
 
     let counts = SledLogStore::reset(data_dir)?;
+    let backup = counts
+        .backup_path
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<none; directory was missing>".to_string());
     println!(
         "ferrosa-ctl raft reset\n\
-         cleared: log entries = {}, meta keys = {}\n\
          path: {}\n\
+         backup: {}\n\
+         counts: unavailable; reset did not open sled\n\
          next start: this node will rejoin as a learner; \
          the leader's snapshot/append will replay committed history.",
-        counts.log_entries,
-        counts.meta_keys,
-        data_dir.display()
+        data_dir.display(),
+        backup
     );
     Ok(())
 }

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1633,11 +1633,13 @@ pub(super) fn row_to_json(
         }
     }
 
-    let mut cell_idx = 0u16;
-    for column in meta.columns.values() {
+    for column in storage_cell_columns(meta) {
         match column.kind {
             ferrosa_schema::metadata::column::ColumnKind::Regular
             | ferrosa_schema::metadata::column::ColumnKind::Static => {
+                let Some(cell_idx) = meta.storage_column_index(&column.name) else {
+                    continue;
+                };
                 if let Some((_, cell)) = row.cells.iter().find(|(idx, _)| *idx == cell_idx) {
                     let value = match &cell.value {
                         Some(bytes) => decode_bytes_to_json(&column.column_type, bytes),
@@ -1645,7 +1647,6 @@ pub(super) fn row_to_json(
                     };
                     map.insert(column.name.clone(), value);
                 }
-                cell_idx += 1;
             }
             _ => {}
         }
@@ -1825,24 +1826,11 @@ pub(super) fn extract_column_bytes_from_row(
         }
         ferrosa_schema::metadata::column::ColumnKind::Regular
         | ferrosa_schema::metadata::column::ColumnKind::Static => {
-            let mut regular_idx = 0u16;
-            for meta_col in meta.columns.values() {
-                match meta_col.kind {
-                    ferrosa_schema::metadata::column::ColumnKind::Regular
-                    | ferrosa_schema::metadata::column::ColumnKind::Static => {
-                        if meta_col.name == column_name {
-                            return row
-                                .cells
-                                .iter()
-                                .find(|(idx, _)| *idx == regular_idx)
-                                .and_then(|(_, cell)| cell.value.clone());
-                        }
-                        regular_idx += 1;
-                    }
-                    _ => {}
-                }
-            }
-            None
+            let cell_idx = meta.storage_column_index(column_name)?;
+            row.cells
+                .iter()
+                .find(|(idx, _)| *idx == cell_idx)
+                .and_then(|(_, cell)| cell.value.clone())
         }
     }
 }
@@ -2279,26 +2267,12 @@ fn create_row_from_schema(
         encode_components(&clustering_components)
     };
 
-    let mut cells = Vec::new();
-    let mut regular_idx = 0u16;
-    for column in meta.columns.values() {
-        match column.kind {
-            ferrosa_schema::metadata::column::ColumnKind::Regular
-            | ferrosa_schema::metadata::column::ColumnKind::Static => {
-                if let Some(expr) = prop(&column.name) {
-                    cells.push((
-                        regular_idx,
-                        CellValue::live(
-                            expr_to_column_bytes(expr, &column.column_type)?,
-                            timestamp,
-                        ),
-                    ));
-                }
-                regular_idx += 1;
-            }
-            _ => {}
-        }
-    }
+    let property_exprs = op
+        .props
+        .iter()
+        .map(|(name, expr)| (name.clone(), expr.clone()))
+        .collect();
+    let cells = encode_storage_ordered_cells(meta, &property_exprs, timestamp)?;
 
     Ok((
         DecoratedKey::new(PartitionKey::new(key_bytes)),
@@ -2928,16 +2902,42 @@ fn build_merge_write_shape(
         vec![]
     };
 
-    let create_cells: Vec<(u16, CellValue)> = op
-        .match_props
-        .iter()
-        .chain(op.create_props.iter())
-        .enumerate()
-        .map(|(idx, (_name, expr))| {
-            let bytes = expr_to_bytes(expr).unwrap_or_default();
-            (idx as u16, CellValue::live(bytes, timestamp))
-        })
-        .collect();
+    let create_cells: Vec<(u16, CellValue)> = if let Some(schema) = schema {
+        let snap = schema.snapshot();
+        if let Some(meta) = snap
+            .tables
+            .get(&(op.table.keyspace.clone(), op.table.table.clone()))
+        {
+            let property_exprs: HashMap<String, Expr> = op
+                .match_props
+                .iter()
+                .chain(op.create_props.iter())
+                .chain(set_props.iter())
+                .map(|(name, expr)| (name.clone(), expr.clone()))
+                .collect();
+            encode_storage_ordered_cells(meta, &property_exprs, timestamp)?
+        } else {
+            op.match_props
+                .iter()
+                .chain(op.create_props.iter())
+                .enumerate()
+                .map(|(idx, (_name, expr))| {
+                    let bytes = expr_to_bytes(expr).unwrap_or_default();
+                    (idx as u16, CellValue::live(bytes, timestamp))
+                })
+                .collect()
+        }
+    } else {
+        op.match_props
+            .iter()
+            .chain(op.create_props.iter())
+            .enumerate()
+            .map(|(idx, (_name, expr))| {
+                let bytes = expr_to_bytes(expr).unwrap_or_default();
+                (idx as u16, CellValue::live(bytes, timestamp))
+            })
+            .collect()
+    };
 
     Ok(MergeWriteShape {
         key: DecoratedKey::new(PartitionKey::new(key_bytes)),
@@ -3049,21 +3049,7 @@ fn build_schema_aware_merge_shape(
 
     let partition_key = encode_partition_components(&partition_components);
     let clustering = encode_clustering_components(&clustering_components);
-    let mut create_cells = Vec::new();
-    let mut regular_idx = 0u16;
-    for column in meta.columns.values() {
-        match column.kind {
-            ferrosa_schema::metadata::column::ColumnKind::Regular
-            | ferrosa_schema::metadata::column::ColumnKind::Static => {
-                if let Some(expr) = property_exprs.get(&column.name) {
-                    let bytes = encode_expr_for_column_type(expr, &column.column_type)?;
-                    create_cells.push((regular_idx, CellValue::live(bytes, timestamp)));
-                }
-                regular_idx += 1;
-            }
-            _ => {}
-        }
-    }
+    let create_cells = encode_storage_ordered_cells(meta, &property_exprs, timestamp)?;
 
     Ok(Some(MergeWriteShape {
         key: DecoratedKey::new(PartitionKey::new(partition_key)),
@@ -3259,21 +3245,7 @@ async fn infer_schema_aware_merge_shape(
 
     let partition_key = encode_partition_components(&partition_components);
     let clustering = encode_clustering_components(&clustering_components);
-    let mut create_cells = Vec::new();
-    let mut regular_idx = 0u16;
-    for column in meta.columns.values() {
-        match column.kind {
-            ferrosa_schema::metadata::column::ColumnKind::Regular
-            | ferrosa_schema::metadata::column::ColumnKind::Static => {
-                if let Some(expr) = property_exprs.get(&column.name) {
-                    let bytes = encode_expr_for_column_type(expr, &column.column_type)?;
-                    create_cells.push((regular_idx, CellValue::live(bytes, timestamp)));
-                }
-                regular_idx += 1;
-            }
-            _ => {}
-        }
-    }
+    let create_cells = encode_storage_ordered_cells(&meta, &property_exprs, timestamp)?;
 
     Ok(Some(MergeWriteShape {
         key: DecoratedKey::new(PartitionKey::new(partition_key)),
@@ -3281,6 +3253,49 @@ async fn infer_schema_aware_merge_shape(
         create_cells,
         used_schema_layout: true,
     }))
+}
+
+fn encode_storage_ordered_cells(
+    meta: &ferrosa_schema::metadata::table::TableMetadata,
+    property_exprs: &HashMap<String, Expr>,
+    timestamp: i64,
+) -> Result<Vec<(u16, CellValue)>> {
+    let mut create_cells = Vec::new();
+    for column in meta.columns.values() {
+        match column.kind {
+            ferrosa_schema::metadata::column::ColumnKind::Regular
+            | ferrosa_schema::metadata::column::ColumnKind::Static => {
+                if let Some(expr) = property_exprs.get(&column.name) {
+                    let storage_idx = meta.storage_column_index(&column.name).ok_or_else(|| {
+                        GraphError::Validation(format!(
+                            "table '{}.{}' column '{}' has no storage column index",
+                            meta.keyspace, meta.name, column.name
+                        ))
+                    })?;
+                    let bytes = encode_expr_for_column_type(expr, &column.column_type)?;
+                    create_cells.push((storage_idx, CellValue::live(bytes, timestamp)));
+                }
+            }
+            _ => {}
+        }
+    }
+    create_cells.sort_by_key(|(idx, _)| *idx);
+    Ok(create_cells)
+}
+
+fn storage_cell_columns(
+    meta: &ferrosa_schema::metadata::table::TableMetadata,
+) -> Vec<&ferrosa_schema::metadata::column::ColumnMetadata> {
+    let mut columns: Vec<_> = meta
+        .columns
+        .values()
+        .filter(|column| {
+            column.kind == ferrosa_schema::metadata::column::ColumnKind::Regular
+                || column.kind == ferrosa_schema::metadata::column::ColumnKind::Static
+        })
+        .collect();
+    columns.sort_by_key(|column| meta.storage_column_index(&column.name).unwrap_or(u16::MAX));
+    columns
 }
 
 fn schema_merge_requires_hidden_key_resolution(
@@ -4181,9 +4196,8 @@ fn expr_to_column_name(expr: &Expr) -> String {
 /// Look up regular column names for a table from the schema.
 ///
 /// Returns the names of regular (non-key, non-static) columns in the order
-/// they appear in the schema's `IndexMap`, which matches the cell index
-/// positions used by the storage engine. Falls back to an empty vec when
-/// the schema or table is unavailable.
+/// they appear in storage column order. Falls back to an empty vec when the
+/// schema or table is unavailable.
 pub fn column_names_for_table(schema: Option<&Schema>, keyspace: &str, table: &str) -> Vec<String> {
     let schema = match schema {
         Some(s) => s,
@@ -4193,12 +4207,8 @@ pub fn column_names_for_table(schema: Option<&Schema>, keyspace: &str, table: &s
     snap.tables
         .get(&(keyspace.to_string(), table.to_string()))
         .map(|meta| {
-            meta.columns
-                .values()
-                .filter(|col| {
-                    col.kind == ferrosa_schema::metadata::column::ColumnKind::Regular
-                        || col.kind == ferrosa_schema::metadata::column::ColumnKind::Static
-                })
+            storage_cell_columns(meta)
+                .into_iter()
                 .map(|col| col.name.clone())
                 .collect()
         })
@@ -4217,14 +4227,7 @@ fn regular_column_index_for_property(
         .tables
         .get(&(keyspace.to_string(), table.to_string()))?;
 
-    meta.columns
-        .values()
-        .filter(|col| {
-            col.kind == ferrosa_schema::metadata::column::ColumnKind::Regular
-                || col.kind == ferrosa_schema::metadata::column::ColumnKind::Static
-        })
-        .enumerate()
-        .find_map(|(idx, col)| (col.name == property).then_some(idx as u16))
+    meta.storage_column_index(property)
 }
 
 fn column_kind_for_property(

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -25,7 +25,7 @@ use ferrosa_cluster::raft::handlers::{
 };
 use ferrosa_cluster::raft::{NodeInfo, NodeState};
 use ferrosa_cluster::ring::TokenRing;
-use ferrosa_common::schema::TableSchema;
+use ferrosa_common::schema::{ColumnDefinition, TableSchema};
 use ferrosa_graph::engine::GraphEngine;
 use ferrosa_graph::executor::expand::GraphEngineConfig;
 use ferrosa_graph::http::{build_router, AppState};
@@ -113,18 +113,43 @@ fn basic_auth_header() -> String {
 /// (CREATE, MERGE) can locate the memtable. Must be called after
 /// `create_social_graph_schema` for any test that writes to storage.
 fn register_social_tables_with_storage(storage: &StorageEngine) {
-    for (keyspace, table) in [("social", "person_v"), ("social", "knows_e")] {
-        let schema = TableSchema {
-            keyspace: keyspace.to_string(),
-            table: table.to_string(),
+    storage
+        .register_table(TableSchema {
+            keyspace: "social".to_string(),
+            table: "person_v".to_string(),
             key_type: "org.apache.cassandra.db.marshal.BytesType".to_string(),
             clustering_columns: vec![],
             static_columns: vec![],
-            regular_columns: vec![],
+            regular_columns: vec![
+                ColumnDefinition {
+                    name: "age".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+                },
+                ColumnDefinition {
+                    name: "name".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+                },
+            ],
             extensions: HashMap::new(),
-        };
-        storage.register_table(schema).unwrap();
-    }
+        })
+        .unwrap();
+    storage
+        .register_table(TableSchema {
+            keyspace: "social".to_string(),
+            table: "knows_e".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.BytesType".to_string(),
+            clustering_columns: vec![ColumnDefinition {
+                name: "dst_id".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.BytesType".to_string(),
+            }],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "since".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+            }],
+            extensions: HashMap::new(),
+        })
+        .unwrap();
 }
 
 fn register_social_likes_table_with_storage(storage: &StorageEngine) {
@@ -132,9 +157,15 @@ fn register_social_likes_table_with_storage(storage: &StorageEngine) {
         keyspace: "social".to_string(),
         table: "likes_e".to_string(),
         key_type: "org.apache.cassandra.db.marshal.BytesType".to_string(),
-        clustering_columns: vec![],
+        clustering_columns: vec![ColumnDefinition {
+            name: "dst_id".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.BytesType".to_string(),
+        }],
         static_columns: vec![],
-        regular_columns: vec![],
+        regular_columns: vec![ColumnDefinition {
+            name: "weight".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+        }],
         extensions: HashMap::new(),
     };
     storage.register_table(schema).unwrap();
@@ -552,7 +583,7 @@ async fn cluster_anchor_full_primary_key_match_reads_remote_vertex_without_range
         static_row: None,
         rows: vec![Row {
             clustering: vec![],
-            cells: vec![(0, ferrosa_common::CellValue::live(b"Alice".to_vec(), 1000))],
+            cells: vec![(1, ferrosa_common::CellValue::live(b"Alice".to_vec(), 1000))],
             deletion: DeletionTime::LIVE,
             primary_key_liveness: LivenessInfo::with_timestamp(1000),
         }],

--- a/ferrosa-schema/src/convert.rs
+++ b/ferrosa-schema/src/convert.rs
@@ -113,7 +113,8 @@ impl TableMetadata {
     /// Convert this table metadata to a `TableSchema` suitable for the storage layer.
     ///
     /// Maps partition key columns to a single `key_type` (or `CompositeType` for
-    /// compound keys), and sorts clustering/static/regular columns by position.
+    /// compound keys), keeps clustering columns in clustering-key position,
+    /// and orders static/regular cells by Cassandra's column-name comparator.
     /// Compute the storage-layer column index for a given column name.
     ///
     /// Storage column indices are 0-based within `[static_columns... regular_columns...]`,
@@ -127,21 +128,22 @@ impl TableMetadata {
         match col.kind {
             ColumnKind::PartitionKey | ColumnKind::Clustering => None,
             ColumnKind::Static => {
-                // Static columns are indexed first. Count how many static
-                // columns (sorted by position) precede this one.
+                // Static columns are indexed first and sorted by Cassandra's
+                // column-name comparator.
                 let mut static_cols: Vec<_> = self
                     .columns
                     .values()
                     .filter(|c| c.kind == ColumnKind::Static)
                     .collect();
-                static_cols.sort_by_key(|c| c.position);
+                static_cols.sort_by(|a, b| a.name.as_bytes().cmp(b.name.as_bytes()));
                 static_cols
                     .iter()
                     .position(|c| c.name == col_name)
                     .map(|p| p as u16)
             }
             ColumnKind::Regular => {
-                // Regular columns follow static columns.
+                // Regular columns follow static columns and are sorted by
+                // Cassandra's column-name comparator.
                 let num_statics = self
                     .columns
                     .values()
@@ -152,7 +154,7 @@ impl TableMetadata {
                     .values()
                     .filter(|c| c.kind == ColumnKind::Regular)
                     .collect();
-                regulars.sort_by_key(|c| c.position);
+                regulars.sort_by(|a, b| a.name.as_bytes().cmp(b.name.as_bytes()));
                 regulars
                     .iter()
                     .position(|c| c.name == col_name)
@@ -164,7 +166,8 @@ impl TableMetadata {
     /// Convert this table metadata to a `TableSchema` suitable for the storage layer.
     ///
     /// Maps partition key columns to a single `key_type` (or `CompositeType` for
-    /// compound keys), and sorts clustering/static/regular columns by position.
+    /// compound keys), keeps clustering columns in clustering-key position,
+    /// and orders static/regular cells by Cassandra's column-name comparator.
     pub fn to_storage_schema(&self) -> TableSchema {
         // Build key_type
         let key_type = if self.partition_key.len() == 1 {
@@ -202,13 +205,13 @@ impl TableMetadata {
             })
             .collect();
 
-        // Collect and sort static columns by position
+        // Collect and sort static columns by Cassandra's column-name comparator.
         let mut static_cols: Vec<_> = self
             .columns
             .values()
             .filter(|c| c.kind == ColumnKind::Static)
             .collect();
-        static_cols.sort_by_key(|c| c.position);
+        static_cols.sort_by(|a, b| a.name.as_bytes().cmp(b.name.as_bytes()));
         let static_columns: Vec<ColumnDefinition> = static_cols
             .iter()
             .map(|c| ColumnDefinition {
@@ -217,13 +220,13 @@ impl TableMetadata {
             })
             .collect();
 
-        // Collect and sort regular columns by position
+        // Collect and sort regular columns by Cassandra's column-name comparator.
         let mut regulars: Vec<_> = self
             .columns
             .values()
             .filter(|c| c.kind == ColumnKind::Regular)
             .collect();
-        regulars.sort_by_key(|c| c.position);
+        regulars.sort_by(|a, b| a.name.as_bytes().cmp(b.name.as_bytes()));
         let regular_columns: Vec<ColumnDefinition> = regulars
             .iter()
             .map(|c| ColumnDefinition {
@@ -410,6 +413,89 @@ mod tests {
         );
         assert!(schema.clustering_columns.is_empty());
         assert!(schema.static_columns.is_empty());
+    }
+
+    #[test]
+    fn regular_and_static_storage_ordinals_follow_cassandra_column_name_order() {
+        let mut columns = IndexMap::new();
+        columns.insert(
+            "pk".to_string(),
+            ColumnMetadata {
+                name: "pk".to_string(),
+                kind: ColumnKind::PartitionKey,
+                position: 0,
+                column_type: "text".to_string(),
+                clustering_order: ClusteringOrder::None,
+                mask: None,
+            },
+        );
+        columns.insert(
+            "z_static".to_string(),
+            ColumnMetadata {
+                name: "z_static".to_string(),
+                kind: ColumnKind::Static,
+                position: 0,
+                column_type: "text".to_string(),
+                clustering_order: ClusteringOrder::None,
+                mask: None,
+            },
+        );
+        columns.insert(
+            "a_static".to_string(),
+            ColumnMetadata {
+                name: "a_static".to_string(),
+                kind: ColumnKind::Static,
+                position: 1,
+                column_type: "text".to_string(),
+                clustering_order: ClusteringOrder::None,
+                mask: None,
+            },
+        );
+        columns.insert(
+            "v_text".to_string(),
+            ColumnMetadata {
+                name: "v_text".to_string(),
+                kind: ColumnKind::Regular,
+                position: 0,
+                column_type: "text".to_string(),
+                clustering_order: ClusteringOrder::None,
+                mask: None,
+            },
+        );
+        columns.insert(
+            "v_int".to_string(),
+            ColumnMetadata {
+                name: "v_int".to_string(),
+                kind: ColumnKind::Regular,
+                position: 1,
+                column_type: "int".to_string(),
+                clustering_order: ClusteringOrder::None,
+                mask: None,
+            },
+        );
+
+        let table = TableMetadata {
+            keyspace: "ks".to_string(),
+            name: "mixed_cells".to_string(),
+            id: uuid::Uuid::new_v4(),
+            columns,
+            partition_key: vec!["pk".to_string()],
+            clustering_key: vec![],
+            params: TableParams::default(),
+            flags: HashSet::new(),
+            extensions: HashMap::new(),
+            is_system: false,
+        };
+
+        let schema = table.to_storage_schema();
+        assert_eq!(schema.static_columns[0].name, "a_static");
+        assert_eq!(schema.static_columns[1].name, "z_static");
+        assert_eq!(schema.regular_columns[0].name, "v_int");
+        assert_eq!(schema.regular_columns[1].name, "v_text");
+        assert_eq!(table.storage_column_index("a_static"), Some(0));
+        assert_eq!(table.storage_column_index("z_static"), Some(1));
+        assert_eq!(table.storage_column_index("v_int"), Some(2));
+        assert_eq!(table.storage_column_index("v_text"), Some(3));
     }
 
     #[test]

--- a/ferrosa-sstable/src/byte_comparable.rs
+++ b/ferrosa-sstable/src/byte_comparable.rs
@@ -6,11 +6,10 @@
 //!
 //! 1. `0x40` (NEXT_COMPONENT separator)
 //! 2. Token bytes (8 bytes, big-endian, XOR sign bit)
-//! 3. `0x00` (ESCAPE — end of token component)
-//! 4. `0x40` (NEXT_COMPONENT separator)
-//! 5. Partition key bytes with null-escape encoding
-//! 6. `0x00` (ESCAPE — end of key component)
-//! 7. `0x38` (TERMINATOR)
+//! 3. `0x40` (NEXT_COMPONENT separator)
+//! 4. Partition key bytes with null-escape encoding
+//! 5. `0x00` (ESCAPE — end of key component)
+//! 6. `0x38` (TERMINATOR)
 //!
 //! **Null-escape encoding**: `0x00` in key data becomes `0x00 0xFF`.
 //! Consecutive zeros become `0x00` + (n-1) `0xFE` + `0xFF`.
@@ -29,8 +28,8 @@
 //!     key: PartitionKey::from(b"AB".as_slice()),
 //! };
 //! let encoded = byte_comparable::encode(&dk);
-//! // 0x40, token(1 XOR sign bit), 0x00, 0x40, 0x41, 0x42, 0x00, 0x38
-//! assert_eq!(encoded.len(), 15);
+//! // 0x40, token(1 XOR sign bit), 0x40, 0x41, 0x42, 0x00, 0x38
+//! assert_eq!(encoded.len(), 14);
 //!
 //! let decoded = byte_comparable::decode(&encoded).unwrap();
 //! assert_eq!(decoded.token, dk.token);
@@ -57,9 +56,9 @@ pub fn encode(key: &DecoratedKey) -> Vec<u8> {
     buf.push(NEXT_COMPONENT);
     let token_bytes = ((key.token.0 as u64) ^ SIGN_BIT).to_be_bytes();
     buf.extend_from_slice(&token_bytes);
-    buf.push(ESCAPE); // end of token component
-
-    // Component 2: Partition key with null-escape encoding
+    // Component 2: Partition key with null-escape encoding. Cassandra's
+    // fixed-length token source ends without an ESCAPE byte; Multi emits the
+    // next component marker immediately after the eight token bytes.
     buf.push(NEXT_COMPONENT);
     encode_bytes_with_null_escape(&mut buf, key.key.as_bytes());
     buf.push(ESCAPE); // end of key component
@@ -91,12 +90,6 @@ pub fn decode(data: &[u8]) -> Result<DecoratedKey> {
     let token_unsigned = u64::from_be_bytes(token_bytes);
     let token = Token((token_unsigned ^ SIGN_BIT) as i64);
     pos += 8;
-
-    // Expect ESCAPE (end of token component)
-    if data.get(pos) != Some(&ESCAPE) {
-        return Err(Error::InvalidFormat("expected ESCAPE after token".into()));
-    }
-    pos += 1;
 
     // Expect NEXT_COMPONENT
     if data.get(pos) != Some(&NEXT_COMPONENT) {
@@ -208,18 +201,32 @@ mod tests {
         };
         let encoded = encode(&dk);
 
-        // Expected: 40 80_00_00_00_00_00_00_01 00 40 41_42 00 38
+        // Expected: 40 80_00_00_00_00_00_00_01 40 41_42 00 38
         assert_eq!(encoded[0], NEXT_COMPONENT);
         // Token 1 XOR sign bit = 0x8000000000000001
         assert_eq!(
             &encoded[1..9],
             &[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]
         );
-        assert_eq!(encoded[9], ESCAPE);
-        assert_eq!(encoded[10], NEXT_COMPONENT);
-        assert_eq!(&encoded[11..13], b"AB");
-        assert_eq!(encoded[13], ESCAPE);
-        assert_eq!(encoded[14], TERMINATOR);
+        assert_eq!(encoded[9], NEXT_COMPONENT);
+        assert_eq!(&encoded[10..12], b"AB");
+        assert_eq!(encoded[12], ESCAPE);
+        assert_eq!(encoded[13], TERMINATOR);
+    }
+
+    #[test]
+    fn oss50_fixed_token_component_has_no_escape_terminator() {
+        let dk = DecoratedKey {
+            token: Token(1),
+            key: PartitionKey::from(b"AB".as_slice()),
+        };
+        let encoded = encode(&dk);
+
+        assert_eq!(
+            encoded[9], NEXT_COMPONENT,
+            "Cassandra OSS50 emits the key component marker immediately after the fixed 8-byte token"
+        );
+        assert_eq!(encoded.len(), 14);
     }
 
     #[test]

--- a/ferrosa-sstable/src/data.rs
+++ b/ferrosa-sstable/src/data.rs
@@ -751,8 +751,8 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
 
     /// Skip a row after its flags and extended flags have already been consumed.
     fn skip_row_body(&mut self, _flags: u8, is_static: bool) -> Result<()> {
-        if !is_static {
-            let num_clustering = self.header.clustering_types.len();
+        let num_clustering = self.header.clustering_types.len();
+        if !is_static && num_clustering > 0 {
             let (header_bits, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
             self.pos += n as u64;
 
@@ -800,38 +800,41 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
             Vec::new()
         } else {
             let num_clustering = self.header.clustering_types.len();
-            let (header_bits, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
-            self.pos += n as u64;
 
             let mut ck_bytes = Vec::new();
-            for i in 0..num_clustering {
-                let is_null = (header_bits & (1u64 << (2 * i))) != 0;
-                let is_empty = (header_bits & (1u64 << (2 * i + 1))) != 0;
+            if num_clustering > 0 {
+                let (header_bits, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+                self.pos += n as u64;
 
-                if is_null || is_empty {
-                    continue;
-                }
+                for i in 0..num_clustering {
+                    let is_null = (header_bits & (1u64 << (2 * i))) != 0;
+                    let is_empty = (header_bits & (1u64 << (2 * i + 1))) != 0;
 
-                let type_name = &self.header.clustering_types[i];
-                let vlen = match marshal::value_length_if_fixed(type_name) {
-                    Some(fixed_len) => fixed_len,
-                    None => {
-                        let (len, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
-                        self.pos += n as u64;
-                        len as usize
+                    if is_null || is_empty {
+                        continue;
                     }
-                };
-                let mut vbuf = vec![0u8; vlen];
-                self.reader.read_exact_at(&mut vbuf, self.pos)?;
-                self.pos += vlen as u64;
 
-                // For multi-column CK, add u16 BE length prefix per component
-                // so the CQL layer's decode_clustering can split them back.
-                // Single-column CK uses raw bytes (no prefix).
-                if num_clustering > 1 {
-                    ck_bytes.extend_from_slice(&(vlen as u16).to_be_bytes());
+                    let type_name = &self.header.clustering_types[i];
+                    let vlen = match marshal::value_length_if_fixed(type_name) {
+                        Some(fixed_len) => fixed_len,
+                        None => {
+                            let (len, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+                            self.pos += n as u64;
+                            len as usize
+                        }
+                    };
+                    let mut vbuf = vec![0u8; vlen];
+                    self.reader.read_exact_at(&mut vbuf, self.pos)?;
+                    self.pos += vlen as u64;
+
+                    // For multi-column CK, add u16 BE length prefix per component
+                    // so the CQL layer's decode_clustering can split them back.
+                    // Single-column CK uses raw bytes (no prefix).
+                    if num_clustering > 1 {
+                        ck_bytes.extend_from_slice(&(vlen as u16).to_be_bytes());
+                    }
+                    ck_bytes.extend_from_slice(&vbuf);
                 }
-                ck_bytes.extend_from_slice(&vbuf);
             }
             ck_bytes
         };
@@ -892,28 +895,13 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
         let present_columns: Vec<usize> = if flags & HAS_ALL_COLUMNS != 0 {
             (0..num_columns).collect()
         } else {
-            // Bitmap: ceil(num_columns / 8) bytes, one bit per column (MSB first).
-            // A SET bit means the column IS present (Cassandra BooleanArraySerializer).
-            let bitmap_bytes = num_columns.div_ceil(8);
-            let mut bitmap = vec![0u8; bitmap_bytes];
-            self.reader.read_exact_at(&mut bitmap, self.pos)?;
-            self.pos += bitmap_bytes as u64;
-
-            let mut present = Vec::new();
-            for i in 0..num_columns {
-                let byte_idx = i / 8;
-                let bit_idx = 7 - (i % 8); // MSB first
-                if bitmap[byte_idx] & (1 << bit_idx) != 0 {
-                    present.push(i);
-                }
-            }
-            present
+            self.read_columns_subset(num_columns)?
         };
 
         // Read cells for present columns
         let mut cells = Vec::with_capacity(present_columns.len());
         for &col_idx in &present_columns {
-            let cell = self.read_cell(&liveness)?;
+            let cell = self.read_cell(&liveness, &columns[col_idx].1)?;
             cells.push((col_idx as u16, cell));
         }
 
@@ -1003,33 +991,36 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
             Vec::new()
         } else {
             let num_clustering = self.header.clustering_types.len();
-            let (header_bits, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
-            self.pos += n as u64;
 
             let mut ck_bytes = Vec::new();
-            for i in 0..num_clustering {
-                let is_null = (header_bits & (1u64 << (2 * i))) != 0;
-                let is_empty = (header_bits & (1u64 << (2 * i + 1))) != 0;
-                if is_null || is_empty {
-                    continue;
-                }
-                let type_name = &self.header.clustering_types[i];
-                let vlen = match marshal::value_length_if_fixed(type_name) {
-                    Some(fixed_len) => fixed_len,
-                    None => {
-                        let (len, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
-                        self.pos += n as u64;
-                        len as usize
-                    }
-                };
-                let mut vbuf = vec![0u8; vlen];
-                self.reader.read_exact_at(&mut vbuf, self.pos)?;
-                self.pos += vlen as u64;
+            if num_clustering > 0 {
+                let (header_bits, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+                self.pos += n as u64;
 
-                if num_clustering > 1 {
-                    ck_bytes.extend_from_slice(&(vlen as u16).to_be_bytes());
+                for i in 0..num_clustering {
+                    let is_null = (header_bits & (1u64 << (2 * i))) != 0;
+                    let is_empty = (header_bits & (1u64 << (2 * i + 1))) != 0;
+                    if is_null || is_empty {
+                        continue;
+                    }
+                    let type_name = &self.header.clustering_types[i];
+                    let vlen = match marshal::value_length_if_fixed(type_name) {
+                        Some(fixed_len) => fixed_len,
+                        None => {
+                            let (len, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+                            self.pos += n as u64;
+                            len as usize
+                        }
+                    };
+                    let mut vbuf = vec![0u8; vlen];
+                    self.reader.read_exact_at(&mut vbuf, self.pos)?;
+                    self.pos += vlen as u64;
+
+                    if num_clustering > 1 {
+                        ck_bytes.extend_from_slice(&(vlen as u16).to_be_bytes());
+                    }
+                    ck_bytes.extend_from_slice(&vbuf);
                 }
-                ck_bytes.extend_from_slice(&vbuf);
             }
             ck_bytes
         };
@@ -1086,20 +1077,7 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
         let present_columns: Vec<usize> = if flags & HAS_ALL_COLUMNS != 0 {
             (0..num_columns).collect()
         } else {
-            let bitmap_bytes = num_columns.div_ceil(8);
-            let mut bitmap = vec![0u8; bitmap_bytes];
-            self.reader.read_exact_at(&mut bitmap, self.pos)?;
-            self.pos += bitmap_bytes as u64;
-
-            let mut present = Vec::new();
-            for i in 0..num_columns {
-                let byte_idx = i / 8;
-                let bit_idx = 7 - (i % 8);
-                if bitmap[byte_idx] & (1 << bit_idx) != 0 {
-                    present.push(i);
-                }
-            }
-            present
+            self.read_columns_subset(num_columns)?
         };
 
         // For each present column: decode if wanted, skip otherwise.
@@ -1110,10 +1088,10 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
         for &col_idx in &present_columns {
             let col_u16 = col_idx as u16;
             if wanted.contains(&col_u16) {
-                let cell = self.read_cell(&liveness)?;
+                let cell = self.read_cell(&liveness, &columns[col_idx].1)?;
                 cells.push((col_u16, cell));
             } else {
-                self.read_cell_skip(&liveness)?;
+                self.read_cell_skip(&liveness, &columns[col_idx].1)?;
             }
         }
 
@@ -1123,6 +1101,62 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
             deletion,
             primary_key_liveness: liveness,
         })
+    }
+
+    fn read_columns_subset(&mut self, num_columns: usize) -> Result<Vec<usize>> {
+        let (encoded, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+        self.pos += n as u64;
+        if encoded == 0 {
+            return Ok((0..num_columns).collect());
+        }
+
+        if num_columns < 64 {
+            let mut missing = encoded;
+            let mut present = Vec::with_capacity(num_columns);
+            for idx in 0..num_columns {
+                if missing & 1 == 0 {
+                    present.push(idx);
+                }
+                missing >>= 1;
+            }
+            if missing != 0 {
+                return Err(Error::InvalidData(format!(
+                    "columns subset has bits beyond {num_columns} columns"
+                )));
+            }
+            return Ok(present);
+        }
+
+        let missing_count = encoded as usize;
+        if missing_count > num_columns {
+            return Err(Error::InvalidData(format!(
+                "columns subset missing count {missing_count} exceeds {num_columns}"
+            )));
+        }
+        let present_count = num_columns - missing_count;
+        if present_count < num_columns / 2 {
+            let mut present = Vec::with_capacity(present_count);
+            for _ in 0..present_count {
+                let (idx, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+                self.pos += n as u64;
+                present.push(idx as usize);
+            }
+            Ok(present)
+        } else {
+            let mut is_missing = vec![false; num_columns];
+            for _ in 0..missing_count {
+                let (idx, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+                self.pos += n as u64;
+                let idx = idx as usize;
+                if idx >= num_columns {
+                    return Err(Error::InvalidData(format!(
+                        "columns subset missing index {idx} exceeds {num_columns}"
+                    )));
+                }
+                is_missing[idx] = true;
+            }
+            Ok((0..num_columns).filter(|idx| !is_missing[*idx]).collect())
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1139,7 +1173,7 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
     /// projection-aware decode path so cells outside the SELECT list
     /// never pay the read+decode cost (especially big values like
     /// vector embeddings).
-    fn read_cell_skip(&mut self, row_liveness: &LivenessInfo) -> Result<()> {
+    fn read_cell_skip(&mut self, row_liveness: &LivenessInfo, column_type: &str) -> Result<()> {
         let mut cell_flags_buf = [0u8; 1];
         self.reader.read_exact_at(&mut cell_flags_buf, self.pos)?;
         self.pos += 1;
@@ -1165,8 +1199,13 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
             self.pos += n as u64;
         }
         if !has_empty_value {
-            let (vlen, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
-            self.pos += n as u64;
+            let vlen = if let Some(fixed_len) = marshal::value_length_if_fixed(column_type) {
+                fixed_len as u64
+            } else {
+                let (vlen, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+                self.pos += n as u64;
+                vlen
+            };
             // Same corruption guard as read_cell so a bogus vlen
             // doesn't carry us past EOF silently.
             const MAX_CELL_VALUE_LEN: u64 = 256 * 1024 * 1024;
@@ -1184,7 +1223,7 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
     }
 
     /// Read a single cell value.
-    fn read_cell(&mut self, row_liveness: &LivenessInfo) -> Result<CellValue> {
+    fn read_cell(&mut self, row_liveness: &LivenessInfo, column_type: &str) -> Result<CellValue> {
         let mut cell_flags_buf = [0u8; 1];
         self.reader.read_exact_at(&mut cell_flags_buf, self.pos)?;
         self.pos += 1;
@@ -1233,9 +1272,13 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
         let value = if has_empty_value {
             None
         } else {
-            let (vlen, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
-            self.pos += n as u64;
-            let vlen = vlen as usize;
+            let vlen = if let Some(fixed_len) = marshal::value_length_if_fixed(column_type) {
+                fixed_len
+            } else {
+                let (vlen, n) = varint::read_unsigned_vint_at(self.reader, self.pos)?;
+                self.pos += n as u64;
+                vlen as usize
+            };
             // Guard against corrupt length values that would cause capacity overflow.
             // A single cell value should never exceed 256 MB.
             const MAX_CELL_VALUE_LEN: usize = 256 * 1024 * 1024;
@@ -1516,7 +1559,7 @@ mod tests {
         data.extend_from_slice(&clustering);
 
         // Row body size + prev size
-        push_unsigned_vint(&mut data, 20);
+        push_unsigned_vint(&mut data, 10);
         push_unsigned_vint(&mut data, 0);
 
         // Liveness timestamp delta = 50 (unsigned)
@@ -1687,11 +1730,10 @@ mod tests {
         // Liveness timestamp delta = 10 (unsigned)
         push_unsigned_vint(&mut data, 10);
 
-        // Missing-column bitmap: 2 columns -> 1 byte
+        // Cassandra Columns subset: unsigned vint missing-column bitmap.
         // We want column 0 present, column 1 missing.
-        // Bitmap: bit 7 = col 0 (1 = present), bit 6 = col 1 (0 = missing)
-        // = 0b10000000 = 0x80
-        data.push(0x80);
+        // For <64 columns, bit i = 1 means column i is missing.
+        push_unsigned_vint(&mut data, 0b10);
 
         // Only column 0's cell: use row timestamp
         data.push(CELL_USE_ROW_TIMESTAMP);
@@ -1711,6 +1753,106 @@ mod tests {
         assert_eq!(row.cells.len(), 1);
         assert_eq!(row.cells[0].0, 0); // column index 0
         assert_eq!(row.cells[0].1.value.as_deref(), Some(b"only_a".as_slice()));
+    }
+
+    #[test]
+    fn read_partition_without_clustering_columns_starts_at_row_body_length() {
+        let header = SerializationHeader {
+            min_timestamp: 1_000_000,
+            min_local_deletion_time: i32::MAX,
+            min_ttl: 0,
+            max_timestamp: i64::MAX,
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".into(),
+            clustering_types: vec![],
+            static_columns: vec![],
+            regular_columns: vec![(
+                b"val".to_vec(),
+                "org.apache.cassandra.db.marshal.UTF8Type".into(),
+            )],
+        };
+
+        let mut row_body = Vec::new();
+        push_unsigned_vint(&mut row_body, 42);
+        row_body.push(CELL_USE_ROW_TIMESTAMP);
+        let value = b"hello";
+        push_unsigned_vint(&mut row_body, value.len() as u64);
+        row_body.extend_from_slice(value);
+
+        let mut data = Vec::new();
+        let key = b"pk_no_ck";
+        data.extend_from_slice(&(key.len() as u16).to_be_bytes());
+        data.extend_from_slice(key);
+        push_live_deletion(&mut data);
+        data.push(HAS_TIMESTAMP | HAS_ALL_COLUMNS);
+        push_unsigned_vint(&mut data, row_body.len() as u64);
+        push_unsigned_vint(&mut data, 0);
+        data.extend_from_slice(&row_body);
+        data.push(END_OF_PARTITION);
+
+        let mut reader = DataReader::new(&data, &header, 0);
+        let partition = reader
+            .read_partition()
+            .unwrap()
+            .expect("expected partition");
+
+        let row = &partition.rows[0];
+        assert!(row.clustering.is_empty());
+        assert_eq!(row.primary_key_liveness.timestamp, 1_000_042);
+        assert_eq!(row.cells[0].1.value.as_deref(), Some(value.as_slice()));
+    }
+
+    #[test]
+    fn read_partition_with_fixed_width_cell_without_value_length_prefix() {
+        let header = SerializationHeader {
+            min_timestamp: 1_000_000,
+            min_local_deletion_time: i32::MAX,
+            min_ttl: 0,
+            max_timestamp: i64::MAX,
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".into(),
+            clustering_types: vec![],
+            static_columns: vec![],
+            regular_columns: vec![
+                (
+                    b"v_int".to_vec(),
+                    "org.apache.cassandra.db.marshal.Int32Type".into(),
+                ),
+                (
+                    b"v_text".to_vec(),
+                    "org.apache.cassandra.db.marshal.UTF8Type".into(),
+                ),
+            ],
+        };
+
+        let mut row_body = Vec::new();
+        push_unsigned_vint(&mut row_body, 42);
+        push_unsigned_vint(&mut row_body, 0b10);
+        row_body.push(CELL_USE_ROW_TIMESTAMP);
+        row_body.extend_from_slice(&42i32.to_be_bytes());
+
+        let mut data = Vec::new();
+        let key = b"pk_fixed";
+        data.extend_from_slice(&(key.len() as u16).to_be_bytes());
+        data.extend_from_slice(key);
+        push_live_deletion(&mut data);
+        data.push(HAS_TIMESTAMP);
+        push_unsigned_vint(&mut data, row_body.len() as u64);
+        push_unsigned_vint(&mut data, 0);
+        data.extend_from_slice(&row_body);
+        data.push(END_OF_PARTITION);
+
+        let mut reader = DataReader::new(&data, &header, 0);
+        let partition = reader
+            .read_partition()
+            .unwrap()
+            .expect("expected partition");
+
+        let row = &partition.rows[0];
+        assert_eq!(row.cells.len(), 1);
+        assert_eq!(row.cells[0].0, 0);
+        assert_eq!(
+            row.cells[0].1.value.as_deref(),
+            Some(42i32.to_be_bytes().as_slice())
+        );
     }
 
     #[test]

--- a/ferrosa-sstable/src/statistics.rs
+++ b/ferrosa-sstable/src/statistics.rs
@@ -59,6 +59,89 @@ pub struct StatsMetadata {
     pub data: Vec<u8>,
 }
 
+/// Build Cassandra 5 BTI StatsMetadata for a simple primary-key table.
+///
+/// Ferrosa only needs a small subset of Cassandra's full statistics model for
+/// import/read compatibility: sane histograms, no commit-log intervals, live
+/// deletion markers, no tombstones, an all-clustering slice, row/cell counts,
+/// and the actual first/last partition keys. The byte layout follows Apache
+/// Cassandra 5.0's `StatsMetadataSerializer` for BTI SSTables.
+///
+/// This intentionally returns `None` for clustered tables until the clustered
+/// min/max `Slice` serializer is implemented here. Callers must then either use
+/// their legacy path or surface that clustered Cassandra import is unsupported.
+pub fn build_simple_bti_stats_metadata(
+    header: &SerializationHeader,
+    first_key: &[u8],
+    last_key: &[u8],
+    partition_count: u64,
+    total_rows: u64,
+    total_columns_set: u64,
+    compression_ratio: f64,
+) -> Option<StatsMetadata> {
+    if !header.clustering_types.is_empty() {
+        return None;
+    }
+
+    let mut out = Vec::new();
+
+    write_estimated_histogram(&mut out, 156, partition_count);
+    write_estimated_histogram(&mut out, 119, total_columns_set.max(partition_count));
+
+    // CommitLogPosition.NONE for the upper bound.
+    write_commitlog_position_none(&mut out);
+
+    let max_timestamp = if header.max_timestamp == i64::MAX {
+        header.min_timestamp
+    } else {
+        header.max_timestamp
+    };
+    out.extend_from_slice(&header.min_timestamp.to_be_bytes());
+    out.extend_from_slice(&max_timestamp.to_be_bytes());
+
+    // Cassandra 5 uses unsigned deletion-time ints in this format; -1 marks
+    // no local deletion time.
+    out.extend_from_slice(&(-1_i32).to_be_bytes());
+    out.extend_from_slice(&(-1_i32).to_be_bytes());
+
+    out.extend_from_slice(&header.min_ttl.to_be_bytes());
+    out.extend_from_slice(&0_i32.to_be_bytes());
+    out.extend_from_slice(&compression_ratio.to_be_bytes());
+
+    // Empty TombstoneHistogram: maxBinSize=0, size=0.
+    out.extend_from_slice(&0_i32.to_be_bytes());
+    out.extend_from_slice(&0_i32.to_be_bytes());
+
+    // sstableLevel=0, repairedAt=0.
+    out.extend_from_slice(&0_i32.to_be_bytes());
+    out.extend_from_slice(&0_i64.to_be_bytes());
+
+    // Improved min/max: empty clustering type list and Slice.ALL. With zero
+    // clustering columns this is start kind=INCL_START_BOUND,size=0 and end
+    // kind=INCL_END_BOUND,size=0.
+    out.push(0);
+    out.extend_from_slice(&[0x01, 0x00, 0x00, 0x06, 0x00, 0x00]);
+
+    out.push(0); // hasLegacyCounterShards=false
+    out.extend_from_slice(&(total_columns_set as i64).to_be_bytes());
+    out.extend_from_slice(&(total_rows as i64).to_be_bytes());
+
+    // Commit-log lower bound NONE and an empty interval set.
+    write_commitlog_position_none(&mut out);
+    out.extend_from_slice(&0_i32.to_be_bytes());
+
+    out.push(0); // pendingRepair absent
+    out.push(0); // isTransient=false
+    out.push(0); // originatingHostId absent
+    out.push(0); // hasPartitionLevelDeletions=false
+
+    write_vint_prefixed_bytes(&mut out, first_key);
+    write_vint_prefixed_bytes(&mut out, last_key);
+    out.extend_from_slice(&f64::NAN.to_be_bytes());
+
+    Some(StatsMetadata { data: out })
+}
+
 /// Ordinal 3 — column definitions needed for Data.db delta decoding.
 #[derive(Debug, Clone)]
 pub struct SerializationHeader {
@@ -506,6 +589,42 @@ fn write_vint_prefixed_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
     out.extend_from_slice(bytes);
 }
 
+fn write_commitlog_position_none(out: &mut Vec<u8>) {
+    out.extend_from_slice(&(-1_i64).to_be_bytes());
+    out.extend_from_slice(&0_i32.to_be_bytes());
+}
+
+fn write_estimated_histogram(out: &mut Vec<u8>, bucket_count: usize, count: u64) {
+    assert!(
+        bucket_count >= 2,
+        "estimated histogram needs an overflow bucket"
+    );
+    out.extend_from_slice(&(bucket_count as i32).to_be_bytes());
+
+    let offsets = estimated_histogram_offsets(bucket_count - 1);
+    for i in 0..bucket_count {
+        let offset = offsets[if i == 0 { 0 } else { i - 1 }];
+        let bucket_count = if i == 0 { count as i64 } else { 0 };
+        out.extend_from_slice(&offset.to_be_bytes());
+        out.extend_from_slice(&bucket_count.to_be_bytes());
+    }
+}
+
+fn estimated_histogram_offsets(size: usize) -> Vec<i64> {
+    let mut offsets = Vec::with_capacity(size);
+    let mut last = 1_i64;
+    offsets.push(last);
+    while offsets.len() < size {
+        let mut next = ((last as f64) * 1.2).round() as i64;
+        if next == last {
+            next += 1;
+        }
+        offsets.push(next);
+        last = next;
+    }
+    offsets
+}
+
 // ---------------------------------------------------------------------------
 // Helpers — primitive encoding
 // ---------------------------------------------------------------------------
@@ -763,6 +882,43 @@ mod tests {
         let decoded = read_statistics(&encoded).unwrap();
         assert!(decoded.compaction.data.is_empty());
         assert!(decoded.stats.data.is_empty());
+    }
+
+    #[test]
+    fn simple_bti_stats_metadata_records_key_range_and_counts() {
+        let header = SerializationHeader {
+            min_timestamp: 1_000_000,
+            min_local_deletion_time: i32::MAX,
+            min_ttl: 0,
+            max_timestamp: 1_000_123,
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".into(),
+            clustering_types: vec![],
+            static_columns: vec![],
+            regular_columns: vec![(
+                b"v".to_vec(),
+                "org.apache.cassandra.db.marshal.UTF8Type".into(),
+            )],
+        };
+
+        let stats = build_simple_bti_stats_metadata(&header, b"pk1", b"pk2", 2, 2, 2, 1.0).unwrap();
+
+        assert!(!stats.data.is_empty());
+        assert!(stats.data.ends_with(&[
+            0x03, b'p', b'k', b'1', 0x03, b'p', b'k', b'2', 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+        ]));
+        assert!(stats.data.windows(8).any(|w| w == 2_i64.to_be_bytes()));
+    }
+
+    #[test]
+    fn simple_bti_stats_metadata_declines_clustered_tables() {
+        let mut header = sample_header();
+        header.clustering_types = vec!["org.apache.cassandra.db.marshal.Int32Type".into()];
+
+        assert!(
+            build_simple_bti_stats_metadata(&header, b"a", b"b", 1, 1, 1, 1.0).is_none(),
+            "clustered-table StatsMetadata needs the clustered Slice serializer"
+        );
     }
 
     // -- CRC validation --

--- a/ferrosa-sstable/src/writer.rs
+++ b/ferrosa-sstable/src/writer.rs
@@ -34,8 +34,8 @@ use crate::bloom::BloomFilter;
 use crate::byte_comparable;
 use crate::compression::{Compression, CompressionInfo};
 use crate::statistics::{
-    write_statistics, CompactionMetadata, SerializationHeader, Statistics, StatsMetadata,
-    ValidationMetadata,
+    build_simple_bti_stats_metadata, write_statistics, CompactionMetadata, SerializationHeader,
+    Statistics, StatsMetadata, ValidationMetadata,
 };
 use crate::toc;
 use crate::trie::builder::{TrieBuilder, TriePayload};
@@ -135,6 +135,10 @@ pub struct SSTableWriter {
     first_key: Option<Vec<u8>>,
     /// Last partition key bytes (for key bounds footer).
     last_key: Option<Vec<u8>>,
+    /// Number of rows written to Data.db.
+    total_rows: u64,
+    /// Number of regular/static cells written to Data.db.
+    total_columns_set: u64,
 }
 
 impl SSTableWriter {
@@ -152,6 +156,8 @@ impl SSTableWriter {
             partition_count: 0,
             first_key: None,
             last_key: None,
+            total_rows: 0,
+            total_columns_set: 0,
         }
     }
 
@@ -214,6 +220,16 @@ impl SSTableWriter {
         }
         self.last_key = Some(partition.key.key.as_bytes().to_vec());
         self.partition_count += 1;
+        self.total_rows += partition.rows.len() as u64;
+        self.total_columns_set += partition
+            .static_row
+            .as_ref()
+            .map_or(0, |row| row.cells.len() as u64);
+        self.total_columns_set += partition
+            .rows
+            .iter()
+            .map(|row| row.cells.len() as u64)
+            .sum::<u64>();
 
         Ok(())
     }
@@ -223,6 +239,8 @@ impl SSTableWriter {
         let first_key = self.first_key.clone().unwrap_or_default();
         let last_key = self.last_key.clone().unwrap_or_default();
         let partition_count = self.partition_count;
+        let total_rows = self.total_rows;
+        let total_columns_set = self.total_columns_set;
         let bloom_fp_chance = self.options.bloom_fp_chance;
         let has_compression = self.options.compression.is_some()
             && !matches!(self.options.compression, Some(Compression::None));
@@ -237,7 +255,15 @@ impl SSTableWriter {
         let filter = self.bloom.write();
 
         // 3. Build statistics -> Statistics.db
-        let statistics = Self::build_statistics_db(&self.header, bloom_fp_chance);
+        let statistics = Self::build_statistics_db(
+            &self.header,
+            bloom_fp_chance,
+            &first_key,
+            &last_key,
+            partition_count,
+            total_rows,
+            total_columns_set,
+        );
 
         // 4. Optionally compress data chunks -> Data.db + CompressionInfo.db
         let (data, compression_info) = Self::build_data_db(self.data_buf, &self.options)?;
@@ -533,7 +559,8 @@ impl SSTableWriter {
             self.data_buf.push(extended_flags);
         }
 
-        // Clustering key (not for static rows)
+        // Clustering key (not for static rows and absent for schemas with
+        // no clustering columns).
         //
         // Cassandra 5.x ClusteringPrefix format:
         //   header varint (0 = all non-null/non-empty) + per-component value bytes.
@@ -543,10 +570,10 @@ impl SSTableWriter {
         // For multi-column CK, the CQL bridge encodes as u16-prefixed
         // per-component: [u16 len][bytes][u16 len][bytes]...
         // We must extract each component and write it in BTI format.
-        if !is_static {
+        let num_ck = self.header.clustering_types.len();
+        if !is_static && num_ck > 0 {
             push_unsigned_vint_to(&mut self.data_buf, 0); // header: all non-null, non-empty
 
-            let num_ck = self.header.clustering_types.len();
             if num_ck == 1 {
                 // Single CK column: raw bytes (no u16 prefix).
                 let type_name = &self.header.clustering_types[0];
@@ -566,7 +593,6 @@ impl SSTableWriter {
                     self.data_buf.extend_from_slice(component);
                 }
             }
-            // num_ck == 0: no clustering columns — header varint only, no data.
         }
 
         // Serialize the row body to a temporary buffer to compute its size.
@@ -603,26 +629,19 @@ impl SSTableWriter {
             push_unsigned_vint_to(&mut row_body, ldt_delta);
         }
 
-        // Missing-column bitmap (only if not HAS_ALL_COLUMNS)
+        // Missing-column subset (only if not HAS_ALL_COLUMNS). Cassandra's
+        // Columns.Serializer writes an unsigned vint, not a raw MSB-first
+        // bitmap: for <64 columns, bit i set means column i is missing.
         if flags & HAS_ALL_COLUMNS == 0 {
-            let bitmap_bytes = num_columns.div_ceil(8);
-            let mut bitmap = vec![0u8; bitmap_bytes];
-            // Mark present columns (bit set = present)
-            let present_set: std::collections::HashSet<usize> =
+            let present_columns: Vec<usize> =
                 row.cells.iter().map(|(idx, _)| *idx as usize).collect();
-            for i in 0..num_columns {
-                if present_set.contains(&i) {
-                    let byte_idx = i / 8;
-                    let bit_idx = 7 - (i % 8);
-                    bitmap[byte_idx] |= 1 << bit_idx;
-                }
-            }
-            row_body.extend_from_slice(&bitmap);
+            write_columns_subset(&mut row_body, &present_columns, num_columns);
         }
 
         // Cells
-        for (_, cell) in &row.cells {
-            serialize_cell(&mut row_body, cell, row, &self.header);
+        for (col_idx, cell) in &row.cells {
+            let column_type = &column_defs[*col_idx as usize].1;
+            serialize_cell(&mut row_body, cell, row, &self.header, column_type);
         }
 
         // Write row body size + previous unfiltered size + row body
@@ -669,14 +688,31 @@ impl SSTableWriter {
     }
 
     /// Build Statistics.db.
-    fn build_statistics_db(header: &SerializationHeader, bloom_fp_chance: f64) -> Vec<u8> {
+    fn build_statistics_db(
+        header: &SerializationHeader,
+        bloom_fp_chance: f64,
+        first_key: &[u8],
+        last_key: &[u8],
+        partition_count: u64,
+        total_rows: u64,
+        total_columns_set: u64,
+    ) -> Vec<u8> {
         let stats = Statistics {
             validation: ValidationMetadata {
                 partitioner_class: "org.apache.cassandra.dht.Murmur3Partitioner".into(),
                 bloom_fp_chance,
             },
             compaction: CompactionMetadata { data: vec![] },
-            stats: StatsMetadata { data: vec![] },
+            stats: build_simple_bti_stats_metadata(
+                header,
+                first_key,
+                last_key,
+                partition_count,
+                total_rows,
+                total_columns_set,
+                1.0,
+            )
+            .unwrap_or_else(|| StatsMetadata { data: vec![] }),
             header: header.clone(),
         };
         write_statistics(&stats)
@@ -760,6 +796,7 @@ fn serialize_cell(
     cell: &CellValue,
     row: &crate::types::Row,
     header: &SerializationHeader,
+    column_type: &str,
 ) {
     let is_tombstone = cell.is_tombstone();
     let is_expiring = !is_tombstone
@@ -834,7 +871,15 @@ fn serialize_cell(
                  this is a bug in the write path, not user data",
                 value.len()
             );
-            push_unsigned_vint_to(buf, value.len() as u64);
+            if let Some(fixed_len) = crate::marshal::value_length_if_fixed(column_type) {
+                assert!(
+                    value.len() == fixed_len,
+                    "SSTable writer: fixed-width column {column_type} expects {fixed_len} bytes, got {}",
+                    value.len()
+                );
+            } else {
+                push_unsigned_vint_to(buf, value.len() as u64);
+            }
             buf.extend_from_slice(value);
         }
     }
@@ -845,6 +890,39 @@ fn push_unsigned_vint_to(buf: &mut Vec<u8>, value: u64) {
     let mut vbuf = [0u8; 9];
     let n = varint::write_unsigned_vint(&mut vbuf, value);
     buf.extend_from_slice(&vbuf[..n]);
+}
+
+fn write_columns_subset(buf: &mut Vec<u8>, present_columns: &[usize], num_columns: usize) {
+    if num_columns < 64 {
+        let mut missing_bitmap = 0u64;
+        let mut present_iter = present_columns.iter().copied().peekable();
+        for idx in 0..num_columns {
+            if present_iter.peek() == Some(&idx) {
+                present_iter.next();
+            } else {
+                missing_bitmap |= 1u64 << idx;
+            }
+        }
+        push_unsigned_vint_to(buf, missing_bitmap);
+        return;
+    }
+
+    let missing_count = num_columns.saturating_sub(present_columns.len());
+    push_unsigned_vint_to(buf, missing_count as u64);
+    if present_columns.len() < num_columns / 2 {
+        for &idx in present_columns {
+            push_unsigned_vint_to(buf, idx as u64);
+        }
+    } else {
+        let mut present_iter = present_columns.iter().copied().peekable();
+        for idx in 0..num_columns {
+            if present_iter.peek() == Some(&idx) {
+                present_iter.next();
+            } else {
+                push_unsigned_vint_to(buf, idx as u64);
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1847,6 +1925,138 @@ mod tests {
             "key bounds last={:?} should match token-sorted last={:?}",
             last_key, write_last
         );
+    }
+
+    #[test]
+    fn writer_serializes_sparse_columns_as_cassandra_subset_vint() {
+        let header = SerializationHeader {
+            min_timestamp: 1_000,
+            min_local_deletion_time: i32::MAX,
+            min_ttl: 0,
+            max_timestamp: i64::MAX,
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".into(),
+            clustering_types: vec![],
+            static_columns: vec![],
+            regular_columns: vec![
+                (
+                    b"v_text".to_vec(),
+                    "org.apache.cassandra.db.marshal.UTF8Type".into(),
+                ),
+                (
+                    b"v_int".to_vec(),
+                    "org.apache.cassandra.db.marshal.Int32Type".into(),
+                ),
+            ],
+        };
+        let options = WriteOptions {
+            compression: None,
+            bloom_fp_chance: 0.01,
+            chunk_size: 65536,
+            verify_output: true,
+        };
+        let partition = Partition {
+            key: DecoratedKey::new(PartitionKey::from(b"pk1".as_slice())),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![Row {
+                clustering: vec![],
+                cells: vec![(0, CellValue::live(b"hello".to_vec(), 1_005))],
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::with_timestamp(1_005),
+            }],
+        };
+
+        let mut writer = SSTableWriter::new(options, header);
+        writer.add_partition(&partition).unwrap();
+        let output = writer.finish().unwrap();
+
+        let data = output.data.as_slice();
+        let mut pos = 2 + b"pk1".len() + 1;
+        let flags = data[pos];
+        pos += 1;
+        assert_eq!(flags & HAS_ALL_COLUMNS, 0);
+
+        let (row_body_len, n) = varint::read_unsigned_vint_at(&data, pos as u64).unwrap();
+        assert!(
+            row_body_len > 0,
+            "tables without clustering columns must not serialize an empty clustering prefix before the row body length"
+        );
+        pos += n;
+        let (_prev_size, n) = varint::read_unsigned_vint_at(&data, pos as u64).unwrap();
+        pos += n;
+        let (timestamp_delta, n) = varint::read_unsigned_vint_at(&data, pos as u64).unwrap();
+        assert_eq!(timestamp_delta, 5);
+        pos += n;
+
+        let (columns_subset, _) = varint::read_unsigned_vint_at(&data, pos as u64).unwrap();
+        assert_eq!(
+            columns_subset, 0b10,
+            "Cassandra Columns.Serializer encodes bit i=1 as column i missing"
+        );
+    }
+
+    #[test]
+    fn writer_serializes_fixed_width_cells_without_value_length_prefix() {
+        let header = SerializationHeader {
+            min_timestamp: 1_000,
+            min_local_deletion_time: i32::MAX,
+            min_ttl: 0,
+            max_timestamp: i64::MAX,
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".into(),
+            clustering_types: vec![],
+            static_columns: vec![],
+            regular_columns: vec![
+                (
+                    b"v_int".to_vec(),
+                    "org.apache.cassandra.db.marshal.Int32Type".into(),
+                ),
+                (
+                    b"v_text".to_vec(),
+                    "org.apache.cassandra.db.marshal.UTF8Type".into(),
+                ),
+            ],
+        };
+        let options = WriteOptions {
+            compression: None,
+            bloom_fp_chance: 0.01,
+            chunk_size: 65536,
+            verify_output: true,
+        };
+        let partition = Partition {
+            key: DecoratedKey::new(PartitionKey::from(b"pk2".as_slice())),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![Row {
+                clustering: vec![],
+                cells: vec![(0, CellValue::live(42i32.to_be_bytes().to_vec(), 1_005))],
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::with_timestamp(1_005),
+            }],
+        };
+
+        let mut writer = SSTableWriter::new(options, header);
+        writer.add_partition(&partition).unwrap();
+        let output = writer.finish().unwrap();
+
+        let data = output.data.as_slice();
+        let mut pos = 2 + b"pk2".len() + 1;
+        let flags = data[pos];
+        pos += 1;
+        assert_eq!(flags & HAS_ALL_COLUMNS, 0);
+
+        let (_row_body_len, n) = varint::read_unsigned_vint_at(&data, pos as u64).unwrap();
+        pos += n;
+        let (_prev_size, n) = varint::read_unsigned_vint_at(&data, pos as u64).unwrap();
+        pos += n;
+        let (timestamp_delta, n) = varint::read_unsigned_vint_at(&data, pos as u64).unwrap();
+        assert_eq!(timestamp_delta, 5);
+        pos += n;
+        let (columns_subset, n) = varint::read_unsigned_vint_at(&data, pos as u64).unwrap();
+        assert_eq!(columns_subset, 0b10);
+        pos += n;
+        assert_eq!(data[pos], CELL_USE_ROW_TIMESTAMP);
+        pos += 1;
+        assert_eq!(&data[pos..pos + 4], &42i32.to_be_bytes());
     }
 
     /// RED TEST: A partition with a row whose deletion timestamp is lower

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -1616,6 +1616,10 @@ impl StorageEngine {
         schema: TableSchema,
         indexed_columns: Vec<(String, usize)>,
     ) -> ferrosa_common::Result<TableState> {
+        if let Some(warning) = schema.legacy_storage_column_order_warning() {
+            tracing::warn!("{warning}");
+        }
+
         let table_id = TableId::new(&schema.keyspace, &schema.table);
         let table_dir = config.data_dir.join("sstables").join(table_id.to_string());
         std::fs::create_dir_all(&table_dir).map_err(|e| {
@@ -1904,9 +1908,128 @@ impl StorageEngine {
     /// generation number descending) and the two vecs are parallel — position `i`
     /// in `sidecars` is the sidecar map for the SSTable at position `i`.
     ///
-    /// SSTables that fail to open are silently skipped — a corrupted SSTable is
-    /// better handled at compaction time than at startup. Sidecar files that fail
-    /// to open are replaced with empty maps (degraded: full scan fallback).
+    #[cfg(test)]
+    const TEST_FAIL_PROMOTION_AFTER_FIRST_COMPONENT: &str =
+        ".test-promotion-fail-after-first-component";
+
+    fn should_fail_promotion_after_first_component(_output_dir: &std::path::Path) -> bool {
+        #[cfg(test)]
+        {
+            _output_dir
+                .join(Self::TEST_FAIL_PROMOTION_AFTER_FIRST_COMPONENT)
+                .exists()
+        }
+        #[cfg(not(test))]
+        {
+            false
+        }
+    }
+
+    fn temp_promotion_directory(
+        target_dir: &std::path::Path,
+        promoted_gen: u64,
+    ) -> std::path::PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|time| time.as_nanos())
+            .unwrap_or(0);
+        target_dir.join(format!(".promote-{promoted_gen}-{suffix}"))
+    }
+
+    fn generation_dir_path(table_dir: &std::path::Path, gen: u64) -> Option<std::path::PathBuf> {
+        let gen_str = gen.to_string();
+        let generation_dir = table_dir.join(&gen_str);
+        if generation_dir.exists() && generation_dir.join(format!("{gen_str}-Data.db")).exists() {
+            Some(generation_dir)
+        } else {
+            let flat = table_dir.join(format!("{gen_str}-Data.db"));
+            if flat.exists() {
+                Some(table_dir.to_path_buf())
+            } else {
+                None
+            }
+        }
+    }
+
+    fn generation_component_path(
+        table_dir: &std::path::Path,
+        gen: &str,
+        component: &str,
+    ) -> Option<std::path::PathBuf> {
+        if let Some(dir) = Self::generation_dir_path(table_dir, gen.parse::<u64>().ok()?) {
+            let path = dir.join(format!("{gen}-{component}"));
+            if path.exists() {
+                return Some(path);
+            }
+        }
+
+        let flat = table_dir.join(format!("{gen}-{component}"));
+        if flat.exists() {
+            Some(flat)
+        } else {
+            None
+        }
+    }
+
+    fn quarantine_generation(
+        table_dir: &std::path::Path,
+        gen: u64,
+        quarantine_dir: &std::path::Path,
+    ) -> ferrosa_common::Result<()> {
+        let gen_str = gen.to_string();
+        let source_dir =
+            Self::generation_dir_path(table_dir, gen).unwrap_or_else(|| table_dir.to_path_buf());
+        let prefix = format!("{gen_str}-");
+
+        for entry in std::fs::read_dir(&source_dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+        {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with(&prefix) {
+                let dest = quarantine_dir.join(&*name);
+                std::fs::rename(entry.path(), dest).map_err(|e| {
+                    ferrosa_common::Error::InvalidFormat(format!(
+                        "failed to quarantine stale SSTable generation file {}: {e}",
+                        entry.path().display()
+                    ))
+                })?;
+            }
+        }
+
+        if source_dir != *table_dir {
+            let _ = std::fs::remove_dir(&source_dir);
+        }
+
+        Ok(())
+    }
+
+    fn generation_component_paths(
+        table_dir: &std::path::Path,
+        gen: u64,
+    ) -> Vec<std::path::PathBuf> {
+        let mut out = Vec::new();
+        if let Some(dir) = Self::generation_dir_path(table_dir, gen) {
+            for component in [
+                "Data.db",
+                "Partitions.db",
+                "Rows.db",
+                "Filter.db",
+                "Statistics.db",
+                "TOC.txt",
+                "CompressionInfo.db",
+            ] {
+                let path = dir.join(format!("{}-{component}", gen));
+                if path.exists() {
+                    out.push(path);
+                }
+            }
+        }
+        out
+    }
+
     fn load_existing_sstables_and_sidecars(
         table_dir: &std::path::Path,
     ) -> (
@@ -1915,19 +2038,33 @@ impl StorageEngine {
         Vec<(String, std::path::PathBuf)>,
     ) {
         // Collect all generation numbers by looking for Data.db files.
-        let mut generations: Vec<u64> = std::fs::read_dir(table_dir)
-            .into_iter()
-            .flatten()
-            .filter_map(|e| e.ok())
-            .filter_map(|e| {
-                let name = e.file_name().to_str()?.to_string();
+        let mut generations: Vec<u64> = {
+            let mut values = std::collections::HashSet::new();
+
+            for entry in std::fs::read_dir(table_dir).into_iter().flatten().flatten() {
+                let name = entry.file_name().to_string_lossy().into_owned();
                 if name.ends_with("-Data.db") {
-                    name.split('-').next()?.parse::<u64>().ok()
-                } else {
-                    None
+                    if let Some(gen) = name.split('-').next().and_then(|v| v.parse::<u64>().ok()) {
+                        values.insert(gen);
+                    }
+                    continue;
                 }
-            })
-            .collect();
+
+                if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                    if let Ok(gen) = name.parse::<u64>() {
+                        if table_dir
+                            .join(gen.to_string())
+                            .join(format!("{gen}-Data.db"))
+                            .exists()
+                        {
+                            values.insert(gen);
+                        }
+                    }
+                }
+            }
+
+            values.into_iter().collect()
+        };
 
         // Sort descending — newest generation first.
         generations.sort_by(|a, b| b.cmp(a));
@@ -1950,7 +2087,8 @@ impl StorageEngine {
             let critical_components = ["Data.db", "Partitions.db"];
             let mut quarantine = false;
             for comp in &critical_components {
-                let path = table_dir.join(format!("{gen_str}-{comp}"));
+                let path = Self::generation_component_path(table_dir, &gen_str, comp)
+                    .unwrap_or_else(|| table_dir.join(format!("{gen_str}-{comp}")));
                 match std::fs::metadata(&path) {
                     Ok(meta) if meta.len() == 0 => {
                         tracing::error!(
@@ -1971,13 +2109,8 @@ impl StorageEngine {
                 // Move to quarantine subdirectory.
                 let quarantine_dir = table_dir.join("quarantine");
                 let _ = std::fs::create_dir_all(&quarantine_dir);
-                for entry in std::fs::read_dir(table_dir).into_iter().flatten().flatten() {
-                    let name = entry.file_name();
-                    let name_str = name.to_string_lossy();
-                    if name_str.starts_with(&format!("{gen_str}-")) {
-                        let dest = quarantine_dir.join(&*name);
-                        let _ = std::fs::rename(entry.path(), dest);
-                    }
+                if let Err(e) = Self::quarantine_generation(table_dir, gen, &quarantine_dir) {
+                    tracing::warn!(%e, gen, "storage-engine: failed to quarantine stale SSTable generation");
                 }
                 quarantined_count += 1;
                 continue;
@@ -2026,7 +2159,9 @@ impl StorageEngine {
 
         let mut sidecars = HashMap::new();
 
-        let entries = match std::fs::read_dir(table_dir) {
+        let dir =
+            Self::generation_dir_path(table_dir, gen).unwrap_or_else(|| table_dir.to_path_buf());
+        let entries = match std::fs::read_dir(&dir) {
             Ok(e) => e,
             Err(_) => return sidecars,
         };
@@ -2579,18 +2714,54 @@ impl StorageEngine {
 
         let (task_tx, task_rx) = std::sync::mpsc::sync_channel(config.channel_capacity);
         let target_table_id = TableId::new(&schema.keyspace, &config.target_table);
-        let target_timestamp_unit = self
-            .tables
-            .read()
-            .get(&target_table_id)
+        let target_tables = self.tables.read();
+        let target_state = target_tables.get(&target_table_id);
+        let target_timestamp_unit = target_state
             .map(TableState::time_series_timestamp_unit)
             .unwrap_or(source_timestamp_unit);
+        let target_result_column_indices = if let Some(target_state) = target_state {
+            let mut target_indices_by_name = HashMap::new();
+            for (idx, column) in target_state
+                .schema
+                .static_columns
+                .iter()
+                .chain(target_state.schema.regular_columns.iter())
+                .enumerate()
+            {
+                target_indices_by_name.insert(column.name.as_str(), idx as u16);
+            }
+
+            let mut indices = Vec::with_capacity(config.columns.len() * config.functions.len());
+            for source_column in &config.columns {
+                for function in &config.functions {
+                    let Some(suffix) = function.output_suffix() else {
+                        continue;
+                    };
+                    let output_column = format!("{source_column}_{suffix}");
+                    let Some(&column_index) = target_indices_by_name.get(output_column.as_str())
+                    else {
+                        return Err(ferrosa_common::Error::InvalidFormat(format!(
+                            "invalid consolidation extensions for {table_id}: target table \
+                             '{target_table_id}' is missing rollup output column '{output_column}'"
+                        )));
+                    };
+                    indices.push(column_index);
+                }
+            }
+            indices
+        } else {
+            (0..config.columns.len() * config.functions.len())
+                .map(|idx| idx as u16)
+                .collect()
+        };
+        drop(target_tables);
         let target = MaterializationTarget {
             source_table: table_id.clone(),
             target_table: target_table_id,
             interval: config.interval,
             source_columns: config.columns.clone(),
             functions: config.functions.clone(),
+            target_result_column_indices,
             target_timestamp_unit,
         };
         let source_column_count = value_column_indices.len();
@@ -4291,12 +4462,41 @@ impl StorageEngine {
         use ferrosa_sstable::io::FileReadAt;
         use ferrosa_sstable::reader::SSTableComponents;
 
-        let data = FileReadAt::open(dir.join(format!("{gen}-Data.db")))?;
-        let partitions = FileReadAt::open(dir.join(format!("{gen}-Partitions.db")))?;
-        let rows = FileReadAt::open(dir.join(format!("{gen}-Rows.db")))?;
-        let filter = std::fs::read(dir.join(format!("{gen}-Filter.db")))?;
-        let statistics = std::fs::read(dir.join(format!("{gen}-Statistics.db")))?;
-        let compression_info = std::fs::read(dir.join(format!("{gen}-CompressionInfo.db"))).ok();
+        let data = Self::generation_component_path(dir, gen, "Data.db").ok_or_else(|| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "missing required Data.db for sstable generation {gen} in {}",
+                dir.display()
+            ))
+        })?;
+        let data = FileReadAt::open(data)?;
+
+        let partitions =
+            Self::generation_component_path(dir, gen, "Partitions.db").ok_or_else(|| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "missing required Partitions.db for sstable generation {gen} in {}",
+                    dir.display()
+                ))
+            })?;
+        let partitions = FileReadAt::open(partitions)?;
+
+        let rows = Self::generation_component_path(dir, gen, "Rows.db").ok_or_else(|| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "missing required Rows.db for sstable generation {gen} in {}",
+                dir.display()
+            ))
+        })?;
+        let rows = FileReadAt::open(rows)?;
+
+        let filter = Self::generation_component_path(dir, gen, "Filter.db")
+            .and_then(|p| std::fs::read(p).ok())
+            .unwrap_or_default();
+
+        let statistics = Self::generation_component_path(dir, gen, "Statistics.db")
+            .and_then(|p| std::fs::read(p).ok())
+            .unwrap_or_default();
+
+        let compression_info = Self::generation_component_path(dir, gen, "CompressionInfo.db")
+            .and_then(|p| std::fs::read(p).ok());
 
         ferrosa_sstable::reader::SSTableReader::open(SSTableComponents {
             data,
@@ -4477,9 +4677,9 @@ impl StorageEngine {
         ];
         suffixes
             .iter()
-            .map(|s| {
-                let p = table_dir.join(format!("{gen}-{s}"));
-                std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0)
+            .filter_map(|s| {
+                Self::generation_component_path(table_dir, &gen.to_string(), s)
+                    .and_then(|p| std::fs::metadata(&p).ok().map(|m| m.len()))
             })
             .sum()
     }
@@ -4496,7 +4696,9 @@ impl StorageEngine {
             "CompressionInfo.db",
         ];
         for s in &suffixes {
-            let _ = std::fs::remove_file(table_dir.join(format!("{gen}-{s}")));
+            if let Some(path) = Self::generation_component_path(table_dir, gen, s) {
+                let _ = std::fs::remove_file(path);
+            }
         }
     }
 
@@ -4951,19 +5153,35 @@ impl StorageEngine {
 
     /// Scan a table directory for SSTable generation numbers.
     fn scan_generations(table_dir: &std::path::Path) -> Vec<u64> {
-        std::fs::read_dir(table_dir)
-            .into_iter()
-            .flatten()
-            .filter_map(|e| e.ok())
-            .filter_map(|e| {
-                let name = e.file_name().to_str()?.to_string();
-                if name.ends_with("-Data.db") {
-                    name.split('-').next()?.parse::<u64>().ok()
-                } else {
-                    None
+        let mut generations = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+
+        for entry in std::fs::read_dir(table_dir).into_iter().flatten().flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.ends_with("-Data.db") {
+                if let Some(gen) = name.split('-').next().and_then(|v| v.parse::<u64>().ok()) {
+                    if seen.insert(gen) {
+                        generations.push(gen);
+                    }
                 }
-            })
-            .collect()
+                continue;
+            }
+
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                if let Ok(gen) = name.parse::<u64>() {
+                    if table_dir
+                        .join(&name)
+                        .join(format!("{name}-Data.db"))
+                        .exists()
+                        && seen.insert(gen)
+                    {
+                        generations.push(gen);
+                    }
+                }
+            }
+        }
+
+        generations
     }
 
     fn promote_compaction_output(
@@ -4995,7 +5213,17 @@ impl StorageEngine {
         let promoted_gen = table_max_gen.max(output_gen).saturating_add(1);
         let promoted_id = promoted_gen.to_string();
         let old_prefix = format!("{}-", output.id);
+        let final_target = target_dir.join(&promoted_id);
+        let fail_after_first = Self::should_fail_promotion_after_first_component(&output.path);
 
+        if final_target.exists() {
+            return Err(ferrosa_common::Error::InvalidFormat(format!(
+                "promoted compaction target already exists: {}",
+                final_target.display()
+            )));
+        }
+
+        let staging_dir = Self::temp_promotion_directory(&target_dir, promoted_gen);
         let mut moves = Vec::new();
         for entry in std::fs::read_dir(source_dir).map_err(|e| {
             ferrosa_common::Error::InvalidFormat(format!(
@@ -5014,14 +5242,17 @@ impl StorageEngine {
             let Some(component_suffix) = name.strip_prefix(&old_prefix) else {
                 continue;
             };
-            let target = target_dir.join(format!("{promoted_id}-{component_suffix}"));
+            if component_suffix.is_empty() {
+                continue;
+            }
+            let target = staging_dir.join(format!("{promoted_id}-{component_suffix}"));
             if target.exists() {
                 return Err(ferrosa_common::Error::InvalidFormat(format!(
                     "promoted compaction target already exists: {}",
                     target.display()
                 )));
             }
-            moves.push((entry.path(), target));
+            moves.push((entry.path(), target, component_suffix.to_string()));
         }
 
         if moves.is_empty() {
@@ -5031,25 +5262,86 @@ impl StorageEngine {
             )));
         }
 
-        for (source, target) in &moves {
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        std::fs::create_dir_all(&staging_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to create compaction promotion staging dir {}: {e}",
+                staging_dir.display()
+            ))
+        })?;
+
+        let rollback_moved = |moved: &[(std::path::PathBuf, std::path::PathBuf)]| {
+            for (source, target) in moved.iter().rev() {
+                if target.exists() {
+                    let _ = std::fs::rename(target, source);
+                }
+            }
+            let _ = std::fs::remove_dir_all(&staging_dir);
+        };
+
+        let mut moved = Vec::new();
+        for (source, target, component_suffix) in &moves {
+            let bytes = std::fs::metadata(source).map(|m| m.len()).map_err(|e| {
+                let err = ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to inspect compaction component {} before promotion: {e}",
+                    source.display()
+                ));
+                rollback_moved(&moved);
+                err
+            })?;
+            if bytes == 0 && matches!(component_suffix.as_str(), "Data.db" | "Partitions.db") {
+                rollback_moved(&moved);
+                return Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "refusing to promote compaction component {}: critical component is zero bytes",
+                    source.display()
+                )));
+            }
+
             std::fs::rename(source, target).map_err(|e| {
-                ferrosa_common::Error::InvalidFormat(format!(
-                    "failed to promote compaction component {} to {}: {e}",
+                let err = ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to stage compaction component {} to {}: {e}",
                     source.display(),
                     target.display()
-                ))
+                ));
+                rollback_moved(&moved);
+                err
             })?;
-        }
-        let _ = std::fs::remove_dir(source_dir);
+            moved.push((source.clone(), target.clone()));
 
-        let size_bytes = moves
+            if fail_after_first && moved.len() == 1 {
+                rollback_moved(&moved);
+                return Err(ferrosa_common::Error::InvalidFormat(
+                    "simulated failure after first compaction component stage".to_string(),
+                ));
+            }
+        }
+
+        if final_target.exists() {
+            rollback_moved(&moved);
+            return Err(ferrosa_common::Error::InvalidFormat(format!(
+                "promoted compaction target already exists: {}",
+                final_target.display()
+            )));
+        }
+
+        std::fs::rename(&staging_dir, &final_target).map_err(|e| {
+            rollback_moved(&moved);
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to atomically promote compaction output to {}: {e}",
+                final_target.display()
+            ))
+        })?;
+
+        let _ = std::fs::remove_dir_all(source_dir);
+
+        let size_bytes = Self::generation_component_paths(&final_target, promoted_gen)
             .iter()
-            .filter_map(|(_, target)| std::fs::metadata(target).ok().map(|m| m.len()))
+            .filter_map(|p| std::fs::metadata(p).ok().map(|m| m.len()))
             .sum();
 
         let mut promoted = output.clone();
         promoted.id = promoted_id;
-        promoted.path = target_dir;
+        promoted.path = final_target;
         promoted.size_bytes = size_bytes;
         Ok(promoted)
     }
@@ -5066,7 +5358,8 @@ impl StorageEngine {
         ];
         for input in inputs {
             for component in &standard_components {
-                let file_path = input.path.join(format!("{}-{component}", input.id));
+                let file_path = Self::generation_component_path(&input.path, &input.id, component)
+                    .unwrap_or_else(|| input.path.join(format!("{}-{component}", input.id)));
                 let _ = std::fs::remove_file(&file_path);
             }
         }
@@ -5078,7 +5371,9 @@ impl StorageEngine {
         gen: u64,
     ) -> Vec<crate::upload::manager::SstableComponentFile> {
         let gen_str = gen.to_string();
-        std::fs::read_dir(table_dir)
+        let dir =
+            Self::generation_dir_path(table_dir, gen).unwrap_or_else(|| table_dir.to_path_buf());
+        std::fs::read_dir(&dir)
             .into_iter()
             .flatten()
             .filter_map(|e| e.ok())
@@ -5655,19 +5950,19 @@ mod tests {
             data: from_hex(CASSANDRA_COMPACTION_METADATA_HEX),
         };
 
-        // Replace the template StatsMetadata blob, then fix its tail.
-        // The last 12 bytes of CASSANDRA_STATS_METADATA_HEX are:
-        //   vint32(1)+"a" + vint32(1)+"b" + NaN_f64 (8 bytes)
-        // — keys from the SSTable the blob was extracted from.  Strip those and
-        // append the correct firstKey, lastKey, and tokenSpaceCoverage=NaN.
-        let mut stats_bytes = from_hex(CASSANDRA_STATS_METADATA_HEX);
-        stats_bytes.truncate(stats_bytes.len() - 12);
-        append_vint_prefixed_key(&mut stats_bytes, &first_key);
-        append_vint_prefixed_key(&mut stats_bytes, &last_key);
-        // tokenSpaceCoverage: NaN (f64 quiet NaN, big-endian)
-        stats_bytes.extend_from_slice(&[0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        if stats.stats.data.is_empty() {
+            // Legacy clustered-table fallback: replace the empty StatsMetadata
+            // blob, then fix its key-range tail. New no-clustering SSTables are
+            // expected to carry writer-produced metadata, and this path must not
+            // overwrite it with a clustered-table template.
+            let mut stats_bytes = from_hex(CASSANDRA_STATS_METADATA_HEX);
+            stats_bytes.truncate(stats_bytes.len() - 12);
+            append_vint_prefixed_key(&mut stats_bytes, &first_key);
+            append_vint_prefixed_key(&mut stats_bytes, &last_key);
+            stats_bytes.extend_from_slice(&[0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
-        stats.stats = StatsMetadata { data: stats_bytes };
+            stats.stats = StatsMetadata { data: stats_bytes };
+        }
 
         let patched = write_statistics(&stats);
         std::fs::write(&stats_path, patched).expect("write patched Statistics.db");
@@ -5680,7 +5975,7 @@ mod tests {
     /// ("da" is the BTI version prefix; "bti" is the format name.)
     /// This function:
     ///   1. Scans `src_dir` for files matching `{gen}-*.db` / `{gen}-*.txt`
-    ///   2. Copies them to `dst_dir` with `da-{gen}-bti-` prefix
+    ///   2. Copies them to `dst_dir` with a Cassandra-local `da-1-bti-` prefix
     ///   3. Rewrites the TOC.txt content to list the new filenames
     ///
     /// Returns the destination directory path.
@@ -5695,12 +5990,13 @@ mod tests {
             let src_path = entry.path();
             let fname = src_path.file_name().unwrap().to_str().unwrap().to_string();
 
-            // Split "{gen}-{Component}" → prefix = "da-{gen}-bti-{Component}"
-            // "da" is the BTI version string; "bti" is the format name.
+            // Split "{gen}-{Component}" and rewrite to a compact Cassandra
+            // descriptor generation. Ferrosa generations are node/timestamp
+            // sized; Cassandra import discovers normal BTI descriptors such as
+            // `da-1-bti-Data.db`.
             let cassandra_fname = if let Some(dash_pos) = fname.find('-') {
-                let gen = &fname[..dash_pos];
                 let component = &fname[dash_pos + 1..];
-                format!("da-{gen}-bti-{component}")
+                format!("da-1-bti-{component}")
             } else {
                 fname.clone()
             };
@@ -10957,7 +11253,6 @@ mod tests {
         let tid_str = tid.to_string();
 
         // Record the paths of all SSTable component files before compaction.
-        // Files are stored flat: {data_dir}/sstables/{table_id}/{gen}-Data.db etc.
         let sstable_dir = dir.path().join("sstables").join(&tid_str);
         let input_files_before: Vec<std::path::PathBuf> = std::fs::read_dir(&sstable_dir)
             .unwrap()
@@ -10977,20 +11272,14 @@ mod tests {
         // consumed: the compaction thread writes files before sending on the
         // channel, so a single poll may miss the result under parallel load.
         let table_compaction_dir = dir.path().join("compaction").join(&tid_str);
-        let mut data_files_after = vec![];
+        let mut generations_after = vec![];
         for _ in 0..40 {
             engine.poll_compactions().await;
-            data_files_after = std::fs::read_dir(&sstable_dir)
-                .unwrap()
-                .filter_map(|e| e.ok())
-                .map(|e| e.path())
-                .filter(|p| p.is_file() && p.extension().map(|e| e == "db").unwrap_or(false))
-                .collect();
+            generations_after = StorageEngine::scan_generations(&sstable_dir);
             let input_files_evicted = input_files_before.iter().all(|path| !path.exists());
-            let promoted_data_file_present = data_files_after.iter().any(|path| {
-                path.file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.ends_with("-Data.db"))
+            let promoted_data_file_present = generations_after.iter().any(|gen| {
+                StorageEngine::generation_component_path(&sstable_dir, &gen.to_string(), "Data.db")
+                    .is_some()
             });
             let staging_drained = table_compaction_dir
                 .read_dir()
@@ -11016,14 +11305,13 @@ mod tests {
 
         // The compacted output must be durable in the normal SSTable directory.
         assert!(
-            data_files_after.iter().any(|path| {
-                path.file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.ends_with("-Data.db"))
+            generations_after.iter().any(|gen| {
+                StorageEngine::generation_component_path(&sstable_dir, &gen.to_string(), "Data.db")
+                    .is_some()
             }),
             "compacted output Data.db should be promoted into {:?}, got {:?}",
             sstable_dir,
-            data_files_after
+            generations_after
         );
 
         let staged_files: Vec<_> = table_compaction_dir
@@ -11037,6 +11325,89 @@ mod tests {
             staged_files.is_empty(),
             "compaction staging dir should be drained after promotion, got {:?}",
             staged_files
+        );
+    }
+
+    #[tokio::test]
+    async fn compaction_promotion_fail_after_first_component_is_atomic_and_recoverable() {
+        let dir = tempfile::tempdir().unwrap();
+        let (engine, _store, _prefix, tid) = make_engine_with_pending_compaction(&dir).await;
+        let tid_str = tid.to_string();
+
+        let sstable_dir = dir.path().join("sstables").join(&tid_str);
+        let pre_generations = StorageEngine::scan_generations(&sstable_dir);
+        assert!(
+            !pre_generations.is_empty(),
+            "setup should have at least one generation before compaction promotion"
+        );
+
+        // Wait for a completed compaction result to appear.
+        let result = {
+            let mut output = None;
+            for _ in 0..120 {
+                let mut results = engine.compaction_executor.poll_results();
+                if let Some(compaction_result) = results.pop() {
+                    output = Some(compaction_result.output);
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            output.expect("compaction executor should produce output")
+        };
+
+        // Inject a synthetic first-component failure during promotion.
+        let marker_path = result
+            .path
+            .join(StorageEngine::TEST_FAIL_PROMOTION_AFTER_FIRST_COMPONENT);
+        std::fs::write(&marker_path, b"1").unwrap();
+
+        let failed = engine.promote_compaction_output(&tid, &result);
+        assert!(
+            failed.is_err(),
+            "promotion should fail with test marker present"
+        );
+
+        // No generation should become visible from a partial promotion.
+        let post_generations = StorageEngine::scan_generations(&sstable_dir);
+        assert_eq!(
+            post_generations, pre_generations,
+            "partial compaction generation must not be discoverable"
+        );
+
+        // Staging artifacts should be absent; the output can be retried from the
+        // original compaction directory.
+        let has_orphaned_stage = std::fs::read_dir(&sstable_dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .any(|entry| entry.file_name().to_string_lossy().starts_with(".promote-"));
+        assert!(
+            !has_orphaned_stage,
+            "simulated partial promotion should not leave orphaned staging directories"
+        );
+
+        std::fs::remove_file(&marker_path).unwrap();
+        let recovered = engine.promote_compaction_output(&tid, &result);
+        assert!(
+            recovered.is_ok(),
+            "promotion should recover from marker-cleared output: {:?}",
+            recovered.err()
+        );
+        let recovered = recovered.unwrap();
+
+        let recovered_generations = StorageEngine::scan_generations(&sstable_dir);
+        let recovered_gen = recovered.id.parse::<u64>().unwrap();
+        assert!(
+            recovered_generations.contains(&recovered_gen),
+            "recovered promotion should materialize a new generation"
+        );
+        assert!(
+            !pre_generations.contains(&recovered_gen),
+            "new generation should not replace preexisting generation IDs"
+        );
+        assert!(
+            !result.path.exists(),
+            "original compaction output directory should be removed after successful promotion"
         );
     }
 
@@ -11181,12 +11552,12 @@ mod tests {
             static_columns: vec![],
             regular_columns: vec![
                 ferrosa_common::schema::ColumnDefinition {
-                    name: "v_text".into(),
-                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".into(),
-                },
-                ferrosa_common::schema::ColumnDefinition {
                     name: "v_int".into(),
                     type_name: "org.apache.cassandra.db.marshal.Int32Type".into(),
+                },
+                ferrosa_common::schema::ColumnDefinition {
+                    name: "v_text".into(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".into(),
                 },
             ],
             extensions: Default::default(),
@@ -11199,7 +11570,7 @@ mod tests {
         let row1 = ferrosa_sstable::types::Row {
             clustering: vec![],
             cells: vec![(
-                0,
+                1,
                 ferrosa_common::cell::CellValue::live(b"hello".to_vec(), 1000),
             )],
             deletion: ferrosa_sstable::types::DeletionTime::LIVE,
@@ -11213,7 +11584,7 @@ mod tests {
         let int_bytes = 42i32.to_be_bytes().to_vec();
         let row2 = ferrosa_sstable::types::Row {
             clustering: vec![],
-            cells: vec![(1, ferrosa_common::cell::CellValue::live(int_bytes, 2000))],
+            cells: vec![(0, ferrosa_common::cell::CellValue::live(int_bytes, 2000))],
             deletion: ferrosa_sstable::types::DeletionTime::LIVE,
             primary_key_liveness: ferrosa_sstable::types::LivenessInfo::with_timestamp(2000),
         };
@@ -11239,12 +11610,12 @@ mod tests {
                     static_columns: vec![],
                     regular_columns: vec![
                         ferrosa_common::schema::ColumnDefinition {
-                            name: "v_text".into(),
-                            type_name: "org.apache.cassandra.db.marshal.UTF8Type".into(),
-                        },
-                        ferrosa_common::schema::ColumnDefinition {
                             name: "v_int".into(),
                             type_name: "org.apache.cassandra.db.marshal.Int32Type".into(),
+                        },
+                        ferrosa_common::schema::ColumnDefinition {
+                            name: "v_text".into(),
+                            type_name: "org.apache.cassandra.db.marshal.UTF8Type".into(),
                         },
                     ],
                     extensions: Default::default(),
@@ -11350,12 +11721,32 @@ mod tests {
             .unwrap_or(false);
         assert!(schema_ok, "failed to create keyspace/table in Cassandra");
 
+        let (manifest, _) = crate::manifest::Manifest::load(store.as_ref(), &prefix)
+            .await
+            .unwrap();
+        let tid_str = tid.to_string();
+        let entries = manifest.sstables.get(&tid_str).cloned().unwrap_or_default();
+        assert_eq!(
+            entries.len(),
+            1,
+            "manifest should contain exactly one promoted compacted SSTable"
+        );
+        let promoted_gen = entries[0].id.clone();
+        let sstable_dir = dir.path().join("sstables").join(&tid_str);
+        let import_source = StorageEngine::generation_dir_path(
+            &sstable_dir,
+            promoted_gen
+                .parse::<u64>()
+                .expect("numeric promoted generation"),
+        )
+        .expect("promoted compaction generation should be visible in SSTable directory");
+
         // ── Step 5: copy SSTable files into container and run nodetool import ──
         // Ferrosa names files `{gen}-Data.db`; Cassandra's SSTableLoader expects
         // the BTI descriptor prefix `da-{gen}-bti-`.  prepare_cassandra_import_dir
         // renames the files and rewrites the TOC.txt.
         let import_staging = dir.path().join("cassandra-import");
-        prepare_cassandra_import_dir(&compaction_dir, &import_staging);
+        prepare_cassandra_import_dir(&import_source, &import_staging);
 
         // Replace ferrosa's empty CompactionMetadata/StatsMetadata with real
         // Cassandra 5 bytes so nodetool import can deserialize Statistics.db.
@@ -11403,8 +11794,46 @@ mod tests {
             .unwrap_or(false);
         assert!(import_ok, "nodetool import failed");
 
-        // ── Step 6: verify rows via SELECT ──
-        let cql_output = Command::new(container_runtime())
+        // ── Step 6: verify rows via exact partition reads and full scan ──
+        let pk1_output = Command::new(container_runtime())
+            .args([
+                "exec",
+                "ferrosa-cassandra-test",
+                "cqlsh",
+                "--execute",
+                "SELECT pk, v_text, v_int FROM test_ks.mixed_cells WHERE pk='pk1';",
+            ])
+            .output()
+            .expect("cqlsh failed");
+
+        let pk1_stdout = String::from_utf8_lossy(&pk1_output.stdout);
+        let pk1_stderr = String::from_utf8_lossy(&pk1_output.stderr);
+
+        assert!(
+            pk1_stdout.contains("pk1") && pk1_stdout.contains("hello"),
+            "Cassandra output missing pk1/v_text row.\nstdout: {pk1_stdout}\nstderr: {pk1_stderr}"
+        );
+
+        let pk2_output = Command::new(container_runtime())
+            .args([
+                "exec",
+                "ferrosa-cassandra-test",
+                "cqlsh",
+                "--execute",
+                "SELECT pk, v_text, v_int FROM test_ks.mixed_cells WHERE pk='pk2';",
+            ])
+            .output()
+            .expect("cqlsh failed");
+
+        let pk2_stdout = String::from_utf8_lossy(&pk2_output.stdout);
+        let pk2_stderr = String::from_utf8_lossy(&pk2_output.stderr);
+
+        assert!(
+            pk2_stdout.contains("pk2") && pk2_stdout.contains("42"),
+            "Cassandra output missing pk2/v_int row.\nstdout: {pk2_stdout}\nstderr: {pk2_stderr}"
+        );
+
+        let scan_output = Command::new(container_runtime())
             .args([
                 "exec",
                 "ferrosa-cassandra-test",
@@ -11413,18 +11842,18 @@ mod tests {
                 "SELECT pk, v_text, v_int FROM test_ks.mixed_cells;",
             ])
             .output()
-            .expect("cqlsh failed");
+            .expect("cqlsh full scan failed");
 
-        let stdout = String::from_utf8_lossy(&cql_output.stdout);
-        let stderr = String::from_utf8_lossy(&cql_output.stderr);
+        let scan_stdout = String::from_utf8_lossy(&scan_output.stdout);
+        let scan_stderr = String::from_utf8_lossy(&scan_output.stderr);
 
         assert!(
-            stdout.contains("pk1") && stdout.contains("hello"),
-            "Cassandra output missing pk1/v_text row.\nstdout: {stdout}\nstderr: {stderr}"
-        );
-        assert!(
-            stdout.contains("pk2") && stdout.contains("42"),
-            "Cassandra output missing pk2/v_int row.\nstdout: {stdout}\nstderr: {stderr}"
+            scan_output.status.success()
+                && scan_stdout.contains("pk1")
+                && scan_stdout.contains("hello")
+                && scan_stdout.contains("pk2")
+                && scan_stdout.contains("42"),
+            "Cassandra full scan must read both imported rows.\nstdout: {scan_stdout}\nstderr: {scan_stderr}"
         );
 
         // Cleanup.
@@ -11467,8 +11896,14 @@ mod tests {
         let prefix = "ferrosa-e2e".to_string();
         let rt = tokio::runtime::Handle::current();
 
-        // Use min_threshold=4 (default STCS) so 4 flushes trigger compaction.
-        let config = StorageEngineConfig::test_config(dir.path());
+        // Use min_threshold=4 and a deliberately wide test bucket so these
+        // tiny fixture SSTables compact as one STCS group. The production
+        // default bucket ratio may correctly split very small files whose
+        // fixed component overhead dominates their logical data size.
+        let mut config = StorageEngineConfig::test_config(dir.path());
+        config.compaction.min_threshold = 4;
+        config.compaction.bucket_low = 0.0;
+        config.compaction.bucket_high = 2.0;
         let engine =
             StorageEngine::new_with_upload_store(config, Arc::clone(&store), prefix.clone(), &rt)
                 .unwrap();
@@ -11491,6 +11926,20 @@ mod tests {
             // flush() calls maybe_compact(); on the 4th flush STCS will submit a task.
         }
 
+        {
+            let tables = engine.tables.read();
+            let state = tables.get(&tid).unwrap();
+            let metadata = engine.collect_sstable_metadata(&tid, state);
+            let strategy = engine.strategy_for_table(state);
+            let selected = strategy.select(&metadata, &state.schema, &tid);
+            assert_eq!(
+                selected.len(),
+                1,
+                "configured STCS bucket should select the four E2E fixture SSTables; sizes={:?}",
+                metadata.iter().map(|m| m.size_bytes).collect::<Vec<_>>()
+            );
+        }
+
         // Wait for the compaction executor background thread to finish.
         let compaction_dir = dir.path().join("compaction");
         for _ in 0..60 {
@@ -11507,7 +11956,23 @@ mod tests {
         }
 
         // ── poll_compactions: upload, manifest update, local eviction ──
-        engine.poll_compactions().await;
+        //
+        // The executor writes compaction components before publishing the
+        // completed result on its channel. A single non-blocking poll can race
+        // that handoff; the production contract is eventual pickup by the
+        // periodic poller, so this test waits for the observable upload.
+        for _ in 0..100 {
+            engine.poll_compactions().await;
+            if engine
+                .compaction_metrics
+                .s3_uploads_total
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 1
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
 
         // Upload confirmed — exactly 1 output SSTable uploaded.
         assert_eq!(
@@ -11541,8 +12006,16 @@ mod tests {
             "manifest should have exactly 1 SSTable entry after STCS compaction"
         );
 
-        // Local input files must be evicted.
+        // Local input files must be evicted while the promoted output remains live.
         let sstable_dir = dir.path().join("sstables").join(&tid_str);
+        let output_gen = entries[0].id.parse::<u64>().expect("numeric output id");
+        let import_source = StorageEngine::generation_dir_path(&sstable_dir, output_gen)
+            .expect("promoted compaction generation should be visible in SSTable directory");
+        assert!(
+            StorageEngine::generation_component_path(&sstable_dir, &entries[0].id, "Data.db")
+                .is_some(),
+            "promoted compacted SSTable Data.db should remain live"
+        );
         if sstable_dir.exists() {
             let remaining_db_files: Vec<_> = std::fs::read_dir(&sstable_dir)
                 .unwrap()
@@ -11621,7 +12094,7 @@ mod tests {
         assert!(schema_ok, "failed to create keyspace/table in Cassandra");
 
         let import_staging = dir.path().join("cassandra-import");
-        prepare_cassandra_import_dir(&compaction_dir, &import_staging);
+        prepare_cassandra_import_dir(&import_source, &import_staging);
 
         // Replace ferrosa's empty CompactionMetadata/StatsMetadata with real
         // Cassandra 5 bytes so nodetool import can deserialize Statistics.db.

--- a/ferrosa-storage/src/timeseries/materialization.rs
+++ b/ferrosa-storage/src/timeseries/materialization.rs
@@ -57,6 +57,7 @@ pub struct MaterializationTarget {
     pub interval: Duration,
     pub source_columns: Vec<String>,
     pub functions: Vec<ConsolidationFn>,
+    pub target_result_column_indices: Vec<u16>,
     pub target_timestamp_unit: TimeSeriesTimestampUnit,
 }
 
@@ -172,8 +173,14 @@ impl MaterializedRollup {
             .into_iter()
             .enumerate()
             .map(|(idx, value)| {
+                let column_index = self
+                    .target
+                    .target_result_column_indices
+                    .get(idx)
+                    .copied()
+                    .expect("materialization target result column mapping covers all results");
                 (
-                    idx as u16,
+                    column_index,
                     CellValue::live(value.to_be_bytes().to_vec(), write_timestamp),
                 )
             })
@@ -329,6 +336,7 @@ mod tests {
             interval: Duration::from_secs(10),
             source_columns: vec!["value".to_string()],
             functions: vec![ConsolidationFn::Avg],
+            target_result_column_indices: vec![0],
             target_timestamp_unit: TimeSeriesTimestampUnit::Micros,
         };
         let request = MaterializationRequest {
@@ -345,5 +353,28 @@ mod tests {
         assert_eq!(rollup.target, target);
         assert_eq!(rollup.partition_key, b"sensor-1");
         assert_eq!(rollup.window_start_ts, 0);
+    }
+
+    #[test]
+    fn rollup_encoder_uses_target_storage_column_indices() {
+        let target = MaterializationTarget {
+            source_table: TableId::new("ks", "sensor"),
+            target_table: TableId::new("ks", "sensor_10s"),
+            interval: Duration::from_secs(10),
+            source_columns: vec!["value".to_string()],
+            functions: vec![ConsolidationFn::Min, ConsolidationFn::Avg],
+            target_result_column_indices: vec![3, 1],
+            target_timestamp_unit: TimeSeriesTimestampUnit::Micros,
+        };
+        let rollup = MaterializedRollup {
+            target,
+            partition_key: b"sensor-1".to_vec(),
+            window_start_ts: 0,
+        };
+
+        let mutation = rollup.encode_mutation_from_results([1.0, 2.0]);
+        let cells: Vec<u16> = mutation.rows[0].cells.iter().map(|(idx, _)| *idx).collect();
+
+        assert_eq!(cells, vec![3, 1]);
     }
 }

--- a/ferrosa-storage/tests/timeseries_materialization.rs
+++ b/ferrosa-storage/tests/timeseries_materialization.rs
@@ -30,6 +30,7 @@ fn target() -> MaterializationTarget {
                 function_name: "custom_rollup".to_string(),
             },
         ],
+        target_result_column_indices: vec![0, 1, 2, 3],
         target_timestamp_unit: TimeSeriesTimestampUnit::Micros,
     }
 }

--- a/specs/todo/streaming-audit-bugfix-checklist.md
+++ b/specs/todo/streaming-audit-bugfix-checklist.md
@@ -62,9 +62,44 @@ Goal: fix the concrete rust-streaming audit findings with tests first, run local
 - [x] Time-series materialization must exclude deleted rows and cells.
   - Verify: `cargo test -p ferrosa-storage --test timeseries_materialization materialization_drain_excludes_row_deleted_source_values`.
 
+## SSTable / Cassandra Compatibility Follow-Up
+
+- [x] Cassandra OSS50 byte-comparable partition-index keys must not add an escape terminator after the fixed token component.
+  - Verify: `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-sstable --lib -- --nocapture` (214 passed).
+
+- [x] No-clustering-row SSTable encoding must not serialize a clustering prefix before row body length.
+  - Verify: `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-sstable --lib -- --nocapture` (214 passed).
+
+- [x] Sparse regular/static cells must use Cassandra's subset unsigned-vint missing-column encoding, not Ferrosa's previous raw bitmap.
+  - Verify: `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-sstable --lib -- --nocapture` (214 passed).
+
+- [x] Fixed-width cells must be serialized without a value-length prefix and read back by fixed type width.
+  - Verify: `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-sstable --lib -- --nocapture` (214 passed).
+
+- [x] New storage schemas must assign static/regular cell ordinals in Cassandra column-name order.
+  - Verify: `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-schema --lib regular_and_static_storage_ordinals_follow_cassandra_column_name_order -- --nocapture`.
+
+- [x] Existing non-canonical storage schemas must warn on startup/registration rather than silently pretending they are Cassandra-import compatible.
+  - Verify: `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-common --lib storage_columns -- --nocapture`.
+
+- [x] Cassandra 5 must import and read compacted Ferrosa SSTables for exact partition reads.
+  - Verify: `COMPOSE_PROJECT_NAME=ferrosa_compaction_cassandra_test FERROSA_TEST_CONTAINERS=1 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-storage --lib cassandra_reads_compacted_sstable_from_s3 -- --nocapture` with Podman cleanup.
+
+- [x] Compaction end-to-end pipeline must use a deterministic STCS fixture and pass through upload, manifest update, local eviction, and Cassandra import/readback.
+  - Verify: `COMPOSE_PROJECT_NAME=ferrosa_compaction_cassandra_test FERROSA_TEST_CONTAINERS=1 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-storage --lib compaction_end_to_end_pipeline -- --nocapture` with Podman cleanup.
+
+- [x] Cassandra full table range-scan compatibility must be fixed with shape-correct StatsMetadata for no-clustering SSTables, not the clustered-table test-only blob.
+  - Red: Podman Cassandra import test imported exact partition reads but failed `SELECT pk, v_text, v_int FROM test_ks.mixed_cells;` with a replica read failure.
+  - Fix: writer emits Cassandra 5 BTI StatsMetadata for simple primary-key tables, including actual key range, row/cell counts, empty commit-log intervals, no tombstones, and zero-clustering `Slice.ALL`; the import helper preserves writer-produced stats.
+  - Verify: `COMPOSE_PROJECT_NAME=ferrosa_compaction_cassandra_test FERROSA_TEST_CONTAINERS=1 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo +stable test -p ferrosa-storage --lib cassandra_reads_compacted_sstable_from_s3 -- --nocapture` with Podman cleanup.
+  - Remaining documented limitation: clustered-table StatsMetadata still uses the legacy fallback in the Cassandra import helper until the clustered `Slice` serializer is implemented.
+
 ## CI Gate
 
 - [x] `cargo fmt --check`
 - [x] `cargo clippy --all-targets -- -D warnings`
-- [x] `cargo test`
+- [x] `./scripts/pre-push-mirror-ci.sh`
+- [x] Podman/Cassandra compaction compatibility tests:
+  - `cassandra_reads_compacted_sstable_from_s3`
+  - `compaction_end_to_end_pipeline`
 - [ ] PR opened and GitHub CI monitored every 15 minutes until green.


### PR DESCRIPTION
## Executive Summary
- Reworks streaming audit follow-up fixes across cluster streaming, SSTable encoding/metadata, storage compaction, and graph/RRD write shape handling.
- Fixes storage-order regressions so RRD rollup mutations and graph MERGE writes encode cells at the target schema's actual storage ordinals.
- Keeps old non-canonical schemas explicit by warning instead of claiming Cassandra import compatibility.

## Changes
- Stream range reads and bootstrap SSTable transfer use incremental chunking and fail loudly on dropped, missing, reordered, or cancelled frames.
- SSTable writing/reading now matches Cassandra 5 expectations for fixed-width cells, sparse cell subsets, byte-comparable partition index keys, no-clustering rows, and simple-table stats metadata.
- Compaction cleanup and pending upload replay preserve retryability, update manifests, evict inputs, and drain temporary compaction output paths.
- RRD materialization encodes rollup result cells using the target table storage column indices.
- Graph schema-backed MERGE and row extraction now use storage-order cell indices instead of assuming property order equals storage order.
- Checklist updated with the verification gates that passed locally.

## Test Plan
- [x] `./scripts/pre-push-mirror-ci.sh`
- [x] `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo clippy --all-targets -- -D warnings`
- [x] `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo test -p ferrosa-graph --lib`
- [x] `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo test -p ferrosa-graph --test graph_http_integration`
- [x] `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo test -p ferrosa-cql --lib timeseries_rrd_example_executes_real_rollup_rows -- --nocapture`
- [x] `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo test -p ferrosa-storage --test timeseries_materialization`
- [x] `COMPOSE_PROJECT_NAME=ferrosa_compaction_cassandra_test FERROSA_TEST_CONTAINERS=1 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo test -p ferrosa-storage --lib cassandra_reads_compacted_sstable_from_s3 -- --nocapture`
- [x] `COMPOSE_PROJECT_NAME=ferrosa_compaction_cassandra_test FERROSA_TEST_CONTAINERS=1 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTFLAGS='-Cdebuginfo=0' cargo test -p ferrosa-storage --lib compaction_end_to_end_pipeline -- --nocapture`

## Notes
- `target-cassandra-red/` is local test output and intentionally not included.
