### PR TITLE
fix(net): advertise internode broadcast hostname to avoid stale Raft membership

### DIFF
--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -252,6 +252,7 @@ pub fn partition_peers_by_dc(
     (local, others)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_recovered_topology_refresh_plan(
     local_host_id: uuid::Uuid,
     local_addr: String,
@@ -260,6 +261,7 @@ pub(super) fn build_recovered_topology_refresh_plan(
     rack: &str,
     peers: &[(uuid::Uuid, SocketAddr)],
     peer_cql_broadcasts: &std::collections::HashMap<uuid::Uuid, Option<String>>,
+    peer_internode_broadcasts: &std::collections::HashMap<uuid::Uuid, Option<String>>,
 ) -> Vec<crate::raft::NodeInfo> {
     let mut plan = Vec::with_capacity(peers.len() + 1);
     plan.push(crate::raft::NodeInfo {
@@ -271,9 +273,14 @@ pub(super) fn build_recovered_topology_refresh_plan(
         cql_broadcast: local_cql_broadcast,
     });
     for (peer_uuid, addr) in peers {
+        // Prefer the re-resolvable advertised internode hostname; fall back to
+        // the observed connection IP only when no hostname was advertised.
+        let peer_internode_broadcast = peer_internode_broadcasts.get(peer_uuid).cloned().flatten();
+        let node_addr =
+            super::membership::node_info_addr(*addr, peer_internode_broadcast.as_deref());
         plan.push(crate::raft::NodeInfo {
             host_id: *peer_uuid,
-            addr: addr.to_string(),
+            addr: node_addr,
             data_center: data_center.to_string(),
             rack: rack.to_string(),
             state: crate::raft::NodeState::Normal,
@@ -528,6 +535,18 @@ impl ModeController {
                 )
             })
             .collect();
+        // Parallel map of advertised internode-broadcast hostnames so the
+        // recovered-topology refresh commits re-resolvable hostnames (not frozen
+        // IPs) for peers, matching what trigger_cluster_join commits on join.
+        let peer_internode_broadcasts: std::collections::HashMap<Uuid, Option<String>> = peers
+            .iter()
+            .map(|(peer_uuid, _)| {
+                (
+                    *peer_uuid,
+                    peer_manager.get_peer_internode_broadcast_sync(*peer_uuid),
+                )
+            })
+            .collect();
 
         // Determine whether this node is the seed (responsible for calling
         // raft.initialize()). The seed is the node with the highest UUID among
@@ -710,7 +729,10 @@ impl ModeController {
         let peer_manager_for_ddl = peer_manager.clone();
         let peer_manager_for_bootstrap = peer_manager.clone();
         let local_host_id_for_refresh = self.local_host_id;
-        let local_addr_for_refresh = self.net_config.broadcast_addr.to_string();
+        // Advertise the re-resolvable internode-broadcast HOSTNAME (when configured)
+        // as this node's own NodeInfo.addr, so the seed/self membership entry is not
+        // frozen to the startup IP and re-resolves across container IP churn.
+        let local_addr_for_refresh = self.net_config.advertised_internode_addr();
         let local_raft_addr_for_init = self.net_config.broadcast_addr;
         let local_cql_broadcast_for_refresh = self.config.cql_broadcast.clone();
 
@@ -732,8 +754,9 @@ impl ModeController {
         } else {
             let mut ring = TokenRing::new();
 
-            // Add local node
-            let broadcast = self.net_config.broadcast_addr.to_string();
+            // Add local node — use the re-resolvable internode-broadcast hostname
+            // (when configured) so the seed entry survives container IP churn.
+            let broadcast = self.net_config.advertised_internode_addr();
             ring.add_node(
                 local_node_id,
                 NodeInfo {
@@ -749,11 +772,16 @@ impl ModeController {
             // Add peers
             for (peer_uuid, addr) in &peers {
                 let peer_node_id = uuid_to_node_id(*peer_uuid);
+                let peer_internode_broadcast =
+                    peer_internode_broadcasts.get(peer_uuid).cloned().flatten();
                 ring.add_node(
                     peer_node_id,
                     NodeInfo {
                         host_id: *peer_uuid,
-                        addr: addr.to_string(),
+                        addr: super::membership::node_info_addr(
+                            *addr,
+                            peer_internode_broadcast.as_deref(),
+                        ),
                         data_center: self.config.data_center.clone(),
                         rack: self.config.rack.clone(),
                         state: NodeState::Normal,
@@ -1574,6 +1602,7 @@ impl ModeController {
                             &config_for_promotion.rack,
                             &peers,
                             &peer_cql_broadcasts,
+                            &peer_internode_broadcasts,
                         );
                         let desired_raft_members = build_raft_members_from_node_info(&refresh_plan);
                         let raft_for_membership_repair = raft_arc.clone();
@@ -1637,6 +1666,7 @@ impl ModeController {
                             &config_for_promotion.rack,
                             &peers,
                             &peer_cql_broadcasts,
+                            &peer_internode_broadcasts,
                         );
                         let token_repair_plan = build_recovered_topology_token_repair_plan(
                             &refresh_plan,
@@ -1735,9 +1765,14 @@ impl ModeController {
 
                         for (peer_uuid, addr) in &peers {
                             let peer_node_id = uuid_to_node_id(*peer_uuid);
+                            let peer_internode_broadcast =
+                                peer_internode_broadcasts.get(peer_uuid).cloned().flatten();
                             let node_info = crate::raft::NodeInfo {
                                 host_id: *peer_uuid,
-                                addr: addr.to_string(),
+                                addr: super::membership::node_info_addr(
+                                    *addr,
+                                    peer_internode_broadcast.as_deref(),
+                                ),
                                 data_center: config_for_promotion.data_center.clone(),
                                 rack: config_for_promotion.rack.clone(),
                                 state: crate::raft::NodeState::Normal,

--- a/ferrosa-cluster/src/controller/membership.rs
+++ b/ferrosa-cluster/src/controller/membership.rs
@@ -20,12 +20,28 @@ fn clear_pending_join(pending_joins: &Arc<Mutex<Vec<Uuid>>>, host_id: Uuid) {
     pending.retain(|id| *id != host_id);
 }
 
+/// Resolve the value stored in `NodeInfo.addr` for a peer.
+///
+/// Prefers the peer's advertised internode-broadcast HOSTNAME so the committed
+/// membership/token-ring entry re-resolves on every reconnect (handling
+/// container IP churn). Falls back to the observed connection `SocketAddr` (a
+/// resolved IP literal) only when no hostname was advertised.
+pub(super) fn node_info_addr(
+    addr: std::net::SocketAddr,
+    internode_broadcast: Option<&str>,
+) -> String {
+    match internode_broadcast {
+        Some(host) if !host.trim().is_empty() => host.to_string(),
+        _ => addr.to_string(),
+    }
+}
+
 fn cluster_member_metadata_changed(
     current: &NodeInfo,
-    addr: std::net::SocketAddr,
+    desired_addr: &str,
     cql_broadcast: Option<&str>,
 ) -> bool {
-    if current.addr != addr.to_string() {
+    if current.addr != desired_addr {
         return true;
     }
 
@@ -36,6 +52,7 @@ fn cluster_member_metadata_changed(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_existing_member_metadata_to_ring(
     ring_holder: &Arc<ArcSwap<Option<Arc<TokenRing>>>>,
     peer_node_id: u64,
@@ -43,10 +60,11 @@ fn apply_existing_member_metadata_to_ring(
     host_id: Uuid,
     addr: std::net::SocketAddr,
     cql_broadcast: Option<String>,
+    internode_broadcast: Option<String>,
 ) -> bool {
-    let desired_addr = addr.to_string();
+    let desired_addr = node_info_addr(addr, internode_broadcast.as_deref());
     let desired_cql_broadcast = cql_broadcast.or_else(|| existing.cql_broadcast.clone());
-    if !cluster_member_metadata_changed(existing, addr, desired_cql_broadcast.as_deref()) {
+    if !cluster_member_metadata_changed(existing, &desired_addr, desired_cql_broadcast.as_deref()) {
         return false;
     }
 
@@ -312,7 +330,12 @@ impl ModeController {
         host_id: Uuid,
         addr: std::net::SocketAddr,
         cql_broadcast: Option<String>,
+        internode_broadcast: Option<String>,
     ) -> bool {
+        // The address committed to membership/the ring is the advertised
+        // internode-broadcast HOSTNAME when present (re-resolvable across IP
+        // churn), else the observed connection IP.
+        let desired_addr = node_info_addr(addr, internode_broadcast.as_deref());
         let peer_manager = self.peer_manager.load().as_ref().as_ref().cloned();
         let has_outbound_peer = peer_manager
             .as_ref()
@@ -325,7 +348,7 @@ impl ModeController {
             .and_then(|ring| ring.get_node(peer_node_id).cloned());
 
         if let Some(existing) = existing_member.as_ref() {
-            if !cluster_member_metadata_changed(existing, addr, cql_broadcast.as_deref())
+            if !cluster_member_metadata_changed(existing, &desired_addr, cql_broadcast.as_deref())
                 && has_outbound_peer
             {
                 tracing::debug!(
@@ -372,6 +395,7 @@ impl ModeController {
         let config_clone = self.config.clone();
         let existing_member = existing_member.clone();
         let cql_broadcast = cql_broadcast.clone();
+        let internode_broadcast = internode_broadcast.clone();
         let peer_manager = peer_manager.clone();
         let net_config = self.net_config.clone();
         let local_host_id = self.local_host_id;
@@ -430,6 +454,7 @@ impl ModeController {
                     host_id,
                     addr,
                     cql_broadcast.clone(),
+                    internode_broadcast.clone(),
                 ) {
                     tracing::info!(
                         peer = %host_id,
@@ -491,7 +516,7 @@ impl ModeController {
                 let refresh_cmd = RaftCommand {
                     op: RaftOp::UpdateNodeInfo(NodeInfo {
                         host_id,
-                        addr: addr.to_string(),
+                        addr: desired_addr.clone(),
                         data_center: existing.data_center,
                         rack: existing.rack,
                         state: existing.state,
@@ -576,7 +601,7 @@ impl ModeController {
             // Propose JoinNode via Raft.
             let node_info = NodeInfo {
                 host_id,
-                addr: addr.to_string(),
+                addr: desired_addr.clone(),
                 data_center: config_clone.data_center.clone(),
                 rack: config_clone.rack.clone(),
                 state: NodeState::Normal,
@@ -649,6 +674,88 @@ mod streaming_contract_tests {
     }
 
     #[test]
+    fn node_info_addr_prefers_advertised_internode_hostname_over_resolved_ip() {
+        // When a peer advertises an internode-broadcast hostname, the committed
+        // NodeInfo.addr must be that re-resolvable hostname, NOT the startup-frozen
+        // IP literal observed on the connection. This is the core fix for stale
+        // membership after container IP churn.
+        let observed: std::net::SocketAddr = "10.89.1.176:7000".parse().unwrap();
+        assert_eq!(
+            super::node_info_addr(observed, Some("node1:7000")),
+            "node1:7000",
+            "advertised internode hostname must win over the resolved connection IP"
+        );
+    }
+
+    #[test]
+    fn node_info_addr_falls_back_to_socket_addr_without_advertised_hostname() {
+        let observed: std::net::SocketAddr = "10.89.1.176:7000".parse().unwrap();
+        assert_eq!(super::node_info_addr(observed, None), "10.89.1.176:7000");
+        assert_eq!(
+            super::node_info_addr(observed, Some("  ")),
+            "10.89.1.176:7000"
+        );
+    }
+
+    #[test]
+    fn existing_member_metadata_refresh_commits_hostname_when_internode_broadcast_present() {
+        // The ring update path must store the hostname (not the resolved IP) so
+        // re-resolution at connect time tracks the live container IP.
+        let host_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let node_id = uuid_to_node_id(host_id);
+        let mut ring = TokenRing::new();
+        ring.add_node(
+            node_id,
+            NodeInfo {
+                host_id,
+                addr: "10.89.1.151:7000".to_string(),
+                data_center: "dc1".to_string(),
+                rack: "rack1".to_string(),
+                state: NodeState::Normal,
+                cql_broadcast: None,
+            },
+        );
+        ring.assign_tokens(node_id, &[100, 200]);
+        let existing = ring.get_node(node_id).unwrap().clone();
+        let ring_holder = Arc::new(ArcSwap::from_pointee(Some(Arc::new(ring))));
+
+        let changed = super::apply_existing_member_metadata_to_ring(
+            &ring_holder,
+            node_id,
+            &existing,
+            host_id,
+            // Observed connection IP differs from the previous committed IP…
+            "10.89.1.201:7000".parse().unwrap(),
+            None,
+            // …but the peer advertises a stable hostname, which must be stored.
+            Some("node1:7000".to_string()),
+        );
+
+        assert!(changed);
+        let updated = ring_holder
+            .load()
+            .as_ref()
+            .as_ref()
+            .unwrap()
+            .get_node(node_id)
+            .unwrap()
+            .clone();
+        assert_eq!(
+            updated.addr, "node1:7000",
+            "committed NodeInfo.addr must be the advertised hostname, not the resolved IP"
+        );
+        assert_eq!(
+            ring_holder
+                .load()
+                .as_ref()
+                .as_ref()
+                .unwrap()
+                .tokens_for_node(node_id),
+            vec![100, 200]
+        );
+    }
+
+    #[test]
     fn existing_member_metadata_refresh_updates_local_ring_snapshot_without_losing_tokens() {
         let host_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
         let node_id = uuid_to_node_id(host_id);
@@ -675,6 +782,7 @@ mod streaming_contract_tests {
             host_id,
             "10.89.1.201:17000".parse().unwrap(),
             Some("127.0.0.1:19045".to_string()),
+            None,
         );
 
         assert!(changed);

--- a/ferrosa-cluster/src/controller/peer_events.rs
+++ b/ferrosa-cluster/src/controller/peer_events.rs
@@ -169,9 +169,11 @@ impl ModeController {
                     host_id,
                     addr,
                     cql_broadcast,
+                    internode_broadcast,
                 } => {
                     tracing::info!(peer = %host_id, "new peer connected in cluster mode, triggering join");
-                    if self.trigger_cluster_join(host_id, addr, cql_broadcast) {
+                    if self.trigger_cluster_join(host_id, addr, cql_broadcast, internode_broadcast)
+                    {
                         join_enqueued_invite = Some(host_id);
                     }
                 }
@@ -232,15 +234,17 @@ impl PeerEventListener for ModeController {
         let _guard = self.transition_guard.lock();
         let current_mode = **self.mode.load();
         let all_peers = self.connected_peers.lock().clone();
-        let cql_broadcast = if matches!(current_mode, DeploymentMode::Cluster) {
-            self.peer_manager
-                .load()
-                .as_ref()
-                .as_ref()
-                .and_then(|pm| pm.get_peer_cql_broadcast_sync(host_id))
-        } else {
-            None
-        };
+        let (cql_broadcast, internode_broadcast) =
+            if matches!(current_mode, DeploymentMode::Cluster) {
+                let pm = self.peer_manager.load();
+                let pm = pm.as_ref().as_ref();
+                (
+                    pm.and_then(|pm| pm.get_peer_cql_broadcast_sync(host_id)),
+                    pm.and_then(|pm| pm.get_peer_internode_broadcast_sync(host_id)),
+                )
+            } else {
+                (None, None)
+            };
         let plan = peer_plan::plan_peer_connected(PeerConnectPlanInput {
             mode: current_mode,
             host_id,
@@ -254,6 +258,7 @@ impl PeerEventListener for ModeController {
             last_invite_sent: self.recent_reconnect_invites.lock().get(&host_id).copied(),
             now: std::time::Instant::now(),
             cql_broadcast,
+            internode_broadcast,
         });
         self.execute_peer_event_plan(plan, &all_peers, false);
 
@@ -340,10 +345,15 @@ impl PeerEventListener for ModeController {
 }
 
 impl InboundPeerCallback for ModeController {
-    fn on_inbound_peer(&self, peer_id: PeerId, cql_broadcast: Option<String>) {
+    fn on_inbound_peer(
+        &self,
+        peer_id: PeerId,
+        cql_broadcast: Option<String>,
+        internode_broadcast: Option<String>,
+    ) {
         let (host_id, addr) = peer_id;
         let reverse_addr = std::net::SocketAddr::new(addr.ip(), self.net_config.bind_addr.port());
-        tracing::info!(peer = %host_id, %addr, ?cql_broadcast, "inbound peer connected");
+        tracing::info!(peer = %host_id, %addr, ?cql_broadcast, ?internode_broadcast, "inbound peer connected");
 
         // Store the peer's CQL broadcast address (from handshake) in PeerManager
         // so system.peers can return it instead of the container-internal IP.
@@ -355,6 +365,22 @@ impl InboundPeerCallback for ModeController {
                 ferrosa_net::task_pool::TaskPool::current("peer-cql-broadcast").spawn(async move {
                     pm.set_peer_cql_broadcast(hid, broadcast).await;
                 });
+            }
+        }
+
+        // Store the peer's internode broadcast hostname so the outbound
+        // on_peer_connected path (which reads it back) and committed membership
+        // use the re-resolvable hostname instead of a frozen IP.
+        if let Some(ref broadcast) = internode_broadcast {
+            if let Some(pm) = &**self.peer_manager.load() {
+                let pm = pm.clone();
+                let hid = host_id;
+                let broadcast = broadcast.clone();
+                ferrosa_net::task_pool::TaskPool::current("peer-internode-broadcast").spawn(
+                    async move {
+                        pm.set_peer_internode_broadcast(hid, broadcast).await;
+                    },
+                );
             }
         }
         if let Some(pm) = &**self.peer_manager.load() {
@@ -405,6 +431,7 @@ impl InboundPeerCallback for ModeController {
             last_invite_sent: self.recent_reconnect_invites.lock().get(&host_id).copied(),
             now: std::time::Instant::now(),
             cql_broadcast,
+            internode_broadcast,
         });
         self.execute_peer_event_plan(plan, &all_peers, true);
     }

--- a/ferrosa-cluster/src/controller/peer_plan.rs
+++ b/ferrosa-cluster/src/controller/peer_plan.rs
@@ -28,6 +28,7 @@ pub(super) enum PeerEventAction {
         host_id: Uuid,
         addr: SocketAddr,
         cql_broadcast: Option<String>,
+        internode_broadcast: Option<String>,
     },
     SendClusterInvite {
         host_id: Uuid,
@@ -51,6 +52,7 @@ pub(super) struct PeerConnectPlanInput {
     pub(super) last_invite_sent: Option<Instant>,
     pub(super) now: Instant,
     pub(super) cql_broadcast: Option<String>,
+    pub(super) internode_broadcast: Option<String>,
 }
 
 #[cfg(test)]
@@ -64,6 +66,7 @@ pub(super) struct ConnectedPeerInput {
     pub(super) join_enqueued: bool,
     pub(super) last_reconnect_invite_sent: Option<Instant>,
     pub(super) cql_broadcast: Option<String>,
+    pub(super) internode_broadcast: Option<String>,
     pub(super) now: Instant,
 }
 
@@ -100,6 +103,7 @@ pub(super) fn plan_connected_peer(input: ConnectedPeerInput) -> ConnectedPeerPla
             last_invite_sent: input.last_reconnect_invite_sent,
             now: input.now,
             cql_broadcast: input.cql_broadcast,
+            internode_broadcast: input.internode_broadcast,
         })
         .into_iter()
         .filter(|action| !matches!(action, PeerEventAction::TrackPeer { .. }))
@@ -129,6 +133,7 @@ pub(super) fn plan_peer_connected(input: PeerConnectPlanInput) -> Vec<PeerEventA
                 host_id: input.host_id,
                 addr: input.addr,
                 cql_broadcast: input.cql_broadcast,
+                internode_broadcast: input.internode_broadcast,
             });
             if should_send_cluster_invite(input.join_enqueued, input.last_invite_sent, input.now) {
                 actions.push(PeerEventAction::SendClusterInvite {
@@ -229,6 +234,7 @@ mod tests {
             last_invite_sent: None,
             now,
             cql_broadcast: Some("127.0.0.1:9043".to_string()),
+            internode_broadcast: Some("peer-node:7001".to_string()),
         });
 
         assert_eq!(
@@ -242,6 +248,7 @@ mod tests {
                     host_id: peer,
                     addr: addr(7001),
                     cql_broadcast: Some("127.0.0.1:9043".to_string()),
+                    internode_broadcast: Some("peer-node:7001".to_string()),
                 },
                 PeerEventAction::SendClusterInvite {
                     host_id: peer,
@@ -267,12 +274,14 @@ mod tests {
             last_invite_sent: Some(now),
             now,
             cql_broadcast: None,
+            internode_broadcast: None,
         });
 
         assert!(actions.contains(&PeerEventAction::TriggerClusterJoin {
             host_id: peer,
             addr: addr(7001),
             cql_broadcast: None,
+            internode_broadcast: None,
         }));
         assert!(
             !actions.iter().any(|action| matches!(
@@ -301,6 +310,7 @@ mod tests {
             last_invite_sent: None,
             now,
             cql_broadcast: None,
+            internode_broadcast: None,
         });
         assert!(!no_quorum.contains(&PeerEventAction::RestoreClusterMode));
 
@@ -315,6 +325,7 @@ mod tests {
             last_invite_sent: None,
             now,
             cql_broadcast: None,
+            internode_broadcast: None,
         });
         assert!(quorum.contains(&PeerEventAction::RestoreClusterMode));
     }

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -224,7 +224,7 @@ async fn promote_from_degraded_pair_restores_writes() {
 
     // Enter pair mode via inbound connection. Lower host-id wins primary.
     let peer_addr: SocketAddr = "127.0.0.1:7000".parse().unwrap();
-    controller.on_inbound_peer((peer_id, peer_addr), None);
+    controller.on_inbound_peer((peer_id, peer_addr), None, None);
     assert_eq!(controller.mode(), DeploymentMode::Pair);
     assert_eq!(controller.role(), Some(PairRole::Primary));
 
@@ -273,7 +273,7 @@ async fn degraded_pair_serves_stale_reads() {
 
     // Enter pair mode
     let peer_addr: SocketAddr = "127.0.0.1:7000".parse().unwrap();
-    controller.on_inbound_peer((peer_id, peer_addr), None);
+    controller.on_inbound_peer((peer_id, peer_addr), None, None);
     assert_eq!(controller.mode(), DeploymentMode::Pair);
 
     // Peer disconnects → DegradedPair
@@ -849,6 +849,7 @@ fn peer_event_plan_cluster_connect_existing_member_triggers_join_and_invite() {
         join_enqueued: false,
         last_reconnect_invite_sent: None,
         cql_broadcast: Some("127.0.0.1:38043".to_string()),
+        internode_broadcast: Some("peer-node:7000".to_string()),
         now,
     });
 
@@ -859,6 +860,7 @@ fn peer_event_plan_cluster_connect_existing_member_triggers_join_and_invite() {
                 host_id: peer,
                 addr,
                 cql_broadcast: Some("127.0.0.1:38043".to_string()),
+                internode_broadcast: Some("peer-node:7000".to_string()),
             },
             super::peer_plan::PeerEventAction::SendClusterInvite {
                 host_id: peer,
@@ -885,6 +887,7 @@ fn peer_event_plan_cluster_connect_suppresses_duplicate_invite_with_recent_reser
         join_enqueued: false,
         last_reconnect_invite_sent: Some(now),
         cql_broadcast: None,
+        internode_broadcast: None,
         now,
     });
 
@@ -894,6 +897,7 @@ fn peer_event_plan_cluster_connect_suppresses_duplicate_invite_with_recent_reser
             host_id: peer,
             addr,
             cql_broadcast: None,
+            internode_broadcast: None,
         }));
     assert!(
         !plan.actions.iter().any(|action| matches!(
@@ -919,6 +923,7 @@ fn peer_event_plan_degraded_cluster_restores_only_after_committed_quorum() {
         join_enqueued: false,
         last_reconnect_invite_sent: None,
         cql_broadcast: None,
+        internode_broadcast: None,
         now,
     };
     let still_degraded = super::peer_plan::plan_connected_peer(below_quorum.clone());
@@ -1048,6 +1053,10 @@ fn recovered_topology_refresh_plan_uses_current_live_addresses() {
     let peers = vec![(peer_host_id, "10.89.5.18:7000".parse().unwrap())];
     let peer_cql_broadcasts =
         std::collections::HashMap::from([(peer_host_id, Some("127.0.0.1:38043".to_string()))]);
+    // The peer advertised a re-resolvable internode hostname — the recovered
+    // refresh plan must commit that hostname, not the observed IP.
+    let peer_internode_broadcasts =
+        std::collections::HashMap::from([(peer_host_id, Some("peer-node:7000".to_string()))]);
 
     let plan = build_recovered_topology_refresh_plan(
         local_host_id,
@@ -1057,6 +1066,7 @@ fn recovered_topology_refresh_plan_uses_current_live_addresses() {
         "rack1",
         &peers,
         &peer_cql_broadcasts,
+        &peer_internode_broadcasts,
     );
 
     assert_eq!(plan.len(), 2);
@@ -1065,7 +1075,10 @@ fn recovered_topology_refresh_plan_uses_current_live_addresses() {
     assert_eq!(plan[0].cql_broadcast.as_deref(), Some("127.0.0.1:38042"));
 
     assert_eq!(plan[1].host_id, peer_host_id);
-    assert_eq!(plan[1].addr, "10.89.5.18:7000");
+    assert_eq!(
+        plan[1].addr, "peer-node:7000",
+        "recovered topology must commit the advertised internode hostname, not the observed IP"
+    );
     assert_eq!(plan[1].cql_broadcast.as_deref(), Some("127.0.0.1:38043"));
 }
 
@@ -1075,6 +1088,7 @@ fn recovered_topology_refresh_plan_repairs_tokens_for_every_voter() {
     let peer_host_id = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
     let peers = vec![(peer_host_id, "10.89.5.18:7000".parse().unwrap())];
     let peer_cql_broadcasts = std::collections::HashMap::new();
+    let peer_internode_broadcasts = std::collections::HashMap::new();
     let num_tokens = 4;
 
     let refresh_plan = build_recovered_topology_refresh_plan(
@@ -1085,6 +1099,7 @@ fn recovered_topology_refresh_plan_repairs_tokens_for_every_voter() {
         "rack1",
         &peers,
         &peer_cql_broadcasts,
+        &peer_internode_broadcasts,
     );
     let token_plan = build_recovered_topology_token_repair_plan(&refresh_plan, num_tokens);
 
@@ -1585,6 +1600,7 @@ async fn existing_inbound_cluster_member_with_ephemeral_source_port_does_not_que
     controller.on_inbound_peer(
         (peer2_id, std::net::SocketAddr::new(peer2_addr.ip(), 50318)),
         None,
+        None,
     );
 
     let pending = controller.pending_joins.lock();
@@ -1746,7 +1762,7 @@ async fn reverse_inbound_race_does_not_promote_joiner_to_primary() {
 
     // Live 38xxx shape: the seed's reverse inbound arrives on an ephemeral
     // port before the joiner's canonical outbound `:7000` peer-connected event.
-    controller.on_inbound_peer((peer_id, "10.0.0.1:40370".parse().unwrap()), None);
+    controller.on_inbound_peer((peer_id, "10.0.0.1:40370".parse().unwrap()), None, None);
     assert_eq!(controller.mode(), DeploymentMode::Pair);
     assert_eq!(
         controller.role(),
@@ -2127,7 +2143,7 @@ async fn standalone_inbound_peer_transitions_to_pair() {
 
     // Inbound connection — should also transition, not reject.
     use ferrosa_net::rpc::InboundPeerCallback;
-    controller.on_inbound_peer((peer_id, "10.0.0.2:7000".parse().unwrap()), None);
+    controller.on_inbound_peer((peer_id, "10.0.0.2:7000".parse().unwrap()), None, None);
 
     assert_eq!(
         controller.mode(),

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -459,7 +459,13 @@ impl PeerEventListener for NoopPeerListener {
 }
 
 impl InboundPeerCallback for NoopPeerListener {
-    fn on_inbound_peer(&self, _peer_id: PeerId, _cql_broadcast: Option<String>) {}
+    fn on_inbound_peer(
+        &self,
+        _peer_id: PeerId,
+        _cql_broadcast: Option<String>,
+        _internode_broadcast: Option<String>,
+    ) {
+    }
 }
 
 struct RemoteAnchorHandler {

--- a/ferrosa-net/src/config.rs
+++ b/ferrosa-net/src/config.rs
@@ -48,6 +48,12 @@ pub struct NetConfig {
     /// CQL broadcast address advertised to peers during handshake.
     /// Peers use this for `system.peers.native_address`.
     pub cql_broadcast: Option<String>,
+    /// Raw, unresolved internode broadcast target (hostname:port) advertised to
+    /// peers during the handshake. Unlike [`Self::broadcast_addr`], this preserves
+    /// the configured `FERROSA_INTERNODE_BROADCAST` hostname so peers store the
+    /// hostname (not a startup-frozen IP) in `NodeInfo.addr` and re-resolve it on
+    /// every reconnect — handling container IP churn without stale membership.
+    pub internode_broadcast: Option<String>,
 }
 
 impl Default for NetConfig {
@@ -76,6 +82,7 @@ impl Default for NetConfig {
             tls_ca_path: None,
             require_tls: false,
             cql_broadcast: None,
+            internode_broadcast: None,
         }
     }
 }
@@ -105,6 +112,18 @@ impl NetConfig {
             .map(Duration::from_millis)
     }
 
+    /// The internode address this node advertises to peers for `NodeInfo.addr`.
+    ///
+    /// Prefers the raw, re-resolvable [`Self::internode_broadcast`] hostname when
+    /// configured; otherwise falls back to the resolved [`Self::broadcast_addr`].
+    /// Storing the hostname lets peers re-resolve it on every reconnect, so a
+    /// container IP change is handled without stale committed membership.
+    pub fn advertised_internode_addr(&self) -> String {
+        self.internode_broadcast
+            .clone()
+            .unwrap_or_else(|| self.broadcast_addr.to_string())
+    }
+
     pub fn lane_timeout(&self, lane: Lane) -> Duration {
         match lane {
             Lane::Raft => self.raft_lane_timeout,
@@ -125,6 +144,13 @@ impl NetConfig {
         if let Ok(v) = std::env::var("FERROSA_INTERNODE_BROADCAST") {
             if let Some(addr) = Self::parse_socket_addr(&v) {
                 cfg.broadcast_addr = addr;
+            }
+            // Preserve the RAW (unresolved) hostname:port so it can be advertised
+            // to peers and re-resolved on every reconnect. We keep it even for IP
+            // literals — harmless, since re-resolving an IP is a no-op.
+            let trimmed = v.trim();
+            if !trimmed.is_empty() {
+                cfg.internode_broadcast = Some(trimmed.to_string());
             }
         }
         if let Ok(v) = std::env::var("FERROSA_SEED") {

--- a/ferrosa-net/src/handshake.rs
+++ b/ferrosa-net/src/handshake.rs
@@ -14,6 +14,18 @@ type HmacSha256 = Hmac<Sha256>;
 /// Current protocol version.
 pub const PROTOCOL_VERSION: u8 = 1;
 
+/// Peer metadata learned from a completed handshake.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HandshakePeer {
+    /// The peer's stable host UUID.
+    pub host_id: Uuid,
+    /// The peer's advertised CQL broadcast address (host:port), if any.
+    pub cql_broadcast: Option<String>,
+    /// The peer's advertised internode broadcast hostname (host:port), if any.
+    /// When present, this is the re-resolvable target stored in `NodeInfo.addr`.
+    pub internode_broadcast: Option<String>,
+}
+
 /// Compute PSK auth token: HMAC-SHA256(key=psk, data=cluster_name|host_id|nonce).
 pub fn compute_auth_token(cluster_name: &str, host_id: &Uuid, nonce: u64, psk: &str) -> Vec<u8> {
     let mut mac = HmacSha256::new_from_slice(psk.as_bytes()).expect("HMAC accepts any key length");
@@ -40,12 +52,12 @@ pub fn verify_auth_token(
 
 /// Run initiator side of handshake over a framed connection.
 ///
-/// Returns `(peer_host_id, peer_cql_broadcast)` on success.
+/// Returns the peer's [`HandshakePeer`] metadata on success.
 pub async fn initiate_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>(
     framed: &mut Framed<T, InternodeCodec>,
     config: &NetConfig,
     local_host_id: Uuid,
-) -> Result<(Uuid, Option<String>)> {
+) -> Result<HandshakePeer> {
     use futures::{SinkExt, StreamExt};
 
     let nonce: u64 = rand::random();
@@ -66,6 +78,7 @@ pub async fn initiate_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite 
         supported_compression: vec![0],
         auth_token,
         cql_broadcast: config.cql_broadcast.clone(),
+        internode_broadcast: config.internode_broadcast.clone(),
     };
     let mut body = BytesMut::new();
     handshake.encode(&mut body)?;
@@ -93,10 +106,15 @@ pub async fn initiate_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite 
             accepted,
             reason,
             cql_broadcast,
+            internode_broadcast,
             ..
         } => {
             if accepted {
-                Ok((host_id, cql_broadcast))
+                Ok(HandshakePeer {
+                    host_id,
+                    cql_broadcast,
+                    internode_broadcast,
+                })
             } else {
                 Err(NetError::HandshakeFailed(reason))
             }
@@ -107,12 +125,12 @@ pub async fn initiate_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite 
 
 /// Run acceptor side of handshake over a framed connection.
 ///
-/// Returns `(peer_host_id, peer_cql_broadcast)` on success.
+/// Returns the peer's [`HandshakePeer`] metadata on success.
 pub async fn accept_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>(
     framed: &mut Framed<T, InternodeCodec>,
     config: &NetConfig,
     local_host_id: Uuid,
-) -> Result<(Uuid, Option<String>)> {
+) -> Result<HandshakePeer> {
     use futures::StreamExt;
 
     let hs_frame = framed
@@ -121,13 +139,21 @@ pub async fn accept_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + 
         .ok_or_else(|| NetError::HandshakeFailed("connection closed".into()))??;
     let hs = Message::decode(hs_frame.header.msg_type, &mut hs_frame.body.clone())?;
 
-    let (peer_host_id, peer_cluster, peer_version, peer_token, peer_cql_broadcast) = match hs {
+    let (
+        peer_host_id,
+        peer_cluster,
+        peer_version,
+        peer_token,
+        peer_cql_broadcast,
+        peer_internode_broadcast,
+    ) = match hs {
         Message::Handshake {
             cluster_name,
             host_id,
             protocol_version,
             auth_token,
             cql_broadcast,
+            internode_broadcast,
             ..
         } => (
             host_id,
@@ -135,6 +161,7 @@ pub async fn accept_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + 
             protocol_version,
             auth_token,
             cql_broadcast,
+            internode_broadcast,
         ),
         _ => return Err(NetError::Protocol("expected Handshake".into())),
     };
@@ -144,21 +171,44 @@ pub async fn accept_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + 
             "cluster mismatch: expected '{}', got '{}'",
             config.cluster_name, peer_cluster
         );
-        send_handshake_ack(framed, local_host_id, false, &reason, &config.cql_broadcast).await?;
+        send_handshake_ack(
+            framed,
+            local_host_id,
+            false,
+            &reason,
+            &config.cql_broadcast,
+            &config.internode_broadcast,
+        )
+        .await?;
         return Err(NetError::HandshakeFailed(reason));
     }
 
     if peer_version != PROTOCOL_VERSION {
         let reason = format!("unsupported protocol version: {}", peer_version);
-        send_handshake_ack(framed, local_host_id, false, &reason, &config.cql_broadcast).await?;
+        send_handshake_ack(
+            framed,
+            local_host_id,
+            false,
+            &reason,
+            &config.cql_broadcast,
+            &config.internode_broadcast,
+        )
+        .await?;
         return Err(NetError::HandshakeFailed(reason));
     }
 
     if let Some(psk) = &config.psk {
         if peer_token.len() < 40 {
             let reason = "auth token too short".to_string();
-            send_handshake_ack(framed, local_host_id, false, &reason, &config.cql_broadcast)
-                .await?;
+            send_handshake_ack(
+                framed,
+                local_host_id,
+                false,
+                &reason,
+                &config.cql_broadcast,
+                &config.internode_broadcast,
+            )
+            .await?;
             return Err(NetError::HandshakeFailed(reason));
         }
         let nonce = u64::from_be_bytes(peer_token[..8].try_into().unwrap());
@@ -170,14 +220,33 @@ pub async fn accept_handshake<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + 
             &peer_token[8..],
         ) {
             let reason = "PSK authentication failed".to_string();
-            send_handshake_ack(framed, local_host_id, false, &reason, &config.cql_broadcast)
-                .await?;
+            send_handshake_ack(
+                framed,
+                local_host_id,
+                false,
+                &reason,
+                &config.cql_broadcast,
+                &config.internode_broadcast,
+            )
+            .await?;
             return Err(NetError::HandshakeFailed(reason));
         }
     }
 
-    send_handshake_ack(framed, local_host_id, true, "", &config.cql_broadcast).await?;
-    Ok((peer_host_id, peer_cql_broadcast))
+    send_handshake_ack(
+        framed,
+        local_host_id,
+        true,
+        "",
+        &config.cql_broadcast,
+        &config.internode_broadcast,
+    )
+    .await?;
+    Ok(HandshakePeer {
+        host_id: peer_host_id,
+        cql_broadcast: peer_cql_broadcast,
+        internode_broadcast: peer_internode_broadcast,
+    })
 }
 
 async fn send_handshake_ack<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>(
@@ -186,6 +255,7 @@ async fn send_handshake_ack<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Un
     accepted: bool,
     reason: &str,
     cql_broadcast: &Option<String>,
+    internode_broadcast: &Option<String>,
 ) -> Result<()> {
     use futures::SinkExt;
     let ack = Message::HandshakeAck {
@@ -195,6 +265,7 @@ async fn send_handshake_ack<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Un
         accepted,
         reason: reason.to_string(),
         cql_broadcast: cql_broadcast.clone(),
+        internode_broadcast: internode_broadcast.clone(),
     };
     let mut body = BytesMut::new();
     ack.encode(&mut body)?;
@@ -245,8 +316,8 @@ mod tests {
         let server_fut = accept_handshake(&mut server_framed, &config, server_id);
 
         let (client_res, server_res) = tokio::join!(client_fut, server_fut);
-        assert_eq!(client_res.unwrap().0, server_id);
-        assert_eq!(server_res.unwrap().0, client_id);
+        assert_eq!(client_res.unwrap().host_id, server_id);
+        assert_eq!(server_res.unwrap().host_id, client_id);
     }
 
     #[tokio::test]
@@ -309,8 +380,8 @@ mod tests {
         let server_fut = accept_handshake(&mut server_framed, &config, server_id);
 
         let (client_res, server_res) = tokio::join!(client_fut, server_fut);
-        assert_eq!(client_res.unwrap().0, server_id);
-        assert_eq!(server_res.unwrap().0, client_id);
+        assert_eq!(client_res.unwrap().host_id, server_id);
+        assert_eq!(server_res.unwrap().host_id, client_id);
     }
 
     #[tokio::test]
@@ -337,13 +408,52 @@ mod tests {
         let server_fut = accept_handshake(&mut server_framed, &server_config, server_id);
 
         let (client_res, server_res) = tokio::join!(client_fut, server_fut);
-        let (peer_id, peer_broadcast) = client_res.unwrap();
-        assert_eq!(peer_id, server_id);
-        assert_eq!(peer_broadcast, Some("server-host:19042".into()));
+        let client_peer = client_res.unwrap();
+        assert_eq!(client_peer.host_id, server_id);
+        assert_eq!(client_peer.cql_broadcast, Some("server-host:19042".into()));
 
-        let (peer_id, peer_broadcast) = server_res.unwrap();
-        assert_eq!(peer_id, client_id);
-        assert_eq!(peer_broadcast, Some("client-host:19042".into()));
+        let server_peer = server_res.unwrap();
+        assert_eq!(server_peer.host_id, client_id);
+        assert_eq!(server_peer.cql_broadcast, Some("client-host:19042".into()));
+    }
+
+    #[tokio::test]
+    async fn handshake_exchanges_internode_broadcast() {
+        let (client_io, server_io) = duplex(8192);
+        let mut client_config = test_config("ferrosa", None);
+        client_config.internode_broadcast = Some("client-node:17000".into());
+        let mut server_config = test_config("ferrosa", None);
+        server_config.internode_broadcast = Some("server-node:17000".into());
+
+        let client_id = Uuid::new_v4();
+        let server_id = Uuid::new_v4();
+
+        let mut client_framed = Framed::new(
+            client_io,
+            InternodeCodec::new(client_config.max_frame_body_size),
+        );
+        let mut server_framed = Framed::new(
+            server_io,
+            InternodeCodec::new(server_config.max_frame_body_size),
+        );
+
+        let client_fut = initiate_handshake(&mut client_framed, &client_config, client_id);
+        let server_fut = accept_handshake(&mut server_framed, &server_config, server_id);
+
+        let (client_res, server_res) = tokio::join!(client_fut, server_fut);
+        let client_peer = client_res.unwrap();
+        assert_eq!(client_peer.host_id, server_id);
+        assert_eq!(
+            client_peer.internode_broadcast,
+            Some("server-node:17000".into())
+        );
+
+        let server_peer = server_res.unwrap();
+        assert_eq!(server_peer.host_id, client_id);
+        assert_eq!(
+            server_peer.internode_broadcast,
+            Some("client-node:17000".into())
+        );
     }
 
     #[tokio::test]
@@ -363,13 +473,15 @@ mod tests {
         let server_fut = accept_handshake(&mut server_framed, &config, server_id);
 
         let (client_res, server_res) = tokio::join!(client_fut, server_fut);
-        let (peer_id, peer_broadcast) = client_res.unwrap();
-        assert_eq!(peer_id, server_id);
-        assert_eq!(peer_broadcast, None);
+        let client_peer = client_res.unwrap();
+        assert_eq!(client_peer.host_id, server_id);
+        assert_eq!(client_peer.cql_broadcast, None);
+        assert_eq!(client_peer.internode_broadcast, None);
 
-        let (peer_id, peer_broadcast) = server_res.unwrap();
-        assert_eq!(peer_id, client_id);
-        assert_eq!(peer_broadcast, None);
+        let server_peer = server_res.unwrap();
+        assert_eq!(server_peer.host_id, client_id);
+        assert_eq!(server_peer.cql_broadcast, None);
+        assert_eq!(server_peer.internode_broadcast, None);
     }
 
     #[tokio::test]
@@ -386,6 +498,7 @@ mod tests {
             supported_compression: vec![0],
             auth_token: vec![],
             cql_broadcast: None,
+            internode_broadcast: None,
         };
         use futures::SinkExt;
         let mut body = BytesMut::new();

--- a/ferrosa-net/src/message.rs
+++ b/ferrosa-net/src/message.rs
@@ -47,6 +47,37 @@ fn put_bytes(buf: &mut BytesMut, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// Encode an optional, length-prefixed string as a presence marker byte
+/// (`1` = present, `0` = absent) followed by the string when present.
+fn put_optional_string(buf: &mut BytesMut, value: &Option<String>) -> Result<()> {
+    match value {
+        Some(s) => {
+            buf.put_u8(1);
+            put_string(buf, s)?;
+        }
+        None => {
+            buf.put_u8(0);
+        }
+    }
+    Ok(())
+}
+
+/// Decode an optional, length-prefixed string written by [`put_optional_string`].
+///
+/// Returns `None` when the buffer is exhausted (a pre-extension peer that did
+/// not write this trailing field), preserving backward compatibility.
+fn get_optional_string(buf: &mut Bytes) -> Result<Option<String>> {
+    if buf.remaining() == 0 {
+        return Ok(None);
+    }
+    let marker = buf.get_u8();
+    if marker == 1 {
+        Ok(Some(get_string(buf)?))
+    } else {
+        Ok(None)
+    }
+}
+
 fn get_bytes(buf: &mut Bytes) -> Result<Vec<u8>> {
     if buf.remaining() < 4 {
         return Err(NetError::Protocol("truncated bytes length".into()));
@@ -69,6 +100,9 @@ pub enum Message {
         supported_compression: Vec<u8>, // 0=none, 1=lz4, 2=snappy
         auth_token: Vec<u8>,
         cql_broadcast: Option<String>,
+        /// Raw internode broadcast hostname:port (re-resolvable). Peers store
+        /// this in `NodeInfo.addr` so they can re-resolve it across IP churn.
+        internode_broadcast: Option<String>,
     },
     HandshakeAck {
         host_id: Uuid,
@@ -77,6 +111,9 @@ pub enum Message {
         accepted: bool,
         reason: String,
         cql_broadcast: Option<String>,
+        /// Raw internode broadcast hostname:port (re-resolvable). Peers store
+        /// this in `NodeInfo.addr` so they can re-resolve it across IP churn.
+        internode_broadcast: Option<String>,
     },
     Ping {
         nonce: u64,
@@ -347,6 +384,7 @@ impl Message {
                 supported_compression,
                 auth_token,
                 cql_broadcast,
+                internode_broadcast,
             } => {
                 put_string(buf, cluster_name)?;
                 put_uuid(buf, host_id);
@@ -357,15 +395,10 @@ impl Message {
                 buf.put_slice(supported_compression);
                 put_bytes(buf, auth_token)?;
                 // Optional CQL broadcast address (v1 extension — safe to add after auth_token)
-                match cql_broadcast {
-                    Some(addr) => {
-                        buf.put_u8(1);
-                        put_string(buf, addr)?;
-                    }
-                    None => {
-                        buf.put_u8(0);
-                    }
-                }
+                put_optional_string(buf, cql_broadcast)?;
+                // Optional internode broadcast hostname (v1 extension — appended
+                // after cql_broadcast; absent on pre-extension peers)
+                put_optional_string(buf, internode_broadcast)?;
             }
             Self::HandshakeAck {
                 host_id,
@@ -374,6 +407,7 @@ impl Message {
                 accepted,
                 reason,
                 cql_broadcast,
+                internode_broadcast,
             } => {
                 put_uuid(buf, host_id);
                 buf.put_u8(*protocol_version);
@@ -381,15 +415,9 @@ impl Message {
                 buf.put_u8(if *accepted { 1 } else { 0 });
                 put_string(buf, reason)?;
                 // Optional CQL broadcast address (v1 extension)
-                match cql_broadcast {
-                    Some(addr) => {
-                        buf.put_u8(1);
-                        put_string(buf, addr)?;
-                    }
-                    None => {
-                        buf.put_u8(0);
-                    }
-                }
+                put_optional_string(buf, cql_broadcast)?;
+                // Optional internode broadcast hostname (v1 extension)
+                put_optional_string(buf, internode_broadcast)?;
             }
             Self::Ping { nonce, sent_at } => {
                 buf.put_u64(*nonce);
@@ -518,16 +546,9 @@ impl Message {
                 let supported_compression = body.split_to(comp_len).to_vec();
                 let auth_token = get_bytes(body)?;
                 // Optional CQL broadcast address (v1 extension)
-                let cql_broadcast = if body.remaining() > 0 {
-                    let marker = body.get_u8();
-                    if marker == 1 {
-                        Some(get_string(body)?)
-                    } else {
-                        None
-                    }
-                } else {
-                    None // pre-extension peer — no broadcast field
-                };
+                let cql_broadcast = get_optional_string(body)?;
+                // Optional internode broadcast hostname (v1 extension)
+                let internode_broadcast = get_optional_string(body)?;
                 Self::Handshake {
                     cluster_name,
                     host_id,
@@ -535,6 +556,7 @@ impl Message {
                     supported_compression,
                     auth_token,
                     cql_broadcast,
+                    internode_broadcast,
                 }
             }
             MsgType::HandshakeAck => {
@@ -547,16 +569,9 @@ impl Message {
                 let accepted = body.get_u8() != 0;
                 let reason = get_string(body)?;
                 // Optional CQL broadcast address (v1 extension)
-                let cql_broadcast = if body.remaining() > 0 {
-                    let marker = body.get_u8();
-                    if marker == 1 {
-                        Some(get_string(body)?)
-                    } else {
-                        None
-                    }
-                } else {
-                    None // pre-extension peer — no broadcast field
-                };
+                let cql_broadcast = get_optional_string(body)?;
+                // Optional internode broadcast hostname (v1 extension)
+                let internode_broadcast = get_optional_string(body)?;
                 Self::HandshakeAck {
                     host_id,
                     protocol_version,
@@ -564,6 +579,7 @@ impl Message {
                     accepted,
                     reason,
                     cql_broadcast,
+                    internode_broadcast,
                 }
             }
             MsgType::Ping => {
@@ -774,6 +790,7 @@ mod tests {
             supported_compression: vec![0, 1], // none + lz4
             auth_token: vec![0xAB; 32],
             cql_broadcast: Some("host:19042".into()),
+            internode_broadcast: Some("host:17000".into()),
         };
         let mut buf = BytesMut::new();
         msg.encode(&mut buf).unwrap();
@@ -790,6 +807,7 @@ mod tests {
             supported_compression: vec![0],
             auth_token: vec![],
             cql_broadcast: None,
+            internode_broadcast: None,
         };
         let mut buf = BytesMut::new();
         msg.encode(&mut buf).unwrap();
@@ -806,6 +824,7 @@ mod tests {
             accepted: true,
             reason: String::new(),
             cql_broadcast: Some("192.168.1.5:19042".into()),
+            internode_broadcast: Some("192.168.1.5:17000".into()),
         };
         let mut buf = BytesMut::new();
         msg.encode(&mut buf).unwrap();
@@ -831,6 +850,7 @@ mod tests {
         match decoded {
             Message::Handshake {
                 cql_broadcast,
+                internode_broadcast,
                 cluster_name,
                 host_id: decoded_id,
                 ..
@@ -838,6 +858,38 @@ mod tests {
                 assert_eq!(cluster_name, "ferrosa");
                 assert_eq!(decoded_id, host_id);
                 assert_eq!(cql_broadcast, None);
+                assert_eq!(internode_broadcast, None);
+            }
+            other => panic!("expected Handshake, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn handshake_backward_compat_cql_present_internode_absent() {
+        // A peer that advertises cql_broadcast but predates the
+        // internode_broadcast field: the trailing internode marker is missing.
+        // Decode must yield the cql_broadcast and a None internode_broadcast.
+        let host_id = Uuid::new_v4();
+        let mut buf = BytesMut::new();
+        put_string(&mut buf, "ferrosa").unwrap();
+        put_uuid(&mut buf, &host_id);
+        buf.put_u8(1); // protocol_version
+        buf.put_u8(1); // compression list length
+        buf.put_u8(0); // supported_compression[0] = none
+        put_bytes(&mut buf, &[]).unwrap(); // auth_token (empty)
+        buf.put_u8(1); // cql_broadcast present
+        put_string(&mut buf, "10.0.0.1:19042").unwrap();
+        // No trailing internode_broadcast marker.
+
+        let decoded = Message::decode(MsgType::Handshake, &mut buf.freeze()).unwrap();
+        match decoded {
+            Message::Handshake {
+                cql_broadcast,
+                internode_broadcast,
+                ..
+            } => {
+                assert_eq!(cql_broadcast.as_deref(), Some("10.0.0.1:19042"));
+                assert_eq!(internode_broadcast, None);
             }
             other => panic!("expected Handshake, got {other:?}"),
         }

--- a/ferrosa-net/src/peer.rs
+++ b/ferrosa-net/src/peer.rs
@@ -32,6 +32,9 @@ pub struct PeerManager {
     listener: Arc<dyn PeerEventListener>,
     /// CQL broadcast addresses learned from peer handshakes.
     peer_cql_broadcasts: RwLock<HashMap<uuid::Uuid, String>>,
+    /// Internode broadcast hostnames learned from peer handshakes. Used so the
+    /// committed `NodeInfo.addr` is a re-resolvable hostname, not a frozen IP.
+    peer_internode_broadcasts: RwLock<HashMap<uuid::Uuid, String>>,
     raft_runtime: OnceLock<Arc<tokio::runtime::Runtime>>,
     data_runtime: OnceLock<Arc<tokio::runtime::Runtime>>,
     started_at: tokio::time::Instant,
@@ -76,6 +79,7 @@ impl PeerManager {
             peers: RwLock::new(HashMap::new()),
             listener,
             peer_cql_broadcasts: RwLock::new(HashMap::new()),
+            peer_internode_broadcasts: RwLock::new(HashMap::new()),
             raft_runtime: OnceLock::new(),
             data_runtime: OnceLock::new(),
             started_at: tokio::time::Instant::now(),
@@ -128,6 +132,14 @@ impl PeerManager {
         // Extract the peer's CQL broadcast from the handshake before wrapping in Arc.
         if let Some(broadcast) = pool.peer_cql_broadcast() {
             self.peer_cql_broadcasts
+                .write()
+                .await
+                .insert(host_id, broadcast.to_string());
+        }
+        // Same for the internode broadcast hostname — committed into NodeInfo.addr
+        // so the address re-resolves across container IP churn.
+        if let Some(broadcast) = pool.peer_internode_broadcast() {
+            self.peer_internode_broadcasts
                 .write()
                 .await
                 .insert(host_id, broadcast.to_string());
@@ -403,6 +415,10 @@ impl PeerManager {
     pub async fn remove_peer(&self, host_id: uuid::Uuid) {
         let removed = self.peers.write().await.remove(&host_id);
         self.peer_cql_broadcasts.write().await.remove(&host_id);
+        self.peer_internode_broadcasts
+            .write()
+            .await
+            .remove(&host_id);
         if let Some(state) = removed {
             self.listener.on_peer_disconnected(state.peer_id);
         }
@@ -422,6 +438,32 @@ impl PeerManager {
     /// Returns None if the lock is contended.
     pub fn get_peer_cql_broadcast_sync(&self, host_id: uuid::Uuid) -> Option<String> {
         self.peer_cql_broadcasts
+            .try_read()
+            .ok()
+            .and_then(|guard| guard.get(&host_id).cloned())
+    }
+
+    /// Store a peer's internode broadcast hostname learned during handshake.
+    pub async fn set_peer_internode_broadcast(&self, host_id: uuid::Uuid, addr: String) {
+        self.peer_internode_broadcasts
+            .write()
+            .await
+            .insert(host_id, addr);
+    }
+
+    /// Retrieve a peer's internode broadcast hostname (if known from handshake).
+    pub async fn get_peer_internode_broadcast(&self, host_id: uuid::Uuid) -> Option<String> {
+        self.peer_internode_broadcasts
+            .read()
+            .await
+            .get(&host_id)
+            .cloned()
+    }
+
+    /// Non-blocking version for synchronous contexts (e.g., the cluster-mode
+    /// peer-connected planner). Returns None if the lock is contended.
+    pub fn get_peer_internode_broadcast_sync(&self, host_id: uuid::Uuid) -> Option<String> {
+        self.peer_internode_broadcasts
             .try_read()
             .ok()
             .and_then(|guard| guard.get(&host_id).cloned())

--- a/ferrosa-net/src/pool.rs
+++ b/ferrosa-net/src/pool.rs
@@ -46,6 +46,8 @@ pub struct PriorityPool {
     resolved_addr: SocketAddr,
     /// Peer's CQL broadcast address from handshake (if provided).
     peer_cql_broadcast: Option<String>,
+    /// Peer's internode broadcast hostname from handshake (if provided).
+    peer_internode_broadcast: Option<String>,
     raft: LaneHandle,
     data: LaneHandle,
     bulk: LaneHandle,
@@ -147,6 +149,7 @@ impl PriorityPool {
 
         let peer_host_id = raft_client.peer_host_id();
         let peer_cql_broadcast = raft_client.peer_cql_broadcast().map(String::from);
+        let peer_internode_broadcast = raft_client.peer_internode_broadcast().map(String::from);
         let peer_host = peer_host.to_owned();
 
         // Spawn a lane actor for each connection.  The ctx_builder closure
@@ -221,6 +224,7 @@ impl PriorityPool {
             peer_host_id,
             resolved_addr: peer_addr,
             peer_cql_broadcast,
+            peer_internode_broadcast,
             raft,
             data,
             bulk,
@@ -235,6 +239,11 @@ impl PriorityPool {
     /// Peer's CQL broadcast address from the handshake, if provided.
     pub fn peer_cql_broadcast(&self) -> Option<&str> {
         self.peer_cql_broadcast.as_deref()
+    }
+
+    /// Peer's internode broadcast hostname from the handshake, if provided.
+    pub fn peer_internode_broadcast(&self) -> Option<&str> {
+        self.peer_internode_broadcast.as_deref()
     }
 
     /// The socket address resolved during the initial connection.

--- a/ferrosa-net/src/rpc/client.rs
+++ b/ferrosa-net/src/rpc/client.rs
@@ -57,6 +57,8 @@ pub struct RpcClient {
     peer_host_id: uuid::Uuid,
     /// CQL broadcast address the peer advertised during handshake.
     peer_cql_broadcast: Option<String>,
+    /// Internode broadcast hostname the peer advertised during handshake.
+    peer_internode_broadcast: Option<String>,
     pending: Arc<DashMap<u32, oneshot::Sender<Message>>>,
     tx: mpsc::Sender<Frame>,
     next_stream_id: Arc<AtomicU32>,
@@ -81,6 +83,11 @@ impl RpcClient {
     /// The peer's CQL broadcast address, obtained during the handshake.
     pub fn peer_cql_broadcast(&self) -> Option<&str> {
         self.peer_cql_broadcast.as_deref()
+    }
+
+    /// The peer's internode broadcast hostname, obtained during the handshake.
+    pub fn peer_internode_broadcast(&self) -> Option<&str> {
+        self.peer_internode_broadcast.as_deref()
     }
 
     /// Subscribe to the connection liveness channel.
@@ -160,12 +167,15 @@ impl RpcClient {
     where
         S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
     {
-        let (peer_host_id, peer_cql_broadcast) = tokio::time::timeout(
+        let peer = tokio::time::timeout(
             config.handshake_timeout,
             initiate_handshake(&mut framed, &config, local_host_id),
         )
         .await
         .map_err(|_| NetError::Timeout("handshake".into()))??;
+        let peer_host_id = peer.host_id;
+        let peer_cql_broadcast = peer.cql_broadcast;
+        let peer_internode_broadcast = peer.internode_broadcast;
 
         let pending: Arc<DashMap<u32, oneshot::Sender<Message>>> = Arc::new(DashMap::new());
         let (tx, mut rx) = mpsc::channel::<Frame>(256);
@@ -234,6 +244,7 @@ impl RpcClient {
             peer_addr,
             peer_host_id,
             peer_cql_broadcast,
+            peer_internode_broadcast,
             pending,
             tx,
             next_stream_id: Arc::new(AtomicU32::new(1)),

--- a/ferrosa-net/src/rpc/server.rs
+++ b/ferrosa-net/src/rpc/server.rs
@@ -18,7 +18,12 @@ use crate::task_pool::TaskPool;
 
 /// Callback invoked when the server accepts an inbound peer connection.
 pub trait InboundPeerCallback: Send + Sync {
-    fn on_inbound_peer(&self, peer_id: PeerId, cql_broadcast: Option<String>);
+    fn on_inbound_peer(
+        &self,
+        peer_id: PeerId,
+        cql_broadcast: Option<String>,
+        internode_broadcast: Option<String>,
+    );
 }
 
 pub struct RpcServer {
@@ -253,6 +258,7 @@ impl RpcServer {
                             accepted: false,
                             reason: "overloaded".to_string(),
                             cql_broadcast: None,
+                            internode_broadcast: None,
                         };
                         let mut body = bytes::BytesMut::new();
                         if ack.encode(&mut body).is_ok() {
@@ -315,19 +321,19 @@ impl RpcServer {
         let mut framed = Framed::new(stream, InternodeCodec::new(self.config.max_frame_body_size));
 
         // Handshake with timeout (T5)
-        let (peer_host_id, peer_cql_broadcast) = tokio::time::timeout(
+        let peer = tokio::time::timeout(
             self.config.handshake_timeout,
             accept_handshake(&mut framed, &self.config, self.local_host_id),
         )
         .await
         .map_err(|_| NetError::Timeout("handshake".into()))??;
 
-        let peer_id = (peer_host_id, peer_addr);
+        let peer_id = (peer.host_id, peer_addr);
         tracing::info!(?peer_id, "peer connected (inbound)");
 
         // Notify callback about inbound peer
         if let Some(cb) = &self.inbound_callback {
-            cb.on_inbound_peer(peer_id, peer_cql_broadcast);
+            cb.on_inbound_peer(peer_id, peer.cql_broadcast, peer.internode_broadcast);
         }
 
         // Concurrent frame handling: split read/write, dispatch handlers
@@ -461,10 +467,10 @@ mod tests {
         let client_id = uuid::Uuid::new_v4();
         let stream = TcpStream::connect(addr).await.unwrap();
         let mut framed = Framed::new(stream, InternodeCodec::new(config.max_frame_body_size));
-        let (peer, _cql_broadcast) = initiate_handshake(&mut framed, &config, client_id)
+        let peer = initiate_handshake(&mut framed, &config, client_id)
             .await
             .unwrap();
-        assert_eq!(peer, server_id);
+        assert_eq!(peer.host_id, server_id);
     }
 
     #[tokio::test]

--- a/specs/todo/bug-internode-broadcast-addr-frozen-to-startup-ip.md
+++ b/specs/todo/bug-internode-broadcast-addr-frozen-to-startup-ip.md
@@ -1,0 +1,122 @@
+# BUG: Internode broadcast address frozen to startup IP — stale Raft membership after container IP churn
+
+**Status**: Fixed on branch `fix/internode-broadcast-hostname-resolution` (awaiting verification on a real cluster). See "Suggested fix" — implemented option 1 (advertise + re-resolve the broadcast hostname).
+**Component**: `ferrosa-net` (config), `ferrosa-cluster` (Raft membership / internode routing)
+**Severity**: High — silent read-path degradation in any environment where node IPs change across restarts (podman/docker default networking, k8s pods, DHCP).
+**Found**: 2026-06-05, debugging a live `ferrosa-memory` 3-node dev cluster.
+
+## Symptom
+
+A 3-node cluster reports **0 entities** but a partial edge count (~13k of an expected ~68k) through the
+ferrosa-memory MCP. Data is fully intact on disk (`agent_memory.entity_store` = 920 MB). Reads are silently
+degraded, not failing loudly.
+
+MCP-side log (node addressed by host_id, via a dead IP):
+
+```
+smart_ingest: cross-session exact dedup lookup failed ... error=server error: cluster error: internal:
+  index read from node 1229782938247303441 (11111111-1111-1111-1111-111111111111) via 10.89.1.176:7000:
+  net: timeout: Bulk lane timeout
+viz: failed to stream entities for snapshot: ... streaming range read:
+  ChannelClosedBeforeDone { delivered_done: 0, expected_done: 1 }
+```
+
+- `11111111-1111-1111-1111-111111111111` is node1 (pinned `FERROSA_HOST_ID`).
+- `10.89.1.176` is a **stale** address. node1 is currently at `10.89.1.58`. `10.89.1.176` matches no
+  running container.
+- Distributed **index reads** and **streaming range reads** route to the stale committed IP and time out;
+  most other internode RPC works because it resolves the broadcast DNS name live. Entity range scans depend
+  on the failing paths, so the entity count bottoms out at 0.
+
+### Evidence: the Raft DB is full of dead addresses
+
+Scanning each node's committed Raft state for `N.N.N.N:7000` literals:
+
+```
+$ podman exec ferrosa-memory_node1_1 grep -ao -E '10\.89\.1\.[0-9]+:7000' /var/lib/ferrosa/raft/datacenter1/db | sort | uniq -c
+```
+
+returns **~50 distinct IPs** (`10.89.1.4` … `10.89.1.202`) across all three nodes' DBs, and **none of the
+current IPs** (`.58/.60/.62`) appears anywhere. The committed membership has been chasing container IP churn
+and never converges on the live addresses.
+
+## Root cause
+
+`ferrosa-net/src/config.rs`:
+
+```rust
+pub struct NetConfig {
+    ...
+    /// Address advertised to peers (defaults to bind_addr).
+    pub broadcast_addr: SocketAddr,   // line 13 — a RESOLVED IP:port, not a hostname
+    ...
+}
+
+fn parse_socket_addr(raw: &str) -> Option<SocketAddr> {     // lines 84-94
+    let trimmed = raw.trim();
+    if let Ok(addr) = trimmed.parse() { return Some(addr); } // already an IP
+    let mut resolved = trimmed.to_socket_addrs().ok()?;      // hostname -> IP, ONCE, at startup
+    resolved.next()
+}
+
+// lines 125-128
+if let Ok(v) = std::env::var("FERROSA_INTERNODE_BROADCAST") {
+    if let Some(addr) = Self::parse_socket_addr(&v) {
+        cfg.broadcast_addr = addr;   // frozen resolved IP
+    }
+}
+```
+
+`FERROSA_INTERNODE_BROADCAST=node1:7000` is resolved to an IP exactly once at boot and stored as a
+`SocketAddr`. That IP is advertised to peers and committed into the openraft membership. When the container
+restarts with a new IP, the hostname is never re-resolved against the committed entry, so the membership
+keeps pointing at the previous generation's address. The internode index/range-read routing path uses the
+committed IP literal rather than re-resolving the broadcast hostname.
+
+This contrasts with `FERROSA_CQL_BROADCAST`, which `specs/components.md:383` documents as supporting
+hostname resolution for `system.peers`. The internode broadcast has no equivalent re-resolution.
+
+## Impact
+
+Any deployment where a node's IP can change while its `host_id` is stable:
+- podman/docker default bridge networking (IPs assigned from a pool per `up`)
+- Kubernetes pods (new IP per reschedule)
+- DHCP-leased hosts
+
+The failure is **silent**: containers stay "healthy" (TCP probe passes), most RPC works, but distributed
+index/range reads time out and counts/scans under-report. This violates the project's fail-loud principle —
+a stale-membership read should surface as an error, not a 0 count.
+
+## Suggested fix
+
+1. **Store the broadcast as a resolvable target, re-resolve at connect time.** Keep the configured host:port
+   string and resolve it when establishing/refreshing an internode connection (and when committing membership),
+   rather than freezing an IP at startup. Mirror the CQL broadcast hostname-resolution behavior.
+2. **Or: re-announce on startup.** On boot, if the node's resolved broadcast address differs from its committed
+   membership address, commit a membership update so peers learn the current address.
+3. **Fail loud on stale membership.** An index/range read that times out against a membership address should
+   distinguish "peer unreachable at recorded address" from "empty result" so callers don't silently see 0 rows.
+4. **Periodic membership address reconciliation** for long-lived clusters with DHCP/pod churn.
+
+## Reproduction
+
+1. Bring up a multi-node cluster using `FERROSA_INTERNODE_BROADCAST=<hostname>:7000` with pinned `FERROSA_HOST_ID`s
+   on a network that assigns dynamic IPs (podman/docker default bridge).
+2. `podman compose down && up` (or otherwise recreate containers) several times so each node gets a new IP.
+3. Run a distributed index/range read (e.g. an ANN search or full entity range scan).
+4. Observe `Bulk lane timeout` / `ChannelClosedBeforeDone` against a stale `N.N.N.N:7000` address, and
+   under-reported counts, while `nodetool`-style health stays green.
+
+## Operational mitigation (not a code workaround)
+
+Pin static container IPs so the once-resolved broadcast address stays valid across restarts. Applied in
+`ferrosa-memory/docker-compose.yml` (static `ipv4_address` per node on the `10.89.1.0/24` subnet). This is an
+infra-level mitigation; the bug itself must be fixed here in `ferrosa-net`.
+
+## Related
+
+- `ferrosa-net/src/config.rs:13,84-94,125-128`
+- `ferrosa-cluster/src/state.rs` (`BroadcastResolver`, `peer_broadcast`)
+- `specs/components.md:383` (CQL broadcast hostname resolution — the behavior internode lacks)
+- Possibly interacts with the bulk-lane starvation work (`bug-bulk-write-raft-starvation.md`): a stale
+  address makes the Bulk lane timeout immediately instead of under load.


### PR DESCRIPTION
## Problem

The internode broadcast address was resolved to an IP **once at startup**
(`NetConfig.broadcast_addr: SocketAddr`, resolved via `to_socket_addrs().next()`),
and that frozen IP was committed into `NodeInfo.addr` in the openraft membership /
token ring. After a container restart with a new IP (podman/docker default
networking, k8s pods, DHCP), the committed address kept pointing at the previous,
now-dead IP.

Internode **index reads** and **streaming range reads** (Bulk lane RPCs) then timed
out against stale addresses, silently degrading reads to **0 results** while the data
was fully intact. Observed on a live `ferrosa-memory` 3-node cluster as "0 entities /
partial edge count"; the node's Raft DB had accumulated ~50 dead `10.89.1.x:7000`
addresses across container generations, none of them current.

The connection layer (`reconnect.rs`, `pool.rs`) already re-resolves the peer host
string on every reconnect — but re-resolution was a no-op because the stored value
was a resolved IP literal, not the hostname.

## Fix

Mirror the existing `cql_broadcast` hostname exchange. A parallel, **unresolved**
`internode_broadcast` hostname flows through the handshake and is committed to
`NodeInfo.addr`. The existing reconnect re-resolution then tracks the live IP on
every connect, so container IP churn no longer produces stale membership. The dial
target still uses the observed connection IP; only the committed `NodeInfo.addr` now
carries the re-resolvable hostname.

- **ferrosa-net**: `NetConfig.internode_broadcast` + `advertised_internode_addr()`;
  `Handshake`/`HandshakeAck` carry `internode_broadcast`; `HandshakePeer` struct
  replaces the `(Uuid, Option<String>)` return tuple; `PeerManager`/`pool`/`rpc`
  plumb the advertised hostname.
- **ferrosa-cluster**: `node_info_addr()` prefers the advertised hostname for
  `NodeInfo.addr` (JoinNode, UpdateNodeInfo, ring update, seed/self init), falling
  back to the observed `SocketAddr` when no hostname was advertised.

## Tests

- `ferrosa-net`: `handshake_exchanges_internode_broadcast`,
  `handshake_backward_compat_cql_present_internode_absent` (optional trailing field
  decodes to `None`).
- `ferrosa-cluster`: `node_info_addr_*` precedence + fallback;
  `existing_member_metadata_refresh_commits_hostname_when_internode_broadcast_present`.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --all-targets` ✓ (zero warnings)
- `cargo build --all-targets` ✓
- `cargo test -p ferrosa-net -p ferrosa-cluster` ✓ (net 146, cluster 921, 0 failures)

Bug report: `specs/todo/bug-internode-broadcast-addr-frozen-to-startup-ip.md`
