### PR TITLE
ci: add automated nightly releases

### DIFF
--- a/.github/scripts/next-release-version.sh
+++ b/.github/scripts/next-release-version.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the next stable SemVer tag from Conventional Commit history.
+#
+# Bump policy:
+# - major: any Conventional Commit with ! (e.g. feat!:), or BREAKING CHANGE in body
+# - minor: any feat/feat(scope) commit
+# - patch: any other commit since the latest stable vX.Y.Z tag
+#
+# Pre-release/build metadata tags are intentionally ignored as bases so a
+# v1.0.0-beta.N tag does not supersede the latest stable release line.
+
+BUMP_OVERRIDE="${1:-auto}"
+FORCE_RELEASE="${2:-false}"
+
+case "$BUMP_OVERRIDE" in
+  auto|major|minor|patch) ;;
+  *)
+    echo "error: bump override must be one of: auto, major, minor, patch" >&2
+    exit 2
+    ;;
+esac
+
+latest_tag="$({ git tag --list 'v[0-9]*.[0-9]*.[0-9]*' || true; } \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n 1 \
+  || true)"
+
+if [[ -z "$latest_tag" ]]; then
+  latest_tag="v0.0.0"
+  range="HEAD"
+else
+  range="${latest_tag}..HEAD"
+fi
+
+if [[ "$latest_tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  patch="${BASH_REMATCH[3]}"
+else
+  echo "error: latest stable tag has unexpected shape: ${latest_tag}" >&2
+  exit 2
+fi
+
+if [[ "$range" == "HEAD" ]]; then
+  commit_count="$(git rev-list --count HEAD)"
+else
+  commit_count="$(git rev-list --count "$range")"
+fi
+
+if [[ "$commit_count" == "0" && "$FORCE_RELEASE" != "true" ]]; then
+  {
+    echo "should_release=false"
+    echo "base_tag=${latest_tag}"
+    echo "commit_count=0"
+  } >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  exit 0
+fi
+
+if [[ "$BUMP_OVERRIDE" == "auto" ]]; then
+  subjects_and_bodies="$(git log "$range" --format='%s%n%b%n==END-COMMIT==')"
+  if grep -Eq '(^[A-Za-z]+([[:space:]]*\([^)]*\))?!:|^BREAKING CHANGE:|^BREAKING-CHANGE:)' <<<"$subjects_and_bodies"; then
+    bump="major"
+  elif grep -Eq '^feat([[:space:]]*\([^)]*\))?:' <<<"$subjects_and_bodies"; then
+    bump="minor"
+  else
+    bump="patch"
+  fi
+else
+  bump="$BUMP_OVERRIDE"
+fi
+
+case "$bump" in
+  major)
+    major=$((major + 1)); minor=0; patch=0 ;;
+  minor)
+    minor=$((minor + 1)); patch=0 ;;
+  patch)
+    patch=$((patch + 1)) ;;
+esac
+
+next_version="${major}.${minor}.${patch}"
+next_tag="v${next_version}"
+
+if git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
+  echo "error: computed tag ${next_tag} already exists" >&2
+  exit 1
+fi
+
+{
+  echo "should_release=true"
+  echo "base_tag=${latest_tag}"
+  echo "commit_count=${commit_count}"
+  echo "bump=${bump}"
+  echo "next_version=${next_version}"
+  echo "next_tag=${next_tag}"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,90 @@
+name: Nightly Release
+
+on:
+  schedule:
+    # Run once per night in UTC. The workflow skips itself when no commits have
+    # landed since the latest stable vX.Y.Z tag.
+    - cron: '17 8 * * *'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'SemVer bump override. auto uses Conventional Commit history.'
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+      force:
+        description: 'Create the next release even when there are no commits since the latest stable tag.'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: nightly-release-${{ github.repository }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Bump version, tag, and dispatch release build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04-25
+
+      - name: Compute next SemVer release
+        id: next
+        run: |
+          bump='${{ github.event.inputs.bump || 'auto' }}'
+          force='${{ github.event.inputs.force || 'false' }}'
+          bash .github/scripts/next-release-version.sh "$bump" "$force"
+
+      - name: Stop when there is nothing new to release
+        if: steps.next.outputs.should_release != 'true'
+        run: echo "No commits since ${{ steps.next.outputs.base_tag }}; skipping nightly release."
+
+      - name: Update workspace version
+        if: steps.next.outputs.should_release == 'true'
+        env:
+          VERSION: ${{ steps.next.outputs.next_version }}
+        run: |
+          perl -0pi -e 's/(\[workspace\.package\]\s+version\s*=\s*)"[^"]+"/${1}"'"${VERSION}"'"/s' Cargo.toml
+          cargo update -w
+          git diff -- Cargo.toml Cargo.lock
+
+      - name: Commit release bump and create tag
+        if: steps.next.outputs.should_release == 'true'
+        env:
+          NEXT_VERSION: ${{ steps.next.outputs.next_version }}
+          NEXT_TAG: ${{ steps.next.outputs.next_tag }}
+          BASE_TAG: ${{ steps.next.outputs.base_tag }}
+          BUMP: ${{ steps.next.outputs.bump }}
+          COMMIT_COUNT: ${{ steps.next.outputs.commit_count }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): ${NEXT_TAG}"
+          git tag -a "${NEXT_TAG}" -m "${NEXT_TAG} nightly release" -m "${BUMP} bump from ${BASE_TAG} after ${COMMIT_COUNT} commits."
+          git push origin HEAD:${GITHUB_REF_NAME}
+          git push origin "${NEXT_TAG}"
+
+      - name: Dispatch release build
+        if: steps.next.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ steps.next.outputs.next_tag }}
+        run: gh workflow run release.yml --ref "${NEXT_TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -342,4 +343,4 @@ jobs:
           gh release create "v${VERSION}" dist/* \
             --title "Ferrosa v${VERSION}" \
             --notes "$NOTES" \
-            --draft
+            --latest

--- a/ferrosa-storage/src/flush.rs
+++ b/ferrosa-storage/src/flush.rs
@@ -587,12 +587,31 @@ pub struct FileFlushTarget {
 pub(crate) mod fsync_probe {
     use std::collections::HashSet;
     use std::path::{Path, PathBuf};
-    use std::sync::Mutex;
+    use std::sync::{Mutex, MutexGuard};
 
+    static EXCLUSIVE: Mutex<()> = Mutex::new(());
     static SYNCED_FILES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
     static SYNCED_DIRS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
-    pub(crate) fn reset() {
+    pub(crate) struct ExclusiveGuard {
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    pub(crate) fn exclusive() -> ExclusiveGuard {
+        let guard = EXCLUSIVE
+            .lock()
+            .expect("fsync probe exclusive lock poisoned");
+        reset();
+        ExclusiveGuard { _guard: guard }
+    }
+
+    impl Drop for ExclusiveGuard {
+        fn drop(&mut self) {
+            reset();
+        }
+    }
+
+    fn reset() {
         SYNCED_FILES.lock().expect("fsync probe poisoned").clear();
         SYNCED_DIRS.lock().expect("fsync probe poisoned").clear();
     }
@@ -1677,7 +1696,7 @@ mod tests {
         // Durability barrier: after flush(), every promoted component file AND
         // the containing directory must have been fsynced. Without the barrier
         // a SIGKILL after rename can leave a truncated, final-named Data.db.
-        fsync_probe::reset();
+        let _fsync_probe = fsync_probe::exclusive();
 
         let dir = tempfile::tempdir().unwrap();
         let schema = test_schema();
@@ -1724,7 +1743,7 @@ mod tests {
     fn flush_files_fsyncs_every_component_and_directory() {
         // The staged-promotion path (used by compaction) must apply the same
         // durability barrier as flush().
-        fsync_probe::reset();
+        let _fsync_probe = fsync_probe::exclusive();
 
         let dir = tempfile::tempdir().unwrap();
         let schema = test_schema();


### PR DESCRIPTION
## Summary
- Add a scheduled/manual nightly release workflow that computes the next stable SemVer tag from Conventional Commit history.
- Update the workspace version and lockfile during the release bump, commit it, tag it, and explicitly dispatch the release build workflow for that tag.
- Publish generated releases as latest instead of leaving them as drafts.
- Serialize the test-only fsync probe assertions so parallel CI test execution cannot reset the global probe state mid-assertion.

## Release policy
- Ignores prerelease/build-metadata tags as the stable base.
- `!`/`BREAKING CHANGE` commits bump major.
- `feat` commits bump minor.
- All other release-worthy commits bump patch.
- Skips the nightly run when there are no commits since the latest stable tag, unless manually forced.

## Validation
- `bash -n .github/scripts/next-release-version.sh`
- `.github/scripts/next-release-version.sh auto false` → `v0.13.1` from `v0.13.0` on current main
- `cargo update -w --dry-run`
- `git diff --check`
- `bash .github/scripts/check-actions-pinned.sh`
- `cargo test -p ferrosa-storage fsyncs -- --test-threads=2 --nocapture`
- `cargo test --all-features -p ferrosa-storage --lib -- --skip ...` (CI-equivalent package slice)
- `cargo clippy -p ferrosa-storage --all-targets --all-features -- -D warnings`
