### PR TITLE
docs: refresh Ferrosa Memory 0.13 preview

### DIFF
--- a/docs/ferrosa-memory/getting-started.html
+++ b/docs/ferrosa-memory/getting-started.html
@@ -110,6 +110,39 @@ podman compose version        # full Podman stack only</code></pre>
 ollama list | grep nomic-embed-text-v2-moe</code></pre>
   <div class="warn">If embeddings are skipped, lexical/phonetic search still works, but semantic/vector search quality is degraded.</div>
 
+  <h2>0.13 retrieval defaults</h2>
+  <p>The 0.13 preview keeps live agent turns compact while eval runs use wider candidate generation.</p>
+  <pre><code>[retrieval]
+default_limit = 10
+
+[embeddings]
+provider = "ollama"
+model = "nomic-embed-text-v2-moe"
+dimensions = 768
+
+[eval]
+retrieval_k = 25</code></pre>
+  <p><code>default_limit = 10</code> is used when an agent omits <code>limit</code> or <code>k</code>. Lower it with the <code>config</code> MCP tool if memory results are consuming too much context. Eval runs should widen candidate generation in the harness instead of raising the live default.</p>
+  <p>Best-known BRIGHT-Pro support-doc-closed MCP slice profile for 0.13:</p>
+  <pre><code>candidate_limit=50
+fusion_profile=all
+query_decomposition=llm
+query_task=bright_pro
+query_variant_limit=5
+query_embed_variants=true
+chunk_expansion=none
+rerank=false</code></pre>
+  <p>On the 200-document biology support-closed slice this measured alpha_nDCG <code>0.816</code>, NDCG <code>0.799</code>, aspect_recall <code>0.940</code>, and recall <code>0.796</code>. These are preview slice numbers; full-corpus paper comparisons require the full corpus to be ingested through the same MCP path.</p>
+
+  <h3>Optional live judge/reranker</h3>
+  <pre><code>[judge]
+enabled = false
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+model = "qwen2.5-coder:7b"
+timeout_seconds = 60</code></pre>
+  <p>Keep live judge disabled unless a local or remote model endpoint is available. Judge failures and no-decisions are recorded as abstentions, while agent/user feedback can use compact <code>+1</code> and <code>-1</code> item scores to tune future rankings by workspace, query shape, and retrieval channel.</p>
+
   <h3>3. Clone the public repositories, if contributing from source</h3>
   <pre><code>mkdir -p ~/src/ferrosa-suite
 cd ~/src/ferrosa-suite
@@ -204,6 +237,27 @@ curl -sS -u ferrosa_user:ferrosa_user \
     "expand": {"prev": 1, "next": 1, "max_tokens": 2000}
   }
 }</code></pre>
+
+  <h2>Workbench, hooks, and evals</h2>
+  <p>The workbench at <code>http://127.0.0.1:18765/</code> includes CQL, SPARQL, Datalog, graph/viz, aliases, rules, approvals, explanations, and Judge Config pages. Use the separate viz page at <code>http://127.0.0.1:18766/viz</code> to inspect linked entities and graph neighborhoods.</p>
+  <p>The onboarding flow can install Codex, Claude, and Hermes hooks. Hooks capture session turns, working directory metadata, and compact retrieval feedback so memories learned in a repository can be preferred when future agents work from the same directory.</p>
+  <pre><code>cd ~/src/ferrosa-suite/ferrosa-memory
+./setup.sh --harness auto
+
+# or run only hook installation
+python3 scripts/install-agent-hooks.py --harness auto --verify</code></pre>
+  <p>Agents should call <code>feedback</code> after retrieval when they can judge returned items: <code>1</code> for useful, <code>-1</code> for irrelevant or wrong, <code>0</code> for neutral, and <code>"-"</code> when a judge abstains or fails.</p>
+  <pre><code># deterministic harness smoke test
+scripts/run-official-evals.sh --self-test
+
+# tune MCP fusion/decomposition profiles
+FMEM_EVAL_QUERY_DECOMPOSITION=llm \
+FMEM_EVAL_QUERY_EMBED_VARIANTS=true \
+scripts/run-fusion-ablations.sh
+
+# start a resumable full-corpus BRIGHT-Pro MCP ingest
+scripts/start-bright-pro-full-load.sh</code></pre>
+  <p>The full-corpus loader writes <code>heartbeat.json</code>, <code>progress.json</code>, and <code>load.log</code> under <code>diagnostics/eval-runs/...</code> so long runs can be monitored or resumed without attaching to a terminal.</p>
 
   <h2>Operate safely</h2>
   <p>Stop and start without deleting data:</p>

--- a/docs/ferrosa-memory/getting-started.md
+++ b/docs/ferrosa-memory/getting-started.md
@@ -94,6 +94,53 @@ If you skip this step, warn users and test with lexical/phonetic queries first:
 Nomic embeddings disabled; semantic/vector search is degraded.
 ```
 
+## 0.13 retrieval defaults
+
+The 0.13 preview defaults keep normal agent turns compact while leaving evals enough depth to measure recall:
+
+```toml
+[retrieval]
+default_limit = 10
+
+[embeddings]
+provider = "ollama"
+model = "nomic-embed-text-v2-moe"
+dimensions = 768
+
+[eval]
+retrieval_k = 25
+```
+
+Live retrieval uses `default_limit = 10` when an agent omits `limit` or `k`. Agents and users can lower this with the `config` MCP tool if a session is spending too many tokens on memory. Benchmarks should widen candidate generation in the eval runner rather than increasing the live default.
+
+The best-known BRIGHT-Pro support-doc-closed MCP slice profile for 0.13 is:
+
+```text
+candidate_limit=50
+fusion_profile=all
+query_decomposition=llm
+query_task=bright_pro
+query_variant_limit=5
+query_embed_variants=true
+chunk_expansion=none
+rerank=false
+```
+
+On the 200-document biology support-closed slice this measured alpha_nDCG `0.816`, NDCG `0.799`, aspect_recall `0.940`, and recall `0.796`. These are preview slice numbers; full-corpus paper comparisons require the full corpus to be ingested through the same MCP path.
+
+Optional live judge/reranking is configured separately:
+
+```toml
+[judge]
+enabled = false
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+model = "qwen2.5-coder:7b"
+timeout_seconds = 60
+```
+
+Keep it disabled unless a local or remote model endpoint is available. If the judge fails or abstains, Ferrosa Memory records an abstention rather than a positive or negative judgment. Agent and user feedback can still use compact `+1` and `-1` item feedback to tune future rankings by workspace, query shape, and retrieval channel.
+
 ## Manual source setup
 
 ```bash
@@ -318,10 +365,49 @@ Use the workbench to inspect:
 
 - CQL tables and counts;
 - memory summaries;
-- graph and Datalog query surfaces;
+- graph, CQL, SPARQL, and Datalog query surfaces;
+- the Judge Config page for optional local/remote model provider settings;
 - aliases, rules, approvals, and explanations when enabled.
 
 Use the viz page to inspect graph neighborhoods and entity links. Wait for graph queries to finish before taking screenshots or drawing conclusions from an empty view.
+
+## Agent hooks and feedback
+
+The onboarding flow can install Codex, Claude, and Hermes hooks. Those hooks capture session turns, working directory metadata, and compact retrieval feedback so memories learned in a repository can be preferred when future agents work from the same directory.
+
+From a source checkout:
+
+```bash
+cd ~/src/ferrosa-suite/ferrosa-memory
+./setup.sh --harness auto
+```
+
+or run the hook installer directly:
+
+```bash
+python3 scripts/install-agent-hooks.py --harness auto --verify
+```
+
+Agents should call `feedback` after retrieval when they can judge returned items. Use scores in result order: `1` for useful, `-1` for irrelevant or wrong, `0` for neutral, and `"-"` when a judge abstains or fails.
+
+## Evaluation helpers
+
+Ferrosa Memory includes helper scripts for BRIGHT-Pro and long-memory eval development:
+
+```bash
+# deterministic harness smoke test
+scripts/run-official-evals.sh --self-test
+
+# tune MCP fusion/decomposition profiles
+FMEM_EVAL_QUERY_DECOMPOSITION=llm \
+FMEM_EVAL_QUERY_EMBED_VARIANTS=true \
+scripts/run-fusion-ablations.sh
+
+# start a resumable full-corpus BRIGHT-Pro MCP ingest
+scripts/start-bright-pro-full-load.sh
+```
+
+The full-corpus loader writes `heartbeat.json`, `progress.json`, and `load.log` under `diagnostics/eval-runs/...` so long runs can be monitored or resumed without attaching to a terminal.
 
 ## Safe stop and restart
 

--- a/docs/ferrosa-memory/index.html
+++ b/docs/ferrosa-memory/index.html
@@ -863,7 +863,7 @@
 <section class="hero">
   <div class="hero-badge"><span class="dot"></span> Ferrosa Memory · Developer Preview</div>
   <h1>Linked memory for <span class="gradient">long-running agents.</span></h1>
-  <p>Ferrosa Memory gives agents a developer-preview memory layer: context segments, entities, temporal facts, graph edges, retrieval, Datalog-style derived facts, and operator UIs for query and visualization.</p>
+  <p>Ferrosa Memory gives agents a developer-preview memory layer: context segments, documents, entities, temporal facts, graph edges, hybrid retrieval, feedback-aware reranking, Datalog-style derived facts, and operator UIs for query, judge configuration, and visualization.</p>
   <div class="hero-actions">
     <a href="getting-started.html" class="btn-primary">Quickstart</a>
     <a href="#workbench" class="btn-secondary">Explore the UI</a>
@@ -875,9 +875,20 @@
   <div class="doc-grid">
     <div class="doc-card"><h3>Temporal facts</h3><p>Record what changed over time instead of overwriting history. Current facts stay easy to retrieve, while superseded facts remain inspectable for audit and debugging.</p></div>
     <div class="doc-card"><h3>Graph links</h3><p>Entities, folds, facts, skills, and tags are connected with typed edges so an agent can follow relationships rather than only search text.</p></div>
-    <div class="doc-card"><h3>Retrieval + context windows</h3><p>Hybrid retrieval is designed to find relevant memories, then expand around raw context segments to recover nearby conversation or artifact context.</p></div>
+    <div class="doc-card"><h3>Retrieval + context windows</h3><p>Hybrid retrieval uses lexical, vector, phonetic, graph, workspace, and recency signals, then can expand around raw context or document chunks to recover neighboring evidence.</p></div>
     <div class="doc-card"><h3>Datalog-style materialization</h3><p>Rules can derive and explain higher-level facts from graph state, making memory behavior easier to inspect than opaque summaries alone.</p></div>
   </div>
+</section>
+<section id="release-notes">
+  <div class="section-label cool">0.13 preview highlights</div>
+  <h2>Long-recall work is now wired into the memory service.</h2>
+  <div class="doc-grid">
+    <div class="doc-card"><h3>Document retrieval plane</h3><p>Documents, sections, chunks, and adjacency links can be stored as typed memory so answers that span neighboring chunks can be traversed instead of relying on a single ranked hit.</p></div>
+    <div class="doc-card"><h3>Candidate fanout + fusion</h3><p>Hybrid search can gather candidates from exact/document IDs, BM25, semantic vectors, phonetic matches, workspace boosts, graph neighbors, and recent session context before fusion.</p></div>
+    <div class="doc-card"><h3>Task-aware decomposition</h3><p>BRIGHT-Pro-style queries can generate task-native subqueries and merge candidate pools before final ranking, improving the support-doc-closed eval slice.</p></div>
+    <div class="doc-card"><h3>Feedback learning loop</h3><p>Agents, users, and optional judge models can send compact item feedback. Abstentions are tracked separately, and future ranking can account for workspace-specific relevance.</p></div>
+  </div>
+  <div class="note">Best known 0.13 BRIGHT-Pro support-doc-closed MCP slice settings: retrieval_k=25, candidate_limit=50, fusion_profile=all, query_decomposition=llm, query_embed_variants=true, chunk_expansion=none, rerank=false. On the 200-document biology slice this measured alpha_nDCG 0.816, NDCG 0.799, aspect_recall 0.940, and recall 0.796.</div>
 </section>
 <section id="architecture">
   <div class="section-label">Architecture</div>
@@ -905,7 +916,7 @@ Ferrosa Database storage + graph</code></pre></div>
   <div class="section-label cool">Workbench and visualization</div>
   <h2>Query memory directly, then inspect what was linked.</h2>
   <div class="doc-grid">
-    <div class="doc-card"><h3>Workbench</h3><p>The browser workbench includes Home, Viz, CQL Explorer, SPARQL Explorer, Datalog Explorer, Aliases, Rules, Approvals, and Explanations.</p></div>
+    <div class="doc-card"><h3>Workbench</h3><p>The browser workbench includes Home, Viz, CQL Explorer, SPARQL Explorer, Datalog Explorer, Judge Config, Aliases, Rules, Approvals, and Explanations.</p></div>
     <div class="doc-card"><h3>Query APIs</h3><p>Use <code>/workbench/api/cql/query</code>, <code>/workbench/api/sparql/query</code>, and <code>/workbench/api/datalog/query</code> while evaluating storage, graph, and derived-memory behavior.</p></div>
     <div class="doc-card"><h3>Visualization</h3><p>The viz surface is served separately from the main memory API. In local developer preview, it is available at <code>http://localhost:18766/viz</code>.</p></div>
   </div>
@@ -924,7 +935,7 @@ Ferrosa Database storage + graph</code></pre></div>
 <section id="quickstart">
   <div class="section-label">Quickstart</div>
   <h2>Local developer preview configuration.</h2>
-  <p style="color:var(--text-secondary); max-width:780px;">For the shortest path, run the hosted memory setup script. It downloads the onboarding prompt, optionally clones or updates the public repositories, offers to pull <code>nomic-embed-text-v2-moe</code>, and hands the user to Hermes, Claude, Codex, or another LLM harness. Minimal native mode can use local filesystem storage with no S3/MinIO; the full Compose mode adds a three-node cluster and MinIO for operator testing.</p>
+  <p style="color:var(--text-secondary); max-width:780px;">For the shortest path, run the hosted memory setup script. It downloads the onboarding prompt, optionally clones or updates the public repositories, offers to pull <code>nomic-embed-text-v2-moe</code>, installs Hermes/Claude/Codex hooks when requested, and hands the user to an LLM harness. Minimal native mode can use local filesystem storage with no S3/MinIO; the full Compose mode adds a three-node cluster and MinIO for operator testing.</p>
   <div class="code-block"><pre><code>curl -fsSL https://ferrosadb.com/setup-memory.sh | bash
 
 # Optional semantic/vector search layer:
@@ -942,6 +953,14 @@ keyspace = "agent_memory"
 [viz]
 enabled = true
 bind = "127.0.0.1:18766"
+
+[retrieval]
+default_limit = 10
+
+[embeddings]
+provider = "ollama"
+model = "nomic-embed-text-v2-moe"
+dimensions = 768
 
 [security]
 # For local preview only. Use TLS + auth mapping for shared deployment.

--- a/docs/index.html
+++ b/docs/index.html
@@ -864,7 +864,7 @@
 <section id="products">
   <div class="section-label">Two products, one storage philosophy</div>
   <h2>Pick the layer that matches your problem.</h2>
-  <p style="color:var(--text-secondary); max-width:780px;">Use Ferrosa Database when you want to evaluate CQL-compatible storage, search, graph, SPARQL, and transactions in one system. Use Ferrosa Memory when you want agents to carry linked context across sessions with temporal facts, graph links, retrieval, and inspectable memory operations.</p>
+  <p style="color:var(--text-secondary); max-width:780px;">Use Ferrosa Database when you want to evaluate CQL-compatible storage, search, graph, SPARQL, and transactions in one system. Use Ferrosa Memory when you want agents to carry linked context across sessions with temporal facts, graph links, document/chunk retrieval, feedback-aware reranking, and inspectable memory operations.</p>
   <div class="suite-grid">
     <a class="suite-card" href="/database/">
       <div class="kicker">Ferrosa Database</div>
@@ -875,9 +875,9 @@
     <a class="suite-card memory" href="/ferrosa-memory/">
       <div class="kicker">Ferrosa Memory</div>
       <h3>Agent memory: durable, linked, queryable context.</h3>
-      <p>A developer-preview memory system for agents: temporal facts, entity graphs, folds, retrieval, Datalog-style materialization, workbench query UIs, and visualization for inspecting what the agent is recording and linking.</p>
+      <p>A developer-preview memory system for agents: temporal facts, entity graphs, folds, document/chunk retrieval, task-aware query decomposition, feedback-aware reranking, Datalog-style materialization, workbench query UIs, and visualization for inspecting what the agent is recording and linking.</p>
       <p style="margin-top:1rem;"><span class="pill">MCP on 18765</span> <span class="pill">Viz on 18766</span></p>
-      <div class="pill-row"><span class="pill">MCP</span><span class="pill">Long context</span><span class="pill">Graph memory</span><span class="pill">Datalog</span><span class="pill">Viz</span></div>
+      <div class="pill-row"><span class="pill">MCP</span><span class="pill">Long context</span><span class="pill">Graph memory</span><span class="pill">Hybrid retrieval</span><span class="pill">Feedback</span><span class="pill">Viz</span></div>
     </a>
   </div>
 </section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Public developer-preview documentation for Ferrosa Database and Ferrosa Memory. 
 ## Products
 
 - [Ferrosa Database](database/) — developer-preview database docs, examples, CQL/Cypher/SPARQL notes, and migration guidance.
-- [Ferrosa Memory](ferrosa-memory/) — developer-preview long-context linked memory for agents.
+- [Ferrosa Memory](ferrosa-memory/) — developer-preview long-context linked memory for agents, including 0.13 document/chunk retrieval, task-aware query decomposition, feedback-aware reranking, and Codex/Claude/Hermes hook onboarding.
 - [Ferrosa Memory Getting Started](ferrosa-memory/getting-started.html) — run the local stack, connect MCP clients, and try memory examples.
 
 ## Database Docs


### PR DESCRIPTION
## Summary

Refresh the Ferrosa website docs for the Ferrosa Memory 0.13 release.

This updates the public docs with:
- Ferrosa Memory 0.13 long-recall highlights: document/chunk retrieval, candidate fanout, task-aware query decomposition, and feedback-aware reranking
- current default/recommended config values: live retrieval default_limit=10, eval retrieval_k=25, Ollama nomic-embed-text-v2-moe embeddings, qwen2.5-coder:7b judge examples with 60s timeout
- Workbench Judge Config coverage
- Codex/Claude/Hermes hook onboarding and compact feedback scoring
- BRIGHT-Pro support-doc-closed slice profile and measured preview metrics
- full-corpus loader heartbeat/progress/log guidance

## Release Notes

Best-known Ferrosa Memory 0.13 BRIGHT-Pro support-doc-closed MCP slice profile documented here:

```text
retrieval_k=25
candidate_limit=50
fusion_profile=all
query_decomposition=llm
query_task=bright_pro
query_variant_limit=5
query_embed_variants=true
chunk_expansion=none
rerank=false
```

Measured on the 200-document biology support-closed slice:
- alpha_nDCG: 0.816
- NDCG: 0.799
- aspect_recall: 0.940
- recall: 0.796

The docs label these as preview slice numbers and note that full-corpus paper comparison requires ingesting the full corpus through the same MCP path.

## Validation

- `git diff --check origin/main...HEAD`
- basic Python `HTMLParser` pass over changed static HTML pages
- `rg` verification for 0.13 defaults, BRIGHT-Pro profile, Judge Config, feedback-aware reranking, and hook onboarding coverage

## Scope

Docs only. This PR was prepared from a clean worktree off `origin/main` so it does not include the repair-scheduler feature stack or unrelated local dirty repair files.
