### PR TITLE
ci(release): automate releases on merge + nightly safety-net (tag-only)

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,9 +1,27 @@
-name: Nightly Release
+name: Release (on-merge + nightly)
 
 on:
+  # Release-on-merge: every push to `main` (i.e. a merged PR) cuts the next
+  # SemVer release derived from Conventional Commit history. The `should_release`
+  # guard below skips when nothing releasable landed since the latest tag, so a
+  # doc/CI-only change does not necessarily cut a build. Doc/spec-only pushes are
+  # excluded outright via paths-ignore to avoid a full multi-platform build for
+  # prose-only changes.
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'specs/**'
+      - 'docs/**'
+      - '.github/**'
   schedule:
-    # Run once per night in UTC. The workflow skips itself when no commits have
-    # landed since the latest stable vX.Y.Z tag.
+    # Safety-net nightly in UTC (catches anything the push path missed, e.g. a
+    # release run that failed transiently). Skips itself when no commits have
+    # landed since the latest stable vX.Y.Z tag. Releases are cut as tags only:
+    # the version bump commit is captured by the tag and never pushed to the
+    # `main` branch (its ruleset requires pull requests). `release.yml` builds
+    # from the tag, so the published artifact always carries the correct version.
     - cron: '17 8 * * *'
   workflow_dispatch:
     inputs:
@@ -65,7 +83,7 @@ jobs:
           cargo update -w
           git diff -- Cargo.toml Cargo.lock
 
-      - name: Commit release bump and create tag
+      - name: Create release commit and tag
         if: steps.next.outputs.should_release == 'true'
         env:
           NEXT_VERSION: ${{ steps.next.outputs.next_version }}
@@ -77,9 +95,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock
+          # The release commit carries the version bump and is captured by the
+          # tag. We intentionally do NOT push it to the default branch: the
+          # `main` ruleset requires pull requests, so a direct branch push is
+          # rejected (GH013). The tag is the release artifact source; main's
+          # Cargo.toml version is decorative between releases.
           git commit -m "chore(release): ${NEXT_TAG}"
-          git tag -a "${NEXT_TAG}" -m "${NEXT_TAG} nightly release" -m "${BUMP} bump from ${BASE_TAG} after ${COMMIT_COUNT} commits."
-          git push origin HEAD:${GITHUB_REF_NAME}
+          git tag -a "${NEXT_TAG}" \
+            -m "${NEXT_TAG} (${GITHUB_EVENT_NAME} release)" \
+            -m "${BUMP} bump from ${BASE_TAG} after ${COMMIT_COUNT} commits."
+          # Push the tag only (the branch ruleset does not cover refs/tags/*).
           git push origin "${NEXT_TAG}"
 
       - name: Dispatch release build
@@ -87,4 +112,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           NEXT_TAG: ${{ steps.next.outputs.next_tag }}
-        run: gh workflow run release.yml --ref "${NEXT_TAG}"
+        # Explicit dispatch is required: tags pushed with GITHUB_TOKEN do NOT
+        # trigger release.yml's `on: push` (GitHub's recursion guard). Every
+        # auto-cut release — whether from a merge, the nightly cron, or a manual
+        # dispatch — is a prerelease (the "nightly" channel); a maintainer
+        # promotes it to stable via promote-release.yml.
+        run: gh workflow run release.yml --ref "${NEXT_TAG}" -f prerelease=true

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,43 @@
+name: Promote Release to Stable
+
+# Blesses an existing (nightly/prerelease) release as the stable channel:
+# marks it --latest and clears the prerelease flag. This is the only path by
+# which a release leaves the "nightly" channel and becomes "stable".
+#
+# Releases are cut nightly as prereleases (see nightly-release.yml +
+# release.yml). When a build has been validated, promote its tag here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to promote to stable (e.g. v0.14.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: promote-release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Mark ${{ github.event.inputs.tag }} as stable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Promote tag to stable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          # Fail loudly if the tag has no release to promote.
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "error: no release found for tag ${TAG} in ${REPO}" >&2
+            exit 1
+          fi
+          gh release edit "$TAG" --repo "$REPO" \
+            --draft=false --prerelease=false --latest
+          echo "Promoted ${TAG} to stable (latest, not prerelease)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: >-
+          Mark the GitHub release as a prerelease (the "nightly" channel).
+          Stable releases are promoted separately via promote-release.yml.
+        required: false
+        type: boolean
+        default: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -340,7 +348,18 @@ jobs:
           # Replace VERSION placeholder in notes
           NOTES="${NOTES//VERSION/${VERSION}}"
 
+          # Channel policy: every freshly built release is a prerelease (the
+          # "nightly" channel). A release becomes "stable" only when a human
+          # promotes it (promote-release.yml -> marks it --latest, not pre).
+          # Tag-push events carry no input, so they default to prerelease too.
+          PRERELEASE="${{ github.event.inputs.prerelease }}"
+          if [ "${PRERELEASE}" = "false" ]; then
+            REL_FLAGS=(--latest)
+          else
+            REL_FLAGS=(--prerelease)
+          fi
+
           gh release create "v${VERSION}" dist/* \
             --title "Ferrosa v${VERSION}" \
             --notes "$NOTES" \
-            --latest
+            "${REL_FLAGS[@]}"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -2,8 +2,19 @@
 # ferrosa installer — fetches a release tarball, installs to ~/.ferrosa,
 # offers system-service registration and admin-password setup.
 #
+# It is idempotent: re-running upgrades an existing install in place. When the
+# resolved version already matches what's installed it does nothing (use
+# --force to reinstall).
+#
+# Channels:
+#   stable  (default) — the latest release a maintainer has promoted (GitHub
+#                       "latest"). Resolves via /releases/latest.
+#   nightly           — the newest published release, including the prereleases
+#                       cut automatically each night. Resolves via /releases.
+#
 # Usage:
 #   curl -fsSL https://ferrosadb.com/install.sh | bash
+#   curl -fsSL https://ferrosadb.com/install.sh | bash -s -- --channel nightly
 #   curl -fsSL https://ferrosadb.com/install.sh | bash -s -- --version v0.12.0 --no-service
 set -euo pipefail
 
@@ -14,8 +25,11 @@ BIN_DIR="${INSTALL_ROOT}/bin"
 CONFIG_DIR="${INSTALL_ROOT}/config"
 DATA_DIR="${INSTALL_ROOT}/data"
 LOG_DIR="${INSTALL_ROOT}/logs"
+VERSION_STAMP="${INSTALL_ROOT}/.version"
 
 VERSION=""
+CHANNEL="stable"   # stable|nightly
+FORCE="no"
 WANT_SERVICE=""    # ask|yes|no
 WANT_PASSWORD=""   # ask|yes|no
 
@@ -23,6 +37,8 @@ WANT_PASSWORD=""   # ask|yes|no
 while [ $# -gt 0 ]; do
   case "$1" in
     --version)      VERSION="$2"; shift 2 ;;
+    --channel)      CHANNEL="$2"; shift 2 ;;
+    --force)        FORCE="yes"; shift ;;
     --no-service)   WANT_SERVICE="no"; shift ;;
     --service)      WANT_SERVICE="yes"; shift ;;
     --no-password)  WANT_PASSWORD="no"; shift ;;
@@ -30,14 +46,21 @@ while [ $# -gt 0 ]; do
     -h|--help)
       cat <<EOF
 ferrosa installer
-  --version <tag>           install a specific tag (default: latest)
-  --service / --no-service  enable or skip system-service install
+  --version <tag>            install a specific tag (overrides --channel)
+  --channel stable|nightly   release channel (default: stable)
+  --force                    reinstall even if already up to date
+  --service / --no-service   enable or skip system-service install
   --password / --no-password prompt for or skip admin-password setup
 EOF
       exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
+
+case "$CHANNEL" in
+  stable|nightly) ;;
+  *) echo "error: --channel must be 'stable' or 'nightly'" >&2; exit 2 ;;
+esac
 
 say() { printf ':: %s\n' "$*" >&2; }
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
@@ -57,12 +80,46 @@ detect_target() {
 }
 TARGET=$(detect_target)
 
-# ---------- fetch tag ----------
+# ---------- resolve the tag to install ----------
+# stable  -> /releases/latest (only non-prerelease, maintainer-promoted)
+# nightly -> /releases (newest published, includes nightly prereleases)
+resolve_channel_tag() {
+  case "$CHANNEL" in
+    stable)
+      curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1 ;;
+    nightly)
+      curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1 ;;
+  esac
+}
+
 if [ -z "$VERSION" ]; then
-  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-              | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
+  VERSION=$(resolve_channel_tag) || true
+  [ -n "$VERSION" ] || die "no ${CHANNEL} release found at ${RELEASE_HOST}"
+  say "resolved ${CHANNEL} channel to ${VERSION}"
 fi
-[ -n "$VERSION" ] || die "no release found at https://github.com/${REPO}/releases"
+
+# ---------- idempotency: compare against what's installed ----------
+read_installed_version() {
+  if [ -f "$VERSION_STAMP" ]; then
+    cat "$VERSION_STAMP"
+  elif [ -x "${BIN_DIR}/ferrosa" ]; then
+    # Best-effort fallback for installs predating the version stamp.
+    "${BIN_DIR}/ferrosa" --version 2>/dev/null | awk 'NR==1{print "v"$NF}'
+  fi
+}
+INSTALLED_VERSION="$(read_installed_version || true)"
+IS_UPGRADE="no"; [ -n "$INSTALLED_VERSION" ] && IS_UPGRADE="yes"
+
+if [ "$INSTALLED_VERSION" = "$VERSION" ] && [ "$FORCE" = "no" ]; then
+  say "ferrosa ${VERSION} is already installed (up to date); use --force to reinstall"
+  exit 0
+fi
+
+if [ "$IS_UPGRADE" = "yes" ]; then
+  say "upgrading ferrosa ${INSTALLED_VERSION} -> ${VERSION}"
+fi
 
 TARBALL="ferrosa-${VERSION}-${TARGET}.tar.gz"
 URL="${RELEASE_HOST}/download/${VERSION}/${TARBALL}"
@@ -87,6 +144,9 @@ tar -xzf "$TMP/$TARBALL" -C "$TMP"
 cp "$TMP/ferrosa"     "$BIN_DIR/"
 cp "$TMP/ferrosa-ctl" "$BIN_DIR/"
 chmod +x "$BIN_DIR/ferrosa" "$BIN_DIR/ferrosa-ctl"
+
+# Record the installed version so the next run is idempotent.
+printf '%s\n' "$VERSION" > "$VERSION_STAMP"
 
 if [ ! -f "$CONFIG_DIR/ferrosa.toml" ]; then
   cp "$TMP/config/ferrosa.example.toml" "$CONFIG_DIR/ferrosa.toml"
@@ -131,11 +191,36 @@ do_service() {
   esac
 }
 
+# On upgrade, restart an already-registered service so the new binary is the
+# one actually running (the path is unchanged, so the old process keeps the
+# old inode until restarted).
+restart_service_if_present() {
+  case "$(uname -s)" in
+    Darwin)
+      local plist="$HOME/Library/LaunchAgents/com.ferrosadb.ferrosa.plist"
+      [ -f "$plist" ] || return 0
+      launchctl kickstart -k "gui/$(id -u)/com.ferrosadb.ferrosa" 2>/dev/null \
+        && say "restarted launchd service to apply the upgrade" || true ;;
+    Linux)
+      local unit="$HOME/.config/systemd/user/ferrosa.service"
+      [ -f "$unit" ] || return 0
+      systemctl --user restart ferrosa.service 2>/dev/null \
+        && say "restarted systemd --user service to apply the upgrade" || true ;;
+  esac
+}
+
+# Explicit flags always win. Otherwise: prompt on a fresh install, and on an
+# upgrade quietly restart an existing service without re-prompting.
 case "$WANT_SERVICE" in
   yes) do_service ;;
   no)  : ;;
-  "")  prompt_yes "Register ferrosa as a user service (autostart on login)?" \
-         && do_service ;;
+  "")
+    if [ "$IS_UPGRADE" = "yes" ]; then
+      restart_service_if_present
+    else
+      prompt_yes "Register ferrosa as a user service (autostart on login)?" \
+        && do_service
+    fi ;;
 esac
 
 # ---------- wait for port 9042 ----------
@@ -160,16 +245,23 @@ do_password() {
   "$BIN_DIR/ferrosa-ctl" auth set-password --user ferrosa_admin
 }
 
+# Password is a first-install concern. On upgrade we never re-prompt (the
+# admin already has a password) unless --password was passed explicitly.
 case "$WANT_PASSWORD" in
   yes) do_password ;;
   no)  : ;;
-  "")  prompt_yes "Set the ferrosa_admin password now?" && do_password ;;
+  "")
+    if [ "$IS_UPGRADE" = "yes" ]; then
+      :
+    else
+      prompt_yes "Set the ferrosa_admin password now?" && do_password
+    fi ;;
 esac
 
 # ---------- finish ----------
 cat <<EOF >&2
 
-ferrosa $VERSION installed.
+ferrosa $VERSION installed (${CHANNEL} channel).
 
   binaries: $BIN_DIR
   config:   $CONFIG_DIR/ferrosa.toml
@@ -181,6 +273,9 @@ Add to your shell profile:
 
 If you didn't register a service, run manually:
   FERROSA_CONFIG="$CONFIG_DIR/ferrosa.toml" "$BIN_DIR/ferrosa"
+
+Upgrade later by re-running this installer (idempotent):
+  curl -fsSL https://ferrosadb.com/install.sh | bash -s -- --channel ${CHANNEL}
 
 Docs: https://ferrosadb.com/database/getting-started.html
 EOF

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -1,0 +1,108 @@
+# Release Process & Channels
+
+How ferrosa versions, tags, builds, and ships releases — and how the installer
+consumes them.
+
+## TL;DR
+
+- **Versioning is automatic.** The release job derives the next SemVer from
+  Conventional Commit history. **Do not hand-edit `[workspace.package] version`
+  in `Cargo.toml` in a PR** — it is owned by the release automation and is
+  overwritten.
+- **Releases cut on merge.** Every push to `main` (a merged PR) that carries a
+  releasable commit cuts the next release automatically. A **nightly cron** runs
+  as a safety-net for anything the merge path missed. Both paths share one
+  workflow (`nightly-release.yml`) and the same tag-only mechanics. Doc/spec-only
+  merges are excluded (`paths-ignore`) so prose changes don't trigger a full
+  multi-platform build.
+- **Two channels:**
+  - **nightly** — every automatically cut `vX.Y.Z` release. Marked as a GitHub
+    *prerelease*.
+  - **stable** — a nightly release a maintainer has *promoted*. Marked
+    *latest*, not prerelease.
+- **Releases are tag-only.** The version-bump commit lives on the tag, never on
+  `main`. `main`'s `Cargo.toml` version is therefore decorative between
+  releases; the released artifact always carries the correct version.
+
+## Why tag-only (the bug this fixed)
+
+`main` has a repository **ruleset** (`pull_request` + `required_linear_history`,
+no bypass actors) that rejects any direct branch push:
+
+```
+remote: error: GH013: Repository rule violations found for refs/heads/main.
+remote: - Changes must be made through a pull request.
+```
+
+The old `nightly-release.yml` did `git push origin HEAD:main` and failed every
+night (computing the version, committing, and tagging all succeeded — only the
+branch push was rejected). The ruleset targets **branches only**, so pushing the
+**tag** is allowed. The fix: keep the bump commit local, create the tag on it,
+and push only the tag.
+
+## Pipeline
+
+```
+nightly-release.yml  (on: push→main [merge], cron 08:17 UTC, or manual)
+  └─ next-release-version.sh        # SemVer from Conventional Commits since last vX.Y.Z tag
+  └─ should_release? (commits since last tag) — else skip
+  └─ bump Cargo.toml + commit (local only)
+  └─ git tag vX.Y.Z  →  git push origin vX.Y.Z      # tag only, never main
+  └─ gh workflow run release.yml -f prerelease=true # explicit: GITHUB_TOKEN tag
+                                                    # pushes don't trigger on:push
+release.yml  (per built tag)
+  └─ build musl x86_64/aarch64 + macOS aarch64 tarballs, .deb, Homebrew bottle
+  └─ SHA256SUMS
+  └─ gh release create … --prerelease   # nightly channel by default
+```
+
+Conventional Commit → bump mapping (see `.github/scripts/next-release-version.sh`):
+
+| Commit                                   | Bump  |
+|------------------------------------------|-------|
+| `feat!:` / `BREAKING CHANGE:` in body    | major |
+| `feat:` / `feat(scope):`                 | minor |
+| anything else                            | patch |
+
+A PR with non-Conventional commit subjects silently degrades to a **patch**
+bump. Keep commit subjects conventional so the auto-bump is correct.
+
+## Promoting nightly → stable
+
+When a nightly build is validated, promote its tag:
+
+- **UI:** Actions → *Promote Release to Stable* → enter the tag (e.g. `v0.14.0`).
+- **CLI:** `gh release edit v0.14.0 --repo ferrosadb/ferrosa --prerelease=false --latest`
+
+This marks it `latest` and clears the prerelease flag, so the **stable** channel
+now resolves to it.
+
+## Installer (`docs/install.sh`, served at ferrosadb.com/install.sh)
+
+Idempotent; re-run to upgrade.
+
+| Invocation                                   | Installs                              |
+|----------------------------------------------|---------------------------------------|
+| `… \| bash`                                   | stable (latest promoted release)      |
+| `… \| bash -s -- --channel nightly`           | newest published release (incl. pre)  |
+| `… \| bash -s -- --version v0.13.0`           | that exact tag                        |
+| `… \| bash -s -- --force`                     | reinstall even if up to date          |
+
+It records the installed tag in `~/.ferrosa/.version`; a re-run that resolves to
+the same tag is a no-op (`already up to date`). On a differing version it prints
+`upgrading X -> Y`, replaces the binaries, restarts an already-registered
+service, and does **not** re-prompt for service/password.
+
+Channel resolution:
+- **stable** → `GET /repos/ferrosadb/ferrosa/releases/latest` (non-prerelease only)
+- **nightly** → `GET /repos/ferrosadb/ferrosa/releases?per_page=1` (newest, incl. prerelease)
+
+## Runbook — the nightly release failed
+
+1. `gh run list --workflow=nightly-release.yml` → open the failed run.
+2. `GH013 … refs/heads/main` → the ruleset rejected a branch push. The workflow
+   must push **tags only**; confirm no `git push origin HEAD:…main` remains.
+3. `computed tag … already exists` → a tag for the next version already exists
+   (e.g. a partial prior run). Delete the stray tag or bump past it.
+4. Version came out as `patch` when a `feat` landed → a PR used non-Conventional
+   commit subjects. Fix history hygiene; promotion/bump is commit-driven.


### PR DESCRIPTION
Completes and extends the release automation (extracted from in-progress work so it lands independently of unrelated quarantine changes).

## What this delivers

- **Release on merge.** `nightly-release.yml` now also triggers `on: push → main`. Every merged PR that carries a releasable commit cuts the next SemVer release, derived from Conventional Commit history by `next-release-version.sh` (`feat!`/`BREAKING CHANGE`→major, `feat`→minor, else→patch).
- **Nightly safety-net.** The `cron` stays, catching anything the merge path missed (e.g. a transiently-failed run).
- **Tag-only mechanics (fixes the broken nightly).** `main` has a ruleset (`pull_request` + linear history) that rejects branch pushes (`GH013`) — the old job pushed `HEAD:main` and failed every night. The bump commit is now captured by the **tag** and never pushed to `main`; `release.yml` builds from the tag, so the artifact always carries the right version.
- **Channels.** Every auto-cut release is a **prerelease** (`nightly` channel); a maintainer promotes to **stable** via `promote-release.yml`. `release.yml` gains a `prerelease` input (default true).
- **Installer.** `docs/install.sh` resolves `stable` / `nightly` / pinned `--version`.

## Safety / correctness

- Shared `concurrency` group serializes rapid merges → no tag collisions; version always derives from the latest tag, so tag-only composes across merges.
- `should_release` guard skips when nothing landed since the last tag.
- `paths-ignore` (`**.md`, `specs/**`, `docs/**`, `.github/**`) keeps doc/spec/CI-only merges from triggering a full multi-platform build. **Mixed PRs still release** — paths-ignore only skips when *every* changed file matches.

## Validated

- All three workflows parse as YAML; version script passes `bash -n`.
- Dry-run of `next-release-version.sh` against real tag history: `v0.13.0 → v0.14.0` (9 commits since last tag, `feat` detected → minor).

## Policy choices to confirm

- **Every code merge cuts a prerelease.** That's the requested "publish on merge"; if you'd prefer to batch (e.g. only `feat`/`fix` trigger, `chore`/`refactor` don't), that's a one-line tweak to the trigger/guard.
- **`.github/**` excluded** so CI-only merges don't build. Remove that line if you want CI changes to release too.

Companion fmem PR aligning `ferrosa-memory` to the same model follows separately.