### PR TITLE
feat(index): multi-column conjunction filter predicates for partial indexes

### DIFF
--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -6796,29 +6796,89 @@ fn filter_value_to_term(value: &str, cql_type: &CqlType) -> Result<Term, CqlErro
     }
 }
 
-/// Build a fully-encoded [`ferrosa_index::FilterPredicate`] from the WITH
-/// OPTIONS of a `CREATE INDEX ... USING 'filtered'` statement.
+/// Build one fully-encoded [`ferrosa_index::FilterClause`] from a
+/// `(column, op, value)` triple, resolving the column's **storage** ordinal and
+/// encoding the value to storage bytes. Every failure is loud — a partial index
+/// with a broken clause would silently index the wrong rows.
+fn build_filter_clause(
+    state: &SharedState,
+    ks: &str,
+    table: &str,
+    column: &str,
+    op_str: &str,
+    value_str: &str,
+) -> Result<ferrosa_index::FilterClause, CqlError> {
+    let op = parse_filter_op(op_str)?;
+
+    let snap = state.schema.snapshot();
+    let table_meta = snap
+        .tables
+        .get(&(ks.to_string(), table.to_string()))
+        .ok_or_else(|| CqlError::Invalid(format!("table {ks}.{table} not found")))?;
+
+    // Storage ordinal of the filter column: the cell tag the build/memtable
+    // paths compare the clause against.
+    let column_position = table_meta.storage_column_index(column).ok_or_else(|| {
+        CqlError::Invalid(format!(
+            "filtered index filter column '{column}' is not a column of {ks}.{table}"
+        ))
+    })? as usize;
+
+    let col_meta = table_meta
+        .columns
+        .get(column)
+        .ok_or_else(|| CqlError::Invalid(format!("filter column '{column}' not found")))?;
+    let cql_type = resolve_col_type(&col_meta.column_type, ks, &state.schema)?;
+    // The WITH OPTIONS map always carries the filter value as a string. Coerce
+    // it to the term shape the column's type expects (e.g. `'21'` on an `int`
+    // column becomes an integer literal) before encoding — otherwise a numeric
+    // partial predicate would be rejected as a type mismatch at CREATE time.
+    let term = filter_value_to_term(value_str, &cql_type)?;
+    let cql_value = bridge::term_to_cql_value(&term, &cql_type)?;
+    let value = crate::types::encode_value(&cql_value);
+
+    Ok(ferrosa_index::FilterClause::new(column_position, op, value))
+}
+
+/// Build a fully-encoded [`ferrosa_index::FilterPredicate`] (a conjunction of
+/// one or more clauses) from the WITH OPTIONS of a
+/// `CREATE INDEX ... USING 'filtered'` statement.
 ///
-/// Required options: `filter_column` (the partial-predicate column),
-/// `filter_op` (one of `=`,`!=`,`<`,`>`,`<=`,`>=`), and `filter_value` (a CQL
-/// literal parsed against the filter column's type). The predicate's
-/// `column_position` is the filter column's **storage** ordinal (statics then
-/// regulars, name-sorted) so it matches the cell ordinal the build/memtable
-/// paths compare against. The `value` is encoded to storage bytes here so the
-/// storage layer never needs the CQL type system.
+/// Two accepted forms:
+/// - **Single string** `{'filter': "col <op> lit [AND col <op> lit]..."}` — a
+///   conjunction parsed from a restricted CQL boolean expression. This is the
+///   multi-column form.
+/// - **Legacy three-key** `{'filter_column': .., 'filter_op': .., 'filter_value':
+///   ..}` — a single clause, preserved for backward compatibility.
 ///
 /// Every missing/invalid option fails loud — a partial index with a broken
-/// predicate would silently index every row, an unsound result.
+/// predicate would silently index the wrong rows, an unsound result.
 fn build_filter_predicate_from_options(
     state: &SharedState,
     ks: &str,
     table: &str,
     options: &HashMap<String, String>,
 ) -> Result<ferrosa_index::FilterPredicate, CqlError> {
+    // Preferred form: a single `'filter'` conjunction string.
+    if let Some(filter_expr) = options.get("filter") {
+        let parsed = parse_filter_conjunction(filter_expr)?;
+        let clauses = parsed
+            .into_iter()
+            .map(|(col, op, val)| build_filter_clause(state, ks, table, &col, &op, &val))
+            .collect::<Result<Vec<_>, _>>()?;
+        if clauses.is_empty() {
+            return Err(CqlError::Invalid(
+                "filtered index 'filter' expression parsed to zero clauses".into(),
+            ));
+        }
+        return Ok(ferrosa_index::FilterPredicate::conjunction(clauses));
+    }
+
+    // Legacy single-clause three-key form.
     let filter_column = options.get("filter_column").ok_or_else(|| {
         CqlError::Invalid(
-            "filtered index requires WITH OPTIONS = {'filter_column': ..., 'filter_op': ..., \
-             'filter_value': ...}; missing 'filter_column'"
+            "filtered index requires WITH OPTIONS = {'filter': \"col <op> lit AND ...\"} or the \
+             legacy {'filter_column': ..., 'filter_op': ..., 'filter_value': ...}; missing both"
                 .into(),
         )
     })?;
@@ -6829,42 +6889,92 @@ fn build_filter_predicate_from_options(
         CqlError::Invalid("filtered index WITH OPTIONS missing 'filter_value'".into())
     })?;
 
-    let op = parse_filter_op(filter_op_str)?;
+    let clause = build_filter_clause(state, ks, table, filter_column, filter_op_str, filter_value)?;
+    Ok(ferrosa_index::FilterPredicate::conjunction(vec![clause]))
+}
 
-    let snap = state.schema.snapshot();
-    let table_meta = snap
-        .tables
-        .get(&(ks.to_string(), table.to_string()))
-        .ok_or_else(|| CqlError::Invalid(format!("table {ks}.{table} not found")))?;
+/// Parse a restricted CQL boolean conjunction `col <op> literal [AND col <op>
+/// literal]...` into `(column, op_str, value_str)` triples. The op tokens are
+/// the same symbols [`parse_filter_op`] accepts (`=`,`!=`,`<`,`>`,`<=`,`>=`).
+/// String literals may be single-quoted (`'eng'`); the quotes are stripped.
+/// Any unparseable clause fails loud rather than being silently dropped.
+fn parse_filter_conjunction(expr: &str) -> Result<Vec<(String, String, String)>, CqlError> {
+    // Split on the word `AND` (case-insensitive), surrounded by whitespace.
+    let mut clauses = Vec::new();
+    for raw in split_on_and(expr) {
+        let clause = raw.trim();
+        if clause.is_empty() {
+            continue;
+        }
+        let (column, op, value) = split_clause(clause)?;
+        clauses.push((column, op, value));
+    }
+    if clauses.is_empty() {
+        return Err(CqlError::Invalid(format!(
+            "filtered index 'filter' expression '{expr}' has no clauses"
+        )));
+    }
+    Ok(clauses)
+}
 
-    // Storage ordinal of the filter column: the cell tag the build/memtable
-    // paths compare the predicate against.
-    let column_position = table_meta
-        .storage_column_index(filter_column)
+/// Split a conjunction expression on the keyword `AND` (case-insensitive),
+/// matched only as a whole whitespace-delimited token so column/value text
+/// containing the substring "and" is not split.
+fn split_on_and(expr: &str) -> Vec<String> {
+    let tokens: Vec<&str> = expr.split_whitespace().collect();
+    let mut out = Vec::new();
+    let mut current: Vec<&str> = Vec::new();
+    for tok in tokens {
+        if tok.eq_ignore_ascii_case("and") {
+            out.push(current.join(" "));
+            current.clear();
+        } else {
+            current.push(tok);
+        }
+    }
+    out.push(current.join(" "));
+    out
+}
+
+/// Split a single clause `col <op> literal` into its three parts. The operator
+/// is matched greedily (two-char ops `<=`/`>=`/`!=` before single-char) so
+/// `age>=21` and `age >= 21` both parse. The literal has surrounding single
+/// quotes stripped.
+fn split_clause(clause: &str) -> Result<(String, String, String), CqlError> {
+    // Two-char operators must be tried before single-char to avoid `>=` parsing
+    // as `>`.
+    const TWO_CHAR: &[&str] = &["<=", ">=", "!="];
+    const ONE_CHAR: &[&str] = &["=", "<", ">"];
+
+    let find_op = |ops: &[&str]| -> Option<(usize, usize)> {
+        ops.iter()
+            .filter_map(|op| clause.find(op).map(|idx| (idx, op.len())))
+            .min_by_key(|(idx, _)| *idx)
+    };
+
+    let (op_idx, op_len) = find_op(TWO_CHAR)
+        .or_else(|| find_op(ONE_CHAR))
         .ok_or_else(|| {
             CqlError::Invalid(format!(
-                "filtered index filter_column '{filter_column}' is not a column of {ks}.{table}"
-            ))
-        })? as usize;
+            "filtered index clause '{clause}' has no comparison operator (expected =,!=,<,>,<=,>=)"
+        ))
+        })?;
 
-    let col_meta = table_meta
-        .columns
-        .get(filter_column)
-        .ok_or_else(|| CqlError::Invalid(format!("filter_column '{filter_column}' not found")))?;
-    let cql_type = resolve_col_type(&col_meta.column_type, ks, &state.schema)?;
-    // The WITH OPTIONS map always carries the filter value as a string. Coerce
-    // it to the term shape the column's type expects (e.g. `'21'` on an `int`
-    // column becomes an integer literal) before encoding — otherwise a numeric
-    // partial predicate would be rejected as a type mismatch at CREATE time.
-    let term = filter_value_to_term(filter_value, &cql_type)?;
-    let cql_value = bridge::term_to_cql_value(&term, &cql_type)?;
-    let value = crate::types::encode_value(&cql_value);
-
-    Ok(ferrosa_index::FilterPredicate {
-        column_position,
-        op,
-        value,
-    })
+    let column = clause[..op_idx].trim().to_string();
+    let op = clause[op_idx..op_idx + op_len].to_string();
+    let value_raw = clause[op_idx + op_len..].trim();
+    if column.is_empty() || value_raw.is_empty() {
+        return Err(CqlError::Invalid(format!(
+            "filtered index clause '{clause}' is malformed (expected 'column <op> literal')"
+        )));
+    }
+    // Strip a single pair of surrounding single quotes from string literals.
+    let value = value_raw
+        .strip_prefix('\'')
+        .and_then(|s| s.strip_suffix('\''))
+        .unwrap_or(value_raw)
+        .to_string();
+    Ok((column, op, value))
 }
 
 /// Soundness gate for partial (Filtered) indexes.
@@ -6896,29 +7006,53 @@ fn query_implies_filter_predicate(
     schema: &Schema,
     predicate: &ferrosa_index::FilterPredicate,
 ) -> bool {
+    // Conjunction soundness: the index retains rows where EVERY clause holds, so
+    // the query may serve from it ONLY when each clause is provably implied by
+    // some WHERE constraint on that clause's column. If even one clause is not
+    // implied, withhold the index — serving it would silently drop rows.
+    let clauses = predicate.clauses();
+    if clauses.is_empty() {
+        return false;
+    }
+    clauses
+        .iter()
+        .all(|clause| clause_implied_by_where(clause, where_clauses, table_meta, ks, schema))
+}
+
+/// Is a single filter `clause` provably implied by some WHERE constraint on the
+/// clause's own column? Scans the WHERE clauses for a scalar comparison on the
+/// clause column whose value-set is a provable subset of the clause's retained
+/// set (per [`ferrosa_index::query_constraint_implies_predicate_clause`]).
+fn clause_implied_by_where(
+    clause: &ferrosa_index::FilterClause,
+    where_clauses: &[WhereClause],
+    table_meta: &TableMetadata,
+    ks: &str,
+    schema: &Schema,
+) -> bool {
     for wc in where_clauses {
         if wc.token_fn {
             continue;
         }
         // Map the WHERE op to a filter op; only scalar comparisons can imply a
-        // partial predicate (IN/CONTAINS/LIKE/etc. are not handled and withhold).
+        // clause (IN/CONTAINS/LIKE/etc. are not handled and withhold).
         let Some(query_op) = comparison_to_filter_op(&wc.op) else {
             continue;
         };
-        // Match the WHERE column to the predicate's filter column by storage
-        // ordinal — the same ordinal the predicate was built with.
+        // Match the WHERE column to the clause's column by storage ordinal — the
+        // same ordinal the clause was built with.
         let Some(storage_idx) = table_meta.storage_column_index(&wc.column) else {
             continue;
         };
-        if storage_idx as usize != predicate.column_position {
+        if storage_idx as usize != clause.column_position {
             continue;
         }
-        // Encode the query's literal the same way the predicate value was
-        // encoded, then check subset containment in that byte space.
+        // Encode the query's literal the same way the clause value was encoded,
+        // then check subset containment in that byte space.
         let Ok(key) = term_to_index_key(&wc.value, &wc.column, table_meta, ks, schema) else {
             continue;
         };
-        if ferrosa_index::query_constraint_implies_predicate(query_op, &key.0, predicate) {
+        if ferrosa_index::query_constraint_implies_predicate_clause(query_op, &key.0, clause) {
             return true;
         }
     }
@@ -6963,12 +7097,16 @@ fn filtered_index_covered_columns(
         let Some(pred) = meta.filter_predicate.as_ref() else {
             continue;
         };
-        for (name, _) in table_meta.columns.iter() {
-            if table_meta.storage_column_index(name).map(|i| i as usize)
-                == Some(pred.column_position)
-            {
-                covered.push(name.clone());
-                break;
+        // Mark EVERY conjunction clause's column covered: the partial index has
+        // already enforced all of them, so the planner need not re-filter any.
+        for clause in pred.clauses() {
+            for (name, _) in table_meta.columns.iter() {
+                if table_meta.storage_column_index(name).map(|i| i as usize)
+                    == Some(clause.column_position)
+                {
+                    covered.push(name.clone());
+                    break;
+                }
             }
         }
     }
@@ -10810,6 +10948,45 @@ mod tests {
                 &superuser_auth(),
             )
             .unwrap();
+    }
+
+    #[test]
+    fn parse_filter_conjunction_single_and_multi_clause() {
+        // Single clause.
+        let parsed = parse_filter_conjunction("age > 21").unwrap();
+        assert_eq!(parsed, vec![("age".into(), ">".into(), "21".into())]);
+
+        // Two clauses, mixed ops, quoted string literal stripped.
+        let parsed = parse_filter_conjunction("age >= 21 AND dept = 'eng'").unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                ("age".into(), ">=".into(), "21".into()),
+                ("dept".into(), "=".into(), "eng".into()),
+            ]
+        );
+
+        // Case-insensitive AND, no spaces around the operator.
+        let parsed = parse_filter_conjunction("a<=5 and b!='x'").unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                ("a".into(), "<=".into(), "5".into()),
+                ("b".into(), "!=".into(), "x".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_filter_conjunction_rejects_malformed() {
+        // No operator.
+        assert!(parse_filter_conjunction("age 21").is_err());
+        // Missing value.
+        assert!(parse_filter_conjunction("age >").is_err());
+        // Missing column.
+        assert!(parse_filter_conjunction("> 21").is_err());
+        // Empty expression.
+        assert!(parse_filter_conjunction("   ").is_err());
     }
 
     #[test]
@@ -17123,6 +17300,107 @@ mod tests {
             2,
         )
         .await;
+    }
+
+    /// Filtered (partial) index with a MULTI-COLUMN conjunction predicate
+    /// (`age > 21 AND dept = 'eng'`). The index retains rows where BOTH clauses
+    /// hold. A query implying both clauses uses the index and returns exactly
+    /// the matching rows; a query implying only ONE clause is withheld (serving
+    /// it would drop rows) and, with ALLOW FILTERING, returns the complete set.
+    #[tokio::test]
+    async fn filtered_index_multi_column_conjunction_end_to_end() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ks = None;
+        let ctx = test_ctx(&auth, &ks);
+        for cql in [
+            "CREATE KEYSPACE fmc WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE fmc.people (id int PRIMARY KEY, name text, age int, dept text)",
+            // Partial index on `name`, retaining only rows with age > 21 AND
+            // dept = 'eng' (the multi-column conjunction `filter` form).
+            "CREATE INDEX fmc_eng_adults ON fmc.people (name) USING 'filtered' \
+             WITH OPTIONS = {'filter': 'age > 21 AND dept = ''eng'''}",
+            // id=1: age 30, eng  -> BOTH clauses hold  -> indexed.
+            "INSERT INTO fmc.people (id, name, age, dept) VALUES (1, 'alice', 30, 'eng')",
+            // id=2: age 18, eng  -> age fails           -> excluded.
+            "INSERT INTO fmc.people (id, name, age, dept) VALUES (2, 'alice', 18, 'eng')",
+            // id=3: age 40, sales-> dept fails          -> excluded.
+            "INSERT INTO fmc.people (id, name, age, dept) VALUES (3, 'alice', 40, 'sales')",
+            // id=4: age 26, eng  -> BOTH clauses hold   -> indexed.
+            "INSERT INTO fmc.people (id, name, age, dept) VALUES (4, 'alice', 26, 'eng')",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        // Query implies BOTH clauses: age = 30 ⊆ {age>21} and dept = 'eng' ⊆
+        // {dept='eng'}. The index is usable and returns exactly id=1.
+        let q = "SELECT id FROM fmc.people WHERE name = 'alice' AND age = 30 AND dept = 'eng'";
+        assert_explain_plan(&state, &ctx, q, "fmc_eng_adults").await;
+        let count = assert_index_hit_and_count(&state, &ctx, q, 1).await;
+        assert_eq!(count, 1, "age=30 AND dept=eng implies both clauses, 1 row");
+
+        // Query implies BOTH via a range on age: age > 25 ⊆ {age>21}, dept eng.
+        // id=1 (30) and id=4 (26) are both in the index.
+        let q = "SELECT id FROM fmc.people WHERE name = 'alice' AND age > 25 AND dept = 'eng'";
+        assert_explain_plan(&state, &ctx, q, "fmc_eng_adults").await;
+        let count = assert_index_hit_and_count(&state, &ctx, q, 1).await;
+        assert_eq!(count, 2, "age>25 AND dept=eng implies both clauses, 2 rows");
+
+        // Withheld: implies ONLY the age clause (dept is unconstrained). Using
+        // the index would drop the genuinely-retained eng rows that this query
+        // also wants via the dept-agnostic predicate; serving it is unsound.
+        // The plan must be FullScan and, with ALLOW FILTERING, return the full
+        // set of alices with age>25 (id=1 age30 eng, id=3 age40 sales, id=4
+        // age26 eng).
+        let q = "SELECT id FROM fmc.people WHERE name = 'alice' AND age > 25";
+        {
+            let stmt = crate::parser::parse(&format!("EXPLAIN {q}")).unwrap();
+            match route(&state, &ctx, stmt).await.unwrap() {
+                RouteResult::Result(b) => {
+                    let haystack = String::from_utf8_lossy(&b).into_owned();
+                    assert!(
+                        !haystack.contains("fmc_eng_adults"),
+                        "partial index must be withheld when only one clause is implied, got: {haystack}"
+                    );
+                    assert!(
+                        haystack.contains("FullScan"),
+                        "withheld query must fall to FullScan, got: {haystack}"
+                    );
+                }
+                _ => panic!("expected Result from EXPLAIN"),
+            }
+            let count =
+                assert_index_hit_and_count(&state, &ctx, &format!("{q} ALLOW FILTERING"), 0).await;
+            assert_eq!(
+                count, 3,
+                "withheld query returns the complete set (3 alices with age>25)"
+            );
+        }
+
+        // Withheld: implies ONLY the dept clause (age unconstrained).
+        let q = "SELECT id FROM fmc.people WHERE name = 'alice' AND dept = 'eng'";
+        {
+            let stmt = crate::parser::parse(&format!("EXPLAIN {q}")).unwrap();
+            match route(&state, &ctx, stmt).await.unwrap() {
+                RouteResult::Result(b) => {
+                    let haystack = String::from_utf8_lossy(&b).into_owned();
+                    assert!(
+                        !haystack.contains("fmc_eng_adults"),
+                        "partial index must be withheld when only the dept clause is implied, got: {haystack}"
+                    );
+                }
+                _ => panic!("expected Result from EXPLAIN"),
+            }
+            // All eng alices regardless of age: id=1 (30), id=2 (18), id=4 (26).
+            let count =
+                assert_index_hit_and_count(&state, &ctx, &format!("{q} ALLOW FILTERING"), 0).await;
+            assert_eq!(
+                count, 3,
+                "withheld dept-only query returns all 3 eng alices"
+            );
+        }
     }
 
     /// CREATE INDEX ... USING 'filtered' with a missing/invalid predicate option

--- a/ferrosa-index-builder/src/worker.rs
+++ b/ferrosa-index-builder/src/worker.rs
@@ -368,11 +368,7 @@ mod tests {
     fn build_request_threads_filter_predicate_into_job() {
         use ferrosa_index::{FilterOp, FilterPredicate};
 
-        let predicate = FilterPredicate {
-            column_position: 1,
-            op: FilterOp::Gt,
-            value: vec![0, 0, 0, 21],
-        };
+        let predicate = FilterPredicate::single(1, FilterOp::Gt, vec![0, 0, 0, 21]);
         // Construct the request the way the engine sends it (JSON), to prove the
         // wire field deserializes.
         let json = serde_json::json!({

--- a/ferrosa-index/src/filtered.rs
+++ b/ferrosa-index/src/filtered.rs
@@ -8,91 +8,148 @@
 use ferrosa_common::CellValue;
 
 use crate::{
-    FilterOp, FilterPredicate, IndexBuilder, IndexCapabilities, IndexConfig, IndexFactory,
-    IndexFiles, IndexReader, IndexResult, IndexType,
+    FilterClause, FilterOp, FilterPredicate, IndexBuilder, IndexCapabilities, IndexConfig,
+    IndexFactory, IndexFiles, IndexReader, IndexResult, IndexType,
 };
 
 // ── Predicate evaluation ─────────────────────────────────────────────────────
 
-/// Evaluate a filter predicate against a cell value (raw bytes).
-///
-/// This is the single source of truth for partial-index predicate evaluation.
-/// The storage build path (`LocalBackend::build`) and the memtable write path
-/// both call this so a sidecar and its memtable companion agree on exactly
-/// which rows belong in a filtered index.
-pub fn evaluate_predicate(predicate: &FilterPredicate, cell_value: &[u8]) -> bool {
-    match predicate.op {
-        FilterOp::Eq => cell_value == predicate.value.as_slice(),
-        FilterOp::NotEq => cell_value != predicate.value.as_slice(),
-        FilterOp::Lt => cell_value < predicate.value.as_slice(),
-        FilterOp::Gt => cell_value > predicate.value.as_slice(),
-        FilterOp::LtEq => cell_value <= predicate.value.as_slice(),
-        FilterOp::GtEq => cell_value >= predicate.value.as_slice(),
+/// Evaluate one filter clause's operator against a single cell value (raw
+/// bytes). All comparisons use byte ordering — the same ordering the index was
+/// built in (the clause `value` and the cell both come from one storage
+/// encoding).
+pub fn evaluate_clause(clause: &FilterClause, cell_value: &[u8]) -> bool {
+    match clause.op {
+        FilterOp::Eq => cell_value == clause.value.as_slice(),
+        FilterOp::NotEq => cell_value != clause.value.as_slice(),
+        FilterOp::Lt => cell_value < clause.value.as_slice(),
+        FilterOp::Gt => cell_value > clause.value.as_slice(),
+        FilterOp::LtEq => cell_value <= clause.value.as_slice(),
+        FilterOp::GtEq => cell_value >= clause.value.as_slice(),
     }
+}
+
+/// Evaluate a filter predicate against a SINGLE cell value, treating every
+/// clause as applying to that one value (the single-column case). A conjunction
+/// over distinct columns must instead use [`evaluate_predicate_row`].
+///
+/// An empty conjunction retains nothing (`false`): a partial index with no
+/// clause would otherwise silently index every row.
+///
+/// This is the byte-level evaluator the planner soundness cross-check reasons
+/// against. The build/memtable gating uses [`evaluate_predicate_row`], which
+/// resolves each clause's own column.
+pub fn evaluate_predicate(predicate: &FilterPredicate, cell_value: &[u8]) -> bool {
+    !predicate.clauses.is_empty()
+        && predicate
+            .clauses
+            .iter()
+            .all(|clause| evaluate_clause(clause, cell_value))
+}
+
+/// Evaluate a (possibly multi-column) conjunction predicate against a row,
+/// resolving EACH clause's own column via `lookup`. A row is retained only when
+/// every clause's column is present (live cell) AND its value satisfies the
+/// clause. A missing or tombstoned clause column fails the whole conjunction
+/// (the row does not belong in the partial index).
+///
+/// This is the single source of truth for partial-index gating: the storage
+/// build path (`LocalBackend::build`) and the memtable write path both call it,
+/// so a sidecar and its memtable companion agree on exactly which rows belong.
+///
+/// An empty conjunction retains nothing (`false`).
+pub fn evaluate_predicate_row<'a, F>(predicate: &FilterPredicate, mut lookup: F) -> bool
+where
+    F: FnMut(usize) -> Option<&'a [u8]>,
+{
+    !predicate.clauses.is_empty()
+        && predicate.clauses.iter().all(|clause| {
+            lookup(clause.column_position).is_some_and(|v| evaluate_clause(clause, v))
+        })
 }
 
 // ── Predicate implication (planner soundness) ────────────────────────────────
 
-/// Does a query constraint `(query_op, query_value)` on a column GUARANTEE that
-/// every row it selects is also retained by the partial index `predicate`?
+/// Does a query constraint `(query_op, query_value)` GUARANTEE that every value
+/// it selects also satisfies a single `clause`? Subset containment in the byte
+/// ordering: `{x : query} ⊆ {x : clause}`.
 ///
-/// A filtered index physically holds exactly the rows for which
-/// [`evaluate_predicate`] returns `true`. The planner may serve a query from
-/// that index — treating the filter column as already enforced — ONLY when the
-/// query's value-set on the filter column is a guaranteed **subset** of the
-/// index's retained set. Otherwise the index is missing rows the query needs
-/// and the result would be silently incomplete.
-///
-/// This function returns `true` only when subset containment is *provable* from
-/// the byte ordering, and withholds (`false`) in every ambiguous case — it is
-/// SOUND, never optimistic. All comparisons use the same byte ordering as
-/// [`evaluate_predicate`], so the implication is reasoned in exactly the space
-/// the index was built in (the query literal and the predicate value both come
-/// from the same storage encoding).
+/// Returns `true` only when containment is *provable* from the byte ordering and
+/// withholds (`false`) in every ambiguous case — SOUND, never optimistic. All
+/// comparisons use the same byte ordering as [`evaluate_clause`].
 ///
 /// Examples (with value-order encodings such as ascending integers):
-/// - query `age = 30` implies predicate `age > 21` (the single value 30 is `> 21`)
-/// - query `age > 25` implies predicate `age > 21` (`{x>25} ⊆ {x>21}` since `25 >= 21`)
-/// - query `age >= 21` implies predicate `age > 20` (`{x>=21} ⊆ {x>20}` since `21 > 20`)
-/// - query `age = 18` does NOT imply `age > 21` (18 is not `> 21`) → withheld
-/// - query `age > 10` does NOT imply `age > 21` (selects values below 21) → withheld
-pub fn query_constraint_implies_predicate(
-    query_op: FilterOp,
-    query_value: &[u8],
-    predicate: &FilterPredicate,
-) -> bool {
+/// - query `age = 30` implies clause `age > 21` (the single value 30 is `> 21`)
+/// - query `age > 25` implies clause `age > 21` (`{x>25} ⊆ {x>21}` since `25 >= 21`)
+/// - query `age >= 21` implies clause `age > 20` (`{x>=21} ⊆ {x>20}` since `21 > 20`)
+/// - query `age = 18` does NOT imply `age > 21` → withheld
+/// - query `age > 10` does NOT imply `age > 21` → withheld
+pub fn query_clause_implies(query_op: FilterOp, query_value: &[u8], clause: &FilterClause) -> bool {
     let qv = query_value;
-    let pv = predicate.value.as_slice();
-    match predicate.op {
-        // Predicate retains a single value: only an identical Eq query is a subset.
+    let pv = clause.value.as_slice();
+    match clause.op {
+        // Clause retains a single value: only an identical Eq query is a subset.
         FilterOp::Eq => query_op == FilterOp::Eq && qv == pv,
-        // Predicate retains everything except `pv`: the query's set must exclude `pv`.
+        // Clause retains everything except `pv`: the query's set must exclude `pv`.
         FilterOp::NotEq => query_excludes_value(query_op, qv, pv),
-        // Predicate retains `{x < pv}`.
+        // Clause retains `{x < pv}`.
         FilterOp::Lt => match query_op {
             FilterOp::Eq => qv < pv,
             FilterOp::Lt => qv <= pv,
             FilterOp::LtEq => qv < pv,
             _ => false,
         },
-        // Predicate retains `{x <= pv}`.
+        // Clause retains `{x <= pv}`.
         FilterOp::LtEq => match query_op {
             FilterOp::Eq | FilterOp::Lt | FilterOp::LtEq => qv <= pv,
             _ => false,
         },
-        // Predicate retains `{x > pv}`.
+        // Clause retains `{x > pv}`.
         FilterOp::Gt => match query_op {
             FilterOp::Eq => qv > pv,
             FilterOp::Gt => qv >= pv,
             FilterOp::GtEq => qv > pv,
             _ => false,
         },
-        // Predicate retains `{x >= pv}`.
+        // Clause retains `{x >= pv}`.
         FilterOp::GtEq => match query_op {
             FilterOp::Eq | FilterOp::Gt | FilterOp::GtEq => qv >= pv,
             _ => false,
         },
     }
+}
+
+/// Single-column compatibility shim: does the query constraint imply EVERY
+/// clause of `predicate`, all evaluated against the same `query_value`? Only
+/// meaningful when every clause is on one column. Multi-column conjunctions must
+/// use [`query_constraint_implies_predicate_clause`] per clause with the query
+/// constraint on that clause's own column.
+///
+/// A filtered index physically holds exactly the rows for which
+/// [`evaluate_predicate`] returns `true`. The planner may serve a query from it
+/// ONLY when the query's value-set is a provable subset of the index's retained
+/// set; withholds otherwise.
+pub fn query_constraint_implies_predicate(
+    query_op: FilterOp,
+    query_value: &[u8],
+    predicate: &FilterPredicate,
+) -> bool {
+    !predicate.clauses.is_empty()
+        && predicate
+            .clauses
+            .iter()
+            .all(|clause| query_clause_implies(query_op, query_value, clause))
+}
+
+/// Per-clause implication for the multi-column planner: does the query
+/// constraint on this clause's column imply the clause? A thin alias of
+/// [`query_clause_implies`] kept as the planner-facing name.
+pub fn query_constraint_implies_predicate_clause(
+    query_op: FilterOp,
+    query_value: &[u8],
+    clause: &FilterClause,
+) -> bool {
+    query_clause_implies(query_op, query_value, clause)
 }
 
 /// Does the query constraint's value-set provably EXCLUDE the single value
@@ -174,26 +231,18 @@ impl IndexBuilder for FilteredBuilder {
         cells: &[CellValue],
         column_positions: &[usize],
     ) -> IndexResult<()> {
-        let filter_pos = self.predicate.column_position;
-        if filter_pos >= cells.len() {
-            // Filter column not present -> skip this row
-            return Ok(());
-        }
-
-        let cell = &cells[filter_pos];
-        match &cell.value {
-            Some(value) => {
-                if evaluate_predicate(&self.predicate, value) {
-                    self.inner
-                        .add_row(partition_key, clustering_key, cells, column_positions)
-                } else {
-                    Ok(())
-                }
-            }
-            None => {
-                // Tombstone -> does not match
-                Ok(())
-            }
+        // Conjunction gating: a row belongs in the partial index only when EVERY
+        // clause's column is present (live) and satisfies its comparison. A
+        // missing/tombstoned clause column fails the whole conjunction. The
+        // closure resolves each clause's own column position into `cells`.
+        let matches = evaluate_predicate_row(&self.predicate, |pos| {
+            cells.get(pos).and_then(|c| c.value.as_deref())
+        });
+        if matches {
+            self.inner
+                .add_row(partition_key, clustering_key, cells, column_positions)
+        } else {
+            Ok(())
         }
     }
 
@@ -214,11 +263,7 @@ mod tests {
     /// Helper: build a predicate over column 0 with a single-byte value so the
     /// byte ordering matches the intended numeric ordering (`b"a" < b"b"`).
     fn pred(op: FilterOp, value: &[u8]) -> FilterPredicate {
-        FilterPredicate {
-            column_position: 0,
-            op,
-            value: value.to_vec(),
-        }
+        FilterPredicate::single(0, op, value.to_vec())
     }
 
     /// Soundness + completeness enumeration for the planner implication helper.
@@ -291,9 +336,10 @@ mod tests {
         for (q_op, q_val, predicate, expected) in cases {
             let got = query_constraint_implies_predicate(*q_op, q_val, predicate);
             assert_eq!(
-                got, *expected,
-                "implication {q_op:?} {q_val:?} => predicate {:?} {:?}: expected {expected}, got {got}",
-                predicate.op, predicate.value
+                got,
+                *expected,
+                "implication {q_op:?} {q_val:?} => predicate {:?}: expected {expected}, got {got}",
+                predicate.clauses()
             );
 
             // Cross-check: a claimed implication must never admit a query value
@@ -306,8 +352,8 @@ mod tests {
                     if evaluate_predicate(&q, v) {
                         assert!(
                             evaluate_predicate(predicate, v),
-                            "UNSOUND: query {q_op:?} {q_val:?} selects {v:?} which is NOT retained by predicate {:?} {:?}",
-                            predicate.op, predicate.value
+                            "UNSOUND: query {q_op:?} {q_val:?} selects {v:?} which is NOT retained by predicate {:?}",
+                            predicate.clauses()
                         );
                     }
                 }
@@ -322,11 +368,7 @@ mod tests {
         // Phonetic index on column 0 (name), filter on column 1 (status)
         let inner = Box::new(PhoneticIndexFactory::new(PhoneticAlgorithm::Soundex));
 
-        let predicate = FilterPredicate {
-            column_position: 1,
-            op: FilterOp::Eq,
-            value: b"active".to_vec(),
-        };
+        let predicate = FilterPredicate::single(1, FilterOp::Eq, b"active".to_vec());
 
         let factory = FilteredIndexFactory::new(inner, predicate);
         let config = IndexConfig {
@@ -398,11 +440,7 @@ mod tests {
 
         let inner = Box::new(PhoneticIndexFactory::new(PhoneticAlgorithm::Soundex));
 
-        let predicate = FilterPredicate {
-            column_position: 1,
-            op: FilterOp::NotEq,
-            value: b"deleted".to_vec(),
-        };
+        let predicate = FilterPredicate::single(1, FilterOp::NotEq, b"deleted".to_vec());
 
         let factory = FilteredIndexFactory::new(inner, predicate);
         let config = IndexConfig {
@@ -451,38 +489,22 @@ mod tests {
 
     #[test]
     fn filtered_index_comparison_ops() {
-        let pred_lt = FilterPredicate {
-            column_position: 0,
-            op: FilterOp::Lt,
-            value: b"M".to_vec(),
-        };
+        let pred_lt = FilterPredicate::single(0, FilterOp::Lt, b"M".to_vec());
         assert!(evaluate_predicate(&pred_lt, b"A"));
         assert!(!evaluate_predicate(&pred_lt, b"M"));
         assert!(!evaluate_predicate(&pred_lt, b"Z"));
 
-        let pred_gt = FilterPredicate {
-            column_position: 0,
-            op: FilterOp::Gt,
-            value: b"M".to_vec(),
-        };
+        let pred_gt = FilterPredicate::single(0, FilterOp::Gt, b"M".to_vec());
         assert!(!evaluate_predicate(&pred_gt, b"A"));
         assert!(!evaluate_predicate(&pred_gt, b"M"));
         assert!(evaluate_predicate(&pred_gt, b"Z"));
 
-        let pred_lteq = FilterPredicate {
-            column_position: 0,
-            op: FilterOp::LtEq,
-            value: b"M".to_vec(),
-        };
+        let pred_lteq = FilterPredicate::single(0, FilterOp::LtEq, b"M".to_vec());
         assert!(evaluate_predicate(&pred_lteq, b"A"));
         assert!(evaluate_predicate(&pred_lteq, b"M"));
         assert!(!evaluate_predicate(&pred_lteq, b"Z"));
 
-        let pred_gteq = FilterPredicate {
-            column_position: 0,
-            op: FilterOp::GtEq,
-            value: b"M".to_vec(),
-        };
+        let pred_gteq = FilterPredicate::single(0, FilterOp::GtEq, b"M".to_vec());
         assert!(!evaluate_predicate(&pred_gteq, b"A"));
         assert!(evaluate_predicate(&pred_gteq, b"M"));
         assert!(evaluate_predicate(&pred_gteq, b"Z"));
@@ -493,11 +515,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         let inner = Box::new(PhoneticIndexFactory::new(PhoneticAlgorithm::Soundex));
-        let predicate = FilterPredicate {
-            column_position: 1,
-            op: FilterOp::Eq,
-            value: b"active".to_vec(),
-        };
+        let predicate = FilterPredicate::single(1, FilterOp::Eq, b"active".to_vec());
 
         let factory = FilteredIndexFactory::new(inner, predicate);
         let config = IndexConfig {
@@ -534,11 +552,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         let inner = Box::new(PhoneticIndexFactory::new(PhoneticAlgorithm::Soundex));
-        let predicate = FilterPredicate {
-            column_position: 1,
-            op: FilterOp::Eq,
-            value: b"x".to_vec(),
-        };
+        let predicate = FilterPredicate::single(1, FilterOp::Eq, b"x".to_vec());
 
         let factory = FilteredIndexFactory::new(inner, predicate);
         let config = IndexConfig {
@@ -565,11 +579,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         let inner = Box::new(BTreeIndexFactory);
-        let predicate = FilterPredicate {
-            column_position: 1,
-            op: FilterOp::Eq,
-            value: b"active".to_vec(),
-        };
+        let predicate = FilterPredicate::single(1, FilterOp::Eq, b"active".to_vec());
 
         let factory = FilteredIndexFactory::new(inner, predicate);
         let config = IndexConfig {
@@ -633,5 +643,198 @@ mod tests {
         assert!(pks.contains(&b"pk1".as_slice()));
         assert!(pks.contains(&b"pk3".as_slice()));
         assert!(!pks.contains(&b"pk2".as_slice()));
+    }
+
+    // ── Multi-column conjunction predicates ──────────────────────────────────
+
+    /// A 2-clause conjunction (`age > '2' AND dept = 'eng'`, on columns 1 and 2)
+    /// retains a row only when BOTH clauses hold. `evaluate_predicate_row`
+    /// resolves each clause's own column. A row missing either column fails.
+    #[test]
+    fn evaluate_predicate_row_conjunction_all_clauses() {
+        let predicate = FilterPredicate::conjunction(vec![
+            FilterClause::new(1, FilterOp::Gt, b"2".to_vec()),
+            FilterClause::new(2, FilterOp::Eq, b"eng".to_vec()),
+        ]);
+
+        // Both clauses satisfied -> retained.
+        let cells = [(1usize, b"6".as_slice()), (2usize, b"eng".as_slice())];
+        let lookup = |pos: usize| cells.iter().find(|(p, _)| *p == pos).map(|(_, v)| *v);
+        assert!(evaluate_predicate_row(&predicate, lookup));
+
+        // First clause fails (age not > 2) -> withheld.
+        let cells = [(1usize, b"2".as_slice()), (2usize, b"eng".as_slice())];
+        let lookup = |pos: usize| cells.iter().find(|(p, _)| *p == pos).map(|(_, v)| *v);
+        assert!(!evaluate_predicate_row(&predicate, lookup));
+
+        // Second clause fails (dept != eng) -> withheld.
+        let cells = [(1usize, b"6".as_slice()), (2usize, b"sales".as_slice())];
+        let lookup = |pos: usize| cells.iter().find(|(p, _)| *p == pos).map(|(_, v)| *v);
+        assert!(!evaluate_predicate_row(&predicate, lookup));
+
+        // Second clause column absent -> withheld (conjunction requires every
+        // clause column to be present and live).
+        let cells = [(1usize, b"6".as_slice())];
+        let lookup = |pos: usize| cells.iter().find(|(p, _)| *p == pos).map(|(_, v)| *v);
+        assert!(!evaluate_predicate_row(&predicate, lookup));
+    }
+
+    /// An empty conjunction retains nothing — a partial index with no clause
+    /// would otherwise silently index every row (unsound).
+    #[test]
+    fn empty_conjunction_retains_nothing() {
+        let predicate = FilterPredicate::conjunction(vec![]);
+        let lookup = |_pos: usize| Some(b"anything".as_slice());
+        assert!(!evaluate_predicate_row(&predicate, lookup));
+        assert!(!evaluate_predicate(&predicate, b"anything"));
+    }
+
+    /// Planner soundness + completeness for a 2-clause conjunction. The index is
+    /// usable ONLY when the query implies EVERY clause; if even one clause is
+    /// not provably implied the index must be withheld (serving it would drop
+    /// rows). We model the query as a per-column constraint map and require each
+    /// clause to be implied by the query constraint on that clause's column.
+    #[test]
+    fn conjunction_implication_requires_every_clause() {
+        // Index predicate: age (col 1) > '2'  AND  dept (col 2) = 'eng'.
+        let predicate = FilterPredicate::conjunction(vec![
+            FilterClause::new(1, FilterOp::Gt, b"2".to_vec()),
+            FilterClause::new(2, FilterOp::Eq, b"eng".to_vec()),
+        ]);
+
+        // Helper: prove the conjunction is implied by a set of query constraints
+        // (column_position -> (op, value)). Each clause must be implied by the
+        // query constraint on its own column (withhold if any column is
+        // unconstrained or not provably contained).
+        let implies = |constraints: &[(usize, FilterOp, &[u8])]| -> bool {
+            predicate.clauses().iter().all(|clause| {
+                constraints.iter().any(|(pos, op, val)| {
+                    *pos == clause.column_position
+                        && query_constraint_implies_predicate_clause(*op, val, clause)
+                })
+            })
+        };
+
+        // Query: age = '6' AND dept = 'eng' -> implies BOTH clauses -> usable.
+        assert!(implies(&[
+            (1, FilterOp::Eq, b"6"),
+            (2, FilterOp::Eq, b"eng"),
+        ]));
+        // Query: age > '4' AND dept = 'eng' -> {x>4} ⊆ {x>2} and dept implied.
+        assert!(implies(&[
+            (1, FilterOp::Gt, b"4"),
+            (2, FilterOp::Eq, b"eng"),
+        ]));
+
+        // Withheld: only the age clause is implied; dept is unconstrained.
+        assert!(!implies(&[(1, FilterOp::Eq, b"6")]));
+        // Withheld: dept is implied but age clause is NOT (age = '2' is not > 2).
+        assert!(!implies(&[
+            (1, FilterOp::Eq, b"2"),
+            (2, FilterOp::Eq, b"eng"),
+        ]));
+        // Withheld: dept constrained to a different value (not a subset of 'eng').
+        assert!(!implies(&[
+            (1, FilterOp::Eq, b"6"),
+            (2, FilterOp::Eq, b"sales"),
+        ]));
+        // Withheld: nothing constrained.
+        assert!(!implies(&[]));
+    }
+
+    /// The conjunction build path: only rows where EVERY clause passes reach the
+    /// inner index. Columns: 0 = name (indexed), 1 = age, 2 = dept; predicate is
+    /// `age > '2' AND dept = 'eng'`.
+    #[test]
+    fn conjunction_build_includes_only_rows_matching_all_clauses() {
+        use crate::btree::BTreeIndexFactory;
+
+        let dir = tempfile::tempdir().unwrap();
+        let predicate = FilterPredicate::conjunction(vec![
+            FilterClause::new(1, FilterOp::Gt, b"2".to_vec()),
+            FilterClause::new(2, FilterOp::Eq, b"eng".to_vec()),
+        ]);
+        let factory = FilteredIndexFactory::new(Box::new(BTreeIndexFactory), predicate);
+        let config = IndexConfig {
+            index_type: IndexType::Filtered,
+            column_positions: vec![0],
+            output_dir: dir.path().to_path_buf(),
+            name: "test_conjunction".to_string(),
+        };
+        let mut builder = factory.create_builder(&config).unwrap();
+
+        let row = |age: &[u8], dept: &[u8], v: i64| {
+            vec![
+                CellValue::live(b"alpha".to_vec(), v),
+                CellValue::live(age.to_vec(), v),
+                CellValue::live(dept.to_vec(), v),
+            ]
+        };
+        // pk1: age 6, eng -> BOTH pass -> indexed.
+        builder
+            .add_row(b"pk1", b"", &row(b"6", b"eng", 1), &[0])
+            .unwrap();
+        // pk2: age 6, sales -> dept fails -> excluded.
+        builder
+            .add_row(b"pk2", b"", &row(b"6", b"sales", 2), &[0])
+            .unwrap();
+        // pk3: age 1, eng -> age fails -> excluded.
+        builder
+            .add_row(b"pk3", b"", &row(b"1", b"eng", 3), &[0])
+            .unwrap();
+        // pk4: age 9, eng -> BOTH pass -> indexed.
+        builder
+            .add_row(b"pk4", b"", &row(b"9", b"eng", 4), &[0])
+            .unwrap();
+
+        let files = builder.finish().unwrap();
+        let reader = factory.open_reader(&files).unwrap();
+        let results = reader.lookup(&IndexKey(b"alpha".to_vec())).unwrap();
+        let pks: Vec<&[u8]> = results.iter().map(|r| r.partition_key.as_slice()).collect();
+        assert_eq!(pks.len(), 2, "only rows passing BOTH clauses are indexed");
+        assert!(pks.contains(&b"pk1".as_slice()));
+        assert!(pks.contains(&b"pk4".as_slice()));
+        assert!(!pks.contains(&b"pk2".as_slice()));
+        assert!(!pks.contains(&b"pk3".as_slice()));
+    }
+
+    /// Persistence round-trip of the conjunction predicate via the option-string
+    /// helpers (the shape persisted under `__filter_predicate`).
+    #[test]
+    fn conjunction_predicate_option_string_roundtrip() {
+        let predicate = FilterPredicate::conjunction(vec![
+            FilterClause::new(1, FilterOp::Gt, vec![0, 0, 0, 21]),
+            FilterClause::new(2, FilterOp::Eq, b"eng".to_vec()),
+        ]);
+        let s = predicate.to_option_string().unwrap();
+        let back = FilterPredicate::from_option_string(&s).unwrap();
+        assert_eq!(back, predicate);
+        assert_eq!(back.clauses().len(), 2);
+        assert_eq!(back.version, 2);
+    }
+
+    /// Backward-compatible decode: the LEGACY single-clause flat JSON (the exact
+    /// shape the original `FilterPredicate` serialized) still deserializes into a
+    /// one-clause conjunction. This guarantees old `system_schema.indexes` rows
+    /// and in-flight build requests survive the upgrade.
+    #[test]
+    fn legacy_single_clause_json_decodes() {
+        let legacy = r#"{"column_position":2,"op":"Eq","value":[97,99,116,105,118,101]}"#;
+        let back = FilterPredicate::from_option_string(legacy).unwrap();
+        assert_eq!(back.clauses().len(), 1);
+        let clause = &back.clauses()[0];
+        assert_eq!(clause.column_position, 2);
+        assert_eq!(clause.op, FilterOp::Eq);
+        assert_eq!(clause.value, b"active");
+        // It evaluates exactly like a single-clause predicate.
+        assert!(evaluate_clause(clause, b"active"));
+        assert!(!evaluate_clause(clause, b"inactive"));
+    }
+
+    /// Malformed JSON (neither shape) fails to decode rather than silently
+    /// producing an empty/everything-retaining predicate.
+    #[test]
+    fn malformed_predicate_json_is_rejected() {
+        assert!(FilterPredicate::from_option_string(r#"{"foo":1}"#).is_none());
     }
 }

--- a/ferrosa-index/src/lib.rs
+++ b/ferrosa-index/src/lib.rs
@@ -27,7 +27,10 @@ pub mod hash;
 pub mod phonetic;
 pub mod vector;
 
-pub use filtered::{evaluate_predicate, query_constraint_implies_predicate};
+pub use filtered::{
+    evaluate_clause, evaluate_predicate, evaluate_predicate_row, query_clause_implies,
+    query_constraint_implies_predicate, query_constraint_implies_predicate_clause,
+};
 pub use phonetic::PhoneticAlgorithm;
 
 use ferrosa_common::CellValue;
@@ -276,30 +279,126 @@ pub enum FilterOp {
     GtEq,
 }
 
-/// A filter predicate applied to a specific column during index building.
+/// A single comparison clause of a (possibly multi-column) filter predicate:
+/// `column_position <op> value`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FilterPredicate {
+pub struct FilterClause {
     /// The column position to filter on.
     pub column_position: usize,
     /// The comparison operator.
     pub op: FilterOp,
-    /// The value to compare against.
+    /// The value to compare against (storage encoding).
     pub value: Vec<u8>,
 }
 
+impl FilterClause {
+    /// Construct a single clause.
+    pub fn new(column_position: usize, op: FilterOp, value: Vec<u8>) -> Self {
+        Self {
+            column_position,
+            op,
+            value,
+        }
+    }
+}
+
+/// A filter predicate applied during index building: a **conjunction** of one
+/// or more [`FilterClause`]s. A row is retained only when EVERY clause holds
+/// (logical AND). A single-clause predicate is the common case and is preserved
+/// for backward compatibility on the wire (see this type's custom `Deserialize`,
+/// which still accepts the legacy flat single-clause JSON).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FilterPredicate {
+    /// Wire format version. `1` is the legacy single-clause flat shape (decoded
+    /// transparently); `2` is the conjunction shape serialized here.
+    pub version: u8,
+    /// The conjoined clauses. Non-empty for a well-formed predicate.
+    pub clauses: Vec<FilterClause>,
+}
+
+/// Current serialized wire version for the conjunction shape.
+const FILTER_PREDICATE_VERSION: u8 = 2;
+
 impl FilterPredicate {
+    /// Construct a single-column predicate (the common case).
+    pub fn single(column_position: usize, op: FilterOp, value: Vec<u8>) -> Self {
+        Self {
+            version: FILTER_PREDICATE_VERSION,
+            clauses: vec![FilterClause::new(column_position, op, value)],
+        }
+    }
+
+    /// Construct a conjunction predicate from clauses. The caller provides at
+    /// least one clause; an empty conjunction retains nothing useful and is
+    /// rejected by [`evaluate_predicate`].
+    pub fn conjunction(clauses: Vec<FilterClause>) -> Self {
+        Self {
+            version: FILTER_PREDICATE_VERSION,
+            clauses,
+        }
+    }
+
+    /// The conjoined clauses.
+    pub fn clauses(&self) -> &[FilterClause] {
+        &self.clauses
+    }
+
     /// Serialize this predicate to a JSON string suitable for stashing in an
-    /// index `options` map (the `value` bytes are already in storage encoding,
-    /// so the round-trip is exact and type-system independent).
+    /// index `options` map (the clause `value` bytes are already in storage
+    /// encoding, so the round-trip is exact and type-system independent).
     pub fn to_option_string(&self) -> IndexResult<String> {
         serde_json::to_string(self).map_err(IndexError::from)
     }
 
     /// Reconstruct a predicate from the JSON produced by
-    /// [`to_option_string`](Self::to_option_string). Returns `None` when the
-    /// string is absent or does not deserialize, so callers can fail safe.
+    /// [`to_option_string`](Self::to_option_string), OR from the legacy
+    /// single-clause flat shape (`{"column_position":..,"op":..,"value":..}`).
+    /// Returns `None` when the string is absent or does not deserialize, so
+    /// callers can fail safe.
     pub fn from_option_string(s: &str) -> Option<Self> {
         serde_json::from_str(s).ok()
+    }
+}
+
+impl<'de> Deserialize<'de> for FilterPredicate {
+    /// Accept BOTH wire shapes:
+    /// - conjunction (v2): `{"version":2,"clauses":[{...},...]}`
+    /// - legacy single clause (v1): `{"column_position":..,"op":..,"value":..}`
+    ///
+    /// The legacy shape is the exact JSON the original single-clause
+    /// `FilterPredicate` serialized, so old `system_schema.indexes` rows and
+    /// in-flight build requests keep deserializing after the upgrade.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            // v2 fields
+            version: Option<u8>,
+            clauses: Option<Vec<FilterClause>>,
+            // v1 (legacy flat single-clause) fields
+            column_position: Option<usize>,
+            op: Option<FilterOp>,
+            value: Option<Vec<u8>>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        if let Some(clauses) = wire.clauses {
+            return Ok(FilterPredicate {
+                version: wire.version.unwrap_or(FILTER_PREDICATE_VERSION),
+                clauses,
+            });
+        }
+        match (wire.column_position, wire.op, wire.value) {
+            (Some(column_position), Some(op), Some(value)) => {
+                Ok(FilterPredicate::single(column_position, op, value))
+            }
+            _ => Err(serde::de::Error::custom(
+                "FilterPredicate JSON has neither a `clauses` array (v2) nor a legacy \
+                 `column_position`/`op`/`value` triple (v1)",
+            )),
+        }
     }
 }
 

--- a/ferrosa-schema/src/metadata/index.rs
+++ b/ferrosa-schema/src/metadata/index.rs
@@ -65,11 +65,7 @@ mod tests {
             name: "idx_active".into(),
             index_type: IndexType::Filtered,
             target_columns: vec!["email".into()],
-            filter_predicate: Some(FilterPredicate {
-                column_position: 2,
-                op: FilterOp::Eq,
-                value: b"active".to_vec(),
-            }),
+            filter_predicate: Some(FilterPredicate::single(2, FilterOp::Eq, b"active".to_vec())),
             options: HashMap::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
@@ -140,11 +136,7 @@ mod tests {
             name: "idx_filtered".into(),
             index_type: IndexType::Filtered,
             target_columns: vec!["status".into()],
-            filter_predicate: Some(FilterPredicate {
-                column_position: 0,
-                op: FilterOp::Eq,
-                value: b"active".to_vec(),
-            }),
+            filter_predicate: Some(FilterPredicate::single(0, FilterOp::Eq, b"active".to_vec())),
             options: HashMap::new(),
         };
         let json = serde_json::to_string(&meta).unwrap();
@@ -155,8 +147,57 @@ mod tests {
         assert!(matches!(back.index_type, IndexType::Filtered));
         assert_eq!(back.target_columns, vec!["status"]);
         let pred = back.filter_predicate.unwrap();
-        assert_eq!(pred.column_position, 0);
-        assert!(matches!(pred.op, FilterOp::Eq));
-        assert_eq!(pred.value, b"active");
+        assert_eq!(pred.clauses().len(), 1);
+        let clause = &pred.clauses()[0];
+        assert_eq!(clause.column_position, 0);
+        assert!(matches!(clause.op, FilterOp::Eq));
+        assert_eq!(clause.value, b"active");
+    }
+
+    /// A persisted index metadata row carrying a multi-column conjunction
+    /// predicate round-trips through serde (the shape stored in
+    /// `system_schema.indexes`).
+    #[test]
+    fn index_metadata_conjunction_roundtrip() {
+        use ferrosa_index::FilterClause;
+        let meta = IndexMetadata {
+            keyspace: "ks".into(),
+            table: "tbl".into(),
+            name: "idx_conj".into(),
+            index_type: IndexType::Filtered,
+            target_columns: vec!["name".into()],
+            filter_predicate: Some(FilterPredicate::conjunction(vec![
+                FilterClause::new(1, FilterOp::Gt, vec![0, 0, 0, 21]),
+                FilterClause::new(2, FilterOp::Eq, b"eng".to_vec()),
+            ])),
+            options: HashMap::new(),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: IndexMetadata = serde_json::from_str(&json).unwrap();
+        let pred = back.filter_predicate.unwrap();
+        assert_eq!(pred.clauses().len(), 2);
+        assert_eq!(pred.clauses()[0].column_position, 1);
+        assert!(matches!(pred.clauses()[0].op, FilterOp::Gt));
+        assert_eq!(pred.clauses()[1].column_position, 2);
+        assert_eq!(pred.clauses()[1].value, b"eng");
+    }
+
+    /// Backward-compatible decode: a legacy single-clause flat JSON row (the
+    /// exact shape the old `FilterPredicate` serialized) still deserializes into
+    /// an `IndexMetadata` with a one-clause conjunction.
+    #[test]
+    fn index_metadata_legacy_single_clause_predicate_decodes() {
+        let legacy = r#"{
+            "keyspace":"ks","table":"tbl","name":"idx_legacy",
+            "index_type":"Filtered","target_columns":["status"],
+            "filter_predicate":{"column_position":3,"op":"Eq","value":[97,99,116,105,118,101]},
+            "options":{}
+        }"#;
+        let back: IndexMetadata = serde_json::from_str(legacy).unwrap();
+        let pred = back.filter_predicate.unwrap();
+        assert_eq!(pred.clauses().len(), 1);
+        assert_eq!(pred.clauses()[0].column_position, 3);
+        assert!(matches!(pred.clauses()[0].op, FilterOp::Eq));
+        assert_eq!(pred.clauses()[0].value, b"active");
     }
 }

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -15975,11 +15975,7 @@ mod tests {
             .position(|n| *n == "status")
             .expect("status column present");
 
-        let predicate = FilterPredicate {
-            column_position: status_pos,
-            op: FilterOp::Eq,
-            value: b"active".to_vec(),
-        };
+        let predicate = FilterPredicate::single(status_pos, FilterOp::Eq, b"active".to_vec());
         let mut options = std::collections::HashMap::new();
         options.insert(
             FILTER_PREDICATE_OPTION_KEY.to_string(),

--- a/ferrosa-storage/src/index/remote_backend.rs
+++ b/ferrosa-storage/src/index/remote_backend.rs
@@ -598,11 +598,7 @@ mod tests {
             endpoint: "memory://".into(),
             prefix: "p".into(),
         };
-        let predicate = FilterPredicate {
-            column_position: 1,
-            op: FilterOp::Gt,
-            value: vec![0, 0, 0, 21],
-        };
+        let predicate = FilterPredicate::single(1, FilterOp::Gt, vec![0, 0, 0, 21]);
         let job = IndexBuildJob {
             sstable_id: "gen-7".to_string(),
             index_name: "name_adult_idx".to_string(),

--- a/ferrosa-storage/src/index/scheduler.rs
+++ b/ferrosa-storage/src/index/scheduler.rs
@@ -257,22 +257,20 @@ impl IndexBuildBackend for LocalBackend {
         {
             let pk_bytes = partition.key.key.as_bytes().to_vec();
             for row in &partition.rows {
-                // Partial (filtered) index: skip rows whose filter-column cell
-                // does not satisfy the predicate. The sidecar must hold ONLY
-                // matching rows so the read path (which delegates to a plain
+                // Partial (filtered) index: skip rows that do not satisfy the
+                // predicate. For a multi-column conjunction, EVERY clause's
+                // column must be present (live) and satisfy its comparison. The
+                // sidecar must hold ONLY matching rows so the read path (a plain
                 // btree point/range lookup) returns the partial result set.
-                // `evaluate_predicate` is the shared source of truth with the
+                // `evaluate_predicate_row` is the shared source of truth with the
                 // memtable write path, so sidecar and memtable agree.
                 if let Some(predicate) = job.filter_predicate.as_ref() {
-                    let filter_cell = row
-                        .cells
-                        .iter()
-                        .find(|(pos, _)| *pos as usize == predicate.column_position);
-                    let matches = match filter_cell.and_then(|(_, c)| c.value.as_ref()) {
-                        Some(value) => ferrosa_index::evaluate_predicate(predicate, value),
-                        // Filter column absent or tombstoned -> does not match.
-                        None => false,
-                    };
+                    let matches = ferrosa_index::evaluate_predicate_row(predicate, |col_pos| {
+                        row.cells
+                            .iter()
+                            .find(|(pos, _)| *pos as usize == col_pos)
+                            .and_then(|(_, c)| c.value.as_deref())
+                    });
                     if !matches {
                         continue;
                     }
@@ -1071,11 +1069,7 @@ mod tests {
             priority: BuildPriority::Normal,
             enqueued_at: Instant::now(),
             column_position: 0,
-            filter_predicate: Some(FilterPredicate {
-                column_position: 1,
-                op: FilterOp::Eq,
-                value: b"active".to_vec(),
-            }),
+            filter_predicate: Some(FilterPredicate::single(1, FilterOp::Eq, b"active".to_vec())),
         };
         let result = backend.build(&job).unwrap();
 

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -1157,14 +1157,18 @@ impl<F: FlushTarget> TableStore<F> {
                 // column does not match. `evaluate_predicate` is shared with the
                 // build path so memtable and sidecar never disagree.
                 if let Some(predicate) = self.index_filter_predicates.get(index_name) {
-                    let filter_cell = row
-                        .cells
-                        .iter()
-                        .find(|(idx, _)| *idx as usize == predicate.column_position);
-                    let matches = match filter_cell.and_then(|(_, c)| c.value.as_ref()) {
-                        Some(v) => ferrosa_index::evaluate_predicate(predicate, v),
-                        None => false,
-                    };
+                    // Conjunction gating: a row belongs in the partial index only
+                    // when EVERY clause's column is present (live) and satisfies
+                    // its comparison. `evaluate_predicate_row` resolves each
+                    // clause's own column; it is the shared source of truth with
+                    // the sidecar build path, so memtable and sidecar never
+                    // disagree on which rows belong.
+                    let matches = ferrosa_index::evaluate_predicate_row(predicate, |col_pos| {
+                        row.cells
+                            .iter()
+                            .find(|(idx, _)| *idx as usize == col_pos)
+                            .and_then(|(_, c)| c.value.as_deref())
+                    });
                     if !matches {
                         continue;
                     }

--- a/specs/todo/filtered-index-multi-column-predicate.md
+++ b/specs/todo/filtered-index-multi-column-predicate.md
@@ -1,5 +1,48 @@
 # Filtered (partial) index: multi-column conjunction predicates
 
+Status: IMPLEMENTED (branch `correctness/filtered-multi-column`). The conjunction
+predicate is end-to-end: type/wire format with backward-compatible decode,
+build + memtable gating via a shared row evaluator, CQL `'filter'` conjunction
+parsing, and a sound planner that withholds unless EVERY clause is implied.
+
+What shipped (vs. the deferred plan below):
+
+1. **Type / wire format (`ferrosa-index`)** — `FilterClause { column_position,
+   op, value }` plus `FilterPredicate { version, clauses: Vec<FilterClause> }`
+   (a conjunction; a row is retained iff all clauses hold). Serializes as the v2
+   `{"version":2,"clauses":[...]}` shape; a custom `Deserialize` ALSO accepts the
+   legacy flat single-clause JSON (`{"column_position":..,"op":..,"value":..}`),
+   so old `system_schema.indexes` rows and in-flight build requests survive the
+   upgrade. `evaluate_predicate` is an all-clauses fold; `evaluate_predicate_row`
+   resolves each clause's own column for multi-column gating;
+   `query_constraint_implies_predicate_clause` proves per-clause subset
+   containment. An empty conjunction retains nothing (fail-safe).
+2. **Build path (`ferrosa-storage`)** — `FilteredBuilder`, the `LocalBackend`
+   sidecar scan (`scheduler.rs`), and the memtable write path (`store.rs`) all
+   gate on the shared `evaluate_predicate_row`, so sidecar and memtable agree.
+3. **CQL surface (`ferrosa-cql`)** — `CREATE INDEX ... USING 'filtered' WITH
+   OPTIONS = {'filter': 'col <op> lit AND ...'}` parses a restricted CQL boolean
+   conjunction into clauses (`parse_filter_conjunction`/`split_clause`), each
+   column resolved to its storage ordinal and each literal encoded to storage
+   bytes (`build_filter_clause`). The legacy three-key form is still accepted as
+   a single clause. Any unparseable clause fails loud at CREATE time.
+4. **Planner (`router.rs`)** — `filtered_index_covered_columns` marks ALL
+   conjunction columns covered; `query_implies_filter_predicate` requires every
+   clause to be implied by a WHERE constraint on that clause's own column
+   (withhold if even one is not provably implied).
+5. **Remote builder (`ferrosa-index-builder`)** — no change; the existing
+   `filter_predicate` wire field carries the conjunction type verbatim.
+
+Tests: `ferrosa-index/src/filtered.rs` (conjunction fold, per-clause + withheld
+implication, conjunction build, option-string + legacy-JSON round-trip);
+`ferrosa-schema/src/metadata/index.rs` (conjunction + legacy serde round-trip);
+`ferrosa-cql/src/router.rs` (`filtered_index_multi_column_conjunction_end_to_end`,
+`parse_filter_conjunction_*`).
+
+---
+
+Original spec (deferred plan):
+
 Status: TODO (follow-on to the Filtered partial index, commit `e7762b32`).
 
 ## What already shipped


### PR DESCRIPTION
## Summary

Generalizes the Filtered (partial) index predicate from a single `(column, op, value)` clause to a **version-tagged conjunction** (`Vec<FilterClause>`), implementing `specs/todo/filtered-index-multi-column-predicate.md`. A row is retained iff **every** clause holds; the planner serves a query from the index only when it provably implies **every** clause (sound — never silently drops rows).

## What shipped

- **`ferrosa-index`** — `FilterClause { column_position, op, value }` + `FilterPredicate { version, clauses }`. Serializes as v2 `{"version":2,"clauses":[...]}`; a custom `Deserialize` ALSO accepts the **legacy flat single-clause JSON**, so old `system_schema.indexes` rows and in-flight build requests survive the upgrade. `evaluate_predicate` is an all-clauses fold; `evaluate_predicate_row` resolves each clause's own column (shared build/memtable gating); `query_constraint_implies_predicate_clause` proves per-clause subset containment. Empty conjunction retains nothing (fail-safe).
- **`ferrosa-storage`** — sidecar build (`scheduler.rs`) and memtable write (`store.rs`) gate on the shared `evaluate_predicate_row`, so sidecar and memtable agree on retained rows.
- **`ferrosa-cql`** — `CREATE INDEX ... USING 'filtered' WITH OPTIONS = {'filter': 'col <op> lit AND ...'}` parses a restricted CQL boolean conjunction; each column → storage ordinal, each literal → storage bytes. Legacy three-key form (`filter_column`/`filter_op`/`filter_value`) still accepted as a single clause. Unparseable clauses fail loud at CREATE. Planner marks ALL conjunction columns covered and withholds unless every clause is implied.
- **`ferrosa-index-builder`** — no change; the existing `filter_predicate` wire field carries the conjunction verbatim.

## Tests (TDD)

- `ferrosa-index/src/filtered.rs`: conjunction fold, per-clause + withheld (one-clause-missing) implication, conjunction build, option-string + legacy-JSON round-trip, malformed-JSON rejection.
- `ferrosa-schema/src/metadata/index.rs`: conjunction + legacy single-clause serde round-trip.
- `ferrosa-cql/src/router.rs`: `filtered_index_multi_column_conjunction_end_to_end` (index used when both clauses implied; withheld + complete set via ALLOW FILTERING when only one is), `parse_filter_conjunction_*`.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets` (workspace) clean
- `cargo test -p ferrosa-index -p ferrosa-schema -p ferrosa-index-builder -p ferrosa-cql -p ferrosa-storage` all pass
- `cargo build --all-targets` (workspace) clean

## Deferred

Nothing from the spec is deferred. The conjunction is parsed from the single `'filter'` string form (the cleaner multi-column surface); the alternative repeated/indexed-key form mentioned in the spec was not added since the string form fully covers it.
