### PR TITLE
fix(storage): retry stale-view reads during compaction instead of losing data

### DIFF
--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -11861,6 +11861,94 @@ mod tests {
         handle.join().unwrap();
     }
 
+    /// Deterministic reproduction of the read-vs-compaction data-loss race that
+    /// `concurrent_read_during_compaction` only hit under CI coverage timing. A
+    /// read snapshots the view (still referencing gen2, which solely holds `t2`),
+    /// pauses at a test barrier, and a compaction then merges gen1+gen2 into one
+    /// SSTable and deletes the inputs. When the read resumes it fails to open the
+    /// deleted gen2; it must NOT silently return `Ok(None)` but retry against the
+    /// new view, where the merged SSTable still holds `t2`.
+    #[tokio::test]
+    async fn read_during_compaction_retries_against_new_view() {
+        use crate::store::read_race_test_hook::{ReadViewBarrier, ARMED};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = StorageEngineConfig::test_config(dir.path());
+        config.compaction.min_threshold = 2;
+        let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        // t1 -> gen1, t2 -> gen2. t2 lives ONLY in gen2 (no survivor SSTable).
+        engine
+            .write(&tid, &make_key("t1"), make_row(b"v1", 1000), 1000)
+            .unwrap();
+        engine.flush(&tid).unwrap();
+        engine
+            .write(&tid, &make_key("t2"), make_row(b"v2", 2000), 2000)
+            .unwrap();
+        engine.flush(&tid).unwrap();
+        assert_eq!(engine.sstable_count(&tid), 2);
+
+        // Submit a compaction merging gen1+gen2 and wait until the merged output
+        // is PRODUCED — but not yet swapped in (poll_compactions applies the swap
+        // and deletes the inputs; we control exactly when that happens).
+        {
+            let tables = engine.tables.read();
+            let state = tables.get(&tid).unwrap();
+            let metadata = engine.collect_sstable_metadata(&tid, state);
+            drop(tables);
+            let task = crate::compaction::metadata::CompactionTask {
+                inputs: metadata,
+                output_dir: dir.path().join("compaction"),
+                schema: test_schema(),
+                table_id: tid.clone(),
+            };
+            engine.compaction_executor.submit(task).unwrap();
+        }
+        // Reader thread: arm it so its read pauses right after snapshotting the
+        // still-unswapped view (referencing gen2).
+        let barrier = ReadViewBarrier::new();
+        let b_reader = Arc::clone(&barrier);
+        let eng = Arc::clone(&engine);
+        let rtid = tid.clone();
+        let reader = std::thread::spawn(move || {
+            ARMED.with(|c| *c.borrow_mut() = Some(b_reader));
+            eng.read(&rtid, &make_key("t2"))
+                .expect("read must not error")
+        });
+
+        // With the read holding the old view, drive the swap to completion:
+        // poll until the background merge finishes and poll_compactions applies
+        // it (view -> merged, gen1/gen2 files deleted) out from under the read.
+        // The bound is a generous hang-guard (~30s), NOT a timing assertion: the
+        // background merge always completes, but under a fully parallel test run
+        // the executor thread can be heavily starved, so we wait it out rather
+        // than racing a fixed deadline.
+        barrier.wait_reached();
+        let mut swapped = false;
+        for _ in 0..1500 {
+            engine.poll_compactions().await;
+            if engine.sstable_count(&tid) == 1 {
+                swapped = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            swapped,
+            "compaction swap should merge the two inputs into one (background merge never completed)"
+        );
+        barrier.release();
+
+        let got = reader.join().unwrap();
+        assert!(
+            got.is_some(),
+            "t2 must remain readable across a concurrent compaction that deleted its SSTable"
+        );
+    }
+
     #[test]
     fn commit_log_position_exposed() {
         let dir = tempfile::tempdir().unwrap();

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -709,6 +709,63 @@ pub fn filter_tombstoned_sidecar_entries(
     entries.retain(|_, positions| !positions.is_empty());
 }
 
+/// Test-only deterministic hook for the read-vs-compaction race. A read, right
+/// after it snapshots the store view, pauses at an armed barrier so a test can
+/// interpose a full compaction (view swap + input-file deletion) before the read
+/// opens its SSTables — reproducing the stale-view condition every time instead
+/// of relying on timing.
+#[cfg(test)]
+pub(crate) mod read_race_test_hook {
+    use std::sync::{Arc, Condvar, Mutex};
+
+    /// One-shot rendezvous between a paused read and the test driving it.
+    #[derive(Default)]
+    pub struct ReadViewBarrier {
+        /// `(reached, released)`.
+        state: Mutex<(bool, bool)>,
+        cv: Condvar,
+    }
+
+    impl ReadViewBarrier {
+        pub fn new() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+
+        /// Reader side: signal that the view is snapshotted, then block until
+        /// the test releases.
+        pub(crate) fn reach_and_wait(&self) {
+            let mut g = self.state.lock().unwrap();
+            g.0 = true;
+            self.cv.notify_all();
+            while !g.1 {
+                g = self.cv.wait(g).unwrap();
+            }
+        }
+
+        /// Test side: block until the read has snapshotted its view.
+        pub fn wait_reached(&self) {
+            let mut g = self.state.lock().unwrap();
+            while !g.0 {
+                g = self.cv.wait(g).unwrap();
+            }
+        }
+
+        /// Test side: let the paused read proceed.
+        pub fn release(&self) {
+            let mut g = self.state.lock().unwrap();
+            g.1 = true;
+            self.cv.notify_all();
+        }
+    }
+
+    thread_local! {
+        /// When set on a thread, that thread's next `read_limited_rows` pauses
+        /// once at the barrier right after snapshotting the view.
+        pub static ARMED: std::cell::RefCell<Option<Arc<ReadViewBarrier>>> =
+            const { std::cell::RefCell::new(None) };
+    }
+}
+
 impl<F: FlushTarget> TableStore<F> {
     /// Create a new `TableStore` with an empty memtable and no SSTables.
     pub fn new(schema: TableSchema, flush_target: F, options: WriteOptions) -> Self {
@@ -1218,9 +1275,46 @@ impl<F: FlushTarget> TableStore<F> {
         key: &DecoratedKey,
         row_limit: usize,
     ) -> Result<Option<Partition>> {
+        // A read takes an atomic snapshot of the store view. If an SSTable in
+        // that snapshot is concurrently compacted away (its local file deleted)
+        // before we open it, the data has already moved into a new SSTable in a
+        // newer view — so reload and retry instead of returning a partial result
+        // that silently drops the key (a fail-loud violation). Bounded so a
+        // genuinely corrupt/missing file still falls through to tolerant handling.
+        const MAX_VIEW_RETRIES: usize = 8;
+        for attempt in 0..=MAX_VIEW_RETRIES {
+            let view = self.view.load_full();
+
+            #[cfg(test)]
+            if let Some(barrier) = read_race_test_hook::ARMED.with(|c| c.borrow_mut().take()) {
+                barrier.reach_and_wait();
+            }
+
+            let (result, sstable_open_failed) = self.read_with_view(&view, key, row_limit)?;
+            if sstable_open_failed
+                && attempt < MAX_VIEW_RETRIES
+                && !Arc::ptr_eq(&view, &self.view.load_full())
+            {
+                continue;
+            }
+            return Ok(result);
+        }
+        unreachable!("read retry loop returns within MAX_VIEW_RETRIES")
+    }
+
+    /// One attempt of [`read_limited_rows`] against a fixed `view` snapshot.
+    /// Returns the merged partition (if any) plus whether any SSTable failed to
+    /// open — the signal the caller uses to retry against a fresh view when the
+    /// view was concurrently swapped by compaction.
+    fn read_with_view(
+        &self,
+        guard: &StoreView,
+        key: &DecoratedKey,
+        row_limit: usize,
+    ) -> Result<(Option<Partition>, bool)> {
         let started = Instant::now();
-        let guard = self.view.load();
         let schema = self.schema.load();
+        let mut sstable_open_failed = false;
 
         let mut sources: Vec<Partition> = Vec::new();
         let mut memtable_hits = 0u64;
@@ -1265,6 +1359,7 @@ impl<F: FlushTarget> TableStore<F> {
                     self.sstable_read_errors
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     sstable_errors += 1;
+                    sstable_open_failed = true;
                     continue;
                 }
             };
@@ -1315,7 +1410,7 @@ impl<F: FlushTarget> TableStore<F> {
                 sstable_hits,
                 sstable_errors,
             );
-            return Ok(None);
+            return Ok((None, sstable_open_failed));
         }
 
         let mut merged = merge::merge_partitions(sources);
@@ -1333,7 +1428,7 @@ impl<F: FlushTarget> TableStore<F> {
             sstable_hits,
             sstable_errors,
         );
-        Ok(Some(merged))
+        Ok((Some(merged), sstable_open_failed))
     }
 
     /// Read exactly one clustered row from a partition by clustering-key


### PR DESCRIPTION
## What

`read_limited_rows` takes a single atomic snapshot of the store view. If a concurrent compaction deletes an input SSTable's local file **before** the read opens it, `open_reader` fails — and the point-read loop **swallowed** that error (`continue`) and returned `Ok(None)`, silently dropping a key whose data had already moved into the merged SSTable of a newer view.

This is the real bug behind the intermittently-"flaky" `concurrent_read_during_compaction` test. It's not flaky — the test's invariant ("k2 must always be readable") is correct; the code was wrong. The window only widened enough to fail under CI's coverage-instrumented timing.

## Fix

When an SSTable open fails **and** the view was concurrently swapped (compaction), reload and retry against the fresh view (which holds the merged SSTable). Bounded retry: a genuinely corrupt/missing file (view unchanged) still falls through to the existing tolerant handling — no behavior change for that case.

## Test (deterministic, TDD)

`read_during_compaction_retries_against_new_view` reproduces the race **every run** via a `#[cfg(test)]` thread-local barrier: it pauses a read right after it snapshots the view, lets the test apply a full compaction (swap + input-file delete), then resumes the read.

- **Proven RED→GREEN**: retry disabled → fails on "t2 must remain readable"; retry enabled → passes.
- **No flake**: green across 3 full `ferrosa-storage` lib-suite runs (865 tests each); fmt + clippy clean.

Closes the intermittent failure seen on #101/#102 CI.