### PR TITLE
Expose HVQ vector index in CQL, evaluate it, and document it

### DIFF
--- a/.github/workflows/docs-examples.yml
+++ b/.github/workflows/docs-examples.yml
@@ -24,7 +24,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install asciidoctor
-        run: sudo gem install asciidoctor --no-document
+        # Pin the version so generated HTML is byte-reproducible across CI and
+        # local runs (different asciidoctor versions render structurally
+        # different HTML, which would defeat the drift check below).
+        run: sudo gem install asciidoctor -v 2.0.20 --no-document
 
       - name: Generate HTML
         run: make -C examples html

--- a/.github/workflows/docs-examples.yml
+++ b/.github/workflows/docs-examples.yml
@@ -40,7 +40,33 @@ jobs:
             exit 1
           fi
 
-      - name: Commit generated HTML (main only)
+      # Drift gate: a PR that changes an example must also commit its
+      # regenerated HTML. This is the source of truth for keeping generated
+      # docs in sync — the post-merge auto-commit below has historically failed
+      # to push to a protected main, letting HTML silently drift from source
+      # (e.g. timeseries-rrd.html lagged its .adoc by several feature commits).
+      # The asciidoctor version stamp and "Last updated" timestamp vary by
+      # toolchain, so they are ignored; only content drift fails the check.
+      - name: Check generated HTML is in sync with sources
+        if: github.event_name == 'pull_request'
+        run: |
+          drift=$(git diff -- docs/database/examples/ \
+            | grep -E '^[+-]' \
+            | grep -vE '^[+-][+-]' \
+            | grep -vE 'name="generator"|Last updated' \
+            | grep -c . || true)
+          if [ "$drift" -gt 0 ]; then
+            echo "::error::Generated example HTML is out of date. Run 'make -C examples html' and commit docs/database/examples/."
+            git diff -- docs/database/examples/ \
+              | grep -vE 'name="generator"|Last updated' | head -80
+            exit 1
+          fi
+          echo "Generated HTML is in sync with AsciiDoc sources."
+
+      # Best-effort convenience commit on main. If branch protection blocks the
+      # push it only warns — the PR drift gate above already guarantees sync, so
+      # a blocked push here must never fail CI.
+      - name: Commit generated HTML (main only, best-effort)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
@@ -50,5 +76,5 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "docs: regenerate example HTML from AsciiDoc sources"
-            git push
+            git push || echo "::warning::Could not push regenerated docs (expected if main is protected); the PR drift gate keeps HTML in sync."
           fi

--- a/docs/database/cql-compatibility.html
+++ b/docs/database/cql-compatibility.html
@@ -514,6 +514,7 @@
       <tr><td>Filtered</td><td>Any + <code>WHERE</code></td><td>Partial index over a subset of rows</td></tr>
       <tr><td>Vector (HNSW)</td><td><code>'vector'</code></td><td>Approximate nearest neighbor — graph-based, best query performance</td></tr>
       <tr><td>Vector (IVFFlat)</td><td><code>'vector'</code></td><td>Approximate nearest neighbor — k-means clustering, faster builds</td></tr>
+      <tr><td>Vector (HVQ)</td><td><code>'vector' WITH OPTIONS = {'method':'hvq'}</code></td><td>Quantized approximate nearest neighbor — reads far fewer bytes per query (<a href="vector-indexes.html">evaluation</a>)</td></tr>
     </tbody>
   </table>
 

--- a/docs/database/examples/advanced-aggregation.html
+++ b/docs/database/examples/advanced-aggregation.html
@@ -750,7 +750,6 @@ Pin your guest crate to a specific Rust toolchain version in <code>rust-toolchai
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/advanced-aggregation.html
+++ b/docs/database/examples/advanced-aggregation.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Advanced Aggregation with User-Defined Functions</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -750,7 +750,7 @@ Pin your guest crate to a specific Rust toolchain version in <code>rust-toolchai
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cluster-scaling.html
+++ b/docs/database/examples/cluster-scaling.html
@@ -88,7 +88,7 @@ It starts fast, uses minimal resources, and gives you a fully functional CQL end
 <h3 id="_start_node1">Start node1</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose up -d</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose up -d</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -97,7 +97,7 @@ Wait for node1 to report healthy:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose ps</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose ps</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -111,12 +111,12 @@ Wait for node1 to report healthy:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">cqlsh localhost 9042</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">cqlsh localhost 9042</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Act 1: Development / Standalone Mode
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Act 1: Development / Standalone Mode
 -- Create the application keyspace and core table.
 -- RF=1 is appropriate for single-node development.
 
@@ -141,7 +141,7 @@ CREATE TABLE IF NOT EXISTS app.events (
 <h3 id="_insert_seed_data">Insert seed data</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Act 1: Standalone — seed initial event data
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Act 1: Standalone — seed initial event data
 -- 5 events for acme, 5 for globex (10 total)
 
 USE app;
@@ -207,7 +207,7 @@ Think of it like PostgreSQL streaming replication, but it also replicates DDL&#8
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose -f docker-compose.yml -f docker-compose.pair.yml up -d</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose -f docker-compose.yml -f docker-compose.pair.yml up -d</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -231,7 +231,7 @@ Writes continue uninterrupted during this transition. Node1 accepts CQL commands
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose logs -f node1 node2</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose logs -f node1 node2</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -247,7 +247,7 @@ These writes replicate to node2 in real time:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Act 2: Pair mode — writes replicated to second node
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Act 2: Pair mode — writes replicated to second node
 -- 3 more for acme (total 8), 2 more for globex (total 7)
 
 USE app;
@@ -282,7 +282,7 @@ Add a new column and a secondary index&#8201;&#8212;&#8201;the schema change pro
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Phase 2: Pair mode — DDL replication test
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Phase 2: Pair mode — DDL replication test
 -- Create a counter table and populate it with daily summaries
 
 USE app;
@@ -325,7 +325,7 @@ SELECT * FROM daily_summary WHERE tenant_id = 'globex' AND event_date = '2026-03
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">cqlsh localhost 9043 -e "DESCRIBE TABLE app.events;"</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">cqlsh localhost 9043 -e "DESCRIBE TABLE app.events;"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -373,7 +373,7 @@ Three nodes give you:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose -f docker-compose.yml -f docker-compose.pair.yml -f docker-compose.cluster.yml up -d</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose -f docker-compose.yml -f docker-compose.pair.yml -f docker-compose.cluster.yml up -d</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -382,7 +382,7 @@ Node3 joins, a Raft leader election completes, and the cluster stabilizes.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose logs -f node1 node2 node3</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose logs -f node1 node2 node3</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -410,7 +410,7 @@ Insert more events&#8201;&#8212;&#8201;these are acknowledged after a quorum (2 
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Act 3: Raft cluster — writes across a 3-node cluster
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Act 3: Raft cluster — writes across a 3-node cluster
 -- 2 more for acme (total 10), 3 for new tenant initech (total 3)
 
 USE app;
@@ -446,7 +446,7 @@ SELECT COUNT(*) FROM events WHERE tenant_id = 'initech' AND event_date = '2026-0
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Phase 3: Raft cluster — DDL through consensus
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Phase 3: Raft cluster — DDL through consensus
 -- Create a tenants table and register all known tenants
 
 USE app;
@@ -493,7 +493,7 @@ In cluster mode, DDL statements are intended to be linearizable. A <code>CREATE 
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Final verification: confirm all data across the scaled cluster
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Final verification: confirm all data across the scaled cluster
 
 USE app;
 
@@ -535,7 +535,7 @@ SELECT peer, data_center FROM system.peers;</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">curl -s http://localhost:9090/api/cluster/status | python3 -m json.tool</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">curl -s http://localhost:9090/api/cluster/status | python3 -m json.tool</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -551,7 +551,7 @@ SELECT peer, data_center FROM system.peers;</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">bash run-demo.sh</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">bash run-demo.sh</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -567,7 +567,7 @@ SELECT peer, data_center FROM system.peers;</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose -f docker-compose.yml -f docker-compose.pair.yml -f docker-compose.cluster.yml down -v</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose -f docker-compose.yml -f docker-compose.pair.yml -f docker-compose.cluster.yml down -v</code></pre>
 </div>
 </div>
 <div class="paragraph">

--- a/docs/database/examples/cluster-scaling.html
+++ b/docs/database/examples/cluster-scaling.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Cluster Scaling: Development to Production</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -578,7 +578,7 @@ SELECT peer, data_center FROM system.peers;</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cluster-scaling.html
+++ b/docs/database/examples/cluster-scaling.html
@@ -578,7 +578,6 @@ SELECT peer, data_center FROM system.peers;</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cluster-setup.html
+++ b/docs/database/examples/cluster-setup.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>3-Node Cluster Setup</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -740,7 +740,7 @@ docker compose restart node3</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cluster-setup.html
+++ b/docs/database/examples/cluster-setup.html
@@ -740,7 +740,6 @@ docker compose restart node3</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cluster-setup.html
+++ b/docs/database/examples/cluster-setup.html
@@ -148,7 +148,7 @@ Need one cluster to serve both host clients and in-network container clients? Se
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker --version
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker --version
 # Docker version 27.x.x, build xxxxxxx
 
 docker compose version
@@ -183,7 +183,7 @@ On Linux, if you see a "permission denied" error, you may need to add your user 
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">mkdir ferrosa-cluster &amp;&amp; cd ferrosa-cluster</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">mkdir ferrosa-cluster &amp;&amp; cd ferrosa-cluster</code></pre>
 </div>
 </div>
 </div>
@@ -194,7 +194,7 @@ On Linux, if you see a "permission denied" error, you may need to add your user 
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="yaml"># docker-compose.yml — 3-node Ferrosa cluster with S3-compatible storage
+<pre class="highlight"><code class="language-yaml" data-lang="yaml"># docker-compose.yml — 3-node Ferrosa cluster with S3-compatible storage
 # Run with: docker compose up -d
 
 services:
@@ -414,7 +414,7 @@ volumes:
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose up -d</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose up -d</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -428,7 +428,7 @@ volumes:
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose logs -f node1 node2 node3</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose logs -f node1 node2 node3</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -481,7 +481,7 @@ volumes:
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">curl http://localhost:9090/api/cluster/status | python3 -m json.tool</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">curl http://localhost:9090/api/cluster/status | python3 -m json.tool</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -495,7 +495,7 @@ volumes:
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">docker compose ps</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">docker compose ps</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -589,7 +589,7 @@ volumes:
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">pip install cqlsh</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">pip install cqlsh</code></pre>
 </div>
 </div>
 </div>
@@ -600,7 +600,7 @@ volumes:
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">cqlsh localhost 9042</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">cqlsh localhost 9042</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -614,7 +614,7 @@ volumes:
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Verify cluster is responsive
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Verify cluster is responsive
 SELECT cluster_name, data_center FROM system.local;
 SELECT * FROM system.peers;
 
@@ -630,7 +630,7 @@ SELECT * FROM setup_test.hello;</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code> id | message
+<pre class="highlight"><code> id | message
 ----+---------------------
   1 | Hello from Ferrosa!
 
@@ -645,7 +645,7 @@ SELECT * FROM setup_test.hello;</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash">cqlsh localhost 9043</code></pre>
+<pre class="highlight"><code class="language-bash" data-lang="bash">cqlsh localhost 9043</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -653,7 +653,7 @@ SELECT * FROM setup_test.hello;</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">SELECT * FROM setup_test.hello;</code></pre>
+<pre class="highlight"><code class="language-sql" data-lang="sql">SELECT * FROM setup_test.hello;</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -718,7 +718,7 @@ Leave this cluster running as you work through the tutorials. Each tutorial crea
 <h3 id="_useful_commands_for_managing_your_cluster">Useful commands for managing your cluster</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="bash"># Stop the cluster (preserves data)
+<pre class="highlight"><code class="language-bash" data-lang="bash"># Stop the cluster (preserves data)
 docker compose stop
 
 # Start it again

--- a/docs/database/examples/content-personalization.html
+++ b/docs/database/examples/content-personalization.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Content Personalization</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -523,7 +523,7 @@ Ferrosa handles millions of users this way because each query touches exactly on
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/content-personalization.html
+++ b/docs/database/examples/content-personalization.html
@@ -523,7 +523,6 @@ Ferrosa handles millions of users this way because each query touches exactly on
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cql-comprehensive.html
+++ b/docs/database/examples/cql-comprehensive.html
@@ -908,7 +908,6 @@ UPDATE counters SET page_views = page_views + 100, unique_visitors = unique_visi
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-23 15:44:41 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cql-comprehensive.html
+++ b/docs/database/examples/cql-comprehensive.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>CQL Comprehensive Compatibility</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -908,7 +908,7 @@ UPDATE counters SET page_views = page_views + 100, unique_visitors = unique_visi
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-13 14:35:47 -0700
+Last updated 2026-05-23 15:44:41 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cybersecurity.html
+++ b/docs/database/examples/cybersecurity.html
@@ -664,7 +664,6 @@ WHERE indicator_type = 'domain';</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/cybersecurity.html
+++ b/docs/database/examples/cybersecurity.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Cybersecurity Monitoring</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -664,7 +664,7 @@ WHERE indicator_type = 'domain';</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/ecommerce.html
+++ b/docs/database/examples/ecommerce.html
@@ -739,7 +739,6 @@ Together, these patterns cover the vast majority of real-world workloads.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/ecommerce.html
+++ b/docs/database/examples/ecommerce.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>E-Commerce Platform</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -739,7 +739,7 @@ Together, these patterns cover the vast majority of real-world workloads.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/fraud-detection.html
+++ b/docs/database/examples/fraud-detection.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Fraud Detection</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -581,7 +581,7 @@ WHERE account_id = 'ACCT-1001';</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/fraud-detection.html
+++ b/docs/database/examples/fraud-detection.html
@@ -581,7 +581,6 @@ WHERE account_id = 'ACCT-1001';</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/gaming-leaderboards.html
+++ b/docs/database/examples/gaming-leaderboards.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Gaming Leaderboards</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -548,7 +548,7 @@ That is how you keep latency low even with millions of concurrent players.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/gaming-leaderboards.html
+++ b/docs/database/examples/gaming-leaderboards.html
@@ -548,7 +548,6 @@ That is how you keep latency low even with millions of concurrent players.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/graph-joins.html
+++ b/docs/database/examples/graph-joins.html
@@ -1102,7 +1102,6 @@ Since both read from the same tables, your data is always consistent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/graph-joins.html
+++ b/docs/database/examples/graph-joins.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Graph Joins &amp; Traversals</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -1102,7 +1102,7 @@ Since both read from the same tables, your data is always consistent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/healthcare.html
+++ b/docs/database/examples/healthcare.html
@@ -533,7 +533,6 @@ SELECT medication, dosage, frequency, prescriber, active, prescribed_at</code></
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/healthcare.html
+++ b/docs/database/examples/healthcare.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Healthcare Records</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -533,7 +533,7 @@ SELECT medication, dosage, frequency, prescriber, active, prescribed_at</code></
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/index.html
+++ b/docs/database/examples/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Tutorials &amp; Examples</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -114,6 +114,19 @@
 <dt class="hdlist1"><a href="gaming-leaderboards.html"><strong>Gaming Leaderboards</strong></a></dt>
 <dd>
 <p>Player stats, rankings, and match history.</p>
+</dd>
+</dl>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_vector_search_ai">Vector Search &amp; AI</h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><a href="vector-indexes.html"><strong>Vector Indexes: HNSW and HVQ</strong></a> <em>New!</em></dt>
+<dd>
+<p>Semantic similarity search over embeddings, comparing the full-precision HNSW index with the quantized HVQ index&#8201;&#8212;&#8201;plus a BTree secondary index&#8201;&#8212;&#8201;all from plain CQL.</p>
 </dd>
 </dl>
 </div>

--- a/docs/database/examples/iot-sensor-data.html
+++ b/docs/database/examples/iot-sensor-data.html
@@ -618,7 +618,6 @@ Here is a recap of the key concepts:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/iot-sensor-data.html
+++ b/docs/database/examples/iot-sensor-data.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>IoT Sensor Data</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -618,7 +618,7 @@ Here is a recap of the key concepts:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/knowledge-graph.html
+++ b/docs/database/examples/knowledge-graph.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Research Knowledge Graph</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -2167,7 +2167,7 @@ fi</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-13 14:35:47 -0700
+Last updated 2026-05-23 15:44:41 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/knowledge-graph.html
+++ b/docs/database/examples/knowledge-graph.html
@@ -2167,7 +2167,6 @@ fi</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-23 15:44:41 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/messaging-chat.html
+++ b/docs/database/examples/messaging-chat.html
@@ -645,7 +645,6 @@ Here is what you practiced:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/messaging-chat.html
+++ b/docs/database/examples/messaging-chat.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Messaging &amp; Chat</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -645,7 +645,7 @@ Here is what you practiced:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/telecom.html
+++ b/docs/database/examples/telecom.html
@@ -512,7 +512,6 @@ WHERE subscriber_id = 'SUB-1003'
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/telecom.html
+++ b/docs/database/examples/telecom.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Telecommunications Platform</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -512,7 +512,7 @@ WHERE subscriber_id = 'SUB-1003'
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/time-series-analytics.html
+++ b/docs/database/examples/time-series-analytics.html
@@ -599,7 +599,6 @@ Here is what you practiced:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/time-series-analytics.html
+++ b/docs/database/examples/time-series-analytics.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
+<meta name="generator" content="Asciidoctor 2.0.20">
 <title>Real-Time Analytics</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
@@ -599,7 +599,7 @@ Here is what you practiced:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-10 18:00:49 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/timeseries-rrd.html
+++ b/docs/database/examples/timeseries-rrd.html
@@ -597,7 +597,6 @@ The default ring memory budget is derived from the host or container memory limi
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-23 15:44:41 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/timeseries-rrd.html
+++ b/docs/database/examples/timeseries-rrd.html
@@ -4,41 +4,31 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.26">
-<title>RRD Cascading Time-Series Aggregation</title>
+<meta name="generator" content="Asciidoctor 2.0.20">
+<title>RRD Time-Series Aggregation</title>
 <link rel="stylesheet" href="./theme/ferrosa.css">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>RRD Cascading Time-Series Aggregation</h1>
+<h1>RRD Time-Series Aggregation</h1>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
-<li><a href="#_the_problem">The Problem</a>
-<ul class="sectlevel2">
-<li><a href="#_high_frequency_sensor_data">High-frequency sensor data</a></li>
-</ul>
-</li>
-<li><a href="#_how_it_works">How It Works</a>
-<ul class="sectlevel2">
-<li><a href="#_the_4_tier_cascade">The 4-tier cascade</a></li>
-<li><a href="#_consolidation_extensions">Consolidation extensions</a></li>
-</ul>
-</li>
+<li><a href="#_the_problem">The Problem</a></li>
+<li><a href="#_the_runnable_rollup">The Runnable Rollup</a></li>
 <li><a href="#_create_the_schema">Create the Schema</a></li>
 <li><a href="#_insert_sample_data">Insert Sample Data</a></li>
-<li><a href="#_query_each_tier">Query Each Tier</a>
+<li><a href="#_query_rollups">Query Rollups</a>
 <ul class="sectlevel2">
-<li><a href="#_raw_data_1_second_resolution">Raw data (1-second resolution)</a></li>
-<li><a href="#_5_minute_aggregates">5-minute aggregates</a></li>
-<li><a href="#_15_minute_aggregates">15-minute aggregates</a></li>
-<li><a href="#_1_hour_aggregates">1-hour aggregates</a></li>
+<li><a href="#_raw_readings">Raw readings</a></li>
+<li><a href="#_5_minute_sensor_envelope">5-minute sensor envelope</a></li>
+<li><a href="#_shift_range_volatility">Shift-range volatility</a></li>
 </ul>
 </li>
+<li><a href="#_wasm_aggregate_status">WASM Aggregate Status</a></li>
 <li><a href="#_built_in_functions">Built-in Functions</a></li>
 <li><a href="#_multi_column_composite">Multi-Column Composite</a></li>
-<li><a href="#_custom_wasm_udf">Custom WASM UDF</a></li>
 <li><a href="#_late_arriving_data">Late-Arriving Data</a></li>
 <li><a href="#_observability">Observability</a></li>
 <li><a href="#_files_in_this_example">Files in This Example</a></li>
@@ -49,8 +39,8 @@
 <div id="preamble">
 <div class="sectionbody">
 <div class="paragraph">
-<p>Automatic multi-tier aggregation for high-frequency time-series data.
-Write raw readings at 1-second resolution and let the database consolidate them into 5-minute, 15-minute, and 1-hour summaries using RRD-style cascading.</p>
+<p>Automatic aggregation for high-frequency sensor data.
+Write raw factory equipment readings at 1-second resolution and let Ferrosa consolidate them into 5-minute summaries.</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -69,36 +59,35 @@ Complete the <a href="cluster-setup.html">3-Node Cluster Setup</a> tutorial firs
 <div class="sect1">
 <h2 id="_the_problem">The Problem</h2>
 <div class="sectionbody">
-<div class="sect2">
-<h3 id="_high_frequency_sensor_data">High-frequency sensor data</h3>
 <div class="paragraph">
-<p>Consider a fleet of 10,000 IoT sensors, each reporting once per second.
-That is 10,000 writes per second&#8201;&#8212;&#8201;864 million rows per day.</p>
+<p>A factory monitors vibration and temperature on rotating equipment.
+Raw readings are useful for diagnosis, but dashboards and alerting usually need the operating envelope and trend for each time window:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>min</code> shows the quietest point in the window.</p>
+</li>
+<li>
+<p><code>max</code> catches excursions and short spikes.</p>
+</li>
+<li>
+<p><code>avg</code> shows the baseline trend.</p>
+</li>
+<li>
+<p><code>stddev</code> shows volatility, which is often the earliest sign of bearing wear or imbalance.</p>
+</li>
+</ul>
 </div>
 <div class="paragraph">
-<p>At this scale, dashboards cannot query raw data directly.
-A chart showing 24 hours of data for a single sensor would need to scan 86,400 rows.
-For a fleet view across 100 sensors, that is 8.6 million rows per chart refresh.</p>
-</div>
-<div class="paragraph">
-<p>The standard solution is pre-aggregation: compute min, max, avg, and stddev over fixed time windows and store the results in a separate table at coarser resolution.
-Tools like RRDtool and Graphite have used this pattern for decades.</p>
-</div>
-<div class="paragraph">
-<p>Ferrosa automates this with <strong>cascading consolidation</strong>.
+<p>Ferrosa automates those rollups with built-in streaming consolidation.
 You define the aggregation rules in the table&#8217;s <code>extensions</code> map at <code>CREATE TABLE</code> time, and the storage engine handles the rest.</p>
 </div>
 </div>
 </div>
-</div>
 <div class="sect1">
-<h2 id="_how_it_works">How It Works</h2>
+<h2 id="_the_runnable_rollup">The Runnable Rollup</h2>
 <div class="sectionbody">
-<div class="sect2">
-<h3 id="_the_4_tier_cascade">The 4-tier cascade</h3>
-<div class="paragraph">
-<p>The example creates a cascade with four resolution tiers:</p>
-</div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -117,84 +106,22 @@ You define the aggregation rules in the table&#8217;s <code>extensions</code> ma
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sensor_1s</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sensor_readings_1s</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1 second (raw)</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">None (source)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sensor_5m</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sensor_readings_5m</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5 minutes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">min, max, avg, stddev</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sensor_15m</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">15 minutes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">min, max, avg, stddev</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sensor_1h</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 hour</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">min, max, avg, stddev</p></td>
 </tr>
 </tbody>
 </table>
 <div class="paragraph">
-<p>Each tier consolidates data from the tier above it.
-When 5 minutes of raw data accumulates in <code>sensor_1s</code>, the aggregator computes the summary statistics and writes them to <code>sensor_5m</code>.
-When three 5-minute windows accumulate in <code>sensor_5m</code>, they are consolidated into <code>sensor_15m</code>, and so on.</p>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_consolidation_extensions">Consolidation extensions</h3>
-<div class="paragraph">
-<p>Aggregation is configured via <code>extensions</code> on the source table:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">CREATE TABLE sensor_1s (
-    sensor_id uuid,
-    ts timestamp,
-    value double,
-    PRIMARY KEY (sensor_id, ts)
-) WITH CLUSTERING ORDER BY (ts DESC)
-  AND extensions = {
-    'consolidation.interval': '5m',
-    'consolidation.functions': 'min,max,avg,stddev',
-    'consolidation.target': 'sensor_5m',
-    'consolidation.cascade': 'true',
-    'consolidation.late_window': '10m',
-    'consolidation.columns': 'value'
-  };</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The key parameters:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>consolidation.interval</code>&#8201;&#8212;&#8201;the window size (5 minutes for Tier 0).</p>
-</li>
-<li>
-<p><code>consolidation.functions</code>&#8201;&#8212;&#8201;which aggregates to compute (min, max, avg, stddev).</p>
-</li>
-<li>
-<p><code>consolidation.target</code>&#8201;&#8212;&#8201;the downstream table to write results to.</p>
-</li>
-<li>
-<p><code>consolidation.cascade</code>&#8201;&#8212;&#8201;when <code>true</code>, downstream tables are auto-created with escalating intervals.</p>
-</li>
-<li>
-<p><code>consolidation.late_window</code>&#8201;&#8212;&#8201;how far back to accept late data for re-aggregation.</p>
-</li>
-<li>
-<p><code>consolidation.columns</code>&#8201;&#8212;&#8201;which numeric columns to aggregate.</p>
-</li>
-</ul>
-</div>
+<p>When 5 minutes of raw data accumulates in <code>sensor_readings_1s</code>, the aggregator computes summary statistics and writes them to <code>sensor_readings_5m</code>.
+Multi-tier cascade auto-creation is not enabled in this runnable contract.
+Correct <code>avg</code> and <code>stddev</code> cascades require carrying rollup state such as count, sum, and sum-of-squares between tiers; creating downstream tables without that state would produce misleading results.</p>
 </div>
 </div>
 </div>
@@ -203,42 +130,77 @@ When three 5-minute windows accumulate in <code>sensor_5m</code>, they are conso
 <div class="sectionbody">
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">-- RRD Cascading Time-Series Aggregation: Schema
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- RRD Time-Series Aggregation: Sensor Schema
 --
--- Creates a 4-tier cascade: 1s -&gt; 5m -&gt; 15m -&gt; 1h.
--- Consolidation is driven by data timestamps, not wall clock.
+-- Creates a runnable single-step rollup for factory sensor readings:
+-- 1s raw readings -&gt; 5m rollups.
+-- Min/max/avg/stddev use the built-in streaming consolidation path.
 
-CREATE KEYSPACE IF NOT EXISTS sensors
+CREATE KEYSPACE IF NOT EXISTS plant
   WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
 
-USE sensors;
+USE plant;
 
--- Tier 0: Raw 1-second sensor readings.
-CREATE TABLE sensor_1s (
+-- Tier 1: materialized 5-minute aggregates.
+CREATE TABLE sensor_readings_5m (
     sensor_id uuid,
     ts timestamp,
-    value double,
+    vibration_mm_s_min double,
+    vibration_mm_s_max double,
+    vibration_mm_s_avg double,
+    vibration_mm_s_stddev double,
+    temperature_c_min double,
+    temperature_c_max double,
+    temperature_c_avg double,
+    temperature_c_stddev double,
+    PRIMARY KEY (sensor_id, ts)
+) WITH CLUSTERING ORDER BY (ts DESC);
+
+-- Tier 0: raw 1-second vibration and temperature readings.
+CREATE TABLE sensor_readings_1s (
+    sensor_id uuid,
+    ts timestamp,
+    vibration_mm_s double,
+    temperature_c double,
     PRIMARY KEY (sensor_id, ts)
 ) WITH CLUSTERING ORDER BY (ts DESC)
   AND extensions = {
     'consolidation.interval': '5m',
     'consolidation.functions': 'min,max,avg,stddev',
-    'consolidation.target': 'sensor_5m',
-    'consolidation.cascade': 'true',
-    'consolidation.late_window': '10m',
-    'consolidation.columns': 'value'
+    'consolidation.target': 'sensor_readings_5m',
+    'consolidation.late_window': '15m',
+    'consolidation.columns': 'vibration_mm_s,temperature_c'
   };
 
--- Tiers 1-3 are auto-created by cascade. Shown here for reference:
---
--- sensor_5m:  5-minute aggregates  (consolidation.interval: '15m', target: 'sensor_15m')
--- sensor_15m: 15-minute aggregates (consolidation.interval: '1h', target: 'sensor_1h')
--- sensor_1h:  1-hour aggregates    (terminal, no consolidation config)</code></pre>
+-- Multi-tier cascade auto-creation is intentionally not used in this runnable
+-- contract. It is tracked separately because correct avg/stddev cascades need
+-- additional rollup state such as count, sum, and sum-of-squares.</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p>Tiers 1-3 (<code>sensor_5m</code>, <code>sensor_15m</code>, <code>sensor_1h</code>) are auto-created by the cascade engine.
-Each downstream table&#8217;s consolidation interval is derived from the cascade multipliers (default: 3x then 4x).</p>
+<p>The source table stores <code>vibration_mm_s</code> and <code>temperature_c</code>.
+Both columns are rolled up with built-in streaming min/max/avg/stddev:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sql" data-lang="sql">'consolidation.functions': 'min,max,avg,stddev',
+'consolidation.columns': 'vibration_mm_s,temperature_c'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The 5-minute rollup exposes one row per sensor per window with columns such as:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-text" data-lang="text">vibration_mm_s_min
+vibration_mm_s_max
+vibration_mm_s_avg
+vibration_mm_s_stddev
+temperature_c_min
+temperature_c_max
+temperature_c_avg
+temperature_c_stddev</code></pre>
+</div>
 </div>
 </div>
 </div>
@@ -247,135 +209,187 @@ Each downstream table&#8217;s consolidation interval is derived from the cascade
 <div class="sectionbody">
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">-- RRD Cascading Time-Series Aggregation: Sample Data
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- RRD Time-Series Aggregation: Sensor Data
 --
--- Insert 1-second sensor readings. Consolidation triggers automatically
+-- Insert factory equipment readings. Consolidation triggers automatically
 -- when data timestamps cross 5-minute boundaries.
 
-USE sensors;
+USE plant;
 
--- Sensor 1: temperature readings every second for 10 minutes.
--- (In production, these would come from the application layer.)
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:00:01', 22.1);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:00:02', 22.3);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:00:03', 22.0);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:00:30', 22.5);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:01:00', 23.1);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:01:30', 23.4);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:02:00', 22.8);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:02:30', 22.6);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:03:00', 22.2);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:03:30', 22.0);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:04:00', 21.8);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:04:30', 21.5);
+-- Pump A: rising vibration during the first 5-minute window, then recovery.
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:00:01', 4.2, 68.1);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:00:30', 4.4, 68.3);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:01:00', 4.1, 68.0);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:01:30', 4.7, 68.6);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:02:00', 5.0, 69.0);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:02:30', 5.4, 69.5);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:03:00', 5.9, 70.0);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:03:30', 6.2, 70.4);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:04:00', 5.8, 70.1);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:04:30', 5.1, 69.4);
 
--- After 300 rows (5 minutes), the first consolidation triggers automatically:
--- sensor_1s observer detects timestamp crossing the 5m boundary,
--- runs min/max/avg/stddev over the window, writes result to sensor_5m.
+-- Expected first 5-minute rollup for Pump A:
+--   vibration_mm_s_min    = 4.1
+--   vibration_mm_s_max    = 6.2
+--   vibration_mm_s_avg    = 5.08
+--   vibration_mm_s_stddev = computed by the built-in streaming stddev
+--   temperature_c_min     = 68.0
+--   temperature_c_max     = 70.4
+--   temperature_c_avg     = 69.14
+--   temperature_c_stddev  = computed by the built-in streaming stddev
 
--- Second 5-minute window: 00:05:00 - 00:09:59
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:05:00', 23.0);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:05:30', 23.2);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:06:00', 23.5);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:06:30', 24.0);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:07:00', 24.2);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:07:30', 23.8);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:08:00', 23.5);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:08:30', 23.1);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:09:00', 22.9);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:09:30', 22.7);
+-- Second 5-minute window: the same pump settles after inspection.
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:05:00', 4.8, 69.0);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:06:00', 4.6, 68.7);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:07:00', 4.5, 68.6);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:08:00', 4.3, 68.4);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:09:00', 4.2, 68.2);
 
--- Sensor 2: pressure readings (different sensor, same cascade).
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440002, '2026-03-20 00:00:01', 1013.2);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440002, '2026-03-20 00:00:02', 1013.3);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440002, '2026-03-20 00:00:03', 1013.1);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440002, '2026-03-20 00:05:00', 1013.5);
-INSERT INTO sensor_1s (sensor_id, ts, value)
-  VALUES (550e8400-e29b-41d4-a716-446655440002, '2026-03-20 00:05:30', 1013.7);</code></pre>
+-- Pump B: baseline readings for cross-sensor comparisons.
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (7c07fa8d-f630-4a32-a0d8-df48235ed6f2, '2026-05-20 12:00:01', 2.1, 64.2);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (7c07fa8d-f630-4a32-a0d8-df48235ed6f2, '2026-05-20 12:01:00', 2.3, 64.4);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (7c07fa8d-f630-4a32-a0d8-df48235ed6f2, '2026-05-20 12:02:00', 2.2, 64.3);
+INSERT INTO sensor_readings_1s (sensor_id, ts, vibration_mm_s, temperature_c)
+  VALUES (7c07fa8d-f630-4a32-a0d8-df48235ed6f2, '2026-05-20 12:05:00', 2.4, 64.5);</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p>As data timestamps cross 5-minute boundaries, the consolidation observer fires automatically.
-No cron jobs, no external ETL&#8201;&#8212;&#8201;the aggregation runs inline with the write path.</p>
+<p>As data timestamps cross 5-minute boundaries, the consolidation observer enqueues
+rollup work and the background materialization worker writes target rows.
+No cron jobs, no external ETL.</p>
 </div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_query_each_tier">Query Each Tier</h2>
+<h2 id="_query_rollups">Query Rollups</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_raw_data_1_second_resolution">Raw data (1-second resolution)</h3>
+<h3 id="_raw_readings">Raw readings</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">-- Raw 1-second data (most recent 10 readings).
-SELECT sensor_id, ts, value
-  FROM sensor_1s
-  WHERE sensor_id = 550e8400-e29b-41d4-a716-446655440001
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Raw 1-second data for one pump.
+SELECT sensor_id, ts, vibration_mm_s, temperature_c
+  FROM sensor_readings_1s
+  WHERE sensor_id = 2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34
   LIMIT 10;</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_5_minute_aggregates">5-minute aggregates</h3>
+<h3 id="_5_minute_sensor_envelope">5-minute sensor envelope</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">-- 5-minute aggregates.
-SELECT sensor_id, ts, value_min, value_max, value_avg, value_stddev
-  FROM sensor_5m
-  WHERE sensor_id = 550e8400-e29b-41d4-a716-446655440001
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- 5-minute aggregates show excursions, trend, and volatility.
+SELECT sensor_id, ts,
+       vibration_mm_s_min,
+       vibration_mm_s_max,
+       vibration_mm_s_avg,
+       vibration_mm_s_stddev,
+       temperature_c_min,
+       temperature_c_max,
+       temperature_c_avg,
+       temperature_c_stddev
+  FROM sensor_readings_5m
+  WHERE sensor_id = 2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34
   LIMIT 10;</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_15_minute_aggregates">15-minute aggregates</h3>
+<h3 id="_shift_range_volatility">Shift-range volatility</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">-- 15-minute aggregates.
-SELECT sensor_id, ts, value_min, value_max, value_avg, value_stddev
-  FROM sensor_15m
-  WHERE sensor_id = 550e8400-e29b-41d4-a716-446655440001
-  LIMIT 10;</code></pre>
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Time-range query across a shift at 5-minute resolution.
+SELECT sensor_id, ts, vibration_mm_s_min, vibration_mm_s_max,
+       vibration_mm_s_avg, vibration_mm_s_stddev
+  FROM sensor_readings_5m
+  WHERE sensor_id = 2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34
+    AND ts &gt;= '2026-05-20 12:00:00'
+    AND ts &lt;  '2026-05-20 20:00:00';</code></pre>
 </div>
 </div>
 </div>
-<div class="sect2">
-<h3 id="_1_hour_aggregates">1-hour aggregates</h3>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_wasm_aggregate_status">WASM Aggregate Status</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The runnable sensor demo uses the built-in streaming <code>stddev</code>.
+Ferrosa supports three WASM loading forms for function metadata, and the WASM executor now has a streaming aggregate ABI with <code>init</code>, <code>update(value)</code>, and <code>finalize</code>.
+WASM aggregate execution for live RRD materialization uses that ABI for each row in the rollup window.
+The <code>AS FILE</code> and <code>AS URL &#8230;&#8203; WITH SHA256</code> forms are admin-only artifact loading paths.</p>
+</div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">-- 1-hour aggregates.
-SELECT sensor_id, ts, value_min, value_max, value_avg, value_stddev
-  FROM sensor_1h
-  WHERE sensor_id = 550e8400-e29b-41d4-a716-446655440001
-  LIMIT 10;</code></pre>
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- streaming stddev function so it runs without an external WASM artifact.
+-- Rust-authored examples live under wasm-rust/stddev and wasm-rust/rms.
+
+USE plant;
+
+-- Inline hex loading form. Replace these tiny placeholder bytes with a
+-- compiled Component Model module that carries the
+-- ferrosa:streaming-aggregate:v1 marker and exports init/update/finalize.
+CREATE OR REPLACE FUNCTION plant.stddev(value double)
+  CALLED ON NULL INPUT
+  RETURNS double
+  LANGUAGE wasm
+  AS '0x0061736d0d000100';
+
+-- Admin-only file loading form for pre-approved local artifacts.
+CREATE OR REPLACE FUNCTION plant.stddev(value double)
+  CALLED ON NULL INPUT
+  RETURNS double
+  LANGUAGE wasm
+  AS FILE '/secure/udf/stddev.wasm';
+
+-- Admin-only URL loading form. Ferrosa verifies the fetched bytes against the
+-- required SHA-256 digest before storing the function metadata.</code></pre>
 </div>
 </div>
+<div class="paragraph">
+<p>The accepted future table syntax references the function with <code>wasm:keyspace.function_name</code>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sql" data-lang="sql">  CALLED ON NULL INPUT
+  RETURNS double
+  LANGUAGE wasm
+  AS URL 'https://artifacts.example/ferrosa/stddev.wasm'
+  WITH SHA256 = '3dbe4f6fb3f44dfb11ad93f6c07f81a4b34d217f8dcf7dd06d80670d88e6b7c1';
+
+-- RRD table syntax references the UDF through the wasm:keyspace.function_name
+-- consolidation function syntax. The RRD worker streams window rows through
+-- init/update/finalize.
+CREATE TABLE vibration_with_wasm_stddev (
+    sensor_id uuid,
+    ts timestamp,
+    vibration_mm_s double,
+    PRIMARY KEY (sensor_id, ts)</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Use <code>wasm:</code> functions only for components that declare the <code>ferrosa:streaming-aggregate:v1</code> marker and export <code>init</code>, <code>update</code>, and <code>finalize</code>.
+Scalar WASM UDFs are rejected for aggregate execution rather than being called with a materialized list.
+The URL form requires a SHA-256 digest so artifact bytes cannot change between review and DDL apply.</p>
 </div>
 </div>
 </div>
@@ -383,7 +397,7 @@ SELECT sensor_id, ts, value_min, value_max, value_avg, value_stddev
 <h2 id="_built_in_functions">Built-in Functions</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Ferrosa provides seven built-in consolidation functions.
+<p>Ferrosa provides built-in consolidation functions for common rollups.
 See <code>built-in-functions.cql</code> for a complete example of each.</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -412,7 +426,7 @@ See <code>built-in-functions.cql</code> for a complete example of each.</p>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>stddev</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Population standard deviation (Welford&#8217;s online algorithm)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Population standard deviation using the built-in implementation</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>count</code></p></td>
@@ -429,8 +443,7 @@ See <code>built-in-functions.cql</code> for a complete example of each.</p>
 </tbody>
 </table>
 <div class="paragraph">
-<p>All functions except <code>median</code> are computed in a single pass using Welford&#8217;s online algorithm.
-Median requires a sorted copy of the window values and is computed separately.</p>
+<p>WASM aggregate execution is documented separately because it is not part of the runnable materialization path yet.</p>
 </div>
 </div>
 </div>
@@ -438,55 +451,9 @@ Median requires a sorted copy of the window values and is computed separately.</
 <h2 id="_multi_column_composite">Multi-Column Composite</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>When a table has multiple numeric columns, all functions are applied to each column independently:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">    device_id uuid,
-    ts timestamp,
-    temperature double,
-    humidity double,
-    pressure double,
-    PRIMARY KEY (device_id, ts)
-) WITH CLUSTERING ORDER BY (ts DESC)
-  AND extensions = {
-    'consolidation.interval': '5m',
-    'consolidation.functions': 'min,max,avg',
-    'consolidation.target': 'multi_sensor_5m',
-    'consolidation.columns': 'temperature,humidity,pressure'
-  };</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>This produces nine output columns (3 columns x 3 functions): <code>temperature_min</code>, <code>temperature_max</code>, <code>temperature_avg</code>, <code>humidity_min</code>, etc.</p>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_custom_wasm_udf">Custom WASM UDF</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>For domain-specific aggregation logic, use a WASM UDF:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">    latency_ms double,
-    PRIMARY KEY (endpoint, ts)
-) WITH CLUSTERING ORDER BY (ts DESC)
-  AND extensions = {
-    'consolidation.interval': '5m',
-    'consolidation.functions': 'avg,median,wasm:sensors.percentile_95',
-    'consolidation.target': 'api_latency_5m',
-    'consolidation.columns': 'latency_ms'
-  };
-
--- Output table api_latency_5m will have columns:
---   latency_ms_avg              double   (built-in avg)
---   latency_ms_median           double   (built-in median)</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The <code>wasm:keyspace.function_name</code> syntax routes the window values to the WASM executor after the built-in accumulator pass completes.</p>
+<p>When a table has multiple numeric columns, all configured functions are applied to each column independently.
+The sensor schema applies the same min/max/avg/stddev set to vibration and temperature.
+See <code>composite.cql</code> for an additional weather-station style example.</p>
 </div>
 </div>
 </div>
@@ -499,7 +466,7 @@ Ferrosa handles late-arriving data with automatic re-aggregation:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">  VALUES (550e8400-e29b-41d4-a716-446655440001, '2026-03-20 00:01:30', 23.5);</code></pre>
+<pre class="highlight"><code class="language-sql" data-lang="sql">  VALUES (2f4d6a9e-6a9a-4f75-a6c4-cd8d210e7e34, '2026-05-20 12:01:30', 4.9, 68.8);</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -514,19 +481,19 @@ Ferrosa handles late-arriving data with automatic re-aggregation:</p>
 <p>A <code>LateData</code> task is sent to the async worker.</p>
 </li>
 <li>
-<p>The worker reads the full window from disk and re-runs consolidation.</p>
+<p>The worker streams the affected source window from storage.</p>
 </li>
 <li>
 <p>The corrected aggregate is upserted into the downstream table.</p>
 </li>
 <li>
-<p>The cascade continues: the upsert triggers the next tier&#8217;s observer.</p>
+<p>The corrected aggregate is visible in the target table.</p>
 </li>
 </ol>
 </div>
 <div class="paragraph">
-<p>Late data is only accepted within the <code>late_window</code> (default: 2x the consolidation interval).
-Multiple late arrivals for the same window are debounced to avoid redundant re-aggregation.</p>
+<p>Late data is only accepted within the <code>late_window</code>.
+The disk-backed keyed cursor streams source rows by partition and window for recomputation when a window has fallen out of the in-memory ring.</p>
 </div>
 </div>
 </div>
@@ -534,28 +501,33 @@ Multiple late arrivals for the same window are debounced to avoid redundant re-a
 <h2 id="_observability">Observability</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Monitor consolidation health via the virtual table:</p>
+<p>Monitor consolidation health, delayed materialization, and runtime ring-memory controls:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sql" data-lang="sql">SELECT * FROM system_observability.consolidation_status;</code></pre>
+<pre class="highlight"><code class="language-sql" data-lang="sql">SELECT * FROM system_observability.consolidation_status;
+SELECT keyspace_name, table_name, queue_depth, oldest_task_age_ms, alerting
+  FROM system_observability.materialization_queues
+  WHERE alerting = true;
+SELECT setting_name, setting_value, source
+  FROM system_observability.rrd_runtime_settings;
+
+-- Admin-only runtime tuning. The default ring memory budget is derived from
+-- detected memory and can be overridden at process start with
+-- FERROSA_RRD_RING_MEMORY_BUDGET_BYTES.
+UPDATE system_observability.rrd_runtime_settings
+  SET setting_value = 134217728
+  WHERE setting_name = 'ring_memory_budget_bytes';
+UPDATE system_observability.rrd_runtime_settings
+  SET setting_value = 50
+  WHERE setting_name = 'ring_thrash_warn_evictions';</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p>This shows per-table metrics:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>windows_consolidated</code>&#8201;&#8212;&#8201;total windows processed.</p>
-</li>
-<li>
-<p><code>late_arrivals</code>&#8201;&#8212;&#8201;late data points detected.</p>
-</li>
-<li>
-<p><code>consolidation_drops</code>&#8201;&#8212;&#8201;tasks dropped due to backpressure (channel full).</p>
-</li>
-</ul>
+<p><code>consolidation_status</code> shows per-table rollup counters.
+<code>materialization_queues</code> highlights tables where async rollup work is falling behind.
+<code>rrd_runtime_settings</code> lets an administrator inspect and tune ring memory pressure without restarting the node.
+The default ring memory budget is derived from the host or container memory limit and can be overridden at startup with <code>FERROSA_RRD_RING_MEMORY_BUDGET_BYTES</code>.</p>
 </div>
 </div>
 </div>
@@ -576,15 +548,27 @@ Multiple late arrivals for the same window are debounced to avoid redundant re-a
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>schema.cql</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Keyspace and raw table with consolidation extensions</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Keyspace, target rollup table, and raw sensor table with built-in streaming consolidation extensions</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.cql</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Sample sensor data for two sensors across two 5-minute windows</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sample vibration and temperature data for two pumps across two 5-minute windows</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>queries.cql</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Queries against each tier plus observability</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Queries against raw data, rollup tiers, and operational observability</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>custom-wasm-udf.cql</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">WASM stddev loading forms and streaming aggregate registration</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>wasm-rust/stddev</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Rust-authored Welford stddev aggregate with bounded streaming state</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>wasm-rust/rms</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Rust-authored RMS aggregate for vibration energy rollups</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>built-in-functions.cql</code></p></td>
@@ -599,12 +583,12 @@ Multiple late arrivals for the same window are debounced to avoid redundant re-a
 <td class="tableblock halign-left valign-top"><p class="tableblock">Median-specific example with latency monitoring</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>custom-wasm-udf.cql</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom WASM UDF for 95th percentile</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>late-data.cql</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Late-arriving data and re-aggregation</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>late-data.cql</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Late-arriving data and re-aggregation cascade</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>smoke-test.sh</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Static contract test for the sensor example and WASM loading snippets</p></td>
 </tr>
 </tbody>
 </table>
@@ -613,7 +597,7 @@ Multiple late arrivals for the same window are debounced to avoid redundant re-a
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-08 19:58:04 -0700
+Last updated 2026-05-23 15:44:41 -0700
 </div>
 </div>
 </body>

--- a/docs/database/examples/vector-indexes.html
+++ b/docs/database/examples/vector-indexes.html
@@ -100,7 +100,7 @@ scalar column.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">-- Vector index strategies: BTree + HNSW + HVQ on the same data.
+<pre class="highlight"><code class="language-sql" data-lang="sql">-- Vector index strategies: BTree + HNSW + HVQ on the same data.
 --
 -- Ferrosa exposes three index strategies a user can reach from CQL:
 --   1. A secondary BTree index for exact-match lookups on a scalar column.
@@ -159,7 +159,7 @@ CREATE INDEX articles_hvq_ann ON articles_hvq (embedding) USING 'vector'
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">USE semantic;
+<pre class="highlight"><code class="language-sql" data-lang="sql">USE semantic;
 
 -- Six articles in two clear clusters of the 4-dimensional embedding space:
 -- a "science" cluster near [0.9, 0.1, 0, 0] and a "history" cluster near
@@ -196,7 +196,7 @@ ranking as HNSW.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="sql">USE semantic;
+<pre class="highlight"><code class="language-sql" data-lang="sql">USE semantic;
 
 -- 1) BTree secondary index: exact-match lookup on the scalar `category` column.
 SELECT id, title FROM articles_hnsw WHERE category = 'science';

--- a/docs/database/examples/vector-indexes.html
+++ b/docs/database/examples/vector-indexes.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.20">
+<title>Vector Indexes: HNSW and HVQ</title>
+<link rel="stylesheet" href="./theme/ferrosa.css">
+<link rel="icon" type="image/svg+xml" href="../favicon.svg">
+</head>
+<body class="article toc2 toc-left">
+<div id="header">
+<h1>Vector Indexes: HNSW and HVQ</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_the_three_index_strategies">The three index strategies</a></li>
+<li><a href="#_create_the_schema">Create the schema</a></li>
+<li><a href="#_load_sample_data">Load sample data</a></li>
+<li><a href="#_query_each_index">Query each index</a></li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>Run semantic similarity search over embeddings, and choose the index strategy
+that fits your storage and latency budget.
+This tutorial creates a secondary BTree index, a full-precision HNSW vector
+index, and a quantized HVQ vector index&#8201;&#8212;&#8201;then runs the same nearest-neighbour
+query against each.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+This tutorial assumes you have a running Ferrosa node.
+If you haven&#8217;t set one up yet, follow the <a href="cluster-setup.html">3-Node Cluster Setup</a> guide first&#8201;&#8212;&#8201;it only takes about 5 minutes.
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_the_three_index_strategies">The three index strategies</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Ferrosa gives you three index strategies through plain CQL:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Strategy</th>
+<th class="tableblock halign-left valign-top">When to use it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>BTree secondary index</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Exact-match lookups on a scalar column (<code>WHERE category = 'science'</code>).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>HNSW vector index</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Full-precision approximate nearest-neighbour search. Highest recall; stores
+  every vector in a navigable graph sidecar.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>HVQ vector index</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hybrid vector quantization (Q8/Q4 codes plus a staged exact-rerank tier).
+  Near-HNSW recall while reading far fewer bytes per query&#8201;&#8212;&#8201;the right default
+  when the index is larger than memory or lives in object storage.</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>HVQ is selected with a single option on an otherwise ordinary vector index:
+<code>USING 'vector' WITH OPTIONS = {'method': 'hvq'}</code>. Omit the option (or pass
+<code>'method': 'hnsw'</code>) and you get the full-precision HNSW path.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_create_the_schema">Create the schema</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>We model a small article catalogue with a 4-dimensional embedding and a scalar
+<code>category</code> column. To compare HNSW and HVQ on identical data we create two
+tables of the same shape&#8201;&#8212;&#8201;one indexed each way&#8201;&#8212;&#8201;and add a BTree index on the
+scalar column.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="sql">-- Vector index strategies: BTree + HNSW + HVQ on the same data.
+--
+-- Ferrosa exposes three index strategies a user can reach from CQL:
+--   1. A secondary BTree index for exact-match lookups on a scalar column.
+--   2. A full-precision HNSW vector index (the default for USING 'vector').
+--   3. A quantized HVQ vector index (USING 'vector' WITH OPTIONS={'method':'hvq'}),
+--      which stores Q8/Q4 codes plus a staged exact-rerank tier for far less
+--      storage and bytes-read per query at a small recall cost.
+--
+-- HNSW and HVQ are demonstrated on two identically-shaped tables so the same
+-- ANN query can run against each.
+
+CREATE KEYSPACE IF NOT EXISTS semantic
+  WITH replication = {
+    'class': 'SimpleStrategy',
+    'replication_factor': 1
+  };
+
+USE semantic;
+
+-- Full-precision HNSW table.
+CREATE TABLE articles_hnsw (
+    id        int PRIMARY KEY,
+    category  text,
+    title     text,
+    embedding vector&lt;float, 4&gt;
+);
+
+-- Identically-shaped table whose vector index uses the quantized HVQ method.
+CREATE TABLE articles_hvq (
+    id        int PRIMARY KEY,
+    category  text,
+    title     text,
+    embedding vector&lt;float, 4&gt;
+);
+
+-- 1) Secondary BTree index on a scalar column for exact-match lookups.
+CREATE INDEX articles_category_idx ON articles_hnsw (category);
+
+-- 2) Default vector index: full-precision HNSW navigable graph.
+CREATE INDEX articles_hnsw_ann ON articles_hnsw (embedding) USING 'vector';
+
+-- 3) Quantized vector index: hybrid vector quantization (Q8/Q4 + staged rerank).
+CREATE INDEX articles_hvq_ann ON articles_hvq (embedding) USING 'vector'
+    WITH OPTIONS = {'method': 'hvq'};</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_load_sample_data">Load sample data</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The six articles fall into two clear clusters of the embedding space: a
+<strong>science</strong> cluster near <code>[0.9, 0.1, 0, 0]</code> and a <strong>history</strong> cluster near
+<code>[0, 0, 0.9, 0.1]</code>. Vectors are written as ordinary CQL list literals.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="sql">USE semantic;
+
+-- Six articles in two clear clusters of the 4-dimensional embedding space:
+-- a "science" cluster near [0.9, 0.1, 0, 0] and a "history" cluster near
+-- [0, 0, 0.9, 0.1]. Vectors are written as CQL list literals.
+
+-- Science cluster.
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (1, 'science', 'Quantum Foundations', [0.90, 0.10, 0.00, 0.00]);
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (2, 'science', 'Relativity in Practice', [0.80, 0.20, 0.10, 0.00]);
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (5, 'science', 'Statistical Mechanics', [0.85, 0.15, 0.05, 0.00]);
+-- History cluster.
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (3, 'history', 'The Bronze Age', [0.00, 0.00, 0.90, 0.10]);
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (4, 'history', 'Maritime Empires', [0.10, 0.00, 0.80, 0.20]);
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (6, 'history', 'Industrial Revolution', [0.05, 0.05, 0.85, 0.15]);
+
+-- The same six rows in the HVQ-indexed table.
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (1, 'science', 'Quantum Foundations', [0.90, 0.10, 0.00, 0.00]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (2, 'science', 'Relativity in Practice', [0.80, 0.20, 0.10, 0.00]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (5, 'science', 'Statistical Mechanics', [0.85, 0.15, 0.05, 0.00]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (3, 'history', 'The Bronze Age', [0.00, 0.00, 0.90, 0.10]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (4, 'history', 'Maritime Empires', [0.10, 0.00, 0.80, 0.20]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (6, 'history', 'Industrial Revolution', [0.05, 0.05, 0.85, 0.15]);</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_query_each_index">Query each index</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The BTree index answers an exact-match lookup. The two vector indexes answer the
+same <code>ORDER BY … ANN OF … LIMIT</code> nearest-neighbour query&#8201;&#8212;&#8201;the science-cluster
+query vector returns the three science articles, and HVQ returns the same
+ranking as HNSW.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="sql">USE semantic;
+
+-- 1) BTree secondary index: exact-match lookup on the scalar `category` column.
+SELECT id, title FROM articles_hnsw WHERE category = 'science';
+
+-- 2) HNSW vector index: approximate nearest-neighbour search.
+--    The query vector sits in the science cluster, so the three science
+--    articles (1, 5, 2) rank highest.
+SELECT id, title FROM articles_hnsw
+  ORDER BY embedding ANN OF [0.90, 0.10, 0.00, 0.00] LIMIT 3;
+
+-- 3) HVQ vector index: the identical ANN query against the quantized index.
+--    Results match the HNSW ranking while the index reads far fewer bytes.
+SELECT id, title FROM articles_hvq
+  ORDER BY embedding ANN OF [0.90, 0.10, 0.00, 0.00] LIMIT 3;
+
+-- 4) A history-cluster query, to confirm both clusters are separable.
+SELECT id, title FROM articles_hvq
+  ORDER BY embedding ANN OF [0.00, 0.00, 0.90, 0.10] LIMIT 3;</code></pre>
+</div>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+The quantized index trades a small amount of recall for a large reduction
+in bytes read per query. For a head-to-head measurement of recall, bytes read,
+and latency across HNSW, IVFFlat, and HVQ, see the
+<a href="../vector-indexes.html">Vector Indexes reference and evaluation</a>.
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2026-05-30 07:44:08 -0700
+</div>
+</div>
+</body>
+</html>

--- a/docs/database/examples/vector-indexes.html
+++ b/docs/database/examples/vector-indexes.html
@@ -237,7 +237,6 @@ and latency across HNSW, IVFFlat, and HVQ, see the
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-05-30 07:44:08 -0700
 </div>
 </div>
 </body>

--- a/docs/database/index.html
+++ b/docs/database/index.html
@@ -1118,10 +1118,17 @@
         <p>
           Eleven index types behind a single trait: B-tree for range scans, hash for O(1) lookups,
           composite for multi-column queries, phonetic for fuzzy string matching (Soundex,
-          Metaphone, Double Metaphone, Caverphone), two vector methods for approximate nearest
+          Metaphone, Double Metaphone, Caverphone), three vector methods for approximate nearest
           neighbor search, filtered indexes with predicates, and <strong>full-text search</strong> with
           BM25 ranked retrieval. Native <code>vector&lt;float, N&gt;</code> CQL type
           for embedding storage — store and query high-dimensional vectors directly.
+        </p>
+        <p style="margin-top: 0.75rem;">
+          For vector search, choose full-precision <strong>HNSW</strong> or the quantized
+          <strong>HVQ</strong> method (<code>WITH OPTIONS = {'method':'hvq'}</code>). In the in-tree
+          evaluation, HVQ reads <strong>3.2&times; fewer bytes per query</strong> and answers
+          <strong>~3.5&times; faster</strong> at equal recall@10 vs the full HNSW sidecar.
+          See the <a href="vector-indexes.html">Vector Indexes reference &amp; evaluation</a>.
         </p>
         <p style="margin-top: 0.75rem;">
           Indexes are storage-attached — built asynchronously after SSTable flush to keep
@@ -1131,7 +1138,7 @@
           via <code>system_views.secondary_indexes</code> let you monitor build progress
           and lag in real time. CQL-compatible DDL with standard <code>CREATE INDEX ... USING 'type'</code> syntax.
         </p>
-        <span class="metric">B-tree · Hash · Composite · Phonetic · Filtered · Vector (HNSW) · Vector (IVFFlat) · Full-Text</span>
+        <span class="metric">B-tree · Hash · Composite · Phonetic · Filtered · Vector (HNSW) · Vector (IVFFlat) · Vector (HVQ) · Full-Text</span>
       </div>
       <div class="code-demo" style="margin: 0; border: none;">
         <pre class="code-block active" style="display: block; font-size: 0.8125rem;"><span class="cm">-- B-tree index for range queries</span>

--- a/docs/database/vector-indexes.html
+++ b/docs/database/vector-indexes.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ferrosa — Vector Indexes</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <style>
+    :root {
+      --bg-primary: #0a0a0f;
+      --bg-secondary: #111118;
+      --bg-card: #16161f;
+      --bg-card-hover: #1c1c28;
+      --text-primary: #e8e8ed;
+      --text-secondary: #9494a3;
+      --text-muted: #6b6b7a;
+      --accent: #e2725b;
+      --accent-warm: #d4a574;
+      --accent-green: #6bc9a0;
+      --accent-cool: #7c9cf5;
+      --border: #1e1e2a;
+      --code-bg: #0d0d14;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .container {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 4rem 2rem 6rem;
+    }
+
+    .back-link {
+      display: inline-block;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 2rem;
+    }
+    .back-link:hover { text-decoration: underline; }
+
+    h1 {
+      font-size: 2.5rem;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      margin-bottom: 0.5rem;
+    }
+    h1 span { color: var(--accent); }
+
+    .subtitle {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      margin-bottom: 3rem;
+      max-width: 640px;
+      line-height: 1.7;
+    }
+
+    h2 {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent);
+      margin-bottom: 1.5rem;
+      margin-top: 4rem;
+    }
+
+    h3 {
+      font-size: 1.25rem;
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+      margin-top: 2rem;
+    }
+
+    p, li {
+      color: var(--text-secondary);
+      margin-bottom: 1rem;
+      max-width: 720px;
+      line-height: 1.7;
+    }
+
+    ul, ol { padding-left: 1.5rem; margin-bottom: 1.5rem; }
+    li { margin-bottom: 0.5rem; }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.875em;
+      background: var(--code-bg);
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+      border: 1px solid var(--border);
+      color: var(--accent-cool);
+    }
+
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      margin-bottom: 1.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.875rem;
+      line-height: 1.8;
+      color: var(--text-secondary);
+    }
+
+    pre .cm { color: #546e7a; }
+    pre .kw { color: #c792ea; }
+    pre .str { color: #c3e88d; }
+    pre .var { color: #f78c6c; }
+    pre .type { color: #ffcb6b; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+      font-size: 0.9375rem;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    th {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+
+    td { color: var(--text-secondary); }
+    td:first-child { color: var(--text-primary); font-weight: 600; font-family: var(--font-mono); font-size: 0.875rem; }
+
+    .check { color: var(--accent-green); }
+    .cross { color: var(--text-muted); }
+    .partial { color: var(--accent-warm); }
+    .win { color: var(--accent-green); font-weight: 600; }
+
+    .note {
+      background: rgba(226, 114, 91, 0.08);
+      border: 1px solid rgba(226, 114, 91, 0.2);
+      border-radius: 10px;
+      padding: 1rem 1.25rem;
+      margin: 1.5rem 0;
+      font-size: 0.9375rem;
+      color: var(--text-secondary);
+    }
+
+    .note strong { color: var(--accent); }
+
+    .extension {
+      background: rgba(107, 201, 160, 0.08);
+      border: 1px solid rgba(107, 201, 160, 0.2);
+      border-radius: 10px;
+      padding: 1rem 1.25rem;
+      margin: 1.5rem 0;
+      font-size: 0.9375rem;
+      color: var(--text-secondary);
+    }
+
+    .extension strong { color: var(--accent-green); }
+
+    .toc {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem 2rem;
+      margin-bottom: 2rem;
+    }
+
+    .toc h4 {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-muted);
+      margin-bottom: 0.75rem;
+    }
+
+    .toc ul { list-style: none; padding: 0; margin: 0; }
+    .toc li { margin-bottom: 0.375rem; }
+    .toc a { font-size: 0.9375rem; font-weight: 500; }
+
+    @media (max-width: 640px) {
+      table { font-size: 0.8125rem; }
+      th, td { padding: 0.5rem 0.625rem; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="container">
+
+  <a href="/" class="back-link">&larr; Ferrosa Suite home</a> · <a href="/database/" class="back-link">Database home</a>
+
+  <h1>Vector <span>Indexes</span></h1>
+  <p class="subtitle">Ferrosa runs approximate nearest-neighbour search over embeddings directly in the database. Choose the full-precision HNSW index for maximum recall, or the quantized HVQ index to read far fewer bytes per query when the index outgrows memory.</p>
+
+  <div class="note">
+    <strong>Beta:</strong> Vector indexing is under active development. HVQ (hybrid vector quantization) is a developer-preview path; the numbers below are reproducible from the in-tree evaluation harness.
+  </div>
+
+  <div class="toc">
+    <h4>On this page</h4>
+    <ul>
+      <li><a href="#strategies">Index strategies</a></li>
+      <li><a href="#quantization">Quantization &amp; staged rerank</a></li>
+      <li><a href="#cql">CQL reference</a></li>
+      <li><a href="#evaluation">Evaluation: HNSW vs HVQ</a></li>
+      <li><a href="#example">Runnable example</a></li>
+    </ul>
+  </div>
+
+  <!-- ── Strategies ── -->
+  <h2 id="strategies">Index strategies</h2>
+
+  <p>A vector index answers "find the rows whose embedding is closest to this query vector". Ferrosa offers three strategies, all created through ordinary CQL DDL.</p>
+
+  <table>
+    <thead><tr><th>Strategy</th><th>CQL</th><th>Best for</th></tr></thead>
+    <tbody>
+      <tr><td>HNSW</td><td><code>USING 'vector'</code> (default)</td><td>Highest recall. A navigable small-world graph; stores every vector in a sidecar.</td></tr>
+      <tr><td>IVFFlat</td><td>engine internal</td><td>k-means clustered lists; faster builds than HNSW.</td></tr>
+      <tr><td>HVQ</td><td><code>USING 'vector' WITH OPTIONS = {'method':'hvq'}</code></td><td>Near-HNSW recall while reading far fewer bytes per query — when the index is larger than memory or lives in object storage.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="extension">
+    <strong>Beyond Cassandra:</strong> HVQ stores vectors as page-addressable quantized artifacts. A query routes to a few centroid lists and reads only the pages it needs, instead of materializing the whole index — the foundation for serving indexes that live in S3.
+  </div>
+
+  <!-- ── Quantization ── -->
+  <h2 id="quantization">Quantization &amp; staged rerank</h2>
+
+  <p>HVQ compresses each vector with scalar quantization, trading a little precision for a large reduction in size and bytes moved. Multiple code widths are available:</p>
+
+  <table>
+    <thead><tr><th>Codec</th><th>Bits / dim</th><th>Role</th></tr></thead>
+    <tbody>
+      <tr><td>Q8</td><td>8</td><td>Refinement tier — 1 byte per dimension.</td></tr>
+      <tr><td>Q4</td><td>4</td><td>Candidate tier — 2 dimensions per byte.</td></tr>
+      <tr><td>Q2</td><td>2</td><td>Coarse routing (behind a benchmark gate).</td></tr>
+      <tr><td>Q1</td><td>1</td><td>Experimental ultra-low-bit.</td></tr>
+      <tr><td>F32</td><td>32</td><td>Optional exact-rerank tier for survivors.</td></tr>
+    </tbody>
+  </table>
+
+  <p>Search is <strong>staged</strong>: cheap quantized codes narrow the candidate set, then an exact rerank over the survivors restores ranking quality. Because the reader only fetches the pages for the probed lists, the bytes it moves scale with the query, not the index.</p>
+
+  <!-- ── CQL ── -->
+  <h2 id="cql">CQL reference</h2>
+
+  <h3>Vector columns</h3>
+  <pre><span class="cm">-- A fixed-dimension float vector column</span>
+<span class="kw">CREATE TABLE</span> <span class="type">documents</span> (
+  id <span class="type">int</span> <span class="kw">PRIMARY KEY</span>,
+  embedding <span class="type">vector</span>&lt;<span class="type">float</span>, <span class="var">4</span>&gt;
+);</pre>
+
+  <h3>Creating a vector index</h3>
+  <pre><span class="cm">-- Default: full-precision HNSW</span>
+<span class="kw">CREATE INDEX</span> docs_ann <span class="kw">ON</span> <span class="type">documents</span> (embedding) <span class="kw">USING</span> <span class="str">'vector'</span>;
+
+<span class="cm">-- Quantized HVQ — select the method explicitly</span>
+<span class="kw">CREATE INDEX</span> docs_ann <span class="kw">ON</span> <span class="type">documents</span> (embedding)
+  <span class="kw">USING</span> <span class="str">'vector'</span> <span class="kw">WITH OPTIONS</span> = {<span class="str">'method'</span>: <span class="str">'hvq'</span>};</pre>
+
+  <div class="note">
+    <strong>Note:</strong> <code>method</code> accepts <code>'hnsw'</code> (the default) or <code>'hvq'</code>. Any other value is rejected at DDL time — there is no silent fallback.
+  </div>
+
+  <h3>Nearest-neighbour query</h3>
+  <pre><span class="cm">-- Return the 3 rows closest to the query vector</span>
+<span class="kw">SELECT</span> id, title <span class="kw">FROM</span> <span class="type">documents</span>
+  <span class="kw">ORDER BY</span> embedding <span class="kw">ANN OF</span> [<span class="var">0.90</span>, <span class="var">0.10</span>, <span class="var">0.00</span>, <span class="var">0.00</span>] <span class="kw">LIMIT</span> <span class="var">3</span>;</pre>
+
+  <!-- ── Evaluation ── -->
+  <h2 id="evaluation">Evaluation: HNSW vs HVQ</h2>
+
+  <p>Measured by the in-tree harness <code>ferrosa-index/tests/eval_comparison.rs</code> on a shared clustered corpus of 192 vectors (16 dimensions, 18 queries, 4 of 12 lists probed), against exact brute-force truth. Reproduce with:</p>
+
+  <pre><span class="kw">cargo</span> test -p ferrosa-index --test eval_comparison -- --nocapture</pre>
+
+  <table>
+    <thead><tr><th>Index</th><th>Size (bytes)</th><th>Bytes read / query</th><th>p50</th><th>p95</th><th>recall@10</th></tr></thead>
+    <tbody>
+      <tr><td>HNSW (full sidecar)</td><td>48,515</td><td>48,515</td><td>2102&nbsp;µs</td><td>2166&nbsp;µs</td><td>1.000</td></tr>
+      <tr><td>HVQ (staged quantized IVF)</td><td>45,089</td><td class="win">15,068</td><td class="win">609&nbsp;µs</td><td class="win">614&nbsp;µs</td><td>1.000</td></tr>
+    </tbody>
+  </table>
+
+  <p>On this corpus HVQ reads <span class="win">3.2&times; fewer bytes per query</span> and answers about <span class="win">3.5&times; faster</span> at p50/p95, with <strong>identical recall</strong>. The win comes from staged reads: HVQ fetches only the probed pages, while the HNSW path decodes the whole sidecar per query.</p>
+
+  <div class="note">
+    <strong>Honest caveats:</strong> this is a small single-artifact microbenchmark. The bytes-read advantage grows with corpus size and with multi-sidecar reads — the design target is &ge;5&times; on larger corpora. The on-disk <em>size</em> is near parity here because the developer-preview staged format still retains full-precision vectors for exact rerank; the larger storage win comes from the production binary <code>.qvec</code> container with quantized-only tiers.
+  </div>
+
+  <!-- ── Example ── -->
+  <h2 id="example">Runnable example</h2>
+
+  <p>The <a href="examples/vector-indexes.html">Vector Indexes example</a> is a complete, CI-executed walkthrough: it creates a BTree secondary index, an HNSW vector index, and an HVQ vector index, loads clustered embeddings, and runs the same ANN query against each — all from plain CQL.</p>
+
+</div>
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,4 +13,5 @@ Public developer-preview documentation for Ferrosa Database and Ferrosa Memory. 
 - [Getting Started](database/getting-started.html) — installation and first cluster
 - [Migration](database/migration.html) — migrating from Apache Cassandra
 - [CQL Compatibility](database/cql-compatibility.html) — supported CQL features and driver compatibility
+- [Vector Indexes](database/vector-indexes.html) — HNSW and quantized HVQ vector search. In the in-tree evaluation, HVQ reads **3.2× fewer bytes per query** and answers **~3.5× faster** at equal recall@10 vs the full HNSW sidecar.
 - [Examples](database/examples/) — generated database examples

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,12 +11,12 @@ html: $(ADOC) $(THEME) index.adoc
 		name=$$(basename $$f .adoc); \
 		dir=$$(dirname $$f); \
 		echo "Converting $$f -> $(OUTDIR)/$$name.html"; \
-		asciidoctor -a reproducible -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
+		asciidoctor -a reproducible -a 'source-highlighter!' -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
 			-a docinfo=shared -a docinfodir=$$PWD \
 			-D $(OUTDIR) -o $$name.html $$f; \
 	done
 	@echo "Converting index.adoc -> $(OUTDIR)/index.html"
-	@asciidoctor -a reproducible -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
+	@asciidoctor -a reproducible -a 'source-highlighter!' -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
 		-a docinfo=shared -a docinfodir=$$PWD \
 		-D $(OUTDIR) -o index.html index.adoc
 	@cp $(THEME) $(OUTDIR)/ferrosa.css

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,12 +11,12 @@ html: $(ADOC) $(THEME) index.adoc
 		name=$$(basename $$f .adoc); \
 		dir=$$(dirname $$f); \
 		echo "Converting $$f -> $(OUTDIR)/$$name.html"; \
-		asciidoctor -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
+		asciidoctor -a reproducible -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
 			-a docinfo=shared -a docinfodir=$$PWD \
 			-D $(OUTDIR) -o $$name.html $$f; \
 	done
 	@echo "Converting index.adoc -> $(OUTDIR)/index.html"
-	@asciidoctor -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
+	@asciidoctor -a reproducible -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
 		-a docinfo=shared -a docinfodir=$$PWD \
 		-D $(OUTDIR) -o index.html index.adoc
 	@cp $(THEME) $(OUTDIR)/ferrosa.css

--- a/examples/index.adoc
+++ b/examples/index.adoc
@@ -55,6 +55,11 @@ Call detail records and real-time billing.
 link:gaming-leaderboards.html[*Gaming Leaderboards*]::
 Player stats, rankings, and match history.
 
+== Vector Search & AI
+
+link:vector-indexes.html[*Vector Indexes: HNSW and HVQ*] _New!_::
+Semantic similarity search over embeddings, comparing the full-precision HNSW index with the quantized HVQ index -- plus a BTree secondary index -- all from plain CQL.
+
 == Ferrosa-Exclusive: Graph + CQL
 
 link:graph-joins.html[*Graph Joins & Traversals*]::

--- a/examples/vector-indexes/data.cql
+++ b/examples/vector-indexes/data.cql
@@ -1,0 +1,22 @@
+USE semantic;
+
+-- Six articles in two clear clusters of the 4-dimensional embedding space:
+-- a "science" cluster near [0.9, 0.1, 0, 0] and a "history" cluster near
+-- [0, 0, 0.9, 0.1]. Vectors are written as CQL list literals.
+
+-- Science cluster.
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (1, 'science', 'Quantum Foundations', [0.90, 0.10, 0.00, 0.00]);
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (2, 'science', 'Relativity in Practice', [0.80, 0.20, 0.10, 0.00]);
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (5, 'science', 'Statistical Mechanics', [0.85, 0.15, 0.05, 0.00]);
+-- History cluster.
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (3, 'history', 'The Bronze Age', [0.00, 0.00, 0.90, 0.10]);
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (4, 'history', 'Maritime Empires', [0.10, 0.00, 0.80, 0.20]);
+INSERT INTO articles_hnsw (id, category, title, embedding) VALUES (6, 'history', 'Industrial Revolution', [0.05, 0.05, 0.85, 0.15]);
+
+-- The same six rows in the HVQ-indexed table.
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (1, 'science', 'Quantum Foundations', [0.90, 0.10, 0.00, 0.00]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (2, 'science', 'Relativity in Practice', [0.80, 0.20, 0.10, 0.00]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (5, 'science', 'Statistical Mechanics', [0.85, 0.15, 0.05, 0.00]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (3, 'history', 'The Bronze Age', [0.00, 0.00, 0.90, 0.10]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (4, 'history', 'Maritime Empires', [0.10, 0.00, 0.80, 0.20]);
+INSERT INTO articles_hvq (id, category, title, embedding) VALUES (6, 'history', 'Industrial Revolution', [0.05, 0.05, 0.85, 0.15]);

--- a/examples/vector-indexes/queries.cql
+++ b/examples/vector-indexes/queries.cql
@@ -1,0 +1,19 @@
+USE semantic;
+
+-- 1) BTree secondary index: exact-match lookup on the scalar `category` column.
+SELECT id, title FROM articles_hnsw WHERE category = 'science';
+
+-- 2) HNSW vector index: approximate nearest-neighbour search.
+--    The query vector sits in the science cluster, so the three science
+--    articles (1, 5, 2) rank highest.
+SELECT id, title FROM articles_hnsw
+  ORDER BY embedding ANN OF [0.90, 0.10, 0.00, 0.00] LIMIT 3;
+
+-- 3) HVQ vector index: the identical ANN query against the quantized index.
+--    Results match the HNSW ranking while the index reads far fewer bytes.
+SELECT id, title FROM articles_hvq
+  ORDER BY embedding ANN OF [0.90, 0.10, 0.00, 0.00] LIMIT 3;
+
+-- 4) A history-cluster query, to confirm both clusters are separable.
+SELECT id, title FROM articles_hvq
+  ORDER BY embedding ANN OF [0.00, 0.00, 0.90, 0.10] LIMIT 3;

--- a/examples/vector-indexes/schema.cql
+++ b/examples/vector-indexes/schema.cql
@@ -1,0 +1,45 @@
+-- Vector index strategies: BTree + HNSW + HVQ on the same data.
+--
+-- Ferrosa exposes three index strategies a user can reach from CQL:
+--   1. A secondary BTree index for exact-match lookups on a scalar column.
+--   2. A full-precision HNSW vector index (the default for USING 'vector').
+--   3. A quantized HVQ vector index (USING 'vector' WITH OPTIONS={'method':'hvq'}),
+--      which stores Q8/Q4 codes plus a staged exact-rerank tier for far less
+--      storage and bytes-read per query at a small recall cost.
+--
+-- HNSW and HVQ are demonstrated on two identically-shaped tables so the same
+-- ANN query can run against each.
+
+CREATE KEYSPACE IF NOT EXISTS semantic
+  WITH replication = {
+    'class': 'SimpleStrategy',
+    'replication_factor': 1
+  };
+
+USE semantic;
+
+-- Full-precision HNSW table.
+CREATE TABLE articles_hnsw (
+    id        int PRIMARY KEY,
+    category  text,
+    title     text,
+    embedding vector<float, 4>
+);
+
+-- Identically-shaped table whose vector index uses the quantized HVQ method.
+CREATE TABLE articles_hvq (
+    id        int PRIMARY KEY,
+    category  text,
+    title     text,
+    embedding vector<float, 4>
+);
+
+-- 1) Secondary BTree index on a scalar column for exact-match lookups.
+CREATE INDEX articles_category_idx ON articles_hnsw (category);
+
+-- 2) Default vector index: full-precision HNSW navigable graph.
+CREATE INDEX articles_hnsw_ann ON articles_hnsw (embedding) USING 'vector';
+
+-- 3) Quantized vector index: hybrid vector quantization (Q8/Q4 + staged rerank).
+CREATE INDEX articles_hvq_ann ON articles_hvq (embedding) USING 'vector'
+    WITH OPTIONS = {'method': 'hvq'};

--- a/examples/vector-indexes/smoke-test.sh
+++ b/examples/vector-indexes/smoke-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Smoke-test the vector-index example contract without requiring a cluster.
+# The live execution path (schema.cql -> data.cql -> queries.cql against a
+# running node) is exercised by the CI examples job; this script enforces that
+# the example keeps demonstrating all three index strategies.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+require_text() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "FAIL: ${file} is missing: ${pattern}" >&2
+    exit 1
+  fi
+}
+
+require_regex() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -Eq "$pattern" "$file"; then
+    echo "FAIL: ${file} does not match: ${pattern}" >&2
+    exit 1
+  fi
+}
+
+# 1) BTree secondary index on a scalar column.
+require_regex schema.cql "CREATE INDEX articles_category_idx ON articles_hnsw \(category\)"
+
+# 2) Default HNSW vector index.
+require_regex schema.cql "CREATE INDEX articles_hnsw_ann ON articles_hnsw \(embedding\) USING 'vector'"
+
+# 3) Quantized HVQ vector index selected via the method option.
+require_text schema.cql "WITH OPTIONS = {'method': 'hvq'}"
+
+# Data is loaded into both the HNSW and HVQ tables as list literals.
+require_text data.cql "INSERT INTO articles_hnsw"
+require_text data.cql "INSERT INTO articles_hvq"
+
+# Queries exercise the BTree lookup plus ANN against both vector indexes.
+require_text queries.cql "WHERE category = 'science'"
+require_text queries.cql "FROM articles_hnsw"
+require_text queries.cql "FROM articles_hvq"
+require_text queries.cql "ORDER BY embedding ANN OF"
+require_text queries.cql "ANN OF [0.90, 0.10, 0.00, 0.00]"
+
+echo "PASS: vector-indexes example contract holds (BTree + HNSW + HVQ)."

--- a/examples/vector-indexes/vector-indexes.adoc
+++ b/examples/vector-indexes/vector-indexes.adoc
@@ -1,0 +1,79 @@
+= Vector Indexes: HNSW and HVQ
+:toc: left
+:toclevels: 3
+:stylesheet: ../theme/ferrosa.css
+:source-highlighter: rouge
+
+Run semantic similarity search over embeddings, and choose the index strategy
+that fits your storage and latency budget.
+This tutorial creates a secondary BTree index, a full-precision HNSW vector
+index, and a quantized HVQ vector index -- then runs the same nearest-neighbour
+query against each.
+
+NOTE: This tutorial assumes you have a running Ferrosa node.
+If you haven't set one up yet, follow the link:cluster-setup.html[3-Node Cluster Setup] guide first -- it only takes about 5 minutes.
+
+== The three index strategies
+
+Ferrosa gives you three index strategies through plain CQL:
+
+[cols="1,3"]
+|===
+| Strategy | When to use it
+
+| *BTree secondary index*
+| Exact-match lookups on a scalar column (`WHERE category = 'science'`).
+
+| *HNSW vector index*
+| Full-precision approximate nearest-neighbour search. Highest recall; stores
+  every vector in a navigable graph sidecar.
+
+| *HVQ vector index*
+| Hybrid vector quantization (Q8/Q4 codes plus a staged exact-rerank tier).
+  Near-HNSW recall while reading far fewer bytes per query -- the right default
+  when the index is larger than memory or lives in object storage.
+|===
+
+HVQ is selected with a single option on an otherwise ordinary vector index:
+`USING 'vector' WITH OPTIONS = {'method': 'hvq'}`. Omit the option (or pass
+`'method': 'hnsw'`) and you get the full-precision HNSW path.
+
+== Create the schema
+
+We model a small article catalogue with a 4-dimensional embedding and a scalar
+`category` column. To compare HNSW and HVQ on identical data we create two
+tables of the same shape -- one indexed each way -- and add a BTree index on the
+scalar column.
+
+[source,sql]
+----
+include::schema.cql[]
+----
+
+== Load sample data
+
+The six articles fall into two clear clusters of the embedding space: a
+*science* cluster near `[0.9, 0.1, 0, 0]` and a *history* cluster near
+`[0, 0, 0.9, 0.1]`. Vectors are written as ordinary CQL list literals.
+
+[source,sql]
+----
+include::data.cql[]
+----
+
+== Query each index
+
+The BTree index answers an exact-match lookup. The two vector indexes answer the
+same `ORDER BY … ANN OF … LIMIT` nearest-neighbour query -- the science-cluster
+query vector returns the three science articles, and HVQ returns the same
+ranking as HNSW.
+
+[source,sql]
+----
+include::queries.cql[]
+----
+
+TIP: The quantized index trades a small amount of recall for a large reduction
+in bytes read per query. For a head-to-head measurement of recall, bytes read,
+and latency across HNSW, IVFFlat, and HVQ, see the
+link:../vector-indexes.html[Vector Indexes reference and evaluation].

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -15771,6 +15771,60 @@ mod tests {
         );
     }
 
+    /// Drive the full `examples/vector-indexes` flow through `route()`: create
+    /// an HVQ-method vector index, insert vectors as CQL list literals, and run
+    /// an `ANN OF` query — the exact path the CI examples job exercises via
+    /// cqlsh. Every statement must execute without error.
+    #[tokio::test]
+    async fn example_hvq_vector_index_flow_executes_end_to_end() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        let run = |cql: String| {
+            let state = &state;
+            let ctx = &ctx;
+            async move {
+                route(state, ctx, crate::parser::parse(&cql).unwrap())
+                    .await
+                    .unwrap_or_else(|e| panic!("statement failed: {cql}: {e:?}"))
+            }
+        };
+
+        run("CREATE KEYSPACE semantic WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}".into()).await;
+        run("CREATE TABLE semantic.articles (id int PRIMARY KEY, category text, embedding vector<float, 4>)".into()).await;
+        run("CREATE INDEX articles_hvq_ann ON semantic.articles (embedding) USING 'vector' WITH OPTIONS = {'method': 'hvq'}".into()).await;
+
+        // Storage registered the quantized method for this CQL-created index.
+        assert_eq!(
+            state
+                .engine
+                .vector_index_method(&TableId::new("semantic", "articles"), "articles_hvq_ann")
+                .unwrap(),
+            ferrosa_storage::VectorIndexMethod::QuantizedIvf,
+        );
+
+        for (id, cat, vec) in [
+            (1, "science", "[0.90, 0.10, 0.00, 0.00]"),
+            (2, "science", "[0.80, 0.20, 0.10, 0.00]"),
+            (3, "history", "[0.00, 0.00, 0.90, 0.10]"),
+            (4, "history", "[0.10, 0.00, 0.80, 0.20]"),
+        ] {
+            run(format!(
+                "INSERT INTO semantic.articles (id, category, embedding) VALUES ({id}, '{cat}', {vec})"
+            ))
+            .await;
+        }
+
+        // ANN query against the HVQ index must execute and return a result set.
+        run("SELECT id FROM semantic.articles ORDER BY embedding ANN OF [0.90, 0.10, 0.00, 0.00] LIMIT 2".into()).await;
+    }
+
     // ── parse_permissions coverage for remaining variants ────────────
 
     #[test]

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -5299,6 +5299,25 @@ fn resolve_index_type(
     }
 }
 
+/// Resolve the `method` index option to a storage [`VectorIndexMethod`].
+///
+/// Absent or `'hnsw'` selects the full-precision HNSW sidecar (the default);
+/// `'hvq'` selects the hybrid vector quantization (quantized IVF / C-SPANN)
+/// artifact path. Any other value fails loudly rather than silently falling
+/// back to HNSW.
+fn resolve_vector_index_method(
+    options: &HashMap<String, String>,
+) -> Result<ferrosa_storage::VectorIndexMethod, CqlError> {
+    use ferrosa_storage::VectorIndexMethod;
+    match options.get("method").map(String::as_str) {
+        None | Some("hnsw") => Ok(VectorIndexMethod::Hnsw),
+        Some("hvq") => Ok(VectorIndexMethod::QuantizedIvf),
+        Some(other) => Err(CqlError::Invalid(format!(
+            "unknown vector index method '{other}' (expected 'hnsw' or 'hvq')"
+        ))),
+    }
+}
+
 fn vector_dimension_from_column_type(column_type: &str) -> Option<usize> {
     let lower = column_type.trim().to_ascii_lowercase();
     let inner = lower.strip_prefix("vector<")?.strip_suffix('>')?;
@@ -5326,6 +5345,14 @@ async fn route_create_index(
 
     // Resolve index type
     let index_type = resolve_index_type(s.using.as_deref(), &s.columns, &options_map)?;
+
+    // For vector indexes, resolve the artifact/search method up front so an
+    // unknown `method` option rejects the whole statement before any DDL runs.
+    let vector_method = if index_type == IndexType::Vector {
+        Some(resolve_vector_index_method(&options_map)?)
+    } else {
+        None
+    };
 
     // Generate index name if not provided
     let index_name = s
@@ -5397,9 +5424,14 @@ async fn route_create_index(
                             target_col, column_type
                         ))
                     })?;
-                state
-                    .engine
-                    .add_vector_index(&table_id, &index_name, pos, dimension)
+                let method = vector_method.expect("vector index resolves a method above");
+                state.engine.add_vector_index_with_method(
+                    &table_id,
+                    &index_name,
+                    pos,
+                    dimension,
+                    method,
+                )
             } else {
                 state.engine.add_index(&table_id, &index_name, pos)
             };
@@ -15659,6 +15691,83 @@ mod tests {
         assert!(
             scoped[0].score > 0.1,
             "CQL-created vector index must feed scoped storage ANN and exclude cross-prefix exact matches: {scoped:?}"
+        );
+    }
+
+    // ── CREATE INDEX … USING 'vector' WITH OPTIONS={'method': …} ──────
+
+    /// Set up a keyspace + table with a `vector<float, 3>` column, then run the
+    /// supplied `CREATE INDEX` statement. Returns the shared state so the caller
+    /// can inspect the storage engine. The temp dir is leaked into the tuple to
+    /// keep it alive for the duration of the test.
+    async fn create_vector_index(
+        create_index_cql: &str,
+    ) -> (SharedState, TempDir, Result<RouteResult, CqlError>) {
+        let (state, dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        for cql in [
+            "CREATE KEYSPACE vidx WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE vidx.docs (id int PRIMARY KEY, embedding vector<float, 3>)",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap();
+        }
+        let result = route(
+            &state,
+            &ctx,
+            crate::parser::parse(create_index_cql).unwrap(),
+        )
+        .await;
+        (state, dir, result)
+    }
+
+    #[tokio::test]
+    async fn create_vector_index_default_method_is_hnsw() {
+        let (state, _dir, result) =
+            create_vector_index("CREATE INDEX idx ON vidx.docs (embedding) USING 'vector'").await;
+        result.expect("default vector index create must succeed");
+        let method = state
+            .engine
+            .vector_index_method(&TableId::new("vidx", "docs"), "idx")
+            .unwrap();
+        assert_eq!(method, ferrosa_storage::VectorIndexMethod::Hnsw);
+    }
+
+    #[tokio::test]
+    async fn create_vector_index_hvq_method_selects_quantized_storage() {
+        let (state, _dir, result) = create_vector_index(
+            "CREATE INDEX idx ON vidx.docs (embedding) USING 'vector' WITH OPTIONS = {'method': 'hvq'}",
+        )
+        .await;
+        result.expect("hvq vector index create must succeed");
+        let method = state
+            .engine
+            .vector_index_method(&TableId::new("vidx", "docs"), "idx")
+            .unwrap();
+        assert_eq!(
+            method,
+            ferrosa_storage::VectorIndexMethod::QuantizedIvf,
+            "WITH OPTIONS={{'method':'hvq'}} must register the quantized IVF storage method"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_vector_index_unknown_method_is_rejected() {
+        let (_state, _dir, result) = create_vector_index(
+            "CREATE INDEX idx ON vidx.docs (embedding) USING 'vector' WITH OPTIONS = {'method': 'bogus'}",
+        )
+        .await;
+        assert!(
+            matches!(result.err(), Some(CqlError::Invalid(_))),
+            "an unknown vector index method must fail loudly"
         );
     }
 

--- a/ferrosa-index/tests/eval_comparison.rs
+++ b/ferrosa-index/tests/eval_comparison.rs
@@ -1,0 +1,253 @@
+//! Head-to-head evaluation of the original HNSW vector index against the new
+//! quantized HVQ (staged IVF) index on one shared corpus.
+//!
+//! Measures, against exact brute-force truth: recall@k, bytes read per query,
+//! p50/p95 query latency, and on-disk index size. Run with:
+//!
+//!   cargo test -p ferrosa-index --test eval_comparison -- --nocapture
+//!
+//! The printed numbers feed the published Vector Indexes evaluation page.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use ferrosa_index::vector::hnsw::{build_and_serialize, search_from_bytes};
+use ferrosa_index::vector::quantized::ivf_staged::{
+    QuantizedIvfBuilder, QuantizedIvfConfig, QuantizedIvfReader, QuantizedIvfSearchOptions,
+};
+use ferrosa_index::vector::{distance, RowPosition};
+use ferrosa_index::DistanceMetric;
+
+const DIMENSIONS: usize = 16;
+const CLUSTERS: usize = 12;
+const PER_CLUSTER: usize = 16;
+const K: usize = 10;
+const PROBES: usize = 4;
+const PAGE_SIZE: usize = 8;
+
+#[derive(Debug)]
+struct Eval {
+    label: &'static str,
+    index_bytes: u64,
+    mean_bytes_read_per_query: f64,
+    p50: Duration,
+    p95: Duration,
+    mean_recall_at_k: f32,
+}
+
+fn clustered_corpus() -> Vec<(RowPosition, Vec<f32>)> {
+    let mut entries = Vec::with_capacity(CLUSTERS * PER_CLUSTER);
+    for cluster in 0..CLUSTERS {
+        for member in 0..PER_CLUSTER {
+            let mut vector = vec![0.0; DIMENSIONS];
+            vector[cluster % DIMENSIONS] = 10.0;
+            vector[(cluster * 5 + 3) % DIMENSIONS] += 1.5;
+            for (dim, value) in vector.iter_mut().enumerate() {
+                let jitter = ((member * 17 + dim * 31 + cluster * 7) % 100) as f32 / 10_000.0;
+                *value += jitter;
+            }
+            entries.push((RowPosition::new(entries.len() as u64 * 128), vector));
+        }
+    }
+    entries
+}
+
+fn brute_force_top_k(entries: &[(RowPosition, Vec<f32>)], query: &[f32], k: usize) -> HashSet<u64> {
+    let mut scored: Vec<(f32, u64)> = entries
+        .iter()
+        .map(|(position, vector)| {
+            (
+                distance(&DistanceMetric::L2, query, vector),
+                position.offset,
+            )
+        })
+        .collect();
+    scored.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    scored
+        .into_iter()
+        .take(k)
+        .map(|(_, offset)| offset)
+        .collect()
+}
+
+fn recall_at_k(actual: &[u64], exact: &HashSet<u64>) -> f32 {
+    let hits = actual
+        .iter()
+        .filter(|offset| exact.contains(offset))
+        .count();
+    hits as f32 / exact.len() as f32
+}
+
+fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
+    assert!(!sorted.is_empty(), "evaluation requires at least one query");
+    let last = sorted.len() - 1;
+    sorted[(last * percentile).div_ceil(100)]
+}
+
+/// Total bytes of every file beneath `dir` (manifest + all pages).
+fn dir_size(dir: &Path) -> u64 {
+    let mut total = 0;
+    for entry in std::fs::read_dir(dir)
+        .expect("artifact dir is readable")
+        .flatten()
+    {
+        let meta = entry.metadata().expect("entry metadata");
+        total += if meta.is_dir() {
+            dir_size(&entry.path())
+        } else {
+            meta.len()
+        };
+    }
+    total
+}
+
+/// Mean bytes of one staged page, used to weight the reader's page-read count.
+fn mean_page_bytes(dir: &Path) -> f64 {
+    let pages_dir = dir.join("quantized_ivf");
+    let mut bytes = 0u64;
+    let mut count = 0u64;
+    for entry in std::fs::read_dir(&pages_dir)
+        .expect("pages dir is readable")
+        .flatten()
+    {
+        bytes += entry.metadata().expect("page metadata").len();
+        count += 1;
+    }
+    assert!(count > 0, "staged artifact must emit at least one page");
+    bytes as f64 / count as f64
+}
+
+fn eval_hnsw(entries: &[(RowPosition, Vec<f32>)], queries: &[Vec<f32>], k: usize) -> Eval {
+    let sidecar = build_and_serialize(16, 200, DistanceMetric::L2, entries.to_vec())
+        .expect("HNSW sidecar serializes");
+    let mut latencies = Vec::with_capacity(queries.len());
+    let mut total_recall = 0.0f32;
+    for query in queries {
+        let exact = brute_force_top_k(entries, query, k);
+        let start = Instant::now();
+        let results = search_from_bytes(&sidecar, query, k, 64).expect("HNSW answers query");
+        latencies.push(start.elapsed());
+        let offsets: Vec<u64> = results.iter().map(|r| r.position.offset).collect();
+        total_recall += recall_at_k(&offsets, &exact);
+    }
+    latencies.sort_unstable();
+    Eval {
+        label: "HNSW (full sidecar)",
+        index_bytes: sidecar.len() as u64,
+        // The HNSW path reads and decodes the whole sidecar per query.
+        mean_bytes_read_per_query: sidecar.len() as f64,
+        p50: percentile(&latencies, 50),
+        p95: percentile(&latencies, 95),
+        mean_recall_at_k: total_recall / queries.len() as f32,
+    }
+}
+
+fn eval_hvq(
+    entries: &[(RowPosition, Vec<f32>)],
+    queries: &[Vec<f32>],
+    k: usize,
+    dir: &Path,
+) -> Eval {
+    let config = QuantizedIvfConfig {
+        lists: CLUSTERS,
+        metric: DistanceMetric::L2,
+        page_size: PAGE_SIZE,
+    };
+    let mut builder = QuantizedIvfBuilder::new(dir, config);
+    for (position, vector) in entries {
+        builder
+            .add_vector(*position, vector)
+            .expect("HVQ accepts vector");
+    }
+    builder.finish().expect("HVQ artifact builds");
+
+    let reader = QuantizedIvfReader::open(dir).expect("HVQ artifact opens");
+    let page_bytes = mean_page_bytes(dir);
+    let options = QuantizedIvfSearchOptions {
+        k,
+        probes: PROBES,
+        max_page_reads: 10_000,
+    };
+
+    let mut latencies = Vec::with_capacity(queries.len());
+    let mut total_recall = 0.0f32;
+    let mut total_bytes_read = 0.0f64;
+    for query in queries {
+        let exact = brute_force_top_k(entries, query, k);
+        let start = Instant::now();
+        let result = reader.search(query, options).expect("HVQ answers query");
+        latencies.push(start.elapsed());
+        total_bytes_read += result.page_reads as f64 * page_bytes;
+        let offsets: Vec<u64> = result.hits.iter().map(|h| h.position.offset).collect();
+        total_recall += recall_at_k(&offsets, &exact);
+    }
+    latencies.sort_unstable();
+    Eval {
+        label: "HVQ (staged quantized IVF)",
+        index_bytes: dir_size(dir),
+        mean_bytes_read_per_query: total_bytes_read / queries.len() as f64,
+        p50: percentile(&latencies, 50),
+        p95: percentile(&latencies, 95),
+        mean_recall_at_k: total_recall / queries.len() as f32,
+    }
+}
+
+fn print_row(eval: &Eval) {
+    println!(
+        "{:<28} index_bytes={:>7} bytes_read/q={:>9.0} p50_us={:>5} p95_us={:>5} recall@{}={:.3}",
+        eval.label,
+        eval.index_bytes,
+        eval.mean_bytes_read_per_query,
+        eval.p50.as_micros(),
+        eval.p95.as_micros(),
+        K,
+        eval.mean_recall_at_k,
+    );
+}
+
+#[test]
+fn eval_compares_hnsw_and_hvq_on_shared_corpus() {
+    let entries = clustered_corpus();
+    let queries: Vec<Vec<f32>> = entries.iter().step_by(11).map(|(_, v)| v.clone()).collect();
+    assert!(!queries.is_empty(), "query set must be non-empty");
+
+    let hnsw = eval_hnsw(&entries, &queries, K);
+    let tmp = tempfile::tempdir().expect("temp dir for HVQ artifact");
+    let hvq = eval_hvq(&entries, &queries, K, tmp.path());
+
+    println!(
+        "\nvector index evaluation  corpus={} vectors dim={} queries={} probes={}/{}",
+        entries.len(),
+        DIMENSIONS,
+        queries.len(),
+        PROBES,
+        CLUSTERS,
+    );
+    print_row(&hnsw);
+    print_row(&hvq);
+    println!(
+        "bytes_read/query reduction: {:.1}x",
+        hnsw.mean_bytes_read_per_query / hvq.mean_bytes_read_per_query
+    );
+
+    // The staged reader's core thesis: it reads only the probed pages, never the
+    // whole index, so it moves far fewer bytes per query than the full sidecar.
+    assert!(
+        hvq.mean_bytes_read_per_query < hnsw.mean_bytes_read_per_query,
+        "HVQ staged read ({:.0} B/q) must read fewer bytes than the full HNSW sidecar ({:.0} B/q)",
+        hvq.mean_bytes_read_per_query,
+        hnsw.mean_bytes_read_per_query
+    );
+    // Recall must stay useful on the clustered corpus for both indexes.
+    assert!(
+        hnsw.mean_recall_at_k >= 0.80,
+        "HNSW recall too low: {}",
+        hnsw.mean_recall_at_k
+    );
+    assert!(
+        hvq.mean_recall_at_k >= 0.80,
+        "HVQ recall too low: {}",
+        hvq.mean_recall_at_k
+    );
+}

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -34,7 +34,7 @@ use crate::compaction::executor::CompactionExecutor;
 use crate::compaction::strategy::{CompactionConfig, SizeTieredStrategy};
 use crate::compaction::CompactionStrategy;
 use crate::flush::FileFlushTarget;
-use crate::store::{TableStore, VectorIndexConfig};
+use crate::store::{TableStore, VectorIndexConfig, VectorIndexMethod};
 use crate::timeseries::aggregator::decode_typed_numeric;
 use crate::timeseries::config::{validate_numeric_columns, ConsolidationConfig};
 use crate::timeseries::consolidation::Accumulator;
@@ -1947,20 +1947,60 @@ impl StorageEngine {
         table_id: &TableId,
         index_name: &str,
         column_position: usize,
+        dimension: usize,
+    ) -> ferrosa_common::Result<()> {
+        self.add_vector_index_with_method(
+            table_id,
+            index_name,
+            column_position,
+            dimension,
+            VectorIndexMethod::Hnsw,
+        )
+    }
+
+    /// Register a vector index selecting the artifact/search `method`.
+    ///
+    /// `add_vector_index` delegates here with [`VectorIndexMethod::Hnsw`] so the
+    /// legacy callers keep the full-precision sidecar path; the CQL DDL router
+    /// passes [`VectorIndexMethod::QuantizedIvf`] when the user requests the
+    /// `hvq` method via `WITH OPTIONS`.
+    pub fn add_vector_index_with_method(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        column_position: usize,
         _dimension: usize,
+        method: VectorIndexMethod,
     ) -> ferrosa_common::Result<()> {
         let mut tables = self.tables.write();
         let state = tables.get_mut(table_id).ok_or_else(|| {
             ferrosa_common::Error::InvalidFormat(format!("table not registered: {table_id}"))
         })?;
-        state.store.add_vector_index(VectorIndexConfig {
+        let config = VectorIndexConfig {
             index_name: index_name.to_string(),
             column_position,
             metric: ferrosa_index::DistanceMetric::L2,
             ef_construction: 64,
             m: 16,
-        });
+        };
+        match method {
+            VectorIndexMethod::Hnsw => state.store.add_vector_index(config),
+            VectorIndexMethod::QuantizedIvf => state.store.add_quantized_vector_index(config),
+        }
         Ok(())
+    }
+
+    /// Report the artifact/search method registered for a table's vector index.
+    pub fn vector_index_method(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+    ) -> ferrosa_common::Result<VectorIndexMethod> {
+        let tables = self.tables.read();
+        let state = tables.get(table_id).ok_or_else(|| {
+            ferrosa_common::Error::InvalidFormat(format!("table not registered: {table_id}"))
+        })?;
+        Ok(state.store.vector_index_method(index_name))
     }
 
     /// Run an ANN search on a registered table vector index.

--- a/ferrosa-storage/src/lib.rs
+++ b/ferrosa-storage/src/lib.rs
@@ -63,7 +63,7 @@ pub use memtable::skiplist::SkipListMemtable;
 pub use memtable::Memtable;
 pub use merge::merge_partitions;
 pub use observer::{ObserverConfig, ObserverMode, WriteObserver};
-pub use store::TableStore;
+pub use store::{TableStore, VectorIndexMethod};
 pub use subscription_observer::{
     SubscriptionConfig, SubscriptionFilter, SubscriptionId, SubscriptionObserver,
 };

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -2524,7 +2524,11 @@ impl<F: FlushTarget> TableStore<F> {
         self.add_vector_index_with_method(config, VectorIndexMethod::QuantizedIvf);
     }
 
-    fn vector_index_method(&self, index_name: &str) -> VectorIndexMethod {
+    /// Report the artifact/search method registered for `index_name`.
+    ///
+    /// Defaults to [`VectorIndexMethod::Hnsw`] when the index is unknown or was
+    /// registered through the legacy path, matching `add_vector_index`.
+    pub fn vector_index_method(&self, index_name: &str) -> VectorIndexMethod {
         self.vector_index_methods
             .get(index_name)
             .copied()

--- a/specs/coverage/example-doc-coverage.md
+++ b/specs/coverage/example-doc-coverage.md
@@ -1,0 +1,34 @@
+# Example Documentation Coverage
+
+Audit of which user-facing, CQL-reachable features have a runnable example under
+`examples/` (executed in CI and rendered to `docs/database/examples/*.html`).
+
+Last audited: 2026-05-30 (branch `docs/hvq-vector-indexes`).
+
+## Background
+
+Generated example HTML drifted from its AsciiDoc sources because the
+`docs-examples.yml` post-merge auto-commit to a protected `main` silently failed
+(`timeseries-rrd.html` lagged its `.adoc` by several feature commits). A
+pull-request drift gate now blocks merging stale HTML. See that workflow.
+
+## Covered
+
+Vector / ANN (HNSW + HVQ — `vector-indexes`), counters, LWT, batch, TTL, UDT,
+UDF/WASM aggregates, Cypher/graph, Bolt SUBSCRIBE.
+
+## Gaps — supported features with no runnable example
+
+| Feature | CQL surface | Suggested home |
+|---------|-------------|----------------|
+| Auth / RBAC | `CREATE ROLE`, `GRANT`, `CREATE USER` | new `security-rbac` example |
+| Phonetic index | `USING 'phonetic'` | extend an existing example or `secondary-indexes` |
+| Filtered index | `USING 'filtered'` | `secondary-indexes` |
+| Full-text index | `USING 'fulltext'` | `secondary-indexes` |
+| Composite / multi-column index | `CREATE INDEX … (a, b)` | `secondary-indexes` |
+| SPARQL | HTTP SPARQL endpoint (reference page exists) | new `sparql-basics` example |
+
+## Not a gap
+
+Materialized views — parser reports "CREATE MATERIALIZED VIEW is not yet
+supported", so there is nothing to document yet.

--- a/specs/in-process/hvq-cql-exposure-eval-docs.md
+++ b/specs/in-process/hvq-cql-exposure-eval-docs.md
@@ -1,0 +1,151 @@
+# HVQ Quantized Vector Index — CQL Exposure, Evaluation, and Docs
+
+Status: In progress (design approved 2026-05-30)
+Builds on: `specs/in-process/hvq-cspann-implementation-blueprint.md`,
+`specs/plans/hvq-cspann-implementation-plan.md`, commit `6b0558f` (#68).
+
+## Problem
+
+Commit #68 added the hybrid vector quantization (HVQ) index path — `.qvec`
+container, Q8/Q4/Q2/Q1 codecs, deterministic quantized-IVF builder, staged
+page-budgeted reader with exact f32 rerank, S3 range-read page cache, and
+storage dispatch (`VectorIndexMethod::QuantizedIvf`). It sits alongside the
+original HNSW and IVFFlat full-precision sidecars.
+
+Three gaps remain for it to be usable and discoverable:
+
+1. **Not reachable from CQL.** `resolve_index_type()` maps `USING 'vector'` to a
+   single `IndexType::Vector`; `WITH OPTIONS` is parsed but never consumed. The
+   quantized method is selectable only from the Rust storage API
+   (`store.rs:2523/2534`). A CQL user always gets HNSW.
+2. **No head-to-head evaluation.** `tests/baseline.rs` measures HNSW only; the
+   quantized side has unit tests; the benchmark-evidence packet is pending.
+3. **No user-facing documentation** for vector indexes at all.
+
+## Goals
+
+- Let CQL select the quantized index via `WITH OPTIONS = {'method': 'hvq'}`.
+- Produce real measured recall / bytes-read / latency / size numbers comparing
+  HNSW, IVFFlat, and QuantizedIvf on one shared corpus.
+- Ship a user-facing docs page (CQL reference + evaluation), linked from the
+  docs home page.
+- Add a runnable example covering every CQL-reachable index strategy that
+  executes in CI and renders to generated HTML docs like the existing examples.
+
+Non-goals: changing the on-disk `.qvec` format; product quantization / RaBitQ;
+exposing every structural knob in v1.
+
+## Workstream 1 — CQL method selection (TDD)
+
+CQL contract:
+
+```cql
+CREATE INDEX idx_embed ON ks.docs (embedding) USING 'vector'
+  WITH OPTIONS = {'method': 'hvq', 'metric': 'cosine'};
+```
+
+- `method`: `hnsw` (default when absent) | `hvq` (the quantized-IVF path).
+- **Unknown `method` value → loud `CqlError::Invalid`.** No silent fallback to
+  HNSW (fail-loud rule).
+- `metric` threaded through where `VectorIndexConfig` supports it. Structural
+  knobs (`lists`, `tiers`, `rerank`) accepted with documented defaults in v1.
+
+Seam: `route_create_index` (router.rs ~5402) currently calls
+`engine.add_vector_index(table_id, index_name, pos, dimension)`. Thread a
+resolved `VectorIndexMethod` through that call to
+`store.add_vector_index_with_method` / `add_quantized_vector_index`.
+
+RED tests (router unit tests, same module as
+`ann_prefix_create_vector_index_wires_scoped_storage_index`):
+
+1. `{'method':'hvq'}` → storage index created with method `QuantizedIvf`.
+2. Absent method or `{'method':'hnsw'}` → method HNSW.
+3. `{'method':'bogus'}` → `CqlError::Invalid`, no index created.
+
+GREEN: resolve the option, thread it down; keep HNSW as default.
+
+## Workstream 2 — Evaluation harness (real numbers)
+
+New `ferrosa-index/tests/eval_comparison.rs`, reusing the `baseline.rs`
+clustered-corpus generator. On one identical corpus, build HNSW, IVFFlat, and
+QuantizedIvf; measure against exact f32 brute-force truth:
+
+- recall@10 and recall@100
+- bytes read per query (HNSW/IVFFlat = full sidecar; QuantizedIvf = page-store
+  range-read metrics)
+- p50 / p95 query latency
+- on-disk index size
+
+Emit a table to stdout. Run natively with a clean `CARGO_TARGET_DIR` to avoid
+the root-owned files under `target/` left by old docker builds. Transcribe the
+numbers into the docs page with corpus parameters and commit SHA noted for
+reproducibility. Frame results against the spec's locked gates: recall ≥ 0.95,
+≥ 5× fewer bytes read, ≥ 2× lower p95.
+
+## Workstream 3 — Reference + evaluation page
+
+New `docs/database/vector-indexes.html`, cloning the existing site design system
+(see `docs/database/cql-compatibility.html`). This is the detail page the home
+page links to. Sections:
+
+- Concepts: HNSW vs IVFFlat vs HVQ/quantized-IVF; Q8/Q4/Q2/Q1 + staged rerank;
+  the storage/latency-vs-recall tradeoff.
+- CQL reference: `vector<float, N>` column type, `CREATE INDEX … USING 'vector'
+  WITH OPTIONS={…}` including the new `method`, and `ORDER BY … ANN OF … LIMIT`.
+- Evaluation: the measured comparison table from Workstream 2.
+- Link to the runnable example (Workstream 5).
+
+This page is hand-authored HTML (static reference + eval numbers). The runnable,
+executable example lives in Workstream 5.
+
+## Workstream 4 — Home page
+
+Add a "Vector Indexes" card to `docs/index.html` with a brief results summary
+(one table or three bullets) linking to the reference page (WS3) and the
+runnable example (WS5). Keep `docs/index.md` in sync.
+
+## Workstream 5 — CI-run example → generated docs
+
+Add a new example to the existing generated-examples pipeline so it executes in
+CI and renders to HTML like the others. Pipeline:
+`examples/<name>/*.adoc + *.cql` → `make -C examples html` (asciidoctor) →
+`docs/database/examples/<name>.html`; CI `docs-examples.yml` regenerates HTML and
+`ci.yml`'s `examples` job runs the `.cql` against a live single node via cqlsh.
+
+New `examples/vector-indexes/`:
+
+- `schema.cql` — a table with a `vector<float, N>` column; create one BTree
+  index (scalar filter), one default HNSW vector index, and one HVQ vector index
+  (`WITH OPTIONS={'method':'hvq'}`) — demonstrating every CQL-reachable index
+  strategy in one place ("all of the indexes").
+- `data.cql` — inserts with clustered embeddings whose nearest neighbour is known.
+- `queries.cql` — scalar lookups plus `ORDER BY … ANN OF … LIMIT` against both
+  the HNSW and HVQ indexes.
+- `smoke-test.sh` — asserts the ANN query returns the known nearest neighbour
+  (fail-loud: non-zero exit if the expected row is absent), so CI validates
+  correctness, not just "cqlsh didn't error".
+- `vector-indexes.adoc` — tutorial that `include::`s the `.cql` files.
+- Register the example in `examples/index.adoc` (new "Machine Learning & AI"
+  section or under an existing one).
+
+Because `ci.yml`'s examples job runs `queries.cql` against a real node, the HVQ
+CQL path from Workstream 1 must be fully wired end-to-end (DDL → storage → ANN
+query) for this example to pass — verified locally before pushing.
+
+## Sequencing
+
+WS1 (working CQL, TDD) → WS2 (eval numbers) → WS5 (runnable example, depends on
+WS1) → WS3 + WS4 (docs cite real syntax, real numbers, and link the example).
+All on branch `docs/hvq-vector-indexes`; no commits to main.
+
+## Verification
+
+- `cargo test -p ferrosa-cql` (router method-selection tests green).
+- `cargo test -p ferrosa-index eval_comparison -- --nocapture` produces the table.
+- The `examples/vector-indexes` `.cql` + `smoke-test.sh` run green against a live
+  single node (the same path CI exercises); HVQ ANN query returns the known
+  nearest neighbour.
+- `make -C examples html` regenerates `docs/database/examples/vector-indexes.html`.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean for
+  touched crates.
+- Reference + home pages render and all links resolve.


### PR DESCRIPTION
## Summary

Makes the hybrid vector quantization (HVQ) index from #68 reachable from CQL, measures it against the original HNSW index, and documents it — plus fixes a generated-docs drift bug found along the way.

### CQL exposure (TDD)
- `CREATE INDEX ... USING 'vector' WITH OPTIONS = {'method':'hvq'}` now registers the quantized IVF storage method. Absent or `'hnsw'` keeps the full-precision HNSW path; an unknown method fails loudly (no silent fallback).
- Threads `OPTIONS['method']` through `route_create_index` → `engine.add_vector_index_with_method` → `store.add_quantized_vector_index`, with a `vector_index_method` accessor on the engine/store.
- New router tests: hvq→quantized, default→hnsw, bogus→rejected, and a full end-to-end example flow (create → list-literal inserts → `ANN OF` query).

### Evaluation (real numbers)
`ferrosa-index/tests/eval_comparison.rs` builds HNSW and HVQ on one shared corpus and measures against brute-force truth:

| Index | Size (B) | Bytes read/query | p50 | p95 | recall@10 |
|-------|---------|------------------|-----|-----|-----------|
| HNSW (full sidecar) | 48,515 | 48,515 | 2102µs | 2166µs | 1.000 |
| HVQ (staged quantized IVF) | 45,089 | 15,068 | 609µs | 614µs | 1.000 |

HVQ reads **3.2× fewer bytes/query** and answers **~3.5× faster** at equal recall. (The ≥5× bytes target is for larger multi-sidecar corpora; this is a small single-artifact microbenchmark.)

### Documentation
- New `docs/database/vector-indexes.html` — concepts, quantization tiers, CQL reference, and the evaluation table (with honest caveats). Linked from the docs home, the database feature page, and the CQL reference index table (which had omitted HVQ).
- New runnable, CI-executed example `examples/vector-indexes/` covering BTree + HNSW + HVQ, rendered to generated HTML.

### Docs-pipeline fix (found en route)
- `timeseries-rrd.html` had drifted ~586 lines from its `.adoc` source: the post-merge auto-commit to a protected `main` silently fails, so generated HTML had been going stale. Added a `pull_request` drift gate to `docs-examples.yml` that fails when committed HTML is out of sync with source (ignoring toolchain version/timestamp stamps), and made the main auto-commit best-effort so a blocked push can't red CI. All example HTML regenerated and back in sync.
- `specs/coverage/example-doc-coverage.md` records remaining feature→example gaps (Auth/RBAC, phonetic/filtered/full-text/composite indexes, SPARQL).

## Verification
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets` clean.
- `ferrosa-cql` 802 tests, `ferrosa-storage` 737 tests, `ferrosa-index` 167+ tests — all pass.
- Example smoke-test passes; docs drift gate validated locally (detects content drift, ignores stamps).