### PR TITLE
docs(examples): link the inline AssemblyScript tutorial on the examples index

### DIFF
--- a/docs/database/examples/index.html
+++ b/docs/database/examples/index.html
@@ -71,7 +71,7 @@
 </dd>
 <dt class="hdlist1"><a href="advanced-aggregation.html"><strong>Advanced Aggregation</strong></a></dt>
 <dd>
-<p>Group-by aggregates with built-in functions and WebAssembly user-defined aggregates.</p>
+<p>Group-by aggregates with built-in functions and WebAssembly user-defined aggregates&#8201;&#8212;&#8201;including writing scalar UDFs as <a href="advanced-aggregation.html#_alternative_inline_assemblyscript">inline AssemblyScript</a> that the server compiles at definition time.</p>
 </dd>
 <dt class="hdlist1"><a href="ecommerce.html"><strong>E-Commerce</strong></a></dt>
 <dd>

--- a/examples/index.adoc
+++ b/examples/index.adoc
@@ -31,7 +31,7 @@ link:timeseries-rrd.html[*RRD Time-Series Aggregation*] _New!_::
 Roll up high-frequency sensor readings into time-window summaries (min/max/avg) automatically -- RRD-style consolidation with streaming built-ins and optional WebAssembly aggregates.
 
 link:advanced-aggregation.html[*Advanced Aggregation*]::
-Group-by aggregates with built-in functions and WebAssembly user-defined aggregates.
+Group-by aggregates with built-in functions and WebAssembly user-defined aggregates -- including writing scalar UDFs as link:advanced-aggregation.html#_alternative_inline_assemblyscript[inline AssemblyScript] that the server compiles at definition time.
 
 link:ecommerce.html[*E-Commerce*]::
 Product catalog, shopping cart, and order processing.


### PR DESCRIPTION
The advanced-aggregation tutorial documents writing scalar UDFs as inline AssemblyScript (added with #77), but the examples index entry didn't mention or link it, so it wasn't discoverable from the examples page.

This adds a deep link from the *Advanced Aggregation* entry on the examples index to the `#_alternative_inline_assemblyscript` subsection, and regenerates `index.html` (verified against the drift gate: 0 content drift; the anchor target exists in `advanced-aggregation.html`).

Audit note: all 18 example tutorials are linked in `examples/index.adoc` — none were missing; this was purely the inline-AssemblyScript subsection's discoverability.