### PR TITLE
feat(geo): prune ST_WITHIN polygon candidates through the R-tree

### DIFF
--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -2853,9 +2853,13 @@ async fn route_geo_select(
                             .to_string(),
                     ));
                 }
-                // Cover the polygon's bounding box, then refine each candidate
-                // with the exact point-in-polygon test. A degenerate polygon has
-                // no bbox and matches nothing.
+                // Cover the polygon's bounding box, then refine each candidate.
+                // The cell cover is coarse, so the fetched rows over-approximate
+                // the polygon's bbox. We bulk-load the candidate points into an
+                // R-tree and query it with the polygon's exact bbox: that prunes
+                // off-bbox candidates in O(log n) before running the expensive
+                // point-in-polygon ray-cast only on the survivors. A degenerate
+                // polygon has no bbox and matches nothing.
                 match geo::polygon_bbox(&polygon) {
                     Some((sw, ne)) => {
                         let ranges = cover_ranges_to_pairs(&geo::cover_bbox(
@@ -2864,13 +2868,21 @@ async fn route_geo_select(
                             geo::DEFAULT_COVER_LEVEL,
                         ));
                         let rows = fetch_rows(ranges)?;
-                        rows.into_iter()
-                            .filter(|row| {
-                                row_geo_point(row, geo_col_idx)
-                                    .map(|(la, lo)| geo::point_in_polygon(la, lo, &polygon))
-                                    .unwrap_or(false)
-                            })
-                            .collect()
+                        // Each candidate carries its row index as the opaque id so
+                        // the R-tree survivors map straight back to source rows.
+                        let candidates: Vec<geo::GeoPoint<usize>> =
+                            rows.iter()
+                                .enumerate()
+                                .filter_map(|(i, row)| {
+                                    row_geo_point(row, geo_col_idx)
+                                        .map(|(lat, lon)| geo::GeoPoint { id: i, lat, lon })
+                                })
+                                .collect();
+                        let mut kept = geo::points_in_polygon_rtree(&candidates, &polygon);
+                        // Stable, deterministic output order (R-tree traversal is
+                        // not input order).
+                        kept.sort_unstable();
+                        kept.into_iter().map(|i| rows[i].clone()).collect()
                     }
                     None => Vec::new(),
                 }

--- a/ferrosa-index/src/geo/geometry.rs
+++ b/ferrosa-index/src/geo/geometry.rs
@@ -91,6 +91,59 @@ pub fn polygon_bbox(poly: &Polygon) -> Option<((f64, f64), (f64, f64))> {
     Some(((min_lat, min_lon), (max_lat, max_lon)))
 }
 
+/// A candidate point fed to [`points_in_polygon_rtree`], tagged with an opaque
+/// caller id so the survivors can be mapped back to their source rows.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeoPoint<T> {
+    /// Opaque caller id (e.g. an index into a side table of rows).
+    pub id: T,
+    /// Point latitude in degrees.
+    pub lat: f64,
+    /// Point longitude in degrees.
+    pub lon: f64,
+}
+
+/// Filter `candidates` to the ids whose point falls inside `poly`, using the
+/// [`Rtree`](super::rtree::Rtree) to **prune** before the exact ray-cast.
+///
+/// The candidate set fetched from a cell-cover of the polygon's bounding box is
+/// a coarse over-approximation: many points lie outside the polygon's true
+/// bbox. Brute force ray-casts every candidate against every polygon edge
+/// (`O(candidates × vertices)`). Instead we bulk-load the candidate points into
+/// an R-tree keyed by their degenerate bbox, query it with the polygon's bbox
+/// to discard everything outside the bbox in `O(log n)` per survivor, then run
+/// the exact [`point_in_polygon`] test only on the (typically far smaller) set
+/// of bbox survivors.
+///
+/// A degenerate polygon (`< 3` vertices) or one with no bbox encloses no points
+/// and yields an empty result. Order of the returned ids follows R-tree
+/// traversal, not input order; callers that need input order should re-sort.
+pub fn points_in_polygon_rtree<T: Clone>(candidates: &[GeoPoint<T>], poly: &Polygon) -> Vec<T> {
+    use super::rtree::{Rtree, RtreeBbox};
+
+    if poly.is_degenerate() {
+        return Vec::new();
+    }
+    let Some((sw, ne)) = polygon_bbox(poly) else {
+        return Vec::new();
+    };
+    let entries: Vec<(RtreeBbox, usize)> = candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (RtreeBbox::point(c.lat, c.lon), i))
+        .collect();
+    let tree = Rtree::bulk_load(entries);
+    let query = RtreeBbox::new(sw, ne);
+    let mut out = Vec::new();
+    for &idx in tree.query_bbox(&query) {
+        let c = &candidates[idx];
+        if point_in_polygon(c.lat, c.lon, poly) {
+            out.push(c.id.clone());
+        }
+    }
+    out
+}
+
 /// Exact point-in-polygon test for `(lat, lon)` against a single-ring polygon,
 /// via ray casting (the even–odd / crossing-number rule).
 ///
@@ -273,6 +326,113 @@ mod tests {
         // A normal SF polygon does not.
         let sf = Polygon::new(vec![(37.70, -122.52), (37.83, -122.52), (37.83, -122.35)]);
         assert!(!sf.crosses_antimeridian());
+    }
+
+    #[test]
+    fn rtree_prune_matches_brute_force_point_in_polygon() {
+        // A polygon around central SF. Build a mixed candidate set: some inside,
+        // some outside the polygon, some outside even its bbox. The R-tree-pruned
+        // filter must return exactly the ids the brute-force ray-cast returns.
+        let poly = Polygon::new(vec![
+            (37.70, -122.52),
+            (37.83, -122.52),
+            (37.83, -122.35),
+            (37.70, -122.35),
+        ]);
+        let candidates = vec![
+            GeoPoint {
+                id: 0u32,
+                lat: 37.7955,
+                lon: -122.3937,
+            }, // Ferry Bldg: in
+            GeoPoint {
+                id: 1,
+                lat: 37.7880,
+                lon: -122.4074,
+            }, // Union Sq: in
+            GeoPoint {
+                id: 2,
+                lat: 37.7694,
+                lon: -122.4862,
+            }, // GG Park: in
+            GeoPoint {
+                id: 3,
+                lat: 40.7580,
+                lon: -73.9855,
+            }, // NYC: out of bbox
+            GeoPoint {
+                id: 4,
+                lat: 37.90,
+                lon: -122.40,
+            }, // N of bbox
+            GeoPoint {
+                id: 5,
+                lat: 37.75,
+                lon: -122.30,
+            }, // E of bbox
+        ];
+
+        let mut got = points_in_polygon_rtree(&candidates, &poly);
+        got.sort_unstable();
+
+        let mut want: Vec<u32> = candidates
+            .iter()
+            .filter(|c| point_in_polygon(c.lat, c.lon, &poly))
+            .map(|c| c.id)
+            .collect();
+        want.sort_unstable();
+
+        assert_eq!(got, want);
+        assert_eq!(got, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn rtree_prune_degenerate_polygon_yields_nothing() {
+        let line = Polygon::new(vec![(0.0, 0.0), (0.0, 1.0)]);
+        let candidates = vec![GeoPoint {
+            id: 7u32,
+            lat: 0.0,
+            lon: 0.5,
+        }];
+        assert!(points_in_polygon_rtree(&candidates, &line).is_empty());
+    }
+
+    #[test]
+    fn rtree_prune_empty_candidates_yields_nothing() {
+        let sq = unit_square();
+        let candidates: Vec<GeoPoint<u32>> = Vec::new();
+        assert!(points_in_polygon_rtree(&candidates, &sq).is_empty());
+    }
+
+    #[test]
+    fn rtree_prune_excludes_concave_notch_point() {
+        // Same concave shape as `concave_polygon_excludes_the_notch`: a point in
+        // the notch is inside the bbox (so survives the R-tree prune) but must be
+        // dropped by the exact ray-cast.
+        let poly = Polygon::new(vec![
+            (0.0, 0.0),
+            (0.0, 4.0),
+            (4.0, 4.0),
+            (4.0, 0.0),
+            (2.0, 0.0),
+            (2.0, 3.0),
+            (1.0, 3.0),
+            (1.0, 0.0),
+        ]);
+        let candidates = vec![
+            GeoPoint {
+                id: 0u32,
+                lat: 0.5,
+                lon: 2.0,
+            }, // body: in
+            GeoPoint {
+                id: 1,
+                lat: 1.5,
+                lon: 1.0,
+            }, // notch (in bbox): out
+        ];
+        let got = points_in_polygon_rtree(&candidates, &poly);
+        assert_eq!(got, vec![0]);
     }
 
     #[test]

--- a/ferrosa-index/src/geo/mod.rs
+++ b/ferrosa-index/src/geo/mod.rs
@@ -18,7 +18,7 @@ pub mod rtree;
 
 pub use cover::{cover_bbox, cover_radius, CellRange, DEFAULT_COVER_LEVEL};
 pub use encode::{encode_cell, encode_point, BITS_PER_AXIS, CELL_ID_BITS};
-pub use geometry::{point_in_polygon, polygon_bbox, Polygon};
+pub use geometry::{point_in_polygon, points_in_polygon_rtree, polygon_bbox, GeoPoint, Polygon};
 pub use knn::{nearest_k, GeoCandidate};
 pub use refine::{haversine_m, within_bbox, within_radius, EARTH_RADIUS_M};
 pub use rtree::{Rtree, RtreeBbox};

--- a/specs/proposed/geospatial-index.md
+++ b/specs/proposed/geospatial-index.md
@@ -139,6 +139,51 @@ any miss once the variant exists — a useful forcing function):
    mirroring `vector/` and `VectorIndexMethod`.
 9. `ST_Within`/`ST_Intersects`/`ST_Contains`, exact predicates, polygon/line support.
 
+## 6a. Phase-2 status & this PR's slice
+
+Phase 1 (point index over BTree, `GEO_NEAREST` / `GEO_WITHIN_RADIUS` /
+`GEO_WITHIN_BBOX` / `ST_WITHIN(point, polygon)`) is **implemented and tested** on
+main: `ferrosa-index/src/geo/` carries the encoder, cover/knn planners, haversine
+refine, single-ring `Polygon` + ray-cast, and a bulk-loaded STR `Rtree`. The CQL
+surface dispatches through `route_geo_select` with EXPLAIN `GeoIndex` and
+`index_usage` accounting.
+
+Phase 2 is decomposed into independent vertical slices so each can land green:
+
+| Slice | What it adds | Status |
+|---|---|---|
+| **P2-a — R-tree in the live `ST_WITHIN` path** | use the existing `geo::rtree` to prune polygon-bbox candidates before the exact ray-cast | **this PR** |
+| **P2-b — stored `GEOMETRY` column (WKB)** | a marshalled geometry type in `ferrosa-common`, WKB parse/serialize, round-trip | deferred |
+| **P2-c — `ST_INTERSECTS` / `ST_CONTAINS`** | predicates between two *stored* geometries, backed by P2-b + the R-tree sidecar | deferred |
+| **P2-d — rich geometry** | multi-ring polygons (holes), linestrings, antimeridian splitting, native `-GEO-` sidecar | deferred |
+
+### What THIS PR (P2-a) delivers
+
+- A pure, tested `geo::points_in_polygon_rtree(candidates, polygon)` helper
+  (`ferrosa-index/src/geo/geometry.rs`): bulk-loads the candidate points into the
+  `Rtree` (degenerate point bboxes), queries it with the polygon's exact bounding
+  box to **prune off-bbox candidates in O(log n)**, then runs `point_in_polygon`
+  only on the survivors. Verified equal to brute-force ray-casting (including a
+  concave-notch case and degenerate/empty inputs).
+- Wires that helper into the live single-polygon `ST_WITHIN` query path
+  (`ferrosa-cql/src/router.rs::route_geo_select`), replacing the prior brute-force
+  `filter(point_in_polygon)` over every fetched candidate. The cell cover is a
+  coarse over-approximation of the polygon bbox, so the R-tree prune removes the
+  rows the cover pulled in beyond the true bbox before any ray-cast runs.
+- End-to-end coverage unchanged and still green: the central-SF and concave-notch
+  `ST_WITHIN` E2E tests both assert EXPLAIN `GeoIndex` + the `index_usage`
+  increment, and now exercise the R-tree-pruned path.
+
+### What THIS PR defers (see `remaining`)
+
+- **Stored `GEOMETRY` column type + WKB marshal** (P2-b) — the foundation for
+  comparing two stored geometries. Not started here; `ST_WITHIN` still operates on
+  the query-literal polygon vs stored *points*.
+- **`ST_INTERSECTS` / `ST_CONTAINS`** between two stored geometries (P2-c).
+- **Multi-ring polygons / holes, linestrings, antimeridian-crossing polygons**
+  (P2-d). Antimeridian `ST_WITHIN` is still rejected loudly (no silent wrong
+  answer), as before.
+
 ## 7. Risks & open questions
 
 - **CRS / distance:** Phase 1 should default to WGS84 spherical (haversine); planar is


### PR DESCRIPTION
## What shipped (Phase-2 slice P2-a)

Wires the existing bulk-loaded `geo::rtree` (previously only a reusable structure, not on the live path) into the live single-polygon `ST_WITHIN` query path so polygon containment uses the R-tree to **prune candidates** instead of brute force.

- **New pure helper** `geo::points_in_polygon_rtree(candidates, polygon)` (`ferrosa-index/src/geo/geometry.rs`): bulk-loads candidate points into the `Rtree` (degenerate point bboxes), queries it with the polygon's exact bbox to drop off-bbox rows in `O(log n)`, then runs the exact `point_in_polygon` ray-cast only on survivors.
- **Live wiring** in `ferrosa-cql/src/router.rs::route_geo_select`: the `WithinPolygon` arm replaces the prior brute-force `filter(point_in_polygon)` over every fetched candidate. The cell cover over-approximates the polygon bbox, so the R-tree prune removes the extra rows before any ray-cast runs. Output order made deterministic.
- **Spec** `specs/proposed/geospatial-index.md`: added §6a with the full Phase-2 decomposition (P2-a..P2-d) and exactly what this PR delivers vs defers.

## Test evidence

- Pure: `rtree_prune_matches_brute_force_point_in_polygon` (equals brute force, incl. central-SF in/out), `rtree_prune_excludes_concave_notch_point`, degenerate-polygon and empty-candidate cases. `cargo test -p ferrosa-index` → all passed, 0 failed, 0 ignored.
- End to end (unchanged, now exercising the pruned path): `geo_st_within_polygon_filters_to_central_sf` and `geo_st_within_concave_polygon_excludes_notch_point` both assert EXPLAIN `GeoIndex` **and** the `index_usage` increment. Full `ferrosa-cql` suite green.
- `cargo fmt --check`, `cargo clippy --all-targets` (zero warnings), `cargo build --all-targets` all clean.

## Deferred (see spec §6a + remaining)

- **P2-b** stored `GEOMETRY` column type + WKB marshal in ferrosa-common (foundation for comparing two stored geometries).
- **P2-c** `ST_INTERSECTS` / `ST_CONTAINS` between two stored geometries.
- **P2-d** multi-ring polygons / holes, linestrings, antimeridian-crossing polygons. Antimeridian `ST_WITHIN` remains rejected loudly (no silent wrong answer).