### PR TITLE
feat(raft): wire openraft PreVote engine fork + flip sprint-03 gate (W3.12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2738,7 +2738,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3400,7 +3400,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3546,7 +3546,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openraft"
 version = "0.9.25+ferrosadb.1"
-source = "git+https://github.com/ferrosadb/openraft.git?branch=main#af87fa60bab5256cac6c08d09f84379e40636294"
+source = "git+https://github.com/ferrosadb/openraft.git?rev=af87fa60bab5256cac6c08d09f84379e40636294#af87fa60bab5256cac6c08d09f84379e40636294"
 dependencies = [
  "anyerror",
  "byte-unit",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "openraft-macros"
 version = "0.9.25+ferrosadb.1"
-source = "git+https://github.com/ferrosadb/openraft.git?branch=main#af87fa60bab5256cac6c08d09f84379e40636294"
+source = "git+https://github.com/ferrosadb/openraft.git?rev=af87fa60bab5256cac6c08d09f84379e40636294#af87fa60bab5256cac6c08d09f84379e40636294"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -4332,7 +4332,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4369,7 +4369,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5064,7 +5064,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5911,7 +5911,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7255,7 +7255,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,15 @@ members = [
 [patch.crates-io]
 # Sprint 3 (ADR-012): the ferrosadb/openraft fork carries PreVote +
 # CheckQuorum + Leadership Transfer + the separate-replication-timeout
-# patch on top of upstream 0.9.24. Pinned to the fork's default branch
-# (`main`) so we pick up rebases automatically; for reproducible builds
-# switch to a specific `rev = "..."` tag. Fork README and rationale:
+# patch on top of upstream 0.9.24. Pinned to an explicit fork commit for
+# reproducible builds. `af87fa60` is the commit that fully wires the engine
+# PreVote path into the election tick (`run_pre_vote_round` gated behind
+# `Config::enable_pre_vote`), closing the runaway-term gap from
+# `bug-raft-stale-candidate-runaway-term-no-prevote.md`; the
+# `sprint-03-engine-prevote` acceptance tests in ferrosa-cluster depend on
+# it. Fork README and rationale:
 #   https://github.com/ferrosadb/openraft/blob/main/README-FERROSADB.md
-openraft = { git = "https://github.com/ferrosadb/openraft.git", branch = "main" }
+openraft = { git = "https://github.com/ferrosadb/openraft.git", rev = "af87fa60bab5256cac6c08d09f84379e40636294" }
 
 # Keep line-table debug info in release builds so container crashes produce a readable backtrace
 # without bloating the binary to full DWARF. Required for gdb backtraces inside the runtime image.

--- a/ferrosa-cluster/Cargo.toml
+++ b/ferrosa-cluster/Cargo.toml
@@ -39,10 +39,9 @@ tokio = { version = "1", features = ["full", "test-util"] }
 
 [features]
 default = []
-# Sprint 3 (ADR-012): enable W3.12 / W3.13 acceptance tests that depend on
-# engine-side PreVote/TimeoutNow handling in the openraft fork. Off by default
-# until the corresponding engine wire-up lands (W3.3, W3.7-engine, W3.8-engine,
-# W3.9 in `specs/in-process/sprint-03-openraft-patches.md`). When the engine
-# work lands, remove this gate and these tests join the default suite.
-sprint-03-engine-prevote = []
+# Sprint 3 (ADR-012): the engine-side PreVote wire-up has landed in the openraft
+# fork (commit pinned in the workspace Cargo.toml), so the W3.12 PreVote
+# acceptance tests now run in the default suite — the `sprint-03-engine-prevote`
+# gate has been removed. The leadership-transfer (W3.13) gate remains until that
+# engine wire-up's acceptance tests land.
 sprint-03-engine-transfer = []

--- a/ferrosa-cluster/tests/raft_election_storm.rs
+++ b/ferrosa-cluster/tests/raft_election_storm.rs
@@ -1036,7 +1036,6 @@ async fn election_storm_guard_fires_at_production_cadence() {
 /// Build a Config that mirrors the sprint-03 ferrosa defaults: PreVote enabled,
 /// CheckQuorum ratio 0.75. Mirrors the wiring in
 /// `controller/cluster.rs:840`. See ADR-012.
-#[cfg(feature = "sprint-03-engine-prevote")]
 fn prevote_checkquorum_raft_config() -> Arc<Config> {
     Arc::new(
         Config {
@@ -1062,22 +1061,19 @@ fn prevote_checkquorum_raft_config() -> Arc<Config> {
 /// most 0** during the partition window — the protocol-level fix for
 /// `bug-raft-stale-candidate-runaway-term-no-prevote.md`.
 ///
-/// # Gating
+/// # Gap closed
 ///
-/// Gated on `#[cfg(feature = "sprint-03-engine-prevote")]` because the
-/// engine-side `handle_pre_vote_req` is not yet wired in the openraft fork
-/// (see `specs/in-process/sprint-03-openraft-patches.md` items W3.3 and
-/// W3.7-engine). Without that wire-up the test fails — node3's term still
-/// advances by 5–10 over the partition window because openraft's existing
-/// election path increments the term unconditionally on election-timer fire.
+/// This test previously sat behind `#[cfg(feature = "sprint-03-engine-prevote")]`
+/// because the engine-side PreVote path was not wired in the openraft fork —
+/// the election tick called `Engine::elect()` unconditionally, incrementing the
+/// term on every timer fire even while partitioned. The fork commit pinned in
+/// the workspace `Cargo.toml` (`af87fa60…`) closes that gap: `handle_tick_election`
+/// now runs a synchronous `run_pre_vote_round()` gated behind
+/// `Config::enable_pre_vote` and only proceeds to `elect()` (term bump) when the
+/// pre-vote is granted by a quorum. A partitioned node therefore cannot win a
+/// pre-vote round and never advances its persisted term — `term_advance == 0`.
 ///
-/// To run the test (and watch it fail until the engine lands):
-///   `cargo test -p ferrosa-cluster --features sprint-03-engine-prevote
-///    --test raft_election_storm ferrosa_partitioned_node_does_not_advance_term`
-///
-/// When the engine wire-up lands, the feature flag is removed and this test
-/// joins the default test suite.
-#[cfg(feature = "sprint-03-engine-prevote")]
+/// The gate is removed; this runs in the default suite.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn ferrosa_partitioned_node_does_not_advance_term() {
     ELECTION_STORM_TERM_JUMPS_TOTAL.store(0, Ordering::Relaxed);


### PR DESCRIPTION
## Summary

Wires the ferrosadb/openraft fork's engine-side **PreVote** path into ferrosa and removes the `sprint-03-engine-prevote` feature gate, so the runaway-term acceptance test runs in the default suite and passes.

The workspace is pinned to fork commit **`af87fa60`** (was `branch=main`, now `rev=...` for reproducible builds). That commit wires the PreVote path into the election tick: `handle_tick_election` runs a synchronous `run_pre_vote_round()` gated behind `Config::enable_pre_vote` and only proceeds to `elect()` (term bump) when a quorum grants the pre-vote. The full engine sequence (PreVote/TimeoutNow message types + handlers, CheckQuorum, LeaderLease, leadership transfer) lives on the fork's `main`.

## Why

Closes the runaway-term gap from `bug-raft-stale-candidate-runaway-term-no-prevote.md`: a partitioned node can no longer win a pre-vote round, so it never advances its persisted term (`term_advance == 0`) during a partition window. Previously openraft's election path bumped the term unconditionally on every election-timer fire, producing the observed election storm.

## Changes

- `Cargo.toml` — pin `openraft` to `rev = "af87fa60..."` (reproducible) instead of `branch = "main"`.
- `ferrosa-cluster/Cargo.toml` — remove the `sprint-03-engine-prevote` feature (engine wire-up has landed). `sprint-03-engine-transfer` (W3.13) gate remains until its acceptance tests land.
- `ferrosa-cluster/tests/raft_election_storm.rs` — un-gate `ferrosa_partitioned_node_does_not_advance_term`; it now runs by default and asserts the partitioned node's term does not advance.

The controller already wires `enable_pre_vote: raft_enable_pre_vote` (`controller/cluster.rs`), defaulting to `true` (`config.rs`).

## Verification

- `cargo build -p ferrosa-cluster` — green
- `cargo test -p ferrosa-cluster --test raft_election_storm` — **4 passed, 0 failed** (incl. the un-gated `ferrosa_partitioned_node_does_not_advance_term`)
- `cargo fmt --check -p ferrosa-cluster` — clean
- `cargo clippy -p ferrosa-cluster --tests` — no warnings

## Related

- openraft fork branch: `correctness/prevote-engine-w3.3` (pushed) carries the staged W3.1/W3.3/W3.7 building blocks; the **complete** implementation that this PR depends on is fork `main` @ `af87fa60`.