### PR TITLE
feat(index): filtered partial index range implication + native remote-builder predicate

### DIFF
--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -6729,6 +6729,55 @@ fn parse_filter_op(op: &str) -> Result<ferrosa_index::FilterOp, CqlError> {
     }
 }
 
+/// Coerce a filtered-index `filter_value` (always a string in the WITH OPTIONS
+/// map) into the [`Term`] shape the column's [`CqlType`] expects.
+///
+/// Text-like columns keep the value verbatim as a string literal. Numeric and
+/// boolean columns parse the string into the matching literal so that, e.g.,
+/// `filter_value':'21'` on an `int` column produces an integer literal rather
+/// than failing the type check that rejects a string literal on an int column.
+/// Parsing failures fail loud — a partial index with an unparseable predicate
+/// value must be rejected at CREATE time, not silently registered.
+fn filter_value_to_term(value: &str, cql_type: &CqlType) -> Result<Term, CqlError> {
+    match cql_type {
+        CqlType::Int
+        | CqlType::Bigint
+        | CqlType::Smallint
+        | CqlType::Tinyint
+        | CqlType::Varint
+        | CqlType::Counter
+        | CqlType::Timestamp => {
+            let n = value.parse::<i64>().map_err(|_| {
+                CqlError::Invalid(format!(
+                    "filtered index filter_value '{value}' is not a valid integer for the \
+                     filter column type"
+                ))
+            })?;
+            Ok(Term::IntegerLiteral(n))
+        }
+        CqlType::Float | CqlType::Double | CqlType::Decimal => {
+            let f = value.parse::<f64>().map_err(|_| {
+                CqlError::Invalid(format!(
+                    "filtered index filter_value '{value}' is not a valid number for the \
+                     filter column type"
+                ))
+            })?;
+            Ok(Term::FloatLiteral(f))
+        }
+        CqlType::Boolean => {
+            let b = value.parse::<bool>().map_err(|_| {
+                CqlError::Invalid(format!(
+                    "filtered index filter_value '{value}' is not a valid boolean (true/false)"
+                ))
+            })?;
+            Ok(Term::BoolLiteral(b))
+        }
+        // Text, inet, timestamps-as-strings, uuid, blob, dates, etc. all accept
+        // a string literal and parse it in `term_to_cql_value`.
+        _ => Ok(Term::StringLiteral(value.to_string())),
+    }
+}
+
 /// Build a fully-encoded [`ferrosa_index::FilterPredicate`] from the WITH
 /// OPTIONS of a `CREATE INDEX ... USING 'filtered'` statement.
 ///
@@ -6785,8 +6834,12 @@ fn build_filter_predicate_from_options(
         .get(filter_column)
         .ok_or_else(|| CqlError::Invalid(format!("filter_column '{filter_column}' not found")))?;
     let cql_type = resolve_col_type(&col_meta.column_type, ks, &state.schema)?;
-    let cql_value =
-        bridge::term_to_cql_value(&Term::StringLiteral(filter_value.clone()), &cql_type)?;
+    // The WITH OPTIONS map always carries the filter value as a string. Coerce
+    // it to the term shape the column's type expects (e.g. `'21'` on an `int`
+    // column becomes an integer literal) before encoding — otherwise a numeric
+    // partial predicate would be rejected as a type mismatch at CREATE time.
+    let term = filter_value_to_term(filter_value, &cql_type)?;
+    let cql_value = bridge::term_to_cql_value(&term, &cql_type)?;
     let value = crate::types::encode_value(&cql_value);
 
     Ok(ferrosa_index::FilterPredicate {
@@ -6805,14 +6858,19 @@ fn build_filter_predicate_from_options(
 /// `indexed_col = v` but fall outside the partial predicate — a silent
 /// correctness bug.
 ///
-/// Conservative, sound rule: the query must carry an `Eq` predicate on the
-/// index's filter column whose encoded value SATISFIES the index predicate. For
-/// an index predicate `status = 'active'`, only a query with `status = 'active'`
-/// qualifies; every such row has `status = 'active'`, which is exactly the set
-/// the index retains, so the result is both correct and complete. A query with
-/// no `status` predicate, or `status = 'inactive'`, does not qualify and the
-/// index is withheld (the planner then falls back to FullScan / the usual
-/// unindexed-column error).
+/// Sound rule: the query must carry a predicate on the index's filter column
+/// whose value-set is a provable SUBSET of the index's retained set (see
+/// [`ferrosa_index::query_constraint_implies_predicate`]). This covers both the
+/// Eq-implies-Eq case and RANGE implication:
+/// - index predicate `status = 'active'`, query `status = 'active'` → usable
+/// - index predicate `age > 21`, query `age = 30` / `age > 25` / `age >= 22` → usable
+/// - index predicate `age > 21`, query `age > 10` / `age >= 21` → withheld
+///   (those queries admit rows the index excludes, so the result would be
+///   incomplete)
+///
+/// A query with no predicate on the filter column, or one whose value-set is
+/// not provably contained, does not qualify and the index is withheld (the
+/// planner then falls back to FullScan / the usual unindexed-column error).
 fn query_implies_filter_predicate(
     where_clauses: &[WhereClause],
     table_meta: &TableMetadata,
@@ -6821,9 +6879,14 @@ fn query_implies_filter_predicate(
     predicate: &ferrosa_index::FilterPredicate,
 ) -> bool {
     for wc in where_clauses {
-        if wc.op != ComparisonOp::Eq || wc.token_fn {
+        if wc.token_fn {
             continue;
         }
+        // Map the WHERE op to a filter op; only scalar comparisons can imply a
+        // partial predicate (IN/CONTAINS/LIKE/etc. are not handled and withhold).
+        let Some(query_op) = comparison_to_filter_op(&wc.op) else {
+            continue;
+        };
         // Match the WHERE column to the predicate's filter column by storage
         // ordinal — the same ordinal the predicate was built with.
         let Some(storage_idx) = table_meta.storage_column_index(&wc.column) else {
@@ -6833,15 +6896,37 @@ fn query_implies_filter_predicate(
             continue;
         }
         // Encode the query's literal the same way the predicate value was
-        // encoded, then check the index predicate accepts it.
+        // encoded, then check subset containment in that byte space.
         let Ok(key) = term_to_index_key(&wc.value, &wc.column, table_meta, ks, schema) else {
             continue;
         };
-        if ferrosa_index::evaluate_predicate(predicate, &key.0) {
+        if ferrosa_index::query_constraint_implies_predicate(query_op, &key.0, predicate) {
             return true;
         }
     }
     false
+}
+
+/// Map a CQL [`ComparisonOp`] to the index [`ferrosa_index::FilterOp`] used by
+/// partial-predicate implication. Only the scalar comparison operators have a
+/// filter-op equivalent; multi-value / pattern operators (`IN`, `CONTAINS`,
+/// `LIKE`, `SoundsLike`, …) return `None` so the planner withholds the partial
+/// index rather than reasoning unsoundly about them.
+fn comparison_to_filter_op(op: &ComparisonOp) -> Option<ferrosa_index::FilterOp> {
+    use ferrosa_index::FilterOp;
+    match op {
+        ComparisonOp::Eq => Some(FilterOp::Eq),
+        ComparisonOp::Ne => Some(FilterOp::NotEq),
+        ComparisonOp::Lt => Some(FilterOp::Lt),
+        ComparisonOp::Gt => Some(FilterOp::Gt),
+        ComparisonOp::Le => Some(FilterOp::LtEq),
+        ComparisonOp::Ge => Some(FilterOp::GtEq),
+        ComparisonOp::In
+        | ComparisonOp::Contains
+        | ComparisonOp::ContainsKey
+        | ComparisonOp::SoundsLike
+        | ComparisonOp::Like => None,
+    }
 }
 
 /// The set of filter-column NAMES covered by the given usable filtered
@@ -16759,6 +16844,146 @@ mod tests {
             count, 2,
             "without the implied predicate, both 'alice' rows must be returned (completeness)"
         );
+    }
+
+    /// Filtered (partial) index, RANGE-implication soundness (true positives):
+    /// a partial index `age > 21` must serve queries whose value-set is a
+    /// provable subset of `{age > 21}` — `age = 30`, `age > 25`, and `age >= 22`.
+    /// Each is index-accelerated (EXPLAIN names the index, not FullScan) and
+    /// returns exactly the implied rows. Built on an `int` column so the storage
+    /// encoding is the positive big-endian range where byte-order == value-order.
+    #[tokio::test]
+    async fn filtered_index_used_when_query_implies_range_predicate() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ks = None;
+        let ctx = test_ctx(&auth, &ks);
+        for cql in [
+            "CREATE KEYSPACE fra WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE fra.people (id int PRIMARY KEY, name text, age int)",
+            // Partial index on `name`, retaining only rows with age > 21.
+            "CREATE INDEX fra_name_adult ON fra.people (name) USING 'filtered' \
+             WITH OPTIONS = {'filter_column':'age','filter_op':'>','filter_value':'21'}",
+            "INSERT INTO fra.people (id, name, age) VALUES (1, 'alice', 30)",
+            "INSERT INTO fra.people (id, name, age) VALUES (2, 'alice', 18)",
+            "INSERT INTO fra.people (id, name, age) VALUES (3, 'alice', 26)",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        // age = 30 ⊆ {age > 21}: implied. Only the age=30 alice (id=1) qualifies.
+        let q = "SELECT id FROM fra.people WHERE name = 'alice' AND age = 30";
+        assert_explain_plan(&state, &ctx, q, "fra_name_adult").await;
+        let count = assert_index_hit_and_count(&state, &ctx, q, 1).await;
+        assert_eq!(
+            count, 1,
+            "age=30 implies age>21 and selects only the 30 row"
+        );
+
+        // age > 25 ⊆ {age > 21}: implied. alice rows with age>25 are id=1 (30)
+        // and id=3 (26); both are in the index, so the index serves them.
+        let q = "SELECT id FROM fra.people WHERE name = 'alice' AND age > 25";
+        assert_explain_plan(&state, &ctx, q, "fra_name_adult").await;
+        let count = assert_index_hit_and_count(&state, &ctx, q, 1).await;
+        assert_eq!(
+            count, 2,
+            "age>25 implies age>21 and selects the 30 and 26 rows"
+        );
+
+        // age >= 22 ⊆ {age > 21}: implied (22 > 21). Same two rows.
+        let q = "SELECT id FROM fra.people WHERE name = 'alice' AND age >= 22";
+        assert_explain_plan(&state, &ctx, q, "fra_name_adult").await;
+        let count = assert_index_hit_and_count(&state, &ctx, q, 1).await;
+        assert_eq!(count, 2, "age>=22 implies age>21");
+    }
+
+    /// Filtered (partial) index, RANGE-implication soundness (withheld cases):
+    /// a query whose filter-column value-set is NOT a provable subset of the
+    /// index's retained set MUST fall to FullScan so no qualifying row is
+    /// dropped. For a `age > 21` partial index, `age > 10` and `age >= 21` both
+    /// admit rows the index excludes (e.g. age 21 itself, age 18), so the index
+    /// is withheld and the complete result set is returned.
+    #[tokio::test]
+    async fn filtered_index_withheld_when_query_does_not_imply_range_predicate() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ks = None;
+        let ctx = test_ctx(&auth, &ks);
+        for cql in [
+            "CREATE KEYSPACE frw WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE frw.people (id int PRIMARY KEY, name text, age int)",
+            "CREATE INDEX frw_name_adult ON frw.people (name) USING 'filtered' \
+             WITH OPTIONS = {'filter_column':'age','filter_op':'>','filter_value':'21'}",
+            // Three alices: age 30 (in index), age 21 (boundary, excluded),
+            // age 18 (excluded).
+            "INSERT INTO frw.people (id, name, age) VALUES (1, 'alice', 30)",
+            "INSERT INTO frw.people (id, name, age) VALUES (2, 'alice', 21)",
+            "INSERT INTO frw.people (id, name, age) VALUES (3, 'alice', 18)",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        // Assert a query is withheld (the partial index is not named and the
+        // plan is FullScan, proving soundness) and that the complete result set
+        // is still returned. Because withholding leaves `age` genuinely
+        // unindexed, the value-returning query must use ALLOW FILTERING — which
+        // is exactly the safe fallback we want: a full scan with a precise
+        // post-filter, never a silently incomplete index read.
+        async fn assert_withheld_full(
+            state: &SharedState,
+            ctx: &RequestContext<'_>,
+            q: &str,
+            index_name: &str,
+            expected_count: i32,
+        ) {
+            let stmt = crate::parser::parse(&format!("EXPLAIN {q}")).unwrap();
+            match route(state, ctx, stmt).await.unwrap() {
+                RouteResult::Result(b) => {
+                    let haystack = String::from_utf8_lossy(&b).into_owned();
+                    assert!(
+                        !haystack.contains(index_name),
+                        "partial index must be withheld for `{q}`, got: {haystack}"
+                    );
+                    assert!(
+                        haystack.contains("FullScan"),
+                        "`{q}` must fall to FullScan, got: {haystack}"
+                    );
+                }
+                _ => panic!("expected Result from EXPLAIN"),
+            }
+            // No partial-index hit is recorded; the complete set is returned via
+            // the full-scan + post-filter path.
+            let count =
+                assert_index_hit_and_count(state, ctx, &format!("{q} ALLOW FILTERING"), 0).await;
+            assert_eq!(
+                count, expected_count,
+                "`{q}` must return the complete set ({expected_count} rows)"
+            );
+        }
+
+        // age > 10 admits age=18 and age=21, neither in the {age>21} index.
+        assert_withheld_full(
+            &state,
+            &ctx,
+            "SELECT id FROM frw.people WHERE name = 'alice' AND age > 10",
+            "frw_name_adult",
+            3,
+        )
+        .await;
+
+        // age >= 21 admits age=21 (the index excludes the boundary).
+        assert_withheld_full(
+            &state,
+            &ctx,
+            "SELECT id FROM frw.people WHERE name = 'alice' AND age >= 21",
+            "frw_name_adult",
+            2,
+        )
+        .await;
     }
 
     /// CREATE INDEX ... USING 'filtered' with a missing/invalid predicate option

--- a/ferrosa-index-builder/src/pull.rs
+++ b/ferrosa-index-builder/src/pull.rs
@@ -89,6 +89,8 @@ pub async fn run(
                             table: (entry.keyspace.clone(), entry.table.clone()),
                             column_position: *col_pos,
                             priority: "normal".into(),
+                            // Pull mode rebuilds btree indexes only; no partial predicate.
+                            filter_predicate: None,
                         };
 
                         let pool = Arc::clone(&pool);

--- a/ferrosa-index-builder/src/worker.rs
+++ b/ferrosa-index-builder/src/worker.rs
@@ -33,6 +33,13 @@ pub struct BuildRequest {
     pub table: (String, String),
     pub column_position: usize,
     pub priority: String,
+    /// Partial-index predicate. `Some` only for a `filtered` index build: the
+    /// fully-encoded [`ferrosa_index::FilterPredicate`] (value bytes already in
+    /// storage encoding) the builder applies at build time so the remote sidecar
+    /// contains exactly the matching rows — never an unfiltered sidecar. Omitted
+    /// (deserializes to `None`) for every other index type.
+    #[serde(default)]
+    pub filter_predicate: Option<ferrosa_index::FilterPredicate>,
 }
 
 /// Response returned from a completed build.
@@ -236,17 +243,7 @@ impl WorkerPool {
         }
 
         // Build the index using LocalBackend (blocking — run on a thread).
-        let index_type = parse_index_type(&req.index_type)?;
-        let job = IndexBuildJob {
-            sstable_id: req.sstable_id.clone(),
-            index_name: req.index_name.clone(),
-            index_type,
-            table: (req.table.0.clone(), req.table.1.clone()),
-            priority: parse_priority(&req.priority),
-            enqueued_at: Instant::now(),
-            column_position: req.column_position,
-            filter_predicate: None,
-        };
+        let job = build_job(req)?;
 
         let job_dir_clone = job_dir.clone();
         let build_result = tokio::task::spawn_blocking(move || {
@@ -301,12 +298,31 @@ impl BuildRequest {
     }
 }
 
+/// Build an [`IndexBuildJob`] from a [`BuildRequest`], carrying the partial
+/// predicate (if any) so a `filtered` build applies it at build time. This is
+/// the single place the wire request is mapped to a job; extracted so the
+/// predicate plumbing is unit-testable without spinning up the HTTP path.
+fn build_job(req: &BuildRequest) -> Result<IndexBuildJob, String> {
+    let index_type = parse_index_type(&req.index_type)?;
+    Ok(IndexBuildJob {
+        sstable_id: req.sstable_id.clone(),
+        index_name: req.index_name.clone(),
+        index_type,
+        table: (req.table.0.clone(), req.table.1.clone()),
+        priority: parse_priority(&req.priority),
+        enqueued_at: Instant::now(),
+        column_position: req.column_position,
+        filter_predicate: req.filter_predicate.clone(),
+    })
+}
+
 fn parse_index_type(s: &str) -> Result<IndexType, String> {
     match s.to_lowercase().as_str() {
         "btree" => Ok(IndexType::BTree),
         "hash" => Ok(IndexType::Hash),
         "composite" => Ok(IndexType::Composite),
         "phonetic" => Ok(IndexType::Phonetic),
+        "filtered" => Ok(IndexType::Filtered),
         "vector" => Ok(IndexType::Vector),
         "fulltext" => Ok(IndexType::FullText),
         "geo" => Ok(IndexType::Geo),
@@ -335,7 +351,69 @@ mod tests {
             Ok(IndexType::FullText)
         ));
         assert!(matches!(parse_index_type("GEO"), Ok(IndexType::Geo)));
+        // Filtered must be recognized now that the remote builder carries the
+        // partial predicate and filters at build time.
+        assert!(matches!(
+            parse_index_type("filtered"),
+            Ok(IndexType::Filtered)
+        ));
         assert!(parse_index_type("unknown").is_err());
+    }
+
+    /// A filtered build request deserializes the wire `filter_predicate` and,
+    /// via `build_job`, threads it into the `IndexBuildJob` so `LocalBackend`
+    /// filters rows at build time. Without this, the remote builder would write
+    /// an UNFILTERED sidecar — a silent correctness bug.
+    #[test]
+    fn build_request_threads_filter_predicate_into_job() {
+        use ferrosa_index::{FilterOp, FilterPredicate};
+
+        let predicate = FilterPredicate {
+            column_position: 1,
+            op: FilterOp::Gt,
+            value: vec![0, 0, 0, 21],
+        };
+        // Construct the request the way the engine sends it (JSON), to prove the
+        // wire field deserializes.
+        let json = serde_json::json!({
+            "sstable_id": "gen-7",
+            "index_name": "name_adult_idx",
+            "index_type": "filtered",
+            "s3_endpoint": "memory://",
+            "s3_bucket": "b",
+            "s3_prefix": "p/ks.tbl/gen-7",
+            "table": ["ks", "tbl"],
+            "column_position": 0,
+            "priority": "normal",
+            "filter_predicate": predicate,
+        });
+        let req: BuildRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(req.filter_predicate.as_ref(), Some(&predicate));
+
+        let job = build_job(&req).unwrap();
+        assert!(matches!(job.index_type, IndexType::Filtered));
+        assert_eq!(job.filter_predicate.as_ref(), Some(&predicate));
+        assert_eq!(job.column_position, 0);
+    }
+
+    /// A non-filtered request omits `filter_predicate`; the job carries `None`.
+    #[test]
+    fn build_request_without_predicate_yields_none() {
+        let json = serde_json::json!({
+            "sstable_id": "gen-1",
+            "index_name": "email_idx",
+            "index_type": "btree",
+            "s3_endpoint": "memory://",
+            "s3_bucket": "b",
+            "s3_prefix": "p/ks.tbl/gen-1",
+            "table": ["ks", "tbl"],
+            "column_position": 0,
+            "priority": "normal",
+        });
+        let req: BuildRequest = serde_json::from_value(json).unwrap();
+        assert!(req.filter_predicate.is_none());
+        let job = build_job(&req).unwrap();
+        assert!(job.filter_predicate.is_none());
     }
 
     #[test]
@@ -363,6 +441,7 @@ mod tests {
                 table: ("ks".into(), "tbl".into()),
                 column_position: 0,
                 priority: "normal".into(),
+                filter_predicate: None,
             })
             .await;
 

--- a/ferrosa-index/src/filtered.rs
+++ b/ferrosa-index/src/filtered.rs
@@ -31,6 +31,90 @@ pub fn evaluate_predicate(predicate: &FilterPredicate, cell_value: &[u8]) -> boo
     }
 }
 
+// ── Predicate implication (planner soundness) ────────────────────────────────
+
+/// Does a query constraint `(query_op, query_value)` on a column GUARANTEE that
+/// every row it selects is also retained by the partial index `predicate`?
+///
+/// A filtered index physically holds exactly the rows for which
+/// [`evaluate_predicate`] returns `true`. The planner may serve a query from
+/// that index — treating the filter column as already enforced — ONLY when the
+/// query's value-set on the filter column is a guaranteed **subset** of the
+/// index's retained set. Otherwise the index is missing rows the query needs
+/// and the result would be silently incomplete.
+///
+/// This function returns `true` only when subset containment is *provable* from
+/// the byte ordering, and withholds (`false`) in every ambiguous case — it is
+/// SOUND, never optimistic. All comparisons use the same byte ordering as
+/// [`evaluate_predicate`], so the implication is reasoned in exactly the space
+/// the index was built in (the query literal and the predicate value both come
+/// from the same storage encoding).
+///
+/// Examples (with value-order encodings such as ascending integers):
+/// - query `age = 30` implies predicate `age > 21` (the single value 30 is `> 21`)
+/// - query `age > 25` implies predicate `age > 21` (`{x>25} ⊆ {x>21}` since `25 >= 21`)
+/// - query `age >= 21` implies predicate `age > 20` (`{x>=21} ⊆ {x>20}` since `21 > 20`)
+/// - query `age = 18` does NOT imply `age > 21` (18 is not `> 21`) → withheld
+/// - query `age > 10` does NOT imply `age > 21` (selects values below 21) → withheld
+pub fn query_constraint_implies_predicate(
+    query_op: FilterOp,
+    query_value: &[u8],
+    predicate: &FilterPredicate,
+) -> bool {
+    let qv = query_value;
+    let pv = predicate.value.as_slice();
+    match predicate.op {
+        // Predicate retains a single value: only an identical Eq query is a subset.
+        FilterOp::Eq => query_op == FilterOp::Eq && qv == pv,
+        // Predicate retains everything except `pv`: the query's set must exclude `pv`.
+        FilterOp::NotEq => query_excludes_value(query_op, qv, pv),
+        // Predicate retains `{x < pv}`.
+        FilterOp::Lt => match query_op {
+            FilterOp::Eq => qv < pv,
+            FilterOp::Lt => qv <= pv,
+            FilterOp::LtEq => qv < pv,
+            _ => false,
+        },
+        // Predicate retains `{x <= pv}`.
+        FilterOp::LtEq => match query_op {
+            FilterOp::Eq | FilterOp::Lt | FilterOp::LtEq => qv <= pv,
+            _ => false,
+        },
+        // Predicate retains `{x > pv}`.
+        FilterOp::Gt => match query_op {
+            FilterOp::Eq => qv > pv,
+            FilterOp::Gt => qv >= pv,
+            FilterOp::GtEq => qv > pv,
+            _ => false,
+        },
+        // Predicate retains `{x >= pv}`.
+        FilterOp::GtEq => match query_op {
+            FilterOp::Eq | FilterOp::Gt | FilterOp::GtEq => qv >= pv,
+            _ => false,
+        },
+    }
+}
+
+/// Does the query constraint's value-set provably EXCLUDE the single value
+/// `excluded`? Used to prove `Q ⊆ {x != excluded}`. Sound: only `true` when
+/// containment is provable from the byte ordering.
+fn query_excludes_value(query_op: FilterOp, query_value: &[u8], excluded: &[u8]) -> bool {
+    match query_op {
+        FilterOp::Eq => query_value != excluded,
+        // `{x != qv}` excludes `excluded` only when `qv == excluded` (then the
+        // two sets are identical); otherwise `excluded` is selected by the query.
+        FilterOp::NotEq => query_value == excluded,
+        // `{x < qv}` excludes `excluded` iff `excluded >= qv`.
+        FilterOp::Lt => excluded >= query_value,
+        // `{x <= qv}` excludes `excluded` iff `excluded > qv`.
+        FilterOp::LtEq => excluded > query_value,
+        // `{x > qv}` excludes `excluded` iff `excluded <= qv`.
+        FilterOp::Gt => excluded <= query_value,
+        // `{x >= qv}` excludes `excluded` iff `excluded < qv`.
+        FilterOp::GtEq => excluded < query_value,
+    }
+}
+
 // ── FilteredIndexFactory ─────────────────────────────────────────────────────
 
 /// An index factory that wraps another factory and filters rows during build.
@@ -126,6 +210,110 @@ mod tests {
     use crate::phonetic::{PhoneticAlgorithm, PhoneticIndexFactory};
     use crate::IndexKey;
     use ferrosa_common::CellValue;
+
+    /// Helper: build a predicate over column 0 with a single-byte value so the
+    /// byte ordering matches the intended numeric ordering (`b"a" < b"b"`).
+    fn pred(op: FilterOp, value: &[u8]) -> FilterPredicate {
+        FilterPredicate {
+            column_position: 0,
+            op,
+            value: value.to_vec(),
+        }
+    }
+
+    /// Soundness + completeness enumeration for the planner implication helper.
+    ///
+    /// Each case asserts BOTH directions: implications that MUST hold (true
+    /// positives — the query's value-set is a provable subset of the index's
+    /// retained set) and implications that MUST be withheld (the query could
+    /// select a row outside the index, so using it would be incomplete).
+    ///
+    /// To make the byte ordering coincide with the intended value ordering we
+    /// use single ASCII bytes where `b"1" < b"2" < ... < b"9"`, standing in for
+    /// the `age` examples in the feature spec.
+    #[test]
+    fn query_constraint_implies_predicate_enumeration() {
+        // For every byte-comparison case below, also cross-check against
+        // `evaluate_predicate`: whenever the helper says the query implies the
+        // predicate, EVERY value the query could select must in fact satisfy the
+        // predicate (no false positive). We probe a small value alphabet.
+        let alphabet: &[&[u8]] = &[b"0", b"2", b"4", b"6", b"8", b"9"];
+
+        // (query_op, query_value, predicate, expected)
+        let cases: &[(FilterOp, &[u8], FilterPredicate, bool)] = &[
+            // ── Eq predicate (single retained value) ──────────────────────────
+            (FilterOp::Eq, b"4", pred(FilterOp::Eq, b"4"), true),
+            (FilterOp::Eq, b"5", pred(FilterOp::Eq, b"4"), false),
+            (FilterOp::Gt, b"4", pred(FilterOp::Eq, b"4"), false),
+            // ── Gt predicate (spec: WHERE age = 30 implies age > 21) ──────────
+            (FilterOp::Eq, b"6", pred(FilterOp::Gt, b"2"), true), // age=6 implies age>2
+            (FilterOp::Eq, b"2", pred(FilterOp::Gt, b"2"), false), // boundary: 2 is not > 2
+            (FilterOp::Eq, b"1", pred(FilterOp::Gt, b"2"), false),
+            (FilterOp::Gt, b"4", pred(FilterOp::Gt, b"2"), true), // age>4 implies age>2 (4>=2)
+            (FilterOp::Gt, b"2", pred(FilterOp::Gt, b"2"), true), // same set
+            (FilterOp::Gt, b"1", pred(FilterOp::Gt, b"2"), false), // selects 2-and-below region
+            (FilterOp::GtEq, b"3", pred(FilterOp::Gt, b"2"), true), // age>=3 implies age>2 (3>2)
+            (FilterOp::GtEq, b"2", pred(FilterOp::Gt, b"2"), false), // includes 2, not > 2
+            (FilterOp::Lt, b"9", pred(FilterOp::Gt, b"2"), false), // unbounded below
+            // ── GtEq predicate (spec: WHERE age >= 21 implies age > 20) ───────
+            (FilterOp::GtEq, b"4", pred(FilterOp::GtEq, b"2"), true),
+            (FilterOp::GtEq, b"2", pred(FilterOp::GtEq, b"2"), true),
+            (FilterOp::GtEq, b"1", pred(FilterOp::GtEq, b"2"), false),
+            (FilterOp::Gt, b"2", pred(FilterOp::GtEq, b"2"), true), // {x>2} ⊆ {x>=2}
+            (FilterOp::Eq, b"2", pred(FilterOp::GtEq, b"2"), true),
+            (FilterOp::Eq, b"1", pred(FilterOp::GtEq, b"2"), false),
+            // ── Lt predicate (mirror of Gt) ──────────────────────────────────
+            (FilterOp::Eq, b"2", pred(FilterOp::Lt, b"6"), true),
+            (FilterOp::Eq, b"6", pred(FilterOp::Lt, b"6"), false),
+            (FilterOp::Lt, b"4", pred(FilterOp::Lt, b"6"), true), // 4<=6
+            (FilterOp::Lt, b"6", pred(FilterOp::Lt, b"6"), true), // same set
+            (FilterOp::Lt, b"8", pred(FilterOp::Lt, b"6"), false),
+            (FilterOp::LtEq, b"4", pred(FilterOp::Lt, b"6"), true), // 4<6
+            (FilterOp::LtEq, b"6", pred(FilterOp::Lt, b"6"), false), // includes 6
+            (FilterOp::Gt, b"0", pred(FilterOp::Lt, b"6"), false),  // unbounded above
+            // ── LtEq predicate (mirror of GtEq) ──────────────────────────────
+            (FilterOp::LtEq, b"4", pred(FilterOp::LtEq, b"6"), true),
+            (FilterOp::LtEq, b"6", pred(FilterOp::LtEq, b"6"), true),
+            (FilterOp::LtEq, b"8", pred(FilterOp::LtEq, b"6"), false),
+            (FilterOp::Lt, b"6", pred(FilterOp::LtEq, b"6"), true), // {x<6} ⊆ {x<=6}
+            (FilterOp::Eq, b"6", pred(FilterOp::LtEq, b"6"), true),
+            // ── NotEq predicate (retains all but one value) ──────────────────
+            (FilterOp::Eq, b"4", pred(FilterOp::NotEq, b"6"), true), // 4 != 6
+            (FilterOp::Eq, b"6", pred(FilterOp::NotEq, b"6"), false), // selects the excluded value
+            (FilterOp::Lt, b"6", pred(FilterOp::NotEq, b"6"), true), // {x<6} excludes 6
+            (FilterOp::Lt, b"8", pred(FilterOp::NotEq, b"6"), false), // {x<8} includes 6
+            (FilterOp::Gt, b"6", pred(FilterOp::NotEq, b"6"), true), // {x>6} excludes 6
+            (FilterOp::GtEq, b"6", pred(FilterOp::NotEq, b"6"), false), // includes 6
+            (FilterOp::NotEq, b"6", pred(FilterOp::NotEq, b"6"), true), // identical set
+            (FilterOp::NotEq, b"4", pred(FilterOp::NotEq, b"6"), false), // {x!=4} includes 6
+        ];
+
+        for (q_op, q_val, predicate, expected) in cases {
+            let got = query_constraint_implies_predicate(*q_op, q_val, predicate);
+            assert_eq!(
+                got, *expected,
+                "implication {q_op:?} {q_val:?} => predicate {:?} {:?}: expected {expected}, got {got}",
+                predicate.op, predicate.value
+            );
+
+            // Cross-check: a claimed implication must never admit a query value
+            // that fails the predicate (no silent incompleteness). We verify
+            // every value in our alphabet that the QUERY would select also
+            // satisfies the index PREDICATE.
+            if got {
+                for v in alphabet {
+                    let q = pred(*q_op, q_val);
+                    if evaluate_predicate(&q, v) {
+                        assert!(
+                            evaluate_predicate(predicate, v),
+                            "UNSOUND: query {q_op:?} {q_val:?} selects {v:?} which is NOT retained by predicate {:?} {:?}",
+                            predicate.op, predicate.value
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn filtered_index_only_includes_matching_rows() {

--- a/ferrosa-index/src/lib.rs
+++ b/ferrosa-index/src/lib.rs
@@ -27,7 +27,7 @@ pub mod hash;
 pub mod phonetic;
 pub mod vector;
 
-pub use filtered::evaluate_predicate;
+pub use filtered::{evaluate_predicate, query_constraint_implies_predicate};
 pub use phonetic::PhoneticAlgorithm;
 
 use ferrosa_common::CellValue;

--- a/ferrosa-storage/src/index/remote_backend.rs
+++ b/ferrosa-storage/src/index/remote_backend.rs
@@ -268,26 +268,7 @@ impl RemoteBackend {
         let endpoint = &self.endpoints[endpoint_idx];
         let url = format!("{endpoint}/internal/index/build");
 
-        let table_id = format!("{}.{}", job.table.0, job.table.1);
-        let s3_prefix = self.s3_resolver.resolve(&table_id, &job.sstable_id);
-
-        let body = serde_json::json!({
-            "sstable_id": job.sstable_id,
-            "index_name": job.index_name,
-            "index_type": format!("{:?}", job.index_type).to_lowercase(),
-            "artifact_kind": if job.index_type == ferrosa_index::IndexType::Vector { Some("hvq_qvec") } else { None },
-            "direct_upload": job.index_type == ferrosa_index::IndexType::Vector,
-            "s3_endpoint": self.s3_resolver.endpoint,
-            "s3_bucket": self.s3_resolver.bucket,
-            "s3_prefix": s3_prefix,
-            "table": [&job.table.0, &job.table.1],
-            "column_position": job.column_position,
-            "priority": match job.priority {
-                super::scheduler::BuildPriority::High => "high",
-                super::scheduler::BuildPriority::Normal => "normal",
-                super::scheduler::BuildPriority::Initial => "initial",
-            },
-        });
+        let body = build_request_body(job, &self.s3_resolver);
 
         let config = ureq::config::Config::builder()
             .timeout_global(Some(self.timeout))
@@ -350,22 +331,52 @@ impl RemoteBackend {
     }
 }
 
+/// Build the JSON request body sent to a remote index builder for `job`.
+///
+/// Mirrors every build parameter the builder needs to reproduce the local
+/// build: identity, S3 location, table, column position, priority — and, for a
+/// partial (Filtered) index, the fully-encoded [`ferrosa_index::FilterPredicate`]
+/// under `filter_predicate` so the builder filters rows at build time exactly as
+/// the local path does. Non-filtered jobs omit the field (the builder then
+/// defaults to an unfiltered build). The predicate value bytes are already in
+/// storage encoding, so the round-trip is type-system independent.
+fn build_request_body(job: &IndexBuildJob, resolver: &S3PathResolver) -> serde_json::Value {
+    let table_id = format!("{}.{}", job.table.0, job.table.1);
+    let s3_prefix = resolver.resolve(&table_id, &job.sstable_id);
+
+    let mut body = serde_json::json!({
+        "sstable_id": job.sstable_id,
+        "index_name": job.index_name,
+        "index_type": format!("{:?}", job.index_type).to_lowercase(),
+        "artifact_kind": if job.index_type == ferrosa_index::IndexType::Vector { Some("hvq_qvec") } else { None },
+        "direct_upload": job.index_type == ferrosa_index::IndexType::Vector,
+        "s3_endpoint": resolver.endpoint,
+        "s3_bucket": resolver.bucket,
+        "s3_prefix": s3_prefix,
+        "table": [&job.table.0, &job.table.1],
+        "column_position": job.column_position,
+        "priority": match job.priority {
+            super::scheduler::BuildPriority::High => "high",
+            super::scheduler::BuildPriority::Normal => "normal",
+            super::scheduler::BuildPriority::Initial => "initial",
+        },
+    });
+
+    // Only attach the predicate for partial indexes; a non-filtered job omits
+    // the field entirely so the builder builds the index unfiltered.
+    if let Some(predicate) = &job.filter_predicate {
+        body["filter_predicate"] = serde_json::to_value(predicate)
+            .expect("FilterPredicate serializes to JSON (Vec<u8>/enum/usize)");
+    }
+
+    body
+}
+
 impl IndexBuildBackend for RemoteBackend {
     fn build(&self, job: &IndexBuildJob) -> Result<IndexBuildResult, String> {
-        // The remote builder wire protocol does not yet carry a partial-index
-        // FilterPredicate, so dispatching a Filtered job remotely would build an
-        // UNFILTERED sidecar — a silent correctness bug. Build it locally
-        // instead (the local fallback applies the predicate the job carries).
-        if job.filter_predicate.is_some() {
-            tracing::info!(
-                sstable_id = %job.sstable_id,
-                index_name = %job.index_name,
-                "filtered index build kept local — remote builder does not carry the partial predicate"
-            );
-            return self.local_fallback.build(job);
-        }
-
-        // Try each available endpoint.
+        // Try each available endpoint. A partial (Filtered) index carries its
+        // predicate in the request body (see `build_request_body`), so the
+        // builder filters at build time — no local-only fallback needed.
         let n = self.endpoints.len();
         let start = self.next_endpoint.fetch_add(1, Ordering::Relaxed) as usize;
         let mut last_error = String::new();
@@ -573,53 +584,68 @@ mod tests {
         assert_eq!(result.artifact_manifest_entries[0].build_id, 9);
     }
 
-    /// A Filtered job must never be dispatched to a remote endpoint (the wire
-    /// protocol carries no predicate), so `build` routes it straight to the
-    /// local fallback. With a missing SSTable the local fallback fails with an
-    /// "open data" error — proving the local path ran and the (unreachable)
-    /// remote endpoint was never contacted.
+    /// A Filtered job is now dispatched to the remote builder: the wire request
+    /// body MUST carry the fully-encoded partial predicate so the builder filters
+    /// at build time (rather than producing an unfiltered sidecar). This asserts
+    /// the predicate round-trips into the request JSON under `filter_predicate`,
+    /// mirroring how `column_position` and the other build params are carried.
     #[test]
-    fn filtered_job_is_built_locally_not_dispatched_remotely() {
+    fn filtered_job_request_body_carries_predicate() {
         use ferrosa_index::{FilterOp, FilterPredicate};
 
-        let dir = tempfile::tempdir().unwrap();
         let resolver = S3PathResolver {
             bucket: "b".into(),
             endpoint: "memory://".into(),
             prefix: "p".into(),
         };
-        let backend = RemoteBackend::new(
-            // An endpoint that would fail loudly if contacted.
-            vec!["http://127.0.0.1:1/never".to_string()],
-            resolver,
-            Duration::from_millis(50),
-            0,
-            3,
-            Duration::from_secs(60),
-            LocalBackend::new(dir.path().to_path_buf()),
-        );
-
+        let predicate = FilterPredicate {
+            column_position: 1,
+            op: FilterOp::Gt,
+            value: vec![0, 0, 0, 21],
+        };
         let job = IndexBuildJob {
-            sstable_id: "missing-gen".to_string(),
-            index_name: "name_active_idx".to_string(),
+            sstable_id: "gen-7".to_string(),
+            index_name: "name_adult_idx".to_string(),
             index_type: ferrosa_index::IndexType::Filtered,
             table: ("ks".to_string(), "tbl".to_string()),
             priority: super::super::scheduler::BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
-            filter_predicate: Some(FilterPredicate {
-                column_position: 1,
-                op: FilterOp::Eq,
-                value: b"active".to_vec(),
-            }),
+            filter_predicate: Some(predicate.clone()),
         };
 
-        let err = backend.build(&job).expect_err(
-            "filtered build must reach the local fallback and fail on the missing SSTable",
-        );
+        let body = build_request_body(&job, &resolver);
+        assert_eq!(body["index_type"], "filtered");
+        assert_eq!(body["column_position"], 0);
+        // The predicate is present and decodes back to the exact predicate.
+        let decoded: FilterPredicate =
+            serde_json::from_value(body["filter_predicate"].clone()).unwrap();
+        assert_eq!(decoded, predicate);
+    }
+
+    /// A non-filtered job carries no `filter_predicate` field (it is omitted, not
+    /// null), so the remote builder defaults to an unfiltered build.
+    #[test]
+    fn non_filtered_job_request_body_omits_predicate() {
+        let resolver = S3PathResolver {
+            bucket: "b".into(),
+            endpoint: "memory://".into(),
+            prefix: "p".into(),
+        };
+        let job = IndexBuildJob {
+            sstable_id: "gen-1".to_string(),
+            index_name: "email_idx".to_string(),
+            index_type: ferrosa_index::IndexType::BTree,
+            table: ("ks".to_string(), "tbl".to_string()),
+            priority: super::super::scheduler::BuildPriority::Normal,
+            enqueued_at: Instant::now(),
+            column_position: 0,
+            filter_predicate: None,
+        };
+        let body = build_request_body(&job, &resolver);
         assert!(
-            err.contains("open data"),
-            "expected a local-fallback file error, got: {err}"
+            body.get("filter_predicate").is_none(),
+            "non-filtered jobs must omit filter_predicate, got: {body}"
         );
     }
 }

--- a/specs/todo/filtered-index-multi-column-predicate.md
+++ b/specs/todo/filtered-index-multi-column-predicate.md
@@ -1,0 +1,90 @@
+# Filtered (partial) index: multi-column conjunction predicates
+
+Status: TODO (follow-on to the Filtered partial index, commit `e7762b32`).
+
+## What already shipped
+
+The Filtered partial index is end-to-end for a **single-column** predicate, and
+the planner now reasons soundly about RANGE implication and the remote builder
+filters natively:
+
+- `ferrosa_index::query_constraint_implies_predicate` — sound subset-containment
+  test over the byte ordering (`Q ⊆ P`). Covers Eq-implies-Eq AND range
+  implication (`age = 30` / `age > 25` / `age >= 22` all imply `age > 21`;
+  `age > 10` / `age >= 21` are withheld). Enumerated true-positive AND withheld
+  cases in `ferrosa-index/src/filtered.rs::query_constraint_implies_predicate_enumeration`,
+  cross-checked against `evaluate_predicate` so no claimed implication admits a
+  non-retained value.
+- `ferrosa-cql/src/router.rs::query_implies_filter_predicate` maps every scalar
+  `ComparisonOp` to a `FilterOp` and calls the helper. End-to-end soundness +
+  completeness proven by `filtered_index_used_when_query_implies_range_predicate`
+  and `filtered_index_withheld_when_query_does_not_imply_range_predicate`.
+- `build_filter_predicate_from_options` now coerces the `filter_value` string to
+  the column's CQL type (`filter_value_to_term`), so numeric/boolean partial
+  predicates (e.g. `age int` with `filter_op:'>' , filter_value:'21'`) are
+  accepted at CREATE time rather than rejected as a string-vs-int type mismatch.
+- Remote builder carries the predicate natively: `build_request_body`
+  (`ferrosa-storage`) serializes `FilterPredicate` into the build request under
+  `filter_predicate`; `ferrosa-index-builder` deserializes it
+  (`BuildRequest::filter_predicate`), recognizes `"filtered"` in
+  `parse_index_type`, and threads it into the job via `build_job`, so a remote
+  filtered build filters at build time. The local-only fallback short-circuit is
+  removed.
+
+## What is deferred (this work item): multi-column conjunction filter
+
+Today `FilterPredicate` is exactly one `(column_position, op, value)`. A filter
+over a conjunction of >1 column — e.g.
+
+```sql
+CREATE INDEX adults_in_eng ON users (name) USING 'filtered'
+  WITH OPTIONS = {'filter': "age > 21 AND dept = 'eng'"}
+```
+
+is not yet supported. Delivering it soundly requires a coordinated change across
+several layers, which is why it is split out rather than half-wired:
+
+1. **Type / wire format (`ferrosa-index`)**: introduce a `FilterPredicate`
+   conjunction (e.g. `FilterPredicate { clauses: Vec<FilterClause> }` where a
+   `FilterClause` is the current `(column_position, op, value)`), keeping a
+   single-clause form for backward compatibility. `evaluate_predicate` becomes an
+   `all(clauses)` fold; `query_constraint_implies_predicate` must prove the query
+   implies **every** clause (the query's row-set must be a subset of the
+   intersection of each clause's retained set). This is the new serialized shape
+   persisted under `__filter_predicate`; bump a version tag so old single-clause
+   JSON still deserializes.
+2. **Build path (`ferrosa-storage`, `FilteredBuilder`/`LocalBackend::build`)**:
+   evaluate the conjunction per row (skip unless all clauses pass). The memtable
+   write path must use the same shared evaluator so sidecar and memtable agree.
+3. **CQL surface (`ferrosa-cql`)**: parse a conjunction from WITH OPTIONS. Either
+   keep the three-key form but allow repeated/indexed keys, or accept a single
+   `'filter'` string parsed as a CQL boolean expression restricted to
+   `col <op> literal AND ...`. Resolve each column's storage ordinal + encode
+   each literal to storage bytes (reuse `filter_value_to_term`). Fail loud on any
+   unparseable clause.
+4. **Planner (`router.rs`)**: `filtered_index_covered_columns` must mark **all**
+   conjunction columns covered, and `query_implies_filter_predicate` must require
+   the query to imply each clause (withhold if even one is not provably implied).
+5. **Remote builder (`ferrosa-index-builder`)**: no change beyond the predicate
+   already round-tripping — once `FilterPredicate` is the conjunction type, the
+   existing `filter_predicate` wire field carries it verbatim.
+
+### Soundness requirement
+
+A multi-column partial index retains `rows where clause_1 AND clause_2 AND ...`.
+The planner may serve a query from it only when the query's filter-column
+constraints provably imply **every** clause (per-clause subset containment via
+`query_constraint_implies_predicate`). If any clause is not implied, withhold the
+index — serving it would silently drop rows. The completeness test must enumerate
+both directions, including the case where one clause is implied but another is
+not (must withhold).
+
+### Tests to add (TDD)
+
+- `ferrosa-index`: conjunction `evaluate_predicate` (all-clauses fold) and
+  `query_constraint_implies_predicate` over a 2-clause predicate, enumerating
+  true-positive and withheld (one-clause-missing) cases.
+- `ferrosa-cql`: end-to-end CREATE with a 2-column filter; a query implying both
+  clauses uses the index and returns exactly the matching rows; a query implying
+  only one clause is withheld and (with ALLOW FILTERING) returns the complete set.
+- Persistence round-trip of the conjunction predicate through `system_schema.indexes`.


### PR DESCRIPTION
## What shipped

Follow-on to the Filtered partial index (commit `e7762b32`). Two of the three requested follow-ons land as a coherent, sound vertical slice; the third (multi-column conjunction) is deferred with a spec.

### 1. RANGE-implication soundness (planner)
The planner now serves a filtered index when the query's value-set on the filter column is a **provable subset** of the index's retained set — not just Eq-implies-Eq.

- New `ferrosa_index::query_constraint_implies_predicate(query_op, query_value, predicate)` — sound subset-containment over the byte ordering used by `evaluate_predicate`. Handles Eq/NotEq/Lt/Gt/LtEq/GtEq predicates against Eq/range queries. Returns `true` ONLY when containment is provable; withholds otherwise.
- `router::query_implies_filter_predicate` maps every scalar `ComparisonOp` to a `FilterOp` (via `comparison_to_filter_op`) and calls the helper. Multi-value/pattern ops (`IN`/`CONTAINS`/`LIKE`/…) withhold.
- `build_filter_predicate_from_options` now coerces the `filter_value` string to the column's CQL type (`filter_value_to_term`), so numeric partial predicates (`age int`, `filter_op:'>'`, `filter_value:'21'`) are accepted at CREATE instead of failing a string-vs-int type check.

Examples now accelerated: `age = 30`, `age > 25`, `age >= 22` all imply `age > 21`. Withheld: `age > 10`, `age >= 21` (admit excluded rows) → FullScan + post-filter, complete result.

### 3. Native remote-builder predicate support
The remote builder now filters at build time instead of forcing a local fallback.

- `ferrosa-storage`: extracted `build_request_body`, which serializes the `FilterPredicate` into the request under `filter_predicate` (omitted for non-filtered jobs). Removed the Filtered local-only short-circuit in `RemoteBackend::build`.
- `ferrosa-index-builder`: `BuildRequest` gains `filter_predicate`; `parse_index_type` recognizes `"filtered"`; new `build_job` threads the predicate into `IndexBuildJob` so `LocalBackend::build` (shared evaluator) skips non-matching rows.

## Deferred
**Item 2 (multi-column conjunction filter)** — requires changing the persisted `FilterPredicate` wire shape to a conjunction across the index/storage/CQL/planner layers; too large for one sound green slice. Captured in `specs/todo/filtered-index-multi-column-predicate.md` with the per-layer plan, the per-clause soundness requirement, and the TDD test list.

## Test evidence
- `ferrosa-index`: `query_constraint_implies_predicate_enumeration` — enumerates true-positive AND withheld cases for all predicate ops, cross-checked against `evaluate_predicate` so no claimed implication admits a non-retained value.
- `ferrosa-cql`: `filtered_index_used_when_query_implies_range_predicate` (age=30/>25/>=22 accelerated, exact rows) and `filtered_index_withheld_when_query_does_not_imply_range_predicate` (age>10/>=21 → FullScan, complete set via ALLOW FILTERING).
- `ferrosa-storage`: `filtered_job_request_body_carries_predicate`, `non_filtered_job_request_body_omits_predicate`.
- `ferrosa-index-builder`: `build_request_threads_filter_predicate_into_job`, `build_request_without_predicate_yields_none`, `parse_index_types` (filtered).

Local green: `cargo fmt --check`, `cargo clippy --all-targets` (workspace), `cargo build --all-targets` (workspace), and `cargo test` for ferrosa-index, ferrosa-index-builder, ferrosa-schema, ferrosa-storage, ferrosa-cql all pass.