### PR TITLE
fix(net): dispatch streaming range-read response frames in wire order

### DIFF
--- a/ferrosa-net/src/codec.rs
+++ b/ferrosa-net/src/codec.rs
@@ -179,6 +179,31 @@ impl MsgType {
                 | Self::RaftInstallSnapshot
         )
     }
+
+    /// Returns true for the streaming range-read RESPONSE frames that
+    /// belong to a single ordered, per-`request_id` stream: chunk,
+    /// heartbeat, and done.
+    ///
+    /// These frames MUST be dispatched in wire order. The coordinator's
+    /// `StreamFrameRouter` enforces a strict, contiguous chunk `seq` and
+    /// closes the route on the first gap; dispatching one task per frame
+    /// lets chunk `seq=N+1` overtake `seq=N` under tokio scheduling and
+    /// trips that check mid-stream, surfacing as
+    /// `ChannelClosedBeforeDone`. The fault stays invisible until a
+    /// single response carries more than one chunk — which is exactly
+    /// what intra-partition row fragmentation (bounded full-scan memory)
+    /// introduced for wide partitions.
+    ///
+    /// The producer-side `RangeReadStreamRequest` is deliberately
+    /// excluded: it runs a long storage read and must stay off the
+    /// frame-reader path. `RangeReadStreamCancel` is likewise excluded —
+    /// it is not part of the ordered response stream.
+    pub fn is_ordered_stream_response(self) -> bool {
+        matches!(
+            self,
+            Self::RangeReadStreamChunk | Self::RangeReadStreamHeartbeat | Self::RangeReadStreamDone
+        )
+    }
 }
 
 impl TryFrom<u8> for MsgType {

--- a/ferrosa-net/src/rpc/server.rs
+++ b/ferrosa-net/src/rpc/server.rs
@@ -409,7 +409,22 @@ impl RpcServer {
                 }
             };
 
-            if msg_type.is_raft() {
+            if msg_type.is_ordered_stream_response() {
+                // Frames of one streaming range-read response (chunk /
+                // heartbeat / done) form a single ordered, per-request
+                // stream. The coordinator's StreamFrameRouter enforces a
+                // strict, contiguous chunk `seq` and closes the route on
+                // the first gap — so spawning one task per frame here lets
+                // chunk seq=N+1 overtake seq=N under tokio scheduling and
+                // trips that check mid-stream (ChannelClosedBeforeDone),
+                // which a wide-partition scan reliably hits once the
+                // response spans many row-capped chunks. Run the handler
+                // inline to preserve wire order. It is non-blocking
+                // (decode + StreamRouter::route via try_send), so it
+                // cannot stall frame reading the way the producer-side
+                // RangeReadStreamRequest storage read would.
+                handler.await;
+            } else if msg_type.is_raft() {
                 self.raft_task_pool().spawn(handler);
             } else {
                 self.data_task_pool().spawn(handler);
@@ -863,5 +878,96 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(resp, Message::Pong { nonce: 2, .. }));
+    }
+
+    /// Regression (range-stream chunk reorder closes route): frames of a
+    /// single streaming range-read response must be dispatched in wire
+    /// order. The coordinator's `StreamFrameRouter` enforces a strict,
+    /// contiguous chunk `seq` and closes the route on the first gap, so a
+    /// reorder here surfaces downstream as `ChannelClosedBeforeDone` — the
+    /// fault a wide-partition scan (many row-capped chunks) reliably hits.
+    ///
+    /// This handler sleeps LONGER for earlier markers. Under the old
+    /// one-task-per-frame dispatch the later (shorter-sleep) frames finish
+    /// first, recording `[2, 1, 0]`. In-order inline dispatch makes the
+    /// reader await each stream-response handler before reading the next
+    /// frame, so the recorded order is exactly the wire order `[0, 1, 2]`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stream_response_frames_dispatch_in_wire_order() {
+        use futures::SinkExt;
+
+        struct OrderRecorder {
+            order: Arc<std::sync::Mutex<Vec<u8>>>,
+        }
+        #[async_trait::async_trait]
+        impl RpcHandler for OrderRecorder {
+            async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
+                if let Message::RangeReadStreamChunk(body) = msg {
+                    let marker = body.first().copied().unwrap_or(0);
+                    // Earlier markers sleep longer: any concurrency would
+                    // let later frames record ahead of earlier ones.
+                    tokio::time::sleep(Duration::from_millis(50 * (3 - marker as u64))).await;
+                    self.order.lock().unwrap().push(marker);
+                }
+                None
+            }
+        }
+
+        let order = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let config = NetConfig {
+            bind_addr: "127.0.0.1:0".parse().unwrap(),
+            ..NetConfig::default()
+        };
+        let server_id = uuid::Uuid::new_v4();
+        let registry = Arc::new(HandlerRegistry::new());
+        registry.register(
+            MsgType::RangeReadStreamChunk,
+            Arc::new(OrderRecorder {
+                order: order.clone(),
+            }),
+        );
+        let server = Arc::new(RpcServer::new(config.clone(), server_id, registry));
+
+        let addr = server.start_and_get_addr().await.unwrap();
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let mut framed = Framed::new(stream, InternodeCodec::new(config.max_frame_body_size));
+        initiate_handshake(&mut framed, &config, uuid::Uuid::new_v4())
+            .await
+            .unwrap();
+
+        // Three chunk frames, markers 0,1,2, sent back-to-back in order.
+        for marker in 0u8..3 {
+            let body = bytes::Bytes::copy_from_slice(&[marker]);
+            let frame = Frame {
+                header: FrameHeader::new(
+                    MsgType::RangeReadStreamChunk,
+                    Lane::Bulk,
+                    1,
+                    u32::try_from(body.len()).unwrap(),
+                ),
+                body,
+            };
+            framed.send(frame).await.unwrap();
+        }
+
+        // Wait until all three frames have been recorded (bounded).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if order.lock().unwrap().len() == 3 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "handler did not observe all three chunk frames within the deadline"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(
+            *order.lock().unwrap(),
+            vec![0, 1, 2],
+            "stream-response frames must be dispatched in wire order; a reorder \
+             closes the StreamFrameRouter route mid-stream (ChannelClosedBeforeDone)"
+        );
     }
 }

--- a/specs/todo/bug-range-stream-chunk-reorder-closes-route.md
+++ b/specs/todo/bug-range-stream-chunk-reorder-closes-route.md
@@ -1,0 +1,112 @@
+---
+type: todo
+priority: P0
+status: fixed
+created: 2026-06-09
+updated: 2026-06-09
+affected-versions: ferrosa main @ 029544d0 (introduced by #91/#92)
+fixed-by: fix/range-stream-chunk-reorder-closes-route
+---
+
+# Bug: multi-chunk streaming range read fails with `ChannelClosedBeforeDone` (chunk frames dispatched out of wire order)
+
+## Symptom
+
+Any streaming range read whose response carries **more than one chunk
+frame** fails intermittently-to-deterministically with:
+
+```
+DbError(ServerError, "server error: cluster error: internal:
+  streaming range read: ChannelClosedBeforeDone { delivered_done: 0, expected_done: 1 }")
+```
+
+Single-chunk responses (small tables, narrow partitions) always
+succeed; the failure rate climbs with the chunk count, so a wide
+partition or a large scan fails almost every time.
+
+Reproduced by the downstream ferrosa-memory CI test
+`derived_cache_count_streams_past_one_hundred_thousand_live_rows`,
+which seeds **100 001 rows into a single partition** and then does a
+paged `SELECT ... ALLOW FILTERING`. It failed 3/3 runs across two
+unrelated PRs; ferrosa-memory `main` last passed on 2026-06-06, the day
+before #91/#92 landed (2026-06-07).
+
+## Why this is a Ferrosa bug
+
+`ferrosa-net`'s connection read loop
+(`rpc/server.rs::handle_connection`) reads frames off the socket in
+order, but **spawns one tokio task per frame**
+(`data_task_pool().spawn(handler)`). Those tasks run concurrently and
+can complete in any order.
+
+The coordinator's `StreamFrameRouter::accept_chunk_seq`
+(`coordinator/stream_frame_router.rs`) enforces a **strict, contiguous
+chunk `seq`**: the first time it observes `seq != next_chunk_seq` it
+declares a gap/reorder and **closes the route**
+(`router.unregister(request_id)`), dropping the per-request channel's
+sender. The consumer's forwarder
+(`coordinator/range_read_stream.rs::forward_remote_range_stream_inner`)
+then sees the channel close with no `Done` and returns
+`ChannelClosedBeforeDone { delivered_done: 0, expected_done: 1 }`.
+
+So two chunk frames whose handler tasks are scheduled out of order
+(`seq=1` wins the `seq_state` mutex before `seq=0`) trip the check and
+kill an otherwise-healthy scan. `delivered_done` is 0 because the
+forwarder counts only `Done` frames — any number of chunks may already
+have been forwarded before the route closed.
+
+## Why it regressed in #91/#92
+
+The seq-strictness in `StreamFrameRouter` is older, but it was latent:
+before #91 the producer (`stream_producer::stream_range_response`)
+chunked by **partition count**, so a single wide partition was emitted
+as exactly **one chunk** — no second frame, no reorder, no trip.
+
+#91 ("bound full-scan memory — intra-partition row streaming") replaced
+that with the row-fragmented producer
+(`stream_request_handler::handle_stream_request`), which splits one wide
+partition into many `~4096`-row chunks
+(`DEFAULT_STREAM_CHUNK_ROW_CAP`). A single 100k-row partition now
+produces ~25 chunk frames — and ~25 concurrently-dispatched handler
+tasks — making the reorder near-certain. The memory fix exposed the
+pre-existing ordering bug.
+
+## Root cause, precisely
+
+Frames of one streaming range-read response (`RangeReadStreamChunk` /
+`RangeReadStreamHeartbeat` / `RangeReadStreamDone`) form a **single
+ordered, per-`request_id` stream**, but the network layer dispatched
+them with the same one-task-per-frame concurrency it uses for
+independent request/response RPCs. Concurrency on an ordered stream is
+pure harm: it reorders chunks (and would corrupt the coordinator's
+token-ordered N-way merge input even if the seq check were relaxed).
+
+## Fix
+
+`ferrosa-net`: dispatch the three streaming-range-read **response**
+frame types in wire order — run the handler inline in the read loop
+instead of spawning a task per frame. The handler for these types is
+non-blocking (`bincode` header decode + `StreamRouter::route` via
+`try_send`), so inline dispatch cannot stall frame reading the way the
+producer-side `RangeReadStreamRequest` storage read would. The
+producer-side request and `RangeReadStreamCancel` keep spawning.
+
+- `ferrosa-net/src/codec.rs` — `MsgType::is_ordered_stream_response()`.
+- `ferrosa-net/src/rpc/server.rs` — inline-dispatch branch + regression
+  test `stream_response_frames_dispatch_in_wire_order` (records the
+  arrival order of three deliberately-skewed chunk handlers; asserts
+  `[0,1,2]`. Fails as `[2,1,0]` on the old spawn path).
+
+This preserves every existing guarantee: the seq check still fails loud
+on genuine wire corruption/loss, and the token-ordered merge still
+receives chunks in order.
+
+## Alternatives considered
+
+- **Reorder-tolerant buffer in `StreamFrameRouter`** (hold out-of-order
+  chunks, release the contiguous prefix): more code on a hot path, and
+  needs a bounded reorder window — too small spuriously fails huge
+  scans, too large defeats #91's memory bound. Rejected.
+- **Relax the seq check**: would let chunks reach the consumer out of
+  token order and silently corrupt the N-way merge. Rejected (violates
+  fail-loud).


### PR DESCRIPTION
## Problem

A streaming range read whose response carries **more than one chunk frame** fails with:

```
ChannelClosedBeforeDone { delivered_done: 0, expected_done: 1 }
```

Single-chunk responses always succeed; the failure rate rises with chunk count, so a wide partition or large scan fails almost every time. Caught by ferrosa-memory CI (`derived_cache_count_streams_past_one_hundred_thousand_live_rows`, 100k rows in one partition) — failed 3/3 across two unrelated PRs; ferrosa-memory `main` last passed 2026-06-06, the day before #91/#92 landed.

## Root cause

`rpc/server.rs::handle_connection` reads frames in order but **spawns one tokio task per frame**, so chunk frames of a single ordered per-request stream are dispatched concurrently and can finish out of order. `StreamFrameRouter::accept_chunk_seq` enforces a strict contiguous chunk `seq` and **closes the route** (`unregister` → sender dropped) on the first gap → the forwarder sees the channel close with no `Done`.

**Latent until #91/#92:** the old producer chunked by partition count (one wide partition = one frame, never reordered). #91's row-fragmented producer splits one wide partition into many ~4096-row chunks (~25 for 100k rows), making reorder near-certain. The memory fix exposed the pre-existing ordering bug.

## Fix

Dispatch the three streaming-range-read **response** frame types (chunk/heartbeat/done) **inline in the read loop** instead of spawning per frame. The handler is non-blocking (header decode + `StreamRouter::route` via `try_send`), so wire order is preserved without stalling frame reading. The producer-side `RangeReadStreamRequest` (long storage read) and `RangeReadStreamCancel` keep spawning.

Preserves every guarantee: the seq check still fails loud on genuine loss/corruption, and the token-ordered N-way merge still receives chunks in order.

- `ferrosa-net/src/codec.rs` — `MsgType::is_ordered_stream_response()`
- `ferrosa-net/src/rpc/server.rs` — inline-dispatch branch + regression test `stream_response_frames_dispatch_in_wire_order` (records arrival order of three deliberately-skewed chunk handlers; **fails `[2,1,0]` on the old spawn path, passes `[0,1,2]` inline**)
- `specs/todo/bug-range-stream-chunk-reorder-closes-route.md` — full writeup

## Test

`cargo test -p ferrosa-net --lib` (147 pass incl. new regression) and `cargo test -p ferrosa-cluster --lib coordinator::stream` (36 pass). fmt + clippy clean.