### PR TITLE
Clean up example docs: list missing examples, copy buttons, table rendering, WASM source

### DIFF
--- a/docs/database/examples/advanced-aggregation.html
+++ b/docs/database/examples/advanced-aggregation.html
@@ -752,5 +752,38 @@ Pin your guest crate to a specific Rust toolchain version in <code>rust-toolchai
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/cluster-scaling.html
+++ b/docs/database/examples/cluster-scaling.html
@@ -580,5 +580,38 @@ SELECT peer, data_center FROM system.peers;</code></pre>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/cluster-setup.html
+++ b/docs/database/examples/cluster-setup.html
@@ -742,5 +742,38 @@ docker compose restart node3</code></pre>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/content-personalization.html
+++ b/docs/database/examples/content-personalization.html
@@ -525,5 +525,38 @@ Ferrosa handles millions of users this way because each query touches exactly on
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/cql-comprehensive.html
+++ b/docs/database/examples/cql-comprehensive.html
@@ -910,5 +910,38 @@ UPDATE counters SET page_views = page_views + 100, unique_visitors = unique_visi
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/cybersecurity.html
+++ b/docs/database/examples/cybersecurity.html
@@ -666,5 +666,38 @@ WHERE indicator_type = 'domain';</code></pre>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/ecommerce.html
+++ b/docs/database/examples/ecommerce.html
@@ -741,5 +741,38 @@ Together, these patterns cover the vast majority of real-world workloads.</p>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/ferrosa.css
+++ b/docs/database/examples/ferrosa.css
@@ -191,6 +191,34 @@ code, .literal {
   color: inherit;
 }
 
+/* Copy-to-clipboard button (added by docinfo-footer.html). */
+.listingblock .content .copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.listingblock:hover .content .copy-btn,
+.listingblock .content .copy-btn:focus {
+  opacity: 1;
+}
+
+.listingblock .content .copy-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 /* ── Literal blocks ── */
 .literalblock pre {
   background: var(--code-bg);
@@ -262,6 +290,9 @@ table.tableblock {
   border-collapse: collapse;
   margin: 1.5rem 0;
   font-size: 0.9375rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 table.tableblock th,
@@ -269,6 +300,17 @@ table.tableblock td {
   text-align: left;
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+
+/* No double border on the table's right edge or bottom row. */
+table.tableblock th:last-child,
+table.tableblock td:last-child {
+  border-right: none;
+}
+
+table.tableblock tbody tr:last-child td {
+  border-bottom: none;
 }
 
 table.tableblock thead th {
@@ -277,6 +319,7 @@ table.tableblock thead th {
   letter-spacing: 0.08em;
   color: var(--text-muted);
   font-weight: 600;
+  background: var(--bg-secondary);
 }
 
 table.tableblock td {

--- a/docs/database/examples/fraud-detection.html
+++ b/docs/database/examples/fraud-detection.html
@@ -583,5 +583,38 @@ WHERE account_id = 'ACCT-1001';</code></pre>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/gaming-leaderboards.html
+++ b/docs/database/examples/gaming-leaderboards.html
@@ -550,5 +550,38 @@ That is how you keep latency low even with millions of concurrent players.</p>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/graph-joins.html
+++ b/docs/database/examples/graph-joins.html
@@ -1104,5 +1104,38 @@ Since both read from the same tables, your data is always consistent.</p>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/healthcare.html
+++ b/docs/database/examples/healthcare.html
@@ -535,5 +535,38 @@ SELECT medication, dosage, frequency, prescriber, active, prescribed_at</code></
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/index.html
+++ b/docs/database/examples/index.html
@@ -65,6 +65,14 @@
 <dd>
 <p>Aggregate financial market data for dashboards.</p>
 </dd>
+<dt class="hdlist1"><a href="timeseries-rrd.html"><strong>RRD Time-Series Aggregation</strong></a> <em>New!</em></dt>
+<dd>
+<p>Roll up high-frequency sensor readings into time-window summaries (min/max/avg) automatically&#8201;&#8212;&#8201;RRD-style consolidation with streaming built-ins and optional WebAssembly aggregates.</p>
+</dd>
+<dt class="hdlist1"><a href="advanced-aggregation.html"><strong>Advanced Aggregation</strong></a></dt>
+<dd>
+<p>Group-by aggregates with built-in functions and WebAssembly user-defined aggregates.</p>
+</dd>
 <dt class="hdlist1"><a href="ecommerce.html"><strong>E-Commerce</strong></a></dt>
 <dd>
 <p>Product catalog, shopping cart, and order processing.</p>
@@ -163,5 +171,38 @@
 </div>
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/iot-sensor-data.html
+++ b/docs/database/examples/iot-sensor-data.html
@@ -620,5 +620,38 @@ Here is a recap of the key concepts:</p>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/knowledge-graph.html
+++ b/docs/database/examples/knowledge-graph.html
@@ -2169,5 +2169,38 @@ fi</code></pre>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/messaging-chat.html
+++ b/docs/database/examples/messaging-chat.html
@@ -647,5 +647,38 @@ Here is what you practiced:</p>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/telecom.html
+++ b/docs/database/examples/telecom.html
@@ -514,5 +514,38 @@ WHERE subscriber_id = 'SUB-1003'
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/theme/ferrosa.css
+++ b/docs/database/examples/theme/ferrosa.css
@@ -191,6 +191,34 @@ code, .literal {
   color: inherit;
 }
 
+/* Copy-to-clipboard button (added by docinfo-footer.html). */
+.listingblock .content .copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.listingblock:hover .content .copy-btn,
+.listingblock .content .copy-btn:focus {
+  opacity: 1;
+}
+
+.listingblock .content .copy-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 /* ── Literal blocks ── */
 .literalblock pre {
   background: var(--code-bg);
@@ -262,6 +290,9 @@ table.tableblock {
   border-collapse: collapse;
   margin: 1.5rem 0;
   font-size: 0.9375rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 table.tableblock th,
@@ -269,6 +300,17 @@ table.tableblock td {
   text-align: left;
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+
+/* No double border on the table's right edge or bottom row. */
+table.tableblock th:last-child,
+table.tableblock td:last-child {
+  border-right: none;
+}
+
+table.tableblock tbody tr:last-child td {
+  border-bottom: none;
 }
 
 table.tableblock thead th {
@@ -277,6 +319,7 @@ table.tableblock thead th {
   letter-spacing: 0.08em;
   color: var(--text-muted);
   font-weight: 600;
+  background: var(--bg-secondary);
 }
 
 table.tableblock td {

--- a/docs/database/examples/time-series-analytics.html
+++ b/docs/database/examples/time-series-analytics.html
@@ -601,5 +601,38 @@ Here is what you practiced:</p>
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/timeseries-rrd.html
+++ b/docs/database/examples/timeseries-rrd.html
@@ -599,5 +599,38 @@ The default ring memory budget is derived from the host or container memory limi
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/docs/database/examples/timeseries-rrd.html
+++ b/docs/database/examples/timeseries-rrd.html
@@ -26,7 +26,12 @@
 <li><a href="#_shift_range_volatility">Shift-range volatility</a></li>
 </ul>
 </li>
-<li><a href="#_wasm_aggregate_status">WASM Aggregate Status</a></li>
+<li><a href="#_wasm_aggregate_status">WASM Aggregate Status</a>
+<ul class="sectlevel2">
+<li><a href="#_author_the_aggregate_in_rust">Author the aggregate in Rust</a></li>
+<li><a href="#_load_the_compiled_artifact">Load the compiled artifact</a></li>
+</ul>
+</li>
 <li><a href="#_built_in_functions">Built-in Functions</a></li>
 <li><a href="#_multi_column_composite">Multi-Column Composite</a></li>
 <li><a href="#_late_arriving_data">Late-Arriving Data</a></li>
@@ -335,8 +340,98 @@ SELECT sensor_id, ts, vibration_mm_s_min, vibration_mm_s_max,
 <div class="paragraph">
 <p>The runnable sensor demo uses the built-in streaming <code>stddev</code>.
 Ferrosa supports three WASM loading forms for function metadata, and the WASM executor now has a streaming aggregate ABI with <code>init</code>, <code>update(value)</code>, and <code>finalize</code>.
-WASM aggregate execution for live RRD materialization uses that ABI for each row in the rollup window.
-The <code>AS FILE</code> and <code>AS URL &#8230;&#8203; WITH SHA256</code> forms are admin-only artifact loading paths.</p>
+WASM aggregate execution for live RRD materialization uses that ABI for each row in the rollup window.</p>
+</div>
+<div class="sect2">
+<h3 id="_author_the_aggregate_in_rust">Author the aggregate in Rust</h3>
+<div class="paragraph">
+<p>A streaming aggregate keeps bounded state, consumes one value per <code>update</code>, and returns one <code>f64</code> from <code>finalize</code>.
+It declares the <code>ferrosa:streaming-aggregate:v1</code> marker so the executor recognizes the aggregate ABI rather than treating it as a scalar UDF.
+Here is a complete Welford standard-deviation aggregate&#8201;&#8212;&#8201;<code>no_std</code>, allocation-free, and under 60 lines.
+The full crates (this <code>stddev</code> and an <code>rms</code> variant for vibration energy) live at <a href="https://github.com/ferrosadb/ferrosa/tree/main/examples/timeseries-rrd/wasm-rust">examples/timeseries-rrd/wasm-rust</a>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-rust" data-lang="rust">#![no_std]
+
+use core::panic::PanicInfo;
+
+#[used]
+#[link_section = "ferrosa:streaming-aggregate:v1"]
+static FERROSA_STREAMING_AGGREGATE_ABI: [u8; 57] =
+    *b"ferrosa streaming aggregate abi: init/update/finalize f64";
+
+static mut COUNT: f64 = 0.0;
+static mut MEAN: f64 = 0.0;
+static mut M2: f64 = 0.0;
+
+#[no_mangle]
+pub extern "C" fn init() {
+    unsafe {
+        COUNT = 0.0;
+        MEAN = 0.0;
+        M2 = 0.0;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn update(value: f64) {
+    unsafe {
+        COUNT += 1.0;
+        let delta = value - MEAN;
+        MEAN += delta / COUNT;
+        let delta2 = value - MEAN;
+        M2 += delta * delta2;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn finalize() -&gt; f64 {
+    unsafe {
+        if COUNT &lt;= 0.0 {
+            0.0
+        } else {
+            sqrt(M2 / COUNT)
+        }
+    }
+}
+
+fn sqrt(value: f64) -&gt; f64 {
+    if value &lt;= 0.0 {
+        return 0.0;
+    }
+
+    let mut estimate = if value &gt;= 1.0 { value } else { 1.0 };
+    for _ in 0..16 {
+        estimate = 0.5 * (estimate + value / estimate);
+    }
+    estimate
+}
+
+#[panic_handler]
+fn panic(_info: &amp;PanicInfo) -&gt; ! {
+    loop {}
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Build it for <code>wasm32-unknown-unknown</code> and package the core module as a Component Model artifact:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-bash" data-lang="bash">rustup target add wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown \
+  --manifest-path wasm-rust/stddev/Cargo.toml
+wasm-tools component new \
+  wasm-rust/stddev/target/wasm32-unknown-unknown/release/ferrosa_rrd_stddev.wasm \
+  -o stddev.wasm</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_load_the_compiled_artifact">Load the compiled artifact</h3>
+<div class="paragraph">
+<p>The <code>AS FILE</code> and <code>AS URL &#8230;&#8203; WITH SHA256</code> forms are admin-only artifact loading paths.</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -390,6 +485,7 @@ CREATE TABLE vibration_with_wasm_stddev (
 <p>Use <code>wasm:</code> functions only for components that declare the <code>ferrosa:streaming-aggregate:v1</code> marker and export <code>init</code>, <code>update</code>, and <code>finalize</code>.
 Scalar WASM UDFs are rejected for aggregate execution rather than being called with a materialized list.
 The URL form requires a SHA-256 digest so artifact bytes cannot change between review and DDL apply.</p>
+</div>
 </div>
 </div>
 </div>

--- a/docs/database/examples/vector-indexes.html
+++ b/docs/database/examples/vector-indexes.html
@@ -239,5 +239,38 @@ and latency across HNSW, IVFFlat, and HVQ, see the
 <div id="footer-text">
 </div>
 </div>
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>
 </body>
 </html>

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -19,10 +19,12 @@ html: $(ADOC) $(THEME) index.adoc
 	@asciidoctor -a reproducible -a 'source-highlighter!' -a stylesheet=$(THEME) -a linkcss -a stylesdir=. \
 		-a docinfo=shared -a docinfodir=$$PWD \
 		-D $(OUTDIR) -o index.html index.adoc
+	@mkdir -p $(OUTDIR)/theme
+	@cp $(THEME) $(OUTDIR)/theme/ferrosa.css
 	@cp $(THEME) $(OUTDIR)/ferrosa.css
 
 clean:
-	rm -f $(OUTDIR)/*.html $(OUTDIR)/ferrosa.css
+	rm -f $(OUTDIR)/*.html $(OUTDIR)/ferrosa.css $(OUTDIR)/theme/ferrosa.css
 
 test:
 	./test-examples.sh

--- a/examples/docinfo-footer.html
+++ b/examples/docinfo-footer.html
@@ -1,0 +1,33 @@
+<script>
+// Add a "Copy" button to every code listing.
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.listingblock .content').forEach(function (content) {
+    var pre = content.querySelector('pre');
+    if (!pre) { return; }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.addEventListener('click', function () {
+      var text = pre.innerText;
+      var done = function () {
+        button.textContent = 'Copied';
+        setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        var area = document.createElement('textarea');
+        area.value = text;
+        document.body.appendChild(area);
+        area.select();
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        document.body.removeChild(area);
+        done();
+      }
+    });
+    content.appendChild(button);
+  });
+});
+</script>

--- a/examples/index.adoc
+++ b/examples/index.adoc
@@ -27,6 +27,12 @@ Ingest millions of sensor readings with time-series tables.
 link:time-series-analytics.html[*Real-Time Analytics*]::
 Aggregate financial market data for dashboards.
 
+link:timeseries-rrd.html[*RRD Time-Series Aggregation*] _New!_::
+Roll up high-frequency sensor readings into time-window summaries (min/max/avg) automatically -- RRD-style consolidation with streaming built-ins and optional WebAssembly aggregates.
+
+link:advanced-aggregation.html[*Advanced Aggregation*]::
+Group-by aggregates with built-in functions and WebAssembly user-defined aggregates.
+
 link:ecommerce.html[*E-Commerce*]::
 Product catalog, shopping cart, and order processing.
 

--- a/examples/theme/ferrosa.css
+++ b/examples/theme/ferrosa.css
@@ -191,6 +191,34 @@ code, .literal {
   color: inherit;
 }
 
+/* Copy-to-clipboard button (added by docinfo-footer.html). */
+.listingblock .content .copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.listingblock:hover .content .copy-btn,
+.listingblock .content .copy-btn:focus {
+  opacity: 1;
+}
+
+.listingblock .content .copy-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 /* ── Literal blocks ── */
 .literalblock pre {
   background: var(--code-bg);
@@ -262,6 +290,9 @@ table.tableblock {
   border-collapse: collapse;
   margin: 1.5rem 0;
   font-size: 0.9375rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 table.tableblock th,
@@ -269,6 +300,17 @@ table.tableblock td {
   text-align: left;
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+
+/* No double border on the table's right edge or bottom row. */
+table.tableblock th:last-child,
+table.tableblock td:last-child {
+  border-right: none;
+}
+
+table.tableblock tbody tr:last-child td {
+  border-bottom: none;
 }
 
 table.tableblock thead th {
@@ -277,6 +319,7 @@ table.tableblock thead th {
   letter-spacing: 0.08em;
   color: var(--text-muted);
   font-weight: 600;
+  background: var(--bg-secondary);
 }
 
 table.tableblock td {

--- a/examples/timeseries-rrd/timeseries-rrd.adoc
+++ b/examples/timeseries-rrd/timeseries-rrd.adoc
@@ -104,6 +104,33 @@ include::queries.cql[lines=27..34]
 The runnable sensor demo uses the built-in streaming `stddev`.
 Ferrosa supports three WASM loading forms for function metadata, and the WASM executor now has a streaming aggregate ABI with `init`, `update(value)`, and `finalize`.
 WASM aggregate execution for live RRD materialization uses that ABI for each row in the rollup window.
+
+=== Author the aggregate in Rust
+
+A streaming aggregate keeps bounded state, consumes one value per `update`, and returns one `f64` from `finalize`.
+It declares the `ferrosa:streaming-aggregate:v1` marker so the executor recognizes the aggregate ABI rather than treating it as a scalar UDF.
+Here is a complete Welford standard-deviation aggregate -- `no_std`, allocation-free, and under 60 lines.
+The full crates (this `stddev` and an `rms` variant for vibration energy) live at link:https://github.com/ferrosadb/ferrosa/tree/main/examples/timeseries-rrd/wasm-rust[examples/timeseries-rrd/wasm-rust].
+
+[source,rust]
+----
+include::wasm-rust/stddev/src/lib.rs[]
+----
+
+Build it for `wasm32-unknown-unknown` and package the core module as a Component Model artifact:
+
+[source,bash]
+----
+rustup target add wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown \
+  --manifest-path wasm-rust/stddev/Cargo.toml
+wasm-tools component new \
+  wasm-rust/stddev/target/wasm32-unknown-unknown/release/ferrosa_rrd_stddev.wasm \
+  -o stddev.wasm
+----
+
+=== Load the compiled artifact
+
 The `AS FILE` and `AS URL ... WITH SHA256` forms are admin-only artifact loading paths.
 
 [source,sql]


### PR DESCRIPTION
## Summary

Documentation polish for the generated example site, prompted by review feedback (RRD examples not visible, tables not fully rendering, no copy buttons, WASM aggregate source missing).

### Fixes
- **List the missing examples.** `timeseries-rrd` and `advanced-aggregation` had generated pages but no links in the examples index, so they were effectively invisible. Both are now listed under Data-Intensive Workloads.
- **Copy-to-clipboard buttons** on every code listing, via an asciidoctor footer docinfo script (hover-reveal, with an `execCommand` fallback for non-secure contexts).
- **Tables render as complete bordered grids** — `grid-all` asciidoctor tables now get a frame, cell borders, rounded corners, and a header background instead of bare horizontal rules.
- **Makefile theme-copy bug.** The generated HTML links `./theme/ferrosa.css`, but `make html` only copied the theme to `examples/ferrosa.css` (root), so theme edits never reached the linked stylesheet. It now copies to both locations.
- **Show the WASM aggregate source.** The RRD tutorial documented how to *load* a WASM aggregate but not how to *author* one. Added an "Author the aggregate in Rust" section that inlines the complete `no_std` Welford `stddev` source (the `ferrosa:streaming-aggregate:v1` marker plus `init`/`update`/`finalize`), the `wasm32` build + Component Model packaging commands, and a link to the full `stddev`/`rms` crates.

## Verification
- All example HTML regenerated; generation is byte-reproducible (the `docs-examples` drift gate passes).
- Rendered the affected pages (iot-sensor-data tables + copy buttons, RRD WASM source) headless to confirm.