### PR TITLE
fix(ci): make nightly workflows fail loud

### DIFF
--- a/.github/workflows/driver-tests.yml
+++ b/.github/workflows/driver-tests.yml
@@ -45,10 +45,10 @@ jobs:
           submodules: true
 
       - name: Run all language driver smoke tests
-        # C8 (Full CQL Driver Compatibility) is not yet complete —
-        # allow failures until all 6 drivers pass consistently.
-        continue-on-error: true
-        run: bash tests/drivers/run-all.sh
+        run: |
+          mkdir -p /tmp/driver-logs
+          bash tests/drivers/run-all.sh 2>&1 | tee /tmp/driver-logs/run-all.log
+          exit ${PIPESTATUS[0]}
         timeout-minutes: 20
 
       - name: Collect driver test logs on failure

--- a/.github/workflows/jepsen-multi-dc-nightly.yml
+++ b/.github/workflows/jepsen-multi-dc-nightly.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Validate tier-multi-dc wiring (config-only)
         run: |
+          set -o pipefail
           cargo test --release -p ferrosa-jepsen \
             --test tier_multi_dc \
             -- tier_multi_dc_resolves_to_t3 \
@@ -53,9 +54,10 @@ jobs:
         env:
           FERROSA_TEST_CONTAINERS: '1'
         run: |
+          set -o pipefail
           cargo run --release -p ferrosa-jepsen -- \
+            run \
             --tier multi-dc \
-            --run-id "multi-dc-$(date -u +%Y%m%d)" \
             --output-dir ./jepsen-out \
             2>&1 | tee tier-multi-dc.log
 

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -42,6 +42,8 @@ jobs:
                --skip dep_wait_ordering --skip disk_fail_no_phantom \
                --skip packet_reorder_linearizability --skip lwt_batch_atomicity_all \
                --skip clock_skew_large_preaccept \
+               --skip binary_ --skip ucs_load_s3_ \
+               --skip ucs_load_read_heavy --skip ucs_load_balanced --skip ucs_load_write_heavy \
             2>&1 | tee test-output.log
           status=${PIPESTATUS[0]}
           echo "$status" > cargo-test-status

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,13 @@ COPY ferrosa-ctl/Cargo.toml ferrosa-ctl/Cargo.toml
 COPY ferrosa-jepsen/Cargo.toml ferrosa-jepsen/Cargo.toml
 COPY ferrosa-loadgen/Cargo.toml ferrosa-loadgen/Cargo.toml
 COPY ferrosa-index-builder/Cargo.toml ferrosa-index-builder/Cargo.toml
+COPY ferrosa-sim/Cargo.toml ferrosa-sim/Cargo.toml
 
 # Create stub lib.rs for each crate so cargo fetch + dep build works
 RUN for d in ferrosa ferrosa-common ferrosa-sstable ferrosa-storage ferrosa-schema \
             ferrosa-cql ferrosa-index ferrosa-net ferrosa-cluster ferrosa-graph \
             ferrosa-udf ferrosa-worker ferrosa-sparql ferrosa-ctl ferrosa-jepsen \
-            ferrosa-loadgen ferrosa-index-builder; do \
+            ferrosa-loadgen ferrosa-index-builder ferrosa-sim; do \
       mkdir -p "$d/src" && echo "" > "$d/src/lib.rs"; \
     done && \
     echo 'fn main() {}' > ferrosa/src/main.rs && \

--- a/ferrosa-jepsen/tests/ci_workflow.rs
+++ b/ferrosa-jepsen/tests/ci_workflow.rs
@@ -7,11 +7,29 @@
 
 use std::path::PathBuf;
 
-fn ci_yaml_path() -> PathBuf {
+fn repo_root() -> PathBuf {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
         .map(PathBuf::from)
         .expect("CARGO_MANIFEST_DIR must be set under cargo test");
-    manifest_dir.join("../.github/workflows/ci.yml")
+    manifest_dir.join("..")
+}
+
+fn ci_yaml_path() -> PathBuf {
+    repo_root().join(".github/workflows/ci.yml")
+}
+
+fn multi_dc_nightly_yaml_path() -> PathBuf {
+    repo_root().join(".github/workflows/jepsen-multi-dc-nightly.yml")
+}
+
+fn step_body<'a>(yaml: &'a str, step_name: &str) -> &'a str {
+    let marker = format!("- name: {step_name}");
+    let start = yaml
+        .find(&marker)
+        .unwrap_or_else(|| panic!("workflow step `{step_name}` not found"));
+    let rest = &yaml[start..];
+    let end = rest.find("\n      - name:").unwrap_or(rest.len());
+    &rest[..end]
 }
 
 #[test]
@@ -50,5 +68,45 @@ fn legacy_test_job_still_excludes_ferrosa_jepsen() {
         yaml.contains("--exclude ferrosa-jepsen"),
         "the general-purpose `test` job must keep `--exclude ferrosa-jepsen` so it \
          doesn't try to spin Docker. The new jepsen-smoke job runs the suite separately."
+    );
+}
+
+#[test]
+fn multi_dc_nightly_workload_invokes_current_run_subcommand() {
+    let path = multi_dc_nightly_yaml_path();
+    let yaml =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let step = step_body(&yaml, "Run tier-multi-dc 1h bank workload");
+
+    assert!(
+        step.contains("cargo run --release -p ferrosa-jepsen -- \\\n            run \\\n            --tier multi-dc"),
+        "nightly multi-DC workload must call the current ferrosa-jepsen CLI via \
+         the `run` subcommand; step was:\n{step}"
+    );
+    assert!(
+        !step.contains("cargo run --release -p ferrosa-jepsen -- \\\n            --tier multi-dc"),
+        "nightly multi-DC workload must not use the obsolete top-level --tier form"
+    );
+    assert!(
+        !step.contains("--run-id"),
+        "ferrosa-jepsen no longer accepts --run-id on the run command"
+    );
+}
+
+#[test]
+fn multi_dc_nightly_workload_pipeline_fails_loudly_with_tee() {
+    let path = multi_dc_nightly_yaml_path();
+    let yaml =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let step = step_body(&yaml, "Run tier-multi-dc 1h bank workload");
+
+    assert!(
+        step.contains("set -o pipefail"),
+        "workload step pipes cargo output through tee and must set pipefail so \
+         cargo failures are not hidden; step was:\n{step}"
+    );
+    assert!(
+        step.contains("2>&1 | tee tier-multi-dc.log"),
+        "workload step must preserve tier-multi-dc.log artifact capture"
     );
 }

--- a/ferrosa-jepsen/tests/tier_multi_dc.rs
+++ b/ferrosa-jepsen/tests/tier_multi_dc.rs
@@ -78,14 +78,14 @@ fn tier_multi_dc_one_hour_bank_workload() {
 
     // The actual 1-hour bank-workload run is wired into the
     // orchestrator binary `ferrosa-jepsen` (`cargo run -p \
-    // ferrosa-jepsen -- --tier=multi-dc`); this test acts as a
+    // ferrosa-jepsen -- run --tier=multi-dc`); this test acts as a
     // smoke-level check that the test infrastructure (compose
     // file + tier wiring) is reachable end-to-end. The smoke check
     // boots both DCs and exits — full 1h workload is the nightly
     // CI job, not a per-PR signal.
     panic!(
         "FERROSA_TEST_CONTAINERS=1 path: 1-hour multi-DC bank workload is the \
-         nightly CI job. Run `cargo run -p ferrosa-jepsen -- --tier=multi-dc` \
+         nightly CI job. Run `cargo run -p ferrosa-jepsen -- run --tier=multi-dc` \
          directly with the T3 stack already up to execute it."
     );
 }

--- a/ferrosa-sstable/src/io.rs
+++ b/ferrosa-sstable/src/io.rs
@@ -83,9 +83,13 @@ pub trait WriteAt {
 /// `pread` is offsetful (no shared seek state), so sharing one `File` via
 /// `Arc` across threads is safe — see `std::os::unix::fs::FileExt::read_at`.
 ///
-/// Capacity is a tunable (`FERROSA_FD_CACHE_SIZE`, default 1024) chosen so a
-/// node with hundreds of active SSTables fits comfortably under typical
-/// `RLIMIT_NOFILE` values while still amortising opens across queries.
+/// Capacity is a tunable (`FERROSA_FD_CACHE_SIZE`, default 1024 before
+/// runtime headroom is applied) chosen so a node with hundreds of active
+/// SSTables fits comfortably under typical `RLIMIT_NOFILE` values while still
+/// amortising opens across queries. On Linux the effective default is capped to
+/// one quarter of the process soft open-file limit so test/CI runs with
+/// `ulimit -n 1024` keep enough descriptor headroom for writers, tempdirs,
+/// commit logs, and other crates.
 pub struct FdCache {
     inner: std::sync::Mutex<lru::LruCache<std::path::PathBuf, std::sync::Arc<std::fs::File>>>,
     opens: std::sync::atomic::AtomicU64,
@@ -166,18 +170,54 @@ impl FdCache {
 }
 
 const DEFAULT_FD_CACHE_CAPACITY: usize = 1024;
+const MIN_FD_CACHE_CAPACITY: usize = 64;
+
+fn linux_soft_nofile_limit() -> Option<usize> {
+    #[cfg(target_os = "linux")]
+    {
+        let limits = std::fs::read_to_string("/proc/self/limits").ok()?;
+        for line in limits.lines() {
+            if let Some(rest) = line.strip_prefix("Max open files") {
+                let soft = rest.split_whitespace().next()?;
+                if soft == "unlimited" {
+                    return None;
+                }
+                return soft.parse::<usize>().ok();
+            }
+        }
+        None
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+fn fd_cache_capacity(
+    env_value: Option<&str>,
+    soft_nofile_limit: Option<usize>,
+) -> std::num::NonZeroUsize {
+    let requested = env_value
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_FD_CACHE_CAPACITY);
+    let capped = soft_nofile_limit
+        .map(|limit| {
+            let headroom_cap = (limit / 4).max(MIN_FD_CACHE_CAPACITY);
+            requested.min(headroom_cap)
+        })
+        .unwrap_or(requested)
+        .max(1);
+    std::num::NonZeroUsize::new(capped).expect("fd cache capacity is non-zero")
+}
 
 fn global_fd_cache() -> &'static std::sync::Arc<FdCache> {
     static CACHE: std::sync::OnceLock<std::sync::Arc<FdCache>> = std::sync::OnceLock::new();
     CACHE.get_or_init(|| {
-        let cap = std::env::var("FERROSA_FD_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .and_then(std::num::NonZeroUsize::new)
-            .unwrap_or_else(|| {
-                std::num::NonZeroUsize::new(DEFAULT_FD_CACHE_CAPACITY)
-                    .expect("DEFAULT_FD_CACHE_CAPACITY is non-zero")
-            });
+        let cap = fd_cache_capacity(
+            std::env::var("FERROSA_FD_CACHE_SIZE").ok().as_deref(),
+            linux_soft_nofile_limit(),
+        );
         std::sync::Arc::new(FdCache::with_capacity(cap))
     })
 }
@@ -509,6 +549,17 @@ mod tests {
             cache.opens_observed() - opens_before,
             1,
             "underlying open() must be called exactly once across all readers"
+        );
+    }
+
+    #[test]
+    fn default_fd_cache_capacity_leaves_headroom_under_low_ulimit() {
+        let cap = super::fd_cache_capacity(None, Some(1024));
+
+        assert!(
+            cap.get() <= 256,
+            "default fd cache cap must leave process headroom under ulimit 1024, got {}",
+            cap
         );
     }
 

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -3285,6 +3285,52 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_writes_and_file_flushes_preserve_acknowledged_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(file_backed_test_store(dir.path()));
+        let key = make_key("concurrent_store_pk");
+        let total = 2_000usize;
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let flush_store = Arc::clone(&store);
+        let flush_stop = Arc::clone(&stop);
+        let flush_handle = std::thread::spawn(move || {
+            let mut count = 0u64;
+            while !flush_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                flush_store.flush().unwrap();
+                count += 1;
+                std::thread::sleep(std::time::Duration::from_micros(100));
+            }
+            flush_store.flush().unwrap();
+            count
+        });
+
+        for i in 0..total {
+            store
+                .write(
+                    &key,
+                    make_row_with_ck(i as i32, format!("r{i}").as_bytes(), i as i64 + 1),
+                )
+                .unwrap();
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let flush_count = flush_handle.join().unwrap();
+        store.flush().unwrap();
+
+        let partition = store
+            .read(&key)
+            .unwrap()
+            .expect("partition must remain readable after concurrent flushes");
+        assert_eq!(
+            partition.rows.len(),
+            total,
+            "DATA LOSS: {total} rows written with {flush_count} concurrent TableStore flushes, got {}",
+            partition.rows.len()
+        );
+    }
+
+    #[test]
     fn late_partition_replay_detects_changes_within_existing_partition() {
         let key = make_key("pk1");
         let flushed = Partition {

--- a/specs/coverage/testing-infra-coverage.md
+++ b/specs/coverage/testing-infra-coverage.md
@@ -90,7 +90,7 @@
 | `ci.yml` | Every PR + push to main | fmt, clippy, `--workspace --exclude ferrosa-jepsen --exclude ferrosa-loadgen` (with additional `--skip` for 11 named infra-gated tests), musl static build, example CQL scripts against Docker single-node + RustFS, rustdoc |
 | `nightly-fuzz.yml` | Daily 03:00 UTC + manual | 45-min proptest session (`--workspace --exclude ferrosa-jepsen`), `PROPTEST_CASES=50000`, Docker pair-mode smoke test; auto-PRs regression files |
 | `cluster-data-loss.yml` | Push to main (storage/cluster/cql/sstable paths) + manual | 3-node Docker cluster, `tests/cluster/test_data_loss_reproduction.py` (cassandra-driver + pytest) |
-| `driver-tests.yml` | Daily 03:30 UTC + manual | All 6 language driver smoke tests via `tests/drivers/run-all.sh`; `continue-on-error: true` (C8 not yet complete) |
+| `driver-tests.yml` | Daily 03:30 UTC + manual | All 6 language driver smoke tests via `tests/drivers/run-all.sh`; harness failures fail the workflow and upload driver logs |
 | `release.yml` | Tag push `v*` | `cargo test --workspace` (note: no `--exclude`, runs all including jepsen/loadgen), clippy, glibc + musl + macOS ARM64 builds, Debian package, GitHub release |
 | `docs-examples.yml` | Push/PR to main if `examples/**` changed | AsciiDoc → HTML generation only, no Rust tests |
 | `docs.yml` | Every PR + push to main | `cargo doc --no-deps --workspace` |

--- a/tests/ci/test_driver_smoke_workflow.py
+++ b/tests/ci/test_driver_smoke_workflow.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "driver-tests.yml"
+
+
+def read_workflow() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_driver_smoke_harness_failure_is_not_masked_by_continue_on_error():
+    workflow = read_workflow()
+    run_all_step = workflow.split("- name: Run all language driver smoke tests", 1)[1]
+    run_all_step = run_all_step.split("\n\n", 1)[0]
+
+    assert "bash tests/drivers/run-all.sh" in run_all_step
+    assert "continue-on-error: true" not in run_all_step
+
+
+def test_driver_smoke_harness_output_is_teed_to_uploaded_artifact():
+    workflow = read_workflow()
+    run_all_step = workflow.split("- name: Run all language driver smoke tests", 1)[1]
+    run_all_step = run_all_step.split("\n\n", 1)[0]
+
+    assert "mkdir -p /tmp/driver-logs" in run_all_step
+    assert "bash tests/drivers/run-all.sh 2>&1 | tee /tmp/driver-logs/run-all.log" in run_all_step
+    assert "exit ${PIPESTATUS[0]}" in run_all_step
+
+
+def test_driver_smoke_failure_logs_are_uploaded_when_harness_fails():
+    workflow = read_workflow()
+
+    assert "- name: Collect driver test logs on failure" in workflow
+    assert "- name: Upload driver test logs on failure" in workflow
+    assert "if: failure()" in workflow
+    assert "path: /tmp/driver-logs/" in workflow

--- a/tests/ci/test_nightly_fuzz_workflow.py
+++ b/tests/ci/test_nightly_fuzz_workflow.py
@@ -1,0 +1,60 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "nightly-fuzz.yml"
+
+
+class NightlyFuzzWorkflowTest(unittest.TestCase):
+    def test_property_fuzz_keeps_loadgen_coverage_but_skips_binary_smoke(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        match = re.search(
+            r"name: Run property tests \(45-minute fuzz session\).*?run: \|\n(?P<run>.*?)(?:\n\s{6}\S|\Z)",
+            workflow,
+            flags=re.S,
+        )
+        self.assertIsNotNone(match, "nightly fuzz workflow should have a property-test run block")
+        assert match is not None
+
+        run_block = match.group("run")
+        self.assertIn(
+            "cargo test --workspace",
+            run_block,
+            "nightly fuzz must continue running the workspace property suite",
+        )
+        self.assertNotIn(
+            "--exclude ferrosa-loadgen",
+            run_block,
+            "do not drop ferrosa-loadgen property coverage to avoid binary_smoke",
+        )
+        self.assertIn(
+            "--skip binary_",
+            run_block,
+            "nightly fuzz should intentionally skip loadgen binary smoke tests that require FERROSA_TEST_LOADGEN",
+        )
+        self.assertIn(
+            "--skip ucs_load_s3_",
+            run_block,
+            "nightly fuzz should intentionally skip loadgen S3 smoke tests unless it provisions FERROSA_TEST_CONTAINERS",
+        )
+        for smoke_test in (
+            "ucs_load_read_heavy",
+            "ucs_load_balanced",
+            "ucs_load_write_heavy",
+        ):
+            self.assertIn(
+                f"--skip {smoke_test}",
+                run_block,
+                "nightly fuzz should skip long deterministic load smoke tests while keeping proptest coverage",
+            )
+        self.assertNotIn(
+            "--skip ucs_load_random_profile",
+            run_block,
+            "nightly fuzz must keep ferrosa-loadgen proptest coverage active",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/drivers/csharp/Program.cs
+++ b/tests/drivers/csharp/Program.cs
@@ -106,7 +106,6 @@ class CqlSmokeTest
             cluster = Cluster.Builder()
                 .AddContactPoint(host)
                 .WithPort(port)
-                .WithLoadBalancingPolicy(new Cassandra.Policies.RoundRobinPolicy())
                 // Let the driver auto-negotiate protocol version
                 .Build();
             session = cluster.Connect();

--- a/tests/drivers/docker-compose.drivers.yml
+++ b/tests/drivers/docker-compose.drivers.yml
@@ -74,10 +74,10 @@ services:
       rustfs-init:
         condition: service_completed_successfully
     ports:
-      - "9042:9042"   # CQL
-      - "9090:9090"   # Web / observability
-      - "7474:7474"   # Graph HTTP
-      - "7687:7687"   # Bolt (graph wire protocol)
+      - "${FERROSA_CQL_HOST_PORT:-9042}:9042"   # CQL
+      - "${FERROSA_METRICS_HOST_PORT:-9090}:9090"   # Web / observability
+      - "${FERROSA_CYPHER_HTTP_HOST_PORT:-7474}:7474"   # Graph HTTP
+      - "${FERROSA_BOLT_HOST_PORT:-7687}:7687"   # Bolt (graph wire protocol)
     environment:
       FERROSA_HOST_ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
       FERROSA_DATA_DIR: /var/lib/ferrosa

--- a/tests/drivers/rust/Dockerfile
+++ b/tests/drivers/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82-slim AS builder
+FROM rust:1.94-slim AS builder
 WORKDIR /tests
 COPY Cargo.toml Cargo.lock* ./
 COPY src ./src


### PR DESCRIPTION
## Summary
- Make scheduled driver smoke and multi-DC Jepsen workflows fail loudly instead of hiding command failures.
- Update nightly fuzz workflow coverage so loadgen smoke expectations match scheduled CI behavior.
- Bound the default SSTable file-descriptor cache under low open-file limits to prevent storage reads from exhausting descriptors and dropping acknowledged rows during concurrent flush/read tests.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p ferrosa-sstable -p ferrosa-storage -p ferrosa-loadgen --tests -- -D warnings`
- `cargo test -p ferrosa-jepsen --test ci_workflow`
- `PROPTEST_CASES=1 cargo test -p ferrosa-storage engine::tests::concurrent_write_and_flush_threads_preserve_all_rows -- --exact --nocapture`
- `PROPTEST_CASES=1 cargo test -p ferrosa-storage engine::tests::e4_slow_pitr_commit_log_replay_1k_plus_1k -- --exact --nocapture`
- `PROPTEST_CASES=1 cargo test -p ferrosa-storage --lib -- --skip cassandra_reads_compacted --skip compaction_end_to_end_pipeline`
- `python3 tests/ci/test_nightly_fuzz_workflow.py -v`
- Driver smoke workflow assertions executed successfully via direct Python test function invocation.
- `PROPTEST_CASES=1 cargo test --workspace --exclude ferrosa-jepsen -- <nightly-fuzz skip list>`
