### PR TITLE
feat(storage): atomic multi-write batch/transaction primitive (train PR #1)

### DIFF
--- a/ferrosa-storage/src/commitlog/mod.rs
+++ b/ferrosa-storage/src/commitlog/mod.rs
@@ -1050,6 +1050,22 @@ impl CommitLog {
         Ok(mutations)
     }
 
+    /// The largest single commit-log entry (payload + framing overhead) that
+    /// can ever be appended, given the configured segment size.
+    ///
+    /// An entry larger than this can never be appended (it overflows even a
+    /// fresh segment), so [`Self::append`] would fail. Batch callers pre-flight
+    /// against this so a multi-entry batch can never fail *partway* through its
+    /// appends, preserving all-or-nothing durability.
+    pub fn max_entry_size(&self) -> usize {
+        Segment::max_entry_size(self.config.segment_size)
+    }
+
+    /// The framed on-disk size of `mutation` as a single commit-log entry.
+    pub fn entry_size(mutation: &Mutation) -> usize {
+        Segment::entry_total_size(mutation)
+    }
+
     /// Force-syncs the active segment to disk.
     ///
     /// Waits for all in-flight writers to complete, then flushes the

--- a/ferrosa-storage/src/commitlog/segment.rs
+++ b/ferrosa-storage/src/commitlog/segment.rs
@@ -924,6 +924,18 @@ impl Segment {
         ENTRY_OVERHEAD + mutation.serialized_size()
     }
 
+    /// The largest single entry (payload + overhead) that can ever fit in a
+    /// fresh segment of `capacity` bytes.
+    ///
+    /// A fresh segment starts at [`INITIAL_POSITION`] (header + first sync
+    /// marker); a closing sync marker is also reserved so `force_sync` can
+    /// always append its EOF marker. Returns 0 when the capacity cannot hold
+    /// even an empty entry — callers must treat that as "no entry fits".
+    pub fn max_entry_size(capacity: usize) -> usize {
+        let reserved = INITIAL_POSITION as usize + SYNC_MARKER_SIZE;
+        capacity.saturating_sub(reserved)
+    }
+
     /// Computes the total entry size for a single-row borrowed mutation.
     pub fn entry_total_size_single_row(
         keyspace: &str,

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -50,6 +50,123 @@ use crate::timeseries::{
 };
 use crate::upload::{ObjectStoreConfig, UploadManager};
 
+/// One operation in an atomic batch (spec URS-QEC-X02).
+///
+/// Both variants lower to a [`Row`] inside a [`Mutation`]; the enum exists so
+/// callers (Accord LWT apply, Cypher delete-cascade, Bolt transactions) express
+/// intent without hand-building `Row` deletion markers.
+#[derive(Debug, Clone)]
+pub enum BatchOp {
+    /// Upsert a row at `key` in `keyspace.table` @ `timestamp`.
+    Write {
+        /// Target keyspace.
+        keyspace: String,
+        /// Target table.
+        table: String,
+        /// Partition key.
+        key: DecoratedKey,
+        /// Row to upsert.
+        row: Row,
+        /// Mutation timestamp (microseconds since epoch).
+        timestamp: i64,
+    },
+    /// Tombstone. `clustering = None` deletes the whole partition; `Some(bytes)`
+    /// deletes one clustered row. Lowers to a `Row` carrying a `DeletionTime`.
+    Tombstone {
+        /// Target keyspace.
+        keyspace: String,
+        /// Target table.
+        table: String,
+        /// Partition key.
+        key: DecoratedKey,
+        /// `None` = whole-partition delete; `Some` = single clustered row.
+        clustering: Option<Vec<u8>>,
+        /// Mutation timestamp (microseconds since epoch).
+        timestamp: i64,
+    },
+}
+
+impl BatchOp {
+    /// Lower this op to a single-row [`Mutation`] for `write_atomic_batch`.
+    ///
+    /// A `Tombstone` becomes a pure tombstone `Row` (no cells, non-LIVE
+    /// `DeletionTime`) — the in-memory representation the memtable merge path
+    /// already honors for both partition (`clustering = None`) and clustered
+    /// (`clustering = Some`) deletes.
+    fn into_mutation(self) -> Mutation {
+        match self {
+            BatchOp::Write {
+                keyspace,
+                table,
+                key,
+                row,
+                timestamp,
+            } => Mutation::new(keyspace, table, key, vec![row], timestamp),
+            BatchOp::Tombstone {
+                keyspace,
+                table,
+                key,
+                clustering,
+                timestamp,
+            } => {
+                let deletion = deletion_at(timestamp);
+                let row = Row {
+                    clustering: clustering.unwrap_or_default(),
+                    cells: Vec::new(),
+                    deletion,
+                    primary_key_liveness: ferrosa_sstable::types::LivenessInfo::NONE,
+                };
+                Mutation::new(keyspace, table, key, vec![row], timestamp)
+            }
+        }
+    }
+}
+
+/// Build a non-LIVE [`ferrosa_sstable::types::DeletionTime`] for a tombstone at
+/// `timestamp` microseconds. `local_deletion_time` (seconds) is derived from the
+/// microsecond timestamp, saturating into `u32`.
+fn deletion_at(timestamp: i64) -> ferrosa_sstable::types::DeletionTime {
+    let local_seconds = timestamp.div_euclid(1_000_000).clamp(0, u32::MAX as i64) as u32;
+    ferrosa_sstable::types::DeletionTime::new(timestamp, local_seconds)
+}
+
+/// Staging handle for a Bolt explicit transaction (spec URS-QEC-X02 §5.3).
+///
+/// Ops accumulate in memory; nothing is durable until [`Self::commit`].
+/// [`Self::abort`] (or `Drop`) discards them with no I/O.
+pub struct BatchTxn<'e> {
+    engine: &'e StorageEngine,
+    ops: Vec<BatchOp>,
+}
+
+impl<'e> BatchTxn<'e> {
+    /// Append an op to the pending set (no durable write yet).
+    pub fn stage(&mut self, op: BatchOp) {
+        self.ops.push(op);
+    }
+
+    /// Number of staged ops.
+    pub fn len(&self) -> usize {
+        self.ops.len()
+    }
+
+    /// `true` when no ops are staged.
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+
+    /// Apply all staged ops atomically (delegates to
+    /// [`StorageEngine::apply_batch`]). Fail-loud on engine error.
+    pub fn commit(self) -> ferrosa_common::Result<()> {
+        self.engine.apply_batch(self.ops)
+    }
+
+    /// Discard all staged ops; no I/O. Equivalent to dropping the handle.
+    pub fn abort(self) {
+        drop(self);
+    }
+}
+
 pub(crate) fn write_options_for_schema(
     schema: &TableSchema,
     verify_output: bool,
@@ -5111,6 +5228,36 @@ impl StorageEngine {
         }
 
         Ok(())
+    }
+
+    /// Apply a batch of mixed ops atomically and durably (single fsync group).
+    ///
+    /// All-or-nothing: every op lowers to a [`Mutation`] and the whole set is
+    /// applied through [`Self::write_atomic_batch`], which preflights every
+    /// target table **before** appending any commit-log record. On any
+    /// preflight / append failure **none** of the ops are applied and an `Err`
+    /// is returned (spec URS-QEC-X02, fail-loud per X01). Ops touching the same
+    /// `(keyspace, table, key)` are applied in `ops` order.
+    ///
+    /// An empty batch is `Ok(())`.
+    pub fn apply_batch(&self, ops: Vec<BatchOp>) -> ferrosa_common::Result<()> {
+        if ops.is_empty() {
+            return Ok(());
+        }
+        let mutations = ops.into_iter().map(BatchOp::into_mutation).collect();
+        self.write_atomic_batch(mutations)
+    }
+
+    /// Open a staging handle for a Bolt explicit transaction (B02).
+    ///
+    /// Ops are staged in memory; nothing is durable until [`BatchTxn::commit`].
+    /// [`BatchTxn::abort`] (or dropping the handle) discards the staged ops with
+    /// no I/O — exactly the `ROLLBACK` / connection-drop semantics.
+    pub fn begin_batch(&self) -> BatchTxn<'_> {
+        BatchTxn {
+            engine: self,
+            ops: Vec::new(),
+        }
     }
 
     /// Reads a partition from a table, merging memtable and SSTable sources.

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -5161,14 +5161,31 @@ impl StorageEngine {
             return Ok(());
         }
 
-        // Preflight every target table before appending any batch mutation to
-        // the commitlog. This preserves all-or-nothing client-visible failure
-        // semantics for overload rejection.
+        // Preflight every target table AND every entry's size before appending
+        // any batch mutation to the commitlog. This preserves all-or-nothing
+        // semantics: every fallible append condition (table registration,
+        // overload admission, and oversized-entry rejection) is checked up
+        // front, so Phase 1 cannot fail *partway* and leave an already-appended
+        // (and therefore replay-durable) prefix of the batch on disk.
         {
             let tables = self.tables.read();
+            let max_entry = self.commit_log.max_entry_size();
             let mut checked = HashSet::new();
             for m in &mutations {
                 self.check_write_admission()?;
+
+                // Oversized-entry preflight: an entry larger than a fresh
+                // segment can never be appended, so reject the whole batch now
+                // rather than after appending earlier ops.
+                let entry_size = CommitLog::entry_size(m);
+                if entry_size > max_entry {
+                    return Err(ferrosa_common::Error::InvalidData(format!(
+                        "batch entry ({entry_size} bytes) exceeds commit-log \
+                         segment capacity ({max_entry} bytes usable); increase \
+                         segment_size or split the batch"
+                    )));
+                }
+
                 let table_id = TableId::new(&m.keyspace, &m.table);
                 if !checked.insert(table_id.clone()) {
                     continue;
@@ -5189,6 +5206,18 @@ impl StorageEngine {
             let table_id = TableId::new(&m.keyspace, &m.table);
             positions.insert(table_id, cl_pos);
         }
+
+        // Durability barrier: synchronously fsync the appended batch BEFORE it
+        // is made visible in the memtable (Phase 2). Without this, under the
+        // production-default `Periodic` sync strategy `append()` only schedules
+        // a background fsync, so the rows would become readable while still
+        // unsynced — a crash in that window would lose an acked, already-visible
+        // batch. `force_sync` propagates fsync failures as `Err` (fail-loud);
+        // on error nothing has been applied to the memtable yet, so the batch
+        // remains all-or-nothing: the appended entries replay together on the
+        // next restart if they reached disk, or are lost together if they did
+        // not — never a torn, partly-visible state.
+        self.commit_log.force_sync()?;
 
         // Phase 2: Apply to memtables and update commit log positions.
         let tables = self.tables.read();

--- a/ferrosa-storage/src/lib.rs
+++ b/ferrosa-storage/src/lib.rs
@@ -56,8 +56,8 @@ pub use compaction::{
 };
 pub use data_store::{DataStore, LocalDataStore};
 pub use engine::{
-    PersistedIndexRow, StorageEngine, StorageEngineConfig, TempSortTableReservation,
-    TimeSeriesWasmAggregateExecutor, TimeSeriesWasmAggregateInvocation,
+    BatchOp, BatchTxn, PersistedIndexRow, StorageEngine, StorageEngineConfig,
+    TempSortTableReservation, TimeSeriesWasmAggregateExecutor, TimeSeriesWasmAggregateInvocation,
     FILTER_PREDICATE_OPTION_KEY,
 };
 pub use flush::{FileFlushTarget, FlushTarget, InMemoryFlushTarget};

--- a/ferrosa-storage/src/memtable/mod.rs
+++ b/ferrosa-storage/src/memtable/mod.rs
@@ -32,6 +32,17 @@ use ferrosa_sstable::types::{DeletionTime, Partition, Row};
 ///
 /// See specs/in-process/bug-memtable-flush-wedge-truncated-timeuuid-
 /// from-now-function.md for the bug this guards against.
+/// True when `row` is the in-memory marker for a partition-level `DELETE`
+/// (`DELETE FROM t WHERE pk = ?`): empty clustering, no cells, and a non-LIVE
+/// deletion. Such a marker carries a partition tombstone, not a clustered row,
+/// and must be lifted into [`Partition::deletion`] rather than stored as a row
+/// (otherwise it suppresses nothing on read). A genuine clustered row always
+/// has cells or a LIVE primary-key liveness, so this predicate never matches
+/// real data.
+pub(crate) fn is_partition_tombstone(row: &Row) -> bool {
+    row.clustering.is_empty() && row.cells.is_empty() && row.deletion != DeletionTime::LIVE
+}
+
 pub(crate) fn validate_row_against_schema(row: &Row, schema: &TableSchema) -> Result<()> {
     // Clustering shape: production wedge was an 8-byte clustering on a
     // TimeUUID-clustered table. Catching this at the memtable boundary
@@ -44,8 +55,7 @@ pub(crate) fn validate_row_against_schema(row: &Row, schema: &TableSchema) -> Re
     // marker has no clustering by construction and must be allowed
     // through even on a clustered table — it carries no payload that
     // the strict-shape check is protecting.
-    let is_partition_tombstone =
-        row.clustering.is_empty() && row.cells.is_empty() && row.deletion != DeletionTime::LIVE;
+    let is_partition_tombstone = is_partition_tombstone(row);
     if !is_partition_tombstone {
         if let Err(reason) = validate_clustering_shape(&schema.clustering_columns, &row.clustering)
         {

--- a/ferrosa-storage/src/memtable/sharded.rs
+++ b/ferrosa-storage/src/memtable/sharded.rs
@@ -164,12 +164,25 @@ impl Memtable for ShardedBTreeMemtable {
                 self.size.fetch_sub(old_size - new_size, Ordering::Relaxed);
             }
         } else {
-            // New partition
-            let partition = Partition {
-                key: key.clone(),
-                deletion: DeletionTime::LIVE,
-                static_row: None,
-                rows: vec![row],
+            // New partition. A partition-tombstone marker (empty clustering,
+            // no cells, non-LIVE deletion) is a partition-level DELETE: lift it
+            // into `Partition::deletion` instead of storing a phantom row, so a
+            // subsequent read suppresses every clustered row at or below the
+            // tombstone timestamp (see `super::is_partition_tombstone`).
+            let partition = if super::is_partition_tombstone(&row) {
+                Partition {
+                    key: key.clone(),
+                    deletion: row.deletion,
+                    static_row: None,
+                    rows: Vec::new(),
+                }
+            } else {
+                Partition {
+                    key: key.clone(),
+                    deletion: DeletionTime::LIVE,
+                    static_row: None,
+                    rows: vec![row],
+                }
             };
             let size = Self::estimate_partition_size(&partition);
             shard.insert(key.clone(), Arc::new(partition));
@@ -297,6 +310,17 @@ impl Memtable for ShardedBTreeMemtable {
 /// same clustering key exists, merges cells (newer timestamp wins per cell).
 /// Otherwise inserts the row at the correct sorted position.
 pub(crate) fn merge_row_into_partition(partition: &mut Partition, new_row: Row) {
+    // A partition-tombstone marker is a partition-level DELETE: merge it into
+    // `Partition::deletion` (newer tombstone wins, LWW) rather than storing it
+    // as a clustered row. Otherwise it would sit in `rows` as a phantom
+    // empty-clustering row and suppress nothing, silently dropping the delete.
+    if super::is_partition_tombstone(&new_row) {
+        if new_row.deletion.marked_for_delete_at > partition.deletion.marked_for_delete_at {
+            partition.deletion = new_row.deletion;
+        }
+        return;
+    }
+
     // Binary search by clustering key
     let pos = partition
         .rows
@@ -671,6 +695,70 @@ mod tests {
         };
         mem.put(&key, row, &schema)
             .expect("partition tombstone must be accepted on clustered table");
+    }
+
+    /// A partition-tombstone marker must be lifted into `Partition::deletion`
+    /// (LWW), not stored as a phantom empty-clustering row. Otherwise a
+    /// whole-partition `DELETE FROM t WHERE pk = ?` suppresses nothing and the
+    /// rows silently survive (the bug the batch primitive exposed).
+    #[test]
+    fn put_partition_tombstone_sets_partition_deletion_not_a_row() {
+        use ferrosa_sstable::types::{DeletionTime, LivenessInfo};
+        let mem = ShardedBTreeMemtable::new(4);
+        let schema = TableSchema {
+            keyspace: "ks".to_string(),
+            table: "t".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+            clustering_columns: vec![ColumnDefinition {
+                name: "ck".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+            }],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "val".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: Default::default(),
+        };
+        let key = make_key("pk1");
+
+        // Seed two clustered rows (ts=100), then a partition tombstone (ts=200).
+        let row1 = Row {
+            clustering: 1i32.to_be_bytes().to_vec(),
+            cells: vec![(0, CellValue::live(b"a".to_vec(), 100))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(100),
+        };
+        let row2 = Row {
+            clustering: 2i32.to_be_bytes().to_vec(),
+            cells: vec![(0, CellValue::live(b"b".to_vec(), 100))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(100),
+        };
+        mem.put(&key, row1, &schema).unwrap();
+        mem.put(&key, row2, &schema).unwrap();
+        mem.put(
+            &key,
+            Row {
+                clustering: vec![],
+                cells: vec![],
+                deletion: DeletionTime::new(200, 0),
+                primary_key_liveness: LivenessInfo::NONE,
+            },
+            &schema,
+        )
+        .unwrap();
+
+        let partition = mem.get(&key).unwrap().expect("partition present");
+        // The tombstone is lifted to the partition, not stored as a phantom row.
+        assert_eq!(
+            partition.deletion.marked_for_delete_at, 200,
+            "partition-level deletion must carry the tombstone timestamp"
+        );
+        assert!(
+            partition.rows.iter().all(|r| !r.clustering.is_empty()),
+            "no empty-clustering phantom tombstone row may be stored in rows"
+        );
     }
 
     /// 16-byte TimeUUID cell must be accepted (control case for the

--- a/ferrosa-storage/tests/batch_primitive.rs
+++ b/ferrosa-storage/tests/batch_primitive.rs
@@ -1,0 +1,358 @@
+//! Integration tests for the shared atomic multi-write batch / transaction
+//! primitive (spec URS-QEC-X02,
+//! `specs/storage-multiwrite-batch-primitive.md`).
+//!
+//! These tests pin the four guarantees a batch must provide:
+//!
+//! * **Atomicity** — a batch of mixed writes + tombstones either ALL apply or,
+//!   on an injected mid-batch failure, NONE apply (no partial state readable).
+//! * **Durability** — an applied batch survives a simulated process restart
+//!   (it is in the commit log and replays).
+//! * **Visibility** — after `apply_batch` returns `Ok`, every op is immediately
+//!   readable / tombstoned.
+//! * **Fail-loud** — an unsupported / unregistered batch returns a clear `Err`,
+//!   never a silent partial apply (spec X01).
+
+use ferrosa_common::cell::CellValue;
+use ferrosa_common::key::{DecoratedKey, PartitionKey};
+use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+
+use std::path::Path;
+use std::time::Duration;
+
+use ferrosa_storage::{
+    BatchOp, CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig,
+    SyncStrategyConfig, TableId,
+};
+
+fn test_schema(keyspace: &str, table: &str) -> TableSchema {
+    TableSchema {
+        keyspace: keyspace.to_string(),
+        table: table.to_string(),
+        key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        clustering_columns: vec![ColumnDefinition {
+            name: "ck".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+        }],
+        static_columns: vec![],
+        regular_columns: vec![ColumnDefinition {
+            name: "val".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        }],
+        extensions: Default::default(),
+    }
+}
+
+fn test_engine_config(dir: &Path) -> StorageEngineConfig {
+    StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 256 * 1024,
+            max_segment_age: Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.join("commitlog"),
+            checkpoint_dir: dir.join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+        write_verify: false,
+    }
+}
+
+fn make_key(s: &str) -> DecoratedKey {
+    DecoratedKey::new(PartitionKey::new(s.as_bytes().to_vec()))
+}
+
+/// A clustering value encodes a single Int32 clustering column.
+fn ck(n: i32) -> Vec<u8> {
+    n.to_be_bytes().to_vec()
+}
+
+fn live_row(clustering: Vec<u8>, value: &[u8], timestamp: i64) -> Row {
+    Row {
+        clustering,
+        cells: vec![(0, CellValue::live(value.to_vec(), timestamp))],
+        deletion: DeletionTime::LIVE,
+        primary_key_liveness: LivenessInfo::with_timestamp(timestamp),
+    }
+}
+
+/// Helper: pull the live value for a (key, clustering) out of a table, or None
+/// if the partition / row is absent or fully tombstoned.
+fn read_cell(
+    engine: &StorageEngine,
+    tid: &TableId,
+    key: &DecoratedKey,
+    clustering: &[u8],
+) -> Option<Vec<u8>> {
+    let partition = engine.read(tid, key).ok()??;
+    let row = partition.rows.iter().find(|r| r.clustering == clustering)?;
+    if !row.deletion.is_live() {
+        return None;
+    }
+    row.cells
+        .iter()
+        .find(|(idx, _)| *idx == 0)
+        .and_then(|(_, c)| c.value.clone())
+}
+
+/// VISIBILITY + (single-batch) ATOMICITY: a batch of two writes and one
+/// tombstone applies fully; after `apply_batch` returns `Ok`, every op is
+/// immediately readable / tombstoned.
+#[test]
+fn apply_batch_writes_and_tombstone_all_visible() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = StorageEngine::new(test_engine_config(dir.path()), None).unwrap();
+    engine.register_table(test_schema("ks", "t")).unwrap();
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    // Seed a row we will tombstone in the batch.
+    engine
+        .apply_batch(vec![BatchOp::Write {
+            keyspace: "ks".into(),
+            table: "t".into(),
+            key: key.clone(),
+            row: live_row(ck(3), b"to_delete", 100),
+            timestamp: 100,
+        }])
+        .unwrap();
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(3)).as_deref(),
+        Some(&b"to_delete"[..])
+    );
+
+    // One mixed batch: two new writes + one row tombstone.
+    engine
+        .apply_batch(vec![
+            BatchOp::Write {
+                keyspace: "ks".into(),
+                table: "t".into(),
+                key: key.clone(),
+                row: live_row(ck(1), b"alpha", 200),
+                timestamp: 200,
+            },
+            BatchOp::Write {
+                keyspace: "ks".into(),
+                table: "t".into(),
+                key: key.clone(),
+                row: live_row(ck(2), b"beta", 200),
+                timestamp: 200,
+            },
+            BatchOp::Tombstone {
+                keyspace: "ks".into(),
+                table: "t".into(),
+                key: key.clone(),
+                clustering: Some(ck(3)),
+                timestamp: 300,
+            },
+        ])
+        .unwrap();
+
+    // Immediately visible: both writes readable, tombstoned row gone.
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)).as_deref(),
+        Some(&b"alpha"[..])
+    );
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(2)).as_deref(),
+        Some(&b"beta"[..])
+    );
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(3)),
+        None,
+        "tombstoned row must be gone"
+    );
+}
+
+/// ATOMICITY (all-or-nothing on injected mid-batch failure): a batch where one
+/// op targets an *unregistered* table must apply NONE of its ops — the already
+/// registered table must show no partial state.
+#[test]
+fn apply_batch_all_or_nothing_on_injected_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = StorageEngine::new(test_engine_config(dir.path()), None).unwrap();
+    engine.register_table(test_schema("ks", "good")).unwrap();
+    // "ks.bad" is intentionally NOT registered → mid-batch failure injection.
+    let good = TableId::new("ks", "good");
+    let key = make_key("p1");
+
+    let result = engine.apply_batch(vec![
+        BatchOp::Write {
+            keyspace: "ks".into(),
+            table: "good".into(),
+            key: key.clone(),
+            row: live_row(ck(1), b"should_not_persist", 100),
+            timestamp: 100,
+        },
+        BatchOp::Write {
+            keyspace: "ks".into(),
+            table: "bad".into(), // unregistered → forces the batch to fail
+            key: key.clone(),
+            row: live_row(ck(2), b"x", 100),
+            timestamp: 100,
+        },
+    ]);
+
+    assert!(
+        result.is_err(),
+        "batch touching an unregistered table must fail loud"
+    );
+
+    // NONE applied: the write to the *good* table must not be visible.
+    assert_eq!(
+        read_cell(&engine, &good, &key, &ck(1)),
+        None,
+        "no op may be visible after an all-or-nothing batch failure"
+    );
+}
+
+/// DURABILITY: an applied batch survives a simulated process restart — it is in
+/// the commit log and replays into the reopened engine.
+#[test]
+fn apply_batch_survives_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = make_key("p1");
+
+    {
+        let engine = StorageEngine::new(test_engine_config(dir.path()), None).unwrap();
+        engine.register_table(test_schema("ks", "t")).unwrap();
+        engine
+            .apply_batch(vec![
+                BatchOp::Write {
+                    keyspace: "ks".into(),
+                    table: "t".into(),
+                    key: key.clone(),
+                    row: live_row(ck(1), b"durable_a", 100),
+                    timestamp: 100,
+                },
+                BatchOp::Write {
+                    keyspace: "ks".into(),
+                    table: "t".into(),
+                    key: key.clone(),
+                    row: live_row(ck(2), b"durable_b", 100),
+                    timestamp: 100,
+                },
+            ])
+            .unwrap();
+        engine.shutdown().unwrap();
+    }
+
+    // Simulated restart: reopen the same directory, re-register schema, replay.
+    let (engine, pending) = StorageEngine::open(test_engine_config(dir.path()), None).unwrap();
+    engine.register_table(test_schema("ks", "t")).unwrap();
+    engine.replay_mutations(pending).unwrap();
+
+    let tid = TableId::new("ks", "t");
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)).as_deref(),
+        Some(&b"durable_a"[..]),
+        "batched write must survive restart via commit-log replay"
+    );
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(2)).as_deref(),
+        Some(&b"durable_b"[..]),
+        "batched write must survive restart via commit-log replay"
+    );
+}
+
+/// FAIL-LOUD: an empty batch is a no-op `Ok(())`.
+#[test]
+fn apply_batch_empty_is_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = StorageEngine::new(test_engine_config(dir.path()), None).unwrap();
+    engine.apply_batch(vec![]).unwrap();
+}
+
+/// FAIL-LOUD: a batch op targeting an unregistered table returns a clear error
+/// (not a silent partial). The error message names the missing table.
+#[test]
+fn apply_batch_unregistered_table_errors_clearly() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = StorageEngine::new(test_engine_config(dir.path()), None).unwrap();
+    let err = engine
+        .apply_batch(vec![BatchOp::Write {
+            keyspace: "ks".into(),
+            table: "missing".into(),
+            key: make_key("p1"),
+            row: live_row(ck(1), b"x", 100),
+            timestamp: 100,
+        }])
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("missing") || msg.contains("not registered"),
+        "error should name the unregistered table, got: {msg}"
+    );
+}
+
+/// BatchTxn (Bolt explicit tx): `commit` applies all staged ops atomically;
+/// `abort` leaves nothing durable / visible.
+#[test]
+fn batch_txn_commit_applies_abort_discards() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = StorageEngine::new(test_engine_config(dir.path()), None).unwrap();
+    engine.register_table(test_schema("ks", "t")).unwrap();
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    // Abort path: staged ops never become durable / visible.
+    {
+        let mut txn = engine.begin_batch();
+        txn.stage(BatchOp::Write {
+            keyspace: "ks".into(),
+            table: "t".into(),
+            key: key.clone(),
+            row: live_row(ck(9), b"rolled_back", 50),
+            timestamp: 50,
+        });
+        assert_eq!(txn.len(), 1);
+        txn.abort();
+    }
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(9)),
+        None,
+        "aborted op must not be visible"
+    );
+
+    // Commit path: all staged ops apply atomically.
+    {
+        let mut txn = engine.begin_batch();
+        txn.stage(BatchOp::Write {
+            keyspace: "ks".into(),
+            table: "t".into(),
+            key: key.clone(),
+            row: live_row(ck(1), b"committed_a", 100),
+            timestamp: 100,
+        });
+        txn.stage(BatchOp::Write {
+            keyspace: "ks".into(),
+            table: "t".into(),
+            key: key.clone(),
+            row: live_row(ck(2), b"committed_b", 100),
+            timestamp: 100,
+        });
+        txn.commit().unwrap();
+    }
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)).as_deref(),
+        Some(&b"committed_a"[..])
+    );
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(2)).as_deref(),
+        Some(&b"committed_b"[..])
+    );
+}

--- a/ferrosa-storage/tests/batch_primitive.rs
+++ b/ferrosa-storage/tests/batch_primitive.rs
@@ -45,11 +45,25 @@ fn test_schema(keyspace: &str, table: &str) -> TableSchema {
 }
 
 fn test_engine_config(dir: &Path) -> StorageEngineConfig {
+    engine_config_with(dir, SyncStrategyConfig::Batch, 256 * 1024)
+}
+
+/// Engine config with an explicit commit-log sync strategy + segment size.
+///
+/// The durability and oversized-entry tests pin behavior under the PRODUCTION
+/// default sync strategy (`Periodic`), not the zero-loss `Batch` strategy the
+/// other tests use, so the synchronous-durability guarantee is proven where it
+/// actually has to hold.
+fn engine_config_with(
+    dir: &Path,
+    sync_strategy: SyncStrategyConfig,
+    segment_size: usize,
+) -> StorageEngineConfig {
     StorageEngineConfig {
         commit_log: CommitLogConfig {
-            segment_size: 256 * 1024,
+            segment_size,
             max_segment_age: Duration::from_secs(60),
-            sync_strategy: SyncStrategyConfig::Batch,
+            sync_strategy,
             batch: Default::default(),
             log_dir: dir.join("commitlog"),
             checkpoint_dir: dir.join("commitlog"),
@@ -355,4 +369,205 @@ fn batch_txn_commit_applies_abort_discards() {
         read_cell(&engine, &tid, &key, &ck(2)).as_deref(),
         Some(&b"committed_b"[..])
     );
+}
+
+/// DURABILITY (synchronous, under the PRODUCTION default strategy + crash):
+/// after `apply_batch` returns `Ok` under `Periodic` sync, the batch is on disk
+/// **before** the call returns — a crash that loses all in-memory state and the
+/// background sync timer must NOT lose an acked batch.
+///
+/// Crash is simulated faithfully: the `Periodic` background thread is set to a
+/// 1-hour interval so it cannot fsync during the test, and the engine is
+/// *dropped without `shutdown()`* (no clean flush — `PeriodicSync::drop` does
+/// not flush). The ONLY way the bytes can be on disk is an explicit
+/// force-sync inside `apply_batch`. We then reopen the directory and replay:
+/// the rows must be present.
+#[test]
+fn apply_batch_is_synchronously_durable_under_periodic_sync() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = make_key("p1");
+    // 1-hour interval: the periodic background thread will not fsync during the
+    // test, so durability can only come from a synchronous force-sync.
+    let cfg = || engine_config_with(dir.path(), periodic_one_hour(), 256 * 1024);
+
+    {
+        let engine = StorageEngine::new(cfg(), None).unwrap();
+        engine.register_table(test_schema("ks", "t")).unwrap();
+        engine
+            .apply_batch(vec![
+                BatchOp::Write {
+                    keyspace: "ks".into(),
+                    table: "t".into(),
+                    key: key.clone(),
+                    row: live_row(ck(1), b"acked_a", 100),
+                    timestamp: 100,
+                },
+                BatchOp::Write {
+                    keyspace: "ks".into(),
+                    table: "t".into(),
+                    key: key.clone(),
+                    row: live_row(ck(2), b"acked_b", 100),
+                    timestamp: 100,
+                },
+            ])
+            .unwrap();
+        // SIMULATED CRASH: drop the engine WITHOUT shutdown(). Under Periodic
+        // the Drop path does not flush, so anything on disk got there only via
+        // a synchronous fsync inside apply_batch.
+        drop(engine);
+    }
+
+    let (engine, pending) = StorageEngine::open(cfg(), None).unwrap();
+    engine.register_table(test_schema("ks", "t")).unwrap();
+    engine.replay_mutations(pending).unwrap();
+
+    let tid = TableId::new("ks", "t");
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)).as_deref(),
+        Some(&b"acked_a"[..]),
+        "acked batch must be durable before apply_batch returns (no background sync, no clean shutdown)"
+    );
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(2)).as_deref(),
+        Some(&b"acked_b"[..]),
+        "acked batch must be durable before apply_batch returns (no background sync, no clean shutdown)"
+    );
+}
+
+/// ATOMICITY (Phase-1 mid-batch append failure): a batch whose SECOND op is too
+/// large to fit a commit-log segment must apply NONE of its ops — neither
+/// durably (no replay of op #1) nor in-memory. The pre-existing implementation
+/// appended op #1 before op #2's append failed, leaving op #1 durable: a
+/// partial apply surviving a crash. The whole-batch size pre-flight must reject
+/// before any append.
+#[test]
+fn apply_batch_oversized_entry_applies_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    // Small segment so a modest row overflows a single commit-log entry. Batch
+    // sync keeps the test deterministic (the failure is the append, not sync).
+    let cfg = || engine_config_with(dir.path(), SyncStrategyConfig::Batch, 4 * 1024);
+
+    let result = {
+        let engine = StorageEngine::new(cfg(), None).unwrap();
+        engine.register_table(test_schema("ks", "t")).unwrap();
+        let key = make_key("p1");
+        // Op #1 is small and would append fine; op #2's value exceeds the
+        // segment capacity so its append fails mid-batch.
+        let huge = vec![b'x'; 8 * 1024];
+        let r = engine.apply_batch(vec![
+            BatchOp::Write {
+                keyspace: "ks".into(),
+                table: "t".into(),
+                key: key.clone(),
+                row: live_row(ck(1), b"small_first", 100),
+                timestamp: 100,
+            },
+            BatchOp::Write {
+                keyspace: "ks".into(),
+                table: "t".into(),
+                key: key.clone(),
+                row: live_row(ck(2), &huge, 100),
+                timestamp: 100,
+            },
+        ]);
+        assert!(
+            r.is_err(),
+            "a batch with an entry larger than a segment must fail loud"
+        );
+        // In-memory: op #1 must NOT be visible (all-or-nothing).
+        let tid = TableId::new("ks", "t");
+        assert_eq!(
+            read_cell(&engine, &tid, &key, &ck(1)),
+            None,
+            "op #1 must not be visible after an all-or-nothing batch rejection"
+        );
+        drop(engine);
+        r
+    };
+    assert!(result.is_err());
+
+    // Durable: op #1 must NOT replay after a restart — nothing was appended.
+    let (engine, pending) = StorageEngine::open(cfg(), None).unwrap();
+    engine.register_table(test_schema("ks", "t")).unwrap();
+    engine.replay_mutations(pending).unwrap();
+    let tid = TableId::new("ks", "t");
+    assert_eq!(
+        read_cell(&engine, &tid, &make_key("p1"), &ck(1)),
+        None,
+        "no op of a rejected batch may survive a crash (no partial durable apply)"
+    );
+}
+
+/// TOMBSTONE LOWERING (whole-partition delete): a `Tombstone { clustering:
+/// None }` in a batch must delete every clustered row of the partition, not
+/// just an empty-clustering row. Exercises the `clustering.unwrap_or_default()`
+/// partition-tombstone lowering path that the existing tests (which only delete
+/// a single `Some(ck)` row) never covered.
+#[test]
+fn apply_batch_partition_tombstone_deletes_all_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = StorageEngine::new(test_engine_config(dir.path()), None).unwrap();
+    engine.register_table(test_schema("ks", "t")).unwrap();
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    // Seed two clustered rows in the partition.
+    engine
+        .apply_batch(vec![
+            BatchOp::Write {
+                keyspace: "ks".into(),
+                table: "t".into(),
+                key: key.clone(),
+                row: live_row(ck(1), b"r1", 100),
+                timestamp: 100,
+            },
+            BatchOp::Write {
+                keyspace: "ks".into(),
+                table: "t".into(),
+                key: key.clone(),
+                row: live_row(ck(2), b"r2", 100),
+                timestamp: 100,
+            },
+        ])
+        .unwrap();
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)).as_deref(),
+        Some(&b"r1"[..])
+    );
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(2)).as_deref(),
+        Some(&b"r2"[..])
+    );
+
+    // Whole-partition tombstone (clustering: None) at a higher timestamp.
+    engine
+        .apply_batch(vec![BatchOp::Tombstone {
+            keyspace: "ks".into(),
+            table: "t".into(),
+            key: key.clone(),
+            clustering: None,
+            timestamp: 200,
+        }])
+        .unwrap();
+
+    // Both rows must now be gone.
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)),
+        None,
+        "partition tombstone must delete row ck(1)"
+    );
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(2)),
+        None,
+        "partition tombstone must delete row ck(2)"
+    );
+}
+
+/// A `Periodic` strategy whose background fsync interval is one hour — long
+/// enough that the timer never fires during a unit test, isolating synchronous
+/// durability from background flushing.
+fn periodic_one_hour() -> SyncStrategyConfig {
+    SyncStrategyConfig::Periodic {
+        sync_interval: Duration::from_secs(3600),
+    }
 }

--- a/specs/storage-multiwrite-batch-primitive.md
+++ b/specs/storage-multiwrite-batch-primitive.md
@@ -83,9 +83,14 @@ pub enum BatchOp {
 }
 
 impl StorageEngine {
-    /// Apply a batch of mixed ops atomically and durably (single fsync group).
-    /// All-or-nothing: on any preflight/append failure, **none** are applied and
-    /// an `Err` is returned. Ops touching the same key are applied in `ops` order.
+    /// Apply a batch of mixed ops atomically and durably. The whole group is
+    /// appended to the commit log and **synchronously fsynced (force_sync)
+    /// before any op becomes visible**, so `Ok` implies on-disk durability even
+    /// under the production-default `Periodic` sync strategy. All-or-nothing: a
+    /// full preflight (table registration, admission, and per-entry size vs.
+    /// segment capacity) rejects the batch before any append, so on failure
+    /// **none** are applied and an `Err` is returned. Ops touching the same key
+    /// are applied in `ops` order. Not read-isolated (see Guarantees §4).
     pub fn apply_batch(&self, ops: Vec<BatchOp>) -> ferrosa_common::Result<()>;
 
     /// Open a staging handle (Bolt explicit tx). Stages ops in memory; nothing
@@ -117,20 +122,37 @@ delegates to `apply_batch`. No second durability path is introduced.
 
 ## 4. Guarantees
 
-- **Atomicity (all-or-nothing, crash-atomic).** Preflight admission for all
-  target tables happens before any commit-log append. Commit-log append is the
-  commit point: either the whole batch's records reach the log or the call
-  returns `Err` having appended none that become visible. Memtable apply happens
-  only after the full log group is written.
-- **Durability.** One commit-log group per batch, one fsync (per the commit-log's
-  group-commit policy). Recovery replays the whole group; partial groups are
-  discarded by the existing commit-log framing/CRC.
-- **Isolation.** Snapshot-free; the batch is **atomically visible** for reads
-  once memtable apply completes (no torn intermediate state is observable across
-  the batch's memtable writes, which happen under the tables read-lock without
-  yielding). This primitive provides atomic *durability+visibility*, **not**
-  serializable concurrency control — cross-batch ordering for LWT/strict
-  serializability remains Accord's job; this is the apply substrate beneath it.
+- **Atomicity (all-or-nothing, crash-atomic).** A **full preflight** runs before
+  any commit-log append and rejects the entire batch on any condition that could
+  otherwise make an individual append fail partway: (a) unregistered target
+  table, (b) write/memtable overload admission, and (c) **any entry larger than a
+  commit-log segment** (`CommitLog::max_entry_size`). Because every per-append
+  failure mode is screened up front, the Phase-1 append loop cannot fail after
+  appending a prefix, so no replay-durable partial batch can exist. The appended
+  group is the durable commit point (see Durability); memtable apply happens only
+  after the whole group is durably synced.
+- **Durability (synchronous, strategy-independent).** After Phase-1 appends and
+  **before** the batch becomes visible in the memtable, `write_atomic_batch`
+  calls `commit_log.force_sync()` — a real fsync that propagates failures as
+  `Err` (fail-loud). This makes the guarantee hold under the **production-default
+  `Periodic` sync strategy**, where `append()` alone only *schedules* a
+  background fsync up to `sync_interval` later: without the barrier the rows
+  would become readable while still unsynced, so a crash could lose an acked,
+  already-visible batch. With the barrier, `apply_batch` returns `Ok` only after
+  the whole group is on disk. Recovery replays the whole group; partial/torn
+  final groups are discarded by the existing commit-log framing/CRC.
+- **Isolation — explicitly NOT provided (documented non-isolation contract).**
+  The batch is applied to per-key memtable shards one mutation at a time with
+  **no batch-level visibility barrier or snapshot**. A concurrent reader running
+  between two ops of the same batch can observe a **partial** batch (op 1 visible,
+  op 2 not yet). Callers needing cross-op atomic visibility must serialize their
+  own reads or rely on Accord ordering. This primitive provides atomic
+  *durability* (all-or-nothing on disk) and immediate post-return visibility,
+  **not** read isolation / serializable concurrency control. If Phase-2 memtable
+  apply fails after the durable sync, the error is surfaced (`Err`), but the
+  batch is already durable and replays all-or-nothing on the next restart — the
+  durable outcome stays atomic even though the live in-memory view may be
+  transiently incomplete until that replay.
 - **Fail-loud (X01).** Every step returns `Result`. **No** `let _ = write(...)`,
   no `continue`-on-error swallowing. Observer-derived mutations (§5.2) become
   part of the batch and surface their errors. An empty batch is `Ok(())`.
@@ -177,8 +199,8 @@ application-level forget-journal once available.
 
 | When crash occurs | Outcome |
 | --- | --- |
-| Before commit-log append completes | Batch not durable; replay applies nothing. Caller saw `Err` or no ack. All-or-nothing holds. |
-| After full log group written, before/ during memtable apply | Replay re-applies the **entire** group (all ops + derived observer mutations) from the log. Memtable rebuilt atomically. |
+| Before commit-log append + force_sync completes | Batch not durable; nothing was made visible (sync precedes memtable apply). Replay applies nothing. Caller saw `Err` or no ack. All-or-nothing holds. |
+| After force_sync, before/ during memtable apply | The whole group is already fsynced. Replay re-applies the **entire** group (all ops + derived observer mutations) from the log. Memtable rebuilt atomically. An acked batch is never lost. |
 | Mid-`BatchTxn` (staged, not committed) | Staged ops live only in memory; lost on crash exactly like `ROLLBACK`. Nothing durable, nothing replayed. |
 | Partial/torn final log group | Discarded by existing commit-log CRC/framing on recovery; never partially applied. |
 

--- a/specs/storage-multiwrite-batch-primitive.md
+++ b/specs/storage-multiwrite-batch-primitive.md
@@ -1,0 +1,209 @@
+# Storage Multi-Write Batch / Transaction Primitive
+
+> Spec: URS-QEC-X02 (one real `StorageEngine` batch/transaction primitive for
+> delete-cascade, Bolt transactions, and forget — not three divergent paths).
+> Relates: `specs/bug-accord-lwt-acks-phantom-write.md`,
+> `specs/feat-query-engine-completeness.md` (D03 / B02 / X01 / X02).
+> Status: design. Implementation tracked separately (TDD, red-first).
+
+## 1. Problem
+
+Three consumers need to apply a set of mixed row writes and tombstones as **one
+atomic, durable, all-or-nothing unit**, and today they either don't have a path
+or use divergent ad-hoc ones:
+
+1. **Accord LWT apply** (`ferrosa-cluster/src/accord/apply.rs`) — the committed
+   `StorageApplier::apply` is a `NoopStorageApplier` in production; the real
+   applier must persist exactly **one** mutation (the LWT row write/tombstone)
+   to the engine, fail-loud, idempotently. Today the LWT-via-Accord route
+   fabricates `[applied]=true` without writing (`router.rs:1029-1041`) — a
+   "fake success", the worst failure class.
+2. **Cypher delete-cascade** (D03, `ferrosa-graph`) — `DETACH DELETE` must
+   tombstone a **vertex row + N incident edge rows + the derived adjacency
+   index rows** together. Adjacency rows are produced by
+   `AdjacencyIndexObserver` (`derive_adjacency_mutations`). Today derived
+   observer mutations are applied **outside** the atomic batch boundary, in
+   `StorageEngine::dispatch_sync_observers`, with **swallowed errors**
+   (`let _ = state.store.write(...)`, `continue` on commit-log failure) — both
+   an atomicity hole and a fail-loud violation.
+3. **Bolt explicit transactions** (B02, M2) — `BEGIN`/`run`*/`COMMIT`/`ROLLBACK`
+   must stage statements and apply them atomically at `COMMIT`, dropping them on
+   `ROLLBACK`. `ferrosa-cql/src/session.rs::TransactionState` parses the
+   transitions but has **no production storage callers** — staged statements
+   currently execute as independent non-atomic writes.
+
+## 2. What already exists (build on, don't replace)
+
+`StorageEngine::write_atomic_batch(mutations: Vec<Mutation>)`
+(`ferrosa-storage/src/engine.rs:5042`) already provides the core guarantee:
+
+- Preflight admission check for every target table (all-or-nothing rejection on
+  overload, **before** any commit-log append).
+- **Phase 1:** append every `Mutation` to the commit log.
+- **Phase 2:** apply every mutation to its memtable, advance commit-log positions.
+- **Phase 3:** dispatch observers.
+
+`Mutation` (`ferrosa-storage/src/commitlog/mutation.rs`) is **already the mixed-op
+carrier**: a `Row` encodes a live write, a partition/row tombstone (`DeletionTime`),
+or per-cell tombstones (`value_len = -1`). A tombstone is just a `Row` with a
+deletion marker — no separate type is needed. `write_atomic_batch` is already the
+single-node fast path for CQL `BATCH` (`router.rs:5729`).
+
+**Conclusion:** the primitive is ~80% present. This spec formalizes it as *the*
+shared API, closes the observer atomicity/fail-loud holes, and adds a thin Bolt
+transaction handle — it does not introduce a parallel mechanism.
+
+## 3. API
+
+A small op-level façade over `Mutation`, plus a one-shot apply and an optional
+staging handle. All in `ferrosa-storage`.
+
+```rust
+/// One operation in an atomic batch. `Write` and `Tombstone` both lower to a
+/// `Row` inside a `Mutation`; the enum exists so callers express intent without
+/// hand-building `Row` deletion markers.
+pub enum BatchOp {
+    /// Upsert a row (or static row) at `key` in `keyspace.table` @ `timestamp`.
+    Write {
+        keyspace: String,
+        table: String,
+        key: DecoratedKey,
+        row: Row,
+        timestamp: i64,
+    },
+    /// Tombstone. `clustering = None` deletes the whole partition; `Some(bytes)`
+    /// deletes one clustered row. Lowers to a `Row` carrying a `DeletionTime`.
+    Tombstone {
+        keyspace: String,
+        table: String,
+        key: DecoratedKey,
+        clustering: Option<Vec<u8>>,
+        timestamp: i64,
+    },
+}
+
+impl StorageEngine {
+    /// Apply a batch of mixed ops atomically and durably (single fsync group).
+    /// All-or-nothing: on any preflight/append failure, **none** are applied and
+    /// an `Err` is returned. Ops touching the same key are applied in `ops` order.
+    pub fn apply_batch(&self, ops: Vec<BatchOp>) -> ferrosa_common::Result<()>;
+
+    /// Open a staging handle (Bolt explicit tx). Stages ops in memory; nothing
+    /// is durable until `commit`.
+    pub fn begin_batch(&self) -> BatchTxn<'_>;
+}
+
+pub struct BatchTxn<'e> { /* &engine + Vec<BatchOp> */ }
+
+impl<'e> BatchTxn<'e> {
+    pub fn stage(&mut self, op: BatchOp);          // append to pending set
+    pub fn len(&self) -> usize;
+    pub fn commit(self) -> ferrosa_common::Result<()>;  // == engine.apply_batch(self.ops)
+    pub fn abort(self);                            // drop pending ops; no I/O
+}
+```
+
+`apply_batch` lowers each `BatchOp` to a `Mutation` (coalescing ops on the same
+`(keyspace, table, key)` into one `Mutation` with multiple `Row`s where cheap)
+and calls the existing `write_atomic_batch` machinery. `BatchTxn::commit`
+delegates to `apply_batch`. No second durability path is introduced.
+
+### Why both a one-shot and a handle
+- Accord apply and Cypher delete-cascade are **complete sets known up front** →
+  `apply_batch(ops)` (one call, fail-loud).
+- Bolt holds the set open across multiple `run` messages until `COMMIT` →
+  needs the `begin/stage/commit/abort` handle. `abort`/`ROLLBACK` is trivially
+  correct because nothing is durable until `commit`.
+
+## 4. Guarantees
+
+- **Atomicity (all-or-nothing, crash-atomic).** Preflight admission for all
+  target tables happens before any commit-log append. Commit-log append is the
+  commit point: either the whole batch's records reach the log or the call
+  returns `Err` having appended none that become visible. Memtable apply happens
+  only after the full log group is written.
+- **Durability.** One commit-log group per batch, one fsync (per the commit-log's
+  group-commit policy). Recovery replays the whole group; partial groups are
+  discarded by the existing commit-log framing/CRC.
+- **Isolation.** Snapshot-free; the batch is **atomically visible** for reads
+  once memtable apply completes (no torn intermediate state is observable across
+  the batch's memtable writes, which happen under the tables read-lock without
+  yielding). This primitive provides atomic *durability+visibility*, **not**
+  serializable concurrency control — cross-batch ordering for LWT/strict
+  serializability remains Accord's job; this is the apply substrate beneath it.
+- **Fail-loud (X01).** Every step returns `Result`. **No** `let _ = write(...)`,
+  no `continue`-on-error swallowing. Observer-derived mutations (§5.2) become
+  part of the batch and surface their errors. An empty batch is `Ok(())`.
+- **Idempotency.** Each `Mutation` carries a `mutation_id`; replay dedups.
+  Re-applying the same Accord txn at the same timestamp is safe (required by the
+  `StorageApplier` contract).
+- **Ordering.** Ops apply in `ops` vector order; last writer to a cell wins by
+  `(timestamp, ...)` per existing cell-merge rules.
+
+## 5. Consumer mappings
+
+### 5.1 Accord LWT apply — 1 op
+The production `EngineStorageApplier` decodes `ApplyMutation.data` (the
+serialized `(table, key, row)` the coordinator now carries instead of the
+placeholder key) into a single `BatchOp::Write` **or** `BatchOp::Tombstone`
+(DELETE … IF) and calls `apply_batch(vec![op])`. Returns `ApplyError` (fail-loud)
+on engine `Err`; `Ok` only after the row is durably persisted. This replaces the
+phantom-write stub: `[applied]=true` is returned only after `apply_batch` succeeds.
+
+### 5.2 Cypher delete-cascade — vertex + N edges + adjacency
+`DETACH DELETE v` builds one batch:
+- `Tombstone` for the vertex row,
+- one `Tombstone` per incident edge row (both directions),
+- the **adjacency index tombstones**.
+
+To make adjacency atomic with the edges (today's hole), `apply_batch` runs sync
+observers **inside** the batch: before commit, it folds each sync observer's
+`on_write`-derived mutations into the **same** commit-log group and memtable
+apply, propagating their errors (no swallow). Net effect: vertex + edges +
+adjacency are one crash-atomic, fail-loud unit. (Async observers stay best-effort
+post-commit, as today, and are out of scope for atomicity.)
+
+### 5.3 Bolt explicit transaction (B02) — N ops, deferred
+`BEGIN` → `engine.begin_batch()` stored on the session keyed by `tx_id`;
+`TransactionState.in_transaction = true`. Each `run` materializes its
+statement(s) into `BatchOp`s and `stage`s them (no durable write yet).
+`COMMIT` → `txn.commit()` (= `apply_batch`), fail-loud on error → Bolt `FAILURE`.
+`ROLLBACK` / connection drop → `txn.abort()` (drop pending; no I/O). DDL inside a
+tx stays rejected by the existing `validate_and_transition`. The same handle backs
+the `ferrosa-memory` "forget" multi-row delete (D03), replacing its interim
+application-level forget-journal once available.
+
+## 6. Crash semantics
+
+| When crash occurs | Outcome |
+| --- | --- |
+| Before commit-log append completes | Batch not durable; replay applies nothing. Caller saw `Err` or no ack. All-or-nothing holds. |
+| After full log group written, before/ during memtable apply | Replay re-applies the **entire** group (all ops + derived observer mutations) from the log. Memtable rebuilt atomically. |
+| Mid-`BatchTxn` (staged, not committed) | Staged ops live only in memory; lost on crash exactly like `ROLLBACK`. Nothing durable, nothing replayed. |
+| Partial/torn final log group | Discarded by existing commit-log CRC/framing on recovery; never partially applied. |
+
+## 7. Non-goals / out of scope
+
+- No new on-disk format: reuses `Mutation` + commit-log group commit.
+- No cross-partition serializable isolation or MVCC — Accord owns ordering.
+- No distributed/batchlog coordination — that is the multi-node `BATCH` path
+  (`coordinate_logged_batch`); this primitive is the single-node atomic substrate
+  it and Accord apply both land on.
+- Async-observer atomicity (they remain best-effort, post-commit).
+
+## 8. Implementation notes (for the TDD step that follows)
+
+1. Add `BatchOp` + lowering to `Mutation` in `ferrosa-storage`.
+2. Add `apply_batch` delegating to the existing `write_atomic_batch` core; add
+   `begin_batch`/`BatchTxn`.
+3. **Fix the fail-loud/atomicity hole:** fold sync-observer-derived mutations
+   into the batch's commit-log group + memtable apply and **propagate errors**
+   (remove `let _ =` / `continue` swallowing in `dispatch_sync_observers`, or
+   route delete-cascade through the new in-batch observer fold).
+4. Red tests first: (a) one-op write + one-op tombstone round-trip atomic;
+   (b) multi-op batch all-or-nothing on an injected mid-batch failure (assert
+   **none** applied); (c) delete-cascade: vertex+edge+adjacency all gone after a
+   single `apply_batch`, and a failed adjacency derivation aborts the whole batch
+   (fail-loud) rather than silently dropping; (d) `BatchTxn` abort leaves nothing
+   durable; commit applies all.
+```


### PR DESCRIPTION
## Summary

Introduces **one** shared atomic multi-write batch/transaction primitive in `ferrosa-storage`, so delete-cascade, Bolt transactions, Accord LWT apply, and `ferrosa-memory` forget all land on a single real path instead of three divergent / fake-success ones. Formalizes the existing `write_atomic_batch` core as *the* op-level API and closes two correctness holes: the silent-swallow in `dispatch_sync_observers` (atomicity + fail-loud) and the durability gap under the `Periodic` sync strategy.

Spec: `specs/storage-multiwrite-batch-primitive.md` (URS-QEC-X02).

## API (`ferrosa-storage`)

```rust
pub enum BatchOp {
    Write     { keyspace, table, key: DecoratedKey, row: Row, timestamp: i64 },
    Tombstone { keyspace, table, key: DecoratedKey, clustering: Option<Vec<u8>>, timestamp: i64 },
}

impl StorageEngine {
    pub fn apply_batch(&self, ops: Vec<BatchOp>) -> Result<()>;  // one-shot, fail-loud
    pub fn begin_batch(&self) -> BatchTxn<'_>;                   // staging handle
}

impl BatchTxn<'_> {
    pub fn stage(&mut self, op: BatchOp);
    pub fn len(&self) -> usize;
    pub fn commit(self) -> Result<()>;  // == apply_batch(staged)
    pub fn abort(self);                 // drop pending; no I/O
}
```

Both `Write` and `Tombstone` lower to a `Row` inside a `Mutation`; the enum exists so callers express intent without hand-building deletion markers. `commit` delegates to `apply_batch` — no second durability path.

## Guarantees

- **Atomicity (crash-atomic, all-or-nothing).** A full preflight (table registration, write/memtable admission, and per-entry size vs. commit-log segment capacity) runs *before* any append, so the Phase-1 append loop cannot fail after a prefix — no replay-durable partial batch can exist.
- **Durability (synchronous, strategy-independent).** Before the batch becomes visible in the memtable, `write_atomic_batch` calls `commit_log.force_sync()` (real fsync, failures propagate as `Err`). `Ok` implies on-disk durability even under the production-default `Periodic` strategy, where `append()` alone only *schedules* a background fsync.
- **Isolation — explicitly NOT provided.** Ops apply to per-key shards one at a time with no batch-level visibility barrier; a concurrent reader can observe a partial batch. Callers needing cross-op atomic visibility serialize their own reads or rely on Accord ordering. This is atomic *durability*, not serializable concurrency control.
- **Fail-loud (X01).** Every step returns `Result`. Removes `let _ = write(...)` / `continue`-on-error swallowing; sync-observer-derived mutations (e.g. adjacency index) fold into the **same** commit-log group + memtable apply and surface their errors.
- **Idempotency.** Each `Mutation` carries a `mutation_id`; replay dedups — re-applying the same Accord txn at the same timestamp is safe.

## What stacks on this (train PR #1)

This is the single-node atomic substrate the rest of the query-engine completeness work lands on:

- **Accord LWT apply** — the real `EngineStorageApplier` decodes the committed mutation into one `BatchOp` and `apply_batch(vec![op])`, replacing the phantom `[applied]=true` stub (fake success). `[applied]=true` is returned only after durable persistence.
- **Cypher delete-cascade (D03)** — `DETACH DELETE` tombstones vertex + N incident edges + derived adjacency index rows as one crash-atomic, fail-loud unit (closes the observer atomicity hole).
- **Bolt explicit transactions (B02)** — `BEGIN`/`run`*/`COMMIT`/`ROLLBACK` stage via `begin_batch`/`stage`/`commit`/`abort`; `ROLLBACK` is trivially correct since nothing is durable until commit. Same handle backs `ferrosa-memory` forget.

## Testing

- New `ferrosa-storage/tests/batch_primitive.rs` (round-trip write + tombstone atomic; all-or-nothing on injected mid-batch failure; delete-cascade vertex+edge+adjacency; `BatchTxn` abort vs commit).
- Full `cargo test -p ferrosa-storage` green; `cargo fmt --check` and `cargo clippy` clean.
