### PR TITLE
fix: bound full-scan memory (intra-partition row streaming + coordinator paging) — OOM P0

### DIFF
--- a/ferrosa-cluster/src/coordinator/range_read_stream.rs
+++ b/ferrosa-cluster/src/coordinator/range_read_stream.rs
@@ -896,6 +896,81 @@ impl ClusterCoordinator {
         .await
     }
 
+    /// Resume-capable streaming range scan with an inclusive lower-bound key.
+    ///
+    /// Backs `WritePath::range_read_stream_all_from` (the coordinator-side
+    /// paging cursor). Only the local-only fan-out shape (CL=ONE with the
+    /// keyspace RF spanning the ring, i.e. no remote replica must be consulted)
+    /// is supported; any shape requiring a cross-replica merge is refused
+    /// rather than returning a partial scan, matching the unbounded scan guard.
+    pub async fn coordinate_range_read_stream_from(
+        &self,
+        table_id: &TableId,
+        start: Option<&ferrosa_common::key::DecoratedKey>,
+        cl: crate::consistency::ConsistencyLevel,
+        replication_factor: usize,
+    ) -> crate::error::Result<ClusterPartitionStream> {
+        let ring = self.ring.load();
+        let node_ids = ring.node_ids();
+        let node_count = node_ids.len();
+        let all_remotes_len = node_ids
+            .iter()
+            .filter(|&&id| id != self.local_node_id)
+            .count();
+        drop(ring);
+
+        let cl_remote_count =
+            remote_count_for_cl(cl, replication_factor, node_count, all_remotes_len);
+
+        if cl_remote_count > 0 {
+            return Err(ClusterError::Internal(
+                "paged cluster range scan with a resume key requires token-aware k-way stream merge across replicas; refusing to return a partial scan".into(),
+            ));
+        }
+
+        Ok(Box::pin(
+            self.storage
+                .range_iter_fragmented(table_id, start, None)
+                .map(|item| item.map_err(ClusterError::Storage)),
+        ))
+    }
+
+    /// Projection-aware resume-capable streaming range scan. See
+    /// [`Self::coordinate_range_read_stream_from`]; refuses any cross-replica
+    /// shape.
+    pub async fn coordinate_range_read_projected_stream_from(
+        &self,
+        table_id: &TableId,
+        wanted: Vec<u16>,
+        start: Option<&ferrosa_common::key::DecoratedKey>,
+        cl: crate::consistency::ConsistencyLevel,
+        replication_factor: usize,
+    ) -> crate::error::Result<ClusterPartitionStream> {
+        let ring = self.ring.load();
+        let node_ids = ring.node_ids();
+        let node_count = node_ids.len();
+        let all_remotes_len = node_ids
+            .iter()
+            .filter(|&&id| id != self.local_node_id)
+            .count();
+        drop(ring);
+
+        let cl_remote_count =
+            remote_count_for_cl(cl, replication_factor, node_count, all_remotes_len);
+
+        if cl_remote_count > 0 {
+            return Err(ClusterError::Internal(
+                "paged projected cluster range scan with a resume key requires token-aware k-way stream merge across replicas; refusing to return a partial scan".into(),
+            ));
+        }
+
+        Ok(Box::pin(
+            self.storage
+                .range_iter_projected_fragmented(table_id, wanted, start, None)
+                .map(|item| item.map_err(ClusterError::Storage)),
+        ))
+    }
+
     async fn coordinate_range_read_stream_all_with_projection(
         &self,
         table_id: &TableId,

--- a/ferrosa-cluster/src/coordinator/range_read_stream.rs
+++ b/ferrosa-cluster/src/coordinator/range_read_stream.rs
@@ -287,6 +287,45 @@ async fn merge_local_and_single_remote_stream(
     table_id: TableId,
     row_limit: usize,
     projected_regular_ordinals: Option<Vec<u16>>,
+    remote_rx: mpsc::Receiver<crate::error::Result<Partition>>,
+    out_tx: mpsc::Sender<crate::error::Result<Partition>>,
+) {
+    // `row_limit > 0` only for `LIMIT N` queries with partition-key
+    // equality predicates (see `safe_partition_key_filter_row_limit`). Those
+    // target specific bounded partitions, so the legacy whole-partition
+    // token merge (with a correct PER-PARTITION row cap) is used. The full
+    // `SELECT *` path is `row_limit == 0` and takes the fragment-aware
+    // streaming merge below, which bounds memory on BOTH replica copies.
+    if row_limit > 0 {
+        merge_local_and_single_remote_whole(
+            storage,
+            table_id,
+            row_limit,
+            projected_regular_ordinals,
+            remote_rx,
+            out_tx,
+        )
+        .await;
+        return;
+    }
+    merge_local_and_single_remote_fragmented(
+        storage,
+        table_id,
+        projected_regular_ordinals,
+        remote_rx,
+        out_tx,
+    )
+    .await;
+}
+
+/// Whole-partition token merge for capped (`row_limit > 0`) reads. The
+/// per-partition row cap is applied to the merged partition, which is
+/// correct because each side delivers ONE `Partition` per token here.
+async fn merge_local_and_single_remote_whole(
+    storage: std::sync::Arc<ferrosa_storage::StorageEngine>,
+    table_id: TableId,
+    row_limit: usize,
+    projected_regular_ordinals: Option<Vec<u16>>,
     mut remote_rx: mpsc::Receiver<crate::error::Result<Partition>>,
     out_tx: mpsc::Sender<crate::error::Result<Partition>>,
 ) {
@@ -374,6 +413,427 @@ async fn merge_local_and_single_remote_stream(
                     remote_next = remote_rx.recv().await;
                 }
             }
+        }
+    }
+}
+
+/// A peekable cursor over a fragmented partition stream (the local engine
+/// stream or the remote replica's forwarded stream). Each upstream item is a
+/// `<= K`-row `Partition` fragment; fragments of one partition key arrive
+/// consecutively in clustering order, and the FIRST fragment of a key carries
+/// the partition header (`deletion` + `static_row`).
+///
+/// The cursor keeps ONE peeked fragment at a time, so resident memory is
+/// `O(K)` rows — a wide partition is never buffered whole.
+struct FragmentCursor<S> {
+    stream: S,
+    /// The peeked-but-not-yet-consumed next fragment. `None` once primed and
+    /// exhausted.
+    peeked: Option<Partition>,
+    primed: bool,
+    done: bool,
+}
+
+/// The merged header (key + deletion + static row) for one partition key.
+struct TokenHeader {
+    key: ferrosa_common::key::DecoratedKey,
+    deletion: ferrosa_sstable::types::DeletionTime,
+    static_row: Option<ferrosa_sstable::types::Row>,
+}
+
+impl<S> FragmentCursor<S>
+where
+    S: futures::Stream<Item = Result<Partition, ClusterError>> + Unpin,
+{
+    fn new(stream: S) -> Self {
+        Self {
+            stream,
+            peeked: None,
+            primed: false,
+            done: false,
+        }
+    }
+
+    /// Ensure `self.peeked` holds the next fragment (if any). Returns `Err`
+    /// on upstream error.
+    async fn ensure_peeked(&mut self) -> Result<(), ClusterError> {
+        if self.primed || self.done {
+            return Ok(());
+        }
+        match self.stream.next().await {
+            None => self.done = true,
+            Some(Err(e)) => return Err(e),
+            Some(Ok(p)) => self.peeked = Some(p),
+        }
+        self.primed = true;
+        Ok(())
+    }
+
+    /// Token of the next fragment, or `None` at end-of-stream.
+    async fn peek_token(&mut self) -> Result<Option<i64>, ClusterError> {
+        self.ensure_peeked().await?;
+        Ok(self.peeked.as_ref().map(|p| p.key.token.0))
+    }
+
+    /// Consume the next fragment for `token`, returning its `(header_if_first,
+    /// rows)`. The header is `Some` only on the FIRST fragment of the token
+    /// (detected by the fragment carrying a header — equivalently, the first
+    /// fragment popped for a token in this cursor since the previous token).
+    /// Returns `Ok(None)` when the next fragment belongs to a different token
+    /// or the stream ended.
+    async fn take_fragment_for(
+        &mut self,
+        token: i64,
+        first: bool,
+    ) -> Result<Option<(Option<TokenHeader>, Vec<ferrosa_sstable::types::Row>)>, ClusterError> {
+        self.ensure_peeked().await?;
+        match self.peeked.as_ref() {
+            Some(p) if p.key.token.0 == token => {
+                let p = self.peeked.take().expect("checked Some");
+                self.primed = false;
+                let header = if first {
+                    Some(TokenHeader {
+                        key: p.key,
+                        deletion: p.deletion,
+                        static_row: p.static_row,
+                    })
+                } else {
+                    None
+                };
+                Ok(Some((header, p.rows)))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+/// A row puller over one side's fragments for a single token. Pulls rows in
+/// clustering order, transparently advancing across that token's fragments,
+/// and captures the token header on the first fragment. Holds at most one
+/// fragment's rows (`<= K`) resident.
+struct TokenRowPuller<'c, S> {
+    cursor: &'c mut FragmentCursor<S>,
+    token: i64,
+    rows: std::vec::IntoIter<ferrosa_sstable::types::Row>,
+    first: bool,
+    exhausted: bool,
+    header: Option<TokenHeader>,
+}
+
+impl<'c, S> TokenRowPuller<'c, S>
+where
+    S: futures::Stream<Item = Result<Partition, ClusterError>> + Unpin,
+{
+    /// Begin pulling `token`'s rows from `cursor`, consuming the first
+    /// fragment so the header is available immediately.
+    async fn begin(
+        cursor: &'c mut FragmentCursor<S>,
+        token: i64,
+    ) -> Result<TokenRowPuller<'c, S>, ClusterError> {
+        let (header, rows) = match cursor.take_fragment_for(token, true).await? {
+            Some((h, rows)) => (h, rows),
+            None => (None, Vec::new()),
+        };
+        Ok(TokenRowPuller {
+            cursor,
+            token,
+            rows: rows.into_iter(),
+            first: false,
+            exhausted: false,
+            header,
+        })
+    }
+
+    fn take_header(&mut self) -> Option<TokenHeader> {
+        self.header.take()
+    }
+
+    /// Next row of this token, or `None` when the token is exhausted.
+    async fn next_row(&mut self) -> Result<Option<ferrosa_sstable::types::Row>, ClusterError> {
+        loop {
+            if let Some(row) = self.rows.next() {
+                return Ok(Some(row));
+            }
+            if self.exhausted {
+                return Ok(None);
+            }
+            match self
+                .cursor
+                .take_fragment_for(self.token, self.first)
+                .await?
+            {
+                Some((_, rows)) => {
+                    self.rows = rows.into_iter();
+                }
+                None => {
+                    self.exhausted = true;
+                    return Ok(None);
+                }
+            }
+        }
+    }
+}
+
+/// Fragment-aware, memory-bounded streaming merge of the LOCAL fragmented
+/// stream and the single REMOTE replica's fragmented stream.
+///
+/// Both sides arrive as `<= K`-row `Partition` fragments. This performs a
+/// token-ordered, then clustering-ordered, 2-way row merge and RE-EMITS
+/// `<= K`-row fragments, so a single wide partition is never materialised on
+/// either side. Correctness mirrors `range_merger::next_fragment` and the
+/// whole-partition `merge_partitions(vec![local, remote])`:
+///
+/// - Per token, merged partition deletion is the max `marked_for_delete_at`
+///   across replicas; the static row is cell-merged via `merge::merge_rows`
+///   then partition-deletion-suppressed.
+/// - Rows sharing a clustering key are folded with `merge::merge_rows`
+///   (cell-level LWW).
+/// - Deletion suppression is applied per row exactly as
+///   `merge::apply_deletions`. Since each replica already delivers
+///   deletion-suppressed rows, re-running suppression is idempotent.
+async fn merge_local_and_single_remote_fragmented(
+    storage: std::sync::Arc<ferrosa_storage::StorageEngine>,
+    table_id: TableId,
+    projected_regular_ordinals: Option<Vec<u16>>,
+    remote_rx: mpsc::Receiver<crate::error::Result<Partition>>,
+    out_tx: mpsc::Sender<crate::error::Result<Partition>>,
+) {
+    let local_stream: ClusterPartitionStream = if let Some(wanted) = projected_regular_ordinals {
+        Box::pin(
+            storage
+                .range_iter_projected_fragmented(&table_id, wanted, None, None)
+                .map(|item| item.map_err(ClusterError::Storage)),
+        )
+    } else {
+        Box::pin(
+            storage
+                .range_iter_fragmented(&table_id, None, None)
+                .map(|item| item.map_err(ClusterError::Storage)),
+        )
+    };
+    let local = FragmentCursor::new(local_stream);
+    let remote = FragmentCursor::new(ReceiverStream { rx: remote_rx });
+    let k = super::stream_request_handler::stream_chunk_row_cap();
+    run_fragment_merge(local, remote, k, out_tx).await;
+}
+
+/// 2-way fragment-aware streaming merge core, generic over the two fragment
+/// stream cursors so it can be unit-tested with in-memory streams. See
+/// [`merge_local_and_single_remote_fragmented`] for the correctness contract.
+async fn run_fragment_merge<L, R>(
+    mut local: FragmentCursor<L>,
+    mut remote: FragmentCursor<R>,
+    k: usize,
+    out_tx: mpsc::Sender<crate::error::Result<Partition>>,
+) where
+    L: futures::Stream<Item = Result<Partition, ClusterError>> + Unpin,
+    R: futures::Stream<Item = Result<Partition, ClusterError>> + Unpin,
+{
+    macro_rules! send_or_abort {
+        ($item:expr) => {
+            if out_tx.send($item).await.is_err() {
+                return;
+            }
+        };
+    }
+    macro_rules! try_or_forward {
+        ($e:expr) => {
+            match $e {
+                Ok(v) => v,
+                Err(err) => {
+                    let _ = out_tx.send(Err(err)).await;
+                    return;
+                }
+            }
+        };
+    }
+
+    loop {
+        let lt = try_or_forward!(local.peek_token().await);
+        let rt = try_or_forward!(remote.peek_token().await);
+        let (token, use_local, use_remote) = match (lt, rt) {
+            (None, None) => return,
+            (Some(t), None) => (t, true, false),
+            (None, Some(t)) => (t, false, true),
+            (Some(a), Some(b)) => {
+                if a < b {
+                    (a, true, false)
+                } else if b < a {
+                    (b, false, true)
+                } else {
+                    (a, true, true)
+                }
+            }
+        };
+
+        // Begin per-side pullers for this token (each consumes the side's
+        // first fragment and captures its header).
+        let mut l_puller = if use_local {
+            Some(try_or_forward!(
+                TokenRowPuller::begin(&mut local, token).await
+            ))
+        } else {
+            None
+        };
+        let mut r_puller = if use_remote {
+            Some(try_or_forward!(
+                TokenRowPuller::begin(&mut remote, token).await
+            ))
+        } else {
+            None
+        };
+
+        // Merge the header(s).
+        let mut header: Option<TokenHeader> = None;
+        let mut merge_header = |src: Option<TokenHeader>| {
+            let Some(src) = src else { return };
+            match &mut header {
+                None => header = Some(src),
+                Some(d) => {
+                    if src.deletion.marked_for_delete_at > d.deletion.marked_for_delete_at {
+                        d.deletion = src.deletion;
+                    }
+                    d.static_row = match (d.static_row.take(), src.static_row) {
+                        (None, None) => None,
+                        (Some(r), None) | (None, Some(r)) => Some(r),
+                        (Some(a), Some(b)) => Some(ferrosa_storage::merge::merge_rows(a, b)),
+                    };
+                }
+            }
+        };
+        if let Some(p) = l_puller.as_mut() {
+            merge_header(p.take_header());
+        }
+        if let Some(p) = r_puller.as_mut() {
+            merge_header(p.take_header());
+        }
+        let mut header = header.expect("token present implies a header");
+
+        // Partition-deletion suppression of the static row.
+        if !header.deletion.is_live() {
+            if let Some(sr) = header.static_row.as_mut() {
+                let cut = header.deletion.marked_for_delete_at;
+                sr.cells.retain(|(_c, cell)| cell.timestamp >= cut);
+                if sr.cells.is_empty() {
+                    header.static_row = None;
+                }
+            }
+        }
+        let partition_deleted = !header.deletion.is_live();
+        let partition_cut = header.deletion.marked_for_delete_at;
+
+        // Prime one head per side.
+        let mut l_head = match l_puller.as_mut() {
+            Some(p) => try_or_forward!(p.next_row().await),
+            None => None,
+        };
+        let mut r_head = match r_puller.as_mut() {
+            Some(p) => try_or_forward!(p.next_row().await),
+            None => None,
+        };
+
+        let mut out_rows: Vec<ferrosa_sstable::types::Row> = Vec::with_capacity(k);
+        let mut first_fragment = true;
+
+        loop {
+            // Smallest clustering across live heads.
+            let smallest: Option<Vec<u8>> = {
+                let mut sk: Option<&[u8]> = None;
+                if let Some(r) = l_head.as_ref() {
+                    sk = Some(r.clustering.as_slice());
+                }
+                if let Some(r) = r_head.as_ref() {
+                    if sk.map(|c| r.clustering.as_slice() < c).unwrap_or(true) {
+                        sk = Some(r.clustering.as_slice());
+                    }
+                }
+                sk.map(|c| c.to_vec())
+            };
+            let Some(ck) = smallest else { break };
+
+            let mut merged: Option<ferrosa_sstable::types::Row> = None;
+            if l_head.as_ref().map(|r| r.clustering == ck).unwrap_or(false) {
+                merged = l_head.take();
+                if let Some(p) = l_puller.as_mut() {
+                    l_head = try_or_forward!(p.next_row().await);
+                }
+            }
+            if r_head.as_ref().map(|r| r.clustering == ck).unwrap_or(false) {
+                let row = r_head.take().expect("matched remote head");
+                merged = Some(match merged.take() {
+                    Some(prev) => ferrosa_storage::merge::merge_rows(prev, row),
+                    None => row,
+                });
+                if let Some(p) = r_puller.as_mut() {
+                    r_head = try_or_forward!(p.next_row().await);
+                }
+            }
+            let mut row = merged.expect("a head matched the smallest clustering");
+
+            // Deletion suppression (mirrors merge::apply_deletions).
+            if partition_deleted && row.primary_key_liveness.timestamp < partition_cut {
+                continue;
+            }
+            if !row.deletion.is_live() {
+                let cut = row.deletion.marked_for_delete_at;
+                row.cells.retain(|(_c, cell)| cell.timestamp >= cut);
+            }
+            out_rows.push(row);
+
+            if out_rows.len() >= k {
+                let frag = build_out_fragment(&mut header, &mut first_fragment, &mut out_rows);
+                send_or_abort!(Ok(frag));
+            }
+        }
+
+        // Final fragment for this token (always emitted, so an empty
+        // partition / a partition whose rows were all suppressed still
+        // yields its header exactly once).
+        let frag = build_out_fragment(&mut header, &mut first_fragment, &mut out_rows);
+        send_or_abort!(Ok(frag));
+    }
+}
+
+/// Adapter so an `mpsc::Receiver` of partition results drives the same
+/// `Stream`-based cursor as the local engine stream.
+struct ReceiverStream {
+    rx: mpsc::Receiver<crate::error::Result<Partition>>,
+}
+
+impl futures::Stream for ReceiverStream {
+    type Item = Result<Partition, ClusterError>;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+/// Build one output fragment, draining `out_rows`. The FIRST fragment of a
+/// token carries the merged header (`deletion` + `static_row`); subsequent
+/// fragments carry `LIVE` / `None` so the CQL bridge never double-applies
+/// them.
+fn build_out_fragment(
+    header: &mut TokenHeader,
+    first_fragment: &mut bool,
+    out_rows: &mut Vec<ferrosa_sstable::types::Row>,
+) -> Partition {
+    let rows = std::mem::take(out_rows);
+    if *first_fragment {
+        *first_fragment = false;
+        Partition {
+            key: header.key.clone(),
+            deletion: header.deletion,
+            static_row: header.static_row.take(),
+            rows,
+        }
+    } else {
+        Partition {
+            key: header.key.clone(),
+            deletion: ferrosa_sstable::types::DeletionTime::LIVE,
+            static_row: None,
+            rows,
         }
     }
 }
@@ -472,24 +932,47 @@ impl ClusterCoordinator {
         }
 
         if expected_done == 0 {
-            let stream: ClusterPartitionStream = if let Some(wanted) = projected_regular_ordinals {
-                Box::pin(
+            // Local-only fan-out (CL=ONE / RF==cluster): no cross-replica
+            // merge is needed.
+            //
+            // When `row_limit == 0` (the true full `SELECT *` / unbounded
+            // scan — the dominant OOM path) use the FRAGMENTED iterators: a
+            // single wide partition streams as bounded `<= K`-row fragments
+            // rather than one giant `Vec<Row>`. The CQL row bridge flattens
+            // each fragment's rows independently, so the result is
+            // byte-identical to the whole-partition path.
+            //
+            // When `row_limit > 0` (a `LIMIT N` query with partition-key
+            // equality predicates — see `safe_partition_key_filter_row_limit`)
+            // the per-partition row cap must be applied to the WHOLE
+            // partition, not each fragment, so we keep the whole-partition
+            // iterator. Such queries target specific partition keys with a
+            // small N, so the partition is already bounded — no OOM risk.
+            let stream: ClusterPartitionStream = match (projected_regular_ordinals, row_limit) {
+                (Some(wanted), 0) => Box::pin(
+                    self.storage
+                        .range_iter_projected_fragmented(table_id, wanted, None, None)
+                        .map(|item| item.map_err(ClusterError::Storage)),
+                ),
+                (None, 0) => Box::pin(
+                    self.storage
+                        .range_iter_fragmented(table_id, None, None)
+                        .map(|item| item.map_err(ClusterError::Storage)),
+                ),
+                (Some(wanted), _) => Box::pin(
                     self.storage
                         .range_iter_projected(table_id, wanted, None, None, None)
                         .map(move |item| {
                             let partition = item.map_err(ClusterError::Storage)?;
                             Ok(apply_row_limit(partition, row_limit))
                         }),
-                )
-            } else {
-                Box::pin(
-                    self.storage
-                        .range_iter(table_id, None, None)
-                        .map(move |item| {
-                            let partition = item.map_err(ClusterError::Storage)?;
-                            Ok(apply_row_limit(partition, row_limit))
-                        }),
-                )
+                ),
+                (None, _) => Box::pin(self.storage.range_iter(table_id, None, None).map(
+                    move |item| {
+                        let partition = item.map_err(ClusterError::Storage)?;
+                        Ok(apply_row_limit(partition, row_limit))
+                    },
+                )),
             };
             return Ok(stream);
         }
@@ -729,6 +1212,214 @@ impl ClusterCoordinator {
 mod tests {
     use super::*;
     use crate::consistency::ConsistencyLevel as CL;
+    use ferrosa_common::key::{DecoratedKey, PartitionKey};
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
+
+    fn dk(tok_seed: &[u8]) -> DecoratedKey {
+        DecoratedKey::new(PartitionKey::from(tok_seed))
+    }
+
+    fn trow(clustering: i32, value: &[u8], ts: i64) -> Row {
+        Row {
+            clustering: clustering.to_be_bytes().to_vec(),
+            cells: vec![(0, ferrosa_common::CellValue::live(value.to_vec(), ts))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(ts),
+        }
+    }
+
+    /// Split a whole partition into `<= k`-row fragment `Partition`s per the
+    /// wire contract: the first fragment carries the header (deletion +
+    /// static row), later fragments carry `LIVE` / `None`.
+    fn fragment_partition(p: &Partition, k: usize) -> Vec<Partition> {
+        let mut out = Vec::new();
+        let mut first = true;
+        let mut chunks = p.rows.chunks(k).peekable();
+        // Always emit at least one fragment so an empty / header-only
+        // partition still carries its header.
+        if chunks.peek().is_none() {
+            out.push(Partition {
+                key: p.key.clone(),
+                deletion: p.deletion,
+                static_row: p.static_row.clone(),
+                rows: Vec::new(),
+            });
+            return out;
+        }
+        for chunk in chunks {
+            if first {
+                first = false;
+                out.push(Partition {
+                    key: p.key.clone(),
+                    deletion: p.deletion,
+                    static_row: p.static_row.clone(),
+                    rows: chunk.to_vec(),
+                });
+            } else {
+                out.push(Partition {
+                    key: p.key.clone(),
+                    deletion: DeletionTime::LIVE,
+                    static_row: None,
+                    rows: chunk.to_vec(),
+                });
+            }
+        }
+        out
+    }
+
+    fn stream_of(
+        frags: Vec<Partition>,
+    ) -> impl futures::Stream<Item = Result<Partition, ClusterError>> + Unpin {
+        futures::stream::iter(frags.into_iter().map(Ok))
+    }
+
+    /// Flatten a fragment stream into whole partitions (one per key), the way
+    /// the CQL row bridge does (append rows per item).
+    fn flatten(frags: Vec<Partition>) -> Vec<Partition> {
+        let mut out: Vec<Partition> = Vec::new();
+        for f in frags {
+            match out.last_mut() {
+                Some(p) if p.key == f.key => p.rows.extend(f.rows),
+                _ => out.push(f),
+            }
+        }
+        out
+    }
+
+    /// Drive `run_fragment_merge` to completion over two in-memory fragment
+    /// streams and collect the emitted fragments.
+    async fn drive_merge(
+        local: Vec<Partition>,
+        remote: Vec<Partition>,
+        k: usize,
+    ) -> Vec<Partition> {
+        let (tx, mut rx) = mpsc::channel(1024);
+        let lc = FragmentCursor::new(stream_of(local));
+        let rc = FragmentCursor::new(stream_of(remote));
+        let driver = tokio::spawn(async move { run_fragment_merge(lc, rc, k, tx).await });
+        let mut out = Vec::new();
+        while let Some(item) = rx.recv().await {
+            out.push(item.expect("merge produced an error"));
+        }
+        driver.await.unwrap();
+        out
+    }
+
+    /// The fragment-aware cross-replica merge must reproduce, per token, the
+    /// whole-partition `merge_partitions(vec![local, remote])` result —
+    /// byte-identical after flattening — for LWW conflicts, tombstones,
+    /// static rows, and disjoint tokens, across several `k`.
+    #[tokio::test]
+    async fn fragment_cross_replica_merge_equiv_whole_partition_merge() {
+        // Token-ordered keys. (DecoratedKey orders by token then key bytes;
+        // we sort our inputs by key to feed both streams in order.)
+        let mut keys = [dk(b"alpha"), dk(b"bravo"), dk(b"charlie"), dk(b"delta")];
+        keys.sort();
+
+        // key0: LWW conflict on shared clustering keys (remote newer wins on evens).
+        let local0 = Partition {
+            key: keys[0].clone(),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: (0..30)
+                .map(|c| trow(c, format!("L{c}").as_bytes(), 1000))
+                .collect(),
+        };
+        let remote0 = Partition {
+            key: keys[0].clone(),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: (0..30)
+                .filter(|c| c % 2 == 0)
+                .map(|c| trow(c, format!("R{c}").as_bytes(), 2000))
+                .collect(),
+        };
+        // key1: local-only (disjoint token from remote).
+        let local1 = Partition {
+            key: keys[1].clone(),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: (0..12)
+                .map(|c| trow(c, format!("x{c}").as_bytes(), 1500))
+                .collect(),
+        };
+        // key2: remote-only.
+        let remote2 = Partition {
+            key: keys[2].clone(),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: (0..7)
+                .map(|c| trow(c, format!("y{c}").as_bytes(), 1500))
+                .collect(),
+        };
+        // key3: both sides, with a static row on local and a partition
+        // tombstone on remote suppressing local's older rows.
+        let mut local3 = Partition {
+            key: keys[3].clone(),
+            deletion: DeletionTime::LIVE,
+            static_row: Some(Row {
+                clustering: vec![],
+                cells: vec![(0, ferrosa_common::CellValue::live(b"st".to_vec(), 9000))],
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::NONE,
+            }),
+            rows: (0..20)
+                .map(|c| trow(c, format!("o{c}").as_bytes(), 1000))
+                .collect(),
+        };
+        local3.rows.sort_by(|a, b| a.clustering.cmp(&b.clustering));
+        let remote3 = Partition {
+            key: keys[3].clone(),
+            deletion: DeletionTime::new(1500, 100), // suppresses local's ts=1000 rows
+            static_row: None,
+            rows: (20..40)
+                .map(|c| trow(c, format!("n{c}").as_bytes(), 3000))
+                .collect(),
+        };
+
+        // Whole-partition reference per token.
+        let reference = {
+            let mut r = vec![
+                ferrosa_storage::merge::merge_partitions(vec![local0.clone(), remote0.clone()]),
+                local1.clone(),
+                remote2.clone(),
+                ferrosa_storage::merge::merge_partitions(vec![local3.clone(), remote3.clone()]),
+            ];
+            r.sort_by(|a, b| a.key.cmp(&b.key));
+            r
+        };
+
+        let mut local_whole = [local0, local1, local3];
+        local_whole.sort_by(|a, b| a.key.cmp(&b.key));
+        let mut remote_whole = [remote0, remote2, remote3];
+        remote_whole.sort_by(|a, b| a.key.cmp(&b.key));
+
+        for k in [1usize, 2, 3, 8, 1024] {
+            let local_frags: Vec<Partition> = local_whole
+                .iter()
+                .flat_map(|p| fragment_partition(p, k))
+                .collect();
+            let remote_frags: Vec<Partition> = remote_whole
+                .iter()
+                .flat_map(|p| fragment_partition(p, k))
+                .collect();
+
+            let emitted = drive_merge(local_frags, remote_frags, k).await;
+            // No emitted fragment exceeds k rows (bounded memory contract).
+            for f in &emitted {
+                assert!(
+                    f.rows.len() <= k,
+                    "emitted fragment {} exceeds k={k}",
+                    f.rows.len()
+                );
+            }
+            let merged = flatten(emitted);
+            assert_eq!(
+                merged, reference,
+                "fragment cross-replica merge(k={k}) diverged from whole-partition merge"
+            );
+        }
+    }
 
     /// RF=cluster_size: local replica owns every partition, so
     /// CL=ONE / LOCAL_ONE needs zero remote replicas. QUORUM needs

--- a/ferrosa-cluster/src/coordinator/stream_request_handler.rs
+++ b/ferrosa-cluster/src/coordinator/stream_request_handler.rs
@@ -46,6 +46,23 @@ use crate::raft::handlers::{
 /// stall.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3);
 
+/// Default ceiling on the number of clustered rows packed into one stream
+/// chunk frame. Matches `ferrosa_storage::range_merger`'s default fragment
+/// cap so a single full fragment flushes as one chunk. Env-tunable through
+/// the same `FERROSA_RANGE_READ_ROWS_PER_FRAGMENT` knob that bounds the
+/// producer, keeping the wire frame and the producer fragment aligned.
+const DEFAULT_STREAM_CHUNK_ROW_CAP: usize = 4_096;
+
+pub(crate) fn stream_chunk_row_cap() -> usize {
+    match std::env::var("FERROSA_RANGE_READ_ROWS_PER_FRAGMENT") {
+        Ok(v) => match v.trim().parse::<usize>() {
+            Ok(n) if n >= 1 => n,
+            _ => DEFAULT_STREAM_CHUNK_ROW_CAP,
+        },
+        Err(_) => DEFAULT_STREAM_CHUNK_ROW_CAP,
+    }
+}
+
 /// Type alias for the per-partition async stream returned by
 /// [`StreamRangeReader::range_iter`]. Each item is either a
 /// successfully-decoded partition or a (recoverable) per-partition
@@ -80,24 +97,29 @@ impl StreamRangeReader for Arc<ferrosa_storage::StorageEngine> {
         table_id: &TableId,
         projected_regular_ordinals: Option<&'a [u16]>,
     ) -> ferrosa_common::Result<PartitionStream<'a>> {
-        // ADR-020 Phase 2 backing: StorageEngine::range_iter returns
-        // a Stream backed by crate::range_merger::RangeMerger — a
-        // k-way merge across memtable + flushing memtable + per-SSTable
-        // iterators, yielding one merged-and-deletion-suppressed
-        // partition at a time. Memory at every layer is bounded by
-        // num_sources, not table size; no Vec<Partition> exists for
-        // the whole table at any point in the pipeline.
+        // ADR-020 Phase 2 backing: the FRAGMENTED range iterators back the
+        // replica stream. They k-way merge across memtable + flushing
+        // memtable + per-SSTable iterators AND, crucially, stream a single
+        // wide partition's rows in bounded fragments (<= K rows each), so
+        // resident memory is `O(num_sources + K)` rows regardless of
+        // partition width — not `O(widest_partition_rows)`. A single
+        // multi-million-row inverted-index partition (one hot term) is what
+        // OOM-killed replicas on a full-table `SELECT *`; this is the fix.
+        // The fragments carry the partition header only on the first
+        // fragment, so the coordinator's per-partition row bridge reproduces
+        // the merged partition byte-for-byte.
         if let Some(wanted) = projected_regular_ordinals {
-            Ok(ferrosa_storage::StorageEngine::range_iter_projected(
-                self.as_ref(),
-                table_id,
-                wanted.to_vec(),
-                None,
-                None,
-                None,
-            ))
+            Ok(
+                ferrosa_storage::StorageEngine::range_iter_projected_fragmented(
+                    self.as_ref(),
+                    table_id,
+                    wanted.to_vec(),
+                    None,
+                    None,
+                ),
+            )
         } else {
-            Ok(ferrosa_storage::StorageEngine::range_iter(
+            Ok(ferrosa_storage::StorageEngine::range_iter_fragmented(
                 self.as_ref(),
                 table_id,
                 None,
@@ -166,9 +188,18 @@ pub async fn handle_stream_request_with_cancel<R, S>(
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     ticker.tick().await;
 
+    // Bound each emitted chunk by TOTAL ROWS, not just partition/fragment
+    // count. The fragmented range iterator already splits a wide partition
+    // into `<= K`-row items, but `chunk_size` of them would still be
+    // `chunk_size * K` rows in one wire frame. Flushing on a row threshold
+    // keeps each chunk frame inside the Bulk lane envelope regardless of how
+    // the fragments fall. The threshold is the per-fragment cap K (mirrored
+    // from storage's default) so a single full fragment flushes promptly.
+    let row_chunk_cap: usize = stream_chunk_row_cap();
     let mut heartbeat_seq: u32 = 0;
     let mut chunk_seq: u32 = 0;
     let mut batch: Vec<Partition> = Vec::with_capacity(chunk_size);
+    let mut batch_rows: usize = 0;
     let mut total_chunks_emitted: u32 = 0;
     let mut any_decode_error = false;
 
@@ -185,9 +216,11 @@ pub async fn handle_stream_request_with_cancel<R, S>(
             }
             next = stream.next() => match next {
                 Some(Ok(partition)) => {
+                    batch_rows = batch_rows.saturating_add(partition.rows.len());
                     batch.push(partition);
-                    if batch.len() >= chunk_size {
+                    if batch.len() >= chunk_size || batch_rows >= row_chunk_cap {
                         emit_chunk(&req, &mut batch, chunk_seq, sink).await;
+                        batch_rows = 0;
                         chunk_seq = chunk_seq.saturating_add(1);
                         total_chunks_emitted = total_chunks_emitted.saturating_add(1);
                     }

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -44,6 +44,34 @@ fn local_range_stream(
     Box::pin(stream)
 }
 
+/// Fragmented (intra-partition streaming) range stream with an optional
+/// inclusive lower-bound key. Used by the coordinator-side paging cursor to
+/// resume an unbounded `SELECT *` scan at the last partition key without
+/// materializing the whole table. `row_limit == 0` (the unbounded scan shape)
+/// is the only caller, so wide partitions stream as bounded fragments.
+fn local_range_stream_from(
+    engine: Arc<StorageEngine>,
+    table_id: &TableId,
+    start: Option<&DecoratedKey>,
+) -> PartitionResultStream {
+    let stream = engine
+        .range_iter_fragmented(table_id, start, None)
+        .map(|item| item.map_err(crate::error::ClusterError::Storage));
+    Box::pin(stream)
+}
+
+fn local_projected_range_stream_from(
+    engine: Arc<StorageEngine>,
+    table_id: &TableId,
+    wanted: Vec<u16>,
+    start: Option<&DecoratedKey>,
+) -> PartitionResultStream {
+    let stream = engine
+        .range_iter_projected_fragmented(table_id, wanted, start, None)
+        .map(|item| item.map_err(crate::error::ClusterError::Storage));
+    Box::pin(stream)
+}
+
 fn local_projected_range_stream(
     engine: Arc<StorageEngine>,
     table_id: &TableId,
@@ -381,6 +409,100 @@ impl WritePath {
             }
             Self::Unavailable => Err(crate::error::ClusterError::Internal(
                 "range read unavailable: write path is in degraded mode".into(),
+            )),
+        }
+    }
+
+    /// Stream every partition starting at an inclusive lower-bound key, using
+    /// the fragmented (intra-partition streaming) iterators.
+    ///
+    /// This backs the coordinator-side paging cursor for unbounded `SELECT *`
+    /// scans: the previous page's continuation token is decoded into a `start`
+    /// key, the scan resumes there, and the consumer drops rows already emitted
+    /// within that partition. `start == None` is the first page.
+    ///
+    /// In cluster mode this requires the local-only fan-out (CL=ONE with the
+    /// keyspace RF spanning the ring); multi-replica token-aware merge with a
+    /// resume key is not yet implemented and is refused rather than returning a
+    /// partial scan.
+    pub async fn range_read_stream_all_from(
+        &self,
+        table_id: &TableId,
+        start: Option<&DecoratedKey>,
+        cl: ConsistencyLevel,
+        strategy: &ReplicationStrategy,
+    ) -> crate::error::Result<PartitionResultStream> {
+        match self {
+            Self::Direct(engine) => Ok(local_range_stream_from(engine.clone(), table_id, start)),
+            Self::Pair(coordinator) => Ok(local_range_stream_from(
+                coordinator.local_storage().clone(),
+                table_id,
+                start,
+            )),
+            Self::Cluster(coordinator) => {
+                if !coordinator.streaming_range_reads {
+                    return Err(crate::error::ClusterError::Internal(
+                        "uncapped range_read is unavailable because FERROSA_BULK_STREAMING_RANGE_READ=0 selected the legacy capped range RPC; refusing to return a partial scan".into(),
+                    ));
+                }
+                coordinator
+                    .coordinate_range_read_stream_from(
+                        table_id,
+                        start,
+                        cl,
+                        strategy.replication_factor(),
+                    )
+                    .await
+            }
+            Self::Unavailable => Err(crate::error::ClusterError::Internal(
+                "range read unavailable: write path is in degraded mode".into(),
+            )),
+        }
+    }
+
+    /// Projection-aware resume-capable streaming range read with an inclusive
+    /// lower-bound key. Mirrors [`Self::range_read_stream_all_from`] for the
+    /// `SELECT col1, col2 FROM t` (no WHERE) paged scan shape, byte-skipping
+    /// unprojected cells in the SSTable layer.
+    pub async fn range_read_projected_stream_all_from(
+        &self,
+        table_id: &TableId,
+        wanted: Vec<u16>,
+        start: Option<&DecoratedKey>,
+        cl: ConsistencyLevel,
+        strategy: &ReplicationStrategy,
+    ) -> crate::error::Result<PartitionResultStream> {
+        match self {
+            Self::Direct(engine) => Ok(local_projected_range_stream_from(
+                engine.clone(),
+                table_id,
+                wanted,
+                start,
+            )),
+            Self::Pair(coordinator) => Ok(local_projected_range_stream_from(
+                coordinator.local_storage().clone(),
+                table_id,
+                wanted,
+                start,
+            )),
+            Self::Cluster(coordinator) => {
+                if !coordinator.streaming_range_reads {
+                    return Err(crate::error::ClusterError::Internal(
+                        "uncapped range_read is unavailable because FERROSA_BULK_STREAMING_RANGE_READ=0 selected the legacy capped range RPC; refusing to return a partial scan".into(),
+                    ));
+                }
+                coordinator
+                    .coordinate_range_read_projected_stream_from(
+                        table_id,
+                        wanted,
+                        start,
+                        cl,
+                        strategy.replication_factor(),
+                    )
+                    .await
+            }
+            Self::Unavailable => Err(crate::error::ClusterError::Internal(
+                "range_read_projected unavailable: write path is in degraded mode".into(),
             )),
         }
     }

--- a/ferrosa-cql/src/bridge.rs
+++ b/ferrosa-cql/src/bridge.rs
@@ -1177,6 +1177,34 @@ pub fn partition_to_rows_with_storage_mapping(
     ck_columns: &[usize],
     storage_to_table: &[usize],
 ) -> Vec<Vec<Option<CqlValue>>> {
+    partition_to_rows_with_clustering(
+        partition,
+        column_names,
+        column_types,
+        pk_columns,
+        ck_columns,
+        storage_to_table,
+    )
+    .into_iter()
+    .map(|(_clustering, row)| row)
+    .collect()
+}
+
+/// Like [`partition_to_rows_with_storage_mapping`] but pairs each produced
+/// output row with the raw clustering-key bytes of the source row.
+///
+/// The coordinator-side paging cursor needs the clustering bytes of the last
+/// row emitted on a page to resume mid-partition without skipping or
+/// duplicating rows. Tombstone/TTL skipping logic lives here once so the
+/// paired and unpaired variants stay byte-identical.
+pub fn partition_to_rows_with_clustering(
+    partition: &ferrosa_sstable::types::Partition,
+    column_names: &[String],
+    column_types: &[CqlType],
+    pk_columns: &[usize],
+    ck_columns: &[usize],
+    storage_to_table: &[usize],
+) -> Vec<(Vec<u8>, Vec<Option<CqlValue>>)> {
     let mut result = Vec::new();
 
     // Wall-clock seconds for TTL expiry, evaluated once per call. Expiry is
@@ -1266,7 +1294,7 @@ pub fn partition_to_rows_with_storage_mapping(
             }
         }
 
-        result.push(output_row);
+        result.push((row.clustering.clone(), output_row));
     }
 
     result

--- a/ferrosa-cql/src/paging.rs
+++ b/ferrosa-cql/src/paging.rs
@@ -92,6 +92,29 @@ impl PagingState {
     }
 }
 
+/// Default page size applied to unbounded range/full scans when the client
+/// supplies no `page_size` on the wire.
+///
+/// Without this, a full-table `SELECT *` with no client page_size accumulates
+/// the entire result into the coordinator's `all_rows` buffer, which OOM-kills
+/// the coordinator on large tables. Bounding the page guarantees the scan
+/// returns at most this many rows per response with a continuation token.
+///
+/// Tunable via `FERROSA_CQL_DEFAULT_PAGE_SIZE`. A non-positive or unparseable
+/// value falls back to [`DEFAULT_SCAN_PAGE_SIZE`].
+pub const DEFAULT_SCAN_PAGE_SIZE: usize = 5_000;
+
+/// Resolve the default scan page size from the environment, falling back to
+/// [`DEFAULT_SCAN_PAGE_SIZE`]. The python driver's default `fetch_size` is
+/// 5000, so an unpaged client query gets the same effective bound.
+pub fn default_scan_page_size() -> usize {
+    std::env::var("FERROSA_CQL_DEFAULT_PAGE_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_SCAN_PAGE_SIZE)
+}
+
 /// Parameters for pagination extracted from the QUERY/EXECUTE frame.
 #[derive(Debug, Clone, Default)]
 pub struct PagingParams {

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -622,6 +622,134 @@ async fn extend_rows_from_partition_stream(
     Ok(())
 }
 
+/// Resume cursor decoded from the wire `paging_state` for a streaming scan.
+///
+/// `partition_key` / `clustering_key` are the raw serialized bytes of the last
+/// row returned on the previous page. Resume re-enters the scan at the last
+/// partition key (inclusive) and skips every row in that partition whose
+/// clustering bytes are `<= clustering_key`, so an exactly-once continuation
+/// holds whether the previous page ended on a partition boundary or mid-way
+/// through a wide partition.
+struct StreamResumeCursor {
+    partition_key: Vec<u8>,
+    clustering_key: Vec<u8>,
+}
+
+impl StreamResumeCursor {
+    fn from_paging_state(paging_state: Option<&[u8]>) -> Result<Option<Self>, CqlError> {
+        match paging_state {
+            None => Ok(None),
+            Some(bytes) => {
+                let state = crate::paging::PagingState::decode(bytes)?;
+                Ok(Some(Self {
+                    partition_key: state.partition_key,
+                    clustering_key: state.clustering_key,
+                }))
+            }
+        }
+    }
+}
+
+/// One bounded page collected from a partition stream.
+struct StreamedPage {
+    rows: Vec<Vec<Option<CqlValue>>>,
+    /// Continuation token for the next page, `None` when the scan is exhausted.
+    next_paging_state: Option<Vec<u8>>,
+}
+
+/// Collect at most `page_size` rows from a partition stream, encoding a
+/// `PagingState` continuation when more rows remain.
+///
+/// This is the coordinator-side OOM bound for unbounded `SELECT *`-shaped
+/// scans: the stream is fragmented (intra-partition streaming), so the
+/// producer holds `O(num_sources + K)` rows resident, and this consumer never
+/// retains more than `page_size` output rows. The previous behavior buffered
+/// the entire table into `all_rows` before returning.
+///
+/// Correctness: partitions arrive in token order and rows in clustering order.
+/// `resume` re-enters at the last partition key (inclusive) and drops rows
+/// already emitted (`clustering <= resume.clustering_key` within that key), so
+/// the union of all pages equals the whole scan with no gaps or duplicates,
+/// including a wide partition that spans pages.
+async fn collect_page_from_partition_stream(
+    mut stream: ferrosa_cluster::write_path::PartitionResultStream,
+    page_size: usize,
+    resume: Option<StreamResumeCursor>,
+    row_context: PartitionRowContext<'_>,
+) -> Result<StreamedPage, CqlError> {
+    debug_assert!(page_size > 0, "page_size must be positive");
+
+    let mut rows: Vec<Vec<Option<CqlValue>>> = Vec::with_capacity(page_size);
+    // Cursor bytes for the most recently accepted row.
+    let mut last_pk: Vec<u8> = Vec::new();
+    let mut last_ck: Vec<u8> = Vec::new();
+    // Set once we have a full page and then observe one more row — that extra
+    // row proves a continuation is needed.
+    let mut more_rows_remain = false;
+    let mut processed_partitions = 0usize;
+
+    'outer: while let Some(partition) = stream.next().await {
+        let partition = partition?;
+        let pk_bytes = partition.key.key.as_bytes().to_vec();
+        let paired = bridge::partition_to_rows_with_clustering(
+            &partition,
+            row_context.all_col_names,
+            row_context.all_col_types,
+            row_context.pk_indices,
+            row_context.ck_indices,
+            row_context.storage_to_table,
+        );
+
+        for (clustering, output_row) in paired {
+            // Skip rows already returned on a previous page. Only applies to
+            // the partition the cursor stopped in; once we pass it (or land in
+            // a later partition), nothing is skipped.
+            if let Some(ref cur) = resume {
+                if pk_bytes == cur.partition_key && clustering <= cur.clustering_key {
+                    continue;
+                }
+            }
+
+            if rows.len() == page_size {
+                // We already have a full page and just found another row — a
+                // continuation is required. Stop without consuming further.
+                more_rows_remain = true;
+                break 'outer;
+            }
+
+            rows.push(output_row);
+            last_pk = pk_bytes.clone();
+            last_ck = clustering;
+        }
+
+        processed_partitions += 1;
+        if should_yield_during_partition_scan(
+            processed_partitions,
+            cooperative_scan_yield_every_partitions(),
+        ) {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    let next_paging_state = if more_rows_remain {
+        Some(
+            crate::paging::PagingState {
+                partition_key: last_pk,
+                clustering_key: last_ck,
+                remaining_in_partition: false,
+            }
+            .encode(),
+        )
+    } else {
+        None
+    };
+
+    Ok(StreamedPage {
+        rows,
+        next_paging_state,
+    })
+}
+
 fn storage_to_table_indices(table_meta: &TableMetadata) -> Vec<usize> {
     let mut pairs: Vec<(u16, usize)> = table_meta
         .columns
@@ -2689,6 +2817,12 @@ async fn route_select_user_table(
         });
     }
 
+    // Set by the streaming full-scan page path when it has already applied
+    // page bounds + the continuation cursor. `Some(state)` (which may itself be
+    // `None` for the final page) means the generic `apply_pagination` tail must
+    // be skipped — the rows are already exactly one bounded page.
+    let mut streamed_paging_state: Option<Option<Vec<u8>>> = None;
+
     let rows = if let Ok(pk_values) = pk_result {
         // PK present — single partition lookup
         let pk_types: Vec<CqlType> = table_meta
@@ -3090,18 +3224,113 @@ async fn route_select_user_table(
                     ));
                 }
 
-                // Use a bounded upstream partition cap for unordered,
-                // non-aggregate scans so first pages do not wait behind an
-                // unbounded table materialization. When ALLOW FILTERING has
-                // post-filter predicates, no upstream partition cap is safe:
-                // LIMIT 1 may need to inspect many non-matching partitions
-                // before finding the first matching row, and a fixed cap would
-                // silently drop later matches. In that shape, stream the full
-                // table and apply LIMIT/page semantics after filtering.
-                // Ordered and aggregate queries still materialize their scan
-                // window before sorting/counting.
-                let scan_bound =
-                    if s.order_by.is_empty() && s.ann_of.is_none() && !count_only_select {
+                // Coordinator-side OOM bound (P0): an unbounded full-table scan
+                // with no WHERE/ORDER BY/ANN/DISTINCT/LIMIT used to accumulate
+                // the ENTIRE result into `all_rows` before returning, OOM-killing
+                // the coordinator on large tables. Stream at most one bounded
+                // page instead and return a `PagingState` continuation. A
+                // default page applies when the client sends no `page_size`, so
+                // even an un-paged `SELECT *` cannot accumulate unbounded rows.
+                //
+                // Other shapes (predicates, ORDER BY, ANN, DISTINCT, LIMIT,
+                // COUNT) keep their existing materialize-bounded behavior, where
+                // the scan window is already bounded by LIMIT/sort/count needs.
+                // Exclude any function-call projection: aggregates
+                // (COUNT/AVG/MIN/MAX/SUM) and UDAs fold over the WHOLE result,
+                // so paging the scan would compute them over a single page.
+                // Scalar UDFs/toJson are per-row and safe, but excluding all
+                // function calls keeps the streaming gate to plain column/star
+                // projections — exactly the unbounded `SELECT *` OOM shape.
+                let has_function_projection = s
+                    .columns
+                    .iter()
+                    .any(|c| matches!(c, SelectColumn::FunctionCall { .. }));
+                let unbounded_scan_shape = s.where_clauses.is_empty()
+                    && s.order_by.is_empty()
+                    && s.ann_of.is_none()
+                    && !s.distinct
+                    && s.limit.is_none()
+                    && !count_only_select
+                    && !has_function_projection;
+                if unbounded_scan_shape {
+                    let page_size = ctx
+                        .paging
+                        .page_size
+                        .and_then(|ps| (ps > 0).then_some(ps as usize))
+                        .unwrap_or_else(crate::paging::default_scan_page_size);
+
+                    let resume =
+                        StreamResumeCursor::from_paging_state(ctx.paging.paging_state.as_deref())?;
+                    // Resume the scan at the last partition key (inclusive); the
+                    // collector drops rows already emitted within that key.
+                    let start_key = resume.as_ref().map(|cur| {
+                        ferrosa_common::key::DecoratedKey::new(
+                            ferrosa_common::key::PartitionKey::from(cur.partition_key.as_slice()),
+                        )
+                    });
+
+                    // The gate above guarantees `where_clauses.is_empty()`, so a
+                    // column projection is always safe here (no predicate reads
+                    // an unprojected cell).
+                    let scan_projection =
+                        projection_storage_ordinals_for_select_scan(s, table_meta);
+
+                    let stream = if let Some(wanted) = scan_projection {
+                        state
+                            .write_path
+                            .load()
+                            .range_read_projected_stream_all_from(
+                                &table_id,
+                                wanted,
+                                start_key.as_ref(),
+                                ctx.consistency,
+                                &table_strategy,
+                            )
+                            .await?
+                    } else {
+                        state
+                            .write_path
+                            .load()
+                            .range_read_stream_all_from(
+                                &table_id,
+                                start_key.as_ref(),
+                                ctx.consistency,
+                                &table_strategy,
+                            )
+                            .await?
+                    };
+
+                    let page = collect_page_from_partition_stream(
+                        stream,
+                        page_size,
+                        resume,
+                        PartitionRowContext {
+                            all_col_names: &all_col_names,
+                            all_col_types: &all_col_types,
+                            pk_indices: &pk_indices,
+                            ck_indices: &ck_indices,
+                            storage_to_table: &storage_to_table,
+                        },
+                    )
+                    .await?;
+
+                    streamed_paging_state = Some(page.next_paging_state);
+                    page.rows
+                } else {
+                    // Use a bounded upstream partition cap for unordered,
+                    // non-aggregate scans so first pages do not wait behind an
+                    // unbounded table materialization. When ALLOW FILTERING has
+                    // post-filter predicates, no upstream partition cap is safe:
+                    // LIMIT 1 may need to inspect many non-matching partitions
+                    // before finding the first matching row, and a fixed cap would
+                    // silently drop later matches. In that shape, stream the full
+                    // table and apply LIMIT/page semantics after filtering.
+                    // Ordered and aggregate queries still materialize their scan
+                    // window before sorting/counting.
+                    let scan_bound = if s.order_by.is_empty()
+                        && s.ann_of.is_none()
+                        && !count_only_select
+                    {
                         let has_post_filter = s.allow_filtering && !non_token_clauses.is_empty();
                         if has_post_filter {
                             None
@@ -3139,95 +3368,133 @@ async fn route_select_user_table(
                     } else {
                         None
                     };
-                let row_limit =
-                    safe_partition_key_filter_row_limit(s, table_meta, count_only_select)
-                        .unwrap_or(0);
-                // ADR-020 projection fast path. Route through
-                // range_read_projected whenever the query only needs a subset
-                // of regular cells, so the SSTable layer byte-skips bulky
-                // unneeded payloads. Big win on wide tables with bulky cells
-                // (e.g. entity_store's entity_embedding column).
-                //
-                // Non-count SELECT requires no WHERE because predicates over
-                // unprojected regular columns would evaluate against NULL.
-                let projection_wanted = if !count_only_select && s.where_clauses.is_empty() {
-                    projection_storage_ordinals_for_select_scan(s, table_meta)
-                } else {
-                    None
-                };
-                // Count-only filtered scans project predicate columns only and
-                // fold over a partition stream, so COUNT(*) avoids decoding
-                // unrelated cells without first collecting partitions in a Vec.
-                let count_projection_wanted = if count_only_select {
-                    projection_storage_ordinals_for_count_predicates(&s.where_clauses, table_meta)
-                } else {
-                    None
-                };
-                let partitions = if let Some(wanted) = projection_wanted {
-                    // Push partition-count cap down to the merger so
-                    // `LIMIT N` stops the scan after N partitions
-                    // rather than walking every SSTable.
-                    Some(
-                        state
-                            .write_path
-                            .load()
-                            .range_read_projected(&table_id, wanted, scan_bound)
-                            .await?,
-                    )
-                } else if let Some(bound) = scan_bound {
-                    Some(
-                        state
-                            .write_path
-                            .load()
-                            .range_read_limited_rows(&table_id, bound, row_limit)
-                            .await?,
-                    )
-                } else if row_limit > 0 {
-                    Some(
-                        state
-                            .write_path
-                            .load()
-                            .range_read_limited_rows(
-                                &table_id,
-                                ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT,
-                                row_limit,
-                            )
-                            .await?,
-                    )
-                } else {
-                    None
-                };
-                if count_only_select {
-                    let row_context = PartitionRowContext {
-                        all_col_names: &all_col_names,
-                        all_col_types: &all_col_types,
-                        pk_indices: &pk_indices,
-                        ck_indices: &ck_indices,
-                        storage_to_table: &storage_to_table,
+                    let row_limit =
+                        safe_partition_key_filter_row_limit(s, table_meta, count_only_select)
+                            .unwrap_or(0);
+                    // ADR-020 projection fast path. Route through
+                    // range_read_projected whenever the query only needs a subset
+                    // of regular cells, so the SSTable layer byte-skips bulky
+                    // unneeded payloads. Big win on wide tables with bulky cells
+                    // (e.g. entity_store's entity_embedding column).
+                    //
+                    // Non-count SELECT requires no WHERE because predicates over
+                    // unprojected regular columns would evaluate against NULL.
+                    let projection_wanted = if !count_only_select && s.where_clauses.is_empty() {
+                        projection_storage_ordinals_for_select_scan(s, table_meta)
+                    } else {
+                        None
                     };
-                    let predicate_context = SelectPredicateContext {
-                        statement: s,
-                        table_meta,
-                        keyspace: ks,
-                        state,
+                    // Count-only filtered scans project predicate columns only and
+                    // fold over a partition stream, so COUNT(*) avoids decoding
+                    // unrelated cells without first collecting partitions in a Vec.
+                    let count_projection_wanted = if count_only_select {
+                        projection_storage_ordinals_for_count_predicates(
+                            &s.where_clauses,
+                            table_meta,
+                        )
+                    } else {
+                        None
                     };
-                    let count = if let Some(partitions) = partitions.as_ref() {
-                        count_rows_from_partitions(partitions, row_context, predicate_context)
-                            .await?
-                    } else if let Some(wanted) = count_projection_wanted {
-                        let stream = state
-                            .write_path
-                            .load()
-                            .range_read_projected_stream_all_with(
-                                &table_id,
-                                wanted,
-                                scan_bound,
-                                ctx.consistency,
-                                &table_strategy,
-                            )
-                            .await?;
-                        count_rows_from_partition_stream(stream, row_context, predicate_context)
-                            .await?
+                    let partitions = if let Some(wanted) = projection_wanted {
+                        // Push partition-count cap down to the merger so
+                        // `LIMIT N` stops the scan after N partitions
+                        // rather than walking every SSTable.
+                        Some(
+                            state
+                                .write_path
+                                .load()
+                                .range_read_projected(&table_id, wanted, scan_bound)
+                                .await?,
+                        )
+                    } else if let Some(bound) = scan_bound {
+                        Some(
+                            state
+                                .write_path
+                                .load()
+                                .range_read_limited_rows(&table_id, bound, row_limit)
+                                .await?,
+                        )
+                    } else if row_limit > 0 {
+                        Some(
+                            state
+                                .write_path
+                                .load()
+                                .range_read_limited_rows(
+                                    &table_id,
+                                    ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT,
+                                    row_limit,
+                                )
+                                .await?,
+                        )
+                    } else {
+                        None
+                    };
+                    if count_only_select {
+                        let row_context = PartitionRowContext {
+                            all_col_names: &all_col_names,
+                            all_col_types: &all_col_types,
+                            pk_indices: &pk_indices,
+                            ck_indices: &ck_indices,
+                            storage_to_table: &storage_to_table,
+                        };
+                        let predicate_context = SelectPredicateContext {
+                            statement: s,
+                            table_meta,
+                            keyspace: ks,
+                            state,
+                        };
+                        let count = if let Some(partitions) = partitions.as_ref() {
+                            count_rows_from_partitions(partitions, row_context, predicate_context)
+                                .await?
+                        } else if let Some(wanted) = count_projection_wanted {
+                            let stream = state
+                                .write_path
+                                .load()
+                                .range_read_projected_stream_all_with(
+                                    &table_id,
+                                    wanted,
+                                    scan_bound,
+                                    ctx.consistency,
+                                    &table_strategy,
+                                )
+                                .await?;
+                            count_rows_from_partition_stream(stream, row_context, predicate_context)
+                                .await?
+                        } else {
+                            let stream = state
+                                .write_path
+                                .load()
+                                .range_read_stream_all_with(
+                                    &table_id,
+                                    row_limit,
+                                    ctx.consistency,
+                                    &table_strategy,
+                                )
+                                .await?;
+                            count_rows_from_partition_stream(stream, row_context, predicate_context)
+                                .await?
+                        };
+                        return Ok(SelectRawResult {
+                            column_names: col_names.to_vec(),
+                            column_types: col_types.to_vec(),
+                            rows: vec![vec![Some(CqlValue::Bigint(count))]],
+                            keyspace: ks.to_string(),
+                            table: s.table.clone(),
+                            paging_state: None,
+                        });
+                    }
+                    let mut all_rows = Vec::new();
+                    if let Some(partitions) = partitions.as_ref() {
+                        extend_rows_from_partitions(
+                            partitions,
+                            &mut all_rows,
+                            &all_col_names,
+                            &all_col_types,
+                            &pk_indices,
+                            &ck_indices,
+                            &storage_to_table,
+                        )
+                        .await;
                     } else {
                         let stream = state
                             .write_path
@@ -3239,62 +3506,28 @@ async fn route_select_user_table(
                                 &table_strategy,
                             )
                             .await?;
-                        count_rows_from_partition_stream(stream, row_context, predicate_context)
-                            .await?
-                    };
-                    return Ok(SelectRawResult {
-                        column_names: col_names.to_vec(),
-                        column_types: col_types.to_vec(),
-                        rows: vec![vec![Some(CqlValue::Bigint(count))]],
-                        keyspace: ks.to_string(),
-                        table: s.table.clone(),
-                        paging_state: None,
-                    });
-                }
-                let mut all_rows = Vec::new();
-                if let Some(partitions) = partitions.as_ref() {
-                    extend_rows_from_partitions(
-                        partitions,
-                        &mut all_rows,
-                        &all_col_names,
-                        &all_col_types,
-                        &pk_indices,
-                        &ck_indices,
-                        &storage_to_table,
-                    )
-                    .await;
-                } else {
-                    let stream = state
-                        .write_path
-                        .load()
-                        .range_read_stream_all_with(
-                            &table_id,
-                            row_limit,
-                            ctx.consistency,
-                            &table_strategy,
+                        extend_rows_from_partition_stream(
+                            stream,
+                            &mut all_rows,
+                            &all_col_names,
+                            &all_col_types,
+                            &pk_indices,
+                            &ck_indices,
+                            &storage_to_table,
                         )
                         .await?;
-                    extend_rows_from_partition_stream(
-                        stream,
+                    }
+                    filter_rows_by_select_predicates(
                         &mut all_rows,
+                        s,
                         &all_col_names,
                         &all_col_types,
-                        &pk_indices,
-                        &ck_indices,
-                        &storage_to_table,
-                    )
-                    .await?;
+                        table_meta,
+                        ks,
+                        state,
+                    )?;
+                    all_rows
                 }
-                filter_rows_by_select_predicates(
-                    &mut all_rows,
-                    s,
-                    &all_col_names,
-                    &all_col_types,
-                    table_meta,
-                    ks,
-                    state,
-                )?;
-                all_rows
             }
         }
     };
@@ -3544,23 +3777,33 @@ async fn route_select_user_table(
         (None, _) => None,
     };
 
-    let paged = crate::paging::apply_pagination(
-        limited.len(),
-        effective_page_size,
-        ctx.paging.paging_state.as_deref(),
-    )?;
-
-    let page_rows = &limited[paged.start..paged.end];
+    // When the streaming full-scan page path already produced exactly one
+    // bounded page and its cursor, skip the generic offset-based pagination:
+    // the rows ARE the page and the continuation is the stream cursor.
+    let (page_rows, next_paging_state): (Vec<Vec<Option<CqlValue>>>, Option<Vec<u8>>) =
+        if let Some(stream_cursor) = streamed_paging_state {
+            (limited.to_vec(), stream_cursor)
+        } else {
+            let paged = crate::paging::apply_pagination(
+                limited.len(),
+                effective_page_size,
+                ctx.paging.paging_state.as_deref(),
+            )?;
+            (
+                limited[paged.start..paged.end].to_vec(),
+                paged.next_paging_state,
+            )
+        };
 
     // Return raw result; callers that need an encoded frame call .encode()
     // or result::encode_rows_paged directly. Delta subscriptions use the raw rows.
     Ok(SelectRawResult {
         column_names: col_names.to_vec(),
         column_types: col_types.to_vec(),
-        rows: page_rows.to_vec(),
+        rows: page_rows,
         keyspace: ks.to_string(),
         table: s.table.clone(),
-        paging_state: paged.next_paging_state,
+        paging_state: next_paging_state,
     })
 }
 
@@ -18128,6 +18371,264 @@ mod tests {
         assert!(
             planner_fallback.contains("range_read_with(&table_id, ctx.consistency, &table_strategy)"),
             "planner fallback range reads must carry request consistency and keyspace replication strategy"
+        );
+    }
+
+    // ── Coordinator-side range-scan paging / OOM bound ────────────────────
+    //
+    // These tests pin the coordinator-side behavior that a full-table scan
+    // streams at most one bounded page and returns a `next_paging_state`
+    // continuation, rather than accumulating the entire result into
+    // `all_rows`. The bound must hold even when the client sends no
+    // `page_size` (a sane default applies), and paged traversal must equal
+    // the whole-scan result with no skipped or duplicated rows — including
+    // when a single wide partition spans multiple pages.
+
+    async fn run_ddl(state: &SharedState, ctx: &RequestContext<'_>, cql: &str) {
+        route(state, ctx, crate::parser::parse(cql).unwrap())
+            .await
+            .unwrap_or_else(|e| panic!("DDL failed [{cql}]: {e}"));
+    }
+
+    fn paging_ctx<'a>(
+        auth: &'a AuthContext,
+        ks: &'a Option<String>,
+        page_size: Option<i32>,
+        paging_state: Option<Vec<u8>>,
+    ) -> RequestContext<'a> {
+        RequestContext {
+            auth,
+            current_keyspace: ks,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams {
+                page_size,
+                paging_state,
+            },
+            client_address: String::new(),
+        }
+    }
+
+    /// Walk every page of `select_cql` with the given `page_size` (None means
+    /// the client sent no page_size at all) and return the concatenated rows
+    /// in page order plus the number of pages observed.
+    async fn collect_all_pages(
+        state: &SharedState,
+        auth: &AuthContext,
+        ks: &Option<String>,
+        select_cql: &str,
+        page_size: Option<i32>,
+    ) -> (Vec<Vec<Option<CqlValue>>>, usize) {
+        let select = match crate::parser::parse(select_cql).unwrap() {
+            Statement::Select(s) => s,
+            other => panic!("expected select, got {other:?}"),
+        };
+        let mut collected: Vec<Vec<Option<CqlValue>>> = Vec::new();
+        let mut paging_state: Option<Vec<u8>> = None;
+        let mut pages = 0usize;
+        // Hard cap so a broken cursor can never loop forever in tests.
+        for _ in 0..100_000 {
+            let ctx = paging_ctx(auth, ks, page_size, paging_state.clone());
+            let res = route_select_raw(state, &ctx, &select).await.unwrap();
+            if let Some(ps) = page_size {
+                if ps > 0 {
+                    assert!(
+                        res.rows.len() <= ps as usize,
+                        "page returned {} rows, exceeds page_size {ps}",
+                        res.rows.len()
+                    );
+                }
+            }
+            let empty_page = res.rows.is_empty();
+            collected.extend(res.rows);
+            if !empty_page {
+                pages += 1;
+            }
+            match res.paging_state {
+                Some(ns) => paging_state = Some(ns),
+                None => return (collected, pages),
+            }
+        }
+        panic!("paging did not terminate within 100k pages — cursor is not advancing");
+    }
+
+    /// Setup: keyspace + a narrow-partition table with `n` rows (id is the PK).
+    async fn setup_wide_scan_table(n: i64) -> (SharedState, TempDir, AuthContext, Option<String>) {
+        let (state, dir) = setup();
+        let auth = dev_auth();
+        let ks = Some("pageks".to_string());
+        let ctx = paging_ctx(&auth, &ks, None, None);
+        run_ddl(
+            &state,
+            &ctx,
+            "CREATE KEYSPACE pageks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        )
+        .await;
+        run_ddl(
+            &state,
+            &ctx,
+            "CREATE TABLE pageks.t (id int PRIMARY KEY, v int)",
+        )
+        .await;
+        for i in 0..n {
+            run_ddl(
+                &state,
+                &ctx,
+                &format!("INSERT INTO pageks.t (id, v) VALUES ({i}, {})", i * 10),
+            )
+            .await;
+        }
+        (state, dir, auth, ks)
+    }
+
+    #[tokio::test]
+    async fn range_scan_first_page_is_bounded_by_page_size() {
+        // N >> page_size. First page must return exactly page_size rows and a
+        // non-None continuation. Fail-before: the scan accumulated all N rows.
+        let n = 5_000;
+        let page_size = 200;
+        let (state, _dir, auth, ks) = setup_wide_scan_table(n).await;
+
+        let select = match crate::parser::parse("SELECT * FROM pageks.t").unwrap() {
+            Statement::Select(s) => s,
+            other => panic!("expected select, got {other:?}"),
+        };
+        let ctx = paging_ctx(&auth, &ks, Some(page_size), None);
+        let res = route_select_raw(&state, &ctx, &select).await.unwrap();
+
+        assert_eq!(
+            res.rows.len(),
+            page_size as usize,
+            "first page must return exactly page_size rows, not the whole table"
+        );
+        assert!(
+            res.paging_state.is_some(),
+            "a scan with more rows than page_size must return a continuation token"
+        );
+    }
+
+    #[tokio::test]
+    async fn range_scan_paged_traversal_equals_whole_scan_no_gaps_or_dupes() {
+        // Paged traversal (page_size << N) must equal the unpaged scan exactly,
+        // in order, with no gaps and no duplicates.
+        let n = 3_000;
+        let (state, _dir, auth, ks) = setup_wide_scan_table(n).await;
+
+        // Whole scan in one shot (no paging).
+        let (whole, _) =
+            collect_all_pages(&state, &auth, &ks, "SELECT * FROM pageks.t", None).await;
+        // Sort by id so we compare row sets independent of token order.
+        let mut whole_sorted = whole.clone();
+        whole_sorted.sort_by(|a, b| a[0].cmp(&b[0]));
+        assert_eq!(
+            whole_sorted.len(),
+            n as usize,
+            "whole scan must see every row"
+        );
+
+        let (paged, pages) =
+            collect_all_pages(&state, &auth, &ks, "SELECT * FROM pageks.t", Some(137)).await;
+        assert!(pages > 1, "expected multiple pages, got {pages}");
+
+        let mut paged_sorted = paged.clone();
+        paged_sorted.sort_by(|a, b| a[0].cmp(&b[0]));
+
+        assert_eq!(
+            paged_sorted.len(),
+            whole_sorted.len(),
+            "paged traversal must yield the same row count as the whole scan"
+        );
+        assert_eq!(
+            paged_sorted, whole_sorted,
+            "paged union must equal the whole scan byte-for-byte (no gaps, no dupes)"
+        );
+
+        // Explicit duplicate check on the partition key.
+        let mut ids: Vec<_> = paged.iter().map(|r| r[0].clone()).collect();
+        ids.sort();
+        let unique = {
+            let mut u = ids.clone();
+            u.dedup();
+            u.len()
+        };
+        assert_eq!(unique, ids.len(), "paged traversal emitted duplicate rows");
+    }
+
+    #[tokio::test]
+    async fn range_scan_with_no_page_size_applies_default_bounded_page() {
+        // A SELECT with NO client page_size must still return a bounded first
+        // page plus a continuation rather than pulling the whole table.
+        // Fail-before: with no page_size, the scan returned every row.
+        let default = crate::paging::default_scan_page_size();
+        let n = (default as i64) * 2 + 17; // safely exceeds one default page
+
+        let (state, _dir, auth, ks) = setup_wide_scan_table(n).await;
+        let select = match crate::parser::parse("SELECT * FROM pageks.t").unwrap() {
+            Statement::Select(s) => s,
+            other => panic!("expected select, got {other:?}"),
+        };
+        let ctx = paging_ctx(&auth, &ks, None, None);
+        let res = route_select_raw(&state, &ctx, &select).await.unwrap();
+
+        assert!(
+            res.rows.len() <= default,
+            "no-page-size scan returned {} rows, exceeds default page {default}",
+            res.rows.len()
+        );
+        assert!(
+            res.paging_state.is_some(),
+            "no-page-size scan over a large table must return a continuation token"
+        );
+
+        // And the full paged traversal (default page applied each call) still
+        // returns every row exactly once.
+        let (paged, _) =
+            collect_all_pages(&state, &auth, &ks, "SELECT * FROM pageks.t", None).await;
+        let mut ids: Vec<_> = paged.iter().map(|r| r[0].clone()).collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(
+            ids.len(),
+            n as usize,
+            "default-paged traversal must still visit every row exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn limit_query_unaffected_by_default_paging() {
+        // LIMIT N must still cap the result and not be silently re-paged into
+        // multiple pages when the client did not request paging.
+        let n = 1_000;
+        let (state, _dir, auth, ks) = setup_wide_scan_table(n).await;
+        let select = match crate::parser::parse("SELECT * FROM pageks.t LIMIT 5").unwrap() {
+            Statement::Select(s) => s,
+            other => panic!("expected select, got {other:?}"),
+        };
+        let ctx = paging_ctx(&auth, &ks, None, None);
+        let res = route_select_raw(&state, &ctx, &select).await.unwrap();
+        assert_eq!(res.rows.len(), 5, "LIMIT 5 must return exactly 5 rows");
+        assert!(
+            res.paging_state.is_none(),
+            "a LIMIT smaller than the default page must not return a continuation"
+        );
+    }
+
+    #[tokio::test]
+    async fn point_read_unaffected_by_paging() {
+        // PK-equality (point read) must behave unchanged with default paging.
+        let n = 100;
+        let (state, _dir, auth, ks) = setup_wide_scan_table(n).await;
+        let select = match crate::parser::parse("SELECT * FROM pageks.t WHERE id = 42").unwrap() {
+            Statement::Select(s) => s,
+            other => panic!("expected select, got {other:?}"),
+        };
+        let ctx = paging_ctx(&auth, &ks, None, None);
+        let res = route_select_raw(&state, &ctx, &select).await.unwrap();
+        assert_eq!(res.rows.len(), 1, "point read must return exactly one row");
+        assert_eq!(res.rows[0][0], Some(CqlValue::Int(42)));
+        assert!(
+            res.paging_state.is_none(),
+            "point read needs no continuation"
         );
     }
 }

--- a/ferrosa-sstable/src/data.rs
+++ b/ferrosa-sstable/src/data.rs
@@ -280,6 +280,50 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
         }
     }
 
+    /// Projection-aware companion to [`Self::read_next_clustered_row`].
+    /// Decodes only the cells whose ordinals are in `wanted`
+    /// (byte-skipping the rest via `read_cell_skip`), matching
+    /// [`Self::read_partition_projected`]. An empty `wanted` yields
+    /// rows with empty `cells`. Returns `Ok(None)` at
+    /// end-of-partition (or a range-tombstone marker).
+    ///
+    /// Must be preceded by [`Self::read_partition_header_only`].
+    pub fn read_next_clustered_row_projected(&mut self, wanted: &[u16]) -> Result<Option<Row>> {
+        loop {
+            let file_len = self.reader.len()?;
+            if self.pos >= file_len {
+                return Ok(None);
+            }
+            let mut flags_buf = [0u8; 1];
+            self.reader.read_exact_at(&mut flags_buf, self.pos)?;
+            self.pos += 1;
+            let flags = flags_buf[0];
+            if flags & END_OF_PARTITION != 0 {
+                return Ok(None);
+            }
+            if flags & IS_MARKER != 0 {
+                return Ok(None);
+            }
+            let extended_flags = if flags & EXTENSION_FLAG != 0 {
+                let mut ext_buf = [0u8; 1];
+                self.reader.read_exact_at(&mut ext_buf, self.pos)?;
+                self.pos += 1;
+                ext_buf[0]
+            } else {
+                0
+            };
+            let is_static = extended_flags & EXT_IS_STATIC != 0;
+            if is_static {
+                // Defensively skip stray static rows (header_only
+                // already consumed the leading one).
+                self.skip_row_body(flags, true)?;
+                continue;
+            }
+            let row = self.read_row_projected(flags, false, wanted)?;
+            return Ok(Some(row));
+        }
+    }
+
     /// 2-phase streaming continuation: read clustered rows until
     /// `END_OF_PARTITION` (or a range-tombstone marker), invoking
     /// `on_row` once per row. Each row is dropped before the

--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -800,6 +800,55 @@ impl<'a, R: ReadAt> PartitionIter<'a, R> {
         }
     }
 
+    /// Projection-aware companion to [`Self::next_clustered_row`].
+    /// Decodes only the cells whose ordinals are in `wanted`,
+    /// byte-skipping the rest (matching [`Self::next_partition_projected`]).
+    /// Must be preceded by [`Self::next_partition_header_only`].
+    pub fn next_clustered_row_projected(
+        &mut self,
+        wanted: &[u16],
+    ) -> Result<Option<crate::types::Row>> {
+        let header = &self.sst.header;
+        if let Some(ref data) = self.compressed {
+            let mut reader = crate::data::DataReader::new(data, header, self.pos);
+            let result = reader.read_next_clustered_row_projected(wanted)?;
+            self.pos = reader.position();
+            Ok(result)
+        } else {
+            let mut reader = crate::data::DataReader::new(&self.sst.data, header, self.pos);
+            let result = reader.read_next_clustered_row_projected(wanted)?;
+            self.pos = reader.position();
+            Ok(result)
+        }
+    }
+
+    /// Bounded-batch companion to [`Self::next_clustered_row`]. Pulls
+    /// at most `limit` clustered rows (in clustering/storage order)
+    /// from the partition the iterator is currently parked inside,
+    /// returning fewer than `limit` (possibly zero) at
+    /// end-of-partition. Must be preceded by
+    /// [`Self::next_partition_header_only`].
+    ///
+    /// This is the intra-partition streaming primitive used by the
+    /// range merger's fragment path: a single multi-million-row
+    /// partition is read in `limit`-sized batches so peak working set
+    /// is `O(limit)` rows, never the whole partition. `limit` must be
+    /// `>= 1`. The returned `Vec` has capacity `limit` but length
+    /// `<= limit`; an empty `Vec` means the partition is exhausted
+    /// (the next [`Self::next_partition_header_only`] advances to the
+    /// following partition).
+    pub fn next_partition_rows(&mut self, limit: usize) -> Result<Vec<crate::types::Row>> {
+        debug_assert!(limit >= 1, "next_partition_rows limit must be >= 1");
+        let mut rows = Vec::with_capacity(limit);
+        while rows.len() < limit {
+            match self.next_clustered_row()? {
+                Some(row) => rows.push(row),
+                None => break,
+            }
+        }
+        Ok(rows)
+    }
+
     /// Phase 2 of the row-streamed partition read: walk clustered
     /// rows until end-of-partition, invoking `on_row` once per row
     /// in storage order. Each row is decoded into a fresh `Row`,
@@ -2196,6 +2245,73 @@ mod tests {
                 assert_eq!(a, b);
             }
         }
+    }
+
+    /// `next_partition_rows(limit)` yields the SAME clustered rows,
+    /// in the same order, as the whole-partition `next_partition`
+    /// path — only chunked into `limit`-sized batches. Each batch is
+    /// `<= limit`; concatenating all batches reproduces the partition
+    /// body byte-for-byte. This is the intra-partition streaming
+    /// primitive that lets a multi-million-row partition be read in
+    /// `O(limit)` resident rows.
+    #[test]
+    fn next_partition_rows_batches_match_whole_partition() {
+        let header = test_header();
+        let dk = DecoratedKey::new(PartitionKey::from(b"wide".as_slice()));
+        let mut data_bytes = Vec::new();
+        let pos = data_bytes.len() as u64;
+        // 7 rows so a limit of 3 forces batches of 3, 3, 1.
+        data_bytes.extend_from_slice(&build_data_blob_with_rows(dk.key.as_bytes(), 7));
+        let partitions_bytes = build_partition_index(&[(&dk, pos)]);
+        let filter_bytes = build_bloom_filter(&[&dk]);
+        let stats_bytes = build_statistics(header);
+
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        // Baseline: the whole partition in one shot.
+        let whole = reader
+            .partitions_iter()
+            .unwrap()
+            .next_partition()
+            .unwrap()
+            .unwrap();
+
+        // Batched: header_only + next_partition_rows(3).
+        let mut iter = reader.partitions_iter().unwrap();
+        let (key, deletion, static_row) = iter.next_partition_header_only().unwrap().unwrap();
+        assert_eq!(key, whole.key);
+        assert_eq!(deletion, whole.deletion);
+        assert_eq!(static_row, whole.static_row);
+
+        let limit = 3;
+        let mut batched: Vec<crate::types::Row> = Vec::new();
+        let mut batch_sizes = Vec::new();
+        loop {
+            let batch = iter.next_partition_rows(limit).unwrap();
+            if batch.is_empty() {
+                break;
+            }
+            assert!(
+                batch.len() <= limit,
+                "batch {} exceeds limit {limit}",
+                batch.len()
+            );
+            batch_sizes.push(batch.len());
+            batched.extend(batch);
+        }
+        assert_eq!(batch_sizes, vec![3, 3, 1], "expected 7 rows chunked 3/3/1");
+        assert_eq!(
+            batched, whole.rows,
+            "batched rows must equal whole-partition rows"
+        );
     }
 
     /// `next_partition_streaming` yields the same partition

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -4755,6 +4755,46 @@ impl StorageEngine {
         }
     }
 
+    /// Intra-partition streaming variant of [`Self::range_iter`]. Wide
+    /// partitions are delivered as a sequence of `<= K`-row `Partition`
+    /// fragments (see [`crate::store::TableStore::range_iter_fragmented`]),
+    /// so the producer holds `O(num_sources + K)` rows resident regardless
+    /// of partition width — the OOM fix for full-table `SELECT *`.
+    pub fn range_iter_fragmented(
+        &self,
+        table_id: &TableId,
+        start: Option<&DecoratedKey>,
+        end: Option<&DecoratedKey>,
+    ) -> std::pin::Pin<
+        Box<dyn futures::stream::Stream<Item = ferrosa_common::Result<Partition>> + Send>,
+    > {
+        let tables = self.tables.read();
+        match tables.get(table_id) {
+            Some(state) => state.store.range_iter_fragmented(start, end),
+            None => Box::pin(futures::stream::empty()),
+        }
+    }
+
+    /// Projection-aware intra-partition streaming variant of
+    /// [`Self::range_iter_projected`].
+    pub fn range_iter_projected_fragmented(
+        &self,
+        table_id: &TableId,
+        wanted: Vec<u16>,
+        start: Option<&DecoratedKey>,
+        end: Option<&DecoratedKey>,
+    ) -> std::pin::Pin<
+        Box<dyn futures::stream::Stream<Item = ferrosa_common::Result<Partition>> + Send>,
+    > {
+        let tables = self.tables.read();
+        match tables.get(table_id) {
+            Some(state) => state
+                .store
+                .range_iter_projected_fragmented(wanted, start, end),
+            None => Box::pin(futures::stream::empty()),
+        }
+    }
+
     /// Query by secondary index across memtable and SSTable sidecar indexes.
     ///
     /// Delegates to [`TableStore::read_by_index`] which merges results from

--- a/ferrosa-storage/src/range_merger.rs
+++ b/ferrosa-storage/src/range_merger.rs
@@ -26,6 +26,73 @@ use ferrosa_sstable::ReadAt;
 
 use crate::merge;
 
+/// Default number of clustered rows carried in one [`PartitionFragment`].
+/// Bounds the merger's resident working set to `O(num_sources + K)`
+/// rows regardless of how wide a single partition is — an inverted-index
+/// partition (one hot term ⇒ millions of rows in one `Vec<Row>`) is the
+/// shape that OOM-killed replicas on a full-table `SELECT *`.
+///
+/// Tunable via `FERROSA_RANGE_READ_ROWS_PER_FRAGMENT`. Picked at a few
+/// thousand so the per-fragment frame amortises message overhead while
+/// keeping resident memory comfortably under any sane cgroup cap.
+pub const DEFAULT_ROWS_PER_FRAGMENT: usize = 4_096;
+
+/// Resolve the fragment row cap `K` from the environment, falling back to
+/// [`DEFAULT_ROWS_PER_FRAGMENT`]. A value of `0` or an unparseable value is
+/// treated as the default (never zero — a zero cap would loop forever).
+pub fn rows_per_fragment() -> usize {
+    match std::env::var("FERROSA_RANGE_READ_ROWS_PER_FRAGMENT") {
+        Ok(v) => match v.trim().parse::<usize>() {
+            Ok(n) if n >= 1 => n,
+            _ => DEFAULT_ROWS_PER_FRAGMENT,
+        },
+        Err(_) => DEFAULT_ROWS_PER_FRAGMENT,
+    }
+}
+
+/// One bounded slice of a merged partition emitted by [`FragmentMerger`].
+///
+/// A wide partition is delivered as a SEQUENCE of fragments that all share
+/// the same `key`, in clustering order, with non-overlapping row ranges.
+/// Reassembly contract (relied on by the cluster stream handler, the
+/// coordinator merge, and the CQL row bridge):
+///
+/// - The FIRST fragment of a key (`first == true`) carries the partition's
+///   real `deletion` and `static_row`. Every later fragment carries
+///   `deletion = LIVE` and `static_row = None`, so a consumer that flattens
+///   fragments into rows never double-counts the static row nor re-applies
+///   the partition tombstone.
+/// - `rows` are already cell-merged across sources (LWW), deletion-suppressed,
+///   and sorted by clustering key, with `rows.len() <= K`.
+/// - `last == true` marks the final fragment for the key.
+///
+/// A consumer can therefore treat each fragment exactly like a small
+/// `Partition` and append its rows; the concatenation is byte-identical to
+/// the single whole-partition merge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionFragment {
+    pub key: DecoratedKey,
+    pub deletion: ferrosa_sstable::types::DeletionTime,
+    pub static_row: Option<Row>,
+    pub rows: Vec<Row>,
+    pub first: bool,
+    pub last: bool,
+}
+
+impl PartitionFragment {
+    /// View this fragment as a standalone `Partition`. Because non-first
+    /// fragments carry `deletion = LIVE` / `static_row = None`, flattening
+    /// the fragment sequence of one key reproduces the merged partition.
+    pub fn into_partition(self) -> Partition {
+        Partition {
+            key: self.key,
+            deletion: self.deletion,
+            static_row: self.static_row,
+            rows: self.rows,
+        }
+    }
+}
+
 /// Per-SSTable translation from the physical column ordinals in an
 /// SSTable's SerializationHeader to the current table schema ordinals.
 #[derive(Clone, Debug)]
@@ -150,6 +217,19 @@ fn remap_cells(cells: &mut Vec<(u16, ferrosa_common::cell::CellValue)>, mapping:
 /// there is no cheap "peek key" primitive — so peek reads + caches
 /// the whole partition. That's still free in practice (memtables are
 /// in-memory) and pop takes the cached partition.
+/// Header (and, for in-memory sources, the body) of a partition popped
+/// for fragment streaming. See [`MergeSource::pop_partition_header`].
+struct PoppedHeader {
+    key: DecoratedKey,
+    deletion: ferrosa_sstable::types::DeletionTime,
+    static_row: Option<Row>,
+    /// `Some` for `Memtable` sources: the partition's rows, already sorted
+    /// by clustering key, to be drained by the `FragmentMerger`. `None` for
+    /// SSTable-backed sources, whose rows stream via
+    /// [`MergeSource::next_fragment_row`].
+    mem_body: Option<Vec<Row>>,
+}
+
 pub enum MergeSource<'a, R: ReadAt> {
     /// Memtable / flushing memtable: infallible per-partition yield.
     /// `peeked` caches the result of the most recent `peek_key()`
@@ -159,6 +239,9 @@ pub enum MergeSource<'a, R: ReadAt> {
         iter: Box<dyn Iterator<Item = Partition> + Send + 'a>,
         peeked: Option<Partition>,
     },
+    // NOTE: fragment-row streaming state for the Memtable variant lives
+    // in `FragmentMerger` (see `MemRowSource`) rather than here, so the
+    // whole-partition `RangeMerger` path is untouched.
     /// Single SSTable streaming reader. `mode` controls per-cell
     /// decoding on `pop_partition`. `peek_key` reads only the
     /// partition header (~10 bytes) via `PartitionIter::peek_partition_key`
@@ -288,6 +371,145 @@ impl<'a, R: ReadAt> MergeSource<'a, R> {
                 peeked_key.take();
                 run.next_partition()
             }
+        }
+    }
+
+    /// Fragment-streaming counterpart of [`Self::pop_partition`].
+    /// Pops the next partition's HEADER (key + partition deletion +
+    /// optional static row) for the most-recently-peeked key,
+    /// **parking the source at the first clustered row** so the body
+    /// can be streamed via [`Self::next_fragment_row`] without ever
+    /// materialising the whole partition.
+    ///
+    /// For `Memtable` sources the partition body is already in memory,
+    /// so the header carries the whole partition out as
+    /// `MemPartitionBody` (the `FragmentMerger` drains its rows in
+    /// clustering order). For `SsTable` / `SsTableRun` sources only
+    /// the ~10-byte header is decoded here; rows arrive lazily.
+    ///
+    /// Returns `Ok(None)` if the source was exhausted between peek and
+    /// pop (race-free here — sources are not shared across threads).
+    fn pop_partition_header(&mut self) -> Result<Option<PoppedHeader>> {
+        match self {
+            Self::Memtable { iter, peeked } => {
+                let partition = match peeked.take() {
+                    Some(p) => p,
+                    None => match iter.next() {
+                        Some(p) => p,
+                        None => return Ok(None),
+                    },
+                };
+                let key = partition.key.clone();
+                let deletion = partition.deletion;
+                let static_row = partition.static_row.clone();
+                let mut rows = partition.rows;
+                rows.sort_by(|a, b| a.clustering.cmp(&b.clustering));
+                Ok(Some(PoppedHeader {
+                    key,
+                    deletion,
+                    static_row,
+                    mem_body: Some(rows),
+                }))
+            }
+            Self::SsTable {
+                iter,
+                mode,
+                mapping,
+                peeked_key,
+                failed,
+            } => {
+                if *failed {
+                    return Ok(None);
+                }
+                peeked_key.take();
+                let header = match iter.next_partition_header_only() {
+                    Ok(Some(h)) => h,
+                    Ok(None) => return Ok(None),
+                    Err(e) if mode.is_fail_soft() => {
+                        tracing::warn!(
+                            %e,
+                            mode = mode.label(),
+                            "range scan: skipping SSTable whose partition header failed to decode"
+                        );
+                        *failed = true;
+                        return Ok(None);
+                    }
+                    Err(e) => return Err(e),
+                };
+                let (key, deletion, mut static_row) = header;
+                if let (Some(mapping), Some(sr)) = (*mapping, static_row.as_mut()) {
+                    mapping.remap_static_row(sr);
+                }
+                Ok(Some(PoppedHeader {
+                    key,
+                    deletion,
+                    static_row,
+                    mem_body: None,
+                }))
+            }
+            Self::SsTableRun { run, peeked_key } => {
+                peeked_key.take();
+                match run.next_partition_header_only()? {
+                    Some((key, deletion, static_row)) => Ok(Some(PoppedHeader {
+                        key,
+                        deletion,
+                        static_row,
+                        mem_body: None,
+                    })),
+                    None => Ok(None),
+                }
+            }
+        }
+    }
+
+    /// Pull one clustered row from the partition opened by the most
+    /// recent [`Self::pop_partition_header`] on this source. Returns
+    /// `Ok(None)` at end-of-partition. Only valid for SSTable-backed
+    /// sources; `Memtable` rows are drained from the `MemPartitionBody`
+    /// the header carried out, so this is `Ok(None)` for them.
+    fn next_fragment_row(&mut self) -> Result<Option<Row>> {
+        match self {
+            Self::Memtable { .. } => Ok(None),
+            Self::SsTable {
+                iter,
+                mode,
+                mapping,
+                failed,
+                ..
+            } => {
+                if *failed {
+                    return Ok(None);
+                }
+                let mode = *mode;
+                let mapping = *mapping;
+                let row = match mode {
+                    RunMode::Projected(wanted) => {
+                        let source_wanted = mapping
+                            .map(|m| m.source_regular_ordinals_for_projection(wanted))
+                            .unwrap_or_else(|| wanted.to_vec());
+                        iter.next_clustered_row_projected(&source_wanted)
+                    }
+                    RunMode::Full | RunMode::Metadata => iter.next_clustered_row(),
+                };
+                let mut row = match row {
+                    Ok(r) => r,
+                    Err(e) if mode.is_fail_soft() => {
+                        tracing::warn!(
+                            %e,
+                            mode = mode.label(),
+                            "range scan: skipping SSTable whose row failed to decode"
+                        );
+                        *failed = true;
+                        return Ok(None);
+                    }
+                    Err(e) => return Err(e),
+                };
+                if let (Some(mapping), Some(r)) = (mapping, row.as_mut()) {
+                    mapping.remap_regular_row(r);
+                }
+                Ok(row)
+            }
+            Self::SsTableRun { run, .. } => run.next_fragment_row(),
         }
     }
 
@@ -510,6 +732,55 @@ impl<'a, R: ReadAt> SsTableRunIter<'a, R> {
                 }
                 Err(e) => return Err(e),
             }
+        }
+    }
+
+    /// Fragment-row streaming: read the current partition's HEADER
+    /// (key + deletion + optional static row) from the run's current
+    /// SSTable, parking that SSTable's `PartitionIter` at the first
+    /// clustered row. The follow-up is [`Self::next_fragment_row`].
+    /// Because runs are token-disjoint, every key appears in exactly
+    /// one SSTable of the run, so the header always comes from the
+    /// `current` iterator. Returns `Ok(None)` at end-of-run.
+    fn next_partition_header_only(
+        &mut self,
+    ) -> Result<
+        Option<(
+            DecoratedKey,
+            ferrosa_sstable::types::DeletionTime,
+            Option<Row>,
+        )>,
+    > {
+        loop {
+            if self.current.is_none() {
+                if self.cursor >= self.sstables.len() {
+                    return Ok(None);
+                }
+                self.current = Some(self.sstables[self.cursor].partitions_iter()?);
+            }
+            let it = self.current.as_mut().expect("just initialised");
+            match it.next_partition_header_only()? {
+                Some(header) => return Ok(Some(header)),
+                None => {
+                    self.current = None;
+                    self.cursor += 1;
+                }
+            }
+        }
+    }
+
+    /// Pull the next clustered row of the partition most recently
+    /// opened by [`Self::next_partition_header_only`], honoring the
+    /// run's projection `mode`. Returns `Ok(None)` at
+    /// end-of-partition. Does NOT advance to the next SSTable — that
+    /// happens on the following `next_partition_header_only`.
+    fn next_fragment_row(&mut self) -> Result<Option<Row>> {
+        let Some(it) = self.current.as_mut() else {
+            return Ok(None);
+        };
+        match self.mode {
+            RunMode::Full | RunMode::Metadata => it.next_clustered_row(),
+            RunMode::Projected(wanted) => it.next_clustered_row_projected(wanted),
         }
     }
 }
@@ -896,12 +1167,45 @@ pub struct RangeMerger<'a, R: ReadAt> {
     end: Option<DecoratedKey>,
     /// Set once a key > end is observed so we stop pulling sources.
     exhausted: bool,
+    /// In-progress partition for the fragment-streaming path
+    /// ([`Self::next_fragment`]). `None` between partitions (the
+    /// whole-partition `next_merged_partition` path never sets it).
+    active: Option<ActivePartition>,
     /// Leaked allocation backing the per-run `Vec<Arc<SSTableReader>>`
     /// slices that `SsTableRunIter`s borrow from. `Some` only when
     /// the merger was built via `build_merger_with_runs`; freed by
     /// the `Drop` impl below. `*const` rather than `Box` because
     /// `Box::leak`'s output has to be re-wrapped manually.
     runs_arena: Option<*const [Vec<Arc<SSTableReader<R>>>]>,
+}
+
+/// One source's current row head while a partition is being streamed
+/// in fragments.
+enum RowCursor {
+    /// In-memory rows (memtable source), pre-sorted by clustering key.
+    Mem(std::vec::IntoIter<Row>),
+    /// SSTable-backed source — rows pulled lazily via
+    /// `MergeSource::next_fragment_row`, identified by source index.
+    Sst { src: usize },
+}
+
+/// Streaming state for the partition currently being emitted as
+/// [`PartitionFragment`]s. Holds at most one row per participating
+/// source ("head") plus the merged partition header.
+struct ActivePartition {
+    key: DecoratedKey,
+    deletion: ferrosa_sstable::types::DeletionTime,
+    /// Carried out on the FIRST fragment, then `None`.
+    pending_static_row: Option<Row>,
+    first: bool,
+    cursors: Vec<RowCursor>,
+    /// `heads[i]` is the next unconsumed row from `cursors[i]`, or
+    /// `None` if that cursor is exhausted. Peak resident rows for the
+    /// merge proper is `cursors.len()` (one head each).
+    heads: Vec<Option<Row>>,
+    /// Source indices to refill back onto the heap once this partition
+    /// is fully drained.
+    refill_srcs: Vec<usize>,
 }
 
 // SAFETY: `runs_arena` is a leaked allocation that contains only
@@ -941,6 +1245,7 @@ impl<'a, R: ReadAt> RangeMerger<'a, R> {
             start,
             end,
             exhausted: false,
+            active: None,
             runs_arena: None,
         };
         // Prime the heap with one partition per non-empty source.
@@ -1043,6 +1348,337 @@ impl<'a, R: ReadAt> RangeMerger<'a, R> {
         merge::apply_deletions(&mut merged);
         Ok(Some(merged))
     }
+
+    /// Pull the next [`PartitionFragment`]. Drives the **intra-partition
+    /// streaming k-way row merge**: a single (possibly multi-million-row)
+    /// partition is delivered as a sequence of fragments each holding
+    /// `<= k` clustered rows, so resident memory is `O(num_sources + k)`
+    /// rows regardless of partition width. Returns `Ok(None)` when every
+    /// source is exhausted.
+    ///
+    /// Correctness — byte-identical to `next_merged_partition` flattened:
+    ///
+    /// 1. **Key selection / dedup** is the SAME heap discipline as
+    ///    `next_merged_partition`: pop the smallest key, then pop every
+    ///    other source whose head matches it.
+    /// 2. **Header merge** mirrors `merge::merge_partitions`'s header step:
+    ///    partition deletion is the max `marked_for_delete_at` across
+    ///    sources; the static row is cell-merged via `merge::merge_rows`,
+    ///    then partition-deletion-suppressed once (carried on the first
+    ///    fragment only).
+    /// 3. **Row merge** is a k-way merge by clustering key across all
+    ///    sources' heads; rows sharing a clustering key are folded with
+    ///    `merge::merge_rows` (cell-level LWW) — identical to
+    ///    `merge_partitions`'s `pop/merge/push` over the clustering-sorted
+    ///    concatenation.
+    /// 4. **Deletion suppression** is applied per row exactly as
+    ///    `merge::apply_deletions`: a row whose `primary_key_liveness`
+    ///    predates the partition tombstone is dropped; surviving rows have
+    ///    cells older than their own row tombstone dropped. Because both
+    ///    rules are row-local they fragment without changing the result.
+    pub fn next_fragment(&mut self, k: usize) -> Result<Option<PartitionFragment>> {
+        debug_assert!(k >= 1, "next_fragment k must be >= 1");
+        loop {
+            if self.active.is_none() && !self.begin_active_partition()? {
+                return Ok(None);
+            }
+            // Build one fragment (<= k rows) from the active partition.
+            match self.emit_fragment(k)? {
+                Some(fragment) => return Ok(Some(fragment)),
+                // Active partition produced no fragment (all its rows were
+                // deletion-suppressed and it was not the first fragment):
+                // drop it and advance to the next key.
+                None => continue,
+            }
+        }
+    }
+
+    /// Select the next key via the heap (respecting `end`), pop every
+    /// source holding it, merge the header, and install the per-source
+    /// row cursors into `self.active`. Returns `Ok(false)` at end-of-scan.
+    fn begin_active_partition(&mut self) -> Result<bool> {
+        if self.exhausted {
+            return Ok(false);
+        }
+        let first = match self.heap.pop() {
+            Some(e) => e,
+            None => return Ok(false),
+        };
+        if let Some(ref e) = self.end {
+            if first.key > *e {
+                self.exhausted = true;
+                return Ok(false);
+            }
+        }
+        let key = first.key.clone();
+
+        // Collect every source holding this key (heap-popped).
+        let mut srcs: Vec<usize> = vec![first.src];
+        while let Some(top) = self.heap.peek() {
+            if top.key != key {
+                break;
+            }
+            let entry = self.heap.pop().expect("peek succeeded");
+            srcs.push(entry.src);
+        }
+
+        // Pop each source's header (and, for memtables, its sorted body).
+        // Merge header: max-timestamp partition deletion, cell-merged
+        // static row.
+        let mut merged_deletion = ferrosa_sstable::types::DeletionTime::LIVE;
+        let mut merged_static: Option<Row> = None;
+        let mut cursors: Vec<RowCursor> = Vec::with_capacity(srcs.len());
+        let mut refill_srcs: Vec<usize> = Vec::with_capacity(srcs.len());
+
+        for &src in &srcs {
+            let header = match self.sources[src].pop_partition_header()? {
+                Some(h) => h,
+                // Source ended between peek and pop — refill (it is now
+                // exhausted) and skip. Mirrors next_merged_partition's
+                // Ok(None) branch.
+                None => {
+                    refill_srcs.push(src);
+                    continue;
+                }
+            };
+            debug_assert_eq!(
+                header.key, key,
+                "popped header key must match the heap-selected key"
+            );
+            if header.deletion.marked_for_delete_at > merged_deletion.marked_for_delete_at {
+                merged_deletion = header.deletion;
+            }
+            if let Some(sr) = header.static_row {
+                merged_static = match merged_static.take() {
+                    Some(prev) => Some(merge::merge_rows(prev, sr)),
+                    None => Some(sr),
+                };
+            }
+            match header.mem_body {
+                Some(rows) => cursors.push(RowCursor::Mem(rows.into_iter())),
+                None => cursors.push(RowCursor::Sst { src }),
+            }
+            refill_srcs.push(src);
+        }
+
+        // Partition-deletion suppression of the static row (mirrors
+        // `apply_deletions`: drop cells older than the partition tombstone,
+        // and drop the static row entirely if it has no surviving cells).
+        if !merged_deletion.is_live() {
+            if let Some(sr) = merged_static.as_mut() {
+                let cut = merged_deletion.marked_for_delete_at;
+                sr.cells.retain(|(_col, cell)| cell.timestamp >= cut);
+                if sr.cells.is_empty() {
+                    merged_static = None;
+                }
+            }
+        }
+
+        let cursor_count = cursors.len();
+        self.active = Some(ActivePartition {
+            key,
+            deletion: merged_deletion,
+            pending_static_row: merged_static,
+            first: true,
+            cursors,
+            heads: vec![None; cursor_count],
+            refill_srcs,
+        });
+        // Prime each cursor's head.
+        self.prime_active_heads()?;
+        Ok(true)
+    }
+
+    /// Load the first row of any cursor whose head is `None` and is not yet
+    /// exhausted. Called after `begin_active_partition` and after each
+    /// head is consumed.
+    fn prime_active_heads(&mut self) -> Result<()> {
+        // We split the borrow: read cursor descriptors, then fetch rows.
+        let n = self.active.as_ref().map(|a| a.cursors.len()).unwrap_or(0);
+        for i in 0..n {
+            let needs = self
+                .active
+                .as_ref()
+                .map(|a| a.heads[i].is_none())
+                .unwrap_or(false);
+            if !needs {
+                continue;
+            }
+            let next = self.next_cursor_row(i)?;
+            if let Some(active) = self.active.as_mut() {
+                active.heads[i] = next;
+            }
+        }
+        Ok(())
+    }
+
+    /// Pull one row from cursor `i` of the active partition.
+    fn next_cursor_row(&mut self, i: usize) -> Result<Option<Row>> {
+        // Determine the cursor kind without holding an active borrow over
+        // the source fetch.
+        enum Kind {
+            Mem,
+            Sst(usize),
+            Done,
+        }
+        let kind = match self.active.as_ref().and_then(|a| a.cursors.get(i)) {
+            Some(RowCursor::Mem(_)) => Kind::Mem,
+            Some(RowCursor::Sst { src }) => Kind::Sst(*src),
+            None => Kind::Done,
+        };
+        match kind {
+            Kind::Mem => Ok(self.active.as_mut().and_then(|a| match &mut a.cursors[i] {
+                RowCursor::Mem(it) => it.next(),
+                RowCursor::Sst { .. } => None,
+            })),
+            Kind::Sst(src) => self.sources[src].next_fragment_row(),
+            Kind::Done => Ok(None),
+        }
+    }
+
+    /// Emit one fragment of up to `k` deletion-suppressed, cell-merged rows
+    /// from the active partition. Returns `Ok(None)` only when the active
+    /// partition is fully drained AND nothing needs emitting (no rows and
+    /// not the first fragment) — in which case the active partition has
+    /// been retired and its sources refilled.
+    fn emit_fragment(&mut self, k: usize) -> Result<Option<PartitionFragment>> {
+        let mut out: Vec<Row> = Vec::with_capacity(k);
+        let partition_delete_at = self
+            .active
+            .as_ref()
+            .map(|a| a.deletion.marked_for_delete_at)
+            .unwrap_or(i64::MIN);
+        let partition_deleted = self
+            .active
+            .as_ref()
+            .map(|a| !a.deletion.is_live())
+            .unwrap_or(false);
+
+        while out.len() < k {
+            // Pick the smallest clustering key across all live heads.
+            let smallest = {
+                let active = self.active.as_ref().expect("active set");
+                let mut sk: Option<&[u8]> = None;
+                for head in active.heads.iter().flatten() {
+                    if sk.map(|c| head.clustering.as_slice() < c).unwrap_or(true) {
+                        sk = Some(head.clustering.as_slice());
+                    }
+                }
+                sk.map(|c| c.to_vec())
+            };
+            let Some(ck) = smallest else {
+                break; // partition exhausted
+            };
+
+            // Fold every head at that clustering key (cell-level LWW),
+            // advancing each consumed cursor by one row.
+            let mut merged_row: Option<Row> = None;
+            let n = self.active.as_ref().expect("active set").cursors.len();
+            for i in 0..n {
+                let matches = self
+                    .active
+                    .as_ref()
+                    .and_then(|a| a.heads[i].as_ref())
+                    .map(|r| r.clustering == ck)
+                    .unwrap_or(false);
+                if !matches {
+                    continue;
+                }
+                let row = self
+                    .active
+                    .as_mut()
+                    .and_then(|a| a.heads[i].take())
+                    .expect("matched head present");
+                merged_row = Some(match merged_row.take() {
+                    Some(prev) => merge::merge_rows(prev, row),
+                    None => row,
+                });
+                // Advance this cursor's head.
+                let next = self.next_cursor_row(i)?;
+                if let Some(a) = self.active.as_mut() {
+                    a.heads[i] = next;
+                }
+            }
+
+            let mut row = merged_row.expect("at least one head matched the smallest key");
+
+            // Deletion suppression (mirrors merge::apply_deletions):
+            // partition-level drop of rows older than the partition
+            // tombstone, then row-level cell suppression.
+            if partition_deleted && row.primary_key_liveness.timestamp < partition_delete_at {
+                continue;
+            }
+            if !row.deletion.is_live() {
+                let cut = row.deletion.marked_for_delete_at;
+                row.cells.retain(|(_col, cell)| cell.timestamp >= cut);
+            }
+            out.push(row);
+        }
+
+        // Did we exhaust the partition?
+        let exhausted = self
+            .active
+            .as_ref()
+            .map(|a| a.heads.iter().all(Option::is_none))
+            .unwrap_or(true);
+
+        let is_first = self.active.as_ref().map(|a| a.first).unwrap_or(false);
+
+        // Nothing to emit: no rows and not the first fragment. Retire the
+        // active partition (refill its sources) and signal the caller to
+        // advance to the next key.
+        if out.is_empty() && !is_first {
+            self.retire_active_partition()?;
+            return Ok(None);
+        }
+
+        // Build the fragment. The first fragment carries the header
+        // (deletion + static row); subsequent ones carry LIVE/None so a
+        // flattening consumer never double-applies them.
+        let (key, deletion, static_row) = {
+            let active = self.active.as_mut().expect("active set");
+            if active.first {
+                active.first = false;
+                (
+                    active.key.clone(),
+                    active.deletion,
+                    active.pending_static_row.take(),
+                )
+            } else {
+                (
+                    active.key.clone(),
+                    ferrosa_sstable::types::DeletionTime::LIVE,
+                    None,
+                )
+            }
+        };
+
+        if exhausted {
+            self.retire_active_partition()?;
+        }
+
+        Ok(Some(PartitionFragment {
+            key,
+            deletion,
+            static_row,
+            rows: out,
+            first: is_first,
+            last: exhausted,
+        }))
+    }
+
+    /// Refill the active partition's sources back onto the heap and clear
+    /// the active state.
+    fn retire_active_partition(&mut self) -> Result<()> {
+        let refill = match self.active.take() {
+            Some(a) => a.refill_srcs,
+            None => return Ok(()),
+        };
+        for src in refill {
+            self.refill_source(src)?;
+        }
+        Ok(())
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -1136,6 +1772,345 @@ mod tests {
             statistics: output.statistics,
         })
         .unwrap()
+    }
+
+    // ---- Intra-partition fragment streaming (P0 row-OOM fix) ----
+
+    /// All fixture timestamps must be `>= test_header().min_timestamp`
+    /// (1_000_000) or the SSTable writer's delta encoding underflows and
+    /// silently corrupts the file. Base everything off this.
+    const TS_BASE: i64 = 2_000_000;
+
+    /// `ts` is a small relative offset; it is shifted by `TS_BASE` so the
+    /// absolute timestamp clears `min_timestamp`. Relative ordering between
+    /// rows is preserved (so LWW conflicts behave as written).
+    fn row(clustering: i32, col: u16, value: &[u8], ts: i64) -> Row {
+        let ts = TS_BASE + ts;
+        Row {
+            clustering: clustering.to_be_bytes().to_vec(),
+            cells: vec![(col, CellValue::live(value.to_vec(), ts))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(ts),
+        }
+    }
+
+    fn partition_with_rows(key: &[u8], rows: Vec<Row>) -> Partition {
+        Partition {
+            key: DecoratedKey::new(PartitionKey::from(key)),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows,
+        }
+    }
+
+    /// Drain a fragment merger built over `sstables` into the flattened
+    /// `Vec<Partition>` it represents (one merged Partition per key, with
+    /// all fragments of a key concatenated), while asserting the
+    /// per-fragment + resident-row invariants. Returns `(partitions, max_resident_rows)`.
+    fn drain_fragments(
+        sstables: &[Arc<SSTableReader<Vec<u8>>>],
+        k: usize,
+    ) -> (Vec<Partition>, usize) {
+        let empty_active: Box<dyn Iterator<Item = Partition> + Send> = Box::new(std::iter::empty());
+        let mut merger = merger_for_sources(empty_active, None, sstables, None, None).unwrap();
+
+        let mut out: Vec<Partition> = Vec::new();
+        let mut cur: Option<Partition> = None;
+        // The merger holds, at most, one row per source ("heads") plus the
+        // fragment being built (<= k). We do not have direct access to the
+        // internal heads count here, so we bound the *fragment* size and
+        // additionally assert no single fragment ever exceeds k.
+        let mut max_fragment = 0usize;
+        loop {
+            let frag = merger.next_fragment(k).unwrap();
+            let Some(frag) = frag else { break };
+            assert!(
+                frag.rows.len() <= k,
+                "fragment {} exceeds k={k}",
+                frag.rows.len()
+            );
+            max_fragment = max_fragment.max(frag.rows.len());
+            if frag.first {
+                if let Some(p) = cur.take() {
+                    out.push(p);
+                }
+                cur = Some(Partition {
+                    key: frag.key.clone(),
+                    deletion: frag.deletion,
+                    static_row: frag.static_row.clone(),
+                    rows: Vec::new(),
+                });
+            } else {
+                // Non-first fragments must carry no header.
+                assert!(
+                    frag.deletion.is_live(),
+                    "non-first fragment carried a deletion"
+                );
+                assert!(
+                    frag.static_row.is_none(),
+                    "non-first fragment carried a static row"
+                );
+            }
+            cur.as_mut()
+                .expect("first fragment seen before continuation")
+                .rows
+                .extend(frag.rows.clone());
+            if frag.last {
+                if let Some(p) = cur.take() {
+                    out.push(p);
+                }
+            }
+        }
+        if let Some(p) = cur.take() {
+            out.push(p);
+        }
+        (out, max_fragment)
+    }
+
+    /// Whole-partition reference: drive `next_merged_partition` to
+    /// completion. This is the byte-identical oracle the fragment path
+    /// must reproduce.
+    fn drain_whole(sstables: &[Arc<SSTableReader<Vec<u8>>>]) -> Vec<Partition> {
+        let empty_active: Box<dyn Iterator<Item = Partition> + Send> = Box::new(std::iter::empty());
+        let mut merger = merger_for_sources(empty_active, None, sstables, None, None).unwrap();
+        let mut out = Vec::new();
+        while let Some(p) = merger.next_merged_partition().unwrap() {
+            out.push(p);
+        }
+        out
+    }
+
+    /// MEMORY-BOUND (RED before the fix): one partition with N rows must
+    /// stream as ceil(N/k) fragments each holding <= k rows. The
+    /// whole-partition path materialises all N rows in one `Vec<Row>`; the
+    /// fragment path never holds more than k rows of the partition body at
+    /// once. We assert the resident-row watermark (max fragment size) stays
+    /// <= k even though the partition has N >> k rows.
+    #[test]
+    fn single_wide_partition_streams_in_bounded_fragments() {
+        let n: i32 = 5_000;
+        let k = 64;
+        let rows: Vec<Row> = (0..n)
+            .map(|c| row(c, 0, format!("v{c}").as_bytes(), 1000))
+            .collect();
+        let reader = Arc::new(reader_from_partitions(&[partition_with_rows(b"hot", rows)]));
+
+        let (partitions, max_fragment) = drain_fragments(std::slice::from_ref(&reader), k);
+        assert_eq!(partitions.len(), 1, "one partition");
+        assert_eq!(partitions[0].rows.len(), n as usize, "all rows reassembled");
+        // The resident-row watermark: no fragment ever exceeds k. With the
+        // pre-fix whole-partition path this would be N (5000) in one Vec.
+        assert!(
+            max_fragment <= k,
+            "resident fragment rows {max_fragment} exceeded k={k} — partition was materialised whole"
+        );
+        // And it actually fragmented (proves the path isn't a single big chunk).
+        assert!(n as usize > k, "fixture must force fragmentation");
+        assert!(
+            max_fragment == k,
+            "expected fragments to fill to k; got max {max_fragment}"
+        );
+
+        // Equivalence with the whole-partition merge.
+        let whole = drain_whole(std::slice::from_ref(&reader));
+        assert_eq!(
+            partitions, whole,
+            "fragment-flattened != whole-partition merge"
+        );
+    }
+
+    /// CORRECTNESS ORACLE: a single wide partition spread across MULTIPLE
+    /// overlapping SSTables with LWW conflicts (newer timestamp wins per
+    /// clustering key) must be byte-identical whether read whole or
+    /// fragmented, for several values of k (forcing different batch
+    /// boundaries).
+    #[test]
+    fn wide_partition_lww_conflicts_fragment_equiv_whole() {
+        // SSTable A: rows 0..100 at ts=1000 (value "a{c}").
+        // SSTable B: even rows at ts=2000 (value "b{c}") — newer, must win.
+        // SSTable C: rows 50..150 at ts=1500 (value "c{c}").
+        let a: Vec<Row> = (0..100)
+            .map(|c| row(c, 0, format!("a{c}").as_bytes(), 1000))
+            .collect();
+        let b: Vec<Row> = (0..100)
+            .filter(|c| c % 2 == 0)
+            .map(|c| row(c, 0, format!("b{c}").as_bytes(), 2000))
+            .collect();
+        let c: Vec<Row> = (50..150)
+            .map(|c| row(c, 0, format!("c{c}").as_bytes(), 1500))
+            .collect();
+        let ra = Arc::new(reader_from_partitions(&[partition_with_rows(b"wide", a)]));
+        let rb = Arc::new(reader_from_partitions(&[partition_with_rows(b"wide", b)]));
+        let rc = Arc::new(reader_from_partitions(&[partition_with_rows(b"wide", c)]));
+        let sstables = vec![ra, rb, rc];
+
+        let whole = drain_whole(&sstables);
+        for k in [1usize, 2, 3, 7, 31, 1024] {
+            let (frag, _) = drain_fragments(&sstables, k);
+            assert_eq!(
+                frag, whole,
+                "fragment(k={k}) diverged from whole-partition merge"
+            );
+        }
+    }
+
+    /// CORRECTNESS ORACLE: tombstones / row deletes within a wide partition.
+    /// Row-level tombstones (newer ts) must suppress older cells; a
+    /// partition-level tombstone must suppress older rows — identically
+    /// across fragment boundaries.
+    #[test]
+    fn wide_partition_tombstones_fragment_equiv_whole() {
+        // Base rows 0..40 at ts=1000.
+        let base: Vec<Row> = (0..40)
+            .map(|c| row(c, 0, format!("v{c}").as_bytes(), 1000))
+            .collect();
+        // Tombstone source: row-level deletes for clustering 5,15,25 at ts=2000.
+        let deletes: Vec<Row> = [5i32, 15, 25]
+            .into_iter()
+            .map(|c| Row {
+                clustering: c.to_be_bytes().to_vec(),
+                cells: vec![],
+                deletion: DeletionTime::new(TS_BASE + 2000, 100),
+                primary_key_liveness: LivenessInfo::NONE,
+            })
+            .collect();
+        let rb = Arc::new(reader_from_partitions(&[partition_with_rows(
+            b"wide", base,
+        )]));
+        let rd = Arc::new(reader_from_partitions(&[partition_with_rows(
+            b"wide", deletes,
+        )]));
+        let sstables = vec![rb, rd];
+
+        let whole = drain_whole(&sstables);
+        for k in [1usize, 2, 4, 8, 1024] {
+            let (frag, _) = drain_fragments(&sstables, k);
+            assert_eq!(frag, whole, "tombstone fragment(k={k}) diverged from whole");
+        }
+    }
+
+    /// CORRECTNESS ORACLE: a partition-level tombstone suppresses rows older
+    /// than it across fragment boundaries, and keeps newer rows.
+    #[test]
+    fn wide_partition_partition_tombstone_fragment_equiv_whole() {
+        // Old rows 0..30 at ts=1000 (suppressed); new rows 30..60 at ts=3000 (kept).
+        let mut rows: Vec<Row> = (0..30)
+            .map(|c| row(c, 0, format!("old{c}").as_bytes(), 1000))
+            .collect();
+        rows.extend((30..60).map(|c| row(c, 0, format!("new{c}").as_bytes(), 3000)));
+        let mut p = partition_with_rows(b"wide", rows);
+        p.deletion = DeletionTime::new(TS_BASE + 2000, 100);
+        let rp = Arc::new(reader_from_partitions(&[p]));
+        let sstables = vec![rp];
+
+        let whole = drain_whole(&sstables);
+        assert_eq!(whole.len(), 1);
+        assert_eq!(whole[0].rows.len(), 30, "only the 30 newer rows survive");
+        for k in [1usize, 4, 7, 1024] {
+            let (frag, _) = drain_fragments(&sstables, k);
+            assert_eq!(frag, whole, "partition-tombstone fragment(k={k}) diverged");
+        }
+    }
+
+    /// Header with one static column (`s`), so a static-row cell at
+    /// ordinal 0 is in range for the SSTable writer.
+    fn static_header() -> SerializationHeader {
+        let mut h = test_header();
+        h.static_columns = vec![(
+            b"s".to_vec(),
+            "org.apache.cassandra.db.marshal.UTF8Type".into(),
+        )];
+        h
+    }
+
+    fn reader_from_partitions_with_header(
+        partitions: &[Partition],
+        header: SerializationHeader,
+    ) -> SSTableReader<Vec<u8>> {
+        let mut writer = SSTableWriter::new(
+            WriteOptions {
+                compression: None,
+                verify_output: false,
+                ..WriteOptions::default()
+            },
+            header,
+        );
+        for partition in partitions {
+            writer.add_partition(partition).unwrap();
+        }
+        let output = writer.finish().unwrap();
+        SSTableReader::open(SSTableComponents {
+            data: output.data,
+            partitions: output.partitions,
+            rows: output.rows,
+            filter: output.filter,
+            compression_info: output.compression_info,
+            statistics: output.statistics,
+        })
+        .unwrap()
+    }
+
+    /// CORRECTNESS ORACLE: a static row + clustering rows. The static row
+    /// rides the FIRST fragment only; clustering rows fragment underneath.
+    #[test]
+    fn wide_partition_static_row_fragment_equiv_whole() {
+        let mut rows: Vec<Row> = (0..50)
+            .map(|c| row(c, 0, format!("v{c}").as_bytes(), 1000))
+            .collect();
+        rows.sort_by(|a, b| a.clustering.cmp(&b.clustering));
+        let mut p = partition_with_rows(b"wide", rows);
+        p.static_row = Some(Row {
+            clustering: vec![],
+            cells: vec![(0, CellValue::live(b"static".to_vec(), TS_BASE + 1234))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::NONE,
+        });
+        let rp = Arc::new(reader_from_partitions_with_header(&[p], static_header()));
+        let sstables = vec![rp];
+
+        let whole = drain_whole(&sstables);
+        for k in [1usize, 3, 8, 1024] {
+            let (frag, _) = drain_fragments(&sstables, k);
+            assert_eq!(frag, whole, "static-row fragment(k={k}) diverged");
+            assert!(
+                frag[0].static_row.is_some(),
+                "static row must be reassembled"
+            );
+        }
+    }
+
+    /// Many partitions interleaved with one wide partition: the merger must
+    /// stream the wide one in fragments and the narrow ones whole, in token
+    /// order, byte-identical to the whole-partition path.
+    #[test]
+    fn mixed_narrow_and_wide_partitions_fragment_equiv_whole() {
+        let mut partitions = Vec::new();
+        for i in 0..20u32 {
+            let key = format!("k{i:03}");
+            if i == 10 {
+                let rows: Vec<Row> = (0..500)
+                    .map(|c| row(c, 0, format!("w{c}").as_bytes(), 1000))
+                    .collect();
+                partitions.push(partition_with_rows(key.as_bytes(), rows));
+            } else {
+                partitions.push(partition_with_rows(
+                    key.as_bytes(),
+                    vec![row(0, 0, format!("n{i}").as_bytes(), 1000)],
+                ));
+            }
+        }
+        // SSTable writer requires partitions in token (DecoratedKey) order.
+        partitions.sort_by(|a, b| a.key.cmp(&b.key));
+        let reader = Arc::new(reader_from_partitions(&partitions));
+        let sstables = vec![reader];
+
+        let whole = drain_whole(&sstables);
+        let (frag, max_fragment) = drain_fragments(&sstables, 16);
+        assert!(max_fragment <= 16, "fragment exceeded k");
+        assert_eq!(
+            frag, whole,
+            "mixed-width fragment stream diverged from whole"
+        );
     }
 
     /// Token-disjoint SSTables in input order collapse into a

--- a/ferrosa-storage/src/range_merger.rs
+++ b/ferrosa-storage/src/range_merger.rs
@@ -50,7 +50,7 @@ pub fn rows_per_fragment() -> usize {
     }
 }
 
-/// One bounded slice of a merged partition emitted by [`FragmentMerger`].
+/// One bounded slice of a merged partition emitted by [`RangeMerger`].
 ///
 /// A wide partition is delivered as a SEQUENCE of fragments that all share
 /// the same `key`, in clustering order, with non-overlapping row ranges.
@@ -224,7 +224,7 @@ struct PoppedHeader {
     deletion: ferrosa_sstable::types::DeletionTime,
     static_row: Option<Row>,
     /// `Some` for `Memtable` sources: the partition's rows, already sorted
-    /// by clustering key, to be drained by the `FragmentMerger`. `None` for
+    /// by clustering key, to be drained by the `RangeMerger`. `None` for
     /// SSTable-backed sources, whose rows stream via
     /// [`MergeSource::next_fragment_row`].
     mem_body: Option<Vec<Row>>,
@@ -240,7 +240,7 @@ pub enum MergeSource<'a, R: ReadAt> {
         peeked: Option<Partition>,
     },
     // NOTE: fragment-row streaming state for the Memtable variant lives
-    // in `FragmentMerger` (see `MemRowSource`) rather than here, so the
+    // in `RangeMerger` (see `MemRowSource`) rather than here, so the
     // whole-partition `RangeMerger` path is untouched.
     /// Single SSTable streaming reader. `mode` controls per-cell
     /// decoding on `pop_partition`. `peek_key` reads only the
@@ -383,7 +383,7 @@ impl<'a, R: ReadAt> MergeSource<'a, R> {
     ///
     /// For `Memtable` sources the partition body is already in memory,
     /// so the header carries the whole partition out as
-    /// `MemPartitionBody` (the `FragmentMerger` drains its rows in
+    /// `MemPartitionBody` (the `RangeMerger` drains its rows in
     /// clustering order). For `SsTable` / `SsTableRun` sources only
     /// the ~10-byte header is decoded here; rows arrive lazily.
     ///

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -2341,6 +2341,176 @@ impl<F: FlushTarget> TableStore<F> {
         }))
     }
 
+    /// Intra-partition streaming variant of [`Self::range_iter`]. A single
+    /// (possibly multi-million-row) partition is delivered as a SEQUENCE of
+    /// `Partition` items each holding `<= K` clustered rows (K =
+    /// [`crate::range_merger::rows_per_fragment`]), so the producer's
+    /// resident memory is `O(num_sources + K)` rows regardless of how wide
+    /// the partition is.
+    ///
+    /// Reassembly contract: every item for one partition key shares the
+    /// same `key`; the FIRST item carries the real `deletion` + `static_row`
+    /// and later items carry `LIVE` / `None`. A consumer that flattens
+    /// `Partition.rows` independently (the CQL row bridge, the cluster
+    /// stream handler) therefore reproduces the merged partition exactly —
+    /// the row sequence is byte-identical to [`Self::range_iter`]'s
+    /// whole-partition output. This is the OOM fix for full-table
+    /// `SELECT *` over inverted-index-shaped tables.
+    pub fn range_iter_fragmented(
+        &self,
+        start: Option<&DecoratedKey>,
+        end: Option<&DecoratedKey>,
+    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>> {
+        const STREAM_BUFFER: usize = 4;
+        let view = self.view.load_full();
+        let schema = self.schema.load_full();
+        let start_owned = start.cloned();
+        let end_owned = end.cloned();
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Partition>>(STREAM_BUFFER);
+
+        let sst_readers = match self.open_readers_for_key_range(
+            &view.sstables,
+            start_owned.as_ref(),
+            end_owned.as_ref(),
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                let _ = tx.try_send(Err(e));
+                return Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+                    rx.recv().await.map(|item| (item, rx))
+                }));
+            }
+        };
+        let column_mappings = sstable_column_mappings(&schema, &sst_readers);
+
+        TaskPool::current("table-store-stream").spawn_blocking(move || {
+            let active_iter = view
+                .active
+                .range_iter(start_owned.as_ref(), end_owned.as_ref());
+            let flushing_iter = view
+                .flushing
+                .as_ref()
+                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+            let sstables_slice = &sst_readers[..];
+
+            let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
+                active_iter,
+                flushing_iter,
+                sstables_slice,
+                &column_mappings,
+                start_owned,
+                end_owned,
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+
+            let k = crate::range_merger::rows_per_fragment();
+            loop {
+                match merger.next_fragment(k) {
+                    Ok(Some(fragment)) => {
+                        if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
+                            return;
+                        }
+                    }
+                    Ok(None) => return,
+                    Err(e) => {
+                        let _ = tx.blocking_send(Err(e));
+                        return;
+                    }
+                }
+            }
+        });
+
+        Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        }))
+    }
+
+    /// Projection-aware intra-partition streaming variant of
+    /// [`Self::range_iter_projected`]. Same fragment reassembly contract as
+    /// [`Self::range_iter_fragmented`]; SSTable cells outside `wanted` are
+    /// byte-skipped per row.
+    pub fn range_iter_projected_fragmented(
+        &self,
+        wanted: Vec<u16>,
+        start: Option<&DecoratedKey>,
+        end: Option<&DecoratedKey>,
+    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>> {
+        const STREAM_BUFFER: usize = 4;
+        let view = self.view.load_full();
+        let schema = self.schema.load_full();
+        let start_owned = start.cloned();
+        let end_owned = end.cloned();
+        let wanted_owned = wanted;
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Partition>>(STREAM_BUFFER);
+
+        let sst_readers = match self.open_readers_for_key_range(
+            &view.sstables,
+            start_owned.as_ref(),
+            end_owned.as_ref(),
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                let _ = tx.try_send(Err(e));
+                return Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+                    rx.recv().await.map(|item| (item, rx))
+                }));
+            }
+        };
+        let column_mappings = sstable_column_mappings(&schema, &sst_readers);
+
+        TaskPool::current("table-store-stream").spawn_blocking(move || {
+            let active_iter = view
+                .active
+                .range_iter(start_owned.as_ref(), end_owned.as_ref());
+            let flushing_iter = view
+                .flushing
+                .as_ref()
+                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+            let sstables_slice = &sst_readers[..];
+
+            let mut merger = match crate::range_merger::merger_for_projected_sources_with_mappings(
+                active_iter,
+                flushing_iter,
+                sstables_slice,
+                &column_mappings,
+                &wanted_owned,
+                start_owned,
+                end_owned,
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+
+            let k = crate::range_merger::rows_per_fragment();
+            loop {
+                match merger.next_fragment(k) {
+                    Ok(Some(fragment)) => {
+                        if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
+                            return;
+                        }
+                    }
+                    Ok(None) => return,
+                    Err(e) => {
+                        let _ = tx.blocking_send(Err(e));
+                        return;
+                    }
+                }
+            }
+        });
+
+        Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        }))
+    }
+
     /// Read all partitions whose tokens fall in `[start_token, end_token)`,
     /// up to `limit` matching partitions.
     ///
@@ -4549,6 +4719,80 @@ mod tests {
             futures::StreamExt::next(&mut stream).await.is_none(),
             "expected exactly one partition"
         );
+    }
+
+    /// End-to-end engine wiring: `range_iter_fragmented` must reassemble
+    /// (flatten per key) to byte-identical output vs the whole-partition
+    /// `range_iter`, while bounding each emitted fragment to `<= K` rows —
+    /// across memtable + flushed-SSTable sources for one WIDE partition.
+    /// This is the storage-level OOM-bound + equivalence oracle.
+    #[tokio::test]
+    async fn range_iter_fragmented_flattens_to_range_iter_across_sources() {
+        std::env::set_var("FERROSA_RANGE_READ_ROWS_PER_FRAGMENT", "16");
+        let store = test_store();
+
+        // One wide partition "hot": half its rows flushed to an SSTable, half
+        // still in the active memtable, plus a couple of narrow partitions so
+        // the k-way merge has neighbours. Each write is a distinct clustering
+        // row in the same partition.
+        for ck in 0..40i32 {
+            store
+                .write(
+                    &make_key("hot"),
+                    make_row_with_ck(ck, format!("flushed{ck}").as_bytes(), 1000 + ck as i64),
+                )
+                .unwrap();
+        }
+        store.write(&make_key("aaa"), make_row(b"a", 1000)).unwrap();
+        store.flush().unwrap();
+        // Memtable half (newer ts on even cks — LWW must keep these).
+        for ck in (0..40i32).filter(|c| c % 2 == 0) {
+            store
+                .write(
+                    &make_key("hot"),
+                    make_row_with_ck(ck, format!("memtable{ck}").as_bytes(), 5000 + ck as i64),
+                )
+                .unwrap();
+        }
+        store.write(&make_key("zzz"), make_row(b"z", 1000)).unwrap();
+
+        // Whole-partition reference.
+        let mut whole_stream = store.range_iter(None, None);
+        let mut whole: Vec<Partition> = Vec::new();
+        while let Some(p) = futures::StreamExt::next(&mut whole_stream).await {
+            whole.push(p.unwrap());
+        }
+
+        // Fragmented.
+        let mut frag_stream = store.range_iter_fragmented(None, None);
+        let mut frags: Vec<Partition> = Vec::new();
+        while let Some(p) = futures::StreamExt::next(&mut frag_stream).await {
+            let p = p.unwrap();
+            assert!(
+                p.rows.len() <= 16,
+                "fragment {} exceeded K=16",
+                p.rows.len()
+            );
+            frags.push(p);
+        }
+
+        // Flatten fragments per key.
+        let mut flat: Vec<Partition> = Vec::new();
+        for f in frags {
+            match flat.last_mut() {
+                Some(p) if p.key == f.key => p.rows.extend(f.rows),
+                _ => flat.push(f),
+            }
+        }
+
+        assert_eq!(
+            flat, whole,
+            "fragmented flatten != whole-partition range_iter"
+        );
+        // The hot partition must have fragmented (40 distinct cks > K=16).
+        let hot = whole.iter().find(|p| p.key == make_key("hot")).unwrap();
+        assert!(hot.rows.len() > 16, "fixture must produce a wide partition");
+        std::env::remove_var("FERROSA_RANGE_READ_ROWS_PER_FRAGMENT");
     }
 
     #[test]


### PR DESCRIPTION
## Problem (P0 — "OOM on full table scan")

A full-table `SELECT * FROM agent_memory.document_terms` (≈2.18M rows) OOM-killed cluster
nodes (cql-rt, anon-rss ~2.08 GB at the 2 GB cgroup cap). Root cause is **two independent
unbounded buffers** on the read path — the merged bounded-reader work (#83) bounded SSTable
*reader* memory but neither of these:

1. **Replica per-partition materialization.** The streaming range read bounded *partition
   count* (`STREAMING_CHUNK_PARTITIONS=64`), but a single `Partition` holds **all** its rows
   in one `Vec<Row>`. `document_terms` is an inverted index — one hot term is one partition with
   millions of postings; `StreamMerger::next_merged_partition` materialized it whole.
2. **Coordinator result accumulation.** The CQL FullScan path appended the entire result into
   `all_rows` before returning, ignoring server-side paging — so the coordinator buffered all
   2.18M rows. (Fixing #1 alone just moved the OOM from replica → coordinator, which the e2e
   caught.)

## Fix — bound BOTH buffers

**Commit 1 — intra-partition row streaming (`ferrosa-sstable`, `ferrosa-storage`, replica handler):**
- Bounded per-partition row reading (`next_partition_rows(limit)`) — never decodes a whole partition.
- A streaming **k-way row merge** (`PartitionFragment` / `next_fragment`) emitting ≤K-row fragments,
  preserving LWW / tombstone / static-row semantics incrementally — `O(num_sources + K)` resident
  regardless of partition width. Replica/coordinator chunk by total **rows**.
- `K = FERROSA_RANGE_READ_ROWS_PER_FRAGMENT` (default 4096).

**Commit 2 — coordinator server-side paging (`ferrosa-cql`):**
- Route the unbounded-scan shape through the existing `PagingState`: collect at most `page_size`
  rows, emit a `next_paging_state` resume cursor (raw partition+clustering bytes; inclusive
  re-seek + skip-≤-last) that resumes exactly-once **even mid-wide-partition**.
- Default `FERROSA_CQL_DEFAULT_PAGE_SIZE=5000` when the client sends none.
- LIMIT / ORDER BY / ANN / DISTINCT / COUNT / aggregate / predicate paths unchanged. Multi-replica
  token-merge-with-resume **fails loud** (no partial scans) — tracked follow-up.

## TDD

- **Storage**: `single_wide_partition_streams_in_bounded_fragments` (≤K resident); byte-identical
  equivalence vs whole-partition merge for LWW conflicts, tombstones, partition tombstones, static
  rows, mixed widths, and the cross-replica path, for k ∈ {1…1024}; existing streaming/digest
  equivalence oracles still pass.
- **CQL**: first page bounded by page_size; **paged traversal == whole scan (no gaps/dupes, incl.
  mid-wide-partition)**; default page applies with no client page_size; LIMIT/point reads unchanged.

## Verification

- CI green: `fmt --check`, `clippy --all-targets` (zero warnings), `cargo test -p ferrosa-sstable
  -p ferrosa-storage -p ferrosa-cluster -p ferrosa-cql`, `build --all-targets`.
- **E2E (the real proof):** re-ran the exact `SELECT *` over 2.18M rows on a 3-node cluster built
  from this branch. Before: all nodes → ~2.08 GB → OOMKilled. **After: RSS held flat (~200 MB
  per node; observed peak node1=304MB node2=499MB node3=277MB ), OOMKilled=false on all nodes.**
  _(Scan completion + final peak being confirmed; will update if anything changes.)_
