### PR TITLE
fix(net): lane reconnect follows peer's advertised hostname (P3 stale-IP)

### DIFF
--- a/ferrosa-net/src/pool.rs
+++ b/ferrosa-net/src/pool.rs
@@ -152,12 +152,20 @@ impl PriorityPool {
         let peer_internode_broadcast = raft_client.peer_internode_broadcast().map(String::from);
         let peer_host = peer_host.to_owned();
 
+        // For *reconnects*, prefer the peer's advertised, re-resolvable internode
+        // broadcast hostname over the connect-time address. Callers frequently
+        // pass an already-resolved IP (e.g. `SocketAddr::to_string()` from Raft
+        // membership); re-resolving an IP is a no-op, so a peer that restarts with
+        // a new IP would be retried at its dead address forever.
+        // Fixes P3: lane reconnect uses stale IP when peer restarts with a new IP.
+        let reconnect_host = pick_reconnect_host(&peer_host, peer_internode_broadcast.as_deref());
+
         // Spawn a lane actor for each connection.  The ctx_builder closure
         // captures the shared config/TLS state and wires up the reconnect
         // context with a handle back to the actor itself.
         let peer_label = format!("{}", peer_host_id.as_fields().0);
         let raft_config = Arc::clone(&config);
-        let raft_peer_host = peer_host.clone();
+        let raft_peer_host = reconnect_host.clone();
         let raft_tls = tls_connector.clone();
         let raft_task_pool_for_ctx = raft_task_pool.clone();
         let raft = spawn_raft_lane_actor_with_timeout(
@@ -177,7 +185,7 @@ impl PriorityPool {
             },
         );
         let data_config = Arc::clone(&config);
-        let data_peer_host = peer_host.clone();
+        let data_peer_host = reconnect_host.clone();
         let data_tls = tls_connector.clone();
         let data_task_pool_for_ctx = data_task_pool.clone();
         let data_ctx = move |h: LaneHandle| ActorReconnectContext {
@@ -199,7 +207,7 @@ impl PriorityPool {
         );
 
         let bulk_config = Arc::clone(&config);
-        let bulk_peer_host = peer_host;
+        let bulk_peer_host = reconnect_host;
         let bulk_tls = tls_connector.clone();
         let bulk_task_pool_for_ctx = bulk_task_pool.clone();
         let bulk_ctx = move |h: LaneHandle| ActorReconnectContext {
@@ -336,6 +344,22 @@ impl PriorityPool {
     }
 }
 
+/// Choose the host string a lane uses for *reconnects*.
+///
+/// Prefers the peer's advertised, re-resolvable internode broadcast hostname
+/// (learned during the handshake) over the connect-time address, which callers
+/// frequently pass as an already-resolved IP. Because re-resolving a literal IP
+/// is a no-op, pinning the reconnect host to an IP means a peer that restarts
+/// with a new IP is retried at its dead address forever
+/// (P3: lane-reconnect-stale-ip). A blank/whitespace broadcast is ignored.
+fn pick_reconnect_host(connect_host: &str, peer_internode_broadcast: Option<&str>) -> String {
+    peer_internode_broadcast
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+        .unwrap_or(connect_host)
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -364,6 +388,31 @@ mod tests {
                 _ => None,
             }
         }
+    }
+
+    // --- P3 lane-reconnect-stale-ip: reconnect host selection ---
+
+    #[test]
+    fn reconnect_prefers_advertised_broadcast_hostname_over_connect_ip() {
+        // Connect-time address is an already-resolved IP (e.g. a
+        // `SocketAddr::to_string()` from Raft membership). The peer advertised a
+        // re-resolvable hostname during the handshake, so reconnects must use it
+        // — otherwise an IP change on peer restart strands the lane forever.
+        assert_eq!(
+            pick_reconnect_host("10.89.0.4:7000", Some("node1:7000")),
+            "node1:7000",
+        );
+    }
+
+    #[test]
+    fn reconnect_falls_back_to_connect_host_without_usable_broadcast() {
+        // No broadcast advertised: keep the connect-time host.
+        assert_eq!(
+            pick_reconnect_host("10.89.0.4:7000", None),
+            "10.89.0.4:7000",
+        );
+        // Blank/whitespace broadcast is ignored, not used as a host.
+        assert_eq!(pick_reconnect_host("node1:7000", Some("   ")), "node1:7000");
     }
 
     #[tokio::test]

--- a/specs/implemented/bug-lane-reconnect-stale-ip-when-peer-restarts.md
+++ b/specs/implemented/bug-lane-reconnect-stale-ip-when-peer-restarts.md
@@ -3,9 +3,9 @@ type: bug
 priority: P3
 reported-by: ferrosa-memory launch debugging
 implemented-by: "codex"
-verified-by: ""
+verified-by: "unit (pool::tests::reconnect_*); live-cluster verification pending"
 created: 2026-04-18
-updated: 2026-05-22
+updated: 2026-06-08
 ---
 
 # Lane reconnect may use stale IP when peer container restarts with new IP
@@ -31,6 +31,29 @@ The cluster controller should pass the container hostname (from the
 compose service name or Raft node configuration) instead of the resolved
 IP. Alternatively, the PeerManager could maintain a mapping from host_id
 to current hostname and update it when peers reconnect from new IPs.
+
+## Resolution (2026-06-08)
+
+Fixed at the `ferrosa-net` pool layer rather than chasing every controller call
+site (`cluster.rs`, `pair.rs`, `membership.rs`, `peer_events.rs` all pass
+`SocketAddr::to_string()`). `PriorityPool::connect` already learns the peer's
+advertised, re-resolvable `internode_broadcast` hostname from the handshake
+(`raft_client.peer_internode_broadcast()`). It now wires that hostname — not the
+connect-time address — into each lane's `ActorReconnectContext.peer_host` via
+`pick_reconnect_host()`, falling back to the connect-time host when the peer
+advertised no usable broadcast. So a reconnect re-resolves the hostname and
+follows the peer to its new IP, regardless of which caller initiated the pool.
+
+This depends on peers advertising a hostname (not an IP) as
+`FERROSA_INTERNODE_BROADCAST` — which the ferrosa-memory compose already does
+(`node1:7000`). A peer that advertises an IP (or nothing) keeps the prior
+behavior.
+
+- Code: `ferrosa-net/src/pool.rs` (`pick_reconnect_host` + `connect` wiring).
+- Tests: `pool::tests::reconnect_prefers_advertised_broadcast_hostname_over_connect_ip`,
+  `pool::tests::reconnect_falls_back_to_connect_host_without_usable_broadcast`.
+- Live verification still pending: restart one node so its container IP changes
+  and confirm peers reconnect without a stale `:7000` `Bulk lane timeout`.
 
 ## Impact
 


### PR DESCRIPTION
## Summary

Fixes **P3: lane reconnect uses stale IP when a peer restarts with a new IP** (`specs/implemented/bug-lane-reconnect-stale-ip-when-peer-restarts.md`).

`ferrosa-net` reconnect already re-resolves `peer_host` every retry, but `PriorityPool::connect` wired the lanes' reconnect host to the **connect-time address** — which controllers pass as an already-resolved IP (`SocketAddr::to_string()` from Raft membership). Re-resolving a literal IP is a no-op, so a peer that churns IP (podman/docker) is retried at its dead `:7000` forever — surfacing downstream as `Bulk lane timeout` / `ChannelClosedBeforeDone` on index and streaming range reads.

## Fix

`PriorityPool::connect` already learns the peer's re-resolvable `internode_broadcast` hostname from the handshake. It now wires that hostname into each lane's `ActorReconnectContext.peer_host` via `pick_reconnect_host()`, falling back to the connect-time host when no usable broadcast was advertised. One change covers every controller call site (`cluster.rs`, `pair.rs`, `membership.rs`, `peer_events.rs`). Pairs with #86 (broadcast-hostname advertisement).

## Test Plan

- [x] TDD: failing unit tests first, then helper + wiring
- [x] `pool::tests::reconnect_prefers_advertised_broadcast_hostname_over_connect_ip`
- [x] `pool::tests::reconnect_falls_back_to_connect_host_without_usable_broadcast`
- [x] 148 ferrosa-net lib tests pass; clippy clean
- [ ] Live: restart a node so its container IP changes; confirm peers reconnect without a stale `:7000` `Bulk lane timeout`