### PR TITLE
feat(cql): close Cassandra-corpus CQL gaps — auth/roles hierarchy, LIST, duration arithmetic, WASM UDFs

### DIFF
--- a/cassandra/doc/modules/cassandra/examples/CQL/create_function.cql
+++ b/cassandra/doc/modules/cassandra/examples/CQL/create_function.cql
@@ -1,15 +1,14 @@
-CREATE OR REPLACE FUNCTION somefunction(somearg int, anotherarg text, complexarg frozen<someUDT>, listarg list)
+-- Ferrosa runs user-defined functions as WebAssembly components, not Java.
+-- The function body is the compiled WASM module: inline hex (a tiny placeholder
+-- below), or `AS FILE '/path.wasm'` / `AS URL '...' WITH SHA256 = '...'`.
+CREATE OR REPLACE FUNCTION somefunction(somearg int, anotherarg text, complexarg frozen<some_udt>, listarg list<int>)
     RETURNS NULL ON NULL INPUT
     RETURNS text
-    LANGUAGE java
-    AS $$
-        // some Java code
-    $$;
+    LANGUAGE wasm
+    AS '0x0061736d0d000100';
 
-CREATE FUNCTION IF NOT EXISTS akeyspace.fname(someArg int)
+CREATE FUNCTION IF NOT EXISTS akeyspace.fname(somearg int)
     CALLED ON NULL INPUT
     RETURNS text
-    LANGUAGE java
-    AS $$
-        // some Java code
-    $$;
+    LANGUAGE wasm
+    AS '0x0061736d0d000100';

--- a/cassandra/doc/modules/cassandra/examples/CQL/function_dollarsign.cql
+++ b/cassandra/doc/modules/cassandra/examples/CQL/function_dollarsign.cql
@@ -1,15 +1,17 @@
+-- WASM UDFs (Ferrosa does not run Java). The body is the compiled WASM module
+-- as inline hex (placeholder below).
 CREATE FUNCTION some_function ( arg int )
     RETURNS NULL ON NULL INPUT
     RETURNS int
-    LANGUAGE java
-    AS $$ return arg; $$;
+    LANGUAGE wasm
+    AS '0x0061736d0d000100';
 
-SELECT some_function(column) FROM atable ...;
-UPDATE atable SET col = some_function(?) ...;
+SELECT some_function(column) FROM atable;
+UPDATE atable SET col = some_function(?) WHERE pk = 1;
 
 CREATE TYPE custom_type (txt text, i int);
-CREATE FUNCTION fct_using_udt ( udtarg frozen )
+CREATE FUNCTION fct_using_udt ( udtarg frozen<custom_type> )
     RETURNS NULL ON NULL INPUT
     RETURNS text
-    LANGUAGE java
-    AS $$ return udtarg.getString("txt"); $$;
+    LANGUAGE wasm
+    AS '0x0061736d0d000100';

--- a/cassandra/doc/modules/cassandra/examples/CQL/function_udfcontext.cql
+++ b/cassandra/doc/modules/cassandra/examples/CQL/function_udfcontext.cql
@@ -1,11 +1,10 @@
 CREATE TYPE custom_type (txt text, i int);
-CREATE FUNCTION fct\_using\_udt ( somearg int )
+
+-- A WASM UDF that returns a UDT value. Ferrosa runs UDFs as WebAssembly
+-- components (inline hex placeholder body below); the WASM module builds and
+-- returns the custom_type value.
+CREATE FUNCTION fct_using_udt ( somearg int )
     RETURNS NULL ON NULL INPUT
     RETURNS custom_type
-    LANGUAGE java
-    AS $$
-        UDTValue udt = udfContext.newReturnUDTValue();
-        udt.setString("txt", "some string");
-        udt.setInt("i", 42);
-        return udt;
-    $$;
+    LANGUAGE wasm
+    AS '0x0061736d0d000100';

--- a/cassandra/doc/modules/cassandra/examples/CQL/uda.cql
+++ b/cassandra/doc/modules/cassandra/examples/CQL/uda.cql
@@ -1,30 +1,20 @@
+-- User-defined aggregate built from WASM state/final functions. Ferrosa runs
+-- UDF/UDA bodies as WebAssembly components (inline hex placeholder below).
 CREATE OR REPLACE FUNCTION test.averageState(state tuple<int,bigint>, val int)
     CALLED ON NULL INPUT
-    RETURNS tuple
-    LANGUAGE java
-    AS $$
-        if (val != null) {
-            state.setInt(0, state.getInt(0)+1);
-            state.setLong(1, state.getLong(1)+val.intValue());
-        }
-        return state;
-    $$;
+    RETURNS tuple<int,bigint>
+    LANGUAGE wasm
+    AS '0x0061736d0d000100';
 
 CREATE OR REPLACE FUNCTION test.averageFinal (state tuple<int,bigint>)
     CALLED ON NULL INPUT
     RETURNS double
-    LANGUAGE java
-    AS $$
-        double r = 0;
-        if (state.getInt(0) == 0) return null;
-        r = state.getLong(1);
-        r /= state.getInt(0);
-        return Double.valueOf(r);
-    $$;
+    LANGUAGE wasm
+    AS '0x0061736d0d000100';
 
 CREATE OR REPLACE AGGREGATE test.average(int)
     SFUNC averageState
-    STYPE tuple
+    STYPE tuple<int,bigint>
     FINALFUNC averageFinal
     INITCOND (0, 0);
 

--- a/docs/database/cql-compatibility.html
+++ b/docs/database/cql-compatibility.html
@@ -341,7 +341,7 @@
       <tr><td>DROP (without TABLE keyword)</td><td><span class="check">Supported</span></td><td>DROP keyspace_name.table_name shorthand</td></tr>
       <tr><td>CREATE MATERIALIZED VIEW</td><td><span class="cross">Not yet</span></td><td>—</td></tr>
       <tr><td>CREATE TYPE (UDT)</td><td><span class="check">Supported</span></td><td>CREATE TYPE, ALTER TYPE, DROP TYPE — full UDT DDL lifecycle</td></tr>
-      <tr><td>CREATE FUNCTION / AGGREGATE</td><td><span class="check">Supported</span></td><td>CREATE/DROP FUNCTION (WASM), CREATE/DROP AGGREGATE — full DDL lifecycle with cluster replication</td></tr>
+      <tr><td>CREATE FUNCTION / AGGREGATE</td><td><span class="check">Supported</span></td><td>CREATE/DROP FUNCTION, CREATE/DROP AGGREGATE — full DDL lifecycle with cluster replication. UDFs are <strong>WebAssembly</strong> components (<code>LANGUAGE wasm AS '&lt;hex&gt;' | AS FILE '…' | AS URL '…' WITH SHA256 = '…'</code>); Java UDFs are not supported. Keyspace-qualified calls (<code>ks.fn(args)</code>) work in SELECT.</td></tr>
     </tbody>
   </table>
 
@@ -475,6 +475,8 @@
       <tr><td>GRANT</td><td><span class="check">Supported</span></td><td>GRANT perm[, perm…] ON resource TO role. Resource: <code>ON TABLE ks.t</code> / <code>ks.t</code>, <code>ON KEYSPACE</code>, <code>ON ALL KEYSPACES</code>, <code>ON ALL ROLES</code>, <code>ON FUNCTION</code>. Unknown permissions are rejected (no silent partial grant).</td></tr>
       <tr><td>REVOKE</td><td><span class="check">Supported</span></td><td>REVOKE perm[, perm…] ON resource FROM role (same resource forms as GRANT)</td></tr>
       <tr><td>GRANT / REVOKE role</td><td><span class="check">Supported</span></td><td><code>GRANT &lt;role&gt; TO &lt;member&gt;</code> / <code>REVOKE &lt;role&gt; FROM &lt;member&gt;</code> — role hierarchy (the member inherits the role's permissions). Replicated additively (one membership edge per op) and cycle-checked at apply, so concurrent grants never clobber and a revoke is never lost to a racing grant.</td></tr>
+      <tr><td>LIST ROLES</td><td><span class="check">Supported</span></td><td><code>LIST ROLES [OF &lt;role&gt;] [NORECURSIVE]</code>; <code>LIST USERS</code> alias</td></tr>
+      <tr><td>LIST PERMISSIONS</td><td><span class="check">Supported</span></td><td><code>LIST [ALL | &lt;permission&gt;] PERMISSIONS [ON &lt;resource&gt;] [OF &lt;role&gt;] [NORECURSIVE]</code> — gated on DESCRIBE over all roles</td></tr>
       <tr><td>ACCESS TO/FROM (network auth)</td><td><span class="cross">Rejected</span></td><td>ACCESS TO DATACENTERS / FROM CIDRS is parsed but rejected — ferrosa has no network authorizer, so an unenforced access restriction fails loud rather than being silently accepted</td></tr>
     </tbody>
   </table>

--- a/docs/database/cql-compatibility.html
+++ b/docs/database/cql-compatibility.html
@@ -211,7 +211,7 @@
   <a href="/" class="back-link">&larr; Ferrosa Suite home</a> · <a href="/database/" class="back-link">Database home</a>
 
   <h1>CQL <span>Reference</span></h1>
-  <p class="subtitle">Ferrosa implements CQL native protocol v4 and v5 compatibility work, including tested driver paths such as cdrs-tokio. This page documents what's supported, what's different, and what Ferrosa adds on top.</p>
+  <p class="subtitle">Ferrosa implements the CQL native protocol with negotiation capped at v4, including tested driver paths such as cdrs-tokio. This page documents what's supported, what's different, and what Ferrosa adds on top.</p>
 
   <div class="note">
     <strong>Beta:</strong> Ferrosa is currently in beta. CQL compatibility is under active development.
@@ -238,7 +238,7 @@
   <h2 id="protocol">Protocol</h2>
 
   <h3>Wire protocol</h3>
-  <p>Ferrosa implements CQL native protocol versions 4 and 5 with the standard 9-byte frame header. Protocol v4 compatibility enables broad CQL driver support including cdrs-tokio. All 16 opcodes are handled:</p>
+  <p>Ferrosa speaks the CQL native protocol with the standard 9-byte frame header and <strong>caps negotiation at protocol v4</strong>. v5 added a modern framing layer that drivers implement inconsistently — some send plain legacy envelopes at v5, others send CRC-checksummed modern frames — so no single server mode serves both. A v5 <code>STARTUP</code> is therefore rejected with a protocol-version error advertising v4 as the maximum, and every compliant driver (gocql, DataStax Java/C#, scylla-rust, cassandra-driver) transparently falls back to the one well-tested v4 transport, including cdrs-tokio. All 16 opcodes are handled:</p>
 
   <table>
     <thead><tr><th>Opcode</th><th>Name</th><th>Direction</th></tr></thead>
@@ -330,7 +330,7 @@
   <table>
     <thead><tr><th>Statement</th><th>Status</th><th>Notes</th></tr></thead>
     <tbody>
-      <tr><td>CREATE KEYSPACE</td><td><span class="check">Supported</span></td><td>WITH replication, IF NOT EXISTS, DURABLE_WRITES</td></tr>
+      <tr><td>CREATE KEYSPACE</td><td><span class="check">Supported</span></td><td>WITH replication (SimpleStrategy / NetworkTopologyStrategy), IF NOT EXISTS, DURABLE_WRITES. Transient replication (<code>'DC1': '3/1'</code>) is rejected — Ferrosa does not implement it, and accepting it would corrupt driver schema metadata.</td></tr>
       <tr><td>ALTER KEYSPACE</td><td><span class="check">Supported</span></td><td>Change replication, durable_writes</td></tr>
       <tr><td>DROP KEYSPACE</td><td><span class="check">Supported</span></td><td>IF EXISTS</td></tr>
       <tr><td>CREATE TABLE</td><td><span class="check">Supported</span></td><td>Partition key, clustering key with order, IF NOT EXISTS, table options (compaction, compression, comment, TTL, gc_grace)</td></tr>
@@ -387,7 +387,7 @@
   <table>
     <thead><tr><th>Statement</th><th>Status</th><th>Notes</th></tr></thead>
     <tbody>
-      <tr><td>SELECT</td><td><span class="check">Supported</span></td><td>WHERE, ORDER BY, LIMIT, DISTINCT, bind markers (?), named bind markers (:name), IN clause, ALLOW FILTERING, token(), CONTAINS / CONTAINS KEY, SOUNDS LIKE, fts_match()</td></tr>
+      <tr><td>SELECT</td><td><span class="check">Supported</span></td><td>WHERE, ORDER BY, LIMIT, DISTINCT, bind markers (?), named bind markers (:name), IN clause, ALLOW FILTERING, token(), CONTAINS / CONTAINS KEY, LIKE, SOUNDS LIKE, fts_match()</td></tr>
       <tr><td>INSERT</td><td><span class="check">Supported</span></td><td>IF NOT EXISTS (LWT), USING TTL, USING TIMESTAMP</td></tr>
       <tr><td>UPDATE</td><td><span class="check">Supported</span></td><td>SET, WHERE, IF conditions (LWT), collection +/- operators, counter increment/decrement</td></tr>
       <tr><td>DELETE</td><td><span class="check">Supported</span></td><td>WHERE, IF EXISTS / IF conditions (LWT), column-level delete, map element delete syntax</td></tr>
@@ -422,7 +422,11 @@
 <span class="kw">EXECUTE</span> stmt <span class="kw">USING</span> <span class="var">550e8400-e29b-41d4-a716-446655440000</span>;</pre>
 
   <h3>Comparison operators</h3>
-  <p>WHERE clauses support: <code>=</code>, <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>!=</code>, <code>IN</code>, <code>CONTAINS</code>, <code>CONTAINS KEY</code></p>
+  <p>WHERE clauses support: <code>=</code>, <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, <code>!=</code>, <code>IN</code>, <code>CONTAINS</code>, <code>CONTAINS KEY</code>, <code>LIKE</code></p>
+  <p><code>LIKE</code> matches text patterns with the <code>%</code> wildcard (any sequence of characters) — <code>'pre%'</code> (prefix), <code>'%suf'</code> (suffix), <code>'%mid%'</code> (contains), or an exact literal. Matching is case-sensitive. As a non-key predicate it is evaluated as a post-scan filter and requires <code>ALLOW FILTERING</code>.</p>
+  <pre><span class="cm">-- names beginning with 'M'</span>
+<span class="kw">SELECT</span> * <span class="kw">FROM</span> <span class="type">cycling.cyclist_name</span>
+  <span class="kw">WHERE</span> firstname <span class="kw">LIKE</span> <span class="str">'M%'</span> <span class="kw">ALLOW FILTERING</span>;</pre>
 
   <h3>Consistency levels</h3>
   <p>Ferrosa supports the following consistency levels for reads and writes:</p>
@@ -456,8 +460,8 @@
       <tr><td>ALTER ROLE</td><td><span class="check">Supported</span></td><td>Change PASSWORD / HASHED PASSWORD, SUPERUSER, LOGIN</td></tr>
       <tr><td>CREATE USER / ALTER USER</td><td><span class="check">Supported</span></td><td>Legacy alias; WITH [HASHED] PASSWORD, SUPERUSER / NOSUPERUSER</td></tr>
       <tr><td>DROP ROLE</td><td><span class="check">Supported</span></td><td>IF EXISTS</td></tr>
-      <tr><td>GRANT</td><td><span class="check">Supported</span></td><td>GRANT permission ON resource TO role</td></tr>
-      <tr><td>REVOKE</td><td><span class="check">Supported</span></td><td>REVOKE permission ON resource FROM role</td></tr>
+      <tr><td>GRANT</td><td><span class="check">Supported</span></td><td>GRANT perm[, perm…] ON resource TO role. Resource: <code>ON TABLE ks.t</code> / <code>ks.t</code>, <code>ON KEYSPACE</code>, <code>ON ALL KEYSPACES</code>, <code>ON ALL ROLES</code>, <code>ON FUNCTION</code>. Unknown permissions are rejected (no silent partial grant).</td></tr>
+      <tr><td>REVOKE</td><td><span class="check">Supported</span></td><td>REVOKE perm[, perm…] ON resource FROM role (same resource forms as GRANT)</td></tr>
       <tr><td>ACCESS TO/FROM (network auth)</td><td><span class="cross">Rejected</span></td><td>ACCESS TO DATACENTERS / FROM CIDRS is parsed but rejected — ferrosa has no network authorizer, so an unenforced access restriction fails loud rather than being silently accepted</td></tr>
     </tbody>
   </table>

--- a/docs/database/cql-compatibility.html
+++ b/docs/database/cql-compatibility.html
@@ -452,13 +452,37 @@
   <table>
     <thead><tr><th>Statement</th><th>Status</th><th>Notes</th></tr></thead>
     <tbody>
-      <tr><td>CREATE ROLE</td><td><span class="check">Supported</span></td><td>WITH PASSWORD, SUPERUSER, LOGIN, IF NOT EXISTS</td></tr>
-      <tr><td>ALTER ROLE</td><td><span class="check">Supported</span></td><td>Change password, superuser, login</td></tr>
+      <tr><td>CREATE ROLE</td><td><span class="check">Supported</span></td><td>WITH PASSWORD, HASHED PASSWORD, SUPERUSER, LOGIN, OPTIONS, IF NOT EXISTS</td></tr>
+      <tr><td>ALTER ROLE</td><td><span class="check">Supported</span></td><td>Change PASSWORD / HASHED PASSWORD, SUPERUSER, LOGIN</td></tr>
+      <tr><td>CREATE USER / ALTER USER</td><td><span class="check">Supported</span></td><td>Legacy alias; WITH [HASHED] PASSWORD, SUPERUSER / NOSUPERUSER</td></tr>
       <tr><td>DROP ROLE</td><td><span class="check">Supported</span></td><td>IF EXISTS</td></tr>
       <tr><td>GRANT</td><td><span class="check">Supported</span></td><td>GRANT permission ON resource TO role</td></tr>
       <tr><td>REVOKE</td><td><span class="check">Supported</span></td><td>REVOKE permission ON resource FROM role</td></tr>
+      <tr><td>ACCESS TO/FROM (network auth)</td><td><span class="cross">Rejected</span></td><td>ACCESS TO DATACENTERS / FROM CIDRS is parsed but rejected — ferrosa has no network authorizer, so an unenforced access restriction fails loud rather than being silently accepted</td></tr>
     </tbody>
   </table>
+
+  <p><strong>HASHED PASSWORD.</strong> <code>CREATE ROLE … WITH HASHED PASSWORD = '&lt;hash&gt;'</code> (and the legacy <code>CREATE USER … WITH HASHED PASSWORD '&lt;hash&gt;'</code>) stores a pre-computed bcrypt or argon2id hash verbatim — it is not re-hashed, which lets you migrate existing credentials. The hash format is validated on the coordinator and rejected if unsupported, so a role can never hold a credential the authenticator cannot verify. Password and hash literals are redacted from any log line or error message.</p>
+
+  <pre><span class="cm">-- Plaintext password — hashed server-side with bcrypt / argon2id</span>
+<span class="kw">CREATE ROLE</span> app_writer <span class="kw">WITH PASSWORD</span> = <span class="str">'S3cret-Pass!'</span> <span class="kw">AND LOGIN</span> = <span class="kw">true</span>;
+
+<span class="cm">-- Migrate an existing credential: a pre-computed hash, stored verbatim</span>
+<span class="kw">CREATE ROLE</span> legacy_user
+  <span class="kw">WITH HASHED PASSWORD</span> = <span class="str">'$2a$10$JSJEMFm6GeaW9XxT5JIheuEtPvat6i7uKbnTcxX3c1wshIIsGyUtG'</span>
+  <span class="kw">AND LOGIN</span> = <span class="kw">true</span>;
+
+<span class="cm">-- Custom authenticator OPTIONS (accepted; not interpreted by the default authenticator)</span>
+<span class="kw">CREATE ROLE</span> svc <span class="kw">WITH PASSWORD</span> = <span class="str">'p'</span> <span class="kw">AND OPTIONS</span> = { <span class="str">'ttl'</span> : <span class="str">'3600'</span> };
+
+<span class="cm">-- Rotate to a new hashed credential, or toggle superuser/login</span>
+<span class="kw">ALTER ROLE</span> app_writer <span class="kw">WITH HASHED PASSWORD</span> = <span class="str">'$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aGFzaA'</span>;
+
+<span class="cm">-- Legacy USER alias: no '=', trailing SUPERUSER / NOSUPERUSER</span>
+<span class="kw">CREATE USER</span> ops <span class="kw">WITH HASHED PASSWORD</span> <span class="str">'$2a$10$JSJEMFm6GeaW9XxT5JIheuEtPvat6i7uKbnTcxX3c1wshIIsGyUtG'</span> <span class="kw">NOSUPERUSER</span>;
+
+<span class="cm">-- Network authorization is parsed but REJECTED (no network authorizer):</span>
+<span class="cm">--   CREATE ROLE r WITH PASSWORD = 'p' AND ACCESS TO DATACENTERS {'DC1'};  -- error</span></pre>
 
   <p>Ferrosa supports column-level permissions, rate limiting per role, and audit logging to configurable sinks (log file, audit table).</p>
 

--- a/docs/database/cql-compatibility.html
+++ b/docs/database/cql-compatibility.html
@@ -462,6 +462,7 @@
       <tr><td>DROP ROLE</td><td><span class="check">Supported</span></td><td>IF EXISTS</td></tr>
       <tr><td>GRANT</td><td><span class="check">Supported</span></td><td>GRANT perm[, perm…] ON resource TO role. Resource: <code>ON TABLE ks.t</code> / <code>ks.t</code>, <code>ON KEYSPACE</code>, <code>ON ALL KEYSPACES</code>, <code>ON ALL ROLES</code>, <code>ON FUNCTION</code>. Unknown permissions are rejected (no silent partial grant).</td></tr>
       <tr><td>REVOKE</td><td><span class="check">Supported</span></td><td>REVOKE perm[, perm…] ON resource FROM role (same resource forms as GRANT)</td></tr>
+      <tr><td>GRANT / REVOKE role</td><td><span class="check">Supported</span></td><td><code>GRANT &lt;role&gt; TO &lt;member&gt;</code> / <code>REVOKE &lt;role&gt; FROM &lt;member&gt;</code> — role hierarchy (the member inherits the role's permissions). Replicated additively (one membership edge per op) and cycle-checked at apply, so concurrent grants never clobber and a revoke is never lost to a racing grant.</td></tr>
       <tr><td>ACCESS TO/FROM (network auth)</td><td><span class="cross">Rejected</span></td><td>ACCESS TO DATACENTERS / FROM CIDRS is parsed but rejected — ferrosa has no network authorizer, so an unenforced access restriction fails loud rather than being silently accepted</td></tr>
     </tbody>
   </table>

--- a/docs/database/cql-compatibility.html
+++ b/docs/database/cql-compatibility.html
@@ -407,8 +407,20 @@
       <tr><td>uuid()</td><td><span class="check">Supported</span></td><td>Generate random UUID</td></tr>
       <tr><td>now()</td><td><span class="check">Supported</span></td><td>Current timeuuid</td></tr>
       <tr><td>toTimestamp()</td><td><span class="check">Supported</span></td><td>Convert timeuuid to timestamp</td></tr>
+      <tr><td>currentDate()</td><td><span class="check">Supported</span></td><td>Today's date (for temporal arithmetic in WHERE)</td></tr>
     </tbody>
   </table>
+
+  <h3>Durations &amp; temporal arithmetic</h3>
+  <p>The <code>duration</code> type accepts both literal forms — compact
+  (<code>2d</code>, <code>1mo3d</code>, <code>89h4m48s</code>) and ISO-8601
+  (<code>P1Y2M3D</code>, <code>PT4H5M6S</code>). A WHERE predicate may add or
+  subtract a duration from a <code>date</code> or <code>timestamp</code>; months
+  and days are applied calendar-aware (e.g. Jan&nbsp;31&nbsp;+&nbsp;1mo clamps to
+  the last day of February).</p>
+  <pre><span class="cm">-- rows from the last two days</span>
+<span class="kw">SELECT</span> * <span class="kw">FROM</span> <span class="type">events</span>
+  <span class="kw">WHERE</span> day &gt;= <span class="fn">currentDate</span>() <span class="kw">-</span> <span class="str">2d</span> <span class="kw">ALLOW FILTERING</span>;</pre>
 
   <h3>Prepared statements</h3>
   <p>Full PREPARE/EXECUTE support with positional bind values. PREPARE responses include <code>pk_count</code> metadata for driver routing. The prepared statement cache uses moka with W-TinyLFU eviction (64 MB default). Bind markers (<code>?</code>) and named bind markers (<code>:name</code>) are both supported.</p>

--- a/docs/database/getting-started.html
+++ b/docs/database/getting-started.html
@@ -288,7 +288,7 @@ ferrosa</pre>
       <tr><th>Service</th><th>Port</th><th>Protocol</th></tr>
     </thead>
     <tbody>
-      <tr><td>CQL Server</td><td><code>9042</code></td><td>CQL native protocol v5</td></tr>
+      <tr><td>CQL Server</td><td><code>9042</code></td><td>CQL native protocol (v4)</td></tr>
       <tr><td>Web Console</td><td><code>9090</code></td><td>HTTP (REST API + static UI + WebSocket)</td></tr>
       <tr><td>Graph HTTP</td><td><code>7474</code></td><td>HTTP/JSON (Cypher queries)</td></tr>
       <tr><td>Prometheus Metrics</td><td><code>9090/metrics</code></td><td>HTTP (text exposition)</td></tr>
@@ -299,7 +299,7 @@ ferrosa</pre>
   <!-- ── Connect ── -->
   <h2 id="connect">Connect a CQL Driver</h2>
 
-  <p>Ferrosa speaks CQL protocol v5 — the same wire protocol as Apache Cassandra. Any standard CQL driver works unchanged.</p>
+  <p>Ferrosa speaks the CQL native protocol (negotiated at v4) — the same wire protocol as Apache Cassandra. Any standard CQL driver works unchanged.</p>
 
   <h3>Python</h3>
   <pre><span class="kw">from</span> cassandra.cluster <span class="kw">import</span> Cluster

--- a/docs/database/index.html
+++ b/docs/database/index.html
@@ -1056,7 +1056,7 @@
       <div class="feature-icon cql">⌨</div>
       <h3>Drop-In CQL Compatibility</h3>
       <p>
-        CQL protocol v4 and v5 — the same wire protocol your drivers already speak.
+        CQL protocol v4 — the same wire protocol your drivers already speak.
         Python, Java, Go, Rust (cdrs-tokio), and Node.js drivers connect without code changes.
         DDL, DML, prepared statements, batch operations, lightweight transactions
         (IF NOT EXISTS, IF conditions), system keyspaces, ALLOW FILTERING,

--- a/docs/database/migration.html
+++ b/docs/database/migration.html
@@ -277,7 +277,7 @@
   </ol>
 
   <div class="success">
-    <strong>Zero driver changes:</strong> Ferrosa speaks CQL protocol v5 with SASL authentication,
+    <strong>Zero driver changes:</strong> Ferrosa speaks the CQL native protocol (negotiated at v4) with SASL authentication,
     LZ4/Snappy compression, and prepared statement support. Your Python, Java, Go, and Node.js
     drivers connect without modification.
   </div>
@@ -288,7 +288,7 @@
   <table>
     <thead><tr><th>Feature</th><th>Status</th><th>Notes</th></tr></thead>
     <tbody>
-      <tr><td>CQL protocol v5</td><td><span class="check">Compatible</span></td><td>All 16 opcodes</td></tr>
+      <tr><td>CQL protocol v4</td><td><span class="check">Compatible</span></td><td>All 16 opcodes; negotiation capped at v4 (v5 STARTUP falls back to v4)</td></tr>
       <tr><td>SASL authentication</td><td><span class="check">Compatible</span></td><td>PasswordAuthenticator flow</td></tr>
       <tr><td>Frame compression</td><td><span class="check">Compatible</span></td><td>LZ4, Snappy</td></tr>
       <tr><td>Prepared statements</td><td><span class="check">Compatible</span></td><td>W-TinyLFU cache</td></tr>

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -1722,7 +1722,7 @@ impl ModeController {
                         let raft_for_drain = raft_arc.clone();
                         let replayed = drain_ddl_queue(rx, |op| {
                             let raft = raft_for_drain.clone();
-                            async move { execute_via_raft(&raft, op).await }
+                            async move { execute_via_raft(&raft, op).await.map(|_| ()) }
                         })
                         .await;
                         if replayed > 0 {
@@ -1790,7 +1790,10 @@ impl ModeController {
                                     );
                                     for (name, ks) in &user_ks {
                                         let op = DdlOperation::CreateKeyspace((*ks).clone());
+                                        // Bootstrap schema hand-off, not a client
+                                        // DDL — no read-your-writes wait needed.
                                         if let Err(e) = crate::ddl_path::forward_ddl_to_leader(
+                                            None,
                                             &peer_manager_for_bootstrap,
                                             leader_uuid,
                                             op,
@@ -1802,7 +1805,10 @@ impl ModeController {
                                     }
                                     for ((ks, _tbl), table) in &user_tables {
                                         let op = DdlOperation::CreateTable(Box::new((*table).clone()));
+                                        // Bootstrap schema hand-off, not a client
+                                        // DDL — no read-your-writes wait needed.
                                         if let Err(e) = crate::ddl_path::forward_ddl_to_leader(
+                                            None,
                                             &peer_manager_for_bootstrap,
                                             leader_uuid,
                                             op,

--- a/ferrosa-cluster/src/controller/cluster_rejoin.rs
+++ b/ferrosa-cluster/src/controller/cluster_rejoin.rs
@@ -202,8 +202,10 @@ pub async fn attempt_rejoin(
                 "cluster_rejoin: sending JoinNode to peer"
             );
 
-            match forward_ddl_to_leader(&peer_manager, *peer_uuid, op).await {
-                Ok(()) => {
+            // Membership op (JoinNode), not a client DDL — no same-node
+            // read-your-writes wait (and a rejoining node has no usable raft yet).
+            match forward_ddl_to_leader(None, &peer_manager, *peer_uuid, op).await {
+                Ok(_committed) => {
                     tracing::info!(
                         attempt,
                         self_id = %self_host_id,

--- a/ferrosa-cluster/src/ddl_path.rs
+++ b/ferrosa-cluster/src/ddl_path.rs
@@ -1545,6 +1545,7 @@ mod tests {
             is_superuser: None,
             can_login: Some(true),
             password: None,
+            hashed_password: None,
             member_of: None,
         };
         ddl.execute(DdlOperation::AlterRole {
@@ -1682,6 +1683,7 @@ mod tests {
             is_superuser: Some(true),
             can_login: None,
             password: None,
+            hashed_password: None,
             member_of: None,
         };
         let op = DdlOperation::AlterRole {

--- a/ferrosa-cluster/src/ddl_path.rs
+++ b/ferrosa-cluster/src/ddl_path.rs
@@ -263,6 +263,40 @@ fn apply_direct(op: &DdlOperation, schema: &Schema, engine: &Arc<StorageEngine>)
                 )
                 .map_err(ClusterError::Storage)?;
         }
+        DdlOperation::GrantRole {
+            member,
+            granted_role,
+        } => {
+            schema
+                .grant_role_internal(member, granted_role)
+                .map_err(|e| ClusterError::Internal(format!("grant_role: {e}")))?;
+            if let Some(role) = schema.snapshot().roles.get(member) {
+                SystemTableWriter::new(Arc::clone(engine))
+                    .apply(
+                        ferrosa_schema::system::persistence::SystemTableMutation::RoleCreated(
+                            role.clone(),
+                        ),
+                    )
+                    .map_err(ClusterError::Storage)?;
+            }
+        }
+        DdlOperation::RevokeRole {
+            member,
+            granted_role,
+        } => {
+            schema
+                .revoke_role_internal(member, granted_role)
+                .map_err(|e| ClusterError::Internal(format!("revoke_role: {e}")))?;
+            if let Some(role) = schema.snapshot().roles.get(member) {
+                SystemTableWriter::new(Arc::clone(engine))
+                    .apply(
+                        ferrosa_schema::system::persistence::SystemTableMutation::RoleCreated(
+                            role.clone(),
+                        ),
+                    )
+                    .map_err(ClusterError::Storage)?;
+            }
+        }
         DdlOperation::CreateIndex(idx) => {
             schema
                 .create_index_internal(idx.clone())
@@ -449,6 +483,20 @@ fn ddl_op_to_raft_command(op: DdlOperation) -> RaftCommand {
             role,
             resource,
             permission,
+        },
+        DdlOperation::GrantRole {
+            member,
+            granted_role,
+        } => RaftOp::GrantRole {
+            member,
+            granted_role,
+        },
+        DdlOperation::RevokeRole {
+            member,
+            granted_role,
+        } => RaftOp::RevokeRole {
+            member,
+            granted_role,
         },
         DdlOperation::CreateIndex(idx) => RaftOp::CreateIndex(idx),
         DdlOperation::DropIndex {

--- a/ferrosa-cluster/src/ddl_path.rs
+++ b/ferrosa-cluster/src/ddl_path.rs
@@ -87,7 +87,9 @@ impl DdlPath {
                 node_map,
             } => {
                 match execute_via_raft(raft, op.clone()).await {
-                    Ok(()) => Ok(()),
+                    // Leader applied the DDL (client_write awaits leader apply),
+                    // so read-your-writes already holds on this node.
+                    Ok(_committed_index) => Ok(()),
                     Err(ClusterError::NotLeader {
                         leader_id: Some(leader_node_id),
                     }) => {
@@ -99,7 +101,12 @@ impl DdlPath {
                             .copied();
 
                         match leader_uuid {
-                            Some(uuid) => forward_ddl_to_leader(peer_manager, uuid, op).await,
+                            // Forward to the leader; `forward_ddl_to_leader` waits
+                            // for THIS node to apply before returning, so the
+                            // client sees its own write on this follower.
+                            Some(uuid) => forward_ddl_to_leader(Some(raft), peer_manager, uuid, op)
+                                .await
+                                .map(|_committed| ()),
                             None => {
                                 // Leader UUID unknown — cannot forward.
                                 Err(ClusterError::Internal(format!(
@@ -334,11 +341,19 @@ fn apply_direct(op: &DdlOperation, schema: &Schema, engine: &Arc<StorageEngine>)
 /// [`Message::PairDdlAck`].  The leader runs a
 /// [`ClusterDdlForwardHandler`] that calls `execute_via_raft` locally —
 /// since the leader is the Raft leader, the proposal succeeds immediately.
+/// Returns the committed Raft log index of the applied DDL (or `0` if the leader
+/// returned a legacy empty ack), so chained forwards can relay it.
+///
+/// Pass `local_raft = Some(..)` on the **client DDL path** so this node waits for
+/// its own state machine to apply the DDL before returning (same-node
+/// read-your-writes). Membership/bootstrap forwards (JoinNode, schema hand-off)
+/// pass `None` — they have no waiting client and may lack a usable local raft.
 pub(crate) async fn forward_ddl_to_leader(
+    local_raft: Option<&FerrosRaft>,
     peer_manager: &PeerManager,
     leader_uuid: Uuid,
     op: DdlOperation,
-) -> Result<()> {
+) -> Result<u64> {
     let body = op.to_bytes()?;
     let resp = match peer_manager
         .send(
@@ -371,7 +386,26 @@ pub(crate) async fn forward_ddl_to_leader(
     };
 
     match resp {
-        Message::PairDdlAck(_) => Ok(()),
+        Message::PairDdlAck(bytes) => {
+            // The leader returns the committed Raft log index of the DDL (8-byte
+            // big-endian). Before acking the client, wait for THIS node's state
+            // machine to apply up to that index, so a following DML on the same
+            // connection observes the schema change (same-node read-your-writes).
+            // Older acks carry an empty payload — skip the wait for those.
+            let committed = if bytes.len() >= 8 {
+                u64::from_be_bytes(
+                    bytes[..8]
+                        .try_into()
+                        .expect("slice of length 8 converts to [u8; 8]"),
+                )
+            } else {
+                0
+            };
+            if let (Some(raft), true) = (local_raft, committed > 0) {
+                wait_for_local_apply(raft, committed, DDL_AGREEMENT_TIMEOUT).await;
+            }
+            Ok(committed)
+        }
         other => Err(ClusterError::Internal(format!(
             "unexpected response from leader during DDL forward: {:?}",
             other.msg_type()
@@ -477,16 +511,12 @@ const DDL_AGREEMENT_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// Polling interval inside [`wait_for_replication_to_catch_up`].
 const DDL_AGREEMENT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(20);
 
-/// Final settle wait after every follower has *replicated* (appended) the
-/// committed entry. Replication lands a few ms before the follower's state
-/// machine actually `apply`s it, so we sleep a hair to drain the apply queue.
-const DDL_AGREEMENT_APPLY_DRAIN: std::time::Duration = std::time::Duration::from_millis(50);
-
-/// Wait until every voter in the current membership has replicated up to
-/// `committed_index`, then sleep [`DDL_AGREEMENT_APPLY_DRAIN`] to cover the
-/// apply-after-append window. Returns `Ok` either when everyone catches up
-/// or when [`DDL_AGREEMENT_TIMEOUT`] expires (caller logs the partial
-/// agreement and proceeds — the eventual-consistency guarantee still holds).
+/// Wait until every voter in the current membership has replicated (appended)
+/// up to `committed_index`. Returns either when everyone catches up or when
+/// [`DDL_AGREEMENT_TIMEOUT`] expires (caller logs the partial agreement and
+/// proceeds — the eventual-consistency guarantee still holds). Deterministic
+/// same-node read-your-writes is handled separately by [`wait_for_local_apply`]
+/// on a forwarding follower; this barrier only drives cross-node replication.
 async fn wait_for_replication_to_catch_up(raft: &FerrosRaft, committed_index: u64) {
     let deadline = tokio::time::Instant::now() + DDL_AGREEMENT_TIMEOUT;
     loop {
@@ -542,7 +572,47 @@ async fn wait_for_replication_to_catch_up(raft: &FerrosRaft, committed_index: u6
         }
         tokio::time::sleep(DDL_AGREEMENT_POLL_INTERVAL).await;
     }
-    tokio::time::sleep(DDL_AGREEMENT_APPLY_DRAIN).await;
+}
+
+/// Wait until THIS node's state machine has applied up to `target_index`.
+///
+/// A node cannot observe a follower's apply progress from the leader (openraft
+/// metrics expose only the replicated/`matched` index), but it can always
+/// observe its OWN `last_applied`. A node that forwards a DDL to the leader uses
+/// this — after the leader confirms the committed index — to guarantee
+/// **same-node read-your-writes**: it returns success to the CQL client only
+/// once its local schema reflects the committed DDL, so a following DML on the
+/// same connection cannot see stale schema. Replaces the previous fixed
+/// `DDL_AGREEMENT_APPLY_DRAIN` sleep, which was a race rather than a guarantee.
+///
+/// Returns `true` if the node caught up before `timeout`.
+pub async fn wait_for_local_apply(
+    raft: &FerrosRaft,
+    target_index: u64,
+    timeout: std::time::Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let applied = raft
+            .metrics()
+            .borrow()
+            .last_applied
+            .map(|lid| lid.index)
+            .unwrap_or(0);
+        if applied >= target_index {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            tracing::warn!(
+                target_index,
+                applied,
+                "ddl_read_your_writes: timed out waiting for local apply; a read \
+                 on this node may briefly observe stale schema"
+            );
+            return false;
+        }
+        tokio::time::sleep(DDL_AGREEMENT_POLL_INTERVAL).await;
+    }
 }
 
 /// Propose a DDL operation through Raft consensus.
@@ -554,19 +624,20 @@ async fn wait_for_replication_to_catch_up(raft: &FerrosRaft, committed_index: u6
 /// the leader hint. The [`DdlPath::Cluster`] arm in `execute()` catches this
 /// and transparently forwards the request to the leader instead of propagating
 /// the error to the CQL client.
-pub(crate) async fn execute_via_raft(raft: &FerrosRaft, op: DdlOperation) -> Result<()> {
+pub(crate) async fn execute_via_raft(raft: &FerrosRaft, op: DdlOperation) -> Result<u64> {
     let cmd = ddl_op_to_raft_command(op);
 
     match raft.client_write(cmd).await {
         Ok(resp) => {
-            // Schema-agreement barrier: openraft's `client_write` returns once
-            // the leader applies, not when followers do. Without this wait, a
-            // CQL client that runs DDL → DML in quick succession will route
-            // the DML to a follower that has not yet applied the ALTER and
-            // get a memtable-validator rejection (see ferrosa-memory cluster-
-            // int "co_occurs_with column first_seen index 3" symptom).
+            // openraft's `client_write` returns once the LEADER applies, so on
+            // the leader read-your-writes already holds. Drive followers'
+            // *log replication* forward (condition-based on the matched index)
+            // so a subsequent request load-balanced to another node has the
+            // entry to apply. Deterministic same-node read-your-writes for a
+            // forwarding follower is handled by `wait_for_local_apply` once the
+            // forward path returns the committed index (below).
             wait_for_replication_to_catch_up(raft, resp.log_id.index).await;
-            Ok(())
+            Ok(resp.log_id.index)
         }
         Err(raft_err) => {
             // Extract a ForwardToLeader hint if present.
@@ -646,7 +717,7 @@ impl ferrosa_net::rpc::handler::RpcHandler for ClusterDdlForwardHandler {
         };
 
         match execute_via_raft(&self.raft, op.clone()).await {
-            Ok(()) => {
+            Ok(committed_index) => {
                 // P0-21: after a successful JoinNode commit, promote the new
                 // node to openraft voter via change_membership so the leader
                 // will replicate / send InstallSnapshot to it.
@@ -754,7 +825,11 @@ impl ferrosa_net::rpc::handler::RpcHandler for ClusterDdlForwardHandler {
                         }
                     });
                 }
-                Some(Message::PairDdlAck(Bytes::new()))
+                // Ack carries the committed log index so the forwarding
+                // follower can wait for its own apply (read-your-writes).
+                Some(Message::PairDdlAck(Bytes::copy_from_slice(
+                    &committed_index.to_be_bytes(),
+                )))
             }
             Err(ClusterError::NotLeader {
                 leader_id: Some(leader_node_id),
@@ -767,17 +842,25 @@ impl ferrosa_net::rpc::handler::RpcHandler for ClusterDdlForwardHandler {
                     .copied();
 
                 match leader_uuid {
-                    Some(uuid) => match forward_ddl_to_leader(&self.peer_manager, uuid, op).await {
-                        Ok(()) => Some(Message::PairDdlAck(Bytes::new())),
-                        Err(e) => {
-                            tracing::error!(
-                                leader_node_id,
-                                leader_uuid = %uuid,
-                                "ClusterDdlForwardHandler: forward to leader failed: {e}"
-                            );
-                            None
+                    Some(uuid) => {
+                        match forward_ddl_to_leader(Some(&self.raft), &self.peer_manager, uuid, op)
+                            .await
+                        {
+                            // Relay the leader's committed index back to the
+                            // original forwarder so it can wait for its own apply.
+                            Ok(committed) => Some(Message::PairDdlAck(Bytes::copy_from_slice(
+                                &committed.to_be_bytes(),
+                            ))),
+                            Err(e) => {
+                                tracing::error!(
+                                    leader_node_id,
+                                    leader_uuid = %uuid,
+                                    "ClusterDdlForwardHandler: forward to leader failed: {e}"
+                                );
+                                None
+                            }
                         }
-                    },
+                    }
                     None => {
                         tracing::error!(
                             leader_node_id,
@@ -1245,6 +1328,7 @@ mod tests {
         peer_manager.add_peer_entry((leader_uuid, addr)).await;
 
         forward_ddl_to_leader(
+            None,
             &peer_manager,
             leader_uuid,
             DdlOperation::CreateKeyspace(simple_keyspace("fwd_ks")),

--- a/ferrosa-cluster/src/pair/ddl.rs
+++ b/ferrosa-cluster/src/pair/ddl.rs
@@ -71,6 +71,18 @@ pub enum DdlOperation {
         resource: Resource,
         permission: Permission,
     },
+    /// Grant role membership: add `granted_role` to `member`'s `member_of`.
+    /// Additive (one edge) so concurrent role grants replicate without
+    /// clobbering each other.
+    GrantRole {
+        member: String,
+        granted_role: String,
+    },
+    /// Revoke role membership: remove `granted_role` from `member`'s `member_of`.
+    RevokeRole {
+        member: String,
+        granted_role: String,
+    },
     CreateIndex(IndexMetadata),
     DropIndex {
         keyspace: String,
@@ -299,6 +311,22 @@ impl DdlCoordinator {
                 self.schema
                     .revoke_internal(role, resource, permission)
                     .map_err(|e| ClusterError::Internal(format!("revoke: {e}")))?;
+            }
+            DdlOperation::GrantRole {
+                member,
+                granted_role,
+            } => {
+                self.schema
+                    .grant_role_internal(member, granted_role)
+                    .map_err(|e| ClusterError::Internal(format!("grant_role: {e}")))?;
+            }
+            DdlOperation::RevokeRole {
+                member,
+                granted_role,
+            } => {
+                self.schema
+                    .revoke_role_internal(member, granted_role)
+                    .map_err(|e| ClusterError::Internal(format!("revoke_role: {e}")))?;
             }
             DdlOperation::CreateIndex(ref idx) => {
                 self.schema

--- a/ferrosa-cluster/src/raft/mod.rs
+++ b/ferrosa-cluster/src/raft/mod.rs
@@ -210,6 +210,16 @@ pub enum RaftOp {
         resource: Resource,
         permission: Permission,
     },
+    /// Grant role membership (additive, one `member_of` edge).
+    GrantRole {
+        member: String,
+        granted_role: String,
+    },
+    /// Revoke role membership (subtractive, one `member_of` edge).
+    RevokeRole {
+        member: String,
+        granted_role: String,
+    },
     CreateIndex(IndexMetadata),
     DropIndex {
         keyspace: String,

--- a/ferrosa-cluster/src/raft/state_machine.rs
+++ b/ferrosa-cluster/src/raft/state_machine.rs
@@ -1260,6 +1260,63 @@ impl FerrosStateMachine {
                 }
             }
 
+            RaftOp::GrantRole {
+                member,
+                granted_role,
+            } => {
+                // Cycle check against the replicated state, which Raft applies
+                // serially — this catches a cycle formed by two independently
+                // committed grants (GRANT a TO b, GRANT b TO a). If it would
+                // cycle, neither the replicated state nor the schema is mutated,
+                // so they stay consistent.
+                if roles_form_cycle(&self.state.roles, &granted_role, &member) {
+                    tracing::warn!(
+                        member,
+                        granted_role,
+                        "Raft apply: grant_role would create a role cycle; skipped"
+                    );
+                } else {
+                    if let Some(role) = self.state.roles.get_mut(&member) {
+                        role.member_of.insert(granted_role.clone());
+                    }
+                    if let Some(writer) = &self.system_writer {
+                        if let Some(role) = self.state.roles.get(&member) {
+                            if let Err(e) =
+                                writer.apply(SystemTableMutation::RoleCreated(role.clone()))
+                            {
+                                tracing::error!(%e, "Raft apply: system table write failed for GrantRole");
+                            }
+                        }
+                    }
+                    if let Some(schema) = &self.schema {
+                        if let Err(e) = schema.grant_role_internal(&member, &granted_role) {
+                            tracing::error!(%e, "Raft apply: schema.grant_role_internal failed");
+                        }
+                    }
+                }
+            }
+            RaftOp::RevokeRole {
+                member,
+                granted_role,
+            } => {
+                if let Some(role) = self.state.roles.get_mut(&member) {
+                    role.member_of.remove(&granted_role);
+                }
+                if let Some(writer) = &self.system_writer {
+                    if let Some(role) = self.state.roles.get(&member) {
+                        if let Err(e) = writer.apply(SystemTableMutation::RoleCreated(role.clone()))
+                        {
+                            tracing::error!(%e, "Raft apply: system table write failed for RevokeRole");
+                        }
+                    }
+                }
+                if let Some(schema) = &self.schema {
+                    if let Err(e) = schema.revoke_role_internal(&member, &granted_role) {
+                        tracing::error!(%e, "Raft apply: schema.revoke_role_internal failed");
+                    }
+                }
+            }
+
             // ---- Topology ----------------------------------------------
             RaftOp::JoinNode(node_info) => {
                 schema_changed = false;
@@ -1564,6 +1621,29 @@ impl RaftStateMachine<FerrosRaftConfig> for FerrosStateMachine {
 /// Convert an error into an `AnyError` for openraft storage errors.
 fn to_any_error(e: impl std::error::Error + Send + Sync + 'static) -> openraft::AnyError {
     openraft::AnyError::new(&e)
+}
+
+/// True if granting `child` membership in `parent` (adding `parent` to
+/// `child.member_of`) would close a cycle in the role hierarchy — i.e. `child`
+/// is already an ancestor of `parent`. Walks upward from `parent`.
+fn roles_form_cycle(roles: &BTreeMap<String, RoleMetadata>, parent: &str, child: &str) -> bool {
+    let mut visited: Vec<String> = Vec::new();
+    let mut stack = vec![parent.to_string()];
+    while let Some(cur) = stack.pop() {
+        if cur == child {
+            return true;
+        }
+        if visited.contains(&cur) {
+            continue;
+        }
+        visited.push(cur.clone());
+        if let Some(r) = roles.get(&cur) {
+            for grandparent in &r.member_of {
+                stack.push(grandparent.clone());
+            }
+        }
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -2754,6 +2834,65 @@ mod tests {
         sm.apply(entries).await.unwrap();
 
         assert!(!sm.state().roles.contains_key("analyst"));
+    }
+
+    #[tokio::test]
+    async fn apply_grant_role_is_additive_and_cycle_safe() {
+        let mut sm = FerrosStateMachine::new();
+        let mk = |name: &str| {
+            RaftOp::CreateRole(RoleMetadata {
+                name: name.to_string(),
+                is_superuser: false,
+                can_login: true,
+                salted_hash: None,
+                member_of: HashSet::new(),
+            })
+        };
+        let grant = |member: &str, role: &str| RaftOp::GrantRole {
+            member: member.to_string(),
+            granted_role: role.to_string(),
+        };
+
+        sm.apply(vec![
+            make_entry(1, 1, mk("a")),
+            make_entry(1, 2, mk("b")),
+            make_entry(1, 3, mk("c")),
+            // Two independent grants to the same member — additive, neither clobbers.
+            make_entry(1, 4, grant("c", "a")),
+            make_entry(1, 5, grant("c", "b")),
+            // a becomes a member of b.
+            make_entry(1, 6, grant("a", "b")),
+            // b -> a would close a cycle (a is already a member of b): must be skipped.
+            make_entry(1, 7, grant("b", "a")),
+        ])
+        .await
+        .unwrap();
+
+        let roles = &sm.state().roles;
+        let c = &roles.get("c").unwrap().member_of;
+        assert!(
+            c.contains("a") && c.contains("b"),
+            "additive grants preserved"
+        );
+        assert!(roles.get("a").unwrap().member_of.contains("b"));
+        assert!(
+            !roles.get("b").unwrap().member_of.contains("a"),
+            "cycle-forming grant must be skipped at apply"
+        );
+
+        // Revoke removes exactly one edge.
+        sm.apply(vec![make_entry(
+            1,
+            8,
+            RaftOp::RevokeRole {
+                member: "c".to_string(),
+                granted_role: "a".to_string(),
+            },
+        )])
+        .await
+        .unwrap();
+        let c = &sm.state().roles.get("c").unwrap().member_of;
+        assert!(!c.contains("a") && c.contains("b"), "revoke is subtractive");
     }
 
     /// Cluster (Raft) replication test: a `RaftOp::CreateRole(role)`

--- a/ferrosa-cluster/tests/ddl_read_your_writes.rs
+++ b/ferrosa-cluster/tests/ddl_read_your_writes.rs
@@ -1,0 +1,110 @@
+//! Read-your-writes for forwarded DDL.
+//!
+//! When a non-leader node forwards a DDL to the leader, it must wait for its
+//! OWN state machine to apply the committed entry before returning success to
+//! the client — otherwise a client connected to that follower can run DDL → DML
+//! in quick succession and have the DML rejected ("schema may still be
+//! propagating") because the follower has the entry replicated but not yet
+//! applied.
+//!
+//! The deterministic mechanism is `ddl_path::wait_for_local_apply`, which polls
+//! the node's own `last_applied` index — observable locally, unlike a
+//! follower's apply progress as seen from the leader.
+
+mod common;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use common::raft_harness::TestCluster;
+use ferrosa_cluster::raft::{RaftCommand, RaftOp};
+use ferrosa_schema::metadata::keyspace::{KeyspaceMetadata, ReplicationParams};
+
+fn create_ks_command(name: &str) -> RaftCommand {
+    let mut opts = HashMap::new();
+    opts.insert("replication_factor".to_string(), "1".to_string());
+    RaftCommand {
+        op: RaftOp::CreateKeyspace(KeyspaceMetadata {
+            name: name.to_string(),
+            durable_writes: true,
+            replication: ReplicationParams {
+                strategy: "SimpleStrategy".to_string(),
+                options: opts,
+            },
+        }),
+        schema_version: uuid::Uuid::new_v4(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn wait_for_local_apply_gives_follower_read_your_writes() {
+    let cluster = TestCluster::with_voters(3).await;
+    let leader_id = cluster
+        .wait_for_all_voters_leader(Duration::from_secs(10))
+        .await
+        .expect("all voters should agree on a leader");
+
+    // Commit a DDL on the leader. client_write returns after the LEADER applies,
+    // so the leader's last_applied is now the committed index of this op.
+    cluster
+        .propose_on_leader(create_ks_command("ryw_ks"))
+        .await
+        .expect("client_write should succeed on the leader");
+
+    let committed = {
+        let nodes = cluster.nodes();
+        let leader = nodes
+            .iter()
+            .find(|n| n.node_id == leader_id)
+            .expect("leader node present");
+        leader
+            .raft
+            .metrics()
+            .borrow()
+            .last_applied
+            .expect("leader has applied the DDL")
+            .index
+    };
+
+    let follower_id = cluster
+        .node_ids()
+        .into_iter()
+        .find(|id| *id != leader_id)
+        .expect("a follower exists in a 3-node cluster");
+
+    // Clone the follower's raft handle out of the guard so we don't hold a
+    // non-Send guard across the await.
+    let follower_raft = {
+        let nodes = cluster.nodes();
+        let follower = nodes
+            .iter()
+            .find(|n| n.node_id == follower_id)
+            .expect("follower node present");
+        follower.raft.clone()
+    };
+
+    // The invariant under test: after wait_for_local_apply returns true, the
+    // follower's own state machine has applied up to the committed DDL index —
+    // so a read on the follower observes the schema change (read-your-writes).
+    let caught_up = ferrosa_cluster::ddl_path::wait_for_local_apply(
+        &follower_raft,
+        committed,
+        Duration::from_secs(2),
+    )
+    .await;
+    assert!(
+        caught_up,
+        "follower failed to apply committed index {committed} within the deadline"
+    );
+
+    let applied = follower_raft
+        .metrics()
+        .borrow()
+        .last_applied
+        .map(|l| l.index)
+        .unwrap_or(0);
+    assert!(
+        applied >= committed,
+        "follower last_applied {applied} < committed {committed}"
+    );
+}

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -32,6 +32,14 @@ pub enum Statement {
         no_recursive: bool,
         users_alias: bool,
     },
+    /// `LIST [ALL | <permission>] PERMISSIONS [ON <resource>] [OF <role>]
+    /// [NORECURSIVE]`. `permission = None` means ALL permissions.
+    ListPermissions {
+        permission: Option<String>,
+        resource: Option<GrantResource>,
+        of: Option<String>,
+        no_recursive: bool,
+    },
     Grant(GrantStatement),
     Revoke(RevokeStatement),
     /// `GRANT <role> TO <member>` — role membership (the member inherits the

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -418,6 +418,11 @@ pub struct AlterTableStatement {
     pub table: String,
     pub add_columns: Vec<(String, CqlTypeName)>,
     pub drop_columns: Vec<String>,
+    /// `RENAME <from> TO <to> [AND ...]` — Cassandra restricts this to primary
+    /// key columns.
+    pub rename_columns: Vec<(String, String)>,
+    /// `ALTER <column> TYPE <new_type>`.
+    pub alter_column_types: Vec<(String, CqlTypeName)>,
     /// Table extensions (e.g. graph metadata: `WITH extensions = {'vertex_label': 'Person'}`).
     pub extensions: Option<Vec<(String, String)>>,
     /// Generic table options (compaction, compression, comment, etc.).

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -34,6 +34,17 @@ pub enum Statement {
     },
     Grant(GrantStatement),
     Revoke(RevokeStatement),
+    /// `GRANT <role> TO <member>` — role membership (the member inherits the
+    /// granted role's permissions).
+    GrantRole {
+        role: String,
+        member: String,
+    },
+    /// `REVOKE <role> FROM <member>`.
+    RevokeRole {
+        role: String,
+        member: String,
+    },
     Use(UseStatement),
     Truncate(TruncateStatement),
     Compact(CompactStatement),

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -200,6 +200,19 @@ pub enum Term {
         name: String,
         args: Vec<Term>,
     },
+    /// A CQL `duration` literal (months, days, nanoseconds).
+    Duration {
+        months: i32,
+        days: i32,
+        nanos: i64,
+    },
+    /// Temporal arithmetic: `base ± offset`, where `offset` is a duration and
+    /// `base` resolves to a `date` or `timestamp`.
+    TemporalArithmetic {
+        base: Box<Term>,
+        subtract: bool,
+        offset: Box<Term>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -502,21 +502,45 @@ pub struct CompactStatement {
     pub table: String,
 }
 
+/// A role's network-authorization `ACCESS` clause (Cassandra's CassandraNetworkAuthorizer
+/// grammar). ferrosa parses these for CQL compatibility; enforcement is a separate concern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoleAccess {
+    /// `ACCESS TO DATACENTERS { 'dc1', 'dc2' }`
+    ToDatacenters(Vec<String>),
+    /// `ACCESS TO ALL DATACENTERS`
+    ToAllDatacenters,
+    /// `ACCESS FROM CIDRS { 'region1' }`
+    FromCidrs(Vec<String>),
+    /// `ACCESS FROM ALL CIDRS`
+    FromAllCidrs,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateRoleStatement {
     pub name: String,
     pub if_not_exists: bool,
+    /// Plaintext `PASSWORD = '...'` — hashed before storage.
     pub password: Option<String>,
+    /// Pre-hashed `HASHED PASSWORD = '...'` — stored verbatim.
+    pub hashed_password: Option<String>,
     pub superuser: Option<bool>,
     pub login: Option<bool>,
+    /// Custom `OPTIONS = { 'k': v }` (passed to the authenticator).
+    pub options: Vec<(String, String)>,
+    /// `ACCESS TO/FROM ...` network-auth clauses.
+    pub access: Vec<RoleAccess>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlterRoleStatement {
     pub name: String,
     pub password: Option<String>,
+    pub hashed_password: Option<String>,
     pub superuser: Option<bool>,
     pub login: Option<bool>,
+    pub options: Vec<(String, String)>,
+    pub access: Vec<RoleAccess>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -195,6 +195,9 @@ pub enum ComparisonOp {
     Contains,
     ContainsKey,
     SoundsLike,
+    /// `LIKE` pattern match (`%` wildcard). Requires ALLOW FILTERING or a
+    /// matching index, evaluated as a post-scan predicate.
+    Like,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/ferrosa-cql/src/bridge.rs
+++ b/ferrosa-cql/src/bridge.rs
@@ -456,13 +456,80 @@ pub fn term_to_cql_value(term: &Term, target: &CqlType) -> Result<CqlValue, CqlE
                     let inner = term_to_cql_value(&args[0], &CqlType::Date)?;
                     Ok(inner)
                 }
+                "currentdate" | "current_date" if args.is_empty() => match target {
+                    CqlType::Date => Ok(CqlValue::Date(today_cql_date())),
+                    _ => Err(CqlError::Invalid(format!(
+                        "type mismatch: currentDate() returns date, but column expects {}",
+                        cql_type_name(target)
+                    ))),
+                },
                 _ => Err(CqlError::Invalid(format!(
                     "unknown function: {name}. If this is a UDF used in WHERE, \
                      the query requires ALLOW FILTERING"
                 ))),
             }
         }
+
+        Term::Duration {
+            months,
+            days,
+            nanos,
+        } => match target {
+            CqlType::Duration => Ok(CqlValue::Duration {
+                months: *months,
+                days: *days,
+                nanos: *nanos,
+            }),
+            _ => Err(CqlError::Invalid(format!(
+                "type mismatch: expected {}, got a duration literal",
+                cql_type_name(target)
+            ))),
+        },
+
+        Term::TemporalArithmetic {
+            base,
+            subtract,
+            offset,
+        } => {
+            // The base resolves to the column's temporal type; the offset is a
+            // duration regardless of the column type.
+            let base_val = term_to_cql_value(base, target)?;
+            let dur = match term_to_cql_value(offset, &CqlType::Duration)? {
+                CqlValue::Duration {
+                    months,
+                    days,
+                    nanos,
+                } => crate::duration::DurationComponents {
+                    months,
+                    days,
+                    nanos,
+                },
+                _ => return Err(CqlError::Invalid("expected a duration offset".into())),
+            };
+            match base_val {
+                CqlValue::Timestamp(ms) => {
+                    crate::duration::apply_to_timestamp_millis(ms, dur, *subtract)
+                        .map(CqlValue::Timestamp)
+                        .ok_or_else(|| CqlError::Invalid("timestamp arithmetic overflow".into()))
+                }
+                CqlValue::Date(d) => crate::duration::apply_to_date_days(d, dur, *subtract)
+                    .map(CqlValue::Date)
+                    .ok_or_else(|| CqlError::Invalid("date arithmetic overflow".into())),
+                _ => Err(CqlError::Invalid(
+                    "temporal arithmetic requires a date or timestamp base".into(),
+                )),
+            }
+        }
     }
+}
+
+/// Today's date as a Cassandra `date` value (days from the Unix epoch, offset by
+/// `2^31`).
+fn today_cql_date() -> u32 {
+    let today = chrono::Utc::now().date_naive();
+    let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("valid epoch");
+    let days = today.signed_duration_since(epoch).num_days();
+    (days + (1i64 << 31)) as u32
 }
 
 /// Human-readable name for a CqlType (for error messages).
@@ -1798,6 +1865,54 @@ mod tests {
             }
             other => panic!("expected CqlValue::Timeuuid, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn duration_literal_and_temporal_arithmetic_eval() {
+        // A duration literal resolves to CqlValue::Duration.
+        let d = Term::Duration {
+            months: 1,
+            days: 2,
+            nanos: 3,
+        };
+        assert_eq!(
+            term_to_cql_value(&d, &CqlType::Duration).unwrap(),
+            CqlValue::Duration {
+                months: 1,
+                days: 2,
+                nanos: 3
+            }
+        );
+
+        // timestamp − 2 days: 2017-01-03 → 2017-01-01.
+        let base_ms = 1_483_401_600_000i64; // 2017-01-03T00:00:00Z
+        let arith = Term::TemporalArithmetic {
+            base: Box::new(Term::IntegerLiteral(base_ms)),
+            subtract: true,
+            offset: Box::new(Term::Duration {
+                months: 0,
+                days: 2,
+                nanos: 0,
+            }),
+        };
+        match term_to_cql_value(&arith, &CqlType::Timestamp).unwrap() {
+            CqlValue::Timestamp(ms) => assert_eq!(ms, base_ms - 2 * 86_400_000),
+            other => panic!("expected Timestamp, got {other:?}"),
+        }
+
+        // date − 2 days: '2017-01-03' → '2017-01-01'.
+        let arith = Term::TemporalArithmetic {
+            base: Box::new(Term::StringLiteral("2017-01-03".into())),
+            subtract: true,
+            offset: Box::new(Term::Duration {
+                months: 0,
+                days: 2,
+                nanos: 0,
+            }),
+        };
+        let expected =
+            term_to_cql_value(&Term::StringLiteral("2017-01-01".into()), &CqlType::Date).unwrap();
+        assert_eq!(term_to_cql_value(&arith, &CqlType::Date).unwrap(), expected);
     }
 
     /// `now()` encodes to exactly 16 bytes when bound into a TimeUUID

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -1117,6 +1117,69 @@ fn increment_auth_attempts_and_reply(phase: &mut ConnectionPhase, err: CqlError)
     HandleResult::Reply(Opcode::Error, err.encode_body())
 }
 
+/// Redact password literals from a CQL string before it is placed in a log
+/// line or error message (threat-model T5: keep `PASSWORD`/`HASHED PASSWORD`
+/// secrets out of logs). Replaces the single-quoted string literal that follows
+/// a `PASSWORD` keyword — covering `PASSWORD = '…'`, `PASSWORD '…'`, and
+/// `HASHED PASSWORD …` — with `'<redacted>'`. Handles `''`-escaped quotes and
+/// is a no-op for queries without a password.
+fn redact_cql_secrets(query: &str) -> String {
+    let mut out = String::with_capacity(query.len());
+    let mut rest = query;
+    while !rest.is_empty() {
+        let at_word_boundary = out
+            .chars()
+            .last()
+            .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+        let is_password_kw = rest.len() >= 8
+            && rest[..8].eq_ignore_ascii_case("password")
+            && rest[8..]
+                .chars()
+                .next()
+                .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+        if at_word_boundary && is_password_kw {
+            out.push_str(&rest[..8]);
+            rest = &rest[8..];
+            // Copy surrounding whitespace and an optional '='.
+            while let Some(c) = rest.chars().next().filter(|c| c.is_whitespace()) {
+                out.push(c);
+                rest = &rest[c.len_utf8()..];
+            }
+            if let Some(stripped) = rest.strip_prefix('=') {
+                out.push('=');
+                rest = stripped;
+                while let Some(c) = rest.chars().next().filter(|c| c.is_whitespace()) {
+                    out.push(c);
+                    rest = &rest[c.len_utf8()..];
+                }
+            }
+            // Redact a following single-quoted literal (handle '' escapes).
+            if rest.starts_with('\'') {
+                let b = rest.as_bytes();
+                let mut j = 1;
+                while j < b.len() {
+                    if b[j] == b'\'' {
+                        if j + 1 < b.len() && b[j + 1] == b'\'' {
+                            j += 2;
+                            continue;
+                        }
+                        j += 1;
+                        break;
+                    }
+                    j += 1;
+                }
+                out.push_str("'<redacted>'");
+                rest = &rest[j..];
+            }
+        } else {
+            let c = rest.chars().next().unwrap();
+            out.push(c);
+            rest = &rest[c.len_utf8()..];
+        }
+    }
+    out
+}
+
 // ── QUERY ────────────────────────────────────────────────────────────────
 
 async fn handle_query(
@@ -1286,8 +1349,9 @@ pub(crate) fn handle_prepare(
     // retriable.  Real Cassandra returns 0x2200 (Invalid) when the table is
     // not found during PREPARE.
     if bound_columns.len() != expected_bind_count {
+        let redacted_query = redact_cql_secrets(query);
         let err = CqlError::Invalid(format!(
-            "PREPARE failed for '{query}': \
+            "PREPARE failed for '{redacted_query}': \
              expected {expected_bind_count} bind-marker column spec(s) \
              but resolved only {}. \
              Table '{table_ks}.{table_name}' may not yet be visible on this node \
@@ -2428,6 +2492,36 @@ fn extract_keyspace_table(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redact_cql_secrets_removes_password_literals() {
+        // PASSWORD = '...'  (ROLE form)
+        let r = redact_cql_secrets("CREATE ROLE x WITH PASSWORD = 'sup3rSecret' AND LOGIN = true");
+        assert!(!r.contains("sup3rSecret"), "secret leaked: {r}");
+        assert!(r.contains("'<redacted>'"));
+        assert!(r.contains("LOGIN = true"));
+
+        // PASSWORD '...'  (legacy USER form, no '=') + trailing keyword.
+        let r2 = redact_cql_secrets("CREATE USER y WITH PASSWORD 'pw1' SUPERUSER");
+        assert!(!r2.contains("pw1"), "secret leaked: {r2}");
+        assert!(r2.ends_with("SUPERUSER"));
+
+        // HASHED PASSWORD hash.
+        let r3 = redact_cql_secrets("ALTER ROLE z WITH HASHED PASSWORD = '$2a$10$abcXYZ'");
+        assert!(!r3.contains("$2a$10$abcXYZ"), "hash leaked: {r3}");
+
+        // Embedded '' escape inside the literal.
+        let r4 = redact_cql_secrets("CREATE ROLE q WITH PASSWORD = 'a''b' AND LOGIN = true");
+        assert!(!r4.contains("a''b"), "escaped-quote secret leaked: {r4}");
+        assert!(r4.contains("LOGIN = true"));
+
+        // No password — unchanged.
+        let q = "SELECT * FROM t WHERE id = 1";
+        assert_eq!(redact_cql_secrets(q), q);
+        // 'password' as a substring of an identifier must not trigger redaction.
+        let q2 = "SELECT password_changed FROM t";
+        assert_eq!(redact_cql_secrets(q2), q2);
+    }
 
     fn build_minimal_schema_for_test() -> Arc<ferrosa_schema::Schema> {
         use ferrosa_schema::audit::TestAuditSink;

--- a/ferrosa-cql/src/duration.rs
+++ b/ferrosa-cql/src/duration.rs
@@ -1,0 +1,402 @@
+//! CQL `duration` literal parsing and temporal (date/timestamp) arithmetic.
+//!
+//! A CQL duration is three signed components — months, days, and nanoseconds —
+//! because months and days are calendar-relative (a month is not a fixed number
+//! of seconds). Literals come in two forms:
+//!
+//! * **compact**: `1y2mo3w4d5h6m7s8ms9us10ns` (units: y, mo, w, d, h, m, s, ms,
+//!   us/µs, ns), and
+//! * **ISO-8601**: `P1Y2M3D`, `P1Y2M3DT4H5M6S`, `P1W`, `PT4H`.
+//!
+//! Arithmetic adds months calendar-aware (clamping to month end), days as
+//! calendar days, and nanoseconds as a fixed offset.
+
+use chrono::{DateTime, Days, Months, NaiveDate, TimeZone, Utc};
+
+const NANOS_PER_MICRO: i64 = 1_000;
+const NANOS_PER_MILLI: i64 = 1_000_000;
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+const NANOS_PER_MIN: i64 = 60 * NANOS_PER_SEC;
+const NANOS_PER_HOUR: i64 = 60 * NANOS_PER_MIN;
+const NANOS_PER_DAY: i64 = 24 * NANOS_PER_HOUR;
+const MONTHS_PER_YEAR: i64 = 12;
+const DAYS_PER_WEEK: i64 = 7;
+
+/// Cassandra's `date` column type is a `u32` counting days from the Unix epoch
+/// with the epoch shifted to the center of the range: `2^31` == 1970-01-01.
+const DATE_EPOCH_OFFSET: i64 = 1 << 31;
+
+/// Parsed duration components.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DurationComponents {
+    pub months: i32,
+    pub days: i32,
+    pub nanos: i64,
+}
+
+/// Add the contribution of `value` of `unit` into the running components.
+fn add_unit(acc: &mut (i64, i64, i64), value: i64, unit: &str) -> Result<(), String> {
+    let (months, days, nanos) = acc;
+    match unit {
+        "y" => *months += value * MONTHS_PER_YEAR,
+        "mo" => *months += value,
+        "w" => *days += value * DAYS_PER_WEEK,
+        "d" => *days += value,
+        "h" => *nanos += value * NANOS_PER_HOUR,
+        "m" => *nanos += value * NANOS_PER_MIN,
+        "s" => *nanos += value * NANOS_PER_SEC,
+        "ms" => *nanos += value * NANOS_PER_MILLI,
+        "us" | "µs" => *nanos += value * NANOS_PER_MICRO,
+        "ns" => *nanos += value,
+        other => return Err(format!("unknown duration unit '{other}'")),
+    }
+    Ok(())
+}
+
+/// Parse a compact-form duration literal: `<n><unit>` repeated, e.g. `2d`,
+/// `1mo3d`, `89h4m48s`, optionally with a leading `-`. The lexer emits this as a
+/// single digit-led identifier token.
+pub fn parse_compact_duration(input: &str) -> Result<DurationComponents, String> {
+    let trimmed = input.trim();
+    let negative = trimmed.starts_with('-');
+    let s = trimmed.strip_prefix('-').unwrap_or(trimmed);
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || !bytes[0].is_ascii_digit() {
+        return Err(format!("invalid duration literal '{input}'"));
+    }
+    let mut acc = (0i64, 0i64, 0i64);
+    let mut i = 0;
+    while i < bytes.len() {
+        let num_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == num_start {
+            return Err(format!("expected a number in duration '{input}'"));
+        }
+        let value: i64 = s[num_start..i]
+            .parse()
+            .map_err(|_| format!("number out of range in '{input}'"))?;
+        let unit_start = i;
+        while i < bytes.len() && !bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == unit_start {
+            return Err(format!("missing unit in duration '{input}'"));
+        }
+        add_unit(&mut acc, value, &s[unit_start..i].to_ascii_lowercase())?;
+    }
+    let sign = if negative { -1 } else { 1 };
+    Ok(DurationComponents {
+        months: i32::try_from(sign * acc.0).map_err(|_| "months out of range".to_string())?,
+        days: i32::try_from(sign * acc.1).map_err(|_| "days out of range".to_string())?,
+        nanos: sign * acc.2,
+    })
+}
+
+/// Returns true if `s` is a compact-form duration literal (digit-led and parses
+/// cleanly), used to disambiguate `2d` from an ordinary identifier.
+pub fn is_compact_duration(s: &str) -> bool {
+    let t = s.strip_prefix('-').unwrap_or(s);
+    t.as_bytes().first().is_some_and(u8::is_ascii_digit) && parse_compact_duration(s).is_ok()
+}
+
+/// Returns true if `s` is an ISO-8601 duration literal: `P` followed only by
+/// digits and the unit letters `YMWDTHS`, with at least one digit AND one unit.
+/// The strict check avoids treating column identifiers that merely start with
+/// `P` (e.g. `Person`, `PT`, `P0000`) as durations.
+pub fn is_iso_duration(s: &str) -> bool {
+    let b = s.as_bytes();
+    if b.len() < 2 || !(b[0] == b'P' || b[0] == b'p') {
+        return false;
+    }
+    let mut has_digit = false;
+    let mut has_unit = false;
+    for &c in &b[1..] {
+        match c.to_ascii_uppercase() {
+            b'0'..=b'9' => has_digit = true,
+            b'Y' | b'M' | b'W' | b'D' | b'H' | b'S' => has_unit = true,
+            b'T' => {}
+            _ => return false,
+        }
+    }
+    has_digit && has_unit
+}
+
+/// Parse an ISO-8601 duration: `P[nY][nMo? no — M][nW][nD][T[nH][nM][nS]]`.
+/// The `M` before `T` is months; after `T` it is minutes.
+pub fn parse_iso_duration(input: &str) -> Result<DurationComponents, String> {
+    let s = input.trim();
+    let mut chars = s.chars().peekable();
+    let negative = matches!(chars.peek(), Some('-'));
+    if negative {
+        chars.next();
+    }
+    if chars.next().map(|c| c.eq_ignore_ascii_case(&'P')) != Some(true) {
+        return Err(format!("invalid ISO-8601 duration: '{input}'"));
+    }
+
+    let mut acc = (0i64, 0i64, 0i64);
+    let mut in_time = false;
+    let mut num = String::new();
+    for c in chars {
+        if c == 'T' || c == 't' {
+            in_time = true;
+            continue;
+        }
+        if c.is_ascii_digit() {
+            num.push(c);
+            continue;
+        }
+        if num.is_empty() {
+            return Err(format!("invalid ISO-8601 duration: '{input}'"));
+        }
+        let value: i64 = num
+            .parse()
+            .map_err(|_| format!("bad number in '{input}'"))?;
+        num.clear();
+        let unit = match (c.to_ascii_uppercase(), in_time) {
+            ('Y', _) => "y",
+            ('M', false) => "mo",
+            ('W', _) => "w",
+            ('D', _) => "d",
+            ('H', true) => "h",
+            ('M', true) => "m",
+            ('S', true) => "s",
+            (other, _) => return Err(format!("invalid ISO-8601 unit '{other}' in '{input}'")),
+        };
+        add_unit(&mut acc, value, unit)?;
+    }
+    if !num.is_empty() {
+        return Err(format!("trailing number in ISO-8601 duration '{input}'"));
+    }
+
+    let sign = if negative { -1 } else { 1 };
+    Ok(DurationComponents {
+        months: i32::try_from(sign * acc.0).map_err(|_| "months out of range".to_string())?,
+        days: i32::try_from(sign * acc.1).map_err(|_| "days out of range".to_string())?,
+        nanos: sign * acc.2,
+    })
+}
+
+/// Apply a signed number of months to a UTC datetime, clamping the day to the
+/// target month's length (chrono's `Months` already does this).
+fn shift_months_dt(dt: DateTime<Utc>, months: i32) -> Option<DateTime<Utc>> {
+    if months >= 0 {
+        dt.checked_add_months(Months::new(months as u32))
+    } else {
+        dt.checked_sub_months(Months::new(months.unsigned_abs()))
+    }
+}
+
+fn shift_days_dt(dt: DateTime<Utc>, days: i32) -> Option<DateTime<Utc>> {
+    if days >= 0 {
+        dt.checked_add_days(Days::new(days as u64))
+    } else {
+        dt.checked_sub_days(Days::new(days.unsigned_abs() as u64))
+    }
+}
+
+/// Apply a duration to a timestamp (milliseconds since the Unix epoch),
+/// `subtract`ing it if requested. Months and days are calendar-aware.
+pub fn apply_to_timestamp_millis(
+    millis: i64,
+    dur: DurationComponents,
+    subtract: bool,
+) -> Option<i64> {
+    let s: i64 = if subtract { -1 } else { 1 };
+    let dt = Utc.timestamp_millis_opt(millis).single()?;
+    let dt = shift_months_dt(dt, (s as i32).checked_mul(dur.months)?)?;
+    let dt = shift_days_dt(dt, (s as i32).checked_mul(dur.days)?)?;
+    let dt = dt.checked_add_signed(chrono::Duration::nanoseconds(s * dur.nanos))?;
+    Some(dt.timestamp_millis())
+}
+
+/// Apply a duration to a `date` (Cassandra `u32`, days from epoch offset by
+/// `2^31`). Sub-day nanosecond components are folded into whole days.
+pub fn apply_to_date_days(date: u32, dur: DurationComponents, subtract: bool) -> Option<u32> {
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1)?;
+    let day_index = i64::from(date) - DATE_EPOCH_OFFSET;
+    let base = if day_index >= 0 {
+        epoch.checked_add_days(Days::new(day_index as u64))?
+    } else {
+        epoch.checked_sub_days(Days::new(day_index.unsigned_abs()))?
+    };
+    let s: i64 = if subtract { -1 } else { 1 };
+
+    let months = (s as i32).checked_mul(dur.months)?;
+    let shifted = if months >= 0 {
+        base.checked_add_months(Months::new(months as u32))?
+    } else {
+        base.checked_sub_months(Months::new(months.unsigned_abs()))?
+    };
+    let extra_days = s.checked_mul(i64::from(dur.days))? + s * (dur.nanos / NANOS_PER_DAY);
+    let result = if extra_days >= 0 {
+        shifted.checked_add_days(Days::new(extra_days as u64))?
+    } else {
+        shifted.checked_sub_days(Days::new(extra_days.unsigned_abs()))?
+    };
+
+    let delta = result.signed_duration_since(epoch).num_days();
+    u32::try_from(delta + DATE_EPOCH_OFFSET).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Datelike;
+
+    #[test]
+    fn compact_durations() {
+        assert_eq!(
+            parse_compact_duration("2d").unwrap(),
+            DurationComponents {
+                months: 0,
+                days: 2,
+                nanos: 0
+            }
+        );
+        assert_eq!(
+            parse_compact_duration("1mo").unwrap(),
+            DurationComponents {
+                months: 1,
+                days: 0,
+                nanos: 0
+            }
+        );
+        assert_eq!(
+            parse_compact_duration("1y").unwrap(),
+            DurationComponents {
+                months: 12,
+                days: 0,
+                nanos: 0
+            }
+        );
+        assert_eq!(
+            parse_compact_duration("1w").unwrap(),
+            DurationComponents {
+                months: 0,
+                days: 7,
+                nanos: 0
+            }
+        );
+        // Compound form, and minutes-vs-month disambiguation by unit text.
+        assert_eq!(
+            parse_compact_duration("1mo3d").unwrap(),
+            DurationComponents {
+                months: 1,
+                days: 3,
+                nanos: 0
+            }
+        );
+        assert_eq!(
+            parse_compact_duration("89h4m48s").unwrap().nanos,
+            89 * NANOS_PER_HOUR + 4 * NANOS_PER_MIN + 48 * NANOS_PER_SEC
+        );
+        assert_eq!(
+            parse_compact_duration("3ms").unwrap().nanos,
+            3 * NANOS_PER_MILLI
+        );
+        assert!(parse_compact_duration("2zz").is_err());
+
+        assert!(is_compact_duration("2d"));
+        assert!(is_compact_duration("89h4m48s"));
+        assert!(!is_compact_duration("hello"));
+        assert!(!is_compact_duration("2abc"));
+        assert!(!is_iso_duration("P0000")); // digits but no unit
+    }
+
+    #[test]
+    fn iso_basic_and_time() {
+        assert_eq!(
+            parse_iso_duration("P1Y2M3D").unwrap(),
+            DurationComponents {
+                months: 14,
+                days: 3,
+                nanos: 0
+            }
+        );
+        assert_eq!(
+            parse_iso_duration("P1W").unwrap(),
+            DurationComponents {
+                months: 0,
+                days: 7,
+                nanos: 0
+            }
+        );
+        let d = parse_iso_duration("PT4H5M6S").unwrap();
+        assert_eq!(d.months, 0);
+        assert_eq!(d.days, 0);
+        assert_eq!(
+            d.nanos,
+            4 * NANOS_PER_HOUR + 5 * NANOS_PER_MIN + 6 * NANOS_PER_SEC
+        );
+        assert!(parse_iso_duration("1Y").is_err()); // missing P
+    }
+
+    #[test]
+    fn iso_month_vs_minute() {
+        // M before T is months; M after T is minutes.
+        let d = parse_iso_duration("P2MT3M").unwrap();
+        assert_eq!(d.months, 2);
+        assert_eq!(d.nanos, 3 * NANOS_PER_MIN);
+    }
+
+    #[test]
+    fn timestamp_arithmetic_calendar_months() {
+        // 2024-01-31 + 1 month clamps to 2024-02-29 (leap year).
+        let jan31 = Utc
+            .with_ymd_and_hms(2024, 1, 31, 0, 0, 0)
+            .unwrap()
+            .timestamp_millis();
+        let plus_month = apply_to_timestamp_millis(
+            jan31,
+            DurationComponents {
+                months: 1,
+                days: 0,
+                nanos: 0,
+            },
+            false,
+        )
+        .unwrap();
+        let dt = Utc.timestamp_millis_opt(plus_month).single().unwrap();
+        assert_eq!((dt.year(), dt.month(), dt.day()), (2024, 2, 29));
+    }
+
+    #[test]
+    fn timestamp_subtract_days() {
+        let base = Utc
+            .with_ymd_and_hms(2017, 1, 3, 0, 0, 0)
+            .unwrap()
+            .timestamp_millis();
+        let minus = apply_to_timestamp_millis(
+            base,
+            DurationComponents {
+                months: 0,
+                days: 2,
+                nanos: 0,
+            },
+            true,
+        )
+        .unwrap();
+        let dt = Utc.timestamp_millis_opt(minus).single().unwrap();
+        assert_eq!((dt.year(), dt.month(), dt.day()), (2017, 1, 1));
+    }
+
+    #[test]
+    fn date_subtract_days_roundtrips() {
+        // 1970-01-03 == DATE_EPOCH_OFFSET + 2.
+        let date = (DATE_EPOCH_OFFSET + 2) as u32;
+        let minus = apply_to_date_days(
+            date,
+            DurationComponents {
+                months: 0,
+                days: 2,
+                nanos: 0,
+            },
+            true,
+        )
+        .unwrap();
+        assert_eq!(minus, DATE_EPOCH_OFFSET as u32); // back to 1970-01-01
+    }
+}

--- a/ferrosa-cql/src/lib.rs
+++ b/ferrosa-cql/src/lib.rs
@@ -21,6 +21,7 @@ pub mod auth;
 pub mod bridge;
 pub mod client;
 pub mod connection;
+pub mod duration;
 pub mod error;
 pub mod event;
 pub mod frame;

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -929,7 +929,9 @@ impl<'input> Parser<'input> {
             match &tok.kind {
                 TokenKind::Keyword(Keyword::Password) => {
                     self.lexer.next_token()?;
-                    self.lexer.expect(&TokenKind::Eq)?;
+                    // `=` is optional: ROLE syntax uses `PASSWORD = 'x'`, the
+                    // legacy USER syntax uses `PASSWORD 'x'`.
+                    self.lexer.eat(&TokenKind::Eq)?;
                     o.password = Some(self.expect_string_literal()?);
                 }
                 TokenKind::Keyword(Keyword::Superuser) => {
@@ -953,7 +955,8 @@ impl<'input> Parser<'input> {
                 TokenKind::Ident(s) if s.eq_ignore_ascii_case("hashed") => {
                     self.lexer.next_token()?;
                     self.lexer.expect(&TokenKind::Keyword(Keyword::Password))?;
-                    self.lexer.expect(&TokenKind::Eq)?;
+                    // `=` is optional (see PASSWORD above).
+                    self.lexer.eat(&TokenKind::Eq)?;
                     o.hashed_password = Some(self.expect_string_literal()?);
                 }
                 TokenKind::Ident(s) if s.eq_ignore_ascii_case("access") => {
@@ -1863,14 +1866,17 @@ impl<'input> Parser<'input> {
     }
 
     fn parse_permissions(&mut self) -> Result<Vec<String>, CqlError> {
-        // ALL [PERMISSIONS] or single permission (SELECT, INSERT, UPDATE, DELETE, etc.)
+        // ALL [PERMISSIONS] or a comma-separated permission list
+        // (SELECT, MODIFY, UNMASK, SELECT_MASKED, ...).
         if self.lexer.eat(&TokenKind::Keyword(Keyword::All))? {
             self.lexer.eat(&TokenKind::Keyword(Keyword::Permissions))?;
             Ok(vec!["ALL".to_string()])
         } else {
-            // Single permission keyword
-            let perm = self.parse_ident()?;
-            Ok(vec![perm.to_uppercase()])
+            let mut perms = vec![self.parse_ident()?.to_uppercase()];
+            while self.lexer.eat(&TokenKind::Comma)? {
+                perms.push(self.parse_ident()?.to_uppercase());
+            }
+            Ok(perms)
         }
     }
 
@@ -1917,6 +1923,14 @@ impl<'input> Parser<'input> {
                 self.lexer.next_token()?;
                 let ks = self.parse_ident()?;
                 Ok(GrantResource::Keyspace(ks))
+            }
+            TokenKind::Keyword(Keyword::Table) => {
+                // Explicit `TABLE [ks.]table` resource form. Resolves to the
+                // same Table resource as the bare `[ks.]table` form below —
+                // the keyword does not widen the grant's scope.
+                self.lexer.next_token()?;
+                let (ks, table) = self.parse_table_ref()?;
+                Ok(GrantResource::Table(ks, table))
             }
             TokenKind::Keyword(Keyword::Role) => {
                 self.lexer.next_token()?;
@@ -3737,6 +3751,35 @@ mod tests {
     }
 
     #[test]
+    fn parse_alter_user_with_password_no_equals() {
+        // Legacy USER syntax omits the '=' after PASSWORD.
+        let stmt = parse("ALTER USER alice WITH PASSWORD 'PASSWORD_A'").unwrap(); // pragma: allowlist secret
+        match stmt {
+            Statement::AlterRole(s) => {
+                assert_eq!(s.name, "alice");
+                assert_eq!(s.password, Some("PASSWORD_A".into()));
+            }
+            other => panic!("expected AlterRole, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_alter_user_with_hashed_password_no_equals() {
+        let stmt =
+            parse("ALTER USER alice WITH HASHED PASSWORD '$2a$10$abcdefghijklmnopqrstuv'").unwrap(); // pragma: allowlist secret
+        match stmt {
+            Statement::AlterRole(s) => {
+                assert_eq!(s.name, "alice");
+                assert_eq!(
+                    s.hashed_password,
+                    Some("$2a$10$abcdefghijklmnopqrstuv".into())
+                );
+            }
+            other => panic!("expected AlterRole, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn parse_alter_role_with_login() {
         let stmt = parse("ALTER ROLE admin WITH LOGIN = false").unwrap();
         match stmt {
@@ -3779,6 +3822,49 @@ mod tests {
                 assert_eq!(s.role, "reader");
             }
             other => panic!("expected Grant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_grant_on_table_keyword() {
+        // Cassandra accepts the explicit `ON TABLE <name>` resource form.
+        let stmt = parse("GRANT SELECT ON TABLE patients TO privileged").unwrap();
+        match stmt {
+            Statement::Grant(s) => {
+                assert_eq!(s.permissions, vec!["SELECT".to_string()]);
+                assert_eq!(s.resource, GrantResource::Table(None, "patients".into()));
+                assert_eq!(s.role, "privileged");
+            }
+            other => panic!("expected Grant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_grant_multiple_permissions() {
+        let stmt = parse("GRANT SELECT, MODIFY ON TABLE patients TO trusted_user").unwrap();
+        match stmt {
+            Statement::Grant(s) => {
+                assert_eq!(
+                    s.permissions,
+                    vec!["SELECT".to_string(), "MODIFY".to_string()]
+                );
+                assert_eq!(s.resource, GrantResource::Table(None, "patients".into()));
+                assert_eq!(s.role, "trusted_user");
+            }
+            other => panic!("expected Grant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_revoke_on_table_keyword() {
+        let stmt = parse("REVOKE UNMASK ON TABLE patients FROM privileged").unwrap();
+        match stmt {
+            Statement::Revoke(s) => {
+                assert_eq!(s.permissions, vec!["UNMASK".to_string()]);
+                assert_eq!(s.resource, GrantResource::Table(None, "patients".into()));
+                assert_eq!(s.role, "privileged");
+            }
+            other => panic!("expected Revoke, got {:?}", other),
         }
     }
 

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -2053,6 +2053,7 @@ impl<'input> Parser<'input> {
                 self.lexer.expect(&TokenKind::Keyword(Keyword::Like))?;
                 Ok(ComparisonOp::SoundsLike)
             }
+            TokenKind::Keyword(Keyword::Like) => Ok(ComparisonOp::Like),
             _ => Err(CqlError::SyntaxError(format!(
                 "expected comparison operator, got {:?} at position {}",
                 tok.kind, tok.pos
@@ -2786,6 +2787,23 @@ mod tests {
                 assert_eq!(s.where_clauses[0].column, "id");
                 assert_eq!(s.where_clauses[0].op, ComparisonOp::Eq);
                 assert_eq!(s.where_clauses[0].value, Term::IntegerLiteral(42));
+            }
+            other => panic!("expected Select, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_select_where_like() {
+        let stmt =
+            parse("SELECT * FROM cycling.cyclist_name WHERE firstname LIKE 'm%' ALLOW FILTERING")
+                .unwrap();
+        match stmt {
+            Statement::Select(s) => {
+                assert_eq!(s.where_clauses.len(), 1);
+                assert_eq!(s.where_clauses[0].column, "firstname");
+                assert_eq!(s.where_clauses[0].op, ComparisonOp::Like);
+                assert_eq!(s.where_clauses[0].value, Term::StringLiteral("m%".into()));
+                assert!(s.allow_filtering);
             }
             other => panic!("expected Select, got {:?}", other),
         }

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -1142,42 +1142,84 @@ impl<'input> Parser<'input> {
     /// the permissions reporting pipeline catches up.
     fn parse_list(&mut self) -> Result<Statement, CqlError> {
         self.lexer.expect(&TokenKind::Keyword(Keyword::List))?;
-        let tok = self.lexer.next_token()?;
-        // ROLES / USERS are matched as case-insensitive identifiers
-        // rather than reserved keywords so user tables named `users`
-        // continue to lex as `Ident("users")` in non-LIST contexts.
-        let users_alias = match &tok.kind {
-            TokenKind::Ident(name) if name.eq_ignore_ascii_case("roles") => false,
-            TokenKind::Ident(name) if name.eq_ignore_ascii_case("users") => true,
-            _ => {
-                return Err(CqlError::SyntaxError(format!(
-                    "expected ROLES or USERS after LIST, got {:?} at position {}",
-                    tok.kind, tok.pos
-                )))
-            }
-        };
+        let tok = self.lexer.peek()?;
 
-        let mut of = None;
-        if self.lexer.eat(&TokenKind::Keyword(Keyword::Of))? {
-            of = Some(self.parse_ident()?);
+        // LIST ALL PERMISSIONS ...
+        if matches!(tok.kind, TokenKind::Keyword(Keyword::All)) {
+            self.lexer.next_token()?;
+            self.expect_permissions_keyword()?;
+            return self.parse_list_permissions_tail(None);
         }
 
-        // Cassandra spells the recursion suppressor as `NORECURSIVE`
-        // — a single token. We accept the bare ident form so existing
-        // tooling that parses LIST output can interoperate.
-        let mut no_recursive = false;
+        // LIST ROLES / USERS — matched as case-insensitive identifiers rather
+        // than reserved keywords so user tables named `users` keep lexing as
+        // `Ident("users")` elsewhere.
+        if let TokenKind::Ident(name) = &tok.kind {
+            if name.eq_ignore_ascii_case("roles") || name.eq_ignore_ascii_case("users") {
+                let users_alias = name.eq_ignore_ascii_case("users");
+                self.lexer.next_token()?;
+                let of = if self.lexer.eat(&TokenKind::Keyword(Keyword::Of))? {
+                    Some(self.parse_ident()?)
+                } else {
+                    None
+                };
+                let no_recursive = self.eat_norecursive()?;
+                return Ok(Statement::ListRoles {
+                    of,
+                    no_recursive,
+                    users_alias,
+                });
+            }
+        }
+
+        // Otherwise: LIST <permission> PERMISSIONS ... (e.g. LIST SELECT PERMISSIONS).
+        let permission = self.parse_ident()?.to_uppercase();
+        self.expect_permissions_keyword()?;
+        self.parse_list_permissions_tail(Some(permission))
+    }
+
+    /// Expect the `PERMISSIONS` keyword.
+    fn expect_permissions_keyword(&mut self) -> Result<(), CqlError> {
+        self.lexer
+            .expect(&TokenKind::Keyword(Keyword::Permissions))?;
+        Ok(())
+    }
+
+    /// Cassandra spells the recursion suppressor `NORECURSIVE` as one token; we
+    /// accept the bare ident form.
+    fn eat_norecursive(&mut self) -> Result<bool, CqlError> {
         let tok = self.lexer.peek()?;
         if let TokenKind::Ident(name) = &tok.kind {
             if name.eq_ignore_ascii_case("norecursive") {
                 self.lexer.next_token()?;
-                no_recursive = true;
+                return Ok(true);
             }
         }
+        Ok(false)
+    }
 
-        Ok(Statement::ListRoles {
+    /// Parse the tail of a `LIST … PERMISSIONS` statement: optional
+    /// `ON <resource>`, `OF <role>`, and `NORECURSIVE`.
+    fn parse_list_permissions_tail(
+        &mut self,
+        permission: Option<String>,
+    ) -> Result<Statement, CqlError> {
+        let resource = if self.lexer.eat(&TokenKind::Keyword(Keyword::On))? {
+            Some(self.parse_resource()?)
+        } else {
+            None
+        };
+        let of = if self.lexer.eat(&TokenKind::Keyword(Keyword::Of))? {
+            Some(self.parse_ident()?)
+        } else {
+            None
+        };
+        let no_recursive = self.eat_norecursive()?;
+        Ok(Statement::ListPermissions {
+            permission,
+            resource,
             of,
             no_recursive,
-            users_alias,
         })
     }
 
@@ -3759,6 +3801,60 @@ mod tests {
                 assert!(users_alias, "USERS variant must be flagged for the alias");
             }
             other => panic!("expected ListRoles, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_list_all_permissions() {
+        let stmt = parse("LIST ALL PERMISSIONS").unwrap();
+        match stmt {
+            Statement::ListPermissions {
+                permission,
+                resource,
+                of,
+                ..
+            } => {
+                assert_eq!(permission, None);
+                assert!(resource.is_none());
+                assert_eq!(of, None);
+            }
+            other => panic!("expected ListPermissions, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_list_specific_permission_of_role() {
+        let stmt = parse("LIST SELECT PERMISSIONS OF carlos").unwrap();
+        match stmt {
+            Statement::ListPermissions { permission, of, .. } => {
+                assert_eq!(permission.as_deref(), Some("SELECT"));
+                assert_eq!(of.as_deref(), Some("carlos"));
+            }
+            other => panic!("expected ListPermissions, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_list_all_permissions_on_resource_of_role() {
+        let stmt = parse("LIST ALL PERMISSIONS ON keyspace1.table1 OF bob").unwrap();
+        match stmt {
+            Statement::ListPermissions {
+                permission,
+                resource,
+                of,
+                ..
+            } => {
+                assert_eq!(permission, None);
+                assert_eq!(
+                    resource,
+                    Some(GrantResource::Table(
+                        Some("keyspace1".into()),
+                        "table1".into()
+                    ))
+                );
+                assert_eq!(of.as_deref(), Some("bob"));
+            }
+            other => panic!("expected ListPermissions, got {:?}", other),
         }
     }
 

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -232,10 +232,16 @@ impl<'input> Parser<'input> {
 
         let mut cols = vec![];
         loop {
-            // Check if this is a function call: ident(...)
-            let name = self.parse_ident()?;
+            // Check if this is a function call: ident(...) or a keyspace-
+            // qualified function: keyspace.function(...) (e.g. a UDF/UDA).
+            let first = self.parse_ident()?;
+            let (keyspace, name) = if self.lexer.eat(&TokenKind::Dot)? {
+                (Some(first), self.parse_ident()?)
+            } else {
+                (None, first)
+            };
             if self.lexer.eat(&TokenKind::LParen)? {
-                // Function call: COUNT(*), WRITETIME(col), TTL(col), etc.
+                // Function call: COUNT(*), WRITETIME(col), TTL(col), ks.udf(col).
                 let mut args = vec![];
                 if self.lexer.eat(&TokenKind::Star)? {
                     // COUNT(*) — represent * as a special term
@@ -256,11 +262,18 @@ impl<'input> Parser<'input> {
                 };
 
                 cols.push(SelectColumn::FunctionCall {
-                    keyspace: None,
+                    keyspace,
                     name,
                     args,
                     alias,
                 });
+            } else if keyspace.is_some() {
+                // `keyspace.name` without `(` — a qualified column is not valid
+                // in a SELECT list (only qualified function calls are).
+                return Err(CqlError::SyntaxError(format!(
+                    "expected a function call after '{}.{name}' in the SELECT list",
+                    keyspace.unwrap()
+                )));
             } else if self.lexer.eat(&TokenKind::Keyword(Keyword::As))? {
                 // Column with alias: col AS alias
                 let alias = self.parse_ident()?;
@@ -3092,6 +3105,27 @@ mod tests {
                 assert_eq!(s.where_clauses[0].value, Term::StringLiteral("m%".into()));
                 assert!(s.allow_filtering);
             }
+            other => panic!("expected Select, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_select_keyspace_qualified_function() {
+        let stmt = parse("SELECT test.average(val) FROM atable").unwrap();
+        match stmt {
+            Statement::Select(s) => match &s.columns[0] {
+                SelectColumn::FunctionCall {
+                    keyspace,
+                    name,
+                    args,
+                    ..
+                } => {
+                    assert_eq!(keyspace.as_deref(), Some("test"));
+                    assert_eq!(name, "average");
+                    assert_eq!(args.len(), 1);
+                }
+                other => panic!("expected qualified FunctionCall, got {:?}", other),
+            },
             other => panic!("expected Select, got {:?}", other),
         }
     }

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -1223,10 +1223,12 @@ impl<'input> Parser<'input> {
                     durable_writes = match t.kind {
                         TokenKind::Keyword(Keyword::True) => Some(true),
                         TokenKind::Keyword(Keyword::False) => Some(false),
-                        _ => return Err(CqlError::SyntaxError(format!(
+                        _ => {
+                            return Err(CqlError::SyntaxError(format!(
                             "expected true or false for DURABLE_WRITES, got {:?} at position {}",
                             t.kind, t.pos
-                        ))),
+                        )))
+                        }
                     };
                 }
                 _ => {
@@ -1263,6 +1265,8 @@ impl<'input> Parser<'input> {
 
         let mut add_columns = vec![];
         let mut drop_columns = vec![];
+        let mut rename_columns: Vec<(String, String)> = vec![];
+        let mut alter_column_types = vec![];
         let mut extensions = None;
         let mut table_options = vec![];
 
@@ -1278,6 +1282,27 @@ impl<'input> Parser<'input> {
                 self.lexer.next_token()?;
                 let col_name = self.parse_ident()?;
                 drop_columns.push(col_name);
+            }
+            TokenKind::Keyword(Keyword::Rename) => {
+                // RENAME <from> TO <to> [AND <from> TO <to> ...]
+                self.lexer.next_token()?;
+                loop {
+                    let from = self.parse_ident()?;
+                    self.lexer.expect(&TokenKind::Keyword(Keyword::To))?;
+                    let to = self.parse_ident()?;
+                    rename_columns.push((from, to));
+                    if !self.lexer.eat(&TokenKind::Keyword(Keyword::And))? {
+                        break;
+                    }
+                }
+            }
+            TokenKind::Keyword(Keyword::Alter) => {
+                // ALTER <column> TYPE <new_type>
+                self.lexer.next_token()?;
+                let col_name = self.parse_ident()?;
+                self.lexer.expect(&TokenKind::Keyword(Keyword::Type))?;
+                let new_type = self.parse_cql_type_name()?;
+                alter_column_types.push((col_name, new_type));
             }
             TokenKind::Keyword(Keyword::With) => {
                 self.lexer.next_token()?;
@@ -1299,7 +1324,8 @@ impl<'input> Parser<'input> {
                 let kind = tok.kind.clone();
                 let pos = tok.pos;
                 return Err(CqlError::SyntaxError(format!(
-                    "expected ADD, DROP, or WITH after ALTER TABLE, got {:?} at position {}",
+                    "expected ADD, DROP, ALTER, RENAME, or WITH after ALTER TABLE, \
+                     got {:?} at position {}",
                     kind, pos
                 )));
             }
@@ -1310,6 +1336,8 @@ impl<'input> Parser<'input> {
             table,
             add_columns,
             drop_columns,
+            rename_columns,
+            alter_column_types,
             extensions,
             table_options,
         })
@@ -3240,6 +3268,49 @@ mod tests {
                     vec![("email".into(), CqlTypeName::Simple("text".into()))]
                 );
                 assert!(s.drop_columns.is_empty());
+            }
+            other => panic!("expected AlterTable, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_alter_table_rename() {
+        let stmt = parse("ALTER TABLE cycling.cyclist_name RENAME id TO cyclist_id").unwrap();
+        match stmt {
+            Statement::AlterTable(s) => {
+                assert_eq!(s.table, "cyclist_name");
+                assert_eq!(s.rename_columns, vec![("id".into(), "cyclist_id".into())]);
+                assert!(s.alter_column_types.is_empty());
+            }
+            other => panic!("expected AlterTable, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_alter_table_rename_multiple() {
+        let stmt = parse("ALTER TABLE t RENAME a TO b AND c TO d").unwrap();
+        match stmt {
+            Statement::AlterTable(s) => {
+                assert_eq!(
+                    s.rename_columns,
+                    vec![("a".into(), "b".into()), ("c".into(), "d".into())]
+                );
+            }
+            other => panic!("expected AlterTable, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_alter_table_alter_type() {
+        let stmt =
+            parse("ALTER TABLE cycling.cyclist_alt_stats ALTER favorite_color TYPE text").unwrap();
+        match stmt {
+            Statement::AlterTable(s) => {
+                assert_eq!(
+                    s.alter_column_types,
+                    vec![("favorite_color".into(), CqlTypeName::Simple("text".into()))]
+                );
+                assert!(s.rename_columns.is_empty());
             }
             other => panic!("expected AlterTable, got {:?}", other),
         }

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -1163,6 +1163,9 @@ impl<'input> Parser<'input> {
             TokenKind::Keyword(Keyword::Table) => {
                 self.parse_alter_table().map(Statement::AlterTable)
             }
+            TokenKind::Keyword(Keyword::Keyspace) => {
+                self.parse_alter_keyspace().map(Statement::AlterKeyspace)
+            }
             TokenKind::Keyword(Keyword::Type) => self.parse_alter_type(),
             // ALTER ROLE / ALTER USER share the same options as CREATE.
             // Both forms accepted — `USER` is the deprecated alias.
@@ -1195,6 +1198,62 @@ impl<'input> Parser<'input> {
             login: opts.login,
             options: opts.options,
             access: opts.access,
+        })
+    }
+
+    fn parse_alter_keyspace(&mut self) -> Result<AlterKeyspaceStatement, CqlError> {
+        self.lexer.expect(&TokenKind::Keyword(Keyword::Keyspace))?;
+        let name = self.parse_ident()?;
+        self.lexer.expect(&TokenKind::Keyword(Keyword::With))?;
+
+        let mut replication = None;
+        let mut durable_writes = None;
+        loop {
+            let tok = self.lexer.peek()?;
+            match &tok.kind {
+                TokenKind::Keyword(Keyword::Replication) => {
+                    self.lexer.next_token()?;
+                    self.lexer.expect(&TokenKind::Eq)?;
+                    replication = Some(self.parse_string_map()?);
+                }
+                TokenKind::Keyword(Keyword::DurableWrites) => {
+                    self.lexer.next_token()?;
+                    self.lexer.expect(&TokenKind::Eq)?;
+                    let t = self.lexer.next_token()?;
+                    durable_writes = match t.kind {
+                        TokenKind::Keyword(Keyword::True) => Some(true),
+                        TokenKind::Keyword(Keyword::False) => Some(false),
+                        _ => return Err(CqlError::SyntaxError(format!(
+                            "expected true or false for DURABLE_WRITES, got {:?} at position {}",
+                            t.kind, t.pos
+                        ))),
+                    };
+                }
+                _ => {
+                    let kind = tok.kind.clone();
+                    let pos = tok.pos;
+                    return Err(CqlError::SyntaxError(format!(
+                        "expected REPLICATION or DURABLE_WRITES after ALTER KEYSPACE ... WITH, \
+                         got {:?} at position {}",
+                        kind, pos
+                    )));
+                }
+            }
+            if !self.lexer.eat(&TokenKind::Keyword(Keyword::And))? {
+                break;
+            }
+        }
+
+        if replication.is_none() && durable_writes.is_none() {
+            return Err(CqlError::SyntaxError(
+                "ALTER KEYSPACE requires REPLICATION or DURABLE_WRITES".to_string(),
+            ));
+        }
+
+        Ok(AlterKeyspaceStatement {
+            name,
+            replication,
+            durable_writes,
         })
     }
 
@@ -3077,6 +3136,42 @@ mod tests {
     // ---------------------------------------------------------------
     // DDL tests
     // ---------------------------------------------------------------
+
+    #[test]
+    fn parse_alter_keyspace_replication() {
+        let stmt = parse(
+            "ALTER KEYSPACE excelsior WITH replication = \
+             {'class': 'SimpleStrategy', 'replication_factor' : '4'}",
+        )
+        .unwrap();
+        match stmt {
+            Statement::AlterKeyspace(s) => {
+                assert_eq!(s.name, "excelsior");
+                assert_eq!(
+                    s.replication,
+                    Some(vec![
+                        ("class".into(), "SimpleStrategy".into()),
+                        ("replication_factor".into(), "4".into()),
+                    ])
+                );
+                assert_eq!(s.durable_writes, None);
+            }
+            other => panic!("expected AlterKeyspace, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_alter_keyspace_durable_writes_only() {
+        let stmt = parse("ALTER KEYSPACE ks WITH DURABLE_WRITES = false").unwrap();
+        match stmt {
+            Statement::AlterKeyspace(s) => {
+                assert_eq!(s.name, "ks");
+                assert_eq!(s.replication, None);
+                assert_eq!(s.durable_writes, Some(false));
+            }
+            other => panic!("expected AlterKeyspace, got {:?}", other),
+        }
+    }
 
     #[test]
     fn parse_create_keyspace() {

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -26,6 +26,18 @@ type OrderByResult = (Vec<(String, OrderDirection)>, Option<(String, Term)>);
 /// Security mitigation M6.
 const MAX_COLLECTION_ELEMENTS: usize = 65_536;
 
+/// Options parsed from a CREATE/ALTER ROLE `WITH …` clause. Shared by the
+/// CREATE and ALTER role parsers (identical grammar).
+#[derive(Default)]
+struct RoleOptionSet {
+    password: Option<String>,
+    hashed_password: Option<String>,
+    superuser: Option<bool>,
+    login: Option<bool>,
+    options: Vec<(String, String)>,
+    access: Vec<RoleAccess>,
+}
+
 /// Parse a CQL statement from the given input string.
 pub fn parse(input: &str) -> Result<Statement, CqlError> {
     let span = tracing::info_span!("cql.parse", cql.statement_type = tracing::field::Empty,);
@@ -906,6 +918,123 @@ impl<'input> Parser<'input> {
     /// Cassandra's grammar is permissive about ordering; we accept a
     /// trailing `SUPERUSER`/`NOSUPERUSER` keyword as a shorthand for
     /// `WITH SUPERUSER = true/false`.
+    /// Parsed `WITH option (AND option)*` set for CREATE/ALTER ROLE.
+    fn parse_role_option_set(&mut self) -> Result<RoleOptionSet, CqlError> {
+        let mut o = RoleOptionSet::default();
+        if !self.lexer.eat(&TokenKind::Keyword(Keyword::With))? {
+            return Ok(o);
+        }
+        loop {
+            let tok = self.lexer.peek()?;
+            match &tok.kind {
+                TokenKind::Keyword(Keyword::Password) => {
+                    self.lexer.next_token()?;
+                    self.lexer.expect(&TokenKind::Eq)?;
+                    o.password = Some(self.expect_string_literal()?);
+                }
+                TokenKind::Keyword(Keyword::Superuser) => {
+                    self.lexer.next_token()?;
+                    self.lexer.expect(&TokenKind::Eq)?;
+                    o.superuser = Some(self.parse_bool()?);
+                }
+                TokenKind::Keyword(Keyword::Login) => {
+                    self.lexer.next_token()?;
+                    self.lexer.expect(&TokenKind::Eq)?;
+                    o.login = Some(self.parse_bool()?);
+                }
+                TokenKind::Keyword(Keyword::Options) => {
+                    self.lexer.next_token()?;
+                    self.lexer.expect(&TokenKind::Eq)?;
+                    // parse_string_map enforces MAX_COLLECTION_ELEMENTS (T8/DoS).
+                    o.options = self.parse_string_map()?;
+                }
+                // `HASHED` and `ACCESS` are not reserved keywords — they lex as
+                // identifiers. Match case-insensitively.
+                TokenKind::Ident(s) if s.eq_ignore_ascii_case("hashed") => {
+                    self.lexer.next_token()?;
+                    self.lexer.expect(&TokenKind::Keyword(Keyword::Password))?;
+                    self.lexer.expect(&TokenKind::Eq)?;
+                    o.hashed_password = Some(self.expect_string_literal()?);
+                }
+                TokenKind::Ident(s) if s.eq_ignore_ascii_case("access") => {
+                    self.lexer.next_token()?;
+                    o.access.push(self.parse_role_access()?);
+                }
+                _ => {
+                    return Err(CqlError::SyntaxError(format!(
+                        "unexpected token {:?} in role options at position {}",
+                        tok.kind, tok.pos
+                    )))
+                }
+            }
+            if !self.lexer.eat(&TokenKind::Keyword(Keyword::And))? {
+                break;
+            }
+        }
+        Ok(o)
+    }
+
+    /// Parse one `ACCESS TO/FROM …` clause (the `ACCESS` token is already consumed).
+    fn parse_role_access(&mut self) -> Result<RoleAccess, CqlError> {
+        let tok = self.lexer.next_token()?;
+        match &tok.kind {
+            TokenKind::Keyword(Keyword::To) => {
+                if self.lexer.eat(&TokenKind::Keyword(Keyword::All))? {
+                    self.expect_ident_ci("DATACENTERS")?;
+                    Ok(RoleAccess::ToAllDatacenters)
+                } else {
+                    self.expect_ident_ci("DATACENTERS")?;
+                    Ok(RoleAccess::ToDatacenters(self.parse_string_set()?))
+                }
+            }
+            TokenKind::Keyword(Keyword::From) => {
+                if self.lexer.eat(&TokenKind::Keyword(Keyword::All))? {
+                    self.expect_ident_ci("CIDRS")?;
+                    Ok(RoleAccess::FromAllCidrs)
+                } else {
+                    self.expect_ident_ci("CIDRS")?;
+                    Ok(RoleAccess::FromCidrs(self.parse_string_set()?))
+                }
+            }
+            other => Err(CqlError::SyntaxError(format!(
+                "expected TO or FROM after ACCESS, got {:?} at position {}",
+                other, tok.pos
+            ))),
+        }
+    }
+
+    /// Expect a (non-keyword) identifier matching `name`, case-insensitively.
+    fn expect_ident_ci(&mut self, name: &str) -> Result<(), CqlError> {
+        let tok = self.lexer.next_token()?;
+        match &tok.kind {
+            TokenKind::Ident(s) if s.eq_ignore_ascii_case(name) => Ok(()),
+            other => Err(CqlError::SyntaxError(format!(
+                "expected {name}, got {:?} at position {}",
+                other, tok.pos
+            ))),
+        }
+    }
+
+    /// Parse `{ 'a', 'b', ... }` — a set of string literals (bounded).
+    fn parse_string_set(&mut self) -> Result<Vec<String>, CqlError> {
+        self.lexer.expect(&TokenKind::LBrace)?;
+        let mut items = Vec::new();
+        if self.lexer.eat(&TokenKind::RBrace)? {
+            return Ok(items);
+        }
+        loop {
+            items.push(self.expect_string_literal()?);
+            if items.len() > MAX_COLLECTION_ELEMENTS {
+                return Err(CqlError::SyntaxError("collection too large".to_string()));
+            }
+            if !self.lexer.eat(&TokenKind::Comma)? {
+                break;
+            }
+        }
+        self.lexer.expect(&TokenKind::RBrace)?;
+        Ok(items)
+    }
+
     fn parse_create_user_as_role(&mut self) -> Result<CreateRoleStatement, CqlError> {
         self.lexer.expect(&TokenKind::Keyword(Keyword::User))?;
 
@@ -913,13 +1042,21 @@ impl<'input> Parser<'input> {
         let name = self.parse_ident()?;
 
         let mut password = None;
+        let mut hashed_password = None;
         let mut superuser = None;
 
         if self.lexer.eat(&TokenKind::Keyword(Keyword::With))? {
+            // Legacy USER grammar: `WITH [HASHED] PASSWORD '...'` (no `=`; we
+            // also tolerate `=` for forgiving compatibility).
             let tok = self.lexer.peek()?;
-            if matches!(&tok.kind, TokenKind::Keyword(Keyword::Password)) {
+            if matches!(&tok.kind, TokenKind::Ident(s) if s.eq_ignore_ascii_case("hashed")) {
                 self.lexer.next_token()?;
-                self.lexer.expect(&TokenKind::Eq)?;
+                self.lexer.expect(&TokenKind::Keyword(Keyword::Password))?;
+                let _ = self.lexer.eat(&TokenKind::Eq)?;
+                hashed_password = Some(self.expect_string_literal()?);
+            } else if matches!(&tok.kind, TokenKind::Keyword(Keyword::Password)) {
+                self.lexer.next_token()?;
+                let _ = self.lexer.eat(&TokenKind::Eq)?;
                 password = Some(self.expect_string_literal()?);
             }
         }
@@ -942,9 +1079,12 @@ impl<'input> Parser<'input> {
             name,
             if_not_exists,
             password,
+            hashed_password,
             superuser,
             // CREATE USER is the alias that defaults LOGIN = true.
             login: Some(true),
+            options: Vec::new(),
+            access: Vec::new(),
         })
     }
 
@@ -953,49 +1093,17 @@ impl<'input> Parser<'input> {
 
         let if_not_exists = self.parse_if_not_exists()?;
         let name = self.parse_ident()?;
-
-        let mut password = None;
-        let mut superuser = None;
-        let mut login = None;
-
-        if self.lexer.eat(&TokenKind::Keyword(Keyword::With))? {
-            loop {
-                let tok = self.lexer.peek()?;
-                match &tok.kind {
-                    TokenKind::Keyword(Keyword::Password) => {
-                        self.lexer.next_token()?;
-                        self.lexer.expect(&TokenKind::Eq)?;
-                        password = Some(self.expect_string_literal()?);
-                    }
-                    TokenKind::Keyword(Keyword::Superuser) => {
-                        self.lexer.next_token()?;
-                        self.lexer.expect(&TokenKind::Eq)?;
-                        superuser = Some(self.parse_bool()?);
-                    }
-                    TokenKind::Keyword(Keyword::Login) => {
-                        self.lexer.next_token()?;
-                        self.lexer.expect(&TokenKind::Eq)?;
-                        login = Some(self.parse_bool()?);
-                    }
-                    _ => {
-                        return Err(CqlError::SyntaxError(format!(
-                            "unexpected token {:?} in CREATE ROLE options at position {}",
-                            tok.kind, tok.pos
-                        )))
-                    }
-                }
-                if !self.lexer.eat(&TokenKind::Keyword(Keyword::And))? {
-                    break;
-                }
-            }
-        }
+        let opts = self.parse_role_option_set()?;
 
         Ok(CreateRoleStatement {
             name,
             if_not_exists,
-            password,
-            superuser,
-            login,
+            password: opts.password,
+            hashed_password: opts.hashed_password,
+            superuser: opts.superuser,
+            login: opts.login,
+            options: opts.options,
+            access: opts.access,
         })
     }
 
@@ -1077,48 +1185,16 @@ impl<'input> Parser<'input> {
         ));
 
         let name = self.parse_ident()?;
-
-        let mut password = None;
-        let mut superuser = None;
-        let mut login = None;
-
-        if self.lexer.eat(&TokenKind::Keyword(Keyword::With))? {
-            loop {
-                let tok = self.lexer.peek()?;
-                match &tok.kind {
-                    TokenKind::Keyword(Keyword::Password) => {
-                        self.lexer.next_token()?;
-                        self.lexer.expect(&TokenKind::Eq)?;
-                        password = Some(self.expect_string_literal()?);
-                    }
-                    TokenKind::Keyword(Keyword::Superuser) => {
-                        self.lexer.next_token()?;
-                        self.lexer.expect(&TokenKind::Eq)?;
-                        superuser = Some(self.parse_bool()?);
-                    }
-                    TokenKind::Keyword(Keyword::Login) => {
-                        self.lexer.next_token()?;
-                        self.lexer.expect(&TokenKind::Eq)?;
-                        login = Some(self.parse_bool()?);
-                    }
-                    _ => {
-                        return Err(CqlError::SyntaxError(format!(
-                            "unexpected token {:?} in ALTER ROLE options at position {}",
-                            tok.kind, tok.pos
-                        )))
-                    }
-                }
-                if !self.lexer.eat(&TokenKind::Keyword(Keyword::And))? {
-                    break;
-                }
-            }
-        }
+        let opts = self.parse_role_option_set()?;
 
         Ok(AlterRoleStatement {
             name,
-            password,
-            superuser,
-            login,
+            password: opts.password,
+            hashed_password: opts.hashed_password,
+            superuser: opts.superuser,
+            login: opts.login,
+            options: opts.options,
+            access: opts.access,
         })
     }
 
@@ -3240,6 +3316,99 @@ mod tests {
                 assert_eq!(s.table, "entity_store");
             }
             other => panic!("expected Compact, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_create_role_with_hashed_password() {
+        // HASHED PASSWORD stores a pre-computed hash; password stays None.
+        let stmt = parse(
+            "CREATE ROLE alice WITH HASHED PASSWORD = '$2a$10$abcdefghijklmnopqrstuv' AND LOGIN = true", // pragma: allowlist secret
+        )
+        .unwrap();
+        match stmt {
+            Statement::CreateRole(s) => {
+                assert_eq!(s.name, "alice");
+                assert_eq!(s.password, None);
+                assert_eq!(
+                    s.hashed_password.as_deref(),
+                    Some("$2a$10$abcdefghijklmnopqrstuv")
+                );
+                assert_eq!(s.login, Some(true));
+            }
+            other => panic!("expected CreateRole, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_create_role_with_options_and_access() {
+        let stmt = parse(
+            "CREATE ROLE carlos WITH OPTIONS = { 'opt1' : 'v1', 'opt2' : 99 } \
+             AND ACCESS TO DATACENTERS {'DC1', 'DC3'}",
+        )
+        .unwrap();
+        match stmt {
+            Statement::CreateRole(s) => {
+                assert_eq!(s.options.len(), 2);
+                assert_eq!(s.options[0], ("opt1".into(), "v1".into()));
+                assert_eq!(s.options[1], ("opt2".into(), "99".into()));
+                assert_eq!(
+                    s.access,
+                    vec![RoleAccess::ToDatacenters(vec!["DC1".into(), "DC3".into()])]
+                );
+            }
+            other => panic!("expected CreateRole, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_create_role_with_access_from_all_cidrs() {
+        let stmt = parse(
+            "CREATE ROLE hob WITH LOGIN = true AND PASSWORD = 'p' AND ACCESS FROM ALL CIDRS", // pragma: allowlist secret
+        )
+        .unwrap();
+        match stmt {
+            Statement::CreateRole(s) => {
+                assert_eq!(s.access, vec![RoleAccess::FromAllCidrs]);
+            }
+            other => panic!("expected CreateRole, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_alter_role_with_hashed_password() {
+        let stmt = parse(
+            "ALTER ROLE bob WITH HASHED PASSWORD = '$argon2id$v=19$m=1' AND SUPERUSER = false",
+        ) // pragma: allowlist secret
+        .unwrap();
+        match stmt {
+            Statement::AlterRole(s) => {
+                assert_eq!(s.hashed_password.as_deref(), Some("$argon2id$v=19$m=1"));
+                assert_eq!(s.password, None);
+                assert_eq!(s.superuser, Some(false));
+            }
+            other => panic!("expected AlterRole, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_create_user_with_hashed_password() {
+        // Legacy USER grammar: no `=`, trailing NOSUPERUSER.
+        let stmt = parse(
+            "CREATE USER bob WITH HASHED PASSWORD '$2a$10$abcdefghijklmnopqrstuv' NOSUPERUSER",
+        ) // pragma: allowlist secret
+        .unwrap();
+        match stmt {
+            Statement::CreateRole(s) => {
+                assert_eq!(
+                    s.hashed_password.as_deref(),
+                    Some("$2a$10$abcdefghijklmnopqrstuv")
+                );
+                assert_eq!(s.password, None);
+                assert_eq!(s.superuser, Some(false));
+                assert_eq!(s.login, Some(true));
+            }
+            other => panic!("expected CreateRole, got {:?}", other),
         }
     }
 

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -2232,7 +2232,7 @@ impl<'input> Parser<'input> {
                 self.lexer.expect(&TokenKind::RParen)?;
                 Term::InList(terms)
             } else {
-                self.parse_term()?
+                self.parse_where_value()?
             };
             clauses.push(WhereClause {
                 column: actual_column,
@@ -2283,6 +2283,56 @@ impl<'input> Parser<'input> {
     // ---------------------------------------------------------------
 
     fn parse_term(&mut self) -> Result<Term, CqlError> {
+        self.parse_primary_term()
+    }
+
+    /// Parse a value in WHERE-predicate position, allowing trailing temporal
+    /// arithmetic `base ± <duration>` (the only place CQL permits `±` after a
+    /// value — elsewhere `+`/`-` are UPDATE SET collection/counter operators).
+    fn parse_where_value(&mut self) -> Result<Term, CqlError> {
+        let base = self.parse_term()?;
+        if matches!(self.lexer.peek()?.kind, TokenKind::Plus | TokenKind::Minus) {
+            let subtract = matches!(self.lexer.next_token()?.kind, TokenKind::Minus);
+            let offset = self.parse_duration_term()?;
+            return Ok(Term::TemporalArithmetic {
+                base: Box::new(base),
+                subtract,
+                offset: Box::new(offset),
+            });
+        }
+        Ok(base)
+    }
+
+    /// Parse a duration literal: ISO-8601 (`P1Y2M3D`) or compact (`2d`,
+    /// `1mo3d`). The lexer emits both forms as a single identifier token.
+    fn parse_duration_term(&mut self) -> Result<Term, CqlError> {
+        let tok = self.lexer.peek()?;
+        if let TokenKind::Ident(s) = &tok.kind {
+            let components = if crate::duration::is_iso_duration(s) {
+                crate::duration::parse_iso_duration(s)
+            } else if crate::duration::is_compact_duration(s) {
+                crate::duration::parse_compact_duration(s)
+            } else {
+                return Err(CqlError::SyntaxError(format!(
+                    "expected a duration, got {:?} at position {}",
+                    tok.kind, tok.pos
+                )));
+            }
+            .map_err(CqlError::SyntaxError)?;
+            self.lexer.next_token()?;
+            return Ok(Term::Duration {
+                months: components.months,
+                days: components.days,
+                nanos: components.nanos,
+            });
+        }
+        Err(CqlError::SyntaxError(format!(
+            "expected a duration, got {:?} at position {}",
+            tok.kind, tok.pos
+        )))
+    }
+
+    fn parse_primary_term(&mut self) -> Result<Term, CqlError> {
         let tok = self.lexer.next_token()?;
         match tok.kind {
             TokenKind::StringLiteral(s) => Ok(Term::StringLiteral(s)),
@@ -2336,6 +2386,26 @@ impl<'input> Parser<'input> {
             // Identifiers and function calls
             TokenKind::Ident(name) => {
                 let name = name.to_string();
+                // A standalone duration literal in value position — ISO-8601
+                // (`P1Y2M3D`) or compact (`2d`, `1mo3d`) — both lex as a single
+                // identifier. Not when followed by `(` (which makes it a call).
+                if self.lexer.peek()?.kind != TokenKind::LParen {
+                    let dur = if crate::duration::is_iso_duration(&name) {
+                        Some(crate::duration::parse_iso_duration(&name))
+                    } else if crate::duration::is_compact_duration(&name) {
+                        Some(crate::duration::parse_compact_duration(&name))
+                    } else {
+                        None
+                    };
+                    if let Some(d) = dur {
+                        let d = d.map_err(CqlError::SyntaxError)?;
+                        return Ok(Term::Duration {
+                            months: d.months,
+                            days: d.days,
+                            nanos: d.nanos,
+                        });
+                    }
+                }
                 if self.lexer.eat(&TokenKind::LParen)? {
                     // Function call: name(args...)
                     self.enter_nesting()?;
@@ -3024,6 +3094,77 @@ mod tests {
             }
             other => panic!("expected Select, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn parse_where_temporal_arithmetic() {
+        let stmt =
+            parse("SELECT * FROM mytable WHERE d >= current_date() - 2d ALLOW FILTERING").unwrap();
+        match stmt {
+            Statement::Select(s) => {
+                assert_eq!(s.where_clauses.len(), 1);
+                match &s.where_clauses[0].value {
+                    Term::TemporalArithmetic {
+                        base,
+                        subtract,
+                        offset,
+                    } => {
+                        assert!(*subtract);
+                        assert!(
+                            matches!(base.as_ref(), Term::FunctionCall { name, .. } if name == "current_date")
+                        );
+                        assert_eq!(
+                            offset.as_ref(),
+                            &Term::Duration {
+                                months: 0,
+                                days: 2,
+                                nanos: 0
+                            }
+                        );
+                    }
+                    other => panic!("expected TemporalArithmetic, got {:?}", other),
+                }
+            }
+            other => panic!("expected Select, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_duration_literals() {
+        // Compact form as a standalone value.
+        let stmt = parse("SELECT * FROM t WHERE x = 1mo3d ALLOW FILTERING").unwrap();
+        match stmt {
+            Statement::Select(s) => assert_eq!(
+                s.where_clauses[0].value,
+                Term::Duration {
+                    months: 1,
+                    days: 3,
+                    nanos: 0
+                }
+            ),
+            other => panic!("expected Select, got {:?}", other),
+        }
+        // ISO-8601 form, and the subtraction operator still untouched for non-WHERE.
+        let stmt = parse("SELECT * FROM t WHERE x = P1Y2M3D ALLOW FILTERING").unwrap();
+        match stmt {
+            Statement::Select(s) => assert_eq!(
+                s.where_clauses[0].value,
+                Term::Duration {
+                    months: 14,
+                    days: 3,
+                    nanos: 0
+                }
+            ),
+            other => panic!("expected Select, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn counter_and_collection_update_not_treated_as_duration() {
+        // Regression: `+`/`-` in UPDATE SET must stay collection/counter ops.
+        assert!(parse("UPDATE t SET n = n + 1 WHERE k = 1").is_ok());
+        assert!(parse("UPDATE t SET tags = tags + {'a'} WHERE k = 1").is_ok());
+        assert!(parse("UPDATE t SET items = items - [1] WHERE k = 1").is_ok());
     }
 
     #[test]

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -921,9 +921,31 @@ impl<'input> Parser<'input> {
     /// Parsed `WITH option (AND option)*` set for CREATE/ALTER ROLE.
     fn parse_role_option_set(&mut self) -> Result<RoleOptionSet, CqlError> {
         let mut o = RoleOptionSet::default();
-        if !self.lexer.eat(&TokenKind::Keyword(Keyword::With))? {
-            return Ok(o);
+        if self.lexer.eat(&TokenKind::Keyword(Keyword::With))? {
+            self.parse_with_role_options(&mut o)?;
         }
+        // Legacy USER syntax allows a trailing bare SUPERUSER / NOSUPERUSER flag
+        // (no `WITH`, no `=`), e.g. `ALTER USER bob SUPERUSER` or
+        // `CREATE USER ops WITH PASSWORD 'p' NOSUPERUSER`. Setting the flag is
+        // still authorized downstream exactly as `SUPERUSER = <bool>` is.
+        let tok = self.lexer.peek()?;
+        match &tok.kind {
+            TokenKind::Keyword(Keyword::Superuser) => {
+                self.lexer.next_token()?;
+                o.superuser = Some(true);
+            }
+            TokenKind::Keyword(Keyword::Nosuperuser) => {
+                self.lexer.next_token()?;
+                o.superuser = Some(false);
+            }
+            _ => {}
+        }
+        Ok(o)
+    }
+
+    /// Parse the `WITH <option> [AND <option> ...]` role-option list (the caller
+    /// has already consumed `WITH`).
+    fn parse_with_role_options(&mut self, o: &mut RoleOptionSet) -> Result<(), CqlError> {
         loop {
             let tok = self.lexer.peek()?;
             match &tok.kind {
@@ -974,7 +996,7 @@ impl<'input> Parser<'input> {
                 break;
             }
         }
-        Ok(o)
+        Ok(())
     }
 
     /// Parse one `ACCESS TO/FROM …` clause (the `ACCESS` token is already consumed).
@@ -3776,6 +3798,33 @@ mod tests {
                 );
             }
             other => panic!("expected AlterRole, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_alter_user_bare_superuser() {
+        // Legacy USER syntax: no WITH, trailing bare SUPERUSER flag.
+        let stmt = parse("ALTER USER bob SUPERUSER").unwrap();
+        match stmt {
+            Statement::AlterRole(s) => {
+                assert_eq!(s.name, "bob");
+                assert_eq!(s.superuser, Some(true));
+                assert_eq!(s.password, None);
+            }
+            other => panic!("expected AlterRole, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_create_user_trailing_nosuperuser() {
+        let stmt = parse("CREATE USER ops WITH PASSWORD 'p' NOSUPERUSER").unwrap(); // pragma: allowlist secret
+        match stmt {
+            Statement::CreateRole(s) => {
+                assert_eq!(s.name, "ops");
+                assert_eq!(s.password, Some("p".into()));
+                assert_eq!(s.superuser, Some(false));
+            }
+            other => panic!("expected CreateRole, got {:?}", other),
         }
     }
 

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -137,8 +137,8 @@ impl<'input> Parser<'input> {
             TokenKind::Keyword(Keyword::Rollback) => self.parse_rollback(),
             TokenKind::Keyword(Keyword::Truncate) => self.parse_truncate().map(Statement::Truncate),
             TokenKind::Keyword(Keyword::Compact) => self.parse_compact().map(Statement::Compact),
-            TokenKind::Keyword(Keyword::Grant) => self.parse_grant().map(Statement::Grant),
-            TokenKind::Keyword(Keyword::Revoke) => self.parse_revoke().map(Statement::Revoke),
+            TokenKind::Keyword(Keyword::Grant) => self.parse_grant(),
+            TokenKind::Keyword(Keyword::Revoke) => self.parse_revoke(),
             TokenKind::Keyword(Keyword::Subscribe) => self.parse_subscribe(),
             TokenKind::Keyword(Keyword::Unsubscribe) => self.parse_unsubscribe(),
             TokenKind::Keyword(Keyword::List) => self.parse_list(),
@@ -1857,34 +1857,86 @@ impl<'input> Parser<'input> {
     // GRANT / REVOKE
     // ---------------------------------------------------------------
 
-    fn parse_grant(&mut self) -> Result<GrantStatement, CqlError> {
+    fn parse_grant(&mut self) -> Result<Statement, CqlError> {
         self.lexer.expect(&TokenKind::Keyword(Keyword::Grant))?;
-        let permissions = self.parse_permissions()?;
+        // `GRANT ALL ...` is always a permission grant.
+        if matches!(self.lexer.peek()?.kind, TokenKind::Keyword(Keyword::All)) {
+            let permissions = self.parse_permissions()?;
+            self.lexer.expect(&TokenKind::Keyword(Keyword::On))?;
+            let resource = self.parse_resource()?;
+            self.lexer.expect(&TokenKind::Keyword(Keyword::To))?;
+            let role = self.parse_ident()?;
+            return Ok(Statement::Grant(GrantStatement {
+                permissions,
+                resource,
+                role,
+            }));
+        }
+
+        let first = self.parse_ident()?;
+        // `GRANT <role> TO <member>` — role membership (no ON / resource).
+        if self.lexer.eat(&TokenKind::Keyword(Keyword::To))? {
+            let member = self.parse_ident()?;
+            return Ok(Statement::GrantRole {
+                role: first,
+                member,
+            });
+        }
+
+        // Otherwise `first` is the first permission of a permission grant.
+        let mut permissions = vec![first.to_uppercase()];
+        while self.lexer.eat(&TokenKind::Comma)? {
+            permissions.push(self.parse_ident()?.to_uppercase());
+        }
         self.lexer.expect(&TokenKind::Keyword(Keyword::On))?;
         let resource = self.parse_resource()?;
         self.lexer.expect(&TokenKind::Keyword(Keyword::To))?;
         let role = self.parse_ident()?;
-
-        Ok(GrantStatement {
+        Ok(Statement::Grant(GrantStatement {
             permissions,
             resource,
             role,
-        })
+        }))
     }
 
-    fn parse_revoke(&mut self) -> Result<RevokeStatement, CqlError> {
+    fn parse_revoke(&mut self) -> Result<Statement, CqlError> {
         self.lexer.expect(&TokenKind::Keyword(Keyword::Revoke))?;
-        let permissions = self.parse_permissions()?;
+        if matches!(self.lexer.peek()?.kind, TokenKind::Keyword(Keyword::All)) {
+            let permissions = self.parse_permissions()?;
+            self.lexer.expect(&TokenKind::Keyword(Keyword::On))?;
+            let resource = self.parse_resource()?;
+            self.lexer.expect(&TokenKind::Keyword(Keyword::From))?;
+            let role = self.parse_ident()?;
+            return Ok(Statement::Revoke(RevokeStatement {
+                permissions,
+                resource,
+                role,
+            }));
+        }
+
+        let first = self.parse_ident()?;
+        // `REVOKE <role> FROM <member>` — role membership.
+        if self.lexer.eat(&TokenKind::Keyword(Keyword::From))? {
+            let member = self.parse_ident()?;
+            return Ok(Statement::RevokeRole {
+                role: first,
+                member,
+            });
+        }
+
+        let mut permissions = vec![first.to_uppercase()];
+        while self.lexer.eat(&TokenKind::Comma)? {
+            permissions.push(self.parse_ident()?.to_uppercase());
+        }
         self.lexer.expect(&TokenKind::Keyword(Keyword::On))?;
         let resource = self.parse_resource()?;
         self.lexer.expect(&TokenKind::Keyword(Keyword::From))?;
         let role = self.parse_ident()?;
-
-        Ok(RevokeStatement {
+        Ok(Statement::Revoke(RevokeStatement {
             permissions,
             resource,
             role,
-        })
+        }))
     }
 
     fn parse_permissions(&mut self) -> Result<Vec<String>, CqlError> {
@@ -3901,6 +3953,30 @@ mod tests {
                 assert_eq!(s.role, "trusted_user");
             }
             other => panic!("expected Grant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_grant_role_to_member() {
+        let stmt = parse("GRANT report_writer TO alice").unwrap();
+        match stmt {
+            Statement::GrantRole { role, member } => {
+                assert_eq!(role, "report_writer");
+                assert_eq!(member, "alice");
+            }
+            other => panic!("expected GrantRole, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_revoke_role_from_member() {
+        let stmt = parse("REVOKE role_a FROM role_b").unwrap();
+        match stmt {
+            Statement::RevokeRole { role, member } => {
+                assert_eq!(role, "role_a");
+                assert_eq!(member, "role_b");
+            }
+            other => panic!("expected RevokeRole, got {:?}", other),
         }
     }
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -5150,6 +5150,20 @@ async fn route_alter_table(
         &Resource::Table(ks.to_string(), s.table.clone()),
     )?;
 
+    // RENAME and ALTER ... TYPE parse, but applying them to live data is not yet
+    // implemented. Reject loudly rather than silently building empty updates and
+    // reporting success — a no-op "success" would be worse than a clear error.
+    if !s.rename_columns.is_empty() {
+        return Err(CqlError::Invalid(
+            "ALTER TABLE ... RENAME is not yet supported".to_string(),
+        ));
+    }
+    if !s.alter_column_types.is_empty() {
+        return Err(CqlError::Invalid(
+            "ALTER TABLE ... ALTER <column> TYPE is not yet supported".to_string(),
+        ));
+    }
+
     let add_columns: Vec<ColumnMetadata> = s
         .add_columns
         .iter()
@@ -15807,6 +15821,8 @@ mod tests {
             table: "t".into(),
             add_columns: vec![],
             drop_columns: vec![],
+            rename_columns: vec![],
+            alter_column_types: vec![],
             extensions: Some(vec![("vertex_label".into(), "Person".into())]),
             table_options: vec![],
         });
@@ -15816,6 +15832,39 @@ mod tests {
             "ALTER TABLE with extensions should succeed: {:?}",
             result.err()
         );
+    }
+
+    /// ALTER TABLE RENAME / ALTER TYPE parse but are not yet executable; they
+    /// must be rejected loudly rather than silently succeeding as a no-op.
+    #[tokio::test]
+    async fn alter_table_rename_and_alter_type_rejected() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        let stmt = crate::parser::parse(
+            "CREATE KEYSPACE atrk WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+        ).unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+        let stmt = crate::parser::parse("CREATE TABLE atrk.t (k int PRIMARY KEY, v text)").unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        let rename = crate::parser::parse("ALTER TABLE atrk.t RENAME k TO k2").unwrap();
+        match route(&state, &ctx, rename).await {
+            Ok(_) => panic!("RENAME must be rejected, not silently succeed"),
+            Err(e) => assert!(format!("{e}").contains("RENAME")),
+        }
+
+        let alter = crate::parser::parse("ALTER TABLE atrk.t ALTER v TYPE blob").unwrap();
+        match route(&state, &ctx, alter).await {
+            Ok(_) => panic!("ALTER TYPE must be rejected, not silently succeed"),
+            Err(e) => assert!(format!("{e}").contains("TYPE")),
+        }
     }
 
     // ── CREATE INDEX with auto-generated name ────────────────────────

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -6635,6 +6635,10 @@ fn evaluate_where_predicates(
                 (CqlValue::Text(a), CqlValue::Text(b)) => phonetic_match(a, b),
                 _ => false,
             },
+            ComparisonOp::Like => match (actual, &expected) {
+                (CqlValue::Text(a), CqlValue::Text(b)) => like_match(a, b),
+                _ => false,
+            },
             ComparisonOp::In => unreachable!("IN handled above"),
             ComparisonOp::Contains | ComparisonOp::ContainsKey => {
                 unreachable!("CONTAINS/CONTAINS KEY handled above")
@@ -6645,6 +6649,65 @@ fn evaluate_where_predicates(
         }
     }
     Ok(true)
+}
+
+/// Cassandra `LIKE` pattern matching. `%` matches any (possibly empty) sequence
+/// of characters; every other character — including `_` — matches literally,
+/// which is Cassandra's SAI `LIKE` semantics. Matching is case-sensitive, the
+/// default for an un-analyzed column.
+fn like_match(text: &str, pattern: &str) -> bool {
+    let segments: Vec<&str> = pattern.split('%').collect();
+    // No wildcard: exact match.
+    if segments.len() == 1 {
+        return text == pattern;
+    }
+    let last = segments.len() - 1;
+    let mut idx = 0usize;
+    for (i, seg) in segments.iter().enumerate() {
+        if seg.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // Leading literal must be a prefix.
+            if !text[idx..].starts_with(seg) {
+                return false;
+            }
+            idx += seg.len();
+        } else if i == last {
+            // Trailing literal must be a suffix of what remains.
+            if !text[idx..].ends_with(seg) {
+                return false;
+            }
+        } else {
+            // Interior literal must occur, in order, at or after the cursor.
+            match text[idx..].find(seg) {
+                Some(pos) => idx += pos + seg.len(),
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod like_match_tests {
+    use super::like_match;
+
+    #[test]
+    fn prefix_suffix_contains_and_exact() {
+        assert!(like_match("mark", "m%"));
+        assert!(like_match("mark", "%k"));
+        assert!(like_match("mark", "%ar%"));
+        assert!(like_match("mark", "m%k"));
+        assert!(like_match("mark", "mark"));
+        assert!(like_match("anything", "%"));
+
+        assert!(!like_match("mark", "M%")); // case-sensitive
+        assert!(!like_match("mark", "%z"));
+        assert!(!like_match("mark", "z%"));
+        assert!(!like_match("mark", "mark2"));
+        assert!(!like_match("ma", "m%k")); // suffix missing
+    }
 }
 
 /// Apply column selection (with `toJson()` support) to system table query results.

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1004,6 +1004,12 @@ pub async fn route(
             .map(RouteResult::Result),
         Statement::Grant(g) => route_grant(state, ctx, g).await.map(RouteResult::Result),
         Statement::Revoke(r) => route_revoke(state, ctx, r).await.map(RouteResult::Result),
+        Statement::GrantRole { role, member } => route_grant_role(state, ctx, role, member, true)
+            .await
+            .map(RouteResult::Result),
+        Statement::RevokeRole { role, member } => route_grant_role(state, ctx, role, member, false)
+            .await
+            .map(RouteResult::Result),
         Statement::Use(u) => {
             validate_keyspace_exists(&state.schema, &u.keyspace)?;
             let body = result::encode_set_keyspace(&u.keyspace);
@@ -5955,6 +5961,75 @@ async fn route_revoke(
                 };
                 ddl.execute(op).await.map_err(CqlError::from)?;
             }
+        }
+        DdlPath::Unavailable | DdlPath::Forming { .. } => {
+            return Err(CqlError::ServerError(
+                "DDL unavailable: peer lost".to_string(),
+            ));
+        }
+    }
+
+    Ok(result::encode_void())
+}
+
+/// `GRANT/REVOKE <role> TO/FROM <member>` — role membership (the member
+/// inherits the role's permissions). Replicates via the additive
+/// `DdlOperation::GrantRole` / `RevokeRole`, which mutate a single `member_of`
+/// edge, so concurrent role grants never clobber one another and cross-grant
+/// cycles are caught at apply.
+async fn route_grant_role(
+    state: &SharedState,
+    ctx: &RequestContext<'_>,
+    role: String,
+    member: String,
+    grant: bool,
+) -> Result<BytesMut, CqlError> {
+    // Authorization: (re)granting a role requires AUTHORIZE on that role.
+    // Superusers pass implicitly through check_permission.
+    state.schema.check_permission(
+        ctx.auth,
+        Permission::Authorize,
+        &Resource::Role(role.clone()),
+    )?;
+
+    // Both roles must exist — fail loud to the client rather than no-op at apply.
+    {
+        let snap = state.schema.snapshot();
+        if !snap.roles.contains_key(&role) {
+            return Err(CqlError::Invalid(format!("role not found: {role}")));
+        }
+        if !snap.roles.contains_key(&member) {
+            return Err(CqlError::Invalid(format!("role not found: {member}")));
+        }
+    }
+
+    let op = if grant {
+        DdlOperation::GrantRole {
+            member: member.clone(),
+            granted_role: role.clone(),
+        }
+    } else {
+        DdlOperation::RevokeRole {
+            member: member.clone(),
+            granted_role: role.clone(),
+        }
+    };
+
+    let ddl_guard = state.ddl_path.load();
+    let ddl = &**ddl_guard;
+    match ddl {
+        DdlPath::Direct { .. } => {
+            if grant {
+                state.schema.grant_role_internal(&member, &role)?;
+            } else {
+                state.schema.revoke_role_internal(&member, &role)?;
+            }
+        }
+        DdlPath::Pair(coordinator) => {
+            coordinator.coordinate_ddl(op).await?;
+        }
+        DdlPath::Cluster { .. } => {
+            ddl.execute(op).await.map_err(CqlError::from)?;
         }
         DdlPath::Unavailable | DdlPath::Forming { .. } => {
             return Err(CqlError::ServerError(
@@ -15790,6 +15865,57 @@ mod tests {
             "GRANT ALL ON KEYSPACE should succeed: {:?}",
             result.err()
         );
+    }
+
+    #[tokio::test]
+    async fn grant_and_revoke_role_membership() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        for r in ["reporter", "alice"] {
+            let stmt = crate::parser::parse(&format!(
+                "CREATE ROLE {r} WITH PASSWORD = 'pw' AND LOGIN = true"
+            ))
+            .unwrap();
+            route(&state, &ctx, stmt).await.unwrap();
+        }
+
+        // GRANT reporter TO alice — alice becomes a member of reporter.
+        let stmt = crate::parser::parse("GRANT reporter TO alice").unwrap();
+        route(&state, &ctx, stmt).await.expect("grant role");
+        assert!(state
+            .schema
+            .snapshot()
+            .roles
+            .get("alice")
+            .unwrap()
+            .member_of
+            .contains("reporter"));
+
+        // Granting a role to a nonexistent member fails loud.
+        let stmt = crate::parser::parse("GRANT reporter TO ghost").unwrap();
+        match route(&state, &ctx, stmt).await {
+            Ok(_) => panic!("granting to a nonexistent role must fail"),
+            Err(e) => assert!(format!("{e}").contains("ghost")),
+        }
+
+        // REVOKE removes the single edge.
+        let stmt = crate::parser::parse("REVOKE reporter FROM alice").unwrap();
+        route(&state, &ctx, stmt).await.expect("revoke role");
+        assert!(!state
+            .schema
+            .snapshot()
+            .roles
+            .get("alice")
+            .unwrap()
+            .member_of
+            .contains("reporter"));
     }
 
     // ── ALTER TABLE with extensions ──────────────────────────────────

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -15457,7 +15457,7 @@ mod tests {
             route(&state, &ctx, stmt).await.is_err(),
             "CREATE ROLE with ACCESS must be rejected, not silently accepted"
         );
-        assert!(state.schema.snapshot().roles.get("netrole").is_none());
+        assert!(!state.schema.snapshot().roles.contains_key("netrole"));
     }
 
     #[tokio::test]

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -5568,6 +5568,15 @@ async fn route_create_role(
         .schema
         .check_permission(ctx.auth, Permission::Create, &Resource::AllRoles)?;
 
+    // Security (threat-model T9): ferrosa has no network authorizer, so reject
+    // ACCESS TO/FROM clauses rather than silently accept an unenforced access
+    // restriction (which would give a false sense of security). Fail loud.
+    if !s.access.is_empty() {
+        return Err(CqlError::Invalid(
+            "ACCESS (network authorization) is not supported".into(),
+        ));
+    }
+
     let base_role = RoleMetadata {
         name: s.name.clone(),
         is_superuser: s.superuser.unwrap_or(false),
@@ -5580,12 +5589,16 @@ async fn route_create_role(
     let ddl = &**ddl_guard;
     match ddl {
         DdlPath::Direct { .. } => {
-            // Direct path: pass the cleartext through; `Schema::create_role`
-            // validates the policy, hashes it under the schema's
-            // write-lock, and emits the audit event.
-            state
-                .schema
-                .create_role(base_role, s.password.as_deref(), ctx.auth)?;
+            // Direct path: `Schema::create_role` hashes the cleartext under the
+            // write-lock; `create_role_hashed` validates and stores a supplied
+            // HASHED PASSWORD verbatim. Both emit the audit event.
+            if let Some(ref h) = s.hashed_password {
+                state.schema.create_role_hashed(base_role, h, ctx.auth)?;
+            } else {
+                state
+                    .schema
+                    .create_role(base_role, s.password.as_deref(), ctx.auth)?;
+            }
         }
         DdlPath::Pair(_) | DdlPath::Cluster { .. } => {
             // Pair/Cluster paths: serialise `DdlOperation::CreateRole(role)`
@@ -5599,7 +5612,11 @@ async fn route_create_role(
             // Hashing on the coordinator also keeps the cleartext
             // password off the wire and out of the Raft log.
             let mut role = base_role;
-            if let Some(ref pw) = s.password {
+            if let Some(ref h) = s.hashed_password {
+                // HASHED PASSWORD: validate on the coordinator, ship verbatim.
+                state.schema.validate_password_hash(h)?;
+                role.salted_hash = Some(h.clone());
+            } else if let Some(ref pw) = s.password {
                 state.schema.password_policy().validate(pw, &s.name)?;
                 role.salted_hash = Some(state.schema.password_hasher().hash_password(pw)?);
             }
@@ -5637,16 +5654,24 @@ async fn route_alter_role(
         .schema
         .check_permission(ctx.auth, Permission::Alter, &Resource::Role(s.name.clone()))?;
 
+    // Security (threat-model T9): reject unenforced ACCESS clauses. Fail loud.
+    if !s.access.is_empty() {
+        return Err(CqlError::Invalid(
+            "ACCESS (network authorization) is not supported".into(),
+        ));
+    }
+
     let ddl_guard = state.ddl_path.load();
     let ddl = &**ddl_guard;
     match ddl {
         DdlPath::Direct { .. } => {
-            // Direct path: pass the cleartext through; `Schema::alter_role`
-            // hashes inside the lock and emits the audit event.
+            // Direct path: `Schema::alter_role` hashes plaintext under the lock,
+            // or validates+stores a HASHED PASSWORD verbatim; emits the audit event.
             let updates = RoleUpdates {
                 is_superuser: s.superuser,
                 can_login: s.login,
                 password: s.password.clone(),
+                hashed_password: s.hashed_password.clone(),
                 member_of: None,
             };
             state.schema.alter_role(&s.name, updates, ctx.auth)?;
@@ -5666,10 +5691,15 @@ async fn route_alter_role(
             } else {
                 None
             };
+            // HASHED PASSWORD: validate on the coordinator before replicating.
+            if let Some(ref h) = s.hashed_password {
+                state.schema.validate_password_hash(h)?;
+            }
             let updates = RoleUpdates {
                 is_superuser: s.superuser,
                 can_login: s.login,
                 password: hashed_password,
+                hashed_password: s.hashed_password.clone(),
                 member_of: None,
             };
             match ddl {
@@ -15344,6 +15374,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_role_with_access_clause_is_rejected() {
+        // Threat T9: ferrosa has no network authorizer, so an ACCESS restriction
+        // must be rejected (fail loud), never silently accepted-and-ignored.
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        let stmt = crate::parser::parse(
+            "CREATE ROLE netrole WITH PASSWORD = 'p' AND ACCESS TO DATACENTERS {'DC1'}", // pragma: allowlist secret
+        )
+        .unwrap();
+        assert!(
+            route(&state, &ctx, stmt).await.is_err(),
+            "CREATE ROLE with ACCESS must be rejected, not silently accepted"
+        );
+        assert!(state.schema.snapshot().roles.get("netrole").is_none());
+    }
+
+    #[tokio::test]
+    async fn create_role_with_hashed_password_stores_hash_verbatim() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        // A valid bcrypt hash string (HASHED PASSWORD input).
+        let hash = "$2a$10$JSJEMFm6GeaW9XxT5JIheuEtPvat6i7uKbnTcxX3c1wshIIsGyUtG";
+        let cql = format!("CREATE ROLE hrole WITH HASHED PASSWORD = '{hash}' AND LOGIN = true");
+        route(&state, &ctx, crate::parser::parse(&cql).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            state
+                .schema
+                .snapshot()
+                .roles
+                .get("hrole")
+                .unwrap()
+                .salted_hash
+                .as_deref(),
+            Some(hash),
+            "HASHED PASSWORD must be stored verbatim"
+        );
+    }
+
+    #[tokio::test]
     async fn alter_role_updates_login() {
         let (state, _dir) = setup();
         let ctx = RequestContext {
@@ -15365,8 +15450,11 @@ mod tests {
         let stmt = Statement::AlterRole(AlterRoleStatement {
             name: "ar_role".into(),
             password: None,
+            hashed_password: None,
             superuser: None,
             login: Some(true),
+            options: Vec::new(),
+            access: Vec::new(),
         });
         let result = route(&state, &ctx, stmt).await;
         assert!(

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1002,6 +1002,14 @@ pub async fn route(
         } => route_list_roles(state, ctx, of, no_recursive, users_alias)
             .await
             .map(RouteResult::Result),
+        Statement::ListPermissions {
+            permission,
+            resource,
+            of,
+            no_recursive,
+        } => route_list_permissions(state, ctx, permission, resource, of, no_recursive)
+            .await
+            .map(RouteResult::Result),
         Statement::Grant(g) => route_grant(state, ctx, g).await.map(RouteResult::Result),
         Statement::Revoke(r) => route_revoke(state, ctx, r).await.map(RouteResult::Result),
         Statement::GrantRole { role, member } => route_grant_role(state, ctx, role, member, true)
@@ -5865,6 +5873,102 @@ async fn route_list_roles(
         &column_types,
         "system_auth",
         "roles",
+        &rows,
+    ))
+}
+
+/// Handle `LIST [ALL | <perm>] PERMISSIONS [ON <resource>] [OF <role>]
+/// [NORECURSIVE]`. Mirrors Cassandra's `system_auth.role_permissions` view —
+/// one row per (role, resource, permission). Gated on DESCRIBE over all roles
+/// (the same check as LIST ROLES) so a caller cannot enumerate grants it has no
+/// authority to see.
+async fn route_list_permissions(
+    state: &SharedState,
+    ctx: &RequestContext<'_>,
+    permission: Option<String>,
+    resource: Option<GrantResource>,
+    of: Option<String>,
+    no_recursive: bool,
+) -> Result<BytesMut, CqlError> {
+    state
+        .schema
+        .check_permission(ctx.auth, Permission::Describe, &Resource::AllRoles)?;
+
+    let snap = state.schema.snapshot();
+
+    // `OF <role>` restricts to that role and — unless NORECURSIVE — the roles it
+    // is a member of, since a role inherits their permissions.
+    let role_filter: Option<HashSet<String>> = of.as_ref().map(|start| {
+        let mut set = HashSet::new();
+        let mut stack = vec![start.clone()];
+        while let Some(name) = stack.pop() {
+            if !set.insert(name.clone()) {
+                continue;
+            }
+            if !no_recursive {
+                if let Some(role) = snap.roles.get(&name) {
+                    for parent in &role.member_of {
+                        stack.push(parent.clone());
+                    }
+                }
+            }
+        }
+        set
+    });
+
+    // `ON <resource>` compares against the stored resource string form.
+    let resource_filter: Option<String> = match resource {
+        Some(r) => Some(ast_resource_to_schema(&r, ctx.current_keyspace)?.to_string()),
+        None => None,
+    };
+
+    let mut perm_rows = ferrosa_schema::query_role_permissions(&snap);
+    perm_rows.sort_by(|a, b| {
+        a.role
+            .cmp(&b.role)
+            .then_with(|| a.resource.cmp(&b.resource))
+    });
+
+    let column_names = vec![
+        "role".to_string(),
+        "resource".to_string(),
+        "permission".to_string(),
+    ];
+    let column_types = vec![CqlType::Varchar, CqlType::Varchar, CqlType::Varchar];
+
+    let mut rows: Vec<Vec<Option<CqlValue>>> = Vec::new();
+    for row in perm_rows {
+        if let Some(ref roles) = role_filter {
+            if !roles.contains(&row.role) {
+                continue;
+            }
+        }
+        if let Some(ref res) = resource_filter {
+            if &row.resource != res {
+                continue;
+            }
+        }
+        let mut perms: Vec<String> = row.permissions.into_iter().collect();
+        perms.sort();
+        for perm in perms {
+            if let Some(ref want) = permission {
+                if &perm != want {
+                    continue;
+                }
+            }
+            rows.push(vec![
+                Some(CqlValue::Text(row.role.clone())),
+                Some(CqlValue::Text(row.resource.clone())),
+                Some(CqlValue::Text(perm)),
+            ]);
+        }
+    }
+
+    Ok(result::encode_rows(
+        &column_names,
+        &column_types,
+        "system_auth",
+        "role_permissions",
         &rows,
     ))
 }
@@ -15916,6 +16020,38 @@ mod tests {
             .unwrap()
             .member_of
             .contains("reporter"));
+    }
+
+    #[tokio::test]
+    async fn list_permissions_reflects_grants() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        for q in [
+            "CREATE KEYSPACE lpks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE lpks.t (k int PRIMARY KEY)",
+            "CREATE ROLE reader WITH PASSWORD = 'pw' AND LOGIN = true",
+            "GRANT SELECT ON lpks.t TO reader",
+        ] {
+            let stmt = crate::parser::parse(q).unwrap();
+            route(&state, &ctx, stmt).await.unwrap();
+        }
+
+        // LIST ALL PERMISSIONS returns a Rows result (kind 0x0002).
+        let stmt = crate::parser::parse("LIST ALL PERMISSIONS OF reader").unwrap();
+        let result = route(&state, &ctx, stmt).await.expect("list permissions");
+        match &result {
+            RouteResult::Result(b) => {
+                assert_eq!(&b[0..4], &0x0002i32.to_be_bytes(), "expected Rows result");
+            }
+            _ => panic!("expected a Rows Result from LIST PERMISSIONS"),
+        }
     }
 
     // ── ALTER TABLE with extensions ──────────────────────────────────

--- a/ferrosa-cql/src/transaction_keys.rs
+++ b/ferrosa-cql/src/transaction_keys.rs
@@ -175,6 +175,26 @@ fn serialize_term_into(term: &Term, buf: &mut Vec<u8>) {
                 serialize_term_into(a, buf);
             }
         }
+        Term::Duration {
+            months,
+            days,
+            nanos,
+        } => {
+            buf.push(0x0F);
+            buf.extend_from_slice(&months.to_be_bytes());
+            buf.extend_from_slice(&days.to_be_bytes());
+            buf.extend_from_slice(&nanos.to_be_bytes());
+        }
+        Term::TemporalArithmetic {
+            base,
+            subtract,
+            offset,
+        } => {
+            buf.push(0x10);
+            buf.push(u8::from(*subtract));
+            serialize_term_into(base, buf);
+            serialize_term_into(offset, buf);
+        }
     }
 }
 

--- a/ferrosa-schema/src/auth/password.rs
+++ b/ferrosa-schema/src/auth/password.rs
@@ -85,6 +85,26 @@ impl PasswordHasher {
         }
     }
 
+    /// Validate that `hash` is a supported password-hash string (bcrypt or
+    /// argon2id PHC). A `HASHED PASSWORD` is stored verbatim, so rejecting an
+    /// unsupported format here prevents a role from ever holding a credential
+    /// that `verify_password_any` cannot interpret (which would otherwise make
+    /// the role permanently unauthenticatable). Fail loud, not silent.
+    pub fn validate_password_hash(hash: &str) -> crate::Result<()> {
+        let supported = hash.starts_with("$2a$")
+            || hash.starts_with("$2b$")
+            || hash.starts_with("$2y$")
+            || hash.starts_with("$argon2id$");
+        if supported {
+            Ok(())
+        } else {
+            Err(SchemaError::InvalidSchema(
+                "unsupported password hash format (expected bcrypt $2a/$2b/$2y or $argon2id)"
+                    .to_string(),
+            ))
+        }
+    }
+
     /// Returns true if the hash algorithm differs from the configured one.
     pub fn needs_rehash(&self, hash: &str) -> bool {
         match self {

--- a/ferrosa-schema/src/auth/role.rs
+++ b/ferrosa-schema/src/auth/role.rs
@@ -47,6 +47,9 @@ pub struct RoleUpdates {
     pub can_login: Option<bool>,
     /// New password (plaintext — will be hashed before storage).
     pub password: Option<String>,
+    /// New pre-computed password hash (`HASHED PASSWORD` — stored verbatim
+    /// after format validation). Mutually exclusive with `password`.
+    pub hashed_password: Option<String>,
     /// New set of parent roles, if changing.
     pub member_of: Option<HashSet<String>>,
 }

--- a/ferrosa-schema/src/registry.rs
+++ b/ferrosa-schema/src/registry.rs
@@ -534,6 +534,48 @@ impl Schema {
         Ok(())
     }
 
+    /// Grant role membership without auth checks: add `granted_role` to
+    /// `member`'s `member_of` set. Additive — it touches exactly one membership
+    /// edge, so concurrently-replicated grants of different edges never clobber
+    /// one another (unlike replacing the whole `member_of` set).
+    ///
+    /// The cycle check runs against the CURRENT state. Because Raft applies
+    /// entries serially, a cycle formed by two independently-committed grants
+    /// (e.g. `GRANT a TO b` and `GRANT b TO a`) is caught when the second entry
+    /// applies — the first edge is already present — so it is rejected rather
+    /// than corrupting the hierarchy. Idempotent if `member` no longer exists.
+    pub fn grant_role_internal(&self, member: &str, granted_role: &str) -> crate::Result<()> {
+        let _lock = self.write_lock.lock().unwrap();
+        let mut snap = (**self.inner.load()).clone();
+        if !snap.roles.contains_key(member) {
+            return Ok(());
+        }
+        if would_create_cycle(&snap, granted_role, member) {
+            return Err(SchemaError::RoleCycleDetected(member.to_string()));
+        }
+        // unwrap: existence checked above, under the write lock.
+        snap.roles
+            .get_mut(member)
+            .unwrap()
+            .member_of
+            .insert(granted_role.to_string());
+        self.inner.store(Arc::new(snap));
+        Ok(())
+    }
+
+    /// Revoke role membership without auth checks: remove `granted_role` from
+    /// `member`'s `member_of` set. Subtractive and idempotent — touches one
+    /// edge, so it never clobbers other concurrently-replicated memberships.
+    pub fn revoke_role_internal(&self, member: &str, granted_role: &str) -> crate::Result<()> {
+        let _lock = self.write_lock.lock().unwrap();
+        let mut snap = (**self.inner.load()).clone();
+        if let Some(role) = snap.roles.get_mut(member) {
+            role.member_of.remove(granted_role);
+        }
+        self.inner.store(Arc::new(snap));
+        Ok(())
+    }
+
     /// Remove a specific permission for a role on a resource without auth checks.
     /// Removes the grant entry entirely if no permissions remain.
     /// Used for pair mode DDL replication.
@@ -2601,7 +2643,7 @@ mod tests {
         // credential that verify_password_any cannot interpret (threat T3).
         let err = schema.create_role_hashed(test_role("badrole"), "not-a-real-hash", &auth);
         assert!(err.is_err(), "unsupported hash format must be rejected");
-        assert!(schema.snapshot().roles.get("badrole").is_none());
+        assert!(!schema.snapshot().roles.contains_key("badrole"));
     }
 
     #[test]
@@ -3219,6 +3261,48 @@ mod tests {
                 },
             )
             .unwrap();
+    }
+
+    #[test]
+    fn grant_and_revoke_role_internal_additive() {
+        let schema = test_schema();
+        schema.create_role_internal(test_role("parent_a")).unwrap();
+        schema.create_role_internal(test_role("parent_b")).unwrap();
+        schema.create_role_internal(test_role("child")).unwrap();
+
+        // Two independent grants — each touches one edge, neither clobbers.
+        schema.grant_role_internal("child", "parent_a").unwrap();
+        schema.grant_role_internal("child", "parent_b").unwrap();
+        let snap = schema.snapshot();
+        let member_of = &snap.roles.get("child").unwrap().member_of;
+        assert!(member_of.contains("parent_a"));
+        assert!(member_of.contains("parent_b"));
+
+        // Revoke is subtractive and leaves the other edge intact.
+        schema.revoke_role_internal("child", "parent_a").unwrap();
+        let snap = schema.snapshot();
+        let member_of = &snap.roles.get("child").unwrap().member_of;
+        assert!(!member_of.contains("parent_a"));
+        assert!(member_of.contains("parent_b"));
+
+        // Idempotent: grant twice, revoke a missing edge.
+        schema.grant_role_internal("child", "parent_b").unwrap();
+        schema.revoke_role_internal("child", "nonexistent").unwrap();
+        // Missing member is a no-op, not an error.
+        schema.grant_role_internal("ghost", "parent_a").unwrap();
+    }
+
+    #[test]
+    fn grant_role_internal_rejects_cycle() {
+        let schema = test_schema();
+        schema.create_role_internal(test_role("a")).unwrap();
+        schema.create_role_internal(test_role("b")).unwrap();
+        // a is a member of b.
+        schema.grant_role_internal("a", "b").unwrap();
+        // Granting b membership in a would close the loop — must be rejected,
+        // even though each grant is individually fine.
+        let err = schema.grant_role_internal("b", "a").unwrap_err();
+        assert!(matches!(err, SchemaError::RoleCycleDetected(_)));
     }
 
     #[test]

--- a/ferrosa-schema/src/registry.rs
+++ b/ferrosa-schema/src/registry.rs
@@ -491,8 +491,10 @@ impl Schema {
             role.can_login = can_login;
         }
         // password field carries the already-hashed value during replication;
-        // store it directly without re-hashing.
-        if let Some(hash) = updates.password {
+        // store it directly without re-hashing. hashed_password (HASHED
+        // PASSWORD) is likewise an already-hashed value, validated on the
+        // coordinator before replication.
+        if let Some(hash) = updates.password.or(updates.hashed_password) {
             role.salted_hash = Some(hash);
         }
         if let Some(member_of) = updates.member_of {
@@ -1189,6 +1191,53 @@ impl Schema {
         Ok(())
     }
 
+    /// Validate a `HASHED PASSWORD` value is a supported hash format. Used by
+    /// the coordinator to fail loud before replicating an unusable credential.
+    pub fn validate_password_hash(&self, hash: &str) -> crate::Result<()> {
+        PasswordHasher::validate_password_hash(hash)
+    }
+
+    /// Create a role from a pre-computed password hash (`HASHED PASSWORD`).
+    ///
+    /// The hash is validated for a supported format and stored **verbatim** —
+    /// it is NOT re-hashed and the password-strength policy is NOT applied
+    /// (there is no plaintext to evaluate). The supplied hash never appears in
+    /// the audit payload.
+    pub fn create_role_hashed(
+        &self,
+        role: RoleMetadata,
+        hashed_password: &str,
+        auth: &AuthContext,
+    ) -> crate::Result<()> {
+        self.check_permission(auth, Permission::Create, &Resource::AllRoles)?;
+        PasswordHasher::validate_password_hash(hashed_password)?;
+        let _guard = self.write_lock.lock().unwrap();
+        let mut snap = (*self.snapshot()).clone();
+        if snap.roles.contains_key(&role.name) {
+            return Err(SchemaError::RoleExists(role.name));
+        }
+        for parent in &role.member_of {
+            if would_create_cycle(&snap, parent, &role.name) {
+                return Err(SchemaError::RoleCycleDetected(role.name));
+            }
+        }
+        let name = role.name.clone();
+        let is_su = role.is_superuser;
+        let mut role = role;
+        role.salted_hash = Some(hashed_password.to_string());
+        snap.roles.insert(role.name.clone(), role);
+        snap.version = Uuid::new_v4();
+        self.inner.store(Arc::new(snap));
+        self.emit_audit_with_actor(
+            AuditEventKind::RoleCreated {
+                role: name,
+                is_superuser: is_su,
+            },
+            auth,
+        );
+        Ok(())
+    }
+
     /// Alter an existing role.
     ///
     /// Requires `Alter` permission on `AllRoles`. Applies non-`None` fields
@@ -1203,11 +1252,23 @@ impl Schema {
     ) -> crate::Result<()> {
         self.check_permission(auth, Permission::Alter, &Resource::AllRoles)?;
         // Validate and hash password outside the write lock (expensive)
-        let new_hash = if let Some(ref pw) = updates.password {
-            self.password_policy.validate(pw, name)?;
-            Some(self.hasher_config.hash_password(pw)?)
-        } else {
-            None
+        // PASSWORD is hashed under policy; HASHED PASSWORD is stored verbatim
+        // after format validation. They are mutually exclusive.
+        let new_hash = match (&updates.password, &updates.hashed_password) {
+            (Some(pw), None) => {
+                self.password_policy.validate(pw, name)?;
+                Some(self.hasher_config.hash_password(pw)?)
+            }
+            (None, Some(h)) => {
+                PasswordHasher::validate_password_hash(h)?;
+                Some(h.clone())
+            }
+            (None, None) => None,
+            (Some(_), Some(_)) => {
+                return Err(SchemaError::InvalidSchema(
+                    "cannot specify both PASSWORD and HASHED PASSWORD".to_string(),
+                ))
+            }
         };
         let _guard = self.write_lock.lock().unwrap();
         let mut snap = (*self.snapshot()).clone();
@@ -2510,6 +2571,61 @@ mod tests {
         assert!(
             PasswordHasher::verify_password_any("s3cretPwd", r.salted_hash.as_ref().unwrap())
                 .unwrap()
+        );
+    }
+
+    #[test]
+    fn create_role_hashed_stores_verbatim_and_authenticates() {
+        let schema = test_schema();
+        let auth = superuser_auth();
+        // A real bcrypt hash of a known password (HASHED PASSWORD input).
+        let hash = bcrypt::hash("KnownPass1", 4).unwrap();
+        schema
+            .create_role_hashed(test_role("hrole"), &hash, &auth)
+            .unwrap();
+
+        let snap = schema.snapshot();
+        let r = snap.roles.get("hrole").expect("role exists");
+        // Stored VERBATIM — not re-hashed under the policy.
+        assert_eq!(r.salted_hash.as_deref(), Some(hash.as_str()));
+        // The known password authenticates; a wrong one does not (fail-closed).
+        assert!(PasswordHasher::verify_password_any("KnownPass1", &hash).unwrap());
+        assert!(!PasswordHasher::verify_password_any("wrong", &hash).unwrap());
+    }
+
+    #[test]
+    fn create_role_hashed_rejects_unsupported_format() {
+        let schema = test_schema();
+        let auth = superuser_auth();
+        // Not bcrypt/argon2 — must be rejected so a role never holds a
+        // credential that verify_password_any cannot interpret (threat T3).
+        let err = schema.create_role_hashed(test_role("badrole"), "not-a-real-hash", &auth);
+        assert!(err.is_err(), "unsupported hash format must be rejected");
+        assert!(schema.snapshot().roles.get("badrole").is_none());
+    }
+
+    #[test]
+    fn alter_role_hashed_stores_verbatim() {
+        let schema = test_schema();
+        let auth = superuser_auth();
+        schema
+            .create_role(test_role("auser"), Some("InitPass1"), &auth)
+            .unwrap();
+        let hash = bcrypt::hash("NewPass2", 4).unwrap();
+        let updates = RoleUpdates {
+            hashed_password: Some(hash.clone()),
+            ..Default::default()
+        };
+        schema.alter_role("auser", updates, &auth).unwrap();
+        assert_eq!(
+            schema
+                .snapshot()
+                .roles
+                .get("auser")
+                .unwrap()
+                .salted_hash
+                .as_deref(),
+            Some(hash.as_str())
         );
     }
 

--- a/specs/consistency/ddl-read-your-writes.md
+++ b/specs/consistency/ddl-read-your-writes.md
@@ -1,0 +1,69 @@
+# Invariant: same-node read-your-writes for forwarded DDL
+
+## Symptom that started this
+
+The Cassandra example corpus produced `keyspace … not found — schema may still be
+propagating` errors. Investigation showed two unrelated things:
+
+1. **Most corpus failures are fixture artifacts, not a bug.** Doc fragments do
+   `USE cycling` before any file creates the `cycling` keyspace (file sort order
+   puts `cyclist_*` before `sai/create-vector-keyspace-cycling.cql`), and others
+   reference keyspaces never created. On a single node, `CREATE KEYSPACE` →
+   immediate use is read-your-writes consistent (reproduced 0/20 failures).
+2. **A real cluster read-your-writes race exists** (this fix).
+
+## Bottom-up invariants
+
+| # | Invariant | Mechanism | Status before | After |
+|---|-----------|-----------|---------------|-------|
+| I1 | A node's `schema.snapshot()` reflects entries up to its `last_applied` | openraft applies committed entries in order | ✅ | ✅ |
+| I2 | Leader read-your-writes: `client_write().await` returns after **leader apply** | openraft `client_write` | ✅ | ✅ |
+| I3 | **Client read-your-writes on its connected node** after a DDL returns OK | — | ⚠️ leader-connected ✅; **follower-connected raced** | ✅ deterministic |
+| I4 | Cluster-wide convergence (every node eventually applies) | Raft replication + apply | ✅ | ✅ |
+
+## Root cause of the I3 gap
+
+A client connects to one node and runs DDL → DML on that connection. For a
+**follower-connected** client the DDL is forwarded to the leader; the leader
+applies it and acks. The follower then returned OK to the client **without
+waiting for its own state machine to apply** the entry. The leader-side barrier
+(`wait_for_replication_to_catch_up`) waited for each follower's **`matched`
+index** (log *replicated*) plus a fixed **50 ms `DDL_AGREEMENT_APPLY_DRAIN`
+sleep** to approximate the follower's **apply**. A node cannot observe a
+follower's apply progress from the leader (openraft metrics expose only
+`matched`), so the apply was approximated with a sleep — a race, not a guarantee.
+Under slow apply the follower served the next DML before applying the DDL →
+"schema not found".
+
+## Fix (condition-based, not timing-based)
+
+A node **can** always observe its **own** `last_applied`. So:
+
+1. `execute_via_raft` now returns the committed log index.
+2. The leader's `ClusterDdlForwardHandler` returns that index in the
+   `PairDdlAck` payload (8-byte big-endian; chained forwards relay it).
+3. `forward_ddl_to_leader` (on the **client DDL path**, `local_raft = Some`)
+   calls `wait_for_local_apply(raft, committed_index, timeout)` — polling the
+   node's own `last_applied` — before returning OK to the client. This makes I3
+   deterministic for follower-connected clients.
+4. The fixed 50 ms `DDL_AGREEMENT_APPLY_DRAIN` sleep is removed; the leader-side
+   replication wait (condition-based on `matched`) remains as a cross-node
+   convergence aid only.
+
+Membership/bootstrap forwards (`JoinNode`, schema hand-off) pass
+`local_raft = None` — they have no waiting client and a rejoining node may lack a
+usable local raft.
+
+## Tests
+
+- `tests/ddl_read_your_writes.rs::wait_for_local_apply_gives_follower_read_your_writes`
+  — 3-node cluster, commits a DDL on the leader, then asserts a **follower**
+  reaches the committed index via `wait_for_local_apply` (I3 mechanism).
+- Existing multi-node DDL/forwarding integration tests guard the protocol change
+  (ack now carries the index; empty acks are still handled).
+
+## Not addressed here (separate concern)
+
+Stale **reads** on a follower reached by a *different* connection than the one
+that ran the DDL (no forward involved) — that needs read-index / leader reads and
+is out of scope for same-connection read-your-writes.

--- a/specs/security/threat-model-cql-roles.md
+++ b/specs/security/threat-model-cql-roles.md
@@ -1,0 +1,55 @@
+# Threat Model — CQL role/auth DDL (CREATE/ALTER ROLE/USER options)
+
+STRIDE analysis for the #74 work that adds `HASHED PASSWORD`, `OPTIONS`, and
+`ACCESS TO/FROM …` to the role/user DDL grammar and execution.
+
+## Scope & assets
+
+- **Data flow:** client → CQL parser → `route_create_role`/`route_alter_role` →
+  `Schema::create_role`/`alter_role` → role store (`salted_hash`) → Raft/DDL log.
+- **Assets:** role credentials (`salted_hash`), authentication integrity (who can
+  log in), authorization state (`SUPERUSER`, `LOGIN`, network access).
+- **Trust boundary:** the CQL wire (untrusted client) → server role store.
+
+## Grounding (verified in code)
+
+- `PasswordHasher::verify_password_any` is **fail-closed**: an unrecognized hash
+  prefix returns `Err`, not `Ok(true)`. The auth path must treat `Err` as denial.
+- `route_create_role` already hashes plaintext on the coordinator to keep
+  cleartext "off the wire and out of the Raft log" (router.rs).
+
+## STRIDE inventory
+
+| # | Cat | Threat | L×I | Mitigation |
+|---|-----|--------|-----|------------|
+| T1 | Spoofing | Admin sets `HASHED PASSWORD` to a hash whose preimage they know → log in as that role | 1×2 | Requires `CREATE/ALTER ROLE` privilege (already an admin op); accept as designed. Still validate the hash format (T3). |
+| T2 | Tampering / EoP | Auth treats a malformed/unknown-format `salted_hash` as a match (fail-open) → any password logs in | 1×3 | **Verified fail-closed**: `verify_password_any` returns `Err` on unknown prefix. Add a test that login with a garbage-hash role is denied. |
+| T3 | Tampering | `HASHED PASSWORD` stores an unverifiable credential (wrong algo) → role can never authenticate, or downstream verify errors | 2×2 | **Validate** the supplied hash is a supported PHC/bcrypt string (`$2a$/$2b$/$2y$/$argon2id$`) at CREATE/ALTER time; reject otherwise (**fail loud**). Store verbatim; do NOT run password-strength policy on a hash. |
+| T4 | Repudiation | Role create/alter not audited | 1×2 | `Schema::create_role/alter_role` already emit audit events; ensure the new fields don't bypass that path. **Never** put password/hash in the audit payload. |
+| **T5** | **Info disclosure (side-channel)** | **Secret in logs.** `CREATE ROLE … WITH PASSWORD='s'` / `HASHED PASSWORD='$2a$…'` carries the secret in the **query text**, which is logged verbatim on error — confirmed at `connection.rs` `"PREPARE failed for '{query}'"`. | **2×3** | **Redact** password/hashed-password literals from any logged query string (PREPARE + QUERY error paths). Add a `redact_role_secrets(query)` helper and a test asserting the secret never appears in the logged text. |
+| T6 | Info disclosure (timing) | Non-constant-time verify, or distinguishable "no such role" vs "bad password" timing/errors → role/credential enumeration | 1×2 | bcrypt/argon2 verify is constant-time; auth returns a uniform `Bad credentials`. Don't weaken: the new paths feed the same verify. |
+| T7 | Info disclosure | `salted_hash` exposed via `SELECT … FROM system_auth.roles` to non-superusers | 1×3 | Existing: router masks `salted_hash` for non-superuser callers (router.rs ~1757). Unchanged by this work. |
+| T8 | DoS | Huge `OPTIONS` map / `ACCESS` set exhausts memory while parsing | 1×2 | Bound `OPTIONS`/`ACCESS` element counts (reuse `MAX_COLLECTION_ELEMENTS`). |
+| **T9** | **EoP / false security** | **Silently ignoring `ACCESS TO/FROM …`.** Operator restricts a role to DC1; ferrosa parses and ignores it → role has no restriction → broader access than intended. | **2×3** | ferrosa has **no network authorizer**, so **reject** `ACCESS` clauses with a clear error rather than silently accept a security control we don't enforce (**fail loud**; matches the project's failure philosophy). Tracked as a separate feature if/when a network authorizer lands. |
+| T10 | EoP | Non-superuser grants itself `SUPERUSER = true` | 1×3 | Existing `Schema::create_role/alter_role` enforce that only superusers may set superuser; unchanged. Add a regression test. |
+
+## Decisions (security-driven)
+
+1. **`HASHED PASSWORD`** — parse; **validate** the value is a supported hash
+   format; store verbatim as `salted_hash` (no re-hash, no strength policy). A
+   role created with a non-bcrypt/argon2 hash is **rejected**, not silently
+   stored unusable.
+2. **`OPTIONS = {…}`** — parse (bounded). Not a deny-control; ferrosa's password
+   authenticator ignores them. Accepted and logged at debug; documented as
+   not-interpreted. (Lower risk than ACCESS — OPTIONS grant nothing.)
+3. **`ACCESS TO/FROM …`** — **rejected** with a clear error. Silently accepting
+   an unenforced *restriction* is worse than not supporting it.
+4. **Secret redaction (T5)** — redact `PASSWORD`/`HASHED PASSWORD` literals from
+   any logged query text.
+
+## Residual risk / open items
+
+- Network authorization (`ACCESS`) enforcement is out of scope; rejecting the
+  syntax is the safe interim. A future feature can implement the authorizer.
+- A full audit that role-DDL audit events never contain secrets should be part
+  of the secure-review pass before merge.

--- a/specs/todo/cql-corpus-foundation-gaps.md
+++ b/specs/todo/cql-corpus-foundation-gaps.md
@@ -1,0 +1,50 @@
+---
+type: feature
+priority: P3
+status: open
+created: 2026-05-31
+context: "Remaining Cassandra CQL example-corpus parse gaps after the auth/duration/role/LIST gap-fill. Each requires a new foundational subsystem; tracked here for triage."
+---
+
+# CQL corpus gap-fill — remaining foundation-dependent features
+
+## Status
+
+The Cassandra example corpus (`ferrosa-cql/tests/cassandra_cql_examples.rs`,
+201 files) is at **~92% parse coverage**. The tractable, no-new-foundation gaps
+are done (auth: roles/HASHED PASSWORD/OPTIONS, GRANT/REVOKE ON TABLE +
+multi-perm, ALTER USER, bare SUPERUSER, GRANT/REVOKE role with additive
+replication, LIST PERMISSIONS; query: LIKE, ALTER KEYSPACE, ALTER TABLE
+RENAME/ALTER TYPE, duration literals + temporal arithmetic, qualified function
+calls; transient-replication rejection; Java→WASM UDF example rewrite).
+
+Everything still failing needs a **new foundational subsystem** (or is a test
+fixture artifact). None are quick parser wins.
+
+## Remaining real gaps (each its own effort/PR)
+
+| Gap | Foundation required | ~count |
+|-----|--------------------|--------|
+| Collection + custom/SAI indexes — `CREATE INDEX … (KEYS(m)/VALUES(m)/ENTRIES(m))`, `CREATE CUSTOM INDEX … USING 'SAI'` with analyzers | secondary-index engine extensions | ~18 |
+| UDF/UDA code bodies — `LANGUAGE <lang> AS $$…$$` | inline language→WASM compiler — see `feature-inline-language-to-wasm-udf.md` | ~10 |
+| JSON I/O — `INSERT … JSON '{…}'` (reverse JSON→typed-value codec; forward `toJson` already exists), `SELECT JSON` (result-encoding chokepoint refactor — `encode_rows` is called from 12+ scattered sites) | JSON codecs / result-path refactor | ~7 |
+| Materialized views — `CREATE MATERIALIZED VIEW … AS SELECT …` | MV maintenance engine | 5 |
+| Dynamic data masking — `… MASKED WITH f()`, `RESTRICT ROWS`, `DROP MASKED`, `UNMASK`/`SELECT_MASKED` permissions | column-masking engine + masked-permission enforcement | ~4 |
+| Expression evaluation inside aggregates — `SELECT AVG(CAST(x AS float))`, `SUM(expr)` | per-row expression evaluator in the aggregate path + `CAST` type coercion | ~3 |
+| Triggers — `CREATE/DROP TRIGGER … USING '<class>'` | **recommend won't-implement** (Cassandra-specific server-side trigger classes) | 2 |
+
+## Not real gaps (~14, fixture artifacts — no action)
+
+- Multi-statement `BEGIN BATCH … APPLY BATCH` chopped on `;` by the corpus
+  statement splitter (BATCH, incl. `COUNTER BATCH`, parses fine).
+- Literal `...` ellipsis placeholders and end-of-line `--` comments after `;`.
+- UDF body fragments leaking past the non-CQL filter.
+
+The realistic parse-coverage ceiling without a new subsystem is ~92%; the
+fixture artifacts are not ferrosa bugs.
+
+## Closest-to-tractable next pick
+
+`INSERT … JSON` — only the **reverse** JSON→typed-value codec is missing (the
+forward `cql_value_to_json` exists); it is bounded and self-contained relative
+to the others.

--- a/specs/todo/feature-inline-language-to-wasm-udf.md
+++ b/specs/todo/feature-inline-language-to-wasm-udf.md
@@ -1,0 +1,83 @@
+---
+type: design
+priority: P3
+status: open
+created: 2026-05-31
+context: "CQL UDF gap-fill — ferrosa runs WASM UDFs, not Java. Explore compiling a high-level language to WASM inline at CREATE FUNCTION time."
+---
+
+# Design: inline language → WASM for `CREATE FUNCTION`
+
+## Goal
+
+Let users write UDF/UDA bodies in a high-level language inside
+`CREATE FUNCTION … AS $$ …source… $$` and have ferrosa compile that source to a
+WASM component **at definition time**, instead of requiring a pre-compiled
+artifact. ferrosa already runs UDFs as WASM components in Wasmtime; this adds a
+source→WASM front end.
+
+Today the only supported form is a pre-compiled WASM module
+(`LANGUAGE wasm AS '<hex>' | AS FILE '<path>' | AS URL '<url>' WITH SHA256 = …`).
+The vendored Cassandra Java-UDF examples were rewritten to this WASM form
+(see `cassandra/doc/modules/cassandra/examples/CQL/{create_function,uda,
+function_dollarsign,function_udfcontext}.cql`).
+
+## Candidate language: AssemblyScript
+
+AssemblyScript (TypeScript-like → WASM) is the strongest fit because its
+toolchain is **embeddable**, unlike Java:
+
+- `asc` is a JavaScript program that drives **binaryen** (shipped as WASM).
+- To keep ferrosa self-contained, embed a small JS engine and run `asc.js` +
+  `binaryen.wasm` in-process.
+
+### Compiler-hosting options
+
+| Option | Trade-off |
+|--------|-----------|
+| **QuickJS via `rquickjs`** (recommended) | Tiny embeddable C engine, mature Rust bindings, self-contained. Risk: `asc.js` targets Node/browser → needs FS/host shims + compat testing. |
+| Shell out to `node asc` | Trivial to prototype, but adds Node.js as a deployment dependency + supply-chain surface. Rejected for a self-contained DB. |
+| Embed V8 (`deno_core`/`rusty_v8`) | Heavy binary/build; overkill. |
+
+Other languages to keep in mind when picking the long-term answer: Rust→WASM
+(needs the Rust toolchain — not embeddable), TinyGo, Grain, or a small DSL
+compiled directly to WASM in Rust (most controllable, least familiar to users).
+The open question the owner wants to think through: **what is the best general
+way to get a language inline → WASM** without dragging in a heavy toolchain.
+
+## Architecture (regardless of language)
+
+1. Parser: `LANGUAGE assemblyscript AS $$ …source… $$` — needs a lexer change for
+   dollar-quoted bodies + the language keyword. (Small.)
+2. **Compile at the coordinator**, then replicate the resulting **WASM bytes**
+   through the existing WASM-UDF storage/replication path, so replicas never
+   compile untrusted source and every node converges on identical bytes
+   (deterministic — matches how DDL already replicates).
+3. The compiled UDF runs under the **existing Wasmtime sandbox** — no new
+   execution surface.
+
+## STRIDE
+
+- **Denial of Service (new):** compiling untrusted source. Bound the compile
+  with CPU/fuel, memory, and wall-clock limits; rate-limit per role.
+  Coordinator-only compilation contains it to one node.
+- **Tampering / EoP:** compiler runs sandboxed (QuickJS/Wasmtime); output runs
+  in the existing UDF sandbox. No raw host access from either stage.
+- **Supply chain:** vendoring `asc` + `binaryen.wasm` pins a toolchain version;
+  capture the version and a digest so compiled output is reproducible/auditable.
+
+## Effort
+
+~1–2 weeks for a solid version. The parser/DDL groundwork (`$$` bodies +
+`LANGUAGE <lang>`) is small; the bulk is the engine integration, compile shims,
+and resource sandboxing. Tractable because Wasmtime is already in-process, but
+its own PR — not a quick gap-close.
+
+## Next steps when picked up
+
+1. Spike `rquickjs` + `asc.js` + `binaryen.wasm`: compile a trivial AS function
+   to WASM in-process, de-risk compat/perf.
+2. Add `$$…$$` dollar-quote lexing + `LANGUAGE assemblyscript` parsing (route to
+   a compile step).
+3. Wire coordinator compile → store WASM bytes via the existing path.
+4. Sandbox limits + STRIDE-DoS tests.


### PR DESCRIPTION
Closes #74.

Closes the tractable CQL gaps surfaced by the Cassandra example corpus
(`ferrosa-cql/tests/cassandra_cql_examples.rs`), raising parse coverage from
**86.3% → ~92.3%**. Every change is TDD'd; security-relevant changes carry a STRIDE note.

## Auth & roles
- Roles `WITH HASHED PASSWORD` / `OPTIONS`; `ACCESS TO/FROM` parsed but **rejected** (no network authorizer — fail loud); password/hash literals redacted from logs.
- `GRANT/REVOKE` with `ON TABLE` and comma-separated permission lists; unknown permissions rejected (no silent partial grant).
- `ALTER USER … [WITH] PASSWORD`, and the legacy bare `SUPERUSER`/`NOSUPERUSER` flag.
- **`GRANT/REVOKE <role> TO/FROM <member>`** (role hierarchy) — new **additive** `DdlOperation`/`RaftOp` mutating one membership edge per op, with an **apply-time** cycle check, so concurrent grants never clobber and a revoke is never lost to a racing grant.
- `LIST ROLES` and `LIST [ALL | <perm>] PERMISSIONS [ON res] [OF role]` (DESCRIBE-gated).
- **STRIDE:** no resource-scope widening, no silent partial grants, apply-time cycle prevention, no lost revoke under concurrency, secret redaction.

## Query / DDL
- `LIKE` pattern predicate (executed under ALLOW FILTERING).
- `ALTER KEYSPACE`; `ALTER TABLE RENAME` / `ALTER … TYPE` (parsed; rejected at execution until applied — fail loud, never a silent no-op).
- **CQL `duration` literals** (compact `2d`/`1mo3d`/`89h4m48s` + ISO-8601 `P1Y2M3D`) and **calendar-aware temporal arithmetic** (`currentDate() - 2d`, `'2017-01-01' - 2d`, months clamp to month-end); added `currentDate()`.
- Keyspace-qualified function calls in SELECT (`ks.fn(args)`).

## Correctness (read-your-writes)
- Deterministic same-node read-your-writes for forwarded DDL: a node waits for its own `last_applied` (new `wait_for_local_apply`) instead of a fixed sleep, so a follower-connected client's DDL→DML no longer races. Invariant analysis in `specs/consistency/ddl-read-your-writes.md`.

## Corpus & docs
- Rewrote the vendored **Java UDF examples as WASM** (ferrosa runs WASM UDFs, not Java).
- `docs/database/cql-compatibility.html` updated throughout (v4 cap, LIKE, transient-replication rejection, GRANT/REVOKE forms, role hierarchy, LIST, duration & temporal arithmetic, WASM-only UDFs).
- Backlog filed: `specs/todo/feature-inline-language-to-wasm-udf.md` (AssemblyScript→WASM inline-compile design) and `specs/todo/cql-corpus-foundation-gaps.md` (remaining foundation-dependent gaps).

## Tests
ferrosa-cql **855**, ferrosa-cluster **888**, ferrosa-schema **338** — all green. Workspace `build --all-targets`, `clippy --all-targets`, `fmt --check` clean.
