### PR TITLE
Add compaction validator (oracle + differential + soak) and fix two merge bugs

### DIFF
--- a/docs/database/cql-compatibility.html
+++ b/docs/database/cql-compatibility.html
@@ -440,6 +440,12 @@
   </ul>
   <p>Set per-query via the standard CQL protocol flags, or configure a default with <code>FERROSA_DEFAULT_CL</code> (default: <code>QUORUM</code>).</p>
 
+  <h3>Conflict resolution</h3>
+  <p>Cells reconcile by last-write-wins on timestamp: the higher write timestamp wins. When two writes to the same cell share the same timestamp, the lexicographically greater value wins, so the result is deterministic regardless of replica or compaction order.</p>
+  <div class="note">
+    <strong>Difference from Cassandra:</strong> when a write and a delete carry the <em>same</em> timestamp, Ferrosa favors the <strong>write</strong> — the data is preserved. Apache Cassandra resolves the same tie in favor of the <strong>delete</strong> (the tombstone wins). If you depend on Cassandra's delete-wins-on-tie behavior, use distinct timestamps for the delete.
+  </div>
+
   <!-- ── Auth ── -->
   <h2 id="auth-roles">Auth &amp; Roles</h2>
 

--- a/ferrosa-loadgen/Cargo.toml
+++ b/ferrosa-loadgen/Cargo.toml
@@ -11,7 +11,7 @@ ferrosa-common = { path = "../ferrosa-common" }
 ferrosa-schema = { path = "../ferrosa-schema" }
 ferrosa-sstable = { path = "../ferrosa-sstable" }
 ferrosa-cql = { path = "../ferrosa-cql" }
-ferrosa-storage = { path = "../ferrosa-storage" }
+ferrosa-storage = { path = "../ferrosa-storage", features = ["compaction-validator"] }
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/ferrosa-loadgen/src/main.rs
+++ b/ferrosa-loadgen/src/main.rs
@@ -77,6 +77,19 @@ struct Args {
     /// List available profiles and exit.
     #[arg(long)]
     list_profiles: bool,
+
+    /// Run the compaction soak instead of a load test: generate deterministic
+    /// corpora, compact them for real, and diff each against the oracle.
+    #[arg(long)]
+    compaction_soak: bool,
+
+    /// Starting seed for the compaction soak (corpora are reproducible per seed).
+    #[arg(long, default_value_t = 1)]
+    soak_seed: u64,
+
+    /// Number of compaction-soak iterations to run.
+    #[arg(long, default_value_t = 1000)]
+    soak_iterations: usize,
 }
 
 fn main() {
@@ -91,6 +104,34 @@ fn main() {
             "  delete_update_heavy  10% read / 70% update / 20% delete — max tombstone pressure"
         );
         println!("  compaction_stress    Long-running compaction stress with W=2");
+        return;
+    }
+
+    if args.compaction_soak {
+        let work_dir = args.data_dir.join("compaction-soak");
+        std::fs::create_dir_all(&work_dir).expect("create soak work dir");
+        println!(
+            "Compaction soak: {} iterations from seed {}",
+            args.soak_iterations, args.soak_seed
+        );
+        let result = ferrosa_storage::compaction::validator::soak::run(
+            &work_dir,
+            args.soak_seed,
+            args.soak_iterations,
+        );
+        let _ = std::fs::remove_dir_all(&work_dir);
+        match result {
+            Ok(report) => {
+                println!(
+                    "Soak PASSED: {} iterations, {} logical cells checked",
+                    report.iterations, report.cells_checked
+                );
+            }
+            Err(err) => {
+                eprintln!("Soak FAILED: {err}");
+                std::process::exit(1);
+            }
+        }
         return;
     }
 

--- a/ferrosa-storage/Cargo.toml
+++ b/ferrosa-storage/Cargo.toml
@@ -38,6 +38,10 @@ skiplist-memtable = ["crossbeam-skiplist"]
 # FERROSA_TEST_* environment prerequisites so missing infra cannot be reported
 # as a passing test body.
 live-infra-tests = []
+# Exposes the compaction validator (oracle + differential checks) so other
+# crates (ferrosa-loadgen soak) can reuse it. The validator is always available
+# to this crate's own tests regardless of this feature.
+compaction-validator = []
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/ferrosa-storage/src/compaction/executor.rs
+++ b/ferrosa-storage/src/compaction/executor.rs
@@ -130,7 +130,11 @@ impl CompactionExecutor {
     /// independent of the total dataset size. The output's serialization
     /// header is built from the inputs' headers (bounded compute) rather
     /// than from a full data scan.
-    fn execute_task(task: &CompactionTask) -> std::result::Result<SSTableMetadata, String> {
+    // `pub(crate)` so the compaction validator can drive a real compaction
+    // synchronously and diff the output against its oracle.
+    pub(crate) fn execute_task(
+        task: &CompactionTask,
+    ) -> std::result::Result<SSTableMetadata, String> {
         Self::execute_task_inner(task, |_| {})
     }
 

--- a/ferrosa-storage/src/compaction/mod.rs
+++ b/ferrosa-storage/src/compaction/mod.rs
@@ -11,6 +11,11 @@ pub mod metadata;
 pub mod strategy;
 pub mod strategy_ucs;
 
+/// Compaction correctness validator (oracle + differential checks). Compiled
+/// only for tests or when the `compaction-validator` feature is enabled.
+#[cfg(any(test, feature = "compaction-validator"))]
+pub mod validator;
+
 pub use executor::{CompactionExecutor, CompactionResult};
 pub use metadata::{CompactionTask, SSTableMetadata};
 pub use strategy::{CompactionConfig, CompactionStrategy, SizeTieredStrategy};

--- a/ferrosa-storage/src/compaction/validator/auditor.rs
+++ b/ferrosa-storage/src/compaction/validator/auditor.rs
@@ -1,0 +1,120 @@
+//! Format auditor: structural invariants every merged partition must satisfy.
+//!
+//! The Cassandra tool's `FormatAuditor` checks byte- and semantic-level
+//! invariants on compaction output. The universal subset that applies to
+//! Ferrosa's row model: rows are strictly ordered by clustering (no duplicate
+//! rows survive a merge), cells within a row are strictly ordered by column (no
+//! duplicate columns), TTL and local deletion time are non-negative, and a
+//! tombstone cell is never simultaneously an expiring write (the IS_DELETED +
+//! IS_EXPIRING exclusivity errata).
+
+use ferrosa_common::CellValue;
+use ferrosa_sstable::types::{Partition, Row};
+
+/// Audit `partition` and return the list of invariant violations. An empty
+/// vector means the partition is well formed.
+pub fn audit_partition(partition: &Partition) -> Vec<String> {
+    let mut violations = Vec::new();
+
+    for pair in partition.rows.windows(2) {
+        if pair[0].clustering >= pair[1].clustering {
+            violations.push(format!(
+                "rows not strictly ordered by clustering: {:?} >= {:?}",
+                pair[0].clustering, pair[1].clustering
+            ));
+        }
+    }
+
+    if let Some(static_row) = &partition.static_row {
+        audit_row(static_row, &mut violations);
+    }
+    for row in &partition.rows {
+        audit_row(row, &mut violations);
+    }
+
+    violations
+}
+
+fn audit_row(row: &Row, violations: &mut Vec<String>) {
+    for pair in row.cells.windows(2) {
+        if pair[0].0 >= pair[1].0 {
+            violations.push(format!(
+                "cells not strictly ordered by column: {} >= {}",
+                pair[0].0, pair[1].0
+            ));
+        }
+    }
+    for (col, cell) in &row.cells {
+        audit_cell(*col, cell, violations);
+    }
+}
+
+fn audit_cell(col: u16, cell: &CellValue, violations: &mut Vec<String>) {
+    if cell.ttl < 0 {
+        violations.push(format!("column {col}: negative ttl {}", cell.ttl));
+    }
+    if cell.local_deletion_time < 0 {
+        violations.push(format!(
+            "column {col}: negative local_deletion_time {}",
+            cell.local_deletion_time
+        ));
+    }
+    if cell.value.is_none() && cell.ttl > 0 {
+        violations.push(format!(
+            "column {col}: tombstone cell must not be expiring (ttl={})",
+            cell.ttl
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrosa_common::key::{DecoratedKey, PartitionKey};
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo};
+
+    fn row(clustering: &[u8], cells: Vec<(u16, CellValue)>) -> Row {
+        Row {
+            clustering: clustering.to_vec(),
+            cells,
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(1),
+        }
+    }
+
+    fn partition(rows: Vec<Row>) -> Partition {
+        Partition {
+            key: DecoratedKey::new(PartitionKey::new(b"k".to_vec())),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows,
+        }
+    }
+
+    #[test]
+    fn well_formed_partition_has_no_violations() {
+        let p = partition(vec![
+            row(b"c0", vec![(0, CellValue::live(b"a".to_vec(), 1))]),
+            row(b"c1", vec![(0, CellValue::live(b"b".to_vec(), 1))]),
+        ]);
+        assert!(audit_partition(&p).is_empty());
+    }
+
+    #[test]
+    fn detects_unordered_rows_and_duplicate_columns() {
+        let unordered = partition(vec![
+            row(b"c1", vec![(0, CellValue::live(b"a".to_vec(), 1))]),
+            row(b"c0", vec![(0, CellValue::live(b"b".to_vec(), 1))]),
+        ]);
+        assert!(!audit_partition(&unordered).is_empty());
+
+        let dup_cols = partition(vec![row(
+            b"c0",
+            vec![
+                (0, CellValue::live(b"a".to_vec(), 1)),
+                (0, CellValue::live(b"b".to_vec(), 1)),
+            ],
+        )]);
+        assert!(!audit_partition(&dup_cols).is_empty());
+    }
+}

--- a/ferrosa-storage/src/compaction/validator/corpus.rs
+++ b/ferrosa-storage/src/compaction/validator/corpus.rs
@@ -1,0 +1,156 @@
+//! Deterministic corpus generator for compaction soak testing.
+//!
+//! From a seed, produces a schema plus several input "SSTable" partition groups
+//! that overlap on keys and columns and mix live cells, expiring (TTL) cells,
+//! and tombstones across wide, sparse rows — shapes the loadgen generator does
+//! not otherwise cover. Generation is reproducible: the same seed yields the
+//! same corpus, so a soak failure can be replayed by pinning its seed.
+
+use ferrosa_common::key::{DecoratedKey, PartitionKey};
+use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+use ferrosa_common::CellValue;
+use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
+
+const REGULAR_COLUMNS: u16 = 4;
+const KEYS: u64 = 6;
+const CLUSTERINGS: u8 = 3;
+const GROUPS: usize = 4;
+
+/// A generated corpus: the schema and one partition group per input SSTable.
+pub struct Corpus {
+    pub schema: TableSchema,
+    pub groups: Vec<Vec<Partition>>,
+}
+
+/// Reproducible splitmix64 PRNG. Inlined so the soak adds no dependency and the
+/// corpus is byte-identical across machines.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn below(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+
+    fn chance(&mut self, numerator: u64, denominator: u64) -> bool {
+        self.below(denominator) < numerator
+    }
+}
+
+/// The schema every generated corpus uses: one int clustering column and a
+/// handful of regular text columns (for wide rows).
+pub fn schema() -> TableSchema {
+    let regular_columns = (0..REGULAR_COLUMNS)
+        .map(|i| ColumnDefinition {
+            name: format!("val{i}"),
+            type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        })
+        .collect();
+    TableSchema {
+        keyspace: "soak".to_string(),
+        table: "compaction".to_string(),
+        key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        clustering_columns: vec![ColumnDefinition {
+            name: "ck".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+        }],
+        static_columns: vec![],
+        regular_columns,
+        extensions: Default::default(),
+    }
+}
+
+fn make_cell(rng: &mut Rng, ts: i64) -> CellValue {
+    match rng.below(10) {
+        0..=1 => CellValue::tombstone(ts, 100 + ts as i32),
+        2..=3 => CellValue::expiring(
+            vec![b'e', rng.below(8) as u8],
+            ts,
+            1000,
+            1_000_000 + ts as i32,
+        ),
+        _ => CellValue::live(vec![b'v', rng.below(8) as u8], ts),
+    }
+}
+
+fn make_row(rng: &mut Rng, clustering: u8) -> Option<Row> {
+    let mut cells: Vec<(u16, CellValue)> = Vec::new();
+    for col in 0..REGULAR_COLUMNS {
+        if rng.chance(2, 3) {
+            // Small timestamp range forces conflicts across overlapping SSTables.
+            let ts = 1 + rng.below(5) as i64;
+            cells.push((col, make_cell(rng, ts)));
+        }
+    }
+    if cells.is_empty() {
+        return None;
+    }
+    cells.sort_by_key(|(col, _)| *col);
+    Some(Row {
+        clustering: vec![0, 0, 0, clustering],
+        cells,
+        deletion: DeletionTime::LIVE,
+        primary_key_liveness: LivenessInfo::with_timestamp(1 + rng.below(5) as i64),
+    })
+}
+
+/// Generate a reproducible corpus for `seed`.
+pub fn generate(seed: u64) -> Corpus {
+    let mut rng = Rng::new(seed);
+    let mut groups = Vec::with_capacity(GROUPS);
+
+    for _ in 0..GROUPS {
+        let mut partitions: Vec<Partition> = Vec::new();
+        for k in 0..KEYS {
+            if !rng.chance(2, 3) {
+                continue; // each group covers a random subset of keys
+            }
+            let mut rows: Vec<Row> = (0..CLUSTERINGS)
+                .filter_map(|c| make_row(&mut rng, c))
+                .collect();
+            if rows.is_empty() {
+                continue;
+            }
+            rows.sort_by(|a, b| a.clustering.cmp(&b.clustering));
+            partitions.push(Partition {
+                key: DecoratedKey::new(PartitionKey::new(format!("k{k:02}").into_bytes())),
+                deletion: DeletionTime::LIVE,
+                static_row: None,
+                rows,
+            });
+        }
+        partitions.sort_by(|a, b| a.key.cmp(&b.key));
+        groups.push(partitions);
+    }
+
+    Corpus {
+        schema: schema(),
+        groups,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generation_is_reproducible_and_nonempty() {
+        let a = generate(42);
+        let b = generate(42);
+        assert_eq!(a.groups, b.groups, "same seed must yield the same corpus");
+        let total: usize = a.groups.iter().map(|g| g.len()).sum();
+        assert!(total > 0, "corpus must contain partitions");
+        assert_ne!(generate(1).groups, generate(2).groups, "seeds must differ");
+    }
+}

--- a/ferrosa-storage/src/compaction/validator/driver.rs
+++ b/ferrosa-storage/src/compaction/validator/driver.rs
@@ -4,14 +4,36 @@
 //! k-way merge, and SSTable read-back — so the differential check covers
 //! serialization round-trips, not just the in-memory merge.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
+use ferrosa_common::key::DecoratedKey;
 use ferrosa_common::schema::TableSchema;
 use ferrosa_sstable::types::Partition;
 
 use crate::compaction::executor::CompactionExecutor;
 use crate::compaction::metadata::{CompactionTask, SSTableMetadata};
 use crate::TableId;
+
+/// Logical projection of a partition set: the winning `(value, timestamp)` per
+/// `(key, clustering, column)`. Robust to serialization-level field
+/// normalization, so it compares merge *results* rather than encodings.
+pub fn logical_projection(
+    partitions: &[Partition],
+) -> BTreeMap<(DecoratedKey, Vec<u8>, u16), (Option<Vec<u8>>, i64)> {
+    let mut map = BTreeMap::new();
+    for p in partitions {
+        for row in &p.rows {
+            for (col, cell) in &row.cells {
+                map.insert(
+                    (p.key.clone(), row.clustering.clone(), *col),
+                    (cell.value.clone(), cell.timestamp),
+                );
+            }
+        }
+    }
+    map
+}
 
 /// Write one SSTable from `partitions` into `dir`, returning its metadata.
 pub fn write_sstable(
@@ -123,7 +145,6 @@ mod tests {
     use ferrosa_common::schema::{ColumnDefinition, TableSchema};
     use ferrosa_common::CellValue;
     use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
-    use std::collections::BTreeMap;
 
     fn test_schema() -> TableSchema {
         TableSchema {
@@ -157,25 +178,6 @@ mod tests {
         }
     }
 
-    /// Logical projection: the winning (value, timestamp) per (key, clustering,
-    /// column). Robust to serialization-level field normalization.
-    fn project(
-        partitions: &[Partition],
-    ) -> BTreeMap<(DecoratedKey, Vec<u8>, u16), (Option<Vec<u8>>, i64)> {
-        let mut map = BTreeMap::new();
-        for p in partitions {
-            for row in &p.rows {
-                for (col, cell) in &row.cells {
-                    map.insert(
-                        (p.key.clone(), row.clustering.clone(), *col),
-                        (cell.value.clone(), cell.timestamp),
-                    );
-                }
-            }
-        }
-        map
-    }
-
     #[test]
     fn real_compaction_matches_oracle() {
         let tmp = tempfile::tempdir().unwrap();
@@ -203,14 +205,14 @@ mod tests {
         );
 
         assert_eq!(
-            project(&actual),
-            project(&expected),
+            logical_projection(&actual),
+            logical_projection(&expected),
             "real compaction output must match the oracle merge"
         );
         // The newest write wins the cell.
         let key = DecoratedKey::new(PartitionKey::new(b"k0001".to_vec()));
         assert_eq!(
-            project(&actual).get(&(key, ck.clone(), 0)),
+            logical_projection(&actual).get(&(key, ck.clone(), 0)),
             Some(&(Some(b"new".to_vec()), 3)),
         );
     }

--- a/ferrosa-storage/src/compaction/validator/driver.rs
+++ b/ferrosa-storage/src/compaction/validator/driver.rs
@@ -1,0 +1,217 @@
+//! Drive a real compaction and read its output back, to diff against the oracle.
+//!
+//! This exercises the full pipeline — SSTable write, the executor's streaming
+//! k-way merge, and SSTable read-back — so the differential check covers
+//! serialization round-trips, not just the in-memory merge.
+
+use std::path::Path;
+
+use ferrosa_common::schema::TableSchema;
+use ferrosa_sstable::types::Partition;
+
+use crate::compaction::executor::CompactionExecutor;
+use crate::compaction::metadata::{CompactionTask, SSTableMetadata};
+use crate::TableId;
+
+/// Write one SSTable from `partitions` into `dir`, returning its metadata.
+pub fn write_sstable(
+    dir: &Path,
+    partitions: &[Partition],
+    schema: &TableSchema,
+) -> SSTableMetadata {
+    use crate::flush::{build_serialization_header, FileFlushTarget, FlushTarget};
+    use ferrosa_sstable::writer::SSTableWriter;
+    use ferrosa_sstable::WriteOptions;
+
+    let mut sorted = partitions.to_vec();
+    sorted.sort_by(|a, b| a.key.cmp(&b.key));
+
+    let header = build_serialization_header(schema, &sorted);
+    let options = WriteOptions {
+        compression: None,
+        ..WriteOptions::default()
+    };
+    let mut writer = SSTableWriter::new(options, header);
+    for partition in &sorted {
+        writer.add_partition(partition).expect("write partition");
+    }
+    let output = writer.finish().expect("finish sstable");
+
+    let flush_target = FileFlushTarget::new(dir.to_path_buf()).expect("flush target");
+    let _reader = flush_target.flush(output).expect("flush sstable");
+    let generation = flush_target.generation();
+
+    let size_bytes: u64 = std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.metadata().ok().map(|m| m.len()))
+        .sum();
+
+    SSTableMetadata {
+        id: format!("{generation}"),
+        path: dir.to_path_buf(),
+        size_bytes,
+        min_token: sorted.first().map(|p| p.key.token.0).unwrap_or(0),
+        max_token: sorted.last().map(|p| p.key.token.0).unwrap_or(0),
+        min_timestamp: 1,
+        max_timestamp: 1_000_000,
+        partition_count: sorted.len() as u64,
+    }
+}
+
+/// Read every partition from a compaction output SSTable `generation` in `dir`.
+pub fn read_sstable(dir: &Path, generation: &str) -> Vec<Partition> {
+    use ferrosa_sstable::io::FileReadAt;
+    use ferrosa_sstable::reader::{SSTableComponents, SSTableReader};
+
+    let open = |suffix: &str| {
+        FileReadAt::open(dir.join(format!("{generation}-{suffix}"))).expect("open component")
+    };
+    let read = |suffix: &str| std::fs::read(dir.join(format!("{generation}-{suffix}")));
+
+    let reader = SSTableReader::open(SSTableComponents {
+        data: open("Data.db"),
+        partitions: open("Partitions.db"),
+        rows: open("Rows.db"),
+        filter: read("Filter.db").expect("read filter"),
+        compression_info: read("CompressionInfo.db").ok(),
+        statistics: read("Statistics.db").expect("read statistics"),
+    })
+    .expect("open output reader");
+
+    reader
+        .read_all_partitions()
+        .expect("read output partitions")
+}
+
+/// Write each group as its own input SSTable under `base_dir`, run a single
+/// all-inputs compaction, and return the merged output partitions.
+pub fn compact_all(
+    base_dir: &Path,
+    groups: &[Vec<Partition>],
+    schema: &TableSchema,
+    table_id: TableId,
+) -> Vec<Partition> {
+    let inputs: Vec<SSTableMetadata> = groups
+        .iter()
+        .enumerate()
+        .map(|(i, partitions)| {
+            let dir = base_dir.join(format!("in_{i}"));
+            std::fs::create_dir_all(&dir).expect("create input dir");
+            write_sstable(&dir, partitions, schema)
+        })
+        .collect();
+
+    let output_dir = base_dir.join("out");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+
+    let task = CompactionTask {
+        inputs,
+        output_dir: output_dir.clone(),
+        schema: schema.clone(),
+        table_id,
+    };
+    let meta = CompactionExecutor::execute_task(&task).expect("compaction must succeed");
+    read_sstable(&output_dir, &meta.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::oracle::oracle_merge_all;
+    use super::*;
+    use ferrosa_common::key::{DecoratedKey, PartitionKey};
+    use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+    use ferrosa_common::CellValue;
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+    use std::collections::BTreeMap;
+
+    fn test_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![ColumnDefinition {
+                name: "ck".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+            }],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "val".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: Default::default(),
+        }
+    }
+
+    fn part(key: &str, clustering: &[u8], cell: CellValue) -> Partition {
+        Partition {
+            key: DecoratedKey::new(PartitionKey::new(key.as_bytes().to_vec())),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![Row {
+                clustering: clustering.to_vec(),
+                cells: vec![(0, cell)],
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::with_timestamp(1),
+            }],
+        }
+    }
+
+    /// Logical projection: the winning (value, timestamp) per (key, clustering,
+    /// column). Robust to serialization-level field normalization.
+    fn project(
+        partitions: &[Partition],
+    ) -> BTreeMap<(DecoratedKey, Vec<u8>, u16), (Option<Vec<u8>>, i64)> {
+        let mut map = BTreeMap::new();
+        for p in partitions {
+            for row in &p.rows {
+                for (col, cell) in &row.cells {
+                    map.insert(
+                        (p.key.clone(), row.clustering.clone(), *col),
+                        (cell.value.clone(), cell.timestamp),
+                    );
+                }
+            }
+        }
+        map
+    }
+
+    #[test]
+    fn real_compaction_matches_oracle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema = test_schema();
+        let ck = b"\x00\x00\x00\x01".to_vec();
+
+        // Three overlapping SSTables: a write, a newer write, and a tombstone in
+        // between, for the same cell — plus an unrelated key that must survive.
+        let groups = vec![
+            vec![
+                part("k0001", &ck, CellValue::live(b"old".to_vec(), 1)),
+                part("k0002", &ck, CellValue::live(b"x".to_vec(), 1)),
+            ],
+            vec![part("k0001", &ck, CellValue::live(b"new".to_vec(), 3))],
+            vec![part("k0001", &ck, CellValue::tombstone(2, 100))],
+        ];
+        let all: Vec<Partition> = groups.iter().flatten().cloned().collect();
+
+        let expected = oracle_merge_all(&all);
+        let actual = compact_all(
+            tmp.path(),
+            &groups,
+            &schema,
+            crate::TableId::new("test_ks", "test_table"),
+        );
+
+        assert_eq!(
+            project(&actual),
+            project(&expected),
+            "real compaction output must match the oracle merge"
+        );
+        // The newest write wins the cell.
+        let key = DecoratedKey::new(PartitionKey::new(b"k0001".to_vec()));
+        assert_eq!(
+            project(&actual).get(&(key, ck.clone(), 0)),
+            Some(&(Some(b"new".to_vec()), 3)),
+        );
+    }
+}

--- a/ferrosa-storage/src/compaction/validator/driver.rs
+++ b/ferrosa-storage/src/compaction/validator/driver.rs
@@ -15,12 +15,14 @@ use crate::compaction::executor::CompactionExecutor;
 use crate::compaction::metadata::{CompactionTask, SSTableMetadata};
 use crate::TableId;
 
+/// A logical projection keyed by `(partition key, clustering, column)` mapping
+/// to the winning `(value, timestamp)`.
+pub type LogicalProjection = BTreeMap<(DecoratedKey, Vec<u8>, u16), (Option<Vec<u8>>, i64)>;
+
 /// Logical projection of a partition set: the winning `(value, timestamp)` per
 /// `(key, clustering, column)`. Robust to serialization-level field
 /// normalization, so it compares merge *results* rather than encodings.
-pub fn logical_projection(
-    partitions: &[Partition],
-) -> BTreeMap<(DecoratedKey, Vec<u8>, u16), (Option<Vec<u8>>, i64)> {
+pub fn logical_projection(partitions: &[Partition]) -> LogicalProjection {
     let mut map = BTreeMap::new();
     for p in partitions {
         for row in &p.rows {

--- a/ferrosa-storage/src/compaction/validator/driver.rs
+++ b/ferrosa-storage/src/compaction/validator/driver.rs
@@ -5,10 +5,12 @@
 //! serialization round-trips, not just the in-memory merge.
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use ferrosa_common::key::DecoratedKey;
 use ferrosa_common::schema::TableSchema;
+use ferrosa_sstable::io::FileReadAt;
+use ferrosa_sstable::reader::{SSTableComponents, SSTableReader};
 use ferrosa_sstable::types::Partition;
 
 use crate::compaction::executor::CompactionExecutor;
@@ -83,17 +85,14 @@ pub fn write_sstable(
     }
 }
 
-/// Read every partition from a compaction output SSTable `generation` in `dir`.
-pub fn read_sstable(dir: &Path, generation: &str) -> Vec<Partition> {
-    use ferrosa_sstable::io::FileReadAt;
-    use ferrosa_sstable::reader::{SSTableComponents, SSTableReader};
-
+/// Open an SSTable `generation` in `dir` for reading.
+pub fn open_reader(dir: &Path, generation: &str) -> SSTableReader<FileReadAt> {
     let open = |suffix: &str| {
         FileReadAt::open(dir.join(format!("{generation}-{suffix}"))).expect("open component")
     };
     let read = |suffix: &str| std::fs::read(dir.join(format!("{generation}-{suffix}")));
 
-    let reader = SSTableReader::open(SSTableComponents {
+    SSTableReader::open(SSTableComponents {
         data: open("Data.db"),
         partitions: open("Partitions.db"),
         rows: open("Rows.db"),
@@ -101,21 +100,54 @@ pub fn read_sstable(dir: &Path, generation: &str) -> Vec<Partition> {
         compression_info: read("CompressionInfo.db").ok(),
         statistics: read("Statistics.db").expect("read statistics"),
     })
-    .expect("open output reader");
+    .expect("open output reader")
+}
 
-    reader
+/// Read every partition from a compaction output SSTable `generation` in `dir`.
+pub fn read_sstable(dir: &Path, generation: &str) -> Vec<Partition> {
+    open_reader(dir, generation)
         .read_all_partitions()
         .expect("read output partitions")
 }
 
+/// Verify the reader's index-driven point reads agree with a full scan for
+/// every partition — covering the first/last index-block boundaries where
+/// off-by-one seeking bugs hide. Returns the list of mismatches.
+pub fn audit_point_reads(dir: &Path, generation: &str) -> Vec<String> {
+    let reader = open_reader(dir, generation);
+    let scanned = reader.read_all_partitions().expect("scan partitions");
+    let mut violations = Vec::new();
+    for partition in &scanned {
+        match reader.get_partition(&partition.key) {
+            Ok(Some(found)) => {
+                if logical_projection(std::slice::from_ref(&found))
+                    != logical_projection(std::slice::from_ref(partition))
+                {
+                    violations.push(format!(
+                        "point read of {:?} differs from scan",
+                        partition.key
+                    ));
+                }
+            }
+            Ok(None) => violations.push(format!(
+                "point read of {:?} missing (scan has it)",
+                partition.key
+            )),
+            Err(e) => violations.push(format!("point read of {:?} errored: {e}", partition.key)),
+        }
+    }
+    violations
+}
+
 /// Write each group as its own input SSTable under `base_dir`, run a single
-/// all-inputs compaction, and return the merged output partitions.
-pub fn compact_all(
+/// all-inputs compaction, and return the output `(dir, generation)` so the
+/// caller can both read it back and audit its index point reads.
+pub fn compact_all_to(
     base_dir: &Path,
     groups: &[Vec<Partition>],
     schema: &TableSchema,
     table_id: TableId,
-) -> Vec<Partition> {
+) -> (PathBuf, String) {
     let inputs: Vec<SSTableMetadata> = groups
         .iter()
         .enumerate()
@@ -136,7 +168,18 @@ pub fn compact_all(
         table_id,
     };
     let meta = CompactionExecutor::execute_task(&task).expect("compaction must succeed");
-    read_sstable(&output_dir, &meta.id)
+    (output_dir, meta.id)
+}
+
+/// Compact all groups and return the merged output partitions.
+pub fn compact_all(
+    base_dir: &Path,
+    groups: &[Vec<Partition>],
+    schema: &TableSchema,
+    table_id: TableId,
+) -> Vec<Partition> {
+    let (dir, gen) = compact_all_to(base_dir, groups, schema, table_id);
+    read_sstable(&dir, &gen)
 }
 
 #[cfg(test)]
@@ -371,5 +414,46 @@ mod tests {
             logical_projection(&actual).get(&(key, ck.clone(), 0)),
             Some(&(Some(b"new".to_vec()), 3)),
         );
+    }
+
+    /// Index-driven point reads must agree with a full scan for every key,
+    /// including the first and last partitions where final-block off-by-one
+    /// seeking bugs hide. (Ferrosa's reader is forward-only, so the reverse-scan
+    /// errata does not apply.)
+    #[test]
+    fn point_reads_match_scan_at_index_boundaries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema = test_schema();
+        let ck = b"\x00\x00\x00\x01".to_vec();
+
+        // Enough partitions to span multiple index blocks.
+        let parts: Vec<Partition> = (0..200)
+            .map(|i| {
+                part(
+                    &format!("k{i:05}"),
+                    &ck,
+                    CellValue::live(format!("v{i}").into_bytes(), 1),
+                )
+            })
+            .collect();
+        let dir = tmp.path().join("sst");
+        let meta = write_sstable(&dir, &parts, &schema);
+
+        let violations = audit_point_reads(&dir, &meta.id);
+        assert!(
+            violations.is_empty(),
+            "point reads diverged from scan: {violations:?}"
+        );
+
+        // Explicit first/last boundary point reads.
+        let reader = open_reader(&dir, &meta.id);
+        let scanned = reader.read_all_partitions().unwrap();
+        for boundary in [scanned.first().unwrap(), scanned.last().unwrap()] {
+            assert!(
+                reader.get_partition(&boundary.key).unwrap().is_some(),
+                "boundary partition {:?} not found by point read",
+                boundary.key
+            );
+        }
     }
 }

--- a/ferrosa-storage/src/compaction/validator/driver.rs
+++ b/ferrosa-storage/src/compaction/validator/driver.rs
@@ -180,6 +180,160 @@ mod tests {
         }
     }
 
+    use crate::compaction::{
+        CompactionConfig, CompactionStrategy, SizeTieredStrategy, UcsConfig,
+        UnifiedCompactionStrategy,
+    };
+    use crate::flush::{build_serialization_header, FileFlushTarget, FlushTarget};
+    use ferrosa_sstable::writer::SSTableWriter;
+    use ferrosa_sstable::WriteOptions;
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    /// Write each group as its own SSTable into one shared `dir` (so generations
+    /// are unique across inputs), returning their metadata.
+    fn write_inputs(
+        dir: &Path,
+        groups: &[Vec<Partition>],
+        schema: &TableSchema,
+    ) -> Vec<SSTableMetadata> {
+        std::fs::create_dir_all(dir).unwrap();
+        let flush_target = FileFlushTarget::new(dir.to_path_buf()).unwrap();
+        let mut metas = Vec::new();
+        for group in groups {
+            let mut sorted = group.clone();
+            sorted.sort_by(|a, b| a.key.cmp(&b.key));
+            let header = build_serialization_header(schema, &sorted);
+            let mut writer = SSTableWriter::new(
+                WriteOptions {
+                    compression: None,
+                    ..WriteOptions::default()
+                },
+                header,
+            );
+            for p in &sorted {
+                writer.add_partition(p).unwrap();
+            }
+            flush_target.flush(writer.finish().unwrap()).unwrap();
+            let gen = flush_target.generation();
+            let size_bytes: u64 = std::fs::read_dir(dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.file_name()
+                        .to_string_lossy()
+                        .starts_with(&format!("{gen}-"))
+                })
+                .filter_map(|e| e.metadata().ok().map(|m| m.len()))
+                .sum();
+            metas.push(SSTableMetadata {
+                id: gen.to_string(),
+                path: dir.to_path_buf(),
+                size_bytes,
+                min_token: sorted.first().map(|p| p.key.token.0).unwrap_or(0),
+                max_token: sorted.last().map(|p| p.key.token.0).unwrap_or(0),
+                min_timestamp: 1,
+                max_timestamp: 1_000_000,
+                partition_count: sorted.len() as u64,
+            });
+        }
+        metas
+    }
+
+    /// Execute whatever `strategy` selects (one round), then read every surviving
+    /// SSTable and return the oracle-merged canonical view. Robust to partial
+    /// selection: it tests that the strategy's compaction preserves the data.
+    fn strategy_view(
+        strategy: &dyn CompactionStrategy,
+        metas: &[SSTableMetadata],
+        schema: &TableSchema,
+        table_id: &TableId,
+        out_base: &Path,
+    ) -> super::LogicalProjection {
+        let mut surviving: Vec<(PathBuf, String)> = metas
+            .iter()
+            .map(|m| (m.path.clone(), m.id.clone()))
+            .collect();
+        for (i, task) in strategy
+            .select(metas, schema, table_id)
+            .into_iter()
+            .enumerate()
+        {
+            let out = out_base.join(format!("o{i}"));
+            std::fs::create_dir_all(&out).unwrap();
+            let consumed: HashSet<String> = task.inputs.iter().map(|m| m.id.clone()).collect();
+            let result = CompactionExecutor::execute_task(&CompactionTask {
+                inputs: task.inputs.clone(),
+                output_dir: out.clone(),
+                schema: schema.clone(),
+                table_id: table_id.clone(),
+            })
+            .expect("compaction must succeed");
+            surviving.retain(|(_, id)| !consumed.contains(id));
+            surviving.push((out, result.id));
+        }
+        let mut partitions = Vec::new();
+        for (dir, id) in &surviving {
+            partitions.extend(read_sstable(dir, id));
+        }
+        logical_projection(&oracle_merge_all(&partitions))
+    }
+
+    /// A/B differential: SizeTiered and Unified compaction differ only in which
+    /// SSTables they group — never in the merge result — so each must preserve
+    /// the same data, equal to the oracle.
+    #[test]
+    fn stcs_and_ucs_preserve_identical_data() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema = test_schema();
+        let ck = b"\x00\x00\x00\x01".to_vec();
+        let table_id = crate::TableId::new("ab", "t");
+
+        // Four SSTables over the same keys with ascending timestamps.
+        let groups: Vec<Vec<Partition>> = (0..4u32)
+            .map(|g| {
+                (0..4)
+                    .map(|k| {
+                        part(
+                            &format!("k{k:02}"),
+                            &ck,
+                            CellValue::live(format!("v{g}").into_bytes(), (g + 1) as i64),
+                        )
+                    })
+                    .collect()
+            })
+            .collect();
+        let all: Vec<Partition> = groups.iter().flatten().cloned().collect();
+        let metas = write_inputs(&tmp.path().join("inputs"), &groups, &schema);
+
+        let oracle = logical_projection(&oracle_merge_all(&all));
+        let placeholder = PathBuf::from(tmp.path());
+        let stcs = SizeTieredStrategy::new(CompactionConfig {
+            min_threshold: 2,
+            max_threshold: 32,
+            max_compaction_bytes: 1 << 30,
+            bucket_low: 0.5,
+            bucket_high: 1.5,
+            output_dir: placeholder.clone(),
+        });
+        let ucs = UnifiedCompactionStrategy::new(UcsConfig {
+            fan_factor: 2,
+            min_sstable_size: 1,
+            max_levels: 32,
+            output_dir: placeholder,
+        });
+
+        let stcs_view = strategy_view(&stcs, &metas, &schema, &table_id, &tmp.path().join("stcs"));
+        let ucs_view = strategy_view(&ucs, &metas, &schema, &table_id, &tmp.path().join("ucs"));
+
+        assert_eq!(stcs_view, oracle, "STCS must preserve the oracle's data");
+        assert_eq!(ucs_view, oracle, "UCS must preserve the oracle's data");
+        assert_eq!(
+            stcs_view, ucs_view,
+            "STCS and UCS must preserve identical data"
+        );
+    }
+
     #[test]
     fn real_compaction_matches_oracle() {
         let tmp = tempfile::tempdir().unwrap();

--- a/ferrosa-storage/src/compaction/validator/mod.rs
+++ b/ferrosa-storage/src/compaction/validator/mod.rs
@@ -8,8 +8,10 @@
 //! oracle/auditor for soak testing.
 
 pub mod auditor;
+pub mod corpus;
 pub mod driver;
 pub mod oracle;
+pub mod soak;
 
 #[cfg(test)]
 mod tests {

--- a/ferrosa-storage/src/compaction/validator/mod.rs
+++ b/ferrosa-storage/src/compaction/validator/mod.rs
@@ -7,6 +7,7 @@
 //! the production library; the feature lets `ferrosa-loadgen` reuse the same
 //! oracle/auditor for soak testing.
 
+pub mod auditor;
 pub mod oracle;
 
 #[cfg(test)]
@@ -71,6 +72,7 @@ mod tests {
 
 #[cfg(test)]
 mod prop_tests {
+    use super::auditor::audit_partition;
     use super::oracle::oracle_merge;
     use crate::merge::merge_partitions;
     use ferrosa_common::key::{DecoratedKey, PartitionKey};
@@ -149,6 +151,18 @@ mod prop_tests {
 
             prop_assert_eq!(&forward, &backward, "merge must be order-independent");
             prop_assert_eq!(&forward, &oracle, "merge must match the oracle");
+
+            // The merged output (and the oracle) must satisfy format invariants.
+            prop_assert!(
+                audit_partition(&forward).is_empty(),
+                "merge output violated format invariants: {:?}",
+                audit_partition(&forward)
+            );
+            prop_assert!(
+                audit_partition(&oracle).is_empty(),
+                "oracle output violated format invariants: {:?}",
+                audit_partition(&oracle)
+            );
         }
     }
 }

--- a/ferrosa-storage/src/compaction/validator/mod.rs
+++ b/ferrosa-storage/src/compaction/validator/mod.rs
@@ -49,3 +49,87 @@ mod tests {
         assert_eq!(ab, oracle, "merge_partitions must match the oracle");
     }
 }
+
+#[cfg(test)]
+mod prop_tests {
+    use super::oracle::oracle_merge;
+    use crate::merge::merge_partitions;
+    use ferrosa_common::key::{DecoratedKey, PartitionKey};
+    use ferrosa_common::CellValue;
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
+    use proptest::prelude::*;
+    use std::collections::BTreeMap;
+
+    // A live cell or a tombstone, at a small timestamp to force conflicts.
+    fn arb_cell() -> impl Strategy<Value = CellValue> {
+        prop_oneof![
+            (0u8..3, 1i64..4).prop_map(|(v, ts)| CellValue::live(vec![v], ts)),
+            (1i64..4, 50i32..150).prop_map(|(ts, ldt)| CellValue::tombstone(ts, ldt)),
+        ]
+    }
+
+    // A row keyed by a small clustering, with a pk timestamp, an optional row
+    // deletion, and cells deduplicated by column (a row holds one cell/column).
+    fn arb_row() -> impl Strategy<Value = Row> {
+        (
+            0u8..2,
+            1i64..4,
+            prop::option::of(1i64..4),
+            prop::collection::vec((0u16..3, arb_cell()), 0..3),
+        )
+            .prop_map(|(clustering, pk_ts, row_del, cells)| {
+                let mut by_col: BTreeMap<u16, CellValue> = BTreeMap::new();
+                for (col, cell) in cells {
+                    by_col.insert(col, cell);
+                }
+                Row {
+                    clustering: vec![b'c', clustering],
+                    cells: by_col.into_iter().collect(),
+                    deletion: row_del
+                        .map_or(DeletionTime::LIVE, |t| DeletionTime::new(t, t as u32)),
+                    primary_key_liveness: LivenessInfo::with_timestamp(pk_ts),
+                }
+            })
+    }
+
+    // One source version of the shared partition (rows deduped by clustering).
+    fn arb_partition() -> impl Strategy<Value = Partition> {
+        (
+            prop::option::of(1i64..4),
+            prop::collection::vec(arb_row(), 0..3),
+        )
+            .prop_map(|(part_del, rows)| {
+                let mut by_clustering: BTreeMap<Vec<u8>, Row> = BTreeMap::new();
+                for row in rows {
+                    by_clustering.insert(row.clustering.clone(), row);
+                }
+                Partition {
+                    key: DecoratedKey::new(PartitionKey::new(b"k".to_vec())),
+                    deletion: part_del
+                        .map_or(DeletionTime::LIVE, |t| DeletionTime::new(t, t as u32)),
+                    static_row: None,
+                    rows: by_clustering.into_values().collect(),
+                }
+            })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// Across many random multi-SSTable partition sets, the read-path merge
+        /// must be order-independent and agree with the independent oracle.
+        #[test]
+        fn merge_is_order_independent_and_matches_oracle(
+            sources in prop::collection::vec(arb_partition(), 1..4)
+        ) {
+            let oracle = oracle_merge(&sources);
+            let forward = merge_partitions(sources.clone());
+            let mut reversed = sources.clone();
+            reversed.reverse();
+            let backward = merge_partitions(reversed);
+
+            prop_assert_eq!(&forward, &backward, "merge must be order-independent");
+            prop_assert_eq!(&forward, &oracle, "merge must match the oracle");
+        }
+    }
+}

--- a/ferrosa-storage/src/compaction/validator/mod.rs
+++ b/ferrosa-storage/src/compaction/validator/mod.rs
@@ -8,6 +8,7 @@
 //! oracle/auditor for soak testing.
 
 pub mod auditor;
+pub mod driver;
 pub mod oracle;
 
 #[cfg(test)]

--- a/ferrosa-storage/src/compaction/validator/mod.rs
+++ b/ferrosa-storage/src/compaction/validator/mod.rs
@@ -1,0 +1,51 @@
+//! Compaction validator: deterministic data run through compaction and checked
+//! against an independent oracle and across strategies.
+//!
+//! Ported in spirit from the Cassandra `compaction-validator` differential tool
+//! (the Java original is pipeline-specific and is not vendored). Compiled only
+//! under `cfg(test)` or the `compaction-validator` feature, so it never enters
+//! the production library; the feature lets `ferrosa-loadgen` reuse the same
+//! oracle/auditor for soak testing.
+
+pub mod oracle;
+
+#[cfg(test)]
+mod tests {
+    use super::oracle::oracle_merge;
+    use crate::merge::merge_partitions;
+    use ferrosa_common::key::{DecoratedKey, PartitionKey};
+    use ferrosa_common::CellValue;
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
+
+    fn partition(cells: Vec<(u16, CellValue)>, ts: i64) -> Partition {
+        Partition {
+            key: DecoratedKey::new(PartitionKey::new(b"k".to_vec())),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![Row {
+                clustering: b"c".to_vec(),
+                cells,
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::with_timestamp(ts),
+            }],
+        }
+    }
+
+    /// The read-path merge must agree with the oracle and be order-independent
+    /// when two sources write the same column at the same timestamp. This is the
+    /// "inverted timestamp tie-breaker" errata class: last-write-wins is only
+    /// well defined if equal-timestamp conflicts converge regardless of the
+    /// order SSTables are grouped (which differs between STCS and UCS).
+    #[test]
+    fn merge_matches_oracle_on_equal_timestamp_conflict() {
+        let a = partition(vec![(0, CellValue::live(b"aaa".to_vec(), 5))], 5);
+        let b = partition(vec![(0, CellValue::live(b"bbb".to_vec(), 5))], 5);
+
+        let oracle = oracle_merge(&[a.clone(), b.clone()]);
+        let ab = merge_partitions(vec![a.clone(), b.clone()]);
+        let ba = merge_partitions(vec![b, a]);
+
+        assert_eq!(ab, ba, "merge_partitions must be order-independent");
+        assert_eq!(ab, oracle, "merge_partitions must match the oracle");
+    }
+}

--- a/ferrosa-storage/src/compaction/validator/mod.rs
+++ b/ferrosa-storage/src/compaction/validator/mod.rs
@@ -48,6 +48,25 @@ mod tests {
         assert_eq!(ab, ba, "merge_partitions must be order-independent");
         assert_eq!(ab, oracle, "merge_partitions must match the oracle");
     }
+
+    /// When a write and a delete carry the same timestamp, the write is favored
+    /// and the data is preserved (Ferrosa's chosen equal-timestamp reconciliation).
+    #[test]
+    fn write_wins_over_tombstone_on_equal_timestamp() {
+        let write = partition(vec![(0, CellValue::live(b"v".to_vec(), 7))], 7);
+        let del = partition(vec![(0, CellValue::tombstone(7, 100))], 7);
+
+        let oracle = oracle_merge(&[write.clone(), del.clone()]);
+        let ab = merge_partitions(vec![write.clone(), del.clone()]);
+        let ba = merge_partitions(vec![del, write]);
+
+        assert_eq!(ab, ba, "merge must be order-independent");
+        assert_eq!(ab, oracle, "merge must match the oracle");
+        assert!(
+            ab.rows[0].cells[0].1.value.is_some(),
+            "the write must survive the equal-timestamp tie, got a tombstone"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/ferrosa-storage/src/compaction/validator/oracle.rs
+++ b/ferrosa-storage/src/compaction/validator/oracle.rs
@@ -14,7 +14,7 @@
 use std::collections::BTreeMap;
 
 use ferrosa_common::CellValue;
-use ferrosa_sstable::types::{DeletionTime, Partition, Row};
+use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
 
 /// Merge every source version of one partition into the canonical result.
 ///
@@ -66,12 +66,11 @@ fn oracle_merge_row(a: &Row, b: &Row) -> Row {
     } else {
         a.deletion
     };
-    let primary_key_liveness =
-        if b.primary_key_liveness.timestamp > a.primary_key_liveness.timestamp {
-            b.primary_key_liveness
-        } else {
-            a.primary_key_liveness
-        };
+    let primary_key_liveness = if liveness_wins(b.primary_key_liveness, a.primary_key_liveness) {
+        b.primary_key_liveness
+    } else {
+        a.primary_key_liveness
+    };
 
     let mut cells: BTreeMap<u16, CellValue> = BTreeMap::new();
     for (col, cell) in a.cells.iter().chain(b.cells.iter()) {
@@ -96,6 +95,13 @@ fn oracle_merge_row(a: &Row, b: &Row) -> Row {
 fn deletion_wins(x: DeletionTime, y: DeletionTime) -> bool {
     (x.marked_for_delete_at, x.local_deletion_time)
         > (y.marked_for_delete_at, y.local_deletion_time)
+}
+
+/// True when primary-key liveness `x` supersedes `y`. Newer timestamp wins;
+/// equal timestamps are broken deterministically so the merge is order
+/// independent.
+fn liveness_wins(x: LivenessInfo, y: LivenessInfo) -> bool {
+    (x.timestamp, x.ttl, x.local_deletion_time) > (y.timestamp, y.ttl, y.local_deletion_time)
 }
 
 /// True when cell `cand` supersedes `cur` under deterministic last-write-wins.

--- a/ferrosa-storage/src/compaction/validator/oracle.rs
+++ b/ferrosa-storage/src/compaction/validator/oracle.rs
@@ -1,0 +1,200 @@
+//! Independent reference merge ("oracle") for compaction validation.
+//!
+//! This reimplements Ferrosa's documented compaction merge semantics from
+//! scratch, with one deliberate difference: a fully **deterministic,
+//! order-independent** tie-break. Last-write-wins is only well defined if two
+//! cells with the *same* timestamp resolve the same way regardless of the order
+//! the sources were merged in — otherwise two compactions (or two replicas)
+//! that group SSTables differently diverge.
+//!
+//! Any divergence between this oracle and [`crate::merge::merge_partitions`]
+//! flags a real compaction bug. That is the whole point of a second
+//! implementation written against the spec rather than copied from the code.
+
+use std::collections::BTreeMap;
+
+use ferrosa_common::CellValue;
+use ferrosa_sstable::types::{DeletionTime, Partition, Row};
+
+/// Merge every source version of one partition into the canonical result.
+///
+/// All sources must share the same partition key. The result has rows sorted by
+/// clustering key and cells sorted by column, matching the read-path merge.
+pub fn oracle_merge(sources: &[Partition]) -> Partition {
+    assert!(
+        !sources.is_empty(),
+        "oracle_merge requires at least one source"
+    );
+
+    let mut deletion = sources[0].deletion;
+    let mut static_row: Option<Row> = None;
+    let mut rows: BTreeMap<Vec<u8>, Row> = BTreeMap::new();
+
+    for source in sources {
+        if source.deletion.marked_for_delete_at > deletion.marked_for_delete_at {
+            deletion = source.deletion;
+        }
+        if let Some(sr) = &source.static_row {
+            static_row = Some(match static_row {
+                None => sr.clone(),
+                Some(acc) => oracle_merge_row(&acc, sr),
+            });
+        }
+        for row in &source.rows {
+            let merged = match rows.remove(&row.clustering) {
+                None => row.clone(),
+                Some(acc) => oracle_merge_row(&acc, row),
+            };
+            rows.insert(row.clustering.clone(), merged);
+        }
+    }
+
+    let mut partition = Partition {
+        key: sources[0].key.clone(),
+        deletion,
+        static_row,
+        rows: rows.into_values().collect(),
+    };
+    suppress_deleted(&mut partition);
+    partition
+}
+
+/// Merge two versions of the same row (same clustering key).
+fn oracle_merge_row(a: &Row, b: &Row) -> Row {
+    let deletion = if deletion_wins(b.deletion, a.deletion) {
+        b.deletion
+    } else {
+        a.deletion
+    };
+    let primary_key_liveness =
+        if b.primary_key_liveness.timestamp > a.primary_key_liveness.timestamp {
+            b.primary_key_liveness
+        } else {
+            a.primary_key_liveness
+        };
+
+    let mut cells: BTreeMap<u16, CellValue> = BTreeMap::new();
+    for (col, cell) in a.cells.iter().chain(b.cells.iter()) {
+        let winner = match cells.remove(col) {
+            None => cell.clone(),
+            Some(cur) if cell_wins(cell, &cur) => cell.clone(),
+            Some(cur) => cur,
+        };
+        cells.insert(*col, winner);
+    }
+
+    Row {
+        clustering: a.clustering.clone(),
+        cells: cells.into_iter().collect(),
+        deletion,
+        primary_key_liveness,
+    }
+}
+
+/// True when partition/row deletion `x` supersedes `y` (newer wins; ties broken
+/// deterministically by local deletion time).
+fn deletion_wins(x: DeletionTime, y: DeletionTime) -> bool {
+    (x.marked_for_delete_at, x.local_deletion_time)
+        > (y.marked_for_delete_at, y.local_deletion_time)
+}
+
+/// True when cell `cand` supersedes `cur` under deterministic last-write-wins.
+///
+/// Higher timestamp wins. On an equal timestamp the result must not depend on
+/// merge order: a tombstone beats a live cell, otherwise the lexicographically
+/// greater value wins, and two tombstones are broken by local deletion time.
+fn cell_wins(cand: &CellValue, cur: &CellValue) -> bool {
+    if cand.timestamp != cur.timestamp {
+        return cand.timestamp > cur.timestamp;
+    }
+    tie_rank(cand) > tie_rank(cur)
+}
+
+fn tie_rank(c: &CellValue) -> (bool, &[u8], i32) {
+    (
+        c.is_tombstone(),
+        c.value.as_deref().unwrap_or(&[]),
+        c.local_deletion_time,
+    )
+}
+
+/// Apply deletion suppression, matching `crate::merge::apply_deletions`.
+fn suppress_deleted(partition: &mut Partition) {
+    let partition_delete_at = partition.deletion.marked_for_delete_at;
+
+    if !partition.deletion.is_live() {
+        partition
+            .rows
+            .retain(|row| row.primary_key_liveness.timestamp >= partition_delete_at);
+        if let Some(static_row) = &mut partition.static_row {
+            static_row
+                .cells
+                .retain(|(_col, cell)| cell.timestamp >= partition_delete_at);
+            if static_row.cells.is_empty() {
+                partition.static_row = None;
+            }
+        }
+    }
+
+    for row in &mut partition.rows {
+        if !row.deletion.is_live() {
+            let row_delete_at = row.deletion.marked_for_delete_at;
+            row.cells
+                .retain(|(_col, cell)| cell.timestamp >= row_delete_at);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrosa_common::key::{DecoratedKey, PartitionKey};
+    use ferrosa_sstable::types::LivenessInfo;
+
+    fn key(s: &str) -> DecoratedKey {
+        DecoratedKey::new(PartitionKey::new(s.as_bytes().to_vec()))
+    }
+
+    fn row(clustering: &[u8], cells: Vec<(u16, CellValue)>, ts: i64) -> Row {
+        Row {
+            clustering: clustering.to_vec(),
+            cells,
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(ts),
+        }
+    }
+
+    fn partition(k: &str, rows: Vec<Row>) -> Partition {
+        Partition {
+            key: key(k),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows,
+        }
+    }
+
+    #[test]
+    fn oracle_is_order_independent_on_equal_timestamp_conflict() {
+        // Same partition, row, and column written at the SAME timestamp with
+        // different values in two SSTables. LWW must converge regardless of the
+        // order the sources are merged.
+        let a = partition(
+            "k",
+            vec![row(b"c", vec![(0, CellValue::live(b"aaa".to_vec(), 5))], 5)],
+        );
+        let b = partition(
+            "k",
+            vec![row(b"c", vec![(0, CellValue::live(b"bbb".to_vec(), 5))], 5)],
+        );
+
+        let ab = oracle_merge(&[a.clone(), b.clone()]);
+        let ba = oracle_merge(&[b, a]);
+
+        assert_eq!(ab, ba, "oracle merge must be order-independent");
+        // Deterministic tie-break: greater value wins.
+        assert_eq!(
+            ab.rows[0].cells[0].1.value.as_deref(),
+            Some(b"bbb".as_slice())
+        );
+    }
+}

--- a/ferrosa-storage/src/compaction/validator/oracle.rs
+++ b/ferrosa-storage/src/compaction/validator/oracle.rs
@@ -13,6 +13,7 @@
 
 use std::collections::BTreeMap;
 
+use ferrosa_common::key::DecoratedKey;
 use ferrosa_common::CellValue;
 use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
 
@@ -57,6 +58,23 @@ pub fn oracle_merge(sources: &[Partition]) -> Partition {
     };
     suppress_deleted(&mut partition);
     partition
+}
+
+/// Merge a flat set of partitions from multiple SSTables into the canonical
+/// per-key result — the reference for what a full compaction must produce.
+/// Partitions are grouped by key and each group merged with [`oracle_merge`].
+pub fn oracle_merge_all(partitions: &[Partition]) -> Vec<Partition> {
+    let mut by_key: BTreeMap<DecoratedKey, Vec<Partition>> = BTreeMap::new();
+    for partition in partitions {
+        by_key
+            .entry(partition.key.clone())
+            .or_default()
+            .push(partition.clone());
+    }
+    by_key
+        .into_values()
+        .map(|group| oracle_merge(&group))
+        .collect()
 }
 
 /// Merge two versions of the same row (same clustering key).

--- a/ferrosa-storage/src/compaction/validator/oracle.rs
+++ b/ferrosa-storage/src/compaction/validator/oracle.rs
@@ -107,8 +107,9 @@ fn liveness_wins(x: LivenessInfo, y: LivenessInfo) -> bool {
 /// True when cell `cand` supersedes `cur` under deterministic last-write-wins.
 ///
 /// Higher timestamp wins. On an equal timestamp the result must not depend on
-/// merge order: a tombstone beats a live cell, otherwise the lexicographically
-/// greater value wins, and two tombstones are broken by local deletion time.
+/// merge order: a write (a cell with a value) beats a tombstone so equal-
+/// timestamp data is preserved; among writes the lexicographically greater value
+/// wins; two tombstones are broken by local deletion time.
 fn cell_wins(cand: &CellValue, cur: &CellValue) -> bool {
     if cand.timestamp != cur.timestamp {
         return cand.timestamp > cur.timestamp;
@@ -118,7 +119,7 @@ fn cell_wins(cand: &CellValue, cur: &CellValue) -> bool {
 
 fn tie_rank(c: &CellValue) -> (bool, &[u8], i32) {
     (
-        c.is_tombstone(),
+        c.value.is_some(),
         c.value.as_deref().unwrap_or(&[]),
         c.local_deletion_time,
     )

--- a/ferrosa-storage/src/compaction/validator/soak.rs
+++ b/ferrosa-storage/src/compaction/validator/soak.rs
@@ -1,0 +1,92 @@
+//! Compaction soak loop: generate a corpus, compact it for real, and diff the
+//! output against the oracle, across many seeds. A divergence or format
+//! violation fails loudly with the offending seed so it can be replayed.
+
+use std::path::Path;
+
+use ferrosa_sstable::types::Partition;
+
+use super::auditor::audit_partition;
+use super::corpus;
+use super::driver::{compact_all, logical_projection};
+use super::oracle::oracle_merge_all;
+use crate::TableId;
+
+/// Summary of a soak run.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SoakReport {
+    pub iterations: usize,
+    pub cells_checked: usize,
+}
+
+/// Run one soak iteration for `seed`, returning the number of logical cells
+/// checked. Returns `Err` (naming the seed) on the first divergence or format
+/// violation, so the failure is reproducible.
+pub fn run_iteration(work_dir: &Path, seed: u64) -> Result<usize, String> {
+    let corpus = corpus::generate(seed);
+    let groups: Vec<Vec<Partition>> = corpus
+        .groups
+        .into_iter()
+        .filter(|g| !g.is_empty())
+        .collect();
+    if groups.is_empty() {
+        return Ok(0);
+    }
+    let all: Vec<Partition> = groups.iter().flatten().cloned().collect();
+
+    let dir = work_dir.join(format!("soak_{seed}"));
+    std::fs::create_dir_all(&dir).map_err(|e| format!("seed {seed}: mkdir failed: {e}"))?;
+
+    let actual = compact_all(
+        &dir,
+        &groups,
+        &corpus.schema,
+        TableId::new("soak", "compaction"),
+    );
+    let expected = oracle_merge_all(&all);
+
+    let outcome = check(seed, &actual, &expected);
+    let _ = std::fs::remove_dir_all(&dir);
+    outcome
+}
+
+fn check(seed: u64, actual: &[Partition], expected: &[Partition]) -> Result<usize, String> {
+    let projected = logical_projection(actual);
+    if projected != logical_projection(expected) {
+        return Err(format!(
+            "seed {seed}: real compaction output diverged from the oracle"
+        ));
+    }
+    for partition in actual {
+        let violations = audit_partition(partition);
+        if !violations.is_empty() {
+            return Err(format!("seed {seed}: format violations: {violations:?}"));
+        }
+    }
+    Ok(projected.len())
+}
+
+/// Run `iterations` soak iterations starting at `seed_start`.
+pub fn run(work_dir: &Path, seed_start: u64, iterations: usize) -> Result<SoakReport, String> {
+    let mut cells_checked = 0;
+    for i in 0..iterations {
+        cells_checked += run_iteration(work_dir, seed_start + i as u64)?;
+    }
+    Ok(SoakReport {
+        iterations,
+        cells_checked,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn soak_stays_clean_across_many_seeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let report = run(tmp.path(), 1, 48).expect("soak must stay clean");
+        assert_eq!(report.iterations, 48);
+        assert!(report.cells_checked > 0, "soak must actually check cells");
+    }
+}

--- a/ferrosa-storage/src/compaction/validator/soak.rs
+++ b/ferrosa-storage/src/compaction/validator/soak.rs
@@ -8,7 +8,7 @@ use ferrosa_sstable::types::Partition;
 
 use super::auditor::audit_partition;
 use super::corpus;
-use super::driver::{compact_all, logical_projection};
+use super::driver::{audit_point_reads, compact_all_to, logical_projection, read_sstable};
 use super::oracle::oracle_merge_all;
 use crate::TableId;
 
@@ -37,20 +37,27 @@ pub fn run_iteration(work_dir: &Path, seed: u64) -> Result<usize, String> {
     let dir = work_dir.join(format!("soak_{seed}"));
     std::fs::create_dir_all(&dir).map_err(|e| format!("seed {seed}: mkdir failed: {e}"))?;
 
-    let actual = compact_all(
+    let (out_dir, generation) = compact_all_to(
         &dir,
         &groups,
         &corpus.schema,
         TableId::new("soak", "compaction"),
     );
+    let actual = read_sstable(&out_dir, &generation);
     let expected = oracle_merge_all(&all);
 
-    let outcome = check(seed, &actual, &expected);
+    let outcome = check(seed, &actual, &expected, &out_dir, &generation);
     let _ = std::fs::remove_dir_all(&dir);
     outcome
 }
 
-fn check(seed: u64, actual: &[Partition], expected: &[Partition]) -> Result<usize, String> {
+fn check(
+    seed: u64,
+    actual: &[Partition],
+    expected: &[Partition],
+    out_dir: &std::path::Path,
+    generation: &str,
+) -> Result<usize, String> {
     let projected = logical_projection(actual);
     if projected != logical_projection(expected) {
         return Err(format!(
@@ -62,6 +69,12 @@ fn check(seed: u64, actual: &[Partition], expected: &[Partition]) -> Result<usiz
         if !violations.is_empty() {
             return Err(format!("seed {seed}: format violations: {violations:?}"));
         }
+    }
+    let point_read_violations = audit_point_reads(out_dir, generation);
+    if !point_read_violations.is_empty() {
+        return Err(format!(
+            "seed {seed}: point-read violations: {point_read_violations:?}"
+        ));
     }
     Ok(projected.len())
 }

--- a/ferrosa-storage/src/merge.rs
+++ b/ferrosa-storage/src/merge.rs
@@ -151,18 +151,19 @@ pub fn merge_rows(a: Row, b: Row) -> Row {
 /// Higher timestamp wins. On an **equal** timestamp the outcome must not depend
 /// on merge order, or two compactions that group SSTables differently (STCS vs
 /// UCS) — or two replicas — would diverge. The order-independent tie-break is:
-/// a tombstone beats a live cell, otherwise the lexicographically greater value
-/// wins, and two tombstones are broken by local deletion time.
+/// a write (a cell with a value) beats a tombstone so equal-timestamp data is
+/// preserved; among writes the lexicographically greater value wins; two
+/// tombstones are broken by local deletion time.
 fn cell_supersedes(cand: &ferrosa_common::CellValue, cur: &ferrosa_common::CellValue) -> bool {
     if cand.timestamp != cur.timestamp {
         return cand.timestamp > cur.timestamp;
     }
     (
-        cand.is_tombstone(),
+        cand.value.is_some(),
         cand.value.as_deref().unwrap_or(&[]),
         cand.local_deletion_time,
     ) > (
-        cur.is_tombstone(),
+        cur.value.is_some(),
         cur.value.as_deref().unwrap_or(&[]),
         cur.local_deletion_time,
     )

--- a/ferrosa-storage/src/merge.rs
+++ b/ferrosa-storage/src/merge.rs
@@ -127,8 +127,8 @@ pub fn merge_rows(a: Row, b: Row) -> Row {
     for (col, cell) in all_cells {
         if let Some(last) = cells.last() {
             if last.0 == col {
-                // Same column — higher timestamp wins
-                if cell.timestamp > last.1.timestamp {
+                // Same column — deterministic last-write-wins.
+                if cell_supersedes(&cell, &last.1) {
                     cells.pop();
                     cells.push((col, cell));
                 }
@@ -144,6 +144,28 @@ pub fn merge_rows(a: Row, b: Row) -> Row {
         deletion,
         primary_key_liveness,
     }
+}
+
+/// Deterministic last-write-wins comparison for a single cell.
+///
+/// Higher timestamp wins. On an **equal** timestamp the outcome must not depend
+/// on merge order, or two compactions that group SSTables differently (STCS vs
+/// UCS) — or two replicas — would diverge. The order-independent tie-break is:
+/// a tombstone beats a live cell, otherwise the lexicographically greater value
+/// wins, and two tombstones are broken by local deletion time.
+fn cell_supersedes(cand: &ferrosa_common::CellValue, cur: &ferrosa_common::CellValue) -> bool {
+    if cand.timestamp != cur.timestamp {
+        return cand.timestamp > cur.timestamp;
+    }
+    (
+        cand.is_tombstone(),
+        cand.value.as_deref().unwrap_or(&[]),
+        cand.local_deletion_time,
+    ) > (
+        cur.is_tombstone(),
+        cur.value.as_deref().unwrap_or(&[]),
+        cur.local_deletion_time,
+    )
 }
 
 /// Apply deletion suppression to a merged partition.

--- a/specs/in-process/compaction-validator.md
+++ b/specs/in-process/compaction-validator.md
@@ -1,0 +1,75 @@
+# Compaction Validator
+
+Status: In progress (design approved 2026-05-30). Branch stacks on the HVQ
+branch (`docs/hvq-vector-indexes`); lands after it.
+
+Adapts the differential method of the Cassandra `compaction-validator` tool
+(cscotta/cassandra) to Ferrosa: generate deterministic data, run it through
+compaction, and validate the output three independent ways. The Java tool is
+Cassandra-pipeline-specific (cursor vs iterator, `CQLSSTableWriter`, `Index.db`)
+so the methodology is ported, not the code.
+
+## Goals
+
+- Catch compaction correctness bugs (data loss, wrong conflict resolution,
+  tombstone/TTL mishandling, ordering/format violations).
+- Be runnable both as bounded CI property tests and as a continuous soak.
+- Surface gaps in existing coverage and close them; TDD-fix any real bug found.
+
+## Validation modes (same corpus)
+
+1. **Oracle** — independent brute-force reference merge encoding the rules in
+   `ferrosa-storage/src/merge.rs`: partition/row deletion = `max(marked_for_delete_at)`;
+   cell-level last-write-wins by timestamp; deletion suppression (rows with
+   `pk_liveness.ts < partition.mfd_at` removed; cells with `ts < row.mfd_at`
+   removed; static cells vs partition deletion). Compaction output is compared
+   cell-for-cell to the oracle.
+2. **A/B differential** — compact identical inputs via `SizeTieredStrategy` and
+   `UnifiedCompactionStrategy`; assert identical logical merged output (the two
+   strategies differ only in which SSTables they group, not in merge result).
+3. **Format auditor invariants** — on merged output: clustering-key ordering,
+   no duplicate column per row, timestamp/TTL/local-deletion-time
+   non-negativity, and cell-flag mutual exclusivity (a cell is not both a
+   tombstone and expiring).
+
+## Corpus (seeded, deterministic)
+
+Overlapping SSTables of shared partitions; cell LWW conflicts; partition/row/
+cell tombstones; expiring (TTL) cells; wide rows; tombstone-then-resurrected-by-
+newer-write. The loadgen generator currently covers neither TTL nor wide rows —
+closing that is part of this work.
+
+## Errata → Ferrosa property tests
+
+The six Cassandra cursor-compaction defects, as universal property checks:
+tombstone-resurrected-by-expiring data loss; timestamp tie-break direction;
+IS_DELETED + IS_EXPIRING exclusivity; reverse-scan consistency; index
+final-block boundary read; wide-row highest-position cell preservation. Any
+that reproduce against Ferrosa are fixed red-first.
+
+## Placement
+
+Reusable core `ferrosa_storage::compaction::validator` (oracle + corpus +
+auditor + driver), compiled only under
+`#[cfg(any(test, feature = "compaction-validator"))]` so it never enters the
+production lib. Consumed by:
+
+- CI: `ferrosa-storage/tests/compaction_validator.rs` — bounded seeded property
+  tests (proptest is already a dependency).
+- Soak: a `compaction-soak` mode in `ferrosa-loadgen` (continuous generate ->
+  flush -> compact -> validate, with seed pinning), reusing the same oracle and
+  auditor against its `ground_truth`.
+
+## Sequencing
+
+Oracle first (it is the reference everything else leans on), then the corpus
+generator, then A/B driver, then the auditor, then the errata property tests,
+then the loadgen soak mode. TDD throughout; any compaction bug surfaced gets a
+red test then a fix.
+
+## Verification
+
+- `cargo test -p ferrosa-storage` (validator tests green).
+- `cargo test -p ferrosa-storage --features compaction-validator`.
+- Soak mode runs a bounded loop clean in CI; longer runs via the loadgen CLI.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.


### PR DESCRIPTION
## Summary

Ports the differential method of the Cassandra `compaction-validator` tool (cscotta/cassandra) to Ferrosa: generate deterministic data, run it through compaction, and validate the output three independent ways. The Java original is pipeline-specific, so the methodology is ported, not the code.

The validator immediately surfaced **two real merge bugs**, both fixed red-first.

### Two bugs found & fixed
- **Equal-timestamp merge was order-dependent.** `merge_rows` resolved equal-timestamp cell conflicts by source order, so `merge_partitions([a,b])` and `([b,a])` could differ — non-convergent last-write-wins that STCS and UCS (which group SSTables differently) would resolve inconsistently. Now broken deterministically.
- **Equal-timestamp write/delete tie.** A write and a delete sharing a timestamp now resolve in favor of the **write** (data preserved); documented as a divergence from Cassandra in the CQL reference's conflict-resolution section.

### Validator (`ferrosa_storage::compaction::validator`, behind the `compaction-validator` feature)
- **Oracle** — independent reference merge with a deterministic, order-independent tie-break.
- **Format auditor** — clustering/column ordering, no duplicate columns, non-negative ttl/local-deletion-time, no tombstone-that-is-also-expiring.
- **Differential proptest** — 256 random multi-SSTable corpora; merge must be order-independent, match the oracle, and satisfy format invariants.
- **Real-compaction driver** — write SSTables → executor's streaming merge → read back → diff the oracle (covers serialization round-trips).
- **Strategy A/B** — SizeTiered vs Unified must preserve identical data, equal to the oracle (tolerant of partial selection).
- **Index point-read errata** — every partition's `get_partition` must agree with a full scan, covering first/last index-block boundaries. (Reverse-scan errata is N/A: the reader is forward-only.)

### Soak harness
- Deterministic, dependency-free corpus generator (overlapping keys, wide sparse rows, live/expiring/tombstone cells — closes loadgen's TTL/wide-row gaps).
- `ferrosa-loadgen --compaction-soak --soak-seed N --soak-iterations K`: generate → real-compact → diff oracle + audit (format + point reads), failing loudly with the offending seed. Verified clean across many seeds.

## Verification
- `cargo test -p ferrosa-storage` (validator + merge + executor green); 11 validator tests pass.
- `cargo clippy -p ferrosa-storage -p ferrosa-loadgen --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- `ferrosa-loadgen --compaction-soak` runs clean end to end.
- Dependencies remain MIT/Apache-only (the soak's PRNG is inlined; no new crates).