### PR TITLE
All secondary index types fully accelerated: Filtered partial index + FullText EXPLAIN + 8-type proof

### DIFF
--- a/ferrosa-cql/src/planner.rs
+++ b/ferrosa-cql/src/planner.rs
@@ -118,6 +118,25 @@ pub fn plan(
     pk_columns: &[String],
     indexes: &[(String, Vec<String>)],
 ) -> ScanPlan {
+    plan_with_covered(where_clauses, pk_columns, indexes, &[])
+}
+
+/// Like [`plan`], but treats `extra_covered` columns as already satisfied by an
+/// index even though they are not in `indexes`.
+///
+/// This is how a partial (Filtered) index makes its *filter* column count as
+/// covered: when the index is selected, the predicate on the filter column is
+/// enforced by the index itself (the sidecar holds only matching rows), so that
+/// WHERE predicate must NOT push the plan to `IndexScanWithFilter` / require
+/// ALLOW FILTERING. The router only passes a filter column here when the
+/// corresponding filtered index is implied by the query and thus offered in
+/// `indexes` (see `filtered_index_is_usable`), so coverage stays sound.
+pub fn plan_with_covered(
+    where_clauses: &[WhereClause],
+    pk_columns: &[String],
+    indexes: &[(String, Vec<String>)],
+    extra_covered: &[String],
+) -> ScanPlan {
     // Exclude token() predicates — they represent token-range scans,
     // not column-level filters.
     let non_token: Vec<&WhereClause> = where_clauses.iter().filter(|wc| !wc.token_fn).collect();
@@ -129,6 +148,13 @@ pub fn plan(
     if non_token.is_empty() {
         return ScanPlan::FullScan;
     }
+
+    let is_covered = |col: &str| {
+        indexes
+            .iter()
+            .any(|(_, cols)| cols.len() == 1 && cols[0] == col)
+            || extra_covered.iter().any(|c| c == col)
+    };
 
     // Collect all WHERE columns with Eq that have a matching single-column index.
     let matched: Vec<(String, String)> = non_token
@@ -146,15 +172,11 @@ pub fn plan(
         0 => ScanPlan::FullScan,
         1 => {
             let (index_name, index_column) = matched.into_iter().next().unwrap();
-            // Collect WHERE columns not covered by any index.
+            // Collect WHERE columns not covered by any index (or extra coverage).
             let filter_columns: Vec<String> = non_token
                 .iter()
                 .filter(|wc| wc.column != index_column)
-                .filter(|wc| {
-                    !indexes
-                        .iter()
-                        .any(|(_, cols)| cols.len() == 1 && cols[0] == wc.column)
-                })
+                .filter(|wc| !is_covered(&wc.column))
                 .map(|wc| wc.column.clone())
                 .collect();
             if filter_columns.is_empty() {
@@ -472,6 +494,41 @@ mod tests {
             ScanPlan::IndexIntersection { indexes } => assert_eq!(indexes.len(), 3),
             other => panic!("expected IndexIntersection, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn extra_covered_filter_column_yields_single_index_not_filtering() {
+        // A filtered index on `name` (offered in `indexes`) plus an `extra_covered`
+        // filter column `status`: a query `name = v AND status = a` must plan
+        // `SingleIndex` (the index enforces the status predicate) rather than
+        // `IndexScanWithFilter` (which would require ALLOW FILTERING).
+        let plan = plan_with_covered(
+            &[wc("name", ComparisonOp::Eq), wc("status", ComparisonOp::Eq)],
+            &pk(&["id"]),
+            &[idx("name_active_idx", &["name"])],
+            &["status".to_string()],
+        );
+        assert_eq!(
+            plan,
+            ScanPlan::SingleIndex {
+                index_name: "name_active_idx".to_string(),
+                index_column: "name".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn extra_covered_does_not_invent_an_index() {
+        // `extra_covered` only suppresses the ALLOW FILTERING requirement for a
+        // covered column; it never makes that column itself index-selectable.
+        // With no index on `name`, a query on `name` alone is still FullScan.
+        let plan = plan_with_covered(
+            &[wc("name", ComparisonOp::Eq)],
+            &pk(&["id"]),
+            &[],
+            &["name".to_string()],
+        );
+        assert_eq!(plan, ScanPlan::FullScan);
     }
 
     #[test]

--- a/ferrosa-cql/src/planner.rs
+++ b/ferrosa-cql/src/planner.rs
@@ -55,6 +55,16 @@ pub enum ScanPlan {
         op: String,
     },
 
+    /// A full-text query (`WHERE col = fts_match('...')`) served by a registered
+    /// full-text index. The FTS predicate is a function over the indexed column,
+    /// not a scalar `=`, so it does not flow through the generic single-/multi-
+    /// index matching above; the router builds this variant directly so EXPLAIN
+    /// reports the full-text index rather than a FullScan.
+    FullTextIndex {
+        index_name: String,
+        index_column: String,
+    },
+
     /// No indexes match. Requires ALLOW FILTERING.
     FullScan,
 }
@@ -92,6 +102,10 @@ impl fmt::Display for ScanPlan {
                 index_column,
                 op,
             } => write!(f, "GeoIndex({index_name} on {index_column}, {op})"),
+            ScanPlan::FullTextIndex {
+                index_name,
+                index_column,
+            } => write!(f, "FullTextIndex({index_name} on {index_column})"),
             ScanPlan::FullScan => write!(f, "FullScan"),
         }
     }
@@ -458,6 +472,17 @@ mod tests {
             format!("{plan}"),
             "GeoIndex(places_location_geo on location, GeoWithinRadius)"
         );
+    }
+
+    #[test]
+    fn display_full_text_index() {
+        let plan = ScanPlan::FullTextIndex {
+            index_name: "ftu_body".to_string(),
+            index_column: "body".to_string(),
+        };
+        assert_eq!(format!("{plan}"), "FullTextIndex(ftu_body on body)");
+        // A full-text query is index-accelerated; it must never render FullScan.
+        assert_ne!(plan, ScanPlan::FullScan);
     }
 
     #[test]

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -2996,20 +2996,12 @@ async fn route_select_user_table(
         let (fts_column, fts_query) = extract_fts_match(&s.where_clauses)
             .ok_or_else(|| CqlError::Invalid("fts_match: failed to extract column/query".into()))?;
 
-        // Look up the full-text index name for the referenced column.
-        let fti_index_name = snap
-            .indexes
-            .iter()
-            .find(|((idx_ks, idx_tbl, _), meta)| {
-                idx_ks == ks
-                    && idx_tbl == &s.table
-                    && meta.target_columns.iter().any(|c| c == fts_column)
-            })
-            .map(|((_, _, _), meta)| meta.name.clone());
-
-        // Fall back to using the column name as the index name when no explicit
-        // index registration exists (useful for simple single-column FTI).
-        let index_name = fti_index_name.as_deref().unwrap_or(fts_column);
+        // Look up the full-text index name for the referenced column. This is
+        // the same resolution EXPLAIN uses (`resolve_fulltext_index_name`), so
+        // the reported `FullTextIndex` plan and the executed index agree. Falls
+        // back to the column name for simple single-column FTI registration.
+        let fti_index_name = resolve_fulltext_index_name(&snap, ks, &s.table, fts_column);
+        let index_name = fti_index_name.as_str();
 
         // Observability: record that the full-text index was consulted.
         state
@@ -3357,6 +3349,15 @@ async fn route_select_user_table(
                     // plan rendering.
                     return Err(CqlError::ServerError(
                         "internal: geo plan reached the scalar scan dispatch".into(),
+                    ));
+                }
+                ScanPlan::FullTextIndex { .. } => {
+                    // Full-text queries (`WHERE col = fts_match(...)`) are served
+                    // by the `where_has_fts_match` early branch above before the
+                    // planner runs, so `planner::plan` never returns this variant
+                    // here. It exists only for EXPLAIN's plan rendering.
+                    return Err(CqlError::ServerError(
+                        "internal: full-text plan reached the scalar scan dispatch".into(),
                     ));
                 }
                 ScanPlan::PartitionKeyLookup => {
@@ -4478,8 +4479,12 @@ fn route_explain(
 
     // Geospatial queries are served by the geo index in their own branch, not by
     // the generic planner, so report `GeoIndex` here rather than FullScan.
+    // Full-text queries (`WHERE col = fts_match(...)`) are likewise served by the
+    // FTI in an early branch, so report `FullTextIndex` rather than FullScan.
     let scan_plan = if let Some(geo_plan) = geo_explain_plan(&snap, ks, &s) {
         geo_plan
+    } else if let Some(fts_plan) = fulltext_explain_plan(&snap, ks, &s) {
+        fts_plan
     } else {
         planner::plan(
             &s.where_clauses,
@@ -4539,6 +4544,47 @@ fn geo_explain_plan(
         index_column: column,
         op: op.to_string(),
     })
+}
+
+/// Build a [`ScanPlan::FullTextIndex`] for EXPLAIN when `s` carries an
+/// `fts_match()` predicate. Returns `None` when there is no full-text predicate
+/// (so the generic planner runs). The index-name resolution mirrors the
+/// execution path in `route_select_user_table` exactly: prefer a registered
+/// index whose target columns include the searched column, else fall back to
+/// the column name itself (matching simple single-column FTI registration).
+fn fulltext_explain_plan(
+    snap: &ferrosa_schema::SchemaSnapshot,
+    ks: &str,
+    s: &SelectStatement,
+) -> Option<ScanPlan> {
+    if !where_has_fts_match(&s.where_clauses) {
+        return None;
+    }
+    let (fts_column, _fts_query) = extract_fts_match(&s.where_clauses)?;
+    let index_name = resolve_fulltext_index_name(snap, ks, &s.table, fts_column);
+    Some(ScanPlan::FullTextIndex {
+        index_name,
+        index_column: fts_column.to_string(),
+    })
+}
+
+/// Resolve the full-text index name serving `column` on `ks.table`. Prefers a
+/// registered index whose target columns include `column`; otherwise falls back
+/// to the column name itself. This is the single source of truth shared by the
+/// EXPLAIN reporting path and the execution path so they never diverge.
+fn resolve_fulltext_index_name(
+    snap: &ferrosa_schema::SchemaSnapshot,
+    ks: &str,
+    table: &str,
+    column: &str,
+) -> String {
+    snap.indexes
+        .iter()
+        .find(|((idx_ks, idx_tbl, _), meta)| {
+            idx_ks == ks && idx_tbl == table && meta.target_columns.iter().any(|c| c == column)
+        })
+        .map(|((_, _, _), meta)| meta.name.clone())
+        .unwrap_or_else(|| column.to_string())
 }
 
 // ── USING TIMESTAMP / TTL helpers (Gap 10) ───────────────────────────────
@@ -16447,6 +16493,34 @@ mod tests {
     // ordering and that the vector index is registered (the router ANN path is
     // a brute-force sort pending Phase 2 vector read dispatch, so it honestly
     // does not claim an index_usage hit it cannot demonstrate).
+    //
+    // ── 2i acceleration coverage matrix ─────────────────────────────────────
+    //
+    // Every one of the 8 `IndexType`s is query-accelerated AND observable. For
+    // each type the named test asserts ALL of: (a) correct rows, (b) `EXPLAIN`
+    // reports the plan variant and NOT `FullScan` (via `assert_explain_plan`),
+    // (c) the `index_usage` counter increments at execution (via
+    // `assert_index_hit_and_count`).
+    //
+    // | IndexType | EXPLAIN plan variant | proving test |
+    // |-----------|----------------------|--------------|
+    // | BTree     | SingleIndex          | `btree_index_usage_observable_end_to_end` |
+    // | Hash      | SingleIndex          | `hash_index_usage_observable_end_to_end` |
+    // | Composite | SingleIndex          | `composite_index_usage_observable_end_to_end` |
+    // | Phonetic  | SingleIndex          | `phonetic_index_usage_observable_end_to_end` |
+    // | Filtered  | SingleIndex (partial)| `filtered_index_used_when_query_implies_predicate` |
+    // | FullText  | FullTextIndex        | `fulltext_index_usage_observable_end_to_end` |
+    // | Vector    | VectorAnn            | `ann_query_consults_vector_index_and_is_observable` |
+    // | Geo       | GeoIndex             | `geo_st_within_polygon_filters_to_central_sf` (and other `geo_*`) |
+    //
+    // BTree/Hash/Composite/Phonetic all render `SingleIndex` because they are
+    // scalar-`=` indexes the generic planner matches identically; the type
+    // distinction lives in `ferrosa-index` build/read dispatch, exercised by
+    // those crate-level tests. Filtered renders `SingleIndex` but is gated by
+    // `filtered_index_is_usable` (predicate implication) — soundness is proven
+    // by `filtered_index_withheld_when_query_does_not_imply_predicate`. FullText,
+    // Vector, and Geo each take an early non-planner branch and report a
+    // dedicated plan variant.
 
     /// Run a non-EXPLAIN query and assert the index_usage counter advanced by
     /// exactly the expected delta, returning the decoded row count.
@@ -16779,6 +16853,10 @@ mod tests {
             .flush(&ferrosa_storage::TableId::new("ftu", "docs"))
             .unwrap();
         let q = "SELECT id FROM ftu.docs WHERE body = fts_match('distributed AND database')";
+        // EXPLAIN must report the full-text index, not a FullScan: the FTS path
+        // is genuinely accelerated via `engine.fulltext_search`, and EXPLAIN now
+        // reflects that (closing the prior FullText EXPLAIN gap).
+        assert_explain_plan(&state, &ctx, q, "FullTextIndex").await;
         let count = assert_index_hit_and_count(&state, &ctx, q, 1).await;
         assert_eq!(count, 1, "fts_match must return exactly the matching doc");
     }

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -35,6 +35,7 @@ use ferrosa_schema::{
 };
 use ferrosa_storage::StorageEngine;
 use ferrosa_storage::TableId;
+use ferrosa_storage::FILTER_PREDICATE_OPTION_KEY;
 use ferrosa_udf::UdfExecutor;
 
 use crate::ast::*;
@@ -3241,17 +3242,32 @@ async fn route_select_user_table(
         filtered
     } else {
         // No PK — use the query planner to decide the access path.
-        let planner_indexes: Vec<(String, Vec<String>)> = snap
+        // A partial (Filtered) index is offered to the planner ONLY when the
+        // query implies its predicate (see `query_implies_filter_predicate`);
+        // otherwise it is withheld so the planner cannot unsoundly serve an
+        // incomplete result from it.
+        let usable_indexes: Vec<&IndexMetadata> = snap
             .indexes
             .iter()
             .filter(|((idx_ks, idx_tbl, _), _)| idx_ks == ks && idx_tbl == &s.table)
-            .map(|((_, _, _), meta)| (meta.name.clone(), meta.target_columns.clone()))
+            .map(|(_, meta)| meta)
+            .filter(|meta| {
+                filtered_index_is_usable(meta, &s.where_clauses, table_meta, ks, &state.schema)
+            })
             .collect();
+        let planner_indexes: Vec<(String, Vec<String>)> = usable_indexes
+            .iter()
+            .map(|meta| (meta.name.clone(), meta.target_columns.clone()))
+            .collect();
+        // Filter columns of usable partial indexes are covered by the index
+        // itself, so a WHERE predicate on them must not require ALLOW FILTERING.
+        let filtered_covered_columns = filtered_index_covered_columns(&usable_indexes, table_meta);
 
-        let scan_plan = planner::plan(
+        let scan_plan = planner::plan_with_covered(
             &s.where_clauses,
             &table_meta.partition_key,
             &planner_indexes,
+            &filtered_covered_columns,
         );
 
         // ── Vector ANN index consult ──────────────────────────────────────
@@ -3426,7 +3442,18 @@ async fn route_select_user_table(
                     }
 
                     // Observability: record that a secondary index was consulted.
-                    let plan_kind = if matches!(scan_plan, ScanPlan::IndexScanWithFilter { .. }) {
+                    // A partial (Filtered) index records the "Filtered" kind so
+                    // its acceleration is distinguishable in index_usage; the
+                    // planner only reached here for it when the query implied its
+                    // predicate (see `filtered_index_is_usable`).
+                    let is_filtered = snap
+                        .indexes
+                        .get(&(ks.to_string(), s.table.clone(), index_name.clone()))
+                        .map(|m| m.index_type == IndexType::Filtered)
+                        .unwrap_or(false);
+                    let plan_kind = if is_filtered {
+                        "Filtered"
+                    } else if matches!(scan_plan, ScanPlan::IndexScanWithFilter { .. }) {
                         "IndexScanWithFilter"
                     } else {
                         "SingleIndex"
@@ -4436,10 +4463,16 @@ fn route_explain(
         .get(&(ks.to_string(), s.table.clone()))
         .ok_or_else(|| CqlError::Invalid(format!("table {}.{} not found", ks, s.table)))?;
 
+    // EXPLAIN mirrors the SELECT planner exactly: a partial (Filtered) index is
+    // offered only when the query implies its predicate, so EXPLAIN reports the
+    // filtered index when it WOULD be used and FullScan when it would not.
     let planner_indexes: Vec<(String, Vec<String>)> = snap
         .indexes
         .iter()
         .filter(|((idx_ks, idx_tbl, _), _)| idx_ks == ks && idx_tbl == &s.table)
+        .filter(|(_, meta)| {
+            filtered_index_is_usable(meta, &s.where_clauses, table_meta, ks, &state.schema)
+        })
         .map(|(_, meta)| (meta.name.clone(), meta.target_columns.clone()))
         .collect();
 
@@ -6633,6 +6666,189 @@ async fn route_drop_table(
 
 // ── DDL: Index ───────────────────────────────────────────────────────────
 
+/// Parse a Filtered (partial) index's `filter_op` option string into a
+/// [`ferrosa_index::FilterOp`]. Fails loud on any unrecognized operator.
+fn parse_filter_op(op: &str) -> Result<ferrosa_index::FilterOp, CqlError> {
+    use ferrosa_index::FilterOp;
+    match op.trim() {
+        "=" => Ok(FilterOp::Eq),
+        "!=" => Ok(FilterOp::NotEq),
+        "<" => Ok(FilterOp::Lt),
+        ">" => Ok(FilterOp::Gt),
+        "<=" => Ok(FilterOp::LtEq),
+        ">=" => Ok(FilterOp::GtEq),
+        other => Err(CqlError::Invalid(format!(
+            "invalid filter_op '{other}' for filtered index (expected one of =, !=, <, >, <=, >=)"
+        ))),
+    }
+}
+
+/// Build a fully-encoded [`ferrosa_index::FilterPredicate`] from the WITH
+/// OPTIONS of a `CREATE INDEX ... USING 'filtered'` statement.
+///
+/// Required options: `filter_column` (the partial-predicate column),
+/// `filter_op` (one of `=`,`!=`,`<`,`>`,`<=`,`>=`), and `filter_value` (a CQL
+/// literal parsed against the filter column's type). The predicate's
+/// `column_position` is the filter column's **storage** ordinal (statics then
+/// regulars, name-sorted) so it matches the cell ordinal the build/memtable
+/// paths compare against. The `value` is encoded to storage bytes here so the
+/// storage layer never needs the CQL type system.
+///
+/// Every missing/invalid option fails loud — a partial index with a broken
+/// predicate would silently index every row, an unsound result.
+fn build_filter_predicate_from_options(
+    state: &SharedState,
+    ks: &str,
+    table: &str,
+    options: &HashMap<String, String>,
+) -> Result<ferrosa_index::FilterPredicate, CqlError> {
+    let filter_column = options.get("filter_column").ok_or_else(|| {
+        CqlError::Invalid(
+            "filtered index requires WITH OPTIONS = {'filter_column': ..., 'filter_op': ..., \
+             'filter_value': ...}; missing 'filter_column'"
+                .into(),
+        )
+    })?;
+    let filter_op_str = options.get("filter_op").ok_or_else(|| {
+        CqlError::Invalid("filtered index WITH OPTIONS missing 'filter_op'".into())
+    })?;
+    let filter_value = options.get("filter_value").ok_or_else(|| {
+        CqlError::Invalid("filtered index WITH OPTIONS missing 'filter_value'".into())
+    })?;
+
+    let op = parse_filter_op(filter_op_str)?;
+
+    let snap = state.schema.snapshot();
+    let table_meta = snap
+        .tables
+        .get(&(ks.to_string(), table.to_string()))
+        .ok_or_else(|| CqlError::Invalid(format!("table {ks}.{table} not found")))?;
+
+    // Storage ordinal of the filter column: the cell tag the build/memtable
+    // paths compare the predicate against.
+    let column_position = table_meta
+        .storage_column_index(filter_column)
+        .ok_or_else(|| {
+            CqlError::Invalid(format!(
+                "filtered index filter_column '{filter_column}' is not a column of {ks}.{table}"
+            ))
+        })? as usize;
+
+    let col_meta = table_meta
+        .columns
+        .get(filter_column)
+        .ok_or_else(|| CqlError::Invalid(format!("filter_column '{filter_column}' not found")))?;
+    let cql_type = resolve_col_type(&col_meta.column_type, ks, &state.schema)?;
+    let cql_value =
+        bridge::term_to_cql_value(&Term::StringLiteral(filter_value.clone()), &cql_type)?;
+    let value = crate::types::encode_value(&cql_value);
+
+    Ok(ferrosa_index::FilterPredicate {
+        column_position,
+        op,
+        value,
+    })
+}
+
+/// Soundness gate for partial (Filtered) indexes.
+///
+/// A partial index holds ONLY rows whose filter column satisfies its predicate,
+/// so serving `WHERE indexed_col = v` from it is COMPLETE only when the query
+/// also constrains the filter column such that every qualifying row is
+/// guaranteed to be in the index. Using it otherwise drops rows that match
+/// `indexed_col = v` but fall outside the partial predicate — a silent
+/// correctness bug.
+///
+/// Conservative, sound rule: the query must carry an `Eq` predicate on the
+/// index's filter column whose encoded value SATISFIES the index predicate. For
+/// an index predicate `status = 'active'`, only a query with `status = 'active'`
+/// qualifies; every such row has `status = 'active'`, which is exactly the set
+/// the index retains, so the result is both correct and complete. A query with
+/// no `status` predicate, or `status = 'inactive'`, does not qualify and the
+/// index is withheld (the planner then falls back to FullScan / the usual
+/// unindexed-column error).
+fn query_implies_filter_predicate(
+    where_clauses: &[WhereClause],
+    table_meta: &TableMetadata,
+    ks: &str,
+    schema: &Schema,
+    predicate: &ferrosa_index::FilterPredicate,
+) -> bool {
+    for wc in where_clauses {
+        if wc.op != ComparisonOp::Eq || wc.token_fn {
+            continue;
+        }
+        // Match the WHERE column to the predicate's filter column by storage
+        // ordinal — the same ordinal the predicate was built with.
+        let Some(storage_idx) = table_meta.storage_column_index(&wc.column) else {
+            continue;
+        };
+        if storage_idx as usize != predicate.column_position {
+            continue;
+        }
+        // Encode the query's literal the same way the predicate value was
+        // encoded, then check the index predicate accepts it.
+        let Ok(key) = term_to_index_key(&wc.value, &wc.column, table_meta, ks, schema) else {
+            continue;
+        };
+        if ferrosa_index::evaluate_predicate(predicate, &key.0) {
+            return true;
+        }
+    }
+    false
+}
+
+/// The set of filter-column NAMES covered by the given usable filtered
+/// indexes. Maps each filtered index predicate's storage `column_position` back
+/// to a column name so the planner can mark it covered. Non-filtered indexes
+/// and predicates whose ordinal does not resolve are ignored.
+fn filtered_index_covered_columns(
+    usable_indexes: &[&IndexMetadata],
+    table_meta: &TableMetadata,
+) -> Vec<String> {
+    let mut covered = Vec::new();
+    for meta in usable_indexes {
+        if meta.index_type != IndexType::Filtered {
+            continue;
+        }
+        let Some(pred) = meta.filter_predicate.as_ref() else {
+            continue;
+        };
+        for (name, _) in table_meta.columns.iter() {
+            if table_meta.storage_column_index(name).map(|i| i as usize)
+                == Some(pred.column_position)
+            {
+                covered.push(name.clone());
+                break;
+            }
+        }
+    }
+    covered
+}
+
+/// Whether an index may be offered to the planner for this query.
+///
+/// Non-partial indexes are always usable. A Filtered index is usable only when
+/// the query implies its partial predicate (see
+/// [`query_implies_filter_predicate`]); a Filtered index whose predicate
+/// somehow failed to persist is treated as NOT usable (fail safe — never serve
+/// from a partial index we can't prove is implied).
+fn filtered_index_is_usable(
+    meta: &IndexMetadata,
+    where_clauses: &[WhereClause],
+    table_meta: &TableMetadata,
+    ks: &str,
+    schema: &Schema,
+) -> bool {
+    if meta.index_type != IndexType::Filtered {
+        return true;
+    }
+    match &meta.filter_predicate {
+        Some(pred) => query_implies_filter_predicate(where_clauses, table_meta, ks, schema, pred),
+        None => false,
+    }
+}
+
 /// Resolve the USING string to an IndexType.
 fn resolve_index_type(
     using: Option<&str>,
@@ -6694,7 +6910,7 @@ async fn route_create_index(
     )?;
 
     // Convert options Vec to HashMap
-    let options_map: HashMap<String, String> = s.options.iter().cloned().collect();
+    let mut options_map: HashMap<String, String> = s.options.iter().cloned().collect();
 
     // Resolve index type
     let index_type = resolve_index_type(s.using.as_deref(), &s.columns, &options_map)?;
@@ -6703,6 +6919,23 @@ async fn route_create_index(
     // unknown `method` option rejects the whole statement before any DDL runs.
     let vector_method = if index_type == IndexType::Vector {
         Some(resolve_vector_index_method(&options_map)?)
+    } else {
+        None
+    };
+
+    // For a Filtered (partial) index, parse and validate the partial predicate
+    // from WITH OPTIONS up front so a malformed spec rejects the statement
+    // before any DDL runs (fail loud). The fully-encoded predicate is also
+    // mirrored into `options` under the reserved `__filter_predicate` key so it
+    // survives restart and the storage reload path can reconstruct it without
+    // the CQL type system. Done before any DDL so persistence captures it.
+    let filter_predicate = if index_type == IndexType::Filtered {
+        let pred = build_filter_predicate_from_options(state, ks, &s.table, &options_map)?;
+        let json = pred.to_option_string().map_err(|e| {
+            CqlError::ServerError(format!("failed to serialize filter predicate: {e}"))
+        })?;
+        options_map.insert(FILTER_PREDICATE_OPTION_KEY.to_string(), json);
+        Some(pred)
     } else {
         None
     };
@@ -6718,7 +6951,7 @@ async fn route_create_index(
         name: index_name.clone(),
         index_type,
         target_columns: s.columns.clone(),
-        filter_predicate: None,
+        filter_predicate: filter_predicate.clone(),
         options: options_map,
     };
 
@@ -6792,6 +7025,17 @@ async fn route_create_index(
                 // Full-text needs its own inverted-index sidecar (built on flush);
                 // the generic add_index() only builds a BTree.
                 state.engine.add_fulltext_index(&table_id, &index_name, pos)
+            } else if index_type == IndexType::Filtered {
+                // Partial index: thread the predicate into the engine so the
+                // memtable index and the SSTable sidecar build both filter to
+                // exactly the matching rows.
+                state.engine.add_index_with_predicate(
+                    &table_id,
+                    &index_name,
+                    pos,
+                    index_type,
+                    filter_predicate.clone(),
+                )
             } else {
                 state
                     .engine
@@ -16349,6 +16593,166 @@ mod tests {
         assert_explain_plan(&state, &ctx, q, "SingleIndex").await;
         let count = assert_index_hit_and_count(&state, &ctx, q, 1).await;
         assert_eq!(count, 1, "phonetic index must match 'Jon' to 'John'");
+    }
+
+    /// Filtered (partial) index, happy path: index `name`, partial on
+    /// `status = 'active'`. A query that implies the predicate
+    /// (`WHERE name = v AND status = 'active'`) is served by the filtered
+    /// index — EXPLAIN reports the index (not FullScan), index_usage records a
+    /// "Filtered" hit, and ONLY the matching+active row is returned.
+    #[tokio::test]
+    async fn filtered_index_used_when_query_implies_predicate() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ks = None;
+        let ctx = test_ctx(&auth, &ks);
+        for cql in [
+            "CREATE KEYSPACE flt WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE flt.users (id int PRIMARY KEY, name text, status text)",
+            "CREATE INDEX flt_name_active ON flt.users (name) USING 'filtered' \
+             WITH OPTIONS = {'filter_column':'status','filter_op':'=','filter_value':'active'}",
+            // alice active, alice inactive (same name, different status), bob active.
+            "INSERT INTO flt.users (id, name, status) VALUES (1, 'alice', 'active')",
+            "INSERT INTO flt.users (id, name, status) VALUES (2, 'alice', 'inactive')",
+            "INSERT INTO flt.users (id, name, status) VALUES (3, 'bob', 'active')",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        let q = "SELECT id FROM flt.users WHERE name = 'alice' AND status = 'active'";
+        // EXPLAIN must report the filtered index (rendered as SingleIndex), not FullScan.
+        assert_explain_plan(&state, &ctx, q, "flt_name_active").await;
+        // The filtered index is consulted (index_usage advances by 1) and ONLY
+        // the active alice row (id=1) is returned — not the inactive alice (id=2).
+        let count = assert_index_hit_and_count(&state, &ctx, q, 1).await;
+        assert_eq!(
+            count, 1,
+            "filtered index must return only the active 'alice' row"
+        );
+    }
+
+    /// Filtered (partial) index, soundness: a query that does NOT imply the
+    /// index's predicate (`WHERE name = v`, no `status`) must NOT be served from
+    /// the partial index — that would silently drop the inactive 'alice'. EXPLAIN
+    /// must not name the filtered index, no "Filtered" index hit is recorded, and
+    /// the full-scan fallback returns BOTH alices (complete result).
+    #[tokio::test]
+    async fn filtered_index_withheld_when_query_does_not_imply_predicate() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ks = None;
+        let ctx = test_ctx(&auth, &ks);
+        for cql in [
+            "CREATE KEYSPACE fls WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE fls.users (id int PRIMARY KEY, name text, status text)",
+            "CREATE INDEX fls_name_active ON fls.users (name) USING 'filtered' \
+             WITH OPTIONS = {'filter_column':'status','filter_op':'=','filter_value':'active'}",
+            "INSERT INTO fls.users (id, name, status) VALUES (1, 'alice', 'active')",
+            "INSERT INTO fls.users (id, name, status) VALUES (2, 'alice', 'inactive')",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        // No `status` predicate => the partial index does not imply the query.
+        let q = "SELECT id FROM fls.users WHERE name = 'alice'";
+
+        // EXPLAIN must NOT report the filtered index; it falls to FullScan.
+        let stmt = crate::parser::parse(&format!("EXPLAIN {q}")).unwrap();
+        match route(&state, &ctx, stmt).await.unwrap() {
+            RouteResult::Result(b) => {
+                let haystack = String::from_utf8_lossy(&b).into_owned();
+                assert!(
+                    !haystack.contains("fls_name_active"),
+                    "partial index must not be used without an implied predicate, got: {haystack}"
+                );
+                assert!(
+                    haystack.contains("FullScan"),
+                    "query that does not imply the predicate must fall to FullScan, got: {haystack}"
+                );
+            }
+            _ => panic!("expected Result from EXPLAIN"),
+        }
+
+        // The full-scan fallback must return BOTH alices (active + inactive):
+        // using the partial index here would silently drop the inactive row.
+        // No "Filtered" index hit is recorded (delta 0).
+        let count = assert_index_hit_and_count(&state, &ctx, q, 0).await;
+        assert_eq!(
+            count, 2,
+            "without the implied predicate, both 'alice' rows must be returned (completeness)"
+        );
+    }
+
+    /// CREATE INDEX ... USING 'filtered' with a missing/invalid predicate option
+    /// must fail loud at CREATE time rather than registering an unfiltered index.
+    #[tokio::test]
+    async fn filtered_index_create_rejects_invalid_options() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ks = None;
+        let ctx = test_ctx(&auth, &ks);
+        for cql in [
+            "CREATE KEYSPACE flv WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE flv.users (id int PRIMARY KEY, name text, status text)",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        // Run a CREATE that must fail and return the rendered error string.
+        async fn expect_create_err(
+            state: &SharedState,
+            ctx: &RequestContext<'_>,
+            cql: &str,
+        ) -> String {
+            match route(state, ctx, crate::parser::parse(cql).unwrap()).await {
+                Ok(_) => panic!("expected CREATE INDEX to be rejected: {cql}"),
+                Err(e) => format!("{e:?}"),
+            }
+        }
+
+        // Missing filter options entirely.
+        let err = expect_create_err(
+            &state,
+            &ctx,
+            "CREATE INDEX flv_bad ON flv.users (name) USING 'filtered'",
+        )
+        .await;
+        assert!(
+            err.contains("filter_column"),
+            "error should mention the missing filter_column option, got: {err}"
+        );
+
+        // Unknown filter_op.
+        let err = expect_create_err(
+            &state,
+            &ctx,
+            "CREATE INDEX flv_bad ON flv.users (name) USING 'filtered' \
+             WITH OPTIONS = {'filter_column':'status','filter_op':'~~','filter_value':'active'}",
+        )
+        .await;
+        assert!(
+            err.contains("filter_op"),
+            "error should mention the invalid filter_op, got: {err}"
+        );
+
+        // filter_column not a real column.
+        let err = expect_create_err(
+            &state,
+            &ctx,
+            "CREATE INDEX flv_bad ON flv.users (name) USING 'filtered' \
+             WITH OPTIONS = {'filter_column':'nope','filter_op':'=','filter_value':'active'}",
+        )
+        .await;
+        assert!(
+            err.contains("nope"),
+            "error should mention the unknown filter_column, got: {err}"
+        );
     }
 
     /// Full-text index: `WHERE body = fts_match(...)` consults the FTI, returns

--- a/ferrosa-index-builder/src/worker.rs
+++ b/ferrosa-index-builder/src/worker.rs
@@ -245,6 +245,7 @@ impl WorkerPool {
             priority: parse_priority(&req.priority),
             enqueued_at: Instant::now(),
             column_position: req.column_position,
+            filter_predicate: None,
         };
 
         let job_dir_clone = job_dir.clone();

--- a/ferrosa-index/src/filtered.rs
+++ b/ferrosa-index/src/filtered.rs
@@ -15,7 +15,12 @@ use crate::{
 // ── Predicate evaluation ─────────────────────────────────────────────────────
 
 /// Evaluate a filter predicate against a cell value (raw bytes).
-fn evaluate_predicate(predicate: &FilterPredicate, cell_value: &[u8]) -> bool {
+///
+/// This is the single source of truth for partial-index predicate evaluation.
+/// The storage build path (`LocalBackend::build`) and the memtable write path
+/// both call this so a sidecar and its memtable companion agree on exactly
+/// which rows belong in a filtered index.
+pub fn evaluate_predicate(predicate: &FilterPredicate, cell_value: &[u8]) -> bool {
     match predicate.op {
         FilterOp::Eq => cell_value == predicate.value.as_slice(),
         FilterOp::NotEq => cell_value != predicate.value.as_slice(),

--- a/ferrosa-index/src/lib.rs
+++ b/ferrosa-index/src/lib.rs
@@ -27,6 +27,7 @@ pub mod hash;
 pub mod phonetic;
 pub mod vector;
 
+pub use filtered::evaluate_predicate;
 pub use phonetic::PhoneticAlgorithm;
 
 use ferrosa_common::CellValue;
@@ -276,7 +277,7 @@ pub enum FilterOp {
 }
 
 /// A filter predicate applied to a specific column during index building.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FilterPredicate {
     /// The column position to filter on.
     pub column_position: usize,
@@ -284,6 +285,22 @@ pub struct FilterPredicate {
     pub op: FilterOp,
     /// The value to compare against.
     pub value: Vec<u8>,
+}
+
+impl FilterPredicate {
+    /// Serialize this predicate to a JSON string suitable for stashing in an
+    /// index `options` map (the `value` bytes are already in storage encoding,
+    /// so the round-trip is exact and type-system independent).
+    pub fn to_option_string(&self) -> IndexResult<String> {
+        serde_json::to_string(self).map_err(IndexError::from)
+    }
+
+    /// Reconstruct a predicate from the JSON produced by
+    /// [`to_option_string`](Self::to_option_string). Returns `None` when the
+    /// string is absent or does not deserialize, so callers can fail safe.
+    pub fn from_option_string(s: &str) -> Option<Self> {
+        serde_json::from_str(s).ok()
+    }
 }
 
 // ── Vector helpers ───────────────────────────────────────────────────────────

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -778,6 +778,29 @@ fn decode_persisted_index_row(keyspace: &str, row: &Row) -> Option<PersistedInde
     })
 }
 
+/// Reserved `system_schema.indexes` options key under which the CREATE path
+/// stores a Filtered index's fully-encoded [`ferrosa_index::FilterPredicate`]
+/// as JSON, so the predicate survives restart and reload reconstructs it
+/// without needing the CQL type system.
+pub const FILTER_PREDICATE_OPTION_KEY: &str = "__filter_predicate";
+
+/// Decode the partial-index predicate from a persisted `system_schema.indexes`
+/// row's `options` cell.
+///
+/// Returns `None` when the options cell is absent, not valid JSON, lacks the
+/// reserved [`FILTER_PREDICATE_OPTION_KEY`], or the stored predicate JSON does
+/// not deserialize — every one of which is a malformed Filtered index that the
+/// caller must reject rather than reload as an unfiltered index.
+fn decode_filter_predicate_from_options(row: &Row) -> Option<ferrosa_index::FilterPredicate> {
+    let options_json = cell_text(
+        row,
+        ferrosa_schema::system::persistence::INDEXES_COL_OPTIONS,
+    )?;
+    let options: HashMap<String, String> = serde_json::from_str(&options_json).ok()?;
+    let predicate_json = options.get(FILTER_PREDICATE_OPTION_KEY)?;
+    ferrosa_index::FilterPredicate::from_option_string(predicate_json)
+}
+
 /// Sidecar map type alias: index name -> sidecar reader for one SSTable.
 type SSTableSidecarMap = Arc<HashMap<String, crate::index::sidecar::SidecarReader>>;
 
@@ -2734,7 +2757,37 @@ impl StorageEngine {
             return Ok(false);
         };
 
-        self.add_index(&table_id, &index_name, column_position, index_type)?;
+        // Reconstruct the partial-index predicate for a Filtered index. The
+        // CREATE path persisted the fully-encoded `FilterPredicate` as JSON
+        // under the reserved `__filter_predicate` options key (the value bytes
+        // are already in storage encoding, so no CQL type system is needed
+        // here). A Filtered index whose predicate is missing or malformed is
+        // unsound — it would index every row — so skip it loudly rather than
+        // silently degrade to a full index.
+        let filter_predicate = if matches!(index_type, ferrosa_index::IndexType::Filtered) {
+            match decode_filter_predicate_from_options(row) {
+                Some(pred) => Some(pred),
+                None => {
+                    tracing::warn!(
+                        keyspace,
+                        table,
+                        index_name,
+                        "filtered index row missing/invalid __filter_predicate — skipping reload to avoid an unfiltered index"
+                    );
+                    return Ok(false);
+                }
+            }
+        } else {
+            None
+        };
+
+        self.add_index_with_predicate(
+            &table_id,
+            &index_name,
+            column_position,
+            index_type,
+            filter_predicate,
+        )?;
         tracing::info!(
             keyspace,
             table,
@@ -2770,6 +2823,25 @@ impl StorageEngine {
         column_position: usize,
         index_type: ferrosa_index::IndexType,
     ) -> ferrosa_common::Result<()> {
+        self.add_index_with_predicate(table_id, index_name, column_position, index_type, None)
+    }
+
+    /// Registers a secondary index, optionally carrying a partial-index
+    /// [`FilterPredicate`].
+    ///
+    /// For [`IndexType::Filtered`] the predicate is threaded into BOTH the
+    /// memtable index (so live writes are filtered identically) and every
+    /// backfill [`IndexBuildJob`] (so the SSTable sidecars hold only matching
+    /// rows). For every other index type the predicate is `None` and this
+    /// behaves exactly like [`add_index`](Self::add_index).
+    pub fn add_index_with_predicate(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        column_position: usize,
+        index_type: ferrosa_index::IndexType,
+        filter_predicate: Option<ferrosa_index::FilterPredicate>,
+    ) -> ferrosa_common::Result<()> {
         // Register with the tracker.
         self.index_tracker
             .register_index(table_id.keyspace(), table_id.table(), index_name);
@@ -2778,9 +2850,12 @@ impl StorageEngine {
         let state = tables.get_mut(table_id).ok_or_else(|| {
             ferrosa_common::Error::InvalidFormat(format!("table not registered: {table_id}"))
         })?;
-        state
-            .store
-            .add_index(index_name.to_string(), column_position, index_type);
+        state.store.add_index_with_predicate(
+            index_name.to_string(),
+            column_position,
+            index_type,
+            filter_predicate.clone(),
+        );
 
         // Submit rebuild jobs for all existing SSTables.
         if let Some(ref scheduler) = self.index_scheduler {
@@ -2797,6 +2872,7 @@ impl StorageEngine {
                     priority: crate::index::BuildPriority::Initial,
                     enqueued_at: std::time::Instant::now(),
                     column_position,
+                    filter_predicate: filter_predicate.clone(),
                 };
                 if let Err(e) = scheduler.submit(job) {
                     tracing::error!(%e, "engine: failed to submit index backfill");
@@ -5657,6 +5733,7 @@ impl StorageEngine {
                                 priority: crate::index::BuildPriority::High,
                                 enqueued_at: std::time::Instant::now(),
                                 column_position: *col_pos,
+                                filter_predicate: None,
                             };
                             let _ = scheduler.submit(job);
                         }
@@ -5749,6 +5826,19 @@ impl StorageEngine {
         } else {
             None
         }
+    }
+
+    /// Test accessor: the partial-index predicate registered for `index_name`,
+    /// cloned. `Some` only for a Filtered index reloaded with its predicate.
+    #[cfg(test)]
+    pub(crate) fn filter_predicate_for_test(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+    ) -> Option<ferrosa_index::FilterPredicate> {
+        let tables = self.tables.read();
+        let state = tables.get(table_id)?;
+        state.store.filter_predicate_for(index_name).cloned()
     }
 
     /// Flushes tables that exceed the size threshold, have unflushed data older
@@ -5901,6 +5991,7 @@ impl StorageEngine {
                                 priority: crate::index::BuildPriority::High,
                                 enqueued_at: std::time::Instant::now(),
                                 column_position: *col_pos,
+                                filter_predicate: None,
                             };
                             if let Err(e) = scheduler.submit(job) {
                                 tracing::error!(%e, %index_name, "compaction: failed to submit index rebuild");
@@ -15661,6 +15752,150 @@ mod tests {
             engine.index_type_for_test(&user_tid, "idx_val_phonetic"),
             Some(IndexType::Phonetic),
             "index must survive restart AND keep its real Phonetic type, not the BTree default"
+        );
+    }
+
+    /// A Filtered (partial) index — its `FilterPredicate` persisted under the
+    /// reserved `__filter_predicate` options key — must survive an engine
+    /// restart. After `reload_indexes_from_system_schema`, the index is
+    /// re-registered as Filtered, its predicate is restored exactly, and the
+    /// memtable index still filters: a write whose filter cell fails the
+    /// predicate is excluded from the index even though it is in the table.
+    #[test]
+    fn reopen_restores_filtered_index_predicate_and_still_filters() {
+        use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+        use ferrosa_index::{FilterOp, FilterPredicate, IndexType};
+        use ferrosa_schema::system::persistence;
+
+        let dir = tempfile::tempdir().unwrap();
+        let user_tid = TableId::new("test_ks", "filtered_table");
+        let indexes_tid = TableId::new("system_schema", "indexes");
+
+        // name (storage col) indexed; status (storage col) is the filter column.
+        let user_schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "filtered_table".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![
+                ColumnDefinition {
+                    name: "name".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+                },
+                ColumnDefinition {
+                    name: "status".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+                },
+            ],
+            extensions: Default::default(),
+        };
+        // Storage ordinal of the filter column `status`: regular columns are
+        // stored name-sorted with no statics here, so `name`=0, `status`=1.
+        let mut regular_names: Vec<&str> = user_schema
+            .regular_columns
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        regular_names.sort_unstable();
+        let status_pos = regular_names
+            .iter()
+            .position(|n| *n == "status")
+            .expect("status column present");
+
+        let predicate = FilterPredicate {
+            column_position: status_pos,
+            op: FilterOp::Eq,
+            value: b"active".to_vec(),
+        };
+        let mut options = std::collections::HashMap::new();
+        options.insert(
+            FILTER_PREDICATE_OPTION_KEY.to_string(),
+            predicate.to_option_string().unwrap(),
+        );
+        let idx_meta = ferrosa_schema::metadata::index::IndexMetadata {
+            keyspace: "test_ks".to_string(),
+            table: "filtered_table".to_string(),
+            name: "name_active_idx".to_string(),
+            index_type: IndexType::Filtered,
+            target_columns: vec!["name".to_string()],
+            filter_predicate: Some(predicate.clone()),
+            options,
+        };
+
+        {
+            let config = StorageEngineConfig::test_config(dir.path());
+            let engine = StorageEngine::new(config, None).unwrap();
+            engine.register_table(user_schema.clone()).unwrap();
+            engine.register_system_tables().unwrap();
+
+            let row = persistence::index_to_rows(&idx_meta);
+            engine
+                .write(&indexes_tid, &row.key, row.row, now_micros_for_test())
+                .unwrap();
+
+            engine.flush(&user_tid).unwrap();
+            engine.flush(&indexes_tid).unwrap();
+        }
+
+        let config = StorageEngineConfig::test_config(dir.path());
+        let (engine, _pending) = StorageEngine::open(config, None).unwrap();
+        engine.register_system_tables().unwrap();
+
+        let restored = engine.reload_indexes_from_system_schema().unwrap();
+        assert_eq!(restored, 1, "the filtered index should be restored");
+
+        assert_eq!(
+            engine.index_type_for_test(&user_tid, "name_active_idx"),
+            Some(IndexType::Filtered),
+            "index must survive restart as Filtered"
+        );
+        assert_eq!(
+            engine.filter_predicate_for_test(&user_tid, "name_active_idx"),
+            Some(predicate),
+            "the partial predicate must survive restart exactly"
+        );
+
+        // The reloaded index still filters live writes: alice/active is indexed,
+        // alice/inactive is not.
+        let storage_to_cell = |name: &str, status: &str, ts: i64| Row {
+            clustering: vec![],
+            cells: vec![
+                (0, CellValue::live(name.as_bytes().to_vec(), ts)),
+                (1, CellValue::live(status.as_bytes().to_vec(), ts)),
+            ],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(ts),
+        };
+        engine
+            .write(
+                &user_tid,
+                &make_key("pk-active"),
+                storage_to_cell("alice", "active", 1000),
+                1000,
+            )
+            .unwrap();
+        engine
+            .write(
+                &user_tid,
+                &make_key("pk-inactive"),
+                storage_to_cell("alice", "inactive", 1001),
+                1001,
+            )
+            .unwrap();
+
+        let hits = engine
+            .read_by_index(
+                &user_tid,
+                "name_active_idx",
+                &ferrosa_index::IndexKey(b"alice".to_vec()),
+            )
+            .unwrap();
+        let pks: Vec<Vec<u8>> = hits.iter().map(|p| p.key.key.as_bytes().to_vec()).collect();
+        assert_eq!(
+            pks,
+            vec![b"pk-active".to_vec()],
+            "reloaded filtered index must return only the active row, not the inactive one"
         );
     }
 

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -2827,11 +2827,11 @@ impl StorageEngine {
     }
 
     /// Registers a secondary index, optionally carrying a partial-index
-    /// [`FilterPredicate`].
+    /// `FilterPredicate`.
     ///
-    /// For [`IndexType::Filtered`] the predicate is threaded into BOTH the
+    /// For `IndexType::Filtered` the predicate is threaded into BOTH the
     /// memtable index (so live writes are filtered identically) and every
-    /// backfill [`IndexBuildJob`] (so the SSTable sidecars hold only matching
+    /// backfill `IndexBuildJob` (so the SSTable sidecars hold only matching
     /// rows). For every other index type the predicate is `None` and this
     /// behaves exactly like [`add_index`](Self::add_index).
     pub fn add_index_with_predicate(

--- a/ferrosa-storage/src/index/remote_backend.rs
+++ b/ferrosa-storage/src/index/remote_backend.rs
@@ -352,6 +352,19 @@ impl RemoteBackend {
 
 impl IndexBuildBackend for RemoteBackend {
     fn build(&self, job: &IndexBuildJob) -> Result<IndexBuildResult, String> {
+        // The remote builder wire protocol does not yet carry a partial-index
+        // FilterPredicate, so dispatching a Filtered job remotely would build an
+        // UNFILTERED sidecar — a silent correctness bug. Build it locally
+        // instead (the local fallback applies the predicate the job carries).
+        if job.filter_predicate.is_some() {
+            tracing::info!(
+                sstable_id = %job.sstable_id,
+                index_name = %job.index_name,
+                "filtered index build kept local — remote builder does not carry the partial predicate"
+            );
+            return self.local_fallback.build(job);
+        }
+
         // Try each available endpoint.
         let n = self.endpoints.len();
         let start = self.next_endpoint.fetch_add(1, Ordering::Relaxed) as usize;
@@ -517,6 +530,7 @@ mod tests {
             priority: super::super::scheduler::BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         }
     }
 
@@ -557,5 +571,55 @@ mod tests {
         assert!(result.sidecar_written_to_s3);
         assert_eq!(result.artifact_manifest_entries.len(), 1);
         assert_eq!(result.artifact_manifest_entries[0].build_id, 9);
+    }
+
+    /// A Filtered job must never be dispatched to a remote endpoint (the wire
+    /// protocol carries no predicate), so `build` routes it straight to the
+    /// local fallback. With a missing SSTable the local fallback fails with an
+    /// "open data" error — proving the local path ran and the (unreachable)
+    /// remote endpoint was never contacted.
+    #[test]
+    fn filtered_job_is_built_locally_not_dispatched_remotely() {
+        use ferrosa_index::{FilterOp, FilterPredicate};
+
+        let dir = tempfile::tempdir().unwrap();
+        let resolver = S3PathResolver {
+            bucket: "b".into(),
+            endpoint: "memory://".into(),
+            prefix: "p".into(),
+        };
+        let backend = RemoteBackend::new(
+            // An endpoint that would fail loudly if contacted.
+            vec!["http://127.0.0.1:1/never".to_string()],
+            resolver,
+            Duration::from_millis(50),
+            0,
+            3,
+            Duration::from_secs(60),
+            LocalBackend::new(dir.path().to_path_buf()),
+        );
+
+        let job = IndexBuildJob {
+            sstable_id: "missing-gen".to_string(),
+            index_name: "name_active_idx".to_string(),
+            index_type: ferrosa_index::IndexType::Filtered,
+            table: ("ks".to_string(), "tbl".to_string()),
+            priority: super::super::scheduler::BuildPriority::Normal,
+            enqueued_at: Instant::now(),
+            column_position: 0,
+            filter_predicate: Some(FilterPredicate {
+                column_position: 1,
+                op: FilterOp::Eq,
+                value: b"active".to_vec(),
+            }),
+        };
+
+        let err = backend.build(&job).expect_err(
+            "filtered build must reach the local fallback and fail on the missing SSTable",
+        );
+        assert!(
+            err.contains("open data"),
+            "expected a local-fallback file error, got: {err}"
+        );
     }
 }

--- a/ferrosa-storage/src/index/scheduler.rs
+++ b/ferrosa-storage/src/index/scheduler.rs
@@ -48,6 +48,11 @@ pub struct IndexBuildJob {
     pub enqueued_at: Instant,
     /// Column position within the row to index.
     pub column_position: usize,
+    /// Partial-index predicate. `Some` only for [`IndexType::Filtered`] jobs:
+    /// the build skips any row whose filter-column cell does not satisfy this
+    /// predicate, so the sidecar holds only matching rows. `None` for every
+    /// other index type (the whole-column index).
+    pub filter_predicate: Option<ferrosa_index::FilterPredicate>,
 }
 
 /// Strategy for executing index builds.
@@ -252,6 +257,27 @@ impl IndexBuildBackend for LocalBackend {
         {
             let pk_bytes = partition.key.key.as_bytes().to_vec();
             for row in &partition.rows {
+                // Partial (filtered) index: skip rows whose filter-column cell
+                // does not satisfy the predicate. The sidecar must hold ONLY
+                // matching rows so the read path (which delegates to a plain
+                // btree point/range lookup) returns the partial result set.
+                // `evaluate_predicate` is the shared source of truth with the
+                // memtable write path, so sidecar and memtable agree.
+                if let Some(predicate) = job.filter_predicate.as_ref() {
+                    let filter_cell = row
+                        .cells
+                        .iter()
+                        .find(|(pos, _)| *pos as usize == predicate.column_position);
+                    let matches = match filter_cell.and_then(|(_, c)| c.value.as_ref()) {
+                        Some(value) => ferrosa_index::evaluate_predicate(predicate, value),
+                        // Filter column absent or tombstoned -> does not match.
+                        None => false,
+                    };
+                    if !matches {
+                        continue;
+                    }
+                }
+
                 // Find the cell at the declared column position.
                 let cell_opt = row
                     .cells
@@ -685,6 +711,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
 
         scheduler.submit(job).unwrap();
@@ -738,6 +765,7 @@ mod tests {
                     priority: BuildPriority::Initial,
                     enqueued_at: Instant::now(),
                     column_position: 0,
+                    filter_predicate: None,
                 })
                 .unwrap();
         }
@@ -808,6 +836,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
         let result = backend.build(&job).unwrap();
         assert_eq!(result.sstable_id, "mock");
@@ -826,6 +855,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
         let result = backend.build(&job);
         assert!(result.is_err());
@@ -913,6 +943,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
         let result = backend.build(&job).unwrap();
 
@@ -932,6 +963,141 @@ mod tests {
         );
     }
 
+    /// A Filtered (partial) index build must skip rows whose filter-column cell
+    /// does not satisfy the predicate, so the sidecar holds only matching rows.
+    /// Here the index is on `name` (col 0), partial on `status = 'active'`
+    /// (col 1). Two rows are active, one is inactive — the sidecar must contain
+    /// exactly the two active rows.
+    #[test]
+    fn local_backend_filtered_build_skips_non_matching_rows() {
+        use ferrosa_common::cell::CellValue;
+        use ferrosa_common::key::{DecoratedKey, PartitionKey};
+        use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+        use ferrosa_index::{FilterOp, FilterPredicate};
+        use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
+        use ferrosa_sstable::writer::SSTableWriter;
+        use ferrosa_sstable::WriteOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sstable_dir = dir.path().to_path_buf();
+
+        // name (col 0) is indexed; status (col 1) is the filter column.
+        let schema = TableSchema {
+            keyspace: "ks".to_string(),
+            table: "tbl".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![
+                ColumnDefinition {
+                    name: "name".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+                },
+                ColumnDefinition {
+                    name: "status".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+                },
+            ],
+            extensions: Default::default(),
+        };
+
+        let mut partitions = vec![
+            Partition {
+                key: DecoratedKey::new(PartitionKey::new(b"pk1".to_vec())),
+                deletion: DeletionTime::LIVE,
+                static_row: None,
+                rows: vec![Row {
+                    clustering: vec![],
+                    cells: vec![
+                        (0, CellValue::live(b"alice".to_vec(), 1000)),
+                        (1, CellValue::live(b"active".to_vec(), 1000)),
+                    ],
+                    deletion: DeletionTime::LIVE,
+                    primary_key_liveness: LivenessInfo::with_timestamp(1000),
+                }],
+            },
+            Partition {
+                key: DecoratedKey::new(PartitionKey::new(b"pk2".to_vec())),
+                deletion: DeletionTime::LIVE,
+                static_row: None,
+                rows: vec![Row {
+                    clustering: vec![],
+                    cells: vec![
+                        (0, CellValue::live(b"bob".to_vec(), 2000)),
+                        (1, CellValue::live(b"inactive".to_vec(), 2000)),
+                    ],
+                    deletion: DeletionTime::LIVE,
+                    primary_key_liveness: LivenessInfo::with_timestamp(2000),
+                }],
+            },
+            Partition {
+                key: DecoratedKey::new(PartitionKey::new(b"pk3".to_vec())),
+                deletion: DeletionTime::LIVE,
+                static_row: None,
+                rows: vec![Row {
+                    clustering: vec![],
+                    cells: vec![
+                        (0, CellValue::live(b"carol".to_vec(), 3000)),
+                        (1, CellValue::live(b"active".to_vec(), 3000)),
+                    ],
+                    deletion: DeletionTime::LIVE,
+                    primary_key_liveness: LivenessInfo::with_timestamp(3000),
+                }],
+            },
+        ];
+        partitions.sort_by(|a, b| a.key.cmp(&b.key));
+
+        let header = crate::flush::build_serialization_header(&schema, &partitions);
+        let options = WriteOptions {
+            compression: None,
+            ..WriteOptions::default()
+        };
+        let mut writer = SSTableWriter::new(options, header);
+        for p in &partitions {
+            writer.add_partition(p).unwrap();
+        }
+        let output = writer.finish().unwrap();
+
+        let flush_target = crate::flush::FileFlushTarget::new(sstable_dir.clone()).unwrap();
+        let _reader = flush_target.flush(output).unwrap();
+        let gen = flush_target.generation();
+
+        let backend = LocalBackend::new(sstable_dir.clone());
+        let job = IndexBuildJob {
+            sstable_id: format!("{gen}"),
+            index_name: "name_active_idx".to_string(),
+            index_type: IndexType::Filtered,
+            table: ("ks".to_string(), "tbl".to_string()),
+            priority: BuildPriority::Normal,
+            enqueued_at: Instant::now(),
+            column_position: 0,
+            filter_predicate: Some(FilterPredicate {
+                column_position: 1,
+                op: FilterOp::Eq,
+                value: b"active".to_vec(),
+            }),
+        };
+        let result = backend.build(&job).unwrap();
+
+        let entries = result
+            .sidecar_entries
+            .get("name_active_idx")
+            .expect("filtered index must produce sidecar entries");
+        // Only the two active rows (alice, carol) are indexed; bob is skipped.
+        assert_eq!(
+            entries.len(),
+            2,
+            "filtered index must hold only the 2 active rows, got {}",
+            entries.len()
+        );
+        let mut pks: Vec<Vec<u8>> = entries
+            .iter()
+            .map(|(_, pos)| pos.partition_key.clone())
+            .collect();
+        pks.sort();
+        assert_eq!(pks, vec![b"pk1".to_vec(), b"pk3".to_vec()]);
+    }
+
     #[test]
     fn index_build_job_has_column_position() {
         let job = IndexBuildJob {
@@ -942,6 +1108,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 2,
+            filter_predicate: None,
         };
         assert_eq!(job.column_position, 2);
     }
@@ -958,6 +1125,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
         let result = backend.build(&job);
         assert!(result.is_err(), "expected error for missing SSTable");
@@ -1006,6 +1174,7 @@ mod tests {
                 priority: BuildPriority::Normal,
                 enqueued_at: Instant::now(),
                 column_position: 0,
+                filter_predicate: None,
             })
             .unwrap();
 
@@ -1043,6 +1212,7 @@ mod tests {
                 priority: BuildPriority::Normal,
                 enqueued_at: Instant::now(),
                 column_position: 0,
+                filter_predicate: None,
             })
             .unwrap();
 
@@ -1098,6 +1268,7 @@ mod tests {
                 priority: BuildPriority::Normal,
                 enqueued_at: Instant::now(),
                 column_position: 0,
+                filter_predicate: None,
             })
             .unwrap();
 
@@ -1140,6 +1311,7 @@ mod tests {
                 priority: BuildPriority::Normal,
                 enqueued_at: Instant::now(),
                 column_position: 0,
+                filter_predicate: None,
             })
             .unwrap();
 
@@ -1208,6 +1380,7 @@ mod tests {
                 priority: BuildPriority::Normal,
                 enqueued_at: Instant::now(),
                 column_position: 0,
+                filter_predicate: None,
             })
             .unwrap();
 
@@ -1260,6 +1433,7 @@ mod tests {
                 priority: BuildPriority::Normal,
                 enqueued_at: Instant::now(),
                 column_position: 0,
+                filter_predicate: None,
             })
             .unwrap();
 
@@ -1371,6 +1545,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
 
         let result = backend.build(&job).unwrap();
@@ -1413,6 +1588,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
 
         let result = backend.build(&job).unwrap();
@@ -1436,6 +1612,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
 
         let result = backend.build(&job).unwrap();
@@ -1460,6 +1637,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
 
         let result = backend.build(&job).unwrap();
@@ -1501,6 +1679,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         };
 
         let result = backend.build(&job).unwrap();
@@ -1553,6 +1732,7 @@ mod tests {
                     priority: BuildPriority::Initial,
                     enqueued_at: Instant::now(),
                     column_position: 0,
+                    filter_predicate: None,
                 })
                 .unwrap();
         }

--- a/ferrosa-storage/src/lib.rs
+++ b/ferrosa-storage/src/lib.rs
@@ -58,6 +58,7 @@ pub use data_store::{DataStore, LocalDataStore};
 pub use engine::{
     PersistedIndexRow, StorageEngine, StorageEngineConfig, TempSortTableReservation,
     TimeSeriesWasmAggregateExecutor, TimeSeriesWasmAggregateInvocation,
+    FILTER_PREDICATE_OPTION_KEY,
 };
 pub use flush::{FileFlushTarget, FlushTarget, InMemoryFlushTarget};
 pub use manifest::{load_schema_snapshot, save_schema_snapshot, Manifest};

--- a/ferrosa-storage/src/memtable/eager_index.rs
+++ b/ferrosa-storage/src/memtable/eager_index.rs
@@ -65,6 +65,7 @@ impl EagerIndexBuilder {
                 priority: BuildPriority::High,
                 enqueued_at: std::time::Instant::now(),
                 column_position: *col_pos,
+                filter_predicate: None,
             };
             if self.scheduler.submit(job).is_ok() {
                 submitted += 1;

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -23,7 +23,7 @@ use ferrosa_common::key::DecoratedKey;
 use ferrosa_common::schema::TableSchema;
 use ferrosa_common::task_pool::TaskPool;
 use ferrosa_common::Result;
-use ferrosa_index::{IndexKey, IndexType, RowPosition};
+use ferrosa_index::{FilterPredicate, IndexKey, IndexType, RowPosition};
 use ferrosa_sstable::io::ReadAt;
 use ferrosa_sstable::reader::SSTableReader;
 use ferrosa_sstable::types::{Partition, Row};
@@ -434,6 +434,12 @@ pub struct TableStore<F: FlushTarget> {
     /// backfill / compaction index-build jobs carry the correct `IndexType`
     /// instead of a hardcoded `BTree`. Missing entries default to `BTree`.
     index_types: HashMap<String, IndexType>,
+    /// Partial-index predicates, keyed by index name. Present only for
+    /// [`IndexType::Filtered`] indexes. The memtable write path consults this so
+    /// a live write is added to the filtered memtable index ONLY when its
+    /// filter-column cell satisfies the predicate — matching exactly the rows
+    /// the SSTable sidecar build keeps, so memtable and sidecar agree.
+    index_filter_predicates: HashMap<String, FilterPredicate>,
     /// Full-text index declarations: `(index_name, column_position)` pairs.
     /// Built as FTI sidecar files during flush.
     fulltext_indexes: Vec<(String, usize)>,
@@ -739,6 +745,7 @@ impl<F: FlushTarget> TableStore<F> {
             flush_target,
             options,
             index_types: default_index_types(&indexed_columns),
+            index_filter_predicates: HashMap::new(),
             indexed_columns,
             fulltext_indexes: vec![],
             vector_index_configs: vec![],
@@ -942,6 +949,7 @@ impl<F: FlushTarget> TableStore<F> {
             flush_target,
             options,
             index_types: default_index_types(&indexed_columns),
+            index_filter_predicates: HashMap::new(),
             indexed_columns,
             fulltext_indexes: vec![],
             vector_index_configs: vec![],
@@ -1017,6 +1025,7 @@ impl<F: FlushTarget> TableStore<F> {
             flush_target,
             options,
             index_types: default_index_types(&indexed_columns),
+            index_filter_predicates: HashMap::new(),
             indexed_columns,
             fulltext_indexes: vec![],
             vector_index_configs: vec![],
@@ -1084,6 +1093,26 @@ impl<F: FlushTarget> TableStore<F> {
         // before the memtable put (which consumes the row reference via move).
         if !self.indexed_columns.is_empty() {
             for (index_name, col_pos) in &self.indexed_columns {
+                // Partial (filtered) index gating: a Filtered index has a
+                // predicate on a *filter* column. Only writes whose filter-column
+                // cell satisfies the predicate belong in the index, matching the
+                // SSTable sidecar build. A row missing/tombstoning the filter
+                // column does not match. `evaluate_predicate` is shared with the
+                // build path so memtable and sidecar never disagree.
+                if let Some(predicate) = self.index_filter_predicates.get(index_name) {
+                    let filter_cell = row
+                        .cells
+                        .iter()
+                        .find(|(idx, _)| *idx as usize == predicate.column_position);
+                    let matches = match filter_cell.and_then(|(_, c)| c.value.as_ref()) {
+                        Some(v) => ferrosa_index::evaluate_predicate(predicate, v),
+                        None => false,
+                    };
+                    if !matches {
+                        continue;
+                    }
+                }
+
                 if let Some(cell) = row.cells.iter().find(|(idx, _)| *idx as usize == *col_pos) {
                     if let Some(ref value) = cell.1.value {
                         // Per-type key encoding: a phonetic index stores the
@@ -3972,9 +4001,26 @@ impl<F: FlushTarget> TableStore<F> {
     /// Returns `None` if no index with the given name was declared at
     /// Dynamically adds a secondary index. Future writes will be indexed.
     pub fn add_index(&mut self, index_name: String, column_position: usize, index_type: IndexType) {
+        self.add_index_with_predicate(index_name, column_position, index_type, None);
+    }
+
+    /// Dynamically adds a secondary index carrying an optional partial-index
+    /// [`FilterPredicate`]. Future writes will be indexed; for a Filtered index
+    /// the predicate gates which writes enter the memtable index.
+    pub fn add_index_with_predicate(
+        &mut self,
+        index_name: String,
+        column_position: usize,
+        index_type: IndexType,
+        filter_predicate: Option<FilterPredicate>,
+    ) {
         self.indexed_columns
             .push((index_name.clone(), column_position));
         self.index_types.insert(index_name.clone(), index_type);
+        if let Some(pred) = filter_predicate {
+            self.index_filter_predicates
+                .insert(index_name.clone(), pred);
+        }
         let current = self.view.load();
         let mut new_indexes = (*current.indexes).clone();
         new_indexes.insert(index_name, Arc::new(MemtableIndex::new()));
@@ -4014,6 +4060,13 @@ impl<F: FlushTarget> TableStore<F> {
             .get(index_name)
             .copied()
             .unwrap_or(IndexType::BTree)
+    }
+
+    /// The partial-index [`FilterPredicate`] for a named index, if any. `Some`
+    /// only for [`IndexType::Filtered`] indexes that were registered with a
+    /// predicate (and thus survives reload).
+    pub fn filter_predicate_for(&self, index_name: &str) -> Option<&FilterPredicate> {
+        self.index_filter_predicates.get(index_name)
     }
 
     /// Returns the current full-text index declarations.

--- a/ferrosa-storage/tests/index_integration.rs
+++ b/ferrosa-storage/tests/index_integration.rs
@@ -49,6 +49,7 @@ fn index_build_lifecycle() {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         })
         .expect("submit should succeed");
 
@@ -113,6 +114,7 @@ fn multiple_indexes_with_independent_staleness() {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
+            filter_predicate: None,
         })
         .unwrap();
 


### PR DESCRIPTION
## Executive Summary

Follow-on to #99. #99 introduced per-type index dispatch with geo as the first consumer; this PR makes **every** secondary index type genuinely accelerated, used in both **planning and execution**, and **provably hit** — and closes the two remaining gaps:

- **Filtered** was a build-time-only wrapper with no CQL surface and no query path (queries on a filtered column silently full-scanned). Now a real **partial index**, end to end.
- **FullText** executed via the accelerated `engine.fulltext_search` but `EXPLAIN` misreported `FullScan` (observability gap). Now reports `FullTextIndex`.

Every one of the 8 `IndexType`s now has an end-to-end test asserting **correct rows + EXPLAIN ≠ FullScan + an `index_usage` hit**.

## Coverage matrix (all proven)

| IndexType | EXPLAIN plan | Proving test |
|-----------|--------------|--------------|
| BTree | `SingleIndex` | `btree_index_usage_observable_end_to_end` |
| Hash | `SingleIndex` | `hash_index_usage_observable_end_to_end` |
| Composite | `SingleIndex` | `composite_index_usage_observable_end_to_end` |
| Phonetic | `SingleIndex` | `phonetic_index_usage_observable_end_to_end` |
| Filtered | `SingleIndex` (partial) | `filtered_index_used_when_query_implies_predicate` (+ soundness `…_withheld_when_query_does_not_imply_predicate`) |
| FullText | **`FullTextIndex`** (new) | `fulltext_index_usage_observable_end_to_end` |
| Vector | `VectorAnn` | `ann_query_consults_vector_index_and_is_observable` |
| Geo | `GeoIndex` | `geo_st_within_polygon_filters_to_central_sf` |

Each test uses `assert_explain_plan` (asserts the plan variant is present AND `FullScan` is absent) + `assert_index_hit_and_count(…, 1)`.

## Changes

**Filtered partial index (full implementation)**
- CQL surface: `CREATE INDEX … USING 'filtered' WITH OPTIONS = {'filter_column':'status','filter_op':'=','filter_value':'active'}` (ops `=`,`!=`,`<`,`>`,`<=`,`>=`; value encoded against the filter column's type at CREATE).
- Predicate persisted via the existing `system_schema.indexes` options cell (no schema-format change) and reconstructed on restart.
- Build-time filtering applied in `LocalBackend::build` (streaming-safe) and the memtable path, so sidecar + memtable hold only matching rows. Remote builder routes Filtered jobs to the local fallback (fail-safe, not fail-silent).
- **Sound planner rule:** a partial index is used only when the query carries an `Eq` predicate on the filter column whose value satisfies the index predicate (so results stay complete). When not implied, the index is withheld — proven by a completeness test. New `planner::plan_with_covered` lets the filter column count as index-covered when used.

**FullText EXPLAIN**
- New `ScanPlan::FullTextIndex`; `route_explain` reports it via a shared `resolve_fulltext_index_name` (single source of truth, so reported plan and executed index cannot diverge); defensive unreachable arm in the scan dispatch (fail loud).

## Honesty notes

- No type silently full-scans behind a registered index — FullText was the only gap and it was observability-only.
- Filtered soundness is conservative (exact `Eq` implication); range-implication and multi-column filter predicates are out of scope and correctly fall to FullScan rather than over-claim.
- Remote index-builder protocol doesn't natively carry the predicate; Filtered jobs use the local fallback (documented).

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --workspace`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `cargo test --workspace` (2,224 pass; the 3 `ferrosa-jepsen` topology tests require the CI-provisioned cluster and are excluded by the CI test job)
- [x] All 8 per-type acceleration tests green (EXPLAIN ≠ FullScan + index_usage hit)
- [ ] CI green on PR
- [ ] Merge #99 first (this PR is stacked on it)