### PR TITLE
fix(storage): make SSTable writes crash-atomic (fsync barrier + WAL ordering) [P0]

### DIFF
--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -553,6 +553,55 @@ impl<R: ReadAt> SSTableReader<R> {
         self.data.len()
     }
 
+    /// Number of partitions reachable by walking `Data.db` from byte 0, using
+    /// the partition-count fast path (no cell decode). On a healthy SSTable this
+    /// equals [`key_count`](Self::key_count). On a `Data.db` truncated mid-file
+    /// the walk stops early and this is strictly less than `key_count`.
+    ///
+    /// Cheap: one streaming pass over partition headers (the same machinery the
+    /// merger's dedup path already uses via `partition_offsets`).
+    pub fn walkable_partition_count(&self) -> u64 {
+        // `partition_offsets()` walks Data.db with `read_partition_count`,
+        // pushing one offset per successfully decoded partition and stopping at
+        // the first read error or clean EOF. Its length is the number of
+        // partitions whose headers are fully present in Data.db.
+        self.partition_offsets().len() as u64
+    }
+
+    /// Reject an SSTable whose `Data.db` is shorter than what its own partition
+    /// index claims. Converts a silent query-time truncation (the P0
+    /// crash-non-atomic-flush corruption) into a loud load-time error.
+    ///
+    /// Detection: the partition index footer records `key_count` (the number of
+    /// partitions written). We walk `Data.db` and count how many partition
+    /// headers are actually reachable. A truncated `Data.db` yields fewer
+    /// reachable partitions than the index claims.
+    ///
+    /// Conservative by construction:
+    /// - An empty index (`key_count == 0`) passes.
+    /// - A zero-byte `Data.db` for a non-empty index is already caught by the
+    ///   startup zero-byte critical-component check; here it would also fail
+    ///   (0 reachable < key_count), which is correct.
+    /// - It does NOT depend on offset arithmetic, Rows.db contents, or
+    ///   byte-comparable key bounds, so it never false-positives on healthy
+    ///   small-partition SSTables (the regression an offset-based check hit).
+    pub fn validate_data_extent(&self) -> Result<()> {
+        let expected = self.key_count();
+        if expected == 0 {
+            return Ok(());
+        }
+        let reachable = self.walkable_partition_count();
+        if reachable < expected {
+            return Err(ferrosa_common::Error::InvalidFormat(format!(
+                "Data.db truncated: index claims {expected} partitions but only {reachable} \
+                 are reachable by walking Data.db (length {}); the SSTable's data was lost \
+                 (likely a non-crash-atomic flush killed mid-write)",
+                self.data_file_length().unwrap_or(0)
+            )));
+        }
+        Ok(())
+    }
+
     /// Returns the approximate total size of this SSTable in bytes.
     ///
     /// Sums the sizes of the data file and the partition index. For
@@ -1235,6 +1284,91 @@ mod tests {
         assert_eq!(row.primary_key_liveness.timestamp, 1_000_042);
         assert_eq!(row.cells.len(), 1);
         assert_eq!(row.cells[0].1.value.as_deref(), Some(b"hello-0".as_slice()));
+    }
+
+    #[test]
+    fn validate_data_extent_passes_for_healthy_sstable() {
+        let header = test_header();
+        let dk1 = DecoratedKey::new(PartitionKey::from(b"k1".as_slice()));
+        let dk2 = DecoratedKey::new(PartitionKey::from(b"k2".as_slice()));
+
+        let mut data_bytes = Vec::new();
+        let pos1 = data_bytes.len() as u64;
+        data_bytes.extend_from_slice(&build_data_blob_with_rows(b"k1", 3));
+        let pos2 = data_bytes.len() as u64;
+        data_bytes.extend_from_slice(&build_data_blob_with_rows(b"k2", 2));
+
+        let partitions_bytes = build_partition_index(&[(&dk1, pos1), (&dk2, pos2)]);
+        let filter_bytes = build_bloom_filter(&[&dk1, &dk2]);
+        let stats_bytes = build_statistics(header);
+
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+        assert_eq!(reader.key_count(), 2);
+        assert_eq!(
+            reader.walkable_partition_count(),
+            2,
+            "all partitions must be reachable in a healthy Data.db"
+        );
+        reader
+            .validate_data_extent()
+            .expect("healthy SSTable must pass extent check");
+    }
+
+    #[test]
+    fn validate_data_extent_rejects_truncated_data_db() {
+        let header = test_header();
+        let dk1 = DecoratedKey::new(PartitionKey::from(b"k1".as_slice()));
+        let dk2 = DecoratedKey::new(PartitionKey::from(b"k2".as_slice()));
+
+        let mut data_bytes = Vec::new();
+        let pos1 = data_bytes.len() as u64;
+        data_bytes.extend_from_slice(&build_data_blob_with_rows(b"k1", 3));
+        let pos2 = data_bytes.len() as u64;
+        data_bytes.extend_from_slice(&build_data_blob_with_rows(b"k2", 2));
+
+        let partitions_bytes = build_partition_index(&[(&dk1, pos1), (&dk2, pos2)]);
+        let filter_bytes = build_bloom_filter(&[&dk1, &dk2]);
+        let stats_bytes = build_statistics(header);
+
+        // Simulate a crash-truncated Data.db: drop the entire second partition
+        // so only one of the two indexed partitions is reachable. Non-zero, but
+        // missing data the index claims exists.
+        let mut truncated = data_bytes.clone();
+        truncated.truncate(pos2 as usize);
+        assert!(!truncated.is_empty(), "fixture must be nonzero");
+
+        let components = SSTableComponents {
+            data: truncated,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        assert_eq!(reader.key_count(), 2, "index must claim 2 partitions");
+        assert_eq!(
+            reader.walkable_partition_count(),
+            1,
+            "only the first partition should be reachable after truncation"
+        );
+
+        let err = reader
+            .validate_data_extent()
+            .expect_err("truncated Data.db must be rejected");
+        assert!(
+            err.to_string().contains("truncated"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -2784,6 +2784,9 @@ impl StorageEngine {
     ) -> ferrosa_common::Result<()> {
         use ferrosa_common::NO_TIMESTAMP;
 
+        // Note: the Data.db-truncation extent check (validate_data_extent) runs
+        // mode-independently in the caller's load loop, BEFORE this smoke test,
+        // so a truncated SSTable is already excluded by the time we get here.
         let partitions = reader.read_all_partitions()?;
         for partition in &partitions {
             if let Some(static_row) = &partition.static_row {
@@ -2965,6 +2968,39 @@ impl StorageEngine {
             });
             match open_result {
                 Ok(reader) => {
+                    // MODE-INDEPENDENT truncation gate (P0 crash-atomic-flush
+                    // defense-in-depth): a Data.db shorter than the extent its
+                    // own index claims is corrupt regardless of repair mode and
+                    // must never be served. We do not move files when mode==Off
+                    // (no destructive action without an explicit repair mode),
+                    // but we always exclude the truncated generation from active
+                    // readers so queries fail loud-at-load instead of returning
+                    // truncated/garbage rows. Conservative: passes every healthy
+                    // SSTable (see SSTableReader::validate_data_extent).
+                    if let Err(e) = reader.validate_data_extent() {
+                        tracing::error!(
+                            %e,
+                            gen,
+                            dir = %table_dir.display(),
+                            mode = ?repair_mode,
+                            "storage-engine: SSTable Data.db is shorter than its index claims (truncated); excluding from active readers"
+                        );
+                        drop(reader);
+                        reader_pool.remove(&(pool_table_key.to_string(), gen_num));
+                        if repair_mode == StartupSstableRepairMode::Quarantine {
+                            let quarantine_dir = table_dir.join("quarantine");
+                            let _ = std::fs::create_dir_all(&quarantine_dir);
+                            if let Err(qe) =
+                                Self::quarantine_generation(table_dir, gen, &quarantine_dir)
+                            {
+                                tracing::warn!(%qe, gen, "storage-engine: failed to quarantine truncated SSTable");
+                            }
+                            quarantined_count += 1;
+                        } else {
+                            excluded_count += 1;
+                        }
+                        continue;
+                    }
                     if repair_mode != StartupSstableRepairMode::Off {
                         smoke_tested_count += 1;
                         if let Err(e) = Self::validate_sstable_for_startup_repair(&reader) {
@@ -5210,6 +5246,16 @@ impl StorageEngine {
             // up to this position are in the memtable we're about to flush.
             let cl_position = **state.last_commit_log_position.load();
 
+            // DURABILITY BARRIER (do not reorder): `store.flush()` only returns
+            // Ok after the SSTable's component files AND their directory entries
+            // are fsynced (see flush.rs `fsync_components`). This is the barrier
+            // that makes the later `commit_log.discard_completed(cl_position)`
+            // safe: we must NOT advance the WAL checkpoint / delete segments
+            // until the SSTable copy of those mutations is durable on disk. If
+            // flush() fails, we return here and the WAL is left intact so replay
+            // can rebuild the memtable. Removing the fsync from flush(), or
+            // moving discard_completed before this line, reintroduces the P0
+            // "kill mid-flush loses both the torn SSTable and the WAL copy" bug.
             state.store.flush()?;
 
             // Reset the unflushed-write timestamp so the next write starts a
@@ -9445,6 +9491,117 @@ mod tests {
         );
     }
 
+    /// P0 crash-non-atomic-flush defense-in-depth: a Data.db truncated below
+    /// the extent its own partition index claims must be EXCLUDED from the live
+    /// view even when startup repair is fully OFF (no smoke test). This is the
+    /// exact production scenario: a SIGKILL mid-flush left a final-named, nonzero
+    /// but truncated Data.db that previously loaded silently and only failed at
+    /// query time. The mode-independent extent gate converts that into a
+    /// loud-at-load exclusion.
+    #[test]
+    fn startup_off_mode_excludes_sstable_with_truncated_data_below_index_extent() {
+        let dir = tempfile::tempdir().unwrap();
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "truncated_extent".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "v".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: Default::default(),
+        };
+        let tid = TableId::new("test_ks", "truncated_extent");
+
+        {
+            let config = StorageEngineConfig::test_config(dir.path());
+            let engine = StorageEngine::new(config, None).unwrap();
+            engine.register_table(schema.clone()).unwrap();
+            // Multiple partitions so the last partition starts at a non-zero
+            // Data.db offset — required for the extent check to have a positive
+            // bound to compare against.
+            for i in 0..16i32 {
+                let pk = DecoratedKey::new(PartitionKey::new(i.to_be_bytes().to_vec()));
+                let row = Row {
+                    clustering: vec![],
+                    cells: vec![(0, CellValue::live(format!("value-{i}").into_bytes(), 1000))],
+                    deletion: DeletionTime::LIVE,
+                    primary_key_liveness: LivenessInfo::with_timestamp(1000),
+                };
+                engine.write(&tid, &pk, row, 1000).unwrap();
+            }
+            engine.flush(&tid).unwrap();
+        }
+
+        let table_dir = dir.path().join("sstables").join(tid.to_string());
+        let data_file = std::fs::read_dir(&table_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .find(|path| {
+                path.file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .ends_with("-Data.db")
+            })
+            .expect("flush must produce a Data.db");
+        let original_len = std::fs::metadata(&data_file).unwrap().len();
+        assert!(
+            original_len > 16,
+            "test needs a Data.db with multiple partitions to truncate"
+        );
+        // Truncate hard — to a single byte — so the file is nonzero (escapes the
+        // zero-byte critical-component check) yet far shorter than the last
+        // partition's indexed offset.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&data_file)
+            .unwrap()
+            .set_len(1)
+            .unwrap();
+        assert_eq!(
+            std::fs::metadata(&data_file).unwrap().len(),
+            1,
+            "Data.db must be nonzero so the zero-byte check does not fire"
+        );
+
+        let pool: crate::store::SharedReaderPool<ferrosa_sstable::io::FileReadAt> =
+            Arc::new(crate::reader_pool::ReaderPool::new(8));
+        // Repair OFF: no smoke test runs. The mode-independent extent gate must
+        // still exclude the truncated generation.
+        let (descriptors, _sidecars, ids) =
+            StorageEngine::load_existing_sstables_and_sidecars_with_repair_mode(
+                &table_dir,
+                &pool,
+                "extent-off",
+                StartupSstableRepairMode::Off,
+            );
+        assert!(
+            ids.is_empty(),
+            "repair-OFF startup must not admit a Data.db truncated below its index extent"
+        );
+        assert!(
+            descriptors.is_empty(),
+            "repair-OFF startup must not produce a descriptor for the truncated SSTable"
+        );
+        assert_eq!(
+            pool.resident(),
+            0,
+            "the excluded truncated SSTable must be evicted from the pool"
+        );
+        // OFF mode is non-destructive: files stay in place for salvage.
+        assert!(
+            data_file.exists(),
+            "repair-OFF must leave truncated components in place for salvage"
+        );
+        assert!(
+            !table_dir.join("quarantine").exists(),
+            "repair-OFF must not move files to quarantine"
+        );
+    }
+
     /// Given a table with one healthy SSTable and one corrupt SSTable, restart
     /// must keep the healthy generation queryable while retaining the corrupt
     /// generation on disk for salvage. This is the production recovery contract:
@@ -11241,6 +11398,77 @@ mod tests {
         assert!(
             after > before,
             "commit_log_position should advance after write"
+        );
+
+        engine.shutdown().unwrap();
+    }
+
+    /// Gap 2 (WAL discarded before durability): `engine.flush()` must NOT
+    /// advance the commit-log checkpoint / discard segments when the SSTable
+    /// flush fails. The WAL is the only other copy of those mutations; if flush
+    /// tears or fails, replay must still be able to rebuild them. We induce a
+    /// flush failure by making the table's SSTable directory read-only, then
+    /// assert (a) flush returns Err and (b) no closed segment was discarded.
+    #[cfg(unix)]
+    #[test]
+    fn flush_failure_does_not_discard_commit_log_before_durability() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig {
+            commit_log: CommitLogConfig {
+                segment_size: 512, // tiny: forces rotation so there are closed segments
+                ..CommitLogConfig::test_config(dir.path())
+            },
+            ..StorageEngineConfig::test_config(dir.path())
+        };
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        for i in 0..20 {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("k{i}")),
+                    make_row(b"value", 1000 + i),
+                    1000 + i,
+                )
+                .unwrap();
+        }
+
+        let closed_before = engine.commit_log.closed_segment_count();
+        assert!(
+            closed_before >= 2,
+            "need multiple closed segments for this test, got {closed_before}"
+        );
+
+        // Make the table's SSTable directory read-only so the flush write/rename
+        // fails. The directory already exists (created on first flush attempt or
+        // table registration); ensure it exists, then strip write perms.
+        let table_dir = dir.path().join("sstables").join(tid.to_string());
+        std::fs::create_dir_all(&table_dir).unwrap();
+        let mut perms = std::fs::metadata(&table_dir).unwrap().permissions();
+        perms.set_mode(0o500); // r-x: no write
+        std::fs::set_permissions(&table_dir, perms).unwrap();
+
+        let flush_result = engine.flush(&tid);
+
+        // Restore perms so the tempdir can be cleaned up regardless of outcome.
+        let mut restore = std::fs::metadata(&table_dir).unwrap().permissions();
+        restore.set_mode(0o700);
+        std::fs::set_permissions(&table_dir, restore).unwrap();
+
+        assert!(
+            flush_result.is_err(),
+            "flush into a read-only SSTable dir must fail, not silently succeed"
+        );
+
+        let closed_after = engine.commit_log.closed_segment_count();
+        assert_eq!(
+            closed_after, closed_before,
+            "commit log segments must NOT be discarded when flush fails: \
+             before={closed_before}, after={closed_after}"
         );
 
         engine.shutdown().unwrap();

--- a/ferrosa-storage/src/flush.rs
+++ b/ferrosa-storage/src/flush.rs
@@ -578,6 +578,58 @@ pub struct FileFlushTarget {
     generation: AtomicU64,
 }
 
+/// Test-only durability observation seam.
+///
+/// Records the set of file paths and directory paths that were fsynced during
+/// flush/promote so tests can assert the durability barrier actually fired on
+/// every component and on the containing directory. Not compiled into release.
+#[cfg(test)]
+pub(crate) mod fsync_probe {
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    static SYNCED_FILES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+    static SYNCED_DIRS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+    pub(crate) fn reset() {
+        SYNCED_FILES.lock().expect("fsync probe poisoned").clear();
+        SYNCED_DIRS.lock().expect("fsync probe poisoned").clear();
+    }
+
+    pub(crate) fn note_file(path: &Path) {
+        SYNCED_FILES
+            .lock()
+            .expect("fsync probe poisoned")
+            .push(path.to_path_buf());
+    }
+
+    pub(crate) fn note_dir(path: &Path) {
+        SYNCED_DIRS
+            .lock()
+            .expect("fsync probe poisoned")
+            .push(path.to_path_buf());
+    }
+
+    pub(crate) fn synced_files() -> HashSet<PathBuf> {
+        SYNCED_FILES
+            .lock()
+            .expect("fsync probe poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn synced_dirs() -> HashSet<PathBuf> {
+        SYNCED_DIRS
+            .lock()
+            .expect("fsync probe poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+}
+
 impl FileFlushTarget {
     /// Create a new file flush target writing to the given directory.
     ///
@@ -705,6 +757,93 @@ impl FileFlushTarget {
             Some("txt") => path.with_extension("txt.tmp"),
             _ => path.with_extension("db.tmp"),
         }
+    }
+
+    /// fsync a single file so its bytes are durable on the underlying device.
+    ///
+    /// Opens the file read-only and calls `sync_all()` (flushes data + metadata).
+    /// This MUST be called on the *final* component path after rename so the
+    /// promoted file's contents survive a power loss / SIGKILL. A missing file
+    /// is a hard error — every component we promote must exist when we claim
+    /// the SSTable is durable.
+    fn fsync_path(path: &Path) -> std::io::Result<()> {
+        let f = std::fs::File::open(path)?;
+        f.sync_all()?;
+        #[cfg(test)]
+        Self::record_fsync(path);
+        Ok(())
+    }
+
+    /// fsync the directory `dir` so that rename directory entries are durable.
+    ///
+    /// On POSIX a `rename(2)` updates the directory; that update lives in the
+    /// page cache until the directory inode is fsynced. Without this, a crash
+    /// after rename but before writeback can lose the final-named entry (or,
+    /// symmetrically, leave a final-named file whose data blocks were never
+    /// flushed). Opening the directory and calling `sync_all()` flushes those
+    /// entries. This is the single barrier that makes the temp→rename→final
+    /// sequence crash-atomic.
+    fn fsync_dir(dir: &Path) -> std::io::Result<()> {
+        let f = std::fs::File::open(dir)?;
+        f.sync_all()?;
+        #[cfg(test)]
+        Self::record_dir_fsync(dir);
+        Ok(())
+    }
+
+    /// fsync every component file that exists for this generation, then fsync
+    /// the containing directory once. Returns Ok only when all component bytes
+    /// AND their directory entries are durable on disk.
+    ///
+    /// Crash-safety ordering: callers rename each component to its final name
+    /// first, then call this. We fsync the final files (their data blocks),
+    /// then fsync `base_dir` (the rename entries). Doing the file fsyncs before
+    /// the directory fsync guarantees that once the directory entry is durable,
+    /// the data it points at is already durable too.
+    fn fsync_components(
+        &self,
+        paths: &FileComponentPaths,
+        has_compression_info: bool,
+    ) -> Result<()> {
+        // Required + always-written components for a generation.
+        let mut components: Vec<&Path> = vec![
+            &paths.data,
+            &paths.partitions,
+            &paths.rows,
+            &paths.filter,
+            &paths.statistics,
+            &paths.toc,
+        ];
+        if has_compression_info {
+            components.push(&paths.compression_info);
+        }
+        for component in components {
+            Self::fsync_path(component).map_err(|e| {
+                ferrosa_common::Error::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("fsync of component {} failed: {e}", component.display()),
+                ))
+            })?;
+        }
+        // One directory fsync after all component fsyncs makes the rename
+        // entries durable. This is the most important step in the barrier.
+        Self::fsync_dir(&self.base_dir).map_err(|e| {
+            ferrosa_common::Error::Io(std::io::Error::new(
+                e.kind(),
+                format!("fsync of base dir {} failed: {e}", self.base_dir.display()),
+            ))
+        })?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn record_fsync(path: &Path) {
+        fsync_probe::note_file(path);
+    }
+
+    #[cfg(test)]
+    fn record_dir_fsync(dir: &Path) {
+        fsync_probe::note_dir(dir);
     }
 
     fn open_reader_from_paths(
@@ -899,9 +1038,17 @@ impl FlushTarget for FileFlushTarget {
 
         let has_compression_info = output.compression_info.is_some();
 
-        // Write to .tmp files first, then atomically rename.
-        // If the process crashes mid-flush, only .tmp files exist — no corrupt
-        // final SSTables. Stale .tmp files are cleaned up on next startup.
+        // Write to .tmp files first, then rename to final names, then fsync.
+        //
+        // temp+rename alone is NOT crash-atomic: rename makes the *name* visible
+        // but neither the file's data blocks nor the directory entry are durable
+        // until fsynced. A SIGKILL after rename but before writeback can leave a
+        // final-named, truncated Data.db (the production corruption this fixes).
+        // The durability barrier below (fsync every component, then fsync the
+        // directory once) is what makes the sequence crash-atomic: this function
+        // returns Ok only after all component bytes AND their directory entries
+        // are durable. Stale .tmp files from a pre-fsync crash are cleaned up on
+        // next startup.
         let tmp = Self::tmp_component_path;
         let toc_tmp = tmp(&paths.toc);
 
@@ -974,11 +1121,17 @@ impl FlushTarget for FileFlushTarget {
             }
         }
 
+        // Durability barrier: fsync every promoted component, then fsync the
+        // directory once. Only after this returns Ok are the bytes and the
+        // rename directory entries durable. The engine relies on this so it can
+        // safely discard the WAL copy after flush() returns.
+        self.fsync_components(&paths, has_compression_info)?;
+
         tracing::info!(
             gen,
             data_bytes = std::fs::metadata(&paths.data).map(|m| m.len()).unwrap_or(0),
             path = %paths.data.display(),
-            "flush: Data.db verified on disk"
+            "flush: Data.db verified and fsynced on disk"
         );
 
         Self::open_reader_from_paths(&paths, has_compression_info)
@@ -1028,6 +1181,14 @@ impl FlushTarget for FileFlushTarget {
             std::fs::rename(tmp(&paths.compression_info), &paths.compression_info)?;
         }
 
+        // Durability barrier: fsync every promoted component, then fsync the
+        // directory once, BEFORE cleaning up staging or returning. This path is
+        // shared by compaction output promotion (compaction/executor.rs), so
+        // compaction inherits the same crash-atomic guarantee: the local output
+        // SSTable is durable before any caller deletes inputs or swaps the
+        // manifest.
+        self.fsync_components(&paths, has_compression_info)?;
+
         let staging_parent = output.staging_dir.parent().map(Path::to_path_buf);
         let _ = std::fs::remove_dir(&output.staging_dir);
         if let Some(parent) = staging_parent {
@@ -1038,7 +1199,7 @@ impl FlushTarget for FileFlushTarget {
             gen,
             data_bytes = std::fs::metadata(&paths.data).map(|m| m.len()).unwrap_or(0),
             path = %paths.data.display(),
-            "flush: staged Data.db promoted"
+            "flush: staged Data.db promoted and fsynced"
         );
 
         Self::open_reader_from_paths(&paths, has_compression_info)
@@ -1508,6 +1669,111 @@ mod tests {
         assert!(
             tmp_files.is_empty(),
             "no .tmp files should remain after successful flush, found: {tmp_files:?}"
+        );
+    }
+
+    #[test]
+    fn flush_fsyncs_every_component_and_directory() {
+        // Durability barrier: after flush(), every promoted component file AND
+        // the containing directory must have been fsynced. Without the barrier
+        // a SIGKILL after rename can leave a truncated, final-named Data.db.
+        fsync_probe::reset();
+
+        let dir = tempfile::tempdir().unwrap();
+        let schema = test_schema();
+        let mut partitions = vec![make_partition("k1", b"v1", 5000)];
+        partitions.sort_by(|a, b| a.key.cmp(&b.key));
+        let header = build_serialization_header(&schema, &partitions);
+        let options = WriteOptions {
+            compression: None,
+            ..WriteOptions::default()
+        };
+        let mut writer = SSTableWriter::new(options, header);
+        for p in &partitions {
+            writer.add_partition(p).unwrap();
+        }
+        let output = writer.finish().unwrap();
+
+        let target = FileFlushTarget::new(dir.path().to_path_buf()).unwrap();
+        let _reader = target.flush(output).unwrap();
+        let gen = target.generation();
+
+        let synced = fsync_probe::synced_files();
+        for suffix in [
+            "Data.db",
+            "Partitions.db",
+            "Rows.db",
+            "Filter.db",
+            "Statistics.db",
+            "TOC.txt",
+        ] {
+            let path = dir.path().join(format!("{gen}-{suffix}"));
+            assert!(
+                synced.contains(&path),
+                "component {suffix} was not fsynced; synced={synced:?}"
+            );
+        }
+        // No compression in this test → CompressionInfo.db not written/synced.
+        assert!(
+            fsync_probe::synced_dirs().contains(&dir.path().to_path_buf()),
+            "containing directory was not fsynced"
+        );
+    }
+
+    #[test]
+    fn flush_files_fsyncs_every_component_and_directory() {
+        // The staged-promotion path (used by compaction) must apply the same
+        // durability barrier as flush().
+        fsync_probe::reset();
+
+        let dir = tempfile::tempdir().unwrap();
+        let schema = test_schema();
+        let mut partitions = vec![
+            make_partition("k1", b"v1", 5000),
+            make_partition("k2", b"v2", 3000),
+        ];
+        partitions.sort_by(|a, b| a.key.cmp(&b.key));
+
+        let target = FileFlushTarget::new(dir.path().to_path_buf()).unwrap();
+        let staging_dir = target
+            .file_output_staging_dir()
+            .unwrap()
+            .expect("file target staging dir");
+        let header = build_serialization_header(&schema, &partitions);
+        let options = WriteOptions::default();
+        let mut writer =
+            SSTableWriter::new_file_backed(options, header, staging_dir.join("Data.raw")).unwrap();
+        for p in &partitions {
+            writer.add_partition(p).unwrap();
+        }
+        let output = writer.finish_to_directory(&staging_dir).unwrap();
+        let has_ci = output.compression_info.is_some();
+
+        let _reader = target.flush_files(output).unwrap();
+        let gen = target.generation();
+
+        let synced = fsync_probe::synced_files();
+        let mut expected = vec![
+            "Data.db",
+            "Partitions.db",
+            "Rows.db",
+            "Filter.db",
+            "Statistics.db",
+            "TOC.txt",
+        ];
+        if has_ci {
+            expected.push("CompressionInfo.db");
+        }
+        for suffix in expected {
+            let path = dir.path().join(format!("{gen}-{suffix}"));
+            assert!(
+                synced.contains(&path),
+                "component {suffix} was not fsynced; synced={synced:?}"
+            );
+        }
+        assert!(
+            fsync_probe::synced_dirs().contains(&dir.path().to_path_buf()),
+            "containing directory was not fsynced"
         );
     }
 

--- a/specs/todo/bug-sstable-writes-not-crash-atomic.md
+++ b/specs/todo/bug-sstable-writes-not-crash-atomic.md
@@ -1,0 +1,89 @@
+# BUG (P0): SSTable writes are not crash-atomic — a kill mid-flush corrupts committed data and loses the WAL copy
+
+**Status**: Open — fix on branch `fix/sstable-crash-atomic-writes`.
+**Severity**: P0 — durable data corruption + data loss from an ordinary process kill. Violates the project "crash over corruption" failure philosophy.
+**Component**: `ferrosa-storage` (`flush.rs`, `engine.rs`, `compaction/executor.rs`), with a defense-in-depth touch in `ferrosa-sstable` (`reader.rs`).
+**Found**: 2026-06-05, root-causing ferrosa-memory SSTable corruption after cgroup OOM-kills.
+
+## Observed
+
+After nodes were OOM-killed (SIGKILL) mid-write, many *committed* SSTables had a `Data.db`
+shorter than their own index/Statistics claim:
+
+```
+read_exact_at: wanted 40245 bytes, got 474
+corrupted DeletionTime flags: 0xa1
+```
+
+Rows in those generations were permanently lost (effective RF=1, no replica to heal from).
+Tables gutted: `temporal_edges` (→10 rows), `context_segments` (→13); 242 `entity_store`
+SSTables quarantined.
+
+## Root cause — two gaps, both from a missing fsync barrier
+
+The flush path (`FileFlushTarget::flush_files` / `flush`, `ferrosa-storage/src/flush.rs:886-1045`)
+writes components to `*.tmp` then `std::fs::rename` to final `{gen}-*.db`. It does **temp+rename
+but never fsyncs**:
+
+- **No `fsync` of the component files** (only the *staging* Data.db is synced in
+  `ferrosa-sstable/src/writer.rs:155,1299,1313`; Partitions/Statistics/Filter/Rows/TOC are
+  written with plain `std::fs::write` and never synced).
+- **No `fsync` of the containing directory** — the renames that create the final directory
+  entries are never made durable.
+
+### Gap 1 — corruption
+A crash after the rename to final names but before page-cache writeback leaves a final-named
+`{gen}-Data.db` whose bytes are partly lost → truncated committed SSTable. `cleanup_stale_tmp_files`
+(`flush.rs:596`) ignores it (not `*.tmp`). Startup (`load_existing_sstables_and_sidecars_with_repair_mode`,
+`engine.rs:2849`) discovers generations purely by presence of `{gen}-Data.db`, quarantines only
+*zero-byte* critical components (`engine.rs:2909-2951`), and `SSTableReader::open` (`reader.rs:222`)
+reads only small components — it never compares `Data.db` length to the index's claimed extent. So a
+truncated-but-nonzero Data.db loads as a valid generation and fails only at query time.
+
+The in-code comment at `flush.rs:902-904` ("If the process crashes mid-flush, only .tmp files exist —
+no corrupt final SSTables") is **false without fsync**: data-block durability and rename durability are
+independent.
+
+### Gap 2 — WAL discarded before durability (data loss)
+`StorageEngine::flush` (`engine.rs:5196`) calls `commit_log.discard_completed(table_id, pos)`
+(`engine.rs:5265`) immediately after `store.flush()` returns (`:5213`) — but `store.flush()` returns
+*before any fsync*. The WAL checkpoint is advanced and segments deleted while the SSTable is still only
+in page cache. If the flush tore (Gap 1), the only other copy of those rows is already gone; replay
+starts after the discarded position and cannot rebuild them.
+
+### Compaction has the same gap
+`compaction/executor.rs:870` promotes its output via the same `flush_files` path. The manifest swap /
+input deletion in `compaction/finalize.rs` is gated on S3 confirmation, but the **local** output SSTable
+has the identical non-durable rename.
+
+## Fix
+
+Apply temp → fsync-file → rename → fsync-dir, and only then signal "committed":
+
+1. **`flush.rs` `flush` and `flush_files`**: fsync **every** promoted component file (Data, Partitions,
+   Rows, Filter, Statistics, TOC, CompressionInfo) before/at rename, then **open `base_dir` and
+   `sync_all()` once** after all renames. Return Ok only after the directory fsync. (The fsync helper
+   pattern already exists — `writer.rs` `sync_data`, `quarantine.rs:194`, the commit log, `accord/sync_writer.rs`.)
+2. **`engine.rs::flush`**: ensure `commit_log.discard_completed` runs only after the SSTable is durably
+   fsynced (fix #1 makes `store.flush()` return post-fsync, making the existing order correct; add an
+   explicit barrier/comment so it cannot regress).
+3. **Compaction** (`compaction/executor.rs:870`): inherits #1; confirm the manifest swap / input deletion
+   is sequenced after the now-durable local promote.
+4. **Defense-in-depth** (`reader.rs:222` open, or the startup critical-component check `engine.rs:2909`):
+   reject/quarantine when `Data.db` length < the maximum extent implied by the partition index +
+   Statistics, converting silent query-time truncation into a loud load-time rejection regardless of
+   repair mode.
+
+## Tests
+
+- A flush/compaction test that injects a crash *after rename, before fsync* (or asserts fsync is invoked
+  on every component + the directory) — the existing `flush_uses_atomic_rename` / `flush_does_not_leave_final_files_if_interrupted`
+  tests assert intent but never assert durability.
+- A load-time test: a truncated (nonzero) `Data.db` is rejected/quarantined at startup, not at first query.
+- A WAL-ordering test: WAL discard does not advance until the SSTable fsync completes.
+
+## Related
+
+- The OOM that triggered the kills: `p0-unbounded-sstable-reader-memory-oom.md` (in-progress on
+  `fix/bounded-sstable-reader-pool`). That bounds memory so kills stop happening; THIS bug ensures a kill
+  (from any cause) never corrupts. Both are needed.


### PR DESCRIPTION
## Problem (P0)

A SIGKILL mid-flush — exactly what a cgroup OOM-kill does — corrupted **committed**
SSTables and lost the WAL copy of the affected rows. Observed on the ferrosa-memory
cluster after OOM-kills: many `Data.db` files shorter than their own index claims
(`read_exact_at: wanted 40245 bytes, got 474`, `corrupted DeletionTime flags`), with
the rows permanently lost (effective RF=1).

**Root cause:** the flush/compaction promote path (`FileFlushTarget::flush` /
`flush_files`) did temp+rename but **never fsynced the component files or the containing
directory** before the engine treated the SSTable as committed and before it called
`commit_log.discard_completed`. So:
- the final-named `Data.db`'s bytes lived only in the page cache → a crash left a
  truncated "valid" generation that startup happily loaded and that failed only at
  query time; and
- the WAL was discarded before the SSTable was durable, so replay could not recover
  the torn rows.

An in-code comment even claimed temp+rename was crash-safe — it isn't without fsync
(data-block durability and rename-entry durability are independent).

This violates the project's **"crash over corruption"** failure philosophy.

## Fix

- **`flush.rs`** — fsync durability barrier: after renaming each component to its final
  name, fsync every component file (`sync_all`) then fsync the containing directory
  once. `flush`/`flush_files` return `Ok` only when all component bytes **and** their
  directory entries are durable. False crash-safety comment replaced; `#[cfg(test)]`
  `fsync_probe` seam added.
- **`engine.rs`** — WAL-discard barrier documented/guarded (`store.flush()` now returns
  post-fsync, so `discard_completed` runs only after durability). Added a
  **mode-independent** startup gate that excludes/quarantines any SSTable whose `Data.db`
  is truncated below its index extent — a loud load-time rejection instead of a silent
  query-time failure.
- **`reader.rs`** — `SSTableReader::validate_data_extent`: rejects a `Data.db` exposing
  fewer partitions than the partition index claims. Partition-count based (offset-free),
  so it never false-positives on healthy small partitions or zero-byte `Rows.db`.

## Tests
- fsync barrier fired on every component + the directory (`flush`, `flush_files`).
- truncated-but-nonzero `Data.db` rejected at load (reproduces the production corruption).
- commit log not discarded when flush fails (WAL-ordering / Gap 2).

## Verification
- `cargo fmt --check` ✓ · `cargo clippy --all-targets` ✓ (zero warnings)
- `cargo test -p ferrosa-storage -p ferrosa-sstable` ✓ (829 + 241 + all integration buckets, 0 failures)
- `cargo build --all-targets` ✓

Pairs with the in-flight `p0-unbounded-sstable-reader-memory-oom` work (bounds memory so
nodes stop OOM-killing); this PR ensures that *any* kill can never corrupt durable state.

Report: `specs/todo/bug-sstable-writes-not-crash-atomic.md`
