### PR TITLE
chore: rename /op-init references to /warp in onboarding docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /releases/
 
 # .claude/skills/ contains symlinks to the research repo (~/.claude/skills/).
-# Other developers: run setup.sh from the research repo, then re-link with /op-init.
+# Other developers: run setup.sh from the research repo, then re-link with /warp.
 .worktrees/
 .claude/worktrees/
 .fastembed_cache/

--- a/setup-precommit.sh
+++ b/setup-precommit.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # setup-precommit.sh — Install pre-commit and configure hooks for this project
 #
-# Copied to projects by /op-init. Run once after cloning:
+# Copied to projects by /warp. Run once after cloning:
 #   ./setup-precommit.sh
 #
 # What it does:


### PR DESCRIPTION
The op-init skill was renamed to warp. Update the two onboarding doc references (.gitignore comment + setup-precommit.sh header) to match. Docs-only.