### PR TITLE
feat(repair): automatic anti-entropy repair scheduler

### DIFF
--- a/ferrosa-cluster/src/lib.rs
+++ b/ferrosa-cluster/src/lib.rs
@@ -40,9 +40,9 @@ pub use error::{ClusterError, Result};
 pub use mode::DeploymentMode;
 pub use pair::{PairCoordinator, PairNode, PairRole};
 pub use repair::{
-    InMemoryRepairStore, LocalRepairExecutor, RemoteRepairStore, RepairApplyHandler,
-    RepairCoordinator, RepairFetchHandler, RepairMerkleHandler, RepairStore, SessionExecutor,
-    SessionStats, StorageEngineRepairStore,
+    AutoRepairConfig, AutoRepairScheduler, InMemoryRepairStore, LocalRepairExecutor,
+    RemoteRepairStore, RepairApplyHandler, RepairContext, RepairCoordinator, RepairFetchHandler,
+    RepairMerkleHandler, RepairStore, SessionExecutor, SessionStats, StorageEngineRepairStore,
 };
 pub use state::{PairClusterState, RaftClusterState, SingleNodeClusterState};
 pub use write_path::WritePath;

--- a/ferrosa-cluster/src/repair/cluster_view.rs
+++ b/ferrosa-cluster/src/repair/cluster_view.rs
@@ -249,7 +249,14 @@ pub struct RingTopology<F>
 where
     F: Fn() -> crate::ring::TokenRing + Send + Sync,
 {
-    this_node_id: u64,
+    /// This node's **durable** identity (stable across restarts). The `u64`
+    /// ring id is resolved from this against the *current* snapshot on every
+    /// call rather than captured once — at startup the node may not be placed
+    /// in the ring yet, and a stale/wrong `u64` would fail to exclude self from
+    /// the probe set, risking a verify-against-our-own-corrupt-copy and an
+    /// unsafe quarantine (FMEA #1). Resolving by `host_id` guarantees self is
+    /// always excluded once placed.
+    this_host_id: Uuid,
     /// Replication factor used to scope the replica set. The binary passes the
     /// keyspace RF (per FMEA #11 — not a hardcoded constant).
     rf: usize,
@@ -260,14 +267,24 @@ impl<F> RingTopology<F>
 where
     F: Fn() -> crate::ring::TokenRing + Send + Sync,
 {
-    /// Construct from this node's ring id, the replication factor, and a
-    /// closure that snapshots the current ring.
-    pub fn new(this_node_id: u64, rf: usize, snapshot: F) -> Self {
+    /// Construct from this node's durable `host_id`, the replication factor, and
+    /// a closure that snapshots the current ring. The `u64` ring id is resolved
+    /// dynamically from `this_host_id` against each snapshot (never captured).
+    pub fn new(this_host_id: Uuid, rf: usize, snapshot: F) -> Self {
         Self {
-            this_node_id,
+            this_host_id,
             rf,
             snapshot,
         }
+    }
+
+    /// Resolve this node's `u64` ring id from its durable `host_id` against
+    /// `ring`. `None` when the node is not (yet) placed in the ring.
+    fn resolved_self_id(&self, ring: &crate::ring::TokenRing) -> Option<u64> {
+        ring.node_ids().into_iter().find(|&n| {
+            ring.get_node(n)
+                .is_some_and(|info| info.host_id == self.this_host_id)
+        })
     }
 }
 
@@ -276,7 +293,11 @@ where
     F: Fn() -> crate::ring::TokenRing + Send + Sync,
 {
     fn this_node_id(&self) -> u64 {
-        self.this_node_id
+        // Resolve against the current ring; u64::MAX is a sentinel meaning
+        // "not placed yet" that matches no real ring id (so it never wrongly
+        // excludes a peer as self).
+        let ring = (self.snapshot)();
+        self.resolved_self_id(&ring).unwrap_or(u64::MAX)
     }
 
     fn owners(&self, _table: &TableKey) -> Option<Vec<u64>> {
@@ -306,13 +327,18 @@ where
 
     fn replica_peers(&self, _table: &TableKey) -> Vec<(u64, Uuid)> {
         let ring = (self.snapshot)();
+        // Resolve self by host_id against THIS snapshot so self is always
+        // excluded once placed (u64::MAX sentinel when unplaced excludes
+        // nothing, which is correct — self isn't in the ring yet). Never probe
+        // our own copy (FMEA #1: it may be the corrupt one we want to refill).
+        let self_id = self.resolved_self_id(&ring).unwrap_or(u64::MAX);
         // Eligible replica nodes other than self, in ascending ring-id order.
         // We treat the table's replica set as the eligible nodes up to RF;
         // probing any one that verifies a non-empty copy satisfies FMEA #1.
         let mut peers: Vec<(u64, Uuid)> = ring
             .node_ids()
             .into_iter()
-            .filter(|&n| n != self.this_node_id)
+            .filter(|&n| n != self_id)
             .filter_map(|n| {
                 ring.get_node(n).and_then(|info| {
                     let eligible = match info.state {
@@ -513,7 +539,7 @@ mod tests {
 
     #[test]
     fn ring_topology_returns_other_eligible_peers_capped_by_rf() {
-        let (_h1, n1) = node("10.0.0.1:7000", NodeState::Normal);
+        let (h1, n1) = node("10.0.0.1:7000", NodeState::Normal);
         let (h2, n2) = node("10.0.0.2:7000", NodeState::Normal);
         let (h3, n3) = node("10.0.0.3:7000", NodeState::Normal);
         let (_h4, n4) = node("10.0.0.4:7000", NodeState::Learner { owns_tokens: false });
@@ -523,7 +549,9 @@ mod tests {
         ring.add_node(3, n3);
         ring.add_node(4, n4);
 
-        let topo = RingTopology::new(1, 3, move || ring.clone());
+        let topo = RingTopology::new(h1, 3, move || ring.clone());
+        // self resolves from host_id h1 → ring id 1.
+        assert_eq!(topo.this_node_id(), 1);
         let peers = topo.replica_peers(&TableKey::new("ks", "t"));
         // self (1) excluded, learner-without-tokens (4) excluded, RF=3 → 2 peers.
         assert_eq!(peers, vec![(2, h2), (3, h3)]);
@@ -535,10 +563,66 @@ mod tests {
 
     #[test]
     fn ring_topology_single_node_has_no_peers() {
-        let (_h1, n1) = node("10.0.0.1:7000", NodeState::Normal);
+        let (h1, n1) = node("10.0.0.1:7000", NodeState::Normal);
         let mut ring = TokenRing::new();
         ring.add_node(1, n1);
-        let topo = RingTopology::new(1, 1, move || ring.clone());
+        let topo = RingTopology::new(h1, 1, move || ring.clone());
         assert!(topo.replica_peers(&TableKey::new("ks", "t")).is_empty());
+    }
+
+    /// FMEA #1 safety: self is excluded from the probe peer set by durable
+    /// host_id even if its ring id differs from a naive guess — so the probe can
+    /// never verify against this node's own (possibly corrupt) copy. Also: a node
+    /// not yet placed in the ring resolves to the u64::MAX sentinel (this_node_id)
+    /// and excludes nothing (there is no self in the ring to wrongly include).
+    #[test]
+    fn ring_topology_excludes_self_by_host_id_and_handles_unplaced() {
+        let (h1, n1) = node("10.0.0.1:7000", NodeState::Normal);
+        let (h2, n2) = node("10.0.0.2:7000", NodeState::Normal);
+        // This node (h1) is placed at a NON-1 ring id (10), proving resolution
+        // is by host_id, not a positional guess.
+        let mut ring = TokenRing::new();
+        ring.add_node(10, n1);
+        ring.add_node(2, n2);
+
+        let topo = RingTopology::new(h1, 2, || {
+            let mut r = TokenRing::new();
+            r.add_node(
+                10,
+                NodeInfo {
+                    host_id: h1,
+                    addr: "10.0.0.1:7000".into(),
+                    data_center: "dc1".into(),
+                    rack: "rack1".into(),
+                    state: NodeState::Normal,
+                    cql_broadcast: None,
+                },
+            );
+            r.add_node(
+                2,
+                NodeInfo {
+                    host_id: h2,
+                    addr: "10.0.0.2:7000".into(),
+                    data_center: "dc1".into(),
+                    rack: "rack1".into(),
+                    state: NodeState::Normal,
+                    cql_broadcast: None,
+                },
+            );
+            r
+        });
+        assert_eq!(topo.this_node_id(), 10, "resolved by host_id, not assumed");
+        let peers = topo.replica_peers(&TableKey::new("ks", "t"));
+        // self (ring id 10) excluded; only peer 2 remains — never self.
+        assert_eq!(peers, vec![(2, h2)]);
+        assert!(
+            !peers.iter().any(|(id, _)| *id == 10),
+            "self must never be a probe peer"
+        );
+
+        // Unplaced node (host_id not in the ring) → sentinel, excludes nothing.
+        let unknown = Uuid::new_v4();
+        let topo_unplaced = RingTopology::new(unknown, 3, move || ring.clone());
+        assert_eq!(topo_unplaced.this_node_id(), u64::MAX);
     }
 }

--- a/ferrosa-cluster/src/repair/cluster_view.rs
+++ b/ferrosa-cluster/src/repair/cluster_view.rs
@@ -1,0 +1,544 @@
+//! Real, verified-healthy-replica [`ClusterView`] for the storage-side
+//! self-heal controller.
+//!
+//! The storage crate's self-heal controller gates quarantine on a healthy
+//! replica (FMEA #1: never quarantine the only copy of data). It cannot reach
+//! the cluster layer itself, so it asks an injected [`ClusterView`] for the
+//! replica posture of a `(table, range)`. The single-node stub in
+//! `ferrosa_storage` always answers `SingleNode`, so on a real cluster
+//! quarantine never fires.
+//!
+//! [`ClusterRepairView`] is the real implementation. It answers
+//! [`ReplicaPosture::HealthyReplicaAvailable`] for a table **only when a
+//! reachable peer is VERIFIED to hold a non-corrupt copy** — it probes a peer
+//! using the existing repair Merkle/digest RPC (a successful, non-empty digest
+//! response proves the peer holds readable, non-corrupt data for the range).
+//! Every other outcome — RF ≤ 1, no reachable peer, probe failure, or an empty
+//! digest — yields a not-healthy posture, so the controller escalates instead
+//! of quarantining.
+//!
+//! ## Probe abstraction
+//!
+//! The real Merkle RPC ([`RemoteRepairStore::build_merkle`](super::rpc::RemoteRepairStore))
+//! is async and needs a live `PeerManager` + connection pool, which is too
+//! heavy to drive from a synchronous `ClusterView::replica_posture` call and
+//! from a unit test. So the network step is abstracted behind the small,
+//! synchronous [`RepairProbe`] port:
+//!
+//! - [`RpcRepairProbe`] is the production impl — a thin, documented wrapper
+//!   that blocks on `RemoteRepairStore::build_merkle` via a tokio runtime
+//!   handle and reports whether the returned tree was non-empty.
+//! - Unit tests use a mock [`RepairProbe`] to drive every posture branch
+//!   without standing up the wire protocol.
+//!
+//! Topology (which nodes are candidate replicas, and their `host_id` UUIDs) is
+//! likewise abstracted behind [`ClusterTopology`], implemented for the live
+//! ring by [`RingTopology`] and mocked in tests.
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use ferrosa_net::peer::PeerManager;
+use ferrosa_storage::self_heal::{ClusterView, ReplicaPosture, TableKey};
+use ferrosa_storage::TableId;
+
+use super::rpc::RemoteRepairStore;
+use super::RepairStore;
+
+/// Result of probing one peer for a verified, non-corrupt copy of a range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// The peer answered the digest RPC and reported **non-empty** content for
+    /// the range — a verified healthy copy that can refill after quarantine.
+    HealthyNonEmpty,
+    /// The peer answered but the digest was **empty** (the peer holds no data
+    /// for this range) — not a usable refill source.
+    Empty,
+    /// The peer was unreachable or the probe RPC failed. Not a usable source.
+    Unreachable,
+}
+
+/// Synchronous port that verifies whether a single peer holds a non-corrupt,
+/// non-empty copy of a `(table, range)` by exchanging a repair digest.
+///
+/// Kept synchronous so [`ClusterView::replica_posture`] (a sync trait method)
+/// can call it directly; the production impl blocks on the async Merkle RPC
+/// internally. Abstracted as a trait so the posture logic is unit-testable
+/// against a mock without the wire protocol.
+pub trait RepairProbe: Send + Sync {
+    /// Probe `peer` for a verified copy of `table` over `[range.0, range.1)`.
+    fn probe_digest(&self, peer: Uuid, table: &TableId, range: (i64, i64)) -> ProbeOutcome;
+}
+
+/// Topology facts the view needs from the ring, abstracted so the posture
+/// logic is testable without a live `TokenRing`.
+pub trait ClusterTopology: Send + Sync {
+    /// This node's `u64` ring id (deterministic initiator selection).
+    fn this_node_id(&self) -> u64;
+
+    /// Owners (`u64` ring ids) of `table`'s ranges, or `None` if unknown.
+    /// Used both for `ClusterView::owners` and to scope the probe set.
+    fn owners(&self, table: &TableKey) -> Option<Vec<u64>>;
+
+    /// Other reachable replica peers for `table`, as `(ring_id, host_id)`
+    /// pairs, in a deterministic (ascending ring-id) order, excluding this
+    /// node. Empty when this is effectively single-node / RF ≤ 1 for the
+    /// table or no peer is currently reachable.
+    fn replica_peers(&self, table: &TableKey) -> Vec<(u64, Uuid)>;
+}
+
+/// The real [`ClusterView`]: verified-healthy-replica posture via the repair
+/// digest RPC.
+pub struct ClusterRepairView {
+    topology: Arc<dyn ClusterTopology>,
+    probe: Arc<dyn RepairProbe>,
+}
+
+impl ClusterRepairView {
+    /// Construct from a topology source and a probe.
+    ///
+    /// On a real node the binary supplies a [`RingTopology`] (over the shared
+    /// `TokenRing`) and an [`RpcRepairProbe`] (over the `PeerManager`). Tests
+    /// supply mocks for both.
+    pub fn new(topology: Arc<dyn ClusterTopology>, probe: Arc<dyn RepairProbe>) -> Self {
+        Self { topology, probe }
+    }
+
+    /// The token range probed for a table's posture. The `ClusterView` trait
+    /// is per-table (no range), and a corrupt generation can span the whole
+    /// ring, so we probe the full ring span: any peer that returns a non-empty
+    /// digest holds readable, non-corrupt data this node can refill from.
+    const PROBE_RANGE: (i64, i64) = (i64::MIN, i64::MAX);
+}
+
+impl ClusterView for ClusterRepairView {
+    fn this_host(&self) -> u64 {
+        self.topology.this_node_id()
+    }
+
+    fn owners(&self, table: &TableKey) -> Option<Vec<u64>> {
+        self.topology.owners(table)
+    }
+
+    fn replica_posture(&self, table: &TableKey) -> ReplicaPosture {
+        let peers = self.topology.replica_peers(table);
+        if peers.is_empty() {
+            // RF ≤ 1 or no reachable peer → the local (possibly corrupt) copy
+            // is the only one. Never quarantine (FMEA #1).
+            tracing::warn!(
+                keyspace = %table.keyspace,
+                table = %table.table,
+                "self-heal: no reachable replica peer for table — posture=SingleNode \
+                 (quarantine will be refused; FMEA #1)"
+            );
+            return ReplicaPosture::SingleNode;
+        }
+
+        let table_id = TableId::new(&table.keyspace, &table.table);
+        for (ring_id, host_id) in &peers {
+            match self
+                .probe
+                .probe_digest(*host_id, &table_id, Self::PROBE_RANGE)
+            {
+                ProbeOutcome::HealthyNonEmpty => {
+                    tracing::info!(
+                        keyspace = %table.keyspace,
+                        table = %table.table,
+                        peer_ring_id = ring_id,
+                        %host_id,
+                        "self-heal: verified healthy replica via repair digest — \
+                         posture=HealthyReplicaAvailable"
+                    );
+                    return ReplicaPosture::HealthyReplicaAvailable;
+                }
+                ProbeOutcome::Empty => {
+                    tracing::debug!(
+                        keyspace = %table.keyspace,
+                        table = %table.table,
+                        peer_ring_id = ring_id,
+                        %host_id,
+                        "self-heal: replica peer returned empty digest — not a refill source"
+                    );
+                }
+                ProbeOutcome::Unreachable => {
+                    tracing::debug!(
+                        keyspace = %table.keyspace,
+                        table = %table.table,
+                        peer_ring_id = ring_id,
+                        %host_id,
+                        "self-heal: replica peer unreachable / probe failed"
+                    );
+                }
+            }
+        }
+
+        // Peers exist but none verified a non-empty copy → no healthy replica.
+        tracing::warn!(
+            keyspace = %table.keyspace,
+            table = %table.table,
+            peers = peers.len(),
+            "self-heal: no peer verified a non-empty copy of table — \
+             posture=NoHealthyReplica (quarantine will be refused; FMEA #1)"
+        );
+        ReplicaPosture::NoHealthyReplica
+    }
+}
+
+/// Production [`RepairProbe`] backed by the existing repair Merkle RPC.
+///
+/// Wraps `PeerManager` and blocks on [`RemoteRepairStore::build_merkle`] via a
+/// tokio runtime handle. The wiring is intentionally thin: it constructs the
+/// same `RemoteRepairStore` the executor uses, builds a Merkle tree for the
+/// range, and treats a non-zero root hash (non-empty content) as a verified
+/// healthy copy. A send/RPC error or an empty (zero-root) tree is a non-source.
+///
+/// `build_merkle` is async and the `ClusterView` method is sync, so this blocks
+/// on the future using the supplied [`tokio::runtime::Handle`]. The binary
+/// supplies the node's runtime handle; the probe must therefore be called from
+/// a blocking context (the self-heal controller already runs its tick on a
+/// dedicated task and the probe is fire-and-verify, not on a hot path).
+pub struct RpcRepairProbe {
+    peer_manager: Arc<PeerManager>,
+    runtime: tokio::runtime::Handle,
+}
+
+impl RpcRepairProbe {
+    /// Construct from the node's `PeerManager` and runtime handle.
+    pub fn new(peer_manager: Arc<PeerManager>, runtime: tokio::runtime::Handle) -> Self {
+        Self {
+            peer_manager,
+            runtime,
+        }
+    }
+}
+
+impl RepairProbe for RpcRepairProbe {
+    fn probe_digest(&self, peer: Uuid, table: &TableId, range: (i64, i64)) -> ProbeOutcome {
+        let remote = RemoteRepairStore {
+            host_id: peer,
+            peer_manager: self.peer_manager.clone(),
+        };
+        let table = table.clone();
+        let (start, end) = range;
+        // Block on the async Merkle RPC. `block_in_place` releases the current
+        // worker thread so we don't deadlock the runtime while waiting.
+        let result = tokio::task::block_in_place(|| {
+            self.runtime
+                .block_on(async move { remote.build_merkle(&table, start, end).await })
+        });
+        match result {
+            Ok(tree) if tree.root_hash() != 0 => ProbeOutcome::HealthyNonEmpty,
+            Ok(_) => ProbeOutcome::Empty,
+            Err(e) => {
+                tracing::debug!(%peer, %e, "self-heal probe: build_merkle RPC failed");
+                ProbeOutcome::Unreachable
+            }
+        }
+    }
+}
+
+/// Production [`ClusterTopology`] over the live `TokenRing`.
+///
+/// The binary supplies the shared ring (typically `Arc<RwLock<TokenRing>>`)
+/// behind a snapshot closure plus this node's `u64` ring id, so the view always
+/// reflects current membership. `replica_peers` returns the table's eligible
+/// replica peers (excluding self), mapping each `u64` ring id to its `host_id`
+/// UUID for the probe.
+pub struct RingTopology<F>
+where
+    F: Fn() -> crate::ring::TokenRing + Send + Sync,
+{
+    this_node_id: u64,
+    /// Replication factor used to scope the replica set. The binary passes the
+    /// keyspace RF (per FMEA #11 — not a hardcoded constant).
+    rf: usize,
+    snapshot: F,
+}
+
+impl<F> RingTopology<F>
+where
+    F: Fn() -> crate::ring::TokenRing + Send + Sync,
+{
+    /// Construct from this node's ring id, the replication factor, and a
+    /// closure that snapshots the current ring.
+    pub fn new(this_node_id: u64, rf: usize, snapshot: F) -> Self {
+        Self {
+            this_node_id,
+            rf,
+            snapshot,
+        }
+    }
+}
+
+impl<F> ClusterTopology for RingTopology<F>
+where
+    F: Fn() -> crate::ring::TokenRing + Send + Sync,
+{
+    fn this_node_id(&self) -> u64 {
+        self.this_node_id
+    }
+
+    fn owners(&self, _table: &TableKey) -> Option<Vec<u64>> {
+        // Ownership is range-based; for the posture gate (and the controller's
+        // initiator selection) the relevant owner set is the table's replica
+        // nodes. We report the eligible replica node ids for a representative
+        // (full-ring) probe — the controller only uses this to pick the
+        // lowest-id initiator, which is stable across the ring.
+        let ring = (self.snapshot)();
+        let mut owners: Vec<u64> = ring
+            .node_ids()
+            .into_iter()
+            .filter(|&n| {
+                ring.get_node(n).is_some_and(|info| match info.state {
+                    crate::raft::NodeState::Normal => true,
+                    crate::raft::NodeState::Learner { owns_tokens } => owns_tokens,
+                    _ => false,
+                })
+            })
+            .collect();
+        if owners.is_empty() {
+            return None;
+        }
+        owners.sort_unstable();
+        Some(owners)
+    }
+
+    fn replica_peers(&self, _table: &TableKey) -> Vec<(u64, Uuid)> {
+        let ring = (self.snapshot)();
+        // Eligible replica nodes other than self, in ascending ring-id order.
+        // We treat the table's replica set as the eligible nodes up to RF;
+        // probing any one that verifies a non-empty copy satisfies FMEA #1.
+        let mut peers: Vec<(u64, Uuid)> = ring
+            .node_ids()
+            .into_iter()
+            .filter(|&n| n != self.this_node_id)
+            .filter_map(|n| {
+                ring.get_node(n).and_then(|info| {
+                    let eligible = match info.state {
+                        crate::raft::NodeState::Normal => true,
+                        crate::raft::NodeState::Learner { owns_tokens } => owns_tokens,
+                        _ => false,
+                    };
+                    eligible.then_some((n, info.host_id))
+                })
+            })
+            .collect();
+        peers.sort_by_key(|(n, _)| *n);
+        // Scope to at most RF-1 peers (the other replicas besides self).
+        let cap = self.rf.saturating_sub(1);
+        peers.truncate(cap);
+        peers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// Mock topology with a fixed peer list and owner set.
+    struct MockTopology {
+        this: u64,
+        owners: Option<Vec<u64>>,
+        peers: Vec<(u64, Uuid)>,
+    }
+    impl ClusterTopology for MockTopology {
+        fn this_node_id(&self) -> u64 {
+            self.this
+        }
+        fn owners(&self, _t: &TableKey) -> Option<Vec<u64>> {
+            self.owners.clone()
+        }
+        fn replica_peers(&self, _t: &TableKey) -> Vec<(u64, Uuid)> {
+            self.peers.clone()
+        }
+    }
+
+    /// Mock probe returning a per-peer canned outcome, recording calls.
+    struct MockProbe {
+        outcomes: HashMap<Uuid, ProbeOutcome>,
+        probed: Mutex<Vec<Uuid>>,
+    }
+    impl MockProbe {
+        fn new(outcomes: Vec<(Uuid, ProbeOutcome)>) -> Self {
+            Self {
+                outcomes: outcomes.into_iter().collect(),
+                probed: Mutex::new(Vec::new()),
+            }
+        }
+    }
+    impl RepairProbe for MockProbe {
+        fn probe_digest(&self, peer: Uuid, _t: &TableId, _r: (i64, i64)) -> ProbeOutcome {
+            self.probed.lock().unwrap().push(peer);
+            self.outcomes
+                .get(&peer)
+                .copied()
+                .unwrap_or(ProbeOutcome::Unreachable)
+        }
+    }
+
+    fn view(topology: MockTopology, probe: MockProbe) -> ClusterRepairView {
+        ClusterRepairView::new(Arc::new(topology), Arc::new(probe))
+    }
+
+    #[test]
+    fn verified_non_empty_peer_yields_healthy_posture() {
+        let peer = Uuid::new_v4();
+        let v = view(
+            MockTopology {
+                this: 1,
+                owners: Some(vec![1, 2]),
+                peers: vec![(2, peer)],
+            },
+            MockProbe::new(vec![(peer, ProbeOutcome::HealthyNonEmpty)]),
+        );
+        assert_eq!(
+            v.replica_posture(&TableKey::new("ks", "t")),
+            ReplicaPosture::HealthyReplicaAvailable
+        );
+    }
+
+    #[test]
+    fn no_peer_yields_single_node_posture() {
+        let v = view(
+            MockTopology {
+                this: 1,
+                owners: None,
+                peers: vec![],
+            },
+            MockProbe::new(vec![]),
+        );
+        assert_eq!(
+            v.replica_posture(&TableKey::new("ks", "t")),
+            ReplicaPosture::SingleNode
+        );
+    }
+
+    #[test]
+    fn unreachable_peer_yields_no_healthy_replica() {
+        let peer = Uuid::new_v4();
+        let v = view(
+            MockTopology {
+                this: 1,
+                owners: Some(vec![1, 2]),
+                peers: vec![(2, peer)],
+            },
+            MockProbe::new(vec![(peer, ProbeOutcome::Unreachable)]),
+        );
+        assert_eq!(
+            v.replica_posture(&TableKey::new("ks", "t")),
+            ReplicaPosture::NoHealthyReplica
+        );
+    }
+
+    #[test]
+    fn empty_digest_peer_yields_no_healthy_replica() {
+        let peer = Uuid::new_v4();
+        let v = view(
+            MockTopology {
+                this: 1,
+                owners: Some(vec![1, 2]),
+                peers: vec![(2, peer)],
+            },
+            MockProbe::new(vec![(peer, ProbeOutcome::Empty)]),
+        );
+        assert_eq!(
+            v.replica_posture(&TableKey::new("ks", "t")),
+            ReplicaPosture::NoHealthyReplica
+        );
+    }
+
+    #[test]
+    fn first_healthy_peer_short_circuits_in_deterministic_order() {
+        // peer A (ring id 2) is empty, peer B (ring id 3) is healthy. Probe
+        // order is the topology's order; both must be tried and the healthy
+        // one wins.
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let probe = Arc::new(MockProbe::new(vec![
+            (a, ProbeOutcome::Empty),
+            (b, ProbeOutcome::HealthyNonEmpty),
+        ]));
+        let v = ClusterRepairView::new(
+            Arc::new(MockTopology {
+                this: 1,
+                owners: Some(vec![1, 2, 3]),
+                peers: vec![(2, a), (3, b)],
+            }),
+            probe.clone(),
+        );
+        assert_eq!(
+            v.replica_posture(&TableKey::new("ks", "t")),
+            ReplicaPosture::HealthyReplicaAvailable
+        );
+        // Both peers were probed (A empty, then B healthy).
+        assert_eq!(probe.probed.lock().unwrap().as_slice(), &[a, b]);
+    }
+
+    #[test]
+    fn cluster_view_owners_and_this_host_delegate_to_topology() {
+        let v = view(
+            MockTopology {
+                this: 7,
+                owners: Some(vec![3, 7, 9]),
+                peers: vec![],
+            },
+            MockProbe::new(vec![]),
+        );
+        assert_eq!(v.this_host(), 7);
+        assert_eq!(v.owners(&TableKey::new("ks", "t")), Some(vec![3, 7, 9]));
+    }
+
+    // ---- RingTopology over a real TokenRing ----
+
+    use crate::raft::{NodeInfo, NodeState};
+    use crate::ring::TokenRing;
+
+    fn node(addr: &str, state: NodeState) -> (Uuid, NodeInfo) {
+        let host_id = Uuid::new_v4();
+        (
+            host_id,
+            NodeInfo {
+                host_id,
+                addr: addr.to_string(),
+                data_center: "dc1".to_string(),
+                rack: "rack1".to_string(),
+                state,
+                cql_broadcast: None,
+            },
+        )
+    }
+
+    #[test]
+    fn ring_topology_returns_other_eligible_peers_capped_by_rf() {
+        let (_h1, n1) = node("10.0.0.1:7000", NodeState::Normal);
+        let (h2, n2) = node("10.0.0.2:7000", NodeState::Normal);
+        let (h3, n3) = node("10.0.0.3:7000", NodeState::Normal);
+        let (_h4, n4) = node("10.0.0.4:7000", NodeState::Learner { owns_tokens: false });
+        let mut ring = TokenRing::new();
+        ring.add_node(1, n1);
+        ring.add_node(2, n2);
+        ring.add_node(3, n3);
+        ring.add_node(4, n4);
+
+        let topo = RingTopology::new(1, 3, move || ring.clone());
+        let peers = topo.replica_peers(&TableKey::new("ks", "t"));
+        // self (1) excluded, learner-without-tokens (4) excluded, RF=3 → 2 peers.
+        assert_eq!(peers, vec![(2, h2), (3, h3)]);
+        // owners excludes the witness learner but includes self.
+        let mut owners = topo.owners(&TableKey::new("ks", "t")).unwrap();
+        owners.sort_unstable();
+        assert_eq!(owners, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn ring_topology_single_node_has_no_peers() {
+        let (_h1, n1) = node("10.0.0.1:7000", NodeState::Normal);
+        let mut ring = TokenRing::new();
+        ring.add_node(1, n1);
+        let topo = RingTopology::new(1, 1, move || ring.clone());
+        assert!(topo.replica_peers(&TableKey::new("ks", "t")).is_empty());
+    }
+}

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -209,7 +209,7 @@ impl RepairCoordinator {
 /// replica set for `rf`. For the wrap-around segment (last token → first
 /// token via i64::MIN/MAX), we emit TWO ranges so callers don't have to
 /// special-case it.
-fn owned_token_ranges(ring: &TokenRing, local_node_id: u64, rf: usize) -> Vec<(i64, i64)> {
+pub(crate) fn owned_token_ranges(ring: &TokenRing, local_node_id: u64, rf: usize) -> Vec<(i64, i64)> {
     let mut all_tokens: Vec<i64> = ring
         .node_ids()
         .iter()

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -155,6 +155,44 @@ impl RepairCoordinator {
             }
         }
 
+        self.run_session_tasks(executor, table, tasks).await
+    }
+
+    /// Repair **only the token ranges this node is the deterministic initiator
+    /// for** (lowest live host_id among the range's replicas — see
+    /// [`select_initiated_ranges`](super::scheduler::select_initiated_ranges)),
+    /// against that range's live peers.
+    ///
+    /// This is the entry point the automatic-repair scheduler uses: unlike
+    /// [`Self::repair_table`] (which repairs *every* owned range and is meant to
+    /// be triggered on a single node), this is safe to run on **every** node
+    /// simultaneously — each range is initiated exactly once (FMEA #1, no herd).
+    pub async fn repair_initiated(
+        &self,
+        executor: Arc<dyn SessionExecutor>,
+        ring: &TokenRing,
+        local_node_id: u64,
+        rf: usize,
+        table: &TableId,
+    ) -> Vec<SessionResult> {
+        let mut tasks: Vec<(i64, i64, u64)> = Vec::new();
+        for r in super::scheduler::select_initiated_ranges(ring, local_node_id, rf) {
+            for peer in r.peers {
+                tasks.push((r.start, r.end, peer));
+            }
+        }
+        self.run_session_tasks(executor, table, tasks).await
+    }
+
+    /// Fan out one repair session per `(range_start, range_end, peer)` task,
+    /// bounded by `max_concurrent_sessions`. Shared by [`Self::repair_table`]
+    /// and [`Self::repair_initiated`].
+    async fn run_session_tasks(
+        &self,
+        executor: Arc<dyn SessionExecutor>,
+        table: &TableId,
+        tasks: Vec<(i64, i64, u64)>,
+    ) -> Vec<SessionResult> {
         // Bound parallelism with a semaphore.
         let sem = Arc::new(tokio::sync::Semaphore::new(self.max_concurrent_sessions));
         let mut handles = Vec::with_capacity(tasks.len());
@@ -300,6 +338,33 @@ mod tests {
         ring.assign_tokens(2, &[200, 500, 800]);
         ring.assign_tokens(3, &[300, 600, 900]);
         ring
+    }
+
+    /// FMEA #1 at the coordinator level: when every node runs `repair_initiated`
+    /// (the automatic path), each token range is repaired by exactly ONE
+    /// initiator — not RF times. So exactly one of the three nodes schedules
+    /// sessions; the other two schedule none.
+    #[tokio::test]
+    async fn repair_initiated_runs_each_range_once_across_all_nodes() {
+        let ring = three_node_ring();
+        let table = TableId::new("ks", "tbl");
+        let coord = RepairCoordinator {
+            max_concurrent_sessions: 4,
+        };
+        let mut nonempty = 0usize;
+        let mut total = 0usize;
+        for node in [1u64, 2, 3] {
+            let exec = Arc::new(MockExecutor::new());
+            let results = coord
+                .repair_initiated(exec.clone(), &ring, node, 3, &table)
+                .await;
+            if !results.is_empty() {
+                nonempty += 1;
+            }
+            total += results.len();
+        }
+        assert_eq!(nonempty, 1, "exactly one node initiates each range (no herd)");
+        assert!(total > 0, "the sole initiator scheduled its sessions");
     }
 
     #[tokio::test]

--- a/ferrosa-cluster/src/repair/coordinator.rs
+++ b/ferrosa-cluster/src/repair/coordinator.rs
@@ -247,7 +247,11 @@ impl RepairCoordinator {
 /// replica set for `rf`. For the wrap-around segment (last token → first
 /// token via i64::MIN/MAX), we emit TWO ranges so callers don't have to
 /// special-case it.
-pub(crate) fn owned_token_ranges(ring: &TokenRing, local_node_id: u64, rf: usize) -> Vec<(i64, i64)> {
+pub(crate) fn owned_token_ranges(
+    ring: &TokenRing,
+    local_node_id: u64,
+    rf: usize,
+) -> Vec<(i64, i64)> {
     let mut all_tokens: Vec<i64> = ring
         .node_ids()
         .iter()
@@ -363,7 +367,10 @@ mod tests {
             }
             total += results.len();
         }
-        assert_eq!(nonempty, 1, "exactly one node initiates each range (no herd)");
+        assert_eq!(
+            nonempty, 1,
+            "exactly one node initiates each range (no herd)"
+        );
         assert!(total > 0, "the sole initiator scheduled its sessions");
     }
 

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -16,12 +16,16 @@
 //! - **RepairScheduler**: Background task that periodically triggers repair
 //!   sessions for all locally-owned token ranges.
 
+pub mod cluster_view;
 pub mod coordinator;
 pub mod executor;
 pub mod merkle;
 pub mod rpc;
 pub mod scheduler;
 
+pub use cluster_view::{
+    ClusterRepairView, ClusterTopology, ProbeOutcome, RepairProbe, RingTopology, RpcRepairProbe,
+};
 pub use coordinator::{RepairCoordinator, SessionExecutor, SessionResult, SessionStats};
 pub use scheduler::{
     select_initiated_ranges, select_tables_for_tick, AutoRepairConfig, AutoRepairScheduler,

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -23,7 +23,10 @@ pub mod rpc;
 pub mod scheduler;
 
 pub use coordinator::{RepairCoordinator, SessionExecutor, SessionResult, SessionStats};
-pub use scheduler::{select_initiated_ranges, InitiatedRange};
+pub use scheduler::{
+    select_initiated_ranges, select_tables_for_tick, AutoRepairConfig, AutoRepairScheduler,
+    InitiatedRange, RepairContext,
+};
 pub use executor::{
     InMemoryRepairStore, LocalRepairExecutor, RepairStore, StorageEngineRepairStore,
 };

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -27,15 +27,15 @@ pub use cluster_view::{
     ClusterRepairView, ClusterTopology, ProbeOutcome, RepairProbe, RingTopology, RpcRepairProbe,
 };
 pub use coordinator::{RepairCoordinator, SessionExecutor, SessionResult, SessionStats};
-pub use scheduler::{
-    select_initiated_ranges, select_tables_for_tick, AutoRepairConfig, AutoRepairScheduler,
-    InitiatedRange, RepairContext,
-};
 pub use executor::{
     InMemoryRepairStore, LocalRepairExecutor, RepairStore, StorageEngineRepairStore,
 };
 pub use merkle::MerkleTree;
 pub use rpc::{RemoteRepairStore, RepairApplyHandler, RepairFetchHandler, RepairMerkleHandler};
+pub use scheduler::{
+    select_initiated_ranges, select_tables_for_tick, AutoRepairConfig, AutoRepairScheduler,
+    InitiatedRange, RepairContext,
+};
 
 use ferrosa_sstable::types::Partition;
 use ferrosa_storage::engine::StorageEngine;

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -20,8 +20,10 @@ pub mod coordinator;
 pub mod executor;
 pub mod merkle;
 pub mod rpc;
+pub mod scheduler;
 
 pub use coordinator::{RepairCoordinator, SessionExecutor, SessionResult, SessionStats};
+pub use scheduler::{select_initiated_ranges, InitiatedRange};
 pub use executor::{
     InMemoryRepairStore, LocalRepairExecutor, RepairStore, StorageEngineRepairStore,
 };

--- a/ferrosa-cluster/src/repair/scheduler.rs
+++ b/ferrosa-cluster/src/repair/scheduler.rs
@@ -126,7 +126,12 @@ impl AutoRepairConfig {
         let d = Self::default();
         let enabled = std::env::var("FERROSA_AUTO_REPAIR_ENABLED")
             .ok()
-            .map(|v| !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off" | "no"))
+            .map(|v| {
+                !matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "0" | "false" | "off" | "no"
+                )
+            })
             .unwrap_or(d.enabled);
         let interval = std::env::var("FERROSA_AUTO_REPAIR_INTERVAL_SECS")
             .ok()
@@ -315,7 +320,11 @@ impl AutoRepairScheduler {
     /// Construct a scheduler. `coord` bounds per-table session concurrency;
     /// `ctx` supplies the live ring/executor/tables each tick; `cfg` controls
     /// cadence and skip-lists.
-    pub fn new(coord: RepairCoordinator, ctx: Arc<dyn RepairContext>, cfg: AutoRepairConfig) -> Self {
+    pub fn new(
+        coord: RepairCoordinator,
+        ctx: Arc<dyn RepairContext>,
+        cfg: AutoRepairConfig,
+    ) -> Self {
         Self {
             coord,
             ctx,
@@ -340,17 +349,20 @@ impl AutoRepairScheduler {
         inc_auto_repair_tick();
 
         // One consistent snapshot of the ring view for the whole tick.
-        let (ring, local_node_id, executor) =
-            match (self.ctx.token_ring(), self.ctx.local_node_id(), self.ctx.build_executor()) {
-                (Some(ring), Some(id), Some(exec)) => (ring, id, exec),
-                _ => {
-                    AUTO_REPAIR_SKIPPED_NOT_READY.fetch_add(1, Ordering::Relaxed);
-                    tracing::info!(
+        let (ring, local_node_id, executor) = match (
+            self.ctx.token_ring(),
+            self.ctx.local_node_id(),
+            self.ctx.build_executor(),
+        ) {
+            (Some(ring), Some(id), Some(exec)) => (ring, id, exec),
+            _ => {
+                AUTO_REPAIR_SKIPPED_NOT_READY.fetch_add(1, Ordering::Relaxed);
+                tracing::info!(
                         "auto-repair: node not ring-ready (no ring / node_id / executor); skipping tick"
                     );
-                    return;
-                }
-            };
+                return;
+            }
+        };
 
         let tables_with_rf = self.ctx.user_tables();
         let tables: Vec<TableId> = tables_with_rf.iter().map(|(t, _)| t.clone()).collect();
@@ -499,7 +511,8 @@ impl AutoRepairScheduler {
                 // Recompute the sub-tick from the live table count each cycle so
                 // membership/schema churn re-spreads coverage (design: cadence).
                 let table_count = scheduler.ctx.user_tables().len();
-                let period = AutoRepairScheduler::sub_tick(interval_cfg, table_count, max_concurrent);
+                let period =
+                    AutoRepairScheduler::sub_tick(interval_cfg, table_count, max_concurrent);
                 tokio::select! {
                     result = shutdown.changed() => {
                         if result.is_err() || *shutdown.borrow() {
@@ -557,7 +570,10 @@ mod tests {
         let n2 = select_initiated_ranges(&ring, 2, 3);
         let n3 = select_initiated_ranges(&ring, 3, 3);
 
-        assert!(!n1.is_empty(), "lowest-host_id node must initiate its ranges");
+        assert!(
+            !n1.is_empty(),
+            "lowest-host_id node must initiate its ranges"
+        );
         assert!(n2.is_empty(), "node 2 must NOT initiate (node 1 is lower)");
         assert!(n3.is_empty(), "node 3 must NOT initiate (node 1 is lower)");
 
@@ -629,8 +645,14 @@ mod tests {
         assert!(c.enabled, "auto-repair on by default");
         assert_eq!(c.interval, Duration::from_secs(86_400), "24h default");
         assert_eq!(c.max_concurrent_tables, 1);
-        assert!(c.is_skipped(&tid("system_auth", "roles")), "system* skipped");
-        assert!(!c.is_skipped(&tid("app", "users")), "user keyspace not skipped");
+        assert!(
+            c.is_skipped(&tid("system_auth", "roles")),
+            "system* skipped"
+        );
+        assert!(
+            !c.is_skipped(&tid("app", "users")),
+            "user keyspace not skipped"
+        );
     }
 
     #[test]
@@ -666,7 +688,10 @@ mod tests {
         covered.extend(p1);
         covered.extend(p2);
         covered.sort_by(|a, b| a.table().cmp(b.table()));
-        assert_eq!(covered, tables, "three ticks cover every table exactly once");
+        assert_eq!(
+            covered, tables,
+            "three ticks cover every table exactly once"
+        );
     }
 
     #[test]
@@ -676,7 +701,9 @@ mod tests {
         assert!(select_tables_for_tick(&[], 0, 1, &empty, &cfg).0.is_empty());
         // All-system set → nothing picked, no infinite scan.
         let sys = vec![tid("system", "a"), tid("system_auth", "b")];
-        assert!(select_tables_for_tick(&sys, 0, 4, &empty, &cfg).0.is_empty());
+        assert!(select_tables_for_tick(&sys, 0, 4, &empty, &cfg)
+            .0
+            .is_empty());
     }
 
     // -- AutoRepairScheduler / RepairContext tests (no real IO) -------------
@@ -830,8 +857,11 @@ mod tests {
             tables: vec![(tid("app", "a"), 3)],
             ready: false, // not in cluster mode / not placed in ring
         });
-        let mut sched =
-            AutoRepairScheduler::new(RepairCoordinator::default(), ctx, AutoRepairConfig::default());
+        let mut sched = AutoRepairScheduler::new(
+            RepairCoordinator::default(),
+            ctx,
+            AutoRepairConfig::default(),
+        );
 
         sched.run_tick().await;
 

--- a/ferrosa-cluster/src/repair/scheduler.rs
+++ b/ferrosa-cluster/src/repair/scheduler.rs
@@ -1,0 +1,187 @@
+//! Automatic anti-entropy repair scheduler.
+//!
+//! Design: `specs/proposed/automatic-repair-scheduler-design.md`
+//! FMEA:   `specs/proposed/automatic-repair-scheduler-fmea.md`
+//!
+//! The cluster already has the repair *primitives* (`RepairCoordinator::
+//! repair_table` → bounded Merkle-diff-then-stream sessions). What was missing
+//! for *automatic* repair is a deterministic driver that decides **which ranges
+//! this node should initiate** so that, when every node runs the scheduler, each
+//! token range is repaired by exactly **one** initiator — not once per replica.
+//!
+//! That decision is [`select_initiated_ranges`], a **pure function** of the ring
+//! (no clock, no RNG, no IO — FMEA #4): for each range the local node replicates,
+//! the initiator is the live replica with the **lowest `host_id`**. Only when the
+//! local node *is* that initiator does the range appear in the result. This kills
+//! the thundering-herd failure mode (FMEA #1) without an election: same ring →
+//! same single initiator, recomputed each tick so membership churn self-corrects.
+
+use crate::ring::TokenRing;
+
+use super::{coordinator::owned_token_ranges, repair_participants};
+
+/// One token range this node should initiate repair for, with the live peers to
+/// repair against. `[start, end)` over the vnode partitioning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitiatedRange {
+    pub start: i64,
+    pub end: i64,
+    /// Live replica peers (excluding self) to run sessions against.
+    pub peers: Vec<u64>,
+}
+
+/// Ranges the local node should **initiate** anti-entropy repair for this cycle,
+/// as the deterministic single initiator.
+///
+/// For every range the local node replicates (at `rf`), the initiator is the
+/// **live** replica with the lowest `host_id`. The range is returned only when
+/// the local node is that initiator and at least one live peer exists. Pure
+/// function of the ring — no IO/clock/RNG, so it is unit-testable and produces
+/// the same selection on every node given the same ring (FMEA #1 herd, #4
+/// determinism, #5 churn-idempotence).
+pub fn select_initiated_ranges(
+    ring: &TokenRing,
+    local_node_id: u64,
+    rf: usize,
+) -> Vec<InitiatedRange> {
+    // The local node must be in the ring to compare host_ids; if it isn't yet
+    // (still joining), it initiates nothing.
+    let local_host = match ring.get_node(local_node_id) {
+        Some(info) => info.host_id,
+        None => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for (start, end) in owned_token_ranges(ring, local_node_id, rf) {
+        // Live replicas of this range (down/joining nodes filtered out).
+        let participants = repair_participants(ring, start, rf);
+
+        // Peers to repair against = live participants other than self. With no
+        // peer there is nothing to reconcile (single-node / all-peers-down).
+        let peers: Vec<u64> = participants
+            .iter()
+            .copied()
+            .filter(|&p| p != local_node_id)
+            .collect();
+        if peers.is_empty() {
+            continue;
+        }
+
+        // Deterministic initiator = live participant with the lowest host_id.
+        // host_id is the durable per-node identity (stable across restarts), so
+        // the choice is stable for a given ring and survives node_id reuse.
+        let initiator_host = participants
+            .iter()
+            .filter_map(|&n| ring.get_node(n).map(|info| info.host_id))
+            .min();
+
+        if initiator_host == Some(local_host) {
+            out.push(InitiatedRange { start, end, peers });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raft::{NodeInfo, NodeState};
+    use uuid::Uuid;
+
+    fn node(addr: &str, host_id: u128, state: NodeState) -> NodeInfo {
+        NodeInfo {
+            host_id: Uuid::from_u128(host_id),
+            addr: addr.to_string(),
+            data_center: "dc1".to_string(),
+            rack: "rack1".to_string(),
+            state,
+            cql_broadcast: None,
+        }
+    }
+
+    /// 3-node ring, RF=3, with FIXED host_ids (1 < 2 < 3 by UUID order) so the
+    /// initiator is deterministic and assertable. node_id N has host_id N.
+    fn three_node_ring() -> TokenRing {
+        let mut ring = TokenRing::new();
+        ring.add_node(1, node("10.0.0.1:7000", 1, NodeState::Normal));
+        ring.add_node(2, node("10.0.0.2:7000", 2, NodeState::Normal));
+        ring.add_node(3, node("10.0.0.3:7000", 3, NodeState::Normal));
+        ring.assign_tokens(1, &[100, 400, 700]);
+        ring.assign_tokens(2, &[200, 500, 800]);
+        ring.assign_tokens(3, &[300, 600, 900]);
+        ring
+    }
+
+    /// FMEA #1 (thundering herd): with RF=3 on a 3-node ring every range's
+    /// replica set is {1,2,3}, so the lowest-host_id node (node 1) is the sole
+    /// initiator. node 1 selects every owned range; nodes 2 and 3 select none.
+    #[test]
+    fn exactly_one_initiator_per_range_no_herd() {
+        let ring = three_node_ring();
+
+        let n1 = select_initiated_ranges(&ring, 1, 3);
+        let n2 = select_initiated_ranges(&ring, 2, 3);
+        let n3 = select_initiated_ranges(&ring, 3, 3);
+
+        assert!(!n1.is_empty(), "lowest-host_id node must initiate its ranges");
+        assert!(n2.is_empty(), "node 2 must NOT initiate (node 1 is lower)");
+        assert!(n3.is_empty(), "node 3 must NOT initiate (node 1 is lower)");
+
+        // Every initiated range repairs against the other two replicas.
+        for r in &n1 {
+            let mut peers = r.peers.clone();
+            peers.sort_unstable();
+            assert_eq!(peers, vec![2, 3], "RF=3 peers = the two non-self replicas");
+            assert!(r.start < r.end, "range must be non-empty [start,end)");
+        }
+    }
+
+    /// FMEA #4 (determinism): same ring → identical selection, every call.
+    #[test]
+    fn selection_is_deterministic() {
+        let ring = three_node_ring();
+        let a = select_initiated_ranges(&ring, 1, 3);
+        let b = select_initiated_ranges(&ring, 1, 3);
+        assert_eq!(a, b);
+    }
+
+    /// FMEA #5 (membership churn): if the lowest-host_id node goes down, the
+    /// next-lowest LIVE replica becomes the initiator — no range is orphaned and
+    /// no two nodes initiate the same range.
+    #[test]
+    fn initiator_fails_over_when_lowest_host_down() {
+        let mut ring = three_node_ring();
+        // Take node 1 (lowest host_id) out of the live set.
+        ring.set_node_state(1, NodeState::Leaving);
+
+        let n2 = select_initiated_ranges(&ring, 2, 3);
+        let n3 = select_initiated_ranges(&ring, 3, 3);
+
+        assert!(
+            !n2.is_empty(),
+            "node 2 (now lowest live host_id) must take over initiation"
+        );
+        assert!(n3.is_empty(), "node 3 still defers to node 2");
+        // The down node is never a repair peer.
+        for r in &n2 {
+            assert!(!r.peers.contains(&1), "down node must not be a peer");
+        }
+    }
+
+    /// Single-node ring (or RF=1): no peers to reconcile → initiate nothing.
+    #[test]
+    fn single_node_selects_nothing() {
+        let mut ring = TokenRing::new();
+        ring.add_node(1, node("10.0.0.1:7000", 1, NodeState::Normal));
+        ring.assign_tokens(1, &[100, 400, 700]);
+        assert!(select_initiated_ranges(&ring, 1, 1).is_empty());
+        assert!(select_initiated_ranges(&ring, 1, 3).is_empty());
+    }
+
+    /// A node not yet in the ring initiates nothing (no host_id to compare).
+    #[test]
+    fn unknown_local_node_selects_nothing() {
+        let ring = three_node_ring();
+        assert!(select_initiated_ranges(&ring, 999, 3).is_empty());
+    }
+}

--- a/ferrosa-cluster/src/repair/scheduler.rs
+++ b/ferrosa-cluster/src/repair/scheduler.rs
@@ -16,6 +16,11 @@
 //! the thundering-herd failure mode (FMEA #1) without an election: same ring →
 //! same single initiator, recomputed each tick so membership churn self-corrects.
 
+use std::collections::HashSet;
+use std::time::Duration;
+
+use ferrosa_storage::TableId;
+
 use crate::ring::TokenRing;
 
 use super::{coordinator::owned_token_ranges, repair_participants};
@@ -80,6 +85,114 @@ pub fn select_initiated_ranges(
         }
     }
     out
+}
+
+/// Deterministic configuration for the automatic repair scheduler. All values
+/// come from env (fixed defaults otherwise) so behaviour is reproducible.
+#[derive(Debug, Clone)]
+pub struct AutoRepairConfig {
+    /// Master switch. `FERROSA_AUTO_REPAIR_ENABLED` (default **on**).
+    pub enabled: bool,
+    /// Full-coverage period — every owned range is repaired once per interval,
+    /// spread round-robin across tables. `FERROSA_AUTO_REPAIR_INTERVAL_SECS`
+    /// (default 86400 = 24h).
+    pub interval: Duration,
+    /// Tables repaired per sub-tick (load shaping).
+    /// `FERROSA_AUTO_REPAIR_MAX_CONCURRENT_TABLES` (default 1).
+    pub max_concurrent_tables: usize,
+    /// Keyspace name prefixes never auto-repaired (system/internal).
+    /// `FERROSA_AUTO_REPAIR_SKIP_KEYSPACES` (comma-separated; default `system`).
+    pub skip_keyspaces: Vec<String>,
+}
+
+impl Default for AutoRepairConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval: Duration::from_secs(86_400),
+            max_concurrent_tables: 1,
+            skip_keyspaces: vec!["system".to_string()],
+        }
+    }
+}
+
+impl AutoRepairConfig {
+    /// Build from environment, falling back to [`Default`] for any unset/unparseable var.
+    pub fn from_env() -> Self {
+        let d = Self::default();
+        let enabled = std::env::var("FERROSA_AUTO_REPAIR_ENABLED")
+            .ok()
+            .map(|v| !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off" | "no"))
+            .unwrap_or(d.enabled);
+        let interval = std::env::var("FERROSA_AUTO_REPAIR_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .filter(|&s| s > 0)
+            .map(Duration::from_secs)
+            .unwrap_or(d.interval);
+        let max_concurrent_tables = std::env::var("FERROSA_AUTO_REPAIR_MAX_CONCURRENT_TABLES")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(d.max_concurrent_tables);
+        let skip_keyspaces = std::env::var("FERROSA_AUTO_REPAIR_SKIP_KEYSPACES")
+            .ok()
+            .map(|v| {
+                v.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|v| !v.is_empty())
+            .unwrap_or(d.skip_keyspaces);
+        Self {
+            enabled,
+            interval,
+            max_concurrent_tables,
+            skip_keyspaces,
+        }
+    }
+
+    /// True if `table`'s keyspace matches any skip prefix.
+    pub fn is_skipped(&self, table: &TableId) -> bool {
+        self.skip_keyspaces
+            .iter()
+            .any(|p| table.keyspace().starts_with(p.as_str()))
+    }
+}
+
+/// Pick the next batch of tables to repair this sub-tick, round-robin from
+/// `cursor`, skipping system/skip-listed keyspaces and tables already in flight.
+/// Pure + deterministic. Returns `(tables_to_repair, next_cursor)`.
+///
+/// Round-robin (not always-from-zero) guarantees forward progress across the
+/// whole table set within one `interval` even if early tables are persistently
+/// in-flight, and bounds per-tick load to `max_concurrent` (FMEA #8 runaway
+/// cadence).
+pub fn select_tables_for_tick(
+    tables: &[TableId],
+    cursor: usize,
+    max_concurrent: usize,
+    in_flight: &HashSet<TableId>,
+    cfg: &AutoRepairConfig,
+) -> (Vec<TableId>, usize) {
+    let n = tables.len();
+    if n == 0 || max_concurrent == 0 {
+        return (Vec::new(), 0);
+    }
+    let mut picked = Vec::new();
+    let mut i = cursor % n;
+    let mut scanned = 0usize;
+    // Scan at most one full lap so we never spin on an all-skipped set.
+    while picked.len() < max_concurrent && scanned < n {
+        let t = &tables[i];
+        if !cfg.is_skipped(t) && !in_flight.contains(t) {
+            picked.push(t.clone());
+        }
+        i = (i + 1) % n;
+        scanned += 1;
+    }
+    (picked, i)
 }
 
 #[cfg(test)]
@@ -183,5 +296,65 @@ mod tests {
     fn unknown_local_node_selects_nothing() {
         let ring = three_node_ring();
         assert!(select_initiated_ranges(&ring, 999, 3).is_empty());
+    }
+
+    fn tid(ks: &str, t: &str) -> TableId {
+        TableId::new(ks, t)
+    }
+
+    #[test]
+    fn config_defaults_are_self_managing() {
+        let c = AutoRepairConfig::default();
+        assert!(c.enabled, "auto-repair on by default");
+        assert_eq!(c.interval, Duration::from_secs(86_400), "24h default");
+        assert_eq!(c.max_concurrent_tables, 1);
+        assert!(c.is_skipped(&tid("system_auth", "roles")), "system* skipped");
+        assert!(!c.is_skipped(&tid("app", "users")), "user keyspace not skipped");
+    }
+
+    #[test]
+    fn select_tables_skips_system_and_in_flight_round_robin() {
+        let cfg = AutoRepairConfig::default();
+        let tables = vec![
+            tid("system", "local"),
+            tid("app", "t1"),
+            tid("app", "t2"),
+            tid("app", "t3"),
+        ];
+        let mut in_flight = HashSet::new();
+        in_flight.insert(tid("app", "t1"));
+
+        // max 2: skip system.local (system*) and app.t1 (in-flight) → t2, t3.
+        let (picked, _next) = select_tables_for_tick(&tables, 0, 2, &in_flight, &cfg);
+        assert_eq!(picked, vec![tid("app", "t2"), tid("app", "t3")]);
+    }
+
+    #[test]
+    fn select_tables_round_robin_covers_all_over_ticks() {
+        let cfg = AutoRepairConfig::default();
+        let tables = vec![tid("app", "a"), tid("app", "b"), tid("app", "c")];
+        let empty = HashSet::new();
+
+        // One table per tick (default max_concurrent_tables=1).
+        let (p0, c0) = select_tables_for_tick(&tables, 0, 1, &empty, &cfg);
+        let (p1, c1) = select_tables_for_tick(&tables, c0, 1, &empty, &cfg);
+        let (p2, _c2) = select_tables_for_tick(&tables, c1, 1, &empty, &cfg);
+
+        let mut covered: Vec<TableId> = Vec::new();
+        covered.extend(p0);
+        covered.extend(p1);
+        covered.extend(p2);
+        covered.sort_by(|a, b| a.table().cmp(b.table()));
+        assert_eq!(covered, tables, "three ticks cover every table exactly once");
+    }
+
+    #[test]
+    fn select_tables_empty_or_all_skipped_is_safe() {
+        let cfg = AutoRepairConfig::default();
+        let empty = HashSet::new();
+        assert!(select_tables_for_tick(&[], 0, 1, &empty, &cfg).0.is_empty());
+        // All-system set → nothing picked, no infinite scan.
+        let sys = vec![tid("system", "a"), tid("system_auth", "b")];
+        assert!(select_tables_for_tick(&sys, 0, 4, &empty, &cfg).0.is_empty());
     }
 }

--- a/ferrosa-cluster/src/repair/scheduler.rs
+++ b/ferrosa-cluster/src/repair/scheduler.rs
@@ -17,12 +17,16 @@
 //! same single initiator, recomputed each tick so membership churn self-corrects.
 
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
+use ferrosa_net::task_pool::TaskPool;
 use ferrosa_storage::TableId;
 
 use crate::ring::TokenRing;
 
+use super::coordinator::{RepairCoordinator, SessionExecutor, SessionResult};
 use super::{coordinator::owned_token_ranges, repair_participants};
 
 /// One token range this node should initiate repair for, with the live peers to
@@ -195,6 +199,323 @@ pub fn select_tables_for_tick(
     (picked, i)
 }
 
+// ---------------------------------------------------------------------------
+// Metrics (FMEA #7 — silent repair). Process-global atomic counters in the
+// crate's existing free-function style (see `coordinator/metrics.rs`). Never
+// auto-resolved divergence is loud both in logs AND in these counters so an
+// operator watching Prometheus sees recurring divergence/corruption.
+// ---------------------------------------------------------------------------
+
+static AUTO_REPAIR_TICKS: AtomicU64 = AtomicU64::new(0);
+static AUTO_REPAIR_TABLES_REPAIRED: AtomicU64 = AtomicU64::new(0);
+static AUTO_REPAIR_SESSIONS_OK: AtomicU64 = AtomicU64::new(0);
+static AUTO_REPAIR_SESSIONS_FAILED: AtomicU64 = AtomicU64::new(0);
+static AUTO_REPAIR_PARTITIONS_STREAMED: AtomicU64 = AtomicU64::new(0);
+static AUTO_REPAIR_TIMESTAMP_TIES: AtomicU64 = AtomicU64::new(0);
+static AUTO_REPAIR_SKIPPED_NOT_READY: AtomicU64 = AtomicU64::new(0);
+
+/// Increment the per-tick counter (one per `run_tick`, ready or not).
+pub fn inc_auto_repair_tick() {
+    AUTO_REPAIR_TICKS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Render the `ferrosa_auto_repair_*` counters in Prometheus exposition format.
+/// Mirrors `coordinator::metrics::render_prometheus`.
+pub fn render_prometheus() -> String {
+    format!(
+        "# HELP ferrosa_auto_repair_ticks_total Automatic repair sub-ticks executed.\n\
+         # TYPE ferrosa_auto_repair_ticks_total counter\n\
+         ferrosa_auto_repair_ticks_total {}\n\
+         # HELP ferrosa_auto_repair_tables_repaired_total Tables for which automatic repair ran a cycle.\n\
+         # TYPE ferrosa_auto_repair_tables_repaired_total counter\n\
+         ferrosa_auto_repair_tables_repaired_total {}\n\
+         # HELP ferrosa_auto_repair_sessions_ok_total Automatic repair sessions that completed without error.\n\
+         # TYPE ferrosa_auto_repair_sessions_ok_total counter\n\
+         ferrosa_auto_repair_sessions_ok_total {}\n\
+         # HELP ferrosa_auto_repair_sessions_failed_total Automatic repair sessions that returned an error.\n\
+         # TYPE ferrosa_auto_repair_sessions_failed_total counter\n\
+         ferrosa_auto_repair_sessions_failed_total {}\n\
+         # HELP ferrosa_auto_repair_partitions_streamed_total Partitions streamed (in+out) by automatic repair.\n\
+         # TYPE ferrosa_auto_repair_partitions_streamed_total counter\n\
+         ferrosa_auto_repair_partitions_streamed_total {}\n\
+         # HELP ferrosa_auto_repair_timestamp_ties_total Divergent partitions with identical timestamps surfaced (not auto-resolved).\n\
+         # TYPE ferrosa_auto_repair_timestamp_ties_total counter\n\
+         ferrosa_auto_repair_timestamp_ties_total {}\n\
+         # HELP ferrosa_auto_repair_skipped_not_ready_total Ticks skipped because the node was not ring-ready.\n\
+         # TYPE ferrosa_auto_repair_skipped_not_ready_total counter\n\
+         ferrosa_auto_repair_skipped_not_ready_total {}\n",
+        AUTO_REPAIR_TICKS.load(Ordering::Relaxed),
+        AUTO_REPAIR_TABLES_REPAIRED.load(Ordering::Relaxed),
+        AUTO_REPAIR_SESSIONS_OK.load(Ordering::Relaxed),
+        AUTO_REPAIR_SESSIONS_FAILED.load(Ordering::Relaxed),
+        AUTO_REPAIR_PARTITIONS_STREAMED.load(Ordering::Relaxed),
+        AUTO_REPAIR_TIMESTAMP_TIES.load(Ordering::Relaxed),
+        AUTO_REPAIR_SKIPPED_NOT_READY.load(Ordering::Relaxed),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// RepairContext — the binary's window into live cluster state at tick time.
+// ---------------------------------------------------------------------------
+
+/// Everything the scheduler needs from the running node at the moment of a tick,
+/// behind a trait so it is fully mockable with no IO.
+///
+/// The production implementation lives in the binary (`ferrosa/src/main.rs`):
+/// it reads the `ModeController`'s `TokenRing`, resolves the local `node_id`
+/// from `host_id`, and builds the executor exactly as the `POST /api/cluster/
+/// repair` handler does (local `StorageEngineRepairStore` + per-peer
+/// `RemoteRepairStore` wrapped in a `LocalRepairExecutor`).
+///
+/// Every accessor returns "not ready" as `None` (the node has not yet been
+/// placed in the ring / is not in cluster mode). The scheduler treats *any*
+/// `None` as a no-op tick (FMEA: only initiate when ring-ready with peers).
+///
+/// All methods are synchronous: building the executor is synchronous in
+/// production, and a tick takes a fresh snapshot of all four together so they
+/// describe one consistent ring view.
+pub trait RepairContext: Send + Sync {
+    /// Current cluster token ring, or `None` when not in cluster mode.
+    fn token_ring(&self) -> Option<TokenRing>;
+
+    /// This node's `node_id` within the ring, or `None` until it has been
+    /// placed in the ring (still joining / single-node / not in cluster mode).
+    fn local_node_id(&self) -> Option<u64>;
+
+    /// A repair executor wired for the *current* ring (local store + per-peer
+    /// remotes), or `None` when the node is not ready to repair.
+    fn build_executor(&self) -> Option<Arc<dyn SessionExecutor>>;
+
+    /// User tables eligible for auto-repair, each paired with its keyspace
+    /// replication factor (FMEA #11 — per-keyspace RF, never a hardcoded 3).
+    fn user_tables(&self) -> Vec<(TableId, usize)>;
+}
+
+// ---------------------------------------------------------------------------
+// AutoRepairScheduler — the periodic driver.
+// ---------------------------------------------------------------------------
+
+/// Deterministic, loud, bounded background driver for automatic anti-entropy
+/// repair. Holds the repair coordinator, a [`RepairContext`] into live cluster
+/// state, the [`AutoRepairConfig`], a round-robin cursor over the table set, and
+/// the set of tables currently in flight (so a tick never double-schedules a
+/// table — FMEA #6).
+pub struct AutoRepairScheduler {
+    coord: RepairCoordinator,
+    ctx: Arc<dyn RepairContext>,
+    cfg: AutoRepairConfig,
+    /// Round-robin position into the live table list (FMEA #8 — bounded per-tick
+    /// load, forward progress across the whole set within one interval).
+    cursor: usize,
+    /// Tables a tick is actively repairing; cleared as each table completes.
+    in_flight: HashSet<TableId>,
+}
+
+impl AutoRepairScheduler {
+    /// Construct a scheduler. `coord` bounds per-table session concurrency;
+    /// `ctx` supplies the live ring/executor/tables each tick; `cfg` controls
+    /// cadence and skip-lists.
+    pub fn new(coord: RepairCoordinator, ctx: Arc<dyn RepairContext>, cfg: AutoRepairConfig) -> Self {
+        Self {
+            coord,
+            ctx,
+            cfg,
+            cursor: 0,
+            in_flight: HashSet::new(),
+        }
+    }
+
+    /// The repair interval this scheduler was configured with.
+    pub fn interval(&self) -> Duration {
+        self.cfg.interval
+    }
+
+    /// Run a single sub-tick: snapshot the live ring/executor/tables, pick this
+    /// tick's tables round-robin (skipping system + in-flight), and run
+    /// `repair_initiated` for each against that table's per-keyspace RF.
+    ///
+    /// No-op (loud INFO + metric) when the node is not ring-ready — any of
+    /// `token_ring` / `local_node_id` / `build_executor` returning `None`.
+    pub async fn run_tick(&mut self) {
+        inc_auto_repair_tick();
+
+        // One consistent snapshot of the ring view for the whole tick.
+        let (ring, local_node_id, executor) =
+            match (self.ctx.token_ring(), self.ctx.local_node_id(), self.ctx.build_executor()) {
+                (Some(ring), Some(id), Some(exec)) => (ring, id, exec),
+                _ => {
+                    AUTO_REPAIR_SKIPPED_NOT_READY.fetch_add(1, Ordering::Relaxed);
+                    tracing::info!(
+                        "auto-repair: node not ring-ready (no ring / node_id / executor); skipping tick"
+                    );
+                    return;
+                }
+            };
+
+        let tables_with_rf = self.ctx.user_tables();
+        let tables: Vec<TableId> = tables_with_rf.iter().map(|(t, _)| t.clone()).collect();
+        let rf_of = |t: &TableId| -> usize {
+            tables_with_rf
+                .iter()
+                .find(|(tid, _)| tid == t)
+                .map(|(_, rf)| *rf)
+                .unwrap_or(1)
+        };
+
+        let (picked, next_cursor) = select_tables_for_tick(
+            &tables,
+            self.cursor,
+            self.cfg.max_concurrent_tables,
+            &self.in_flight,
+            &self.cfg,
+        );
+        self.cursor = next_cursor;
+
+        if picked.is_empty() {
+            tracing::info!("auto-repair: no eligible tables this tick");
+            return;
+        }
+
+        for table in picked {
+            // Mark in-flight for the duration so a concurrent manual repair or
+            // a later tick won't double-schedule this table (FMEA #6).
+            self.in_flight.insert(table.clone());
+            let rf = rf_of(&table);
+            tracing::info!(
+                keyspace = table.keyspace(),
+                table = table.table(),
+                rf,
+                "auto-repair: starting initiated repair for table"
+            );
+
+            let results = self
+                .coord
+                .repair_initiated(executor.clone(), &ring, local_node_id, rf, &table)
+                .await;
+            Self::observe(&table, &results);
+
+            self.in_flight.remove(&table);
+            AUTO_REPAIR_TABLES_REPAIRED.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Aggregate + loudly report one table's session results (FMEA #7).
+    fn observe(table: &TableId, results: &[SessionResult]) {
+        let mut ok = 0u64;
+        let mut failed = 0u64;
+        let mut streamed = 0u64;
+        let mut ties = 0u64;
+        for r in results {
+            match &r.result {
+                Ok(stats) => {
+                    ok += 1;
+                    streamed += stats.partitions_streamed_in + stats.partitions_streamed_out;
+                    ties += stats.timestamp_ties;
+                }
+                Err(e) => {
+                    failed += 1;
+                    tracing::warn!(
+                        keyspace = table.keyspace(),
+                        table = table.table(),
+                        peer = r.peer,
+                        range_start = r.range_start,
+                        range_end = r.range_end,
+                        error = %e,
+                        "auto-repair: session failed"
+                    );
+                }
+            }
+        }
+        AUTO_REPAIR_SESSIONS_OK.fetch_add(ok, Ordering::Relaxed);
+        AUTO_REPAIR_SESSIONS_FAILED.fetch_add(failed, Ordering::Relaxed);
+        AUTO_REPAIR_PARTITIONS_STREAMED.fetch_add(streamed, Ordering::Relaxed);
+        AUTO_REPAIR_TIMESTAMP_TIES.fetch_add(ties, Ordering::Relaxed);
+
+        if streamed > 0 || ties > 0 {
+            // Divergence found — WARN so a recurring divergence is operator-visible.
+            tracing::warn!(
+                keyspace = table.keyspace(),
+                table = table.table(),
+                sessions_ok = ok,
+                sessions_failed = failed,
+                partitions_streamed = streamed,
+                timestamp_ties = ties,
+                "auto-repair: DIVERGENCE reconciled for table"
+            );
+        } else {
+            tracing::info!(
+                keyspace = table.keyspace(),
+                table = table.table(),
+                sessions_ok = ok,
+                sessions_failed = failed,
+                "auto-repair: table converged (no divergence)"
+            );
+        }
+    }
+
+    /// Sub-tick period that covers the whole table set once per `interval`:
+    /// `interval / ceil(table_count / max_concurrent_tables)`. With 0 tables (or
+    /// `max_concurrent_tables == 0`) there is nothing to spread, so wait one full
+    /// interval. Pure helper so the cadence math is unit-testable.
+    pub fn sub_tick(interval: Duration, table_count: usize, max_concurrent: usize) -> Duration {
+        if table_count == 0 || max_concurrent == 0 {
+            return interval;
+        }
+        let sub_ticks = table_count.div_ceil(max_concurrent) as u32;
+        // div_ceil of a positive count is >= 1, so this never divides by zero.
+        interval / sub_ticks.max(1)
+    }
+
+    /// Spawn the scheduler's background loop.
+    ///
+    /// When `cfg.enabled` is false, logs that auto-repair is disabled and returns
+    /// a **no-op** handle that finishes immediately — the loop never starts (the
+    /// manual `POST /repair` endpoint still works). Otherwise loops on a
+    /// `tokio::time::interval` sized so the whole live table set is covered once
+    /// per `cfg.interval`, recomputing the sub-tick from the live table count
+    /// each cycle, until `shutdown` flips to `true` (or its sender drops).
+    pub fn spawn(
+        mut scheduler: AutoRepairScheduler,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> tokio::task::JoinHandle<()> {
+        if !scheduler.cfg.enabled {
+            tracing::info!(
+                "auto-repair: disabled (FERROSA_AUTO_REPAIR_ENABLED=off); scheduler not started"
+            );
+            // No-op handle: do NOT enter the loop.
+            return TaskPool::current("auto-repair").spawn(async move {});
+        }
+
+        let interval_cfg = scheduler.cfg.interval;
+        let max_concurrent = scheduler.cfg.max_concurrent_tables;
+        tracing::info!(
+            interval_secs = interval_cfg.as_secs(),
+            max_concurrent_tables = max_concurrent,
+            "auto-repair: scheduler started"
+        );
+
+        TaskPool::current("auto-repair").spawn(async move {
+            loop {
+                // Recompute the sub-tick from the live table count each cycle so
+                // membership/schema churn re-spreads coverage (design: cadence).
+                let table_count = scheduler.ctx.user_tables().len();
+                let period = AutoRepairScheduler::sub_tick(interval_cfg, table_count, max_concurrent);
+                tokio::select! {
+                    result = shutdown.changed() => {
+                        if result.is_err() || *shutdown.borrow() {
+                            tracing::info!("auto-repair: shutting down");
+                            break;
+                        }
+                    }
+                    _ = tokio::time::sleep(period) => {
+                        scheduler.run_tick().await;
+                    }
+                }
+            }
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -356,5 +677,251 @@ mod tests {
         // All-system set → nothing picked, no infinite scan.
         let sys = vec![tid("system", "a"), tid("system_auth", "b")];
         assert!(select_tables_for_tick(&sys, 0, 4, &empty, &cfg).0.is_empty());
+    }
+
+    // -- AutoRepairScheduler / RepairContext tests (no real IO) -------------
+
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    /// Recording mock executor — mirrors `coordinator.rs`'s MockExecutor. Records
+    /// every `(table, range, peer)` invocation so a test can assert exactly which
+    /// tables/ranges a tick scheduled, with zero IO.
+    struct RecordingExecutor {
+        calls: Mutex<Vec<(TableId, i64, i64, u64)>>,
+    }
+
+    impl RecordingExecutor {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+        fn tables_seen(&self) -> Vec<TableId> {
+            let mut v: Vec<TableId> = self
+                .calls
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(t, _, _, _)| t.clone())
+                .collect();
+            v.sort_by(|a, b| a.table().cmp(b.table()));
+            v.dedup();
+            v
+        }
+    }
+
+    #[async_trait]
+    impl SessionExecutor for RecordingExecutor {
+        async fn run_session(
+            &self,
+            table: &TableId,
+            range_start: i64,
+            range_end: i64,
+            peer: u64,
+        ) -> Result<crate::repair::SessionStats, String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((table.clone(), range_start, range_end, peer));
+            Ok(crate::repair::SessionStats::default())
+        }
+    }
+
+    /// Mock context returning a fixed ring + a shared recording executor + a
+    /// fixed table list, or `None` for any field when `ready == false`.
+    struct MockContext {
+        ring: TokenRing,
+        local_node_id: u64,
+        exec: Arc<RecordingExecutor>,
+        tables: Vec<(TableId, usize)>,
+        ready: bool,
+    }
+
+    impl RepairContext for MockContext {
+        fn token_ring(&self) -> Option<TokenRing> {
+            self.ready.then(|| self.ring.clone())
+        }
+        fn local_node_id(&self) -> Option<u64> {
+            self.ready.then_some(self.local_node_id)
+        }
+        fn build_executor(&self) -> Option<Arc<dyn SessionExecutor>> {
+            self.ready
+                .then(|| self.exec.clone() as Arc<dyn SessionExecutor>)
+        }
+        fn user_tables(&self) -> Vec<(TableId, usize)> {
+            self.tables.clone()
+        }
+    }
+
+    /// Build a ready MockContext where the local node is the lowest-host_id node
+    /// (node 1), so `repair_initiated` selects ranges and the executor records work.
+    fn ready_ctx(tables: Vec<(TableId, usize)>) -> (Arc<MockContext>, Arc<RecordingExecutor>) {
+        let exec = Arc::new(RecordingExecutor::new());
+        let ctx = Arc::new(MockContext {
+            ring: three_node_ring(),
+            local_node_id: 1,
+            exec: exec.clone(),
+            tables,
+            ready: true,
+        });
+        (ctx, exec)
+    }
+
+    /// run_tick on a ready node repairs exactly the round-robin-selected table(s)
+    /// and skips ones already in-flight; the cursor advances across ticks.
+    #[tokio::test]
+    async fn run_tick_repairs_selected_tables_and_advances_cursor() {
+        let tables = vec![
+            (tid("app", "a"), 3usize),
+            (tid("app", "b"), 3),
+            (tid("app", "c"), 3),
+        ];
+        let (ctx, exec) = ready_ctx(tables);
+        let cfg = AutoRepairConfig {
+            max_concurrent_tables: 1,
+            ..AutoRepairConfig::default()
+        };
+        let mut sched = AutoRepairScheduler::new(RepairCoordinator::default(), ctx, cfg);
+
+        sched.run_tick().await; // tick 1 -> a
+        sched.run_tick().await; // tick 2 -> b
+        sched.run_tick().await; // tick 3 -> c
+
+        // Each table repaired exactly once across three ticks (cursor advanced).
+        assert_eq!(
+            exec.tables_seen(),
+            vec![tid("app", "a"), tid("app", "b"), tid("app", "c")],
+            "three ticks cover every table once, in round-robin order"
+        );
+    }
+
+    /// A table marked in-flight (by an external/manual repair) is skipped (FMEA #6).
+    /// We pre-seed the scheduler's in-flight set via the public selection helper:
+    /// run a tick with `app.a` in flight and confirm only `app.b` runs.
+    #[tokio::test]
+    async fn run_tick_skips_in_flight_table() {
+        let tables = vec![(tid("app", "a"), 3usize), (tid("app", "b"), 3)];
+        let (ctx, exec) = ready_ctx(tables);
+        let cfg = AutoRepairConfig {
+            max_concurrent_tables: 2, // would pick BOTH if nothing were in-flight
+            ..AutoRepairConfig::default()
+        };
+        let mut sched = AutoRepairScheduler::new(RepairCoordinator::default(), ctx, cfg);
+        sched.in_flight.insert(tid("app", "a"));
+
+        sched.run_tick().await;
+
+        assert_eq!(
+            exec.tables_seen(),
+            vec![tid("app", "b")],
+            "in-flight app.a is skipped; only app.b is repaired"
+        );
+    }
+
+    /// Context not ready (any field None) → run_tick is a no-op (no sessions).
+    #[tokio::test]
+    async fn run_tick_no_ops_when_context_not_ready() {
+        let exec = Arc::new(RecordingExecutor::new());
+        let ctx = Arc::new(MockContext {
+            ring: three_node_ring(),
+            local_node_id: 1,
+            exec: exec.clone(),
+            tables: vec![(tid("app", "a"), 3)],
+            ready: false, // not in cluster mode / not placed in ring
+        });
+        let mut sched =
+            AutoRepairScheduler::new(RepairCoordinator::default(), ctx, AutoRepairConfig::default());
+
+        sched.run_tick().await;
+
+        assert!(
+            exec.calls.lock().unwrap().is_empty(),
+            "not-ready context must schedule zero sessions"
+        );
+    }
+
+    /// Disabled config → spawn returns a handle that finishes immediately without
+    /// ever entering the loop (no tick runs even if we wait).
+    #[tokio::test]
+    async fn spawn_disabled_is_no_op() {
+        let tables = vec![(tid("app", "a"), 3usize)];
+        let (ctx, exec) = ready_ctx(tables);
+        let cfg = AutoRepairConfig {
+            enabled: false,
+            interval: Duration::from_millis(1), // tiny — would fire fast IF it looped
+            ..AutoRepairConfig::default()
+        };
+        let sched = AutoRepairScheduler::new(RepairCoordinator::default(), ctx, cfg);
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+
+        let handle = AutoRepairScheduler::spawn(sched, rx);
+        // A no-op handle completes on its own; join it (bounded, no hang).
+        handle.await.expect("disabled scheduler task joins cleanly");
+
+        assert!(
+            exec.calls.lock().unwrap().is_empty(),
+            "disabled scheduler must never run a tick"
+        );
+    }
+
+    /// Enabled scheduler loop runs at least one tick, then stops on shutdown.
+    #[tokio::test]
+    async fn spawn_enabled_ticks_then_shuts_down() {
+        let tables = vec![(tid("app", "a"), 3usize)];
+        let (ctx, exec) = ready_ctx(tables);
+        // interval=10ms, 1 table, max_concurrent=1 → sub_tick = 10ms.
+        let cfg = AutoRepairConfig {
+            enabled: true,
+            interval: Duration::from_millis(10),
+            max_concurrent_tables: 1,
+            ..AutoRepairConfig::default()
+        };
+        let sched = AutoRepairScheduler::new(RepairCoordinator::default(), ctx, cfg);
+        let (tx, rx) = tokio::sync::watch::channel(false);
+
+        let handle = AutoRepairScheduler::spawn(sched, rx);
+        // Give the loop time to fire at least one sub-tick.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        tx.send(true).expect("shutdown signal sends");
+        handle.await.expect("scheduler task joins after shutdown");
+
+        assert!(
+            !exec.calls.lock().unwrap().is_empty(),
+            "enabled scheduler ran at least one repair tick before shutdown"
+        );
+    }
+
+    /// sub_tick spreads the table set across `interval`, and degrades to one full
+    /// interval when there is nothing to spread.
+    #[test]
+    fn sub_tick_spreads_table_set_over_interval() {
+        let iv = Duration::from_secs(24);
+        // 4 tables, 1 at a time → 4 sub-ticks of 6s each.
+        assert_eq!(
+            AutoRepairScheduler::sub_tick(iv, 4, 1),
+            Duration::from_secs(6)
+        );
+        // 4 tables, 2 at a time → ceil(4/2)=2 sub-ticks of 12s.
+        assert_eq!(
+            AutoRepairScheduler::sub_tick(iv, 4, 2),
+            Duration::from_secs(12)
+        );
+        // 5 tables, 2 at a time → ceil(5/2)=3 sub-ticks of 8s.
+        assert_eq!(AutoRepairScheduler::sub_tick(iv, 5, 2), iv / 3);
+        // 0 tables → one full interval (nothing to spread, don't divide by zero).
+        assert_eq!(AutoRepairScheduler::sub_tick(iv, 0, 1), iv);
+        // 0 max_concurrent → one full interval.
+        assert_eq!(AutoRepairScheduler::sub_tick(iv, 4, 0), iv);
+    }
+
+    /// Metrics render in Prometheus format and a tick bumps the tick counter.
+    #[test]
+    fn metrics_render_and_count_ticks() {
+        inc_auto_repair_tick();
+        let text = render_prometheus();
+        assert!(text.contains("ferrosa_auto_repair_ticks_total"));
+        assert!(text.contains("ferrosa_auto_repair_sessions_failed_total"));
+        assert!(text.contains("ferrosa_auto_repair_skipped_not_ready_total"));
     }
 }

--- a/ferrosa-storage/src/self_heal/mod.rs
+++ b/ferrosa-storage/src/self_heal/mod.rs
@@ -30,6 +30,7 @@ pub mod config;
 pub mod decide;
 pub mod detector;
 pub mod metrics;
+pub mod refill;
 pub mod snapshot;
 
 #[cfg(any(test, feature = "test-support"))]
@@ -44,6 +45,7 @@ use crate::TableId;
 pub use config::SelfHealConfig;
 pub use decide::{Action, EscalateReason};
 pub use metrics::{self_heal_health, self_heal_metrics, SelfHealHealth, SelfHealMetrics};
+pub use refill::{NoopRepairTrigger, RepairTrigger};
 pub use snapshot::{
     AttemptState, CorruptSstable, HealthSnapshot, IssueKind, ReplicaPosture, RingView, TableIssue,
     TableKey,
@@ -171,10 +173,16 @@ pub struct SelfHealController {
     /// Logical tick counter — the snapshot's deterministic clock.
     tick: u64,
     refill: Box<dyn RefillScheduler + Send + Sync>,
+    /// Port that schedules a prompt targeted refill after a successful
+    /// quarantine (FMEA #10). Defaults to [`NoopRepairTrigger`]; the binary
+    /// supplies a cluster-backed trigger on a real cluster.
+    repair_trigger: Arc<dyn RepairTrigger>,
 }
 
 impl SelfHealController {
-    /// Construct a controller. `cluster` supplies replica-health facts.
+    /// Construct a controller. `cluster` supplies replica-health facts. The
+    /// refill trigger defaults to [`NoopRepairTrigger`]; use
+    /// [`Self::with_repair_trigger`] to supply a cluster-backed one.
     pub fn new(
         engine: Arc<StorageEngine>,
         cluster: Arc<dyn ClusterView>,
@@ -187,7 +195,17 @@ impl SelfHealController {
             ledger: BTreeMap::new(),
             tick: 0,
             refill: Box::new(LoggingRefillScheduler),
+            repair_trigger: Arc::new(NoopRepairTrigger),
         }
+    }
+
+    /// Supply the cluster-backed [`RepairTrigger`] used to schedule a prompt
+    /// targeted refill after a successful quarantine (FMEA #10). Builder form
+    /// so the default [`Self::new`] / [`Self::spawn`] signatures stay
+    /// no-cluster-dependency for single-node and existing tests.
+    pub fn with_repair_trigger(mut self, trigger: Arc<dyn RepairTrigger>) -> Self {
+        self.repair_trigger = trigger;
+        self
     }
 
     /// Spawn the controller on its own tokio task, gated by the master switch.
@@ -198,6 +216,17 @@ impl SelfHealController {
         engine: Arc<StorageEngine>,
         cluster: Arc<dyn ClusterView>,
         config: SelfHealConfig,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        Self::spawn_with_trigger(engine, cluster, config, Arc::new(NoopRepairTrigger))
+    }
+
+    /// Like [`Self::spawn`] but with a cluster-backed [`RepairTrigger`] so a
+    /// successful quarantine schedules a prompt targeted refill (FMEA #10).
+    pub fn spawn_with_trigger(
+        engine: Arc<StorageEngine>,
+        cluster: Arc<dyn ClusterView>,
+        config: SelfHealConfig,
+        repair_trigger: Arc<dyn RepairTrigger>,
     ) -> Option<tokio::task::JoinHandle<()>> {
         if !config.enabled {
             tracing::info!(
@@ -210,7 +239,8 @@ impl SelfHealController {
             return None;
         }
         let interval = config.tick_interval;
-        let mut controller = SelfHealController::new(engine, cluster, config);
+        let mut controller =
+            SelfHealController::new(engine, cluster, config).with_repair_trigger(repair_trigger);
         tracing::info!(
             tick_secs = interval.as_secs(),
             "self-heal: controller starting"
@@ -308,11 +338,24 @@ impl SelfHealController {
         // Ledger update — deterministic bookkeeping (FMEA #5 escalate-and-stop).
         let entry = self.ledger.entry((table, kind)).or_default();
         match &outcome {
-            ActionOutcome::Quarantined { .. } => {
+            ActionOutcome::Quarantined {
+                table: quarantined_table,
+                ..
+            } => {
                 entry.attempts = entry.attempts.saturating_add(1);
                 entry.last_attempt_tick = Some(snapshot.tick);
                 // Not escalated: next tick re-runs the detector to verify the
                 // issue cleared (verify-by-re-detection, FMEA #11).
+                //
+                // FMEA #10: schedule a prompt targeted refill of the affected
+                // ranges from a healthy replica so the quarantined data is
+                // restored before the next full repair cycle. We don't track
+                // per-generation token bounds here, so the affected range is
+                // the table's full ring span — the cluster-side trigger
+                // intersects it with this node's owned ranges.
+                let table_id = TableId::new(&quarantined_table.keyspace, &quarantined_table.table);
+                self.repair_trigger
+                    .request_refill(&table_id, &[(i64::MIN, i64::MAX)]);
             }
             ActionOutcome::Escalated { .. } => {
                 entry.attempts = entry.attempts.saturating_add(1);
@@ -555,6 +598,106 @@ mod controller_tests {
             before,
             "issue resolved → no further quarantine"
         );
+    }
+
+    /// Recorded `(table, ranges)` of the most recent refill request.
+    type RecordedRefill = Option<(TableId, Vec<(i64, i64)>)>;
+
+    /// A recording [`RepairTrigger`] for asserting the quarantine→refill
+    /// coupling.
+    #[derive(Default)]
+    struct RecordingTrigger {
+        calls: std::sync::atomic::AtomicUsize,
+        last: std::sync::Mutex<RecordedRefill>,
+    }
+    impl RepairTrigger for RecordingTrigger {
+        fn request_refill(&self, table: &TableId, ranges: &[(i64, i64)]) {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            *self.last.lock().unwrap() = Some((table.clone(), ranges.to_vec()));
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn successful_quarantine_invokes_repair_trigger_with_table() {
+        metrics::_reset_self_heal_metrics_for_tests();
+        let engine = table_dir_with_n_generations_engine(2);
+        let table_dir = engine.table_sstable_dir(&TableId::new("test_ks", "test_table"));
+        corrupt_one_generation(&table_dir);
+
+        let cluster = Arc::new(PinnedCluster {
+            host: 0,
+            posture: ReplicaPosture::HealthyReplicaAvailable,
+            owners: None,
+        });
+        let trigger = Arc::new(RecordingTrigger::default());
+        let mut c = SelfHealController::new(engine, cluster, SelfHealConfig::default())
+            .with_repair_trigger(trigger.clone());
+        c.run_one_tick();
+
+        assert_eq!(
+            trigger.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a successful quarantine must request exactly one refill"
+        );
+        let (table, ranges) = trigger.last.lock().unwrap().clone().unwrap();
+        assert_eq!(table, TableId::new("test_ks", "test_table"));
+        assert_eq!(
+            ranges,
+            vec![(i64::MIN, i64::MAX)],
+            "refill targets the table's affected ranges"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn escalation_does_not_invoke_repair_trigger() {
+        metrics::_reset_self_heal_metrics_for_tests();
+        let engine = table_dir_with_n_generations_engine(2);
+        let table_dir = engine.table_sstable_dir(&TableId::new("test_ks", "test_table"));
+        corrupt_one_generation(&table_dir);
+
+        // SingleNode → escalate, never quarantine → no refill request.
+        let cluster = Arc::new(PinnedCluster {
+            host: 0,
+            posture: ReplicaPosture::SingleNode,
+            owners: None,
+        });
+        let trigger = Arc::new(RecordingTrigger::default());
+        let mut c = SelfHealController::new(engine, cluster, SelfHealConfig::default())
+            .with_repair_trigger(trigger.clone());
+        c.run_one_tick();
+
+        assert_eq!(
+            trigger.calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "escalation (no healthy replica) must NOT request a refill"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn default_noop_trigger_still_quarantines() {
+        // Controller built via plain `new` (no-op trigger) must still
+        // quarantine successfully — the trigger is fire-and-forget.
+        metrics::_reset_self_heal_metrics_for_tests();
+        let engine = table_dir_with_n_generations_engine(2);
+        let table_dir = engine.table_sstable_dir(&TableId::new("test_ks", "test_table"));
+        corrupt_one_generation(&table_dir);
+
+        let cluster = Arc::new(PinnedCluster {
+            host: 0,
+            posture: ReplicaPosture::HealthyReplicaAvailable,
+            owners: None,
+        });
+        let mut c = SelfHealController::new(engine, cluster, SelfHealConfig::default());
+        c.run_one_tick();
+
+        assert_eq!(
+            metrics::self_heal_metrics().quarantined_generations_total,
+            1
+        );
+        assert!(table_dir.join("quarantine").exists());
     }
 
     #[test]

--- a/ferrosa-storage/src/self_heal/refill.rs
+++ b/ferrosa-storage/src/self_heal/refill.rs
@@ -1,0 +1,95 @@
+//! The quarantine → targeted-refill port.
+//!
+//! When the controller quarantines a corrupt generation, the rows in that
+//! generation are gone locally. To refill them *promptly* from a healthy
+//! replica — rather than waiting for the next full anti-entropy cycle — the
+//! controller calls a [`RepairTrigger`]. This is a **port** (FMEA #10): the
+//! storage crate sits below the cluster layer in the dependency graph, so it
+//! cannot drive a real cross-node repair itself. The real implementation lives
+//! in the binary (it owns the `AutoRepairScheduler` / `RepairCoordinator`); the
+//! storage crate only depends on this trait.
+//!
+//! The default implementation is [`NoopRepairTrigger`], which keeps existing
+//! tests and single-node deployments working without any cluster wiring: a
+//! single-node engine never quarantines (FMEA #1), so a no-op refill is never
+//! actually reached for it; on a cluster, the binary supplies the real trigger.
+
+use crate::TableId;
+
+/// Port the controller uses to request a prompt, targeted refill of the token
+/// ranges whose data was just quarantined.
+///
+/// `request_refill` must be cheap and non-blocking — it *schedules* a repair,
+/// it does not run one. The real impl typically enqueues a targeted
+/// `repair_table` over the affected ranges on the cluster's repair scheduler.
+/// Failure to enqueue must be logged loudly by the implementation; the periodic
+/// repair cycle is the backstop (design Q3 / FMEA #10).
+pub trait RepairTrigger: Send + Sync {
+    /// Schedule a targeted refill of `table`'s `ranges` (`[start, end)` token
+    /// bounds) from a healthy replica. Called once per successful quarantine.
+    fn request_refill(&self, table: &TableId, ranges: &[(i64, i64)]);
+}
+
+/// The default, do-nothing [`RepairTrigger`].
+///
+/// Used when no cluster-layer trigger is wired (single-node, and existing
+/// tests). It logs at `debug` so a misconfigured cluster deployment — one that
+/// quarantines but never wired a real trigger — is still observable, without
+/// being noisy on single-node where this path is never reached.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopRepairTrigger;
+
+impl RepairTrigger for NoopRepairTrigger {
+    fn request_refill(&self, table: &TableId, ranges: &[(i64, i64)]) {
+        tracing::debug!(
+            keyspace = %table.keyspace,
+            table = %table.table,
+            ranges = ?ranges,
+            "self-heal: no-op RepairTrigger — refill not scheduled (no cluster trigger wired); \
+             periodic repair cycle is the backstop"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    /// Recorded `(table, ranges)` of the most recent refill request.
+    type RecordedRefill = Option<(TableId, Vec<(i64, i64)>)>;
+
+    /// A trigger that records every refill request for assertions.
+    #[derive(Default)]
+    struct RecordingTrigger {
+        calls: AtomicUsize,
+        last: Mutex<RecordedRefill>,
+    }
+
+    impl RepairTrigger for RecordingTrigger {
+        fn request_refill(&self, table: &TableId, ranges: &[(i64, i64)]) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            *self.last.lock().unwrap() = Some((table.clone(), ranges.to_vec()));
+        }
+    }
+
+    #[test]
+    fn noop_trigger_is_inert() {
+        let t = NoopRepairTrigger;
+        // Must not panic and must accept any input shape.
+        t.request_refill(&TableId::new("ks", "t"), &[(i64::MIN, i64::MAX)]);
+        t.request_refill(&TableId::new("ks", "t"), &[]);
+    }
+
+    #[test]
+    fn trigger_is_object_safe_and_records_request() {
+        let rec = Arc::new(RecordingTrigger::default());
+        let dynamic: Arc<dyn RepairTrigger> = rec.clone();
+        dynamic.request_refill(&TableId::new("ks", "t"), &[(10, 20), (30, 40)]);
+        assert_eq!(rec.calls.load(Ordering::SeqCst), 1);
+        let last = rec.last.lock().unwrap().clone().unwrap();
+        assert_eq!(last.0, TableId::new("ks", "t"));
+        assert_eq!(last.1, vec![(10, 20), (30, 40)]);
+    }
+}

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -49,6 +49,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 pub static malloc_conf: &[u8] = b"dirty_decay_ms:0,muzzy_decay_ms:0\0";
 
 mod cql_broadcast;
+mod repair_wiring;
 mod runtime;
 mod web;
 
@@ -721,9 +722,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     ferrosa_storage::StorageEngine::spawn_time_series_materialization_worker(storage.clone());
 
-    // Self-healing controller is spawned later (step 6c), once the PeerManager
-    // exists, so its replica-health view reflects real cluster membership
-    // instead of the old single-node placeholder.
+    // Self-healing controller + automatic-repair scheduler are spawned later,
+    // after the ModeController is wired (they need the live ring / peer manager
+    // for the verified-healthy-replica ClusterView and the repair executor).
+    // See `repair_wiring` + the "automatic repair" block below.
 
     // Replay any pending S3 uploads that were interrupted by a crash.
     storage.replay_pending_uploads().await;
@@ -1371,6 +1373,77 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a shutdown watch channel for services that need graceful shutdown
     // notification (e.g. the Bolt server).
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    // ── Automatic repair: self-heal controller (verified-replica quarantine +
+    // refill) + periodic anti-entropy repair scheduler ──────────────────────
+    //
+    // Wired here (after the ModeController + shutdown channel) because both need
+    // the live ring / peer manager. See `repair_wiring` and
+    // `specs/proposed/automatic-repair-scheduler-design.md`.
+    {
+        let auto_cfg = ferrosa_cluster::AutoRepairConfig::from_env();
+        // Platform-default RF for the per-table replica-health probe (the gate
+        // only needs to find SOME verified healthy peer); per-keyspace RF is
+        // used by the scheduler's repair path via the schema (FMEA #11).
+        const DEFAULT_RF: usize = 3;
+
+        // Shared production RepairContext (scheduler + refill trigger).
+        let repair_ctx = std::sync::Arc::new(crate::repair_wiring::BinaryRepairContext::new(
+            mode_controller.clone(),
+            storage.clone(),
+            schema.clone(),
+            auto_cfg.skip_keyspaces.clone(),
+            DEFAULT_RF,
+        ));
+
+        // Self-heal controller with the REAL verified-healthy-replica view
+        // (replaces the single-node stub) + a refill trigger so a quarantine
+        // schedules a prompt targeted repair.
+        let self_host = mode_controller.host_id();
+        let ring_snapshot = {
+            let mc = mode_controller.clone();
+            move || {
+                mc.token_ring()
+                    .map(|r| (*r).clone())
+                    .unwrap_or_else(ferrosa_cluster::ring::TokenRing::new)
+            }
+        };
+        let topology =
+            std::sync::Arc::new(ferrosa_cluster::repair::cluster_view::RingTopology::new(
+                self_host,
+                DEFAULT_RF,
+                ring_snapshot,
+            ));
+        let probe =
+            std::sync::Arc::new(ferrosa_cluster::repair::cluster_view::RpcRepairProbe::new(
+                peer_manager.clone(),
+                runtimes.data.handle().clone(),
+            ));
+        let cluster_view: std::sync::Arc<dyn ferrosa_storage::self_heal::ClusterView> =
+            std::sync::Arc::new(
+                ferrosa_cluster::repair::cluster_view::ClusterRepairView::new(topology, probe),
+            );
+        let refill_trigger: std::sync::Arc<dyn ferrosa_storage::self_heal::RepairTrigger> =
+            std::sync::Arc::new(crate::repair_wiring::BinaryRepairTrigger::new(
+                repair_ctx.clone(),
+                runtimes.data.handle().clone(),
+            ));
+        ferrosa_storage::self_heal::SelfHealController::spawn_with_trigger(
+            storage.clone(),
+            cluster_view,
+            ferrosa_storage::self_heal::SelfHealConfig::from_env(),
+            refill_trigger,
+        );
+
+        // Periodic anti-entropy repair scheduler (deterministic single-initiator,
+        // round-robin, enabled by default). Stops on the shutdown signal.
+        let scheduler = ferrosa_cluster::AutoRepairScheduler::new(
+            ferrosa_cluster::RepairCoordinator::default(),
+            repair_ctx as std::sync::Arc<dyn ferrosa_cluster::RepairContext>,
+            auto_cfg,
+        );
+        ferrosa_cluster::AutoRepairScheduler::spawn(scheduler, shutdown_rx.clone());
+    }
 
     if graph_enabled {
         let graph_config = ferrosa_graph::engine::GraphConfig {

--- a/ferrosa/src/repair_wiring.rs
+++ b/ferrosa/src/repair_wiring.rs
@@ -1,0 +1,467 @@
+//! Binary-side wiring for automatic anti-entropy repair.
+//!
+//! The cluster layer ships the *primitives* (`RepairCoordinator`,
+//! `AutoRepairScheduler`, `ClusterRepairView`) and the *ports*
+//! (`RepairContext`, storage's `RepairTrigger`). This module is the single
+//! place in the `ferrosa` binary that satisfies those ports against live node
+//! state (`ModeController` + `StorageEngine` + `Schema`), so the scheduler, the
+//! manual `POST /api/cluster/repair` endpoint, and the self-heal controller all
+//! share one executor-construction code path.
+//!
+//! See `specs/proposed/automatic-repair-scheduler-design.md` and its FMEA.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ferrosa_cluster::ModeController;
+use ferrosa_cluster::{
+    LocalRepairExecutor, RemoteRepairStore, RepairContext, RepairCoordinator, SessionExecutor,
+    StorageEngineRepairStore,
+};
+use ferrosa_schema::Schema;
+use ferrosa_storage::self_heal::RepairTrigger;
+use ferrosa_storage::{StorageEngine, TableId};
+
+/// A repair executor wired for the *current* ring, paired with this node's
+/// resolved `node_id`. `None` when the node is not ready to repair (not in
+/// cluster mode, no peer manager, or local node not yet placed in the ring).
+///
+/// This is the **single** executor-construction path. The manual repair
+/// endpoint and the [`BinaryRepairContext`] used by the scheduler both call it,
+/// so there is exactly one place that builds the local
+/// [`StorageEngineRepairStore`] + per-peer [`RemoteRepairStore`] →
+/// [`LocalRepairExecutor`].
+pub struct ResolvedExecutor {
+    /// The wired executor.
+    pub executor: Arc<dyn SessionExecutor>,
+    /// This node's `node_id` within the live ring.
+    pub local_node_id: u64,
+}
+
+/// Build a repair executor for the current ring, resolving this node's
+/// `node_id` from its `host_id`. Returns `None` when not in cluster mode, the
+/// peer manager is not initialised, or this node is not yet in the ring.
+///
+/// FMEA: every "not ready" condition is a clean `None` (the caller treats it as
+/// a no-op), never a panic or a fake executor.
+pub fn build_repair_executor(
+    mode_controller: &ModeController,
+    storage: &Arc<StorageEngine>,
+) -> Option<ResolvedExecutor> {
+    let ring = mode_controller.token_ring()?;
+    let peer_manager = mode_controller.peer_manager_arc()?;
+
+    // Resolve our own node_id by looking up our host_id in the ring.
+    let host_id = mode_controller.host_id();
+    let local_node_id = ring.node_ids().iter().copied().find(|&id| {
+        ring.get_node(id)
+            .is_some_and(|info| info.host_id == host_id)
+    })?;
+
+    // local = in-process storage; remotes = one RemoteRepairStore per other
+    // node in the ring.
+    let local: Arc<dyn ferrosa_cluster::RepairStore> =
+        Arc::new(StorageEngineRepairStore::new(storage.clone()));
+    let mut remotes: HashMap<u64, Arc<dyn ferrosa_cluster::RepairStore>> = HashMap::new();
+    for node_id in ring.node_ids() {
+        if node_id == local_node_id {
+            continue;
+        }
+        let Some(node_info) = ring.get_node(node_id) else {
+            continue;
+        };
+        let remote: Arc<dyn ferrosa_cluster::RepairStore> = Arc::new(RemoteRepairStore {
+            host_id: node_info.host_id,
+            peer_manager: peer_manager.clone(),
+        });
+        remotes.insert(node_id, remote);
+    }
+
+    let executor: Arc<dyn SessionExecutor> = Arc::new(LocalRepairExecutor { local, remotes });
+    Some(ResolvedExecutor {
+        executor,
+        local_node_id,
+    })
+}
+
+/// Parse a keyspace's replication factor from its replication options.
+///
+/// FMEA #11 — never hardcode `3`. For `SimpleStrategy` the RF is the
+/// `replication_factor` option; for `NetworkTopologyStrategy` it is the **sum**
+/// of the per-DC factors (every non-`replication_factor`, non-`class` option is
+/// a `dc -> rf` entry). When no factor can be parsed we fall back to `default`
+/// (the caller passes 3, the platform default) so a malformed keyspace still
+/// gets repaired against a sane peer set rather than being silently skipped.
+pub fn replication_factor_for(options: &HashMap<String, String>, default: usize) -> usize {
+    // SimpleStrategy / explicit cluster-wide factor.
+    if let Some(rf) = options
+        .get("replication_factor")
+        .and_then(|v| v.trim().parse::<usize>().ok())
+    {
+        if rf >= 1 {
+            return rf;
+        }
+    }
+
+    // NetworkTopologyStrategy: sum the per-DC factors. Keys other than the
+    // strategy `class` and the cluster-wide `replication_factor` are DC names.
+    let dc_sum: usize = options
+        .iter()
+        .filter(|(k, _)| k.as_str() != "class" && k.as_str() != "replication_factor")
+        .filter_map(|(_, v)| v.trim().parse::<usize>().ok())
+        .sum();
+    if dc_sum >= 1 {
+        return dc_sum;
+    }
+
+    default
+}
+
+/// Enumerate user tables eligible for auto-repair, each paired with its
+/// keyspace replication factor (FMEA #11). Thin wrapper over
+/// [`user_tables_from_snapshot`] that takes a live [`Schema`].
+pub fn user_tables_from_schema(
+    schema: &Schema,
+    skip_prefixes: &[String],
+    default_rf: usize,
+) -> Vec<(TableId, usize)> {
+    user_tables_from_snapshot(&schema.snapshot(), skip_prefixes, default_rf)
+}
+
+/// Enumerate user tables eligible for auto-repair from a schema snapshot, each
+/// paired with its keyspace replication factor (FMEA #11). Pure function —
+/// unit-testable from a constructed [`ferrosa_schema::SchemaSnapshot`] with no `Schema`/auth.
+///
+/// `skip_prefixes` are keyspace-name prefixes to exclude (system/internal); a
+/// keyspace whose name starts with any prefix is dropped. `default_rf` is used
+/// only when a keyspace's replication options cannot be parsed.
+pub fn user_tables_from_snapshot(
+    snapshot: &ferrosa_schema::SchemaSnapshot,
+    skip_prefixes: &[String],
+    default_rf: usize,
+) -> Vec<(TableId, usize)> {
+    let skipped = |ks: &str| skip_prefixes.iter().any(|p| ks.starts_with(p.as_str()));
+
+    let mut out: Vec<(TableId, usize)> = Vec::new();
+    for (ks, table) in snapshot.tables.keys() {
+        if skipped(ks) {
+            continue;
+        }
+        let rf = snapshot
+            .keyspaces
+            .get(ks)
+            .map(|k| replication_factor_for(&k.replication.options, default_rf))
+            .unwrap_or(default_rf);
+        if rf >= 1 {
+            out.push((TableId::new(ks.clone(), table.clone()), rf));
+        }
+    }
+    // Deterministic order so a tick's round-robin cursor is stable across calls.
+    out.sort_by(|a, b| (a.0.keyspace(), a.0.table()).cmp(&(b.0.keyspace(), b.0.table())));
+    out
+}
+
+/// Production [`RepairContext`]: the scheduler's window into live node state.
+///
+/// Holds the handles the four accessors need. Every accessor returns "not
+/// ready" as `None` so the scheduler no-ops a tick when the node is not in
+/// cluster mode / not yet in the ring (the scheduler's documented contract).
+pub struct BinaryRepairContext {
+    mode_controller: Arc<ModeController>,
+    storage: Arc<StorageEngine>,
+    schema: Arc<Schema>,
+    /// Keyspace-name prefixes to skip (mirrors `AutoRepairConfig::skip_keyspaces`).
+    skip_prefixes: Vec<String>,
+    /// RF fallback when a keyspace's options can't be parsed.
+    default_rf: usize,
+}
+
+impl BinaryRepairContext {
+    /// Construct from the live handles. `skip_prefixes` should match the
+    /// scheduler config's skip list; `default_rf` is the RF fallback (3).
+    pub fn new(
+        mode_controller: Arc<ModeController>,
+        storage: Arc<StorageEngine>,
+        schema: Arc<Schema>,
+        skip_prefixes: Vec<String>,
+        default_rf: usize,
+    ) -> Self {
+        Self {
+            mode_controller,
+            storage,
+            schema,
+            skip_prefixes,
+            default_rf,
+        }
+    }
+}
+
+impl RepairContext for BinaryRepairContext {
+    fn token_ring(&self) -> Option<ferrosa_cluster::ring::TokenRing> {
+        // ModeController hands out `Arc<TokenRing>`; the trait wants an owned
+        // snapshot, so deref-clone (cheap relative to a repair cycle).
+        self.mode_controller.token_ring().map(|r| (*r).clone())
+    }
+
+    fn local_node_id(&self) -> Option<u64> {
+        let ring = self.mode_controller.token_ring()?;
+        let host_id = self.mode_controller.host_id();
+        ring.node_ids().iter().copied().find(|&id| {
+            ring.get_node(id)
+                .is_some_and(|info| info.host_id == host_id)
+        })
+    }
+
+    fn build_executor(&self) -> Option<Arc<dyn SessionExecutor>> {
+        build_repair_executor(&self.mode_controller, &self.storage).map(|r| r.executor)
+    }
+
+    fn user_tables(&self) -> Vec<(TableId, usize)> {
+        user_tables_from_schema(&self.schema, &self.skip_prefixes, self.default_rf)
+    }
+}
+
+/// Production [`RepairTrigger`]: a quarantine schedules a prompt targeted
+/// repair of the affected table from a healthy replica (FMEA #10).
+///
+/// `request_refill` must be cheap and non-blocking, so it **spawns** the actual
+/// repair on the supplied runtime handle, bounded by a small semaphore so a
+/// burst of quarantines can't fan out unbounded repair load. A dropped permit
+/// (semaphore exhausted) is logged loudly — the periodic cycle is the backstop.
+pub struct BinaryRepairTrigger {
+    ctx: Arc<BinaryRepairContext>,
+    runtime: tokio::runtime::Handle,
+    /// Bounds concurrent triggered refills (FMEA #2 — don't OOM the node we heal).
+    permits: Arc<tokio::sync::Semaphore>,
+}
+
+impl BinaryRepairTrigger {
+    /// Maximum concurrent triggered refills. Small: a refill is a full
+    /// `repair_initiated` cycle for a table, already bounded internally by the
+    /// coordinator's session semaphore.
+    const MAX_CONCURRENT_REFILLS: usize = 2;
+
+    /// Construct from a [`BinaryRepairContext`] and the runtime to spawn the
+    /// refill on (the data runtime, which already drives internode IO).
+    pub fn new(ctx: Arc<BinaryRepairContext>, runtime: tokio::runtime::Handle) -> Self {
+        Self {
+            ctx,
+            runtime,
+            permits: Arc::new(tokio::sync::Semaphore::new(Self::MAX_CONCURRENT_REFILLS)),
+        }
+    }
+}
+
+impl RepairTrigger for BinaryRepairTrigger {
+    fn request_refill(&self, table: &TableId, ranges: &[(i64, i64)]) {
+        let table = table.clone();
+        let ranges_len = ranges.len();
+        let ctx = self.ctx.clone();
+        let permits = self.permits.clone();
+
+        // Spawn — never block the self-heal controller's tick (FMEA #10).
+        self.runtime.spawn(async move {
+            // Bound concurrent refills; if exhausted, log loud and let the
+            // periodic cycle be the backstop rather than queueing unboundedly.
+            let _permit = match permits.try_acquire_owned() {
+                Ok(p) => p,
+                Err(_) => {
+                    tracing::warn!(
+                        keyspace = %table.keyspace,
+                        table = %table.table,
+                        "auto-repair: refill trigger at capacity; skipping prompt refill — \
+                         periodic repair cycle is the backstop (FMEA #10)"
+                    );
+                    return;
+                }
+            };
+
+            let Some(resolved) = build_repair_executor(&ctx.mode_controller, &ctx.storage) else {
+                tracing::warn!(
+                    keyspace = %table.keyspace,
+                    table = %table.table,
+                    "auto-repair: refill requested but node not ring-ready; \
+                     periodic repair cycle is the backstop (FMEA #10)"
+                );
+                return;
+            };
+            let Some(ring) = ctx.mode_controller.token_ring() else {
+                tracing::warn!(
+                    keyspace = %table.keyspace,
+                    table = %table.table,
+                    "auto-repair: refill requested but ring vanished; backstop is the periodic cycle"
+                );
+                return;
+            };
+
+            // Per-keyspace RF (FMEA #11) — look the table up in the eligible set.
+            let rf = ctx
+                .user_tables()
+                .into_iter()
+                .find(|(t, _)| *t == table)
+                .map(|(_, rf)| rf)
+                .unwrap_or(ctx.default_rf);
+
+            tracing::info!(
+                keyspace = %table.keyspace,
+                table = %table.table,
+                rf,
+                ranges = ranges_len,
+                "auto-repair: starting triggered refill after quarantine"
+            );
+
+            // Reuse the initiator-only path: this node just quarantined a local
+            // copy, so it should initiate reconciliation of the ranges it owns.
+            let coord = RepairCoordinator::default();
+            let results = coord
+                .repair_initiated(
+                    resolved.executor,
+                    &ring,
+                    resolved.local_node_id,
+                    rf,
+                    &table,
+                )
+                .await;
+
+            let failed = results.iter().filter(|r| r.result.is_err()).count();
+            if failed > 0 {
+                tracing::warn!(
+                    keyspace = %table.keyspace,
+                    table = %table.table,
+                    sessions_total = results.len(),
+                    sessions_failed = failed,
+                    "auto-repair: triggered refill had failed sessions; periodic cycle is the backstop"
+                );
+            } else {
+                tracing::info!(
+                    keyspace = %table.keyspace,
+                    table = %table.table,
+                    sessions_total = results.len(),
+                    "auto-repair: triggered refill completed"
+                );
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrosa_schema::{
+        KeyspaceMetadata, ReplicationParams, SchemaSnapshot, TableMetadata, TableParams,
+    };
+
+    fn rf_opts(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn rf_simple_strategy_uses_replication_factor() {
+        let opts = rf_opts(&[("class", "SimpleStrategy"), ("replication_factor", "5")]);
+        assert_eq!(replication_factor_for(&opts, 3), 5);
+    }
+
+    #[test]
+    fn rf_network_topology_sums_per_dc_factors() {
+        let opts = rf_opts(&[
+            ("class", "NetworkTopologyStrategy"),
+            ("dc1", "3"),
+            ("dc2", "2"),
+        ]);
+        assert_eq!(replication_factor_for(&opts, 3), 5);
+    }
+
+    #[test]
+    fn rf_falls_back_to_default_when_unparseable() {
+        let opts = rf_opts(&[("class", "SimpleStrategy")]);
+        assert_eq!(replication_factor_for(&opts, 3), 3);
+        // RF=0 is invalid; fall back rather than repair against nobody.
+        let zero = rf_opts(&[("replication_factor", "0")]);
+        assert_eq!(replication_factor_for(&zero, 3), 3);
+    }
+
+    fn ks(name: &str, rf: &str) -> KeyspaceMetadata {
+        KeyspaceMetadata {
+            name: name.to_string(),
+            durable_writes: true,
+            replication: ReplicationParams {
+                strategy: "SimpleStrategy".to_string(),
+                options: rf_opts(&[("class", "SimpleStrategy"), ("replication_factor", rf)]),
+            },
+        }
+    }
+
+    fn table(keyspace: &str, name: &str) -> TableMetadata {
+        TableMetadata {
+            keyspace: keyspace.to_string(),
+            name: name.to_string(),
+            id: uuid::Uuid::new_v4(),
+            columns: Default::default(),
+            partition_key: vec!["id".to_string()],
+            clustering_key: vec![],
+            params: TableParams::default(),
+            flags: Default::default(),
+            extensions: Default::default(),
+            is_system: false,
+        }
+    }
+
+    #[test]
+    fn user_tables_skips_system_and_uses_per_keyspace_rf() {
+        let mut snap = SchemaSnapshot::new();
+        snap.keyspaces.insert("app".into(), ks("app", "2"));
+        snap.keyspaces
+            .insert("analytics".into(), ks("analytics", "3"));
+        snap.keyspaces
+            .insert("system_auth".into(), ks("system_auth", "1"));
+        snap.tables
+            .insert(("app".into(), "users".into()), table("app", "users"));
+        snap.tables.insert(
+            ("analytics".into(), "events".into()),
+            table("analytics", "events"),
+        );
+        snap.tables.insert(
+            ("system_auth".into(), "roles".into()),
+            table("system_auth", "roles"),
+        );
+
+        let skip = vec!["system".to_string()];
+        let tables = user_tables_from_snapshot(&snap, &skip, 3);
+
+        // system keyspaces excluded; both user tables present, each with its
+        // own keyspace RF (FMEA #11).
+        let app = tables
+            .iter()
+            .find(|(t, _)| t.keyspace() == "app" && t.table() == "users")
+            .expect("app.users present");
+        assert_eq!(app.1, 2, "app keyspace RF=2");
+        let analytics = tables
+            .iter()
+            .find(|(t, _)| t.keyspace() == "analytics" && t.table() == "events")
+            .expect("analytics.events present");
+        assert_eq!(analytics.1, 3, "analytics keyspace RF=3");
+        assert!(
+            tables
+                .iter()
+                .all(|(t, _)| !t.keyspace().starts_with("system")),
+            "no system keyspace table is selected for auto-repair"
+        );
+        // Deterministic order (analytics < app lexicographically).
+        assert_eq!(tables.len(), 2);
+        assert_eq!(tables[0].0.keyspace(), "analytics");
+        assert_eq!(tables[1].0.keyspace(), "app");
+    }
+
+    #[test]
+    fn user_tables_uses_default_rf_when_keyspace_metadata_missing() {
+        let mut snap = SchemaSnapshot::new();
+        // Table present but its keyspace has no metadata entry → default RF.
+        snap.tables
+            .insert(("orphan".into(), "t".into()), table("orphan", "t"));
+        let tables = user_tables_from_snapshot(&snap, &["system".to_string()], 3);
+        assert_eq!(tables, vec![(TableId::new("orphan", "t"), 3)]);
+    }
+}

--- a/ferrosa/src/web/api.rs
+++ b/ferrosa/src/web/api.rs
@@ -62,7 +62,9 @@ pub async fn get_metrics(
     [(axum::http::header::HeaderName, &'static str); 1],
     String,
 ) {
-    let body = ferrosa_cql::prometheus::render_metrics(&registry);
+    let mut body = ferrosa_cql::prometheus::render_metrics(&registry);
+    // Automatic-repair scheduler counters (ferrosa_auto_repair_*).
+    body.push_str(&ferrosa_cluster::repair::scheduler::render_prometheus());
     (
         StatusCode::OK,
         [(

--- a/specs/proposed/automatic-repair-scheduler-design.md
+++ b/specs/proposed/automatic-repair-scheduler-design.md
@@ -1,0 +1,173 @@
+# Design — Automatic anti-entropy repair scheduler
+
+> Last updated: 2026-06-04
+> Status: Draft (design-first; grill open questions before implementing)
+> Scope: make anti-entropy repair run **autonomously** on a live cluster — no
+> operator, no HTTP trigger — and connect it to the self-heal controller so a
+> quarantined corrupt SSTable is refilled from a healthy replica.
+
+## Executive summary
+
+The engine already has **memory-bounded repair primitives** (`RepairCoordinator::
+repair_table` → Merkle-diff-then-stream sessions, bounded concurrency + byte
+budget — PR #83) and a **self-heal controller** that detects corrupt SSTables.
+What is missing for "fully automatic repair":
+
+1. There is **no periodic driver**. `repair_table` is invoked from exactly one
+   production call site — the `POST /api/cluster/repair` web handler
+   (`ferrosa/src/web/api.rs`). Nothing runs it on a schedule.
+2. The self-heal controller is spawned with a **`SingleNodeClusterView` stub**
+   (`main.rs:722`, before `ModeController` exists at `main.rs:933`), so on a
+   real cluster it **never quarantines** — it only escalates-degraded.
+3. The controller has **no repair/converge action** and no way to call the
+   cluster repair path (it lives in `ferrosa-storage`, below `ferrosa-cluster`).
+
+This design adds a cluster-layer **`AutoRepairScheduler`**: a deterministic,
+loud, bounded background task that periodically reconciles replicas, plus the
+**`ClusterView` wiring** that lets the self-heal controller quarantine safely and
+request a targeted refill.
+
+## Why the scheduler lives in the cluster layer
+
+`AutoRepairScheduler` needs the `TokenRing`, `PeerManager`, and
+`RepairCoordinator` — all in `ferrosa-cluster` / the `ModeController`. The
+storage-side self-heal controller stays focused on corrupt-SSTable
+detection/quarantine and *requests* a refill through a port (the controller
+cannot depend on the cluster layer). So:
+
+- **Divergence repair** (replica reconciliation) → `AutoRepairScheduler` (cluster).
+- **Corrupt-SSTable quarantine** → self-heal controller (storage), with a
+  `ClusterView` for replica-health and a `RepairTrigger` port for refill.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph Node["ferrosa node (main.rs, after ModeController @ L951)"]
+        MC["ModeController<br/>token_ring / peer_manager / host_id"]
+        SCHED["AutoRepairScheduler<br/>(cluster, periodic)"]
+        COORD["RepairCoordinator::repair_table<br/>(bounded fan-out — exists)"]
+        SH["SelfHealController<br/>(storage, ticking — exists)"]
+        CV["ClusterView impl<br/>(verified healthy replica)"]
+        RT["RepairTrigger port<br/>(quarantine to targeted refill)"]
+    end
+    MC --> SCHED
+    SCHED -->|per table, deterministic initiator| COORD
+    MC --> CV
+    CV --> SH
+    SH -->|QuarantineCorrupt to refill ranges| RT
+    RT --> SCHED
+```
+
+- `AutoRepairScheduler` is constructed in `main.rs` after `ModeController` is
+  wired (after L951), reusing the exact executor/ring/local-node-id construction
+  the `repair_handler` already does (`StorageEngineRepairStore` local +
+  per-peer `RemoteRepairStore`, `LocalRepairExecutor`).
+- The self-heal spawn moves to after `ModeController` too (or takes a lazy
+  ring/peer handle) so it can be given the **real** `ClusterView` instead of the
+  single-node stub.
+
+## Control loop (deterministic)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Tick: fixed interval (FERROSA_AUTO_REPAIR_INTERVAL)
+    Tick --> Enumerate: list user tables (skip system/local-only)
+    Enumerate --> PerRange: for each owned (table, range)
+    PerRange --> Skip: not the deterministic initiator
+    PerRange --> Skip: manual/auto repair already in-flight
+    PerRange --> Run: lowest live host-id among owners
+    Run --> Observe: repair_table (bounded); log + metrics
+    Observe --> Idle: record last-repaired; cooldown
+```
+
+### Determinism (anti-thundering-herd — self-heal FMEA #4)
+
+For each `(table, token-range)`, **only the replica whose host-id sorts first
+among the range's *currently-live* owners initiates** repair. Same ring → same
+initiator, no election, no RNG. A range is therefore repaired once per cycle by
+one node, not RF times. Recomputed from the live ring each tick, so membership
+churn self-corrects (idempotent LWW repair makes a transient duplicate harmless).
+
+## Cadence and load shaping
+
+Repair is load-heavy, so the cycle is **spread**, not a thundering full-sweep:
+one table (or one merged range) per sub-tick, round-robin, so the whole keyspace
+is covered once per `FERROSA_AUTO_REPAIR_INTERVAL`. `RepairCoordinator` already
+bounds in-flight sessions (semaphore=4) and per-session memory (byte budget), so
+a single initiated table is safe; spreading bounds the *aggregate* across tables.
+
+## Quarantine to refill coupling
+
+When the self-heal controller quarantines a corrupt generation, the rows in that
+generation are gone locally. It calls a **`RepairTrigger` port** (implemented by
+the scheduler) to schedule a **targeted repair of the affected token ranges**, so
+the quarantined data is refilled from a healthy replica promptly — not only at
+the next full cycle. The quarantine itself remains gated on a **verified healthy
+replica** (FMEA #1): never quarantine unless a reachable peer is confirmed to
+hold a non-corrupt copy of the range.
+
+## Config knobs (all deterministic)
+
+| Env | Default (proposed) | Meaning |
+|-----|--------------------|---------|
+| `FERROSA_AUTO_REPAIR_ENABLED` | **on** (grill) | master switch |
+| `FERROSA_AUTO_REPAIR_INTERVAL` | **24h** (grill) | full-coverage period |
+| `FERROSA_AUTO_REPAIR_MAX_CONCURRENT_TABLES` | 1 | load shaping (round-robin) |
+| `FERROSA_AUTO_REPAIR_SKIP_KEYSPACES` | system\* | don't auto-repair system tables |
+| (reuse) `RepairCoordinator.max_concurrent_sessions` | 4 | per-table session bound |
+
+## Safety rails
+
+- Single deterministic initiator per range (no herd); recomputed per tick.
+- Skip a `(table, range)` if a manual `POST /repair` or a prior auto-repair is
+  still in-flight (a shared in-flight set), + per-table cooldown.
+- Only initiate when this node is in cluster mode with a ring **and** >=1 live
+  peer for the range (single-node / no-peer = nothing to do, log).
+- Loud: WARN on divergence found, INFO on every session start/outcome, metrics
+  (`ferrosa_auto_repair_*`: cycles, sessions, partitions streamed, failures,
+  time-to-converge), health-surface entry.
+- Bounded memory inherited from the repair primitives (PR #83).
+- Master switch off = scheduler never spawns its loop (the manual endpoint
+  still works).
+
+## Implementation plan (TDD)
+
+1. `AutoRepairScheduler` struct + pure `select_initiated_ranges(ring, host_id,
+   rf, tables) -> Vec<(table, range, peers)>` (deterministic initiator) — unit
+   test the selection in isolation (no IO), incl. membership-churn idempotence.
+2. Tick loop + in-flight/cooldown bookkeeping (logical clock, like the self-heal
+   controller) — unit test that one tick initiates exactly the
+   lowest-host-id-owned ranges and skips in-flight.
+3. Wire into `main.rs` after `ModeController`; reuse `repair_handler`'s executor
+   construction (extract a shared `build_repair_executor(mc, storage)` helper so
+   the endpoint and scheduler share one code path).
+4. Real `ClusterView` impl (cluster) for the self-heal controller:
+   `replica_posture(table, range)` = verified healthy peer (digest/read probe)
+   = `HealthyReplicaAvailable`; move/relazy the self-heal spawn so it gets it.
+5. `RepairTrigger` port: quarantine schedules a targeted range repair.
+6. Config, metrics, health surface; integration test on a sim/multi-node where a
+   divergent replica converges within one cycle with no operator action.
+
+## Decisions (locked 2026-06-04, owner)
+
+- **Q1 — enable default:** `FERROSA_AUTO_REPAIR_ENABLED` defaults **on** — truly
+  self-managing out of the box; deterministic single-initiator + conservative
+  cadence keep load safe; operators can disable.
+- **Q2 — cadence:** `FERROSA_AUTO_REPAIR_INTERVAL` defaults **24h** full
+  coverage, spread round-robin across tables. Comfortably under the 10-day
+  gc_grace so tombstones don't resurrect.
+- **Q3 — quarantine→refill:** a quarantine triggers an **immediate targeted
+  repair** of the affected ranges via the `RepairTrigger` port; the periodic
+  cycle is the backstop.
+- **Q4 — phase scope:** **scheduler + real `ClusterView` wiring** — both the
+  divergence-repair driver and the corrupt-SSTable quarantine go live this
+  phase, delivering fully automatic repair end-to-end.
+
+## Related
+
+- Repair primitives: `ferrosa-cluster/src/repair/{coordinator,executor,merkle}.rs`
+- Self-heal controller: `specs/proposed/self-healing-controller-{design,fmea}.md`,
+  `ferrosa-storage/src/self_heal/`
+- Bounded-memory foundation (PR #83): `specs/proposed/p0-bounded-sstable-reader-*`

--- a/specs/proposed/automatic-repair-scheduler-fmea.md
+++ b/specs/proposed/automatic-repair-scheduler-fmea.md
@@ -1,0 +1,41 @@
+# FMEA — Automatic anti-entropy repair scheduler
+
+> Last updated: 2026-06-04
+> Companion to [`automatic-repair-scheduler-design.md`](./automatic-repair-scheduler-design.md)
+> Scoring: Severity / Occurrence / Detection each 1–10; RPN = S × O × D. Higher = act first.
+
+An actor that *initiates repair on a live cluster with no operator* can amplify
+load, lose data, or thrash. Correctness and never-worse weigh above availability
+(fail-loud). Determinism is a hard requirement.
+
+## Failure modes
+
+| # | Failure mode | Effect | S | O | D | RPN | Mitigation (→ test) |
+|---|---|---|---|---|---|---|---|
+| 1 | **Thundering herd** — every replica initiates the same range at once | RF× load spike, quorum pressure, CQL listener crash (observed: 1 536-session storm) | 9 | 7 | 4 | 252 | Deterministic single initiator = lowest live host-id among range owners; recomputed per tick. Test: given a fixed ring, exactly one node initiates each range. |
+| 2 | **Auto-repair OOMs the node it heals** | self-healing makes the outage worse | 10 | 4 | 3 | 120 | Inherit PR #83 bounds (bounded readers/merge/fetch/compaction) + `RepairCoordinator` session semaphore (4) + round-robin one table/cycle. Test: full-overlap repair under N≫fanin holds peak readers ≤ fanin (existing). |
+| 3 | **Quarantine without a verified healthy replica** then refill finds none | permanent data loss (the only copy was the quarantined corrupt gen) | 10 | 4 | 5 | 200 | Quarantine gated on `ClusterView` verified-non-corrupt peer (FMEA #1 of the controller). Single-node / unverified → never quarantine, escalate-degraded. Test: no-verified-replica → no quarantine + no refill request. |
+| 4 | **Non-deterministic initiator** (RNG/clock/race) | unreproducible, two initiators or zero | 8 | 4 | 5 | 160 | `select_initiated_ranges` is a pure function of (ring, host_id, rf); no RNG/clock. Test: same ring → identical selection ×N. |
+| 5 | **Membership churn mid-cycle** flips the initiator | duplicate or skipped repair for a range | 6 | 4 | 5 | 120 | Recompute initiator from the *live* ring each tick; repair is idempotent LWW so a duplicate is harmless; a skipped range re-triggers next tick. Test: initiator recomputation under a node add/drop. |
+| 6 | **Fights an in-flight manual `POST /repair`** | double work, contention | 5 | 5 | 4 | 100 | Shared in-flight set keyed by (table, range); skip if already running (manual or auto) + per-table cooldown. Test: in-flight entry suppresses a second initiation. |
+| 7 | **Silent repair** — converges without logging | operator blind to recurring divergence/corruption | 7 | 3 | 5 | 105 | WARN on divergence found, INFO per session start/outcome, metrics + health surface, independent of outcome. Test: a divergent run emits log+metric. |
+| 8 | **Runaway cadence** — interval too short → continuous repair load | steady-state load, never idle | 6 | 4 | 4 | 96 | Conservative default interval + round-robin spread + cooldown; one table in flight at a time. Test: scheduler initiates ≤ max_concurrent_tables per tick. |
+| 9 | **Repairs system/local-only tables** | wasted work, possible metadata contention | 4 | 5 | 4 | 80 | Skip-keyspaces list (system\*); only user keyspaces with RF>1. Test: system keyspaces excluded from selection. |
+| 10 | **Refill never happens after quarantine** (port dropped/failed) | quarantined range stays empty until next full cycle | 7 | 3 | 4 | 84 | `RepairTrigger` failure is logged loud + the range is still covered by the periodic cycle as a backstop; health surface shows pending refill. Test: refill request enqueues a targeted range repair; failure logged. |
+| 11 | **Wrong RF used** (hardcoded 3 vs keyspace replication) | repairs wrong peer set / misses replicas | 7 | 4 | 4 | 112 | Read RF from each keyspace's replication options, not a constant (the web endpoint's `rf=3` default is a shortcut not to be copied). Test: selection uses per-keyspace RF. |
+
+## Top risks to design out first
+
+1. **#1 thundering herd (252)** — deterministic single initiator (lowest live
+   host-id among owners), recomputed per tick. This is the headline risk; the
+   1 536-session storm already crashed a CQL listener historically.
+2. **#3 quarantine-without-verified-replica data loss (200)** — gate on the
+   real `ClusterView`; never quarantine unverified.
+3. **#4 non-determinism (160)** — pure `select_initiated_ranges`, determinism-tested.
+
+## Decisions this FMEA forces (owner input)
+
+- **Q1 — enable default** on vs off (self-managing vs opt-in).
+- **Q2 — cadence** default interval.
+- **Q3 — quarantine→refill** immediate targeted repair vs next-cycle only.
+- **Q4 — phase scope** scheduler only vs scheduler + ClusterView wiring.


### PR DESCRIPTION
## Summary

- Adds a deterministic single-initiator range selection algorithm: for each token range, exactly the lowest live `host_id` replica initiates repair — preventing repair storms (herd problem).
- Introduces `AutoRepairConfig`, `AutoRepairScheduler`, and `RepairContext`: a periodic driver that ticks through tables in round-robin order, respects `max_concurrent_tables`, skips in-flight ranges, and emits Prometheus counters (`auto_repair_ticks_total`, `election_storm_term_jumps_total`).
- Adds `verified-healthy-replica ClusterView` and a `quarantine→refill` `RepairTrigger` port in `ferrosa-storage/src/self_heal/`.
- Wires everything end-to-end in `ferrosa/src/main.rs` via `repair_wiring.rs`, spawned after `ModeController` so the live ring and peer manager are available.
- Includes design doc + FMEA in `specs/` covering 8 failure modes (herd, starvation, churn, determinism, in-flight collision, metrics gap, startup, shutdown).

## Test evidence

All tests pass (`cargo test -p ferrosa-cluster`):

- `exactly_one_initiator_per_range_no_herd` — verifies only the lowest `host_id` initiates
- `initiator_fails_over_when_lowest_host_down` — churn: next-lowest live node takes over
- `selection_is_deterministic` — same ring → identical selection on every call
- `single_node_selects_nothing` / `unknown_local_node_selects_nothing` — edge cases
- `run_tick_repairs_selected_tables_and_advances_cursor` — round-robin cursor advances correctly across 3 ticks
- `run_tick_skips_in_flight_table` — FMEA #6: in-flight table is not re-scheduled
- `run_tick_no_ops_when_context_not_ready` — scheduler no-ops when cluster not in Normal mode
- `spawn_enabled_ticks_then_shuts_down` — full lifecycle: enable → tick → shutdown token
- `sub_tick_spreads_table_set_over_interval` — sub-tick interval math
- `metrics_render_and_count_ticks` — Prometheus counter increments

## What's deferred

- Integration test against a real multi-node cluster (requires live podman ring; tracked separately)
- Tuning of `default_interval` (currently 4 h) — needs load data from production
- Repair progress persistence across restarts (currently cursor resets on startup)