### PR TITLE
fix(accord): real LWT production data path — WIP (train PR #2, stacks on #117)

### DIFF
--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -134,6 +134,36 @@ impl StorageApplier for NoopStorageApplier {
 // EngineStorageApplier — real persistence via StorageEngine
 // ---------------------------------------------------------------------------
 
+/// Map an Accord-agreed [`Timestamp`] to the i64 cell timestamp used for
+/// last-write-wins conflict resolution.
+///
+/// The cell-timestamp domain is `i64` micros-since-epoch; the agreed `t.time`
+/// is the hybrid-logical-clock value that totally orders conflicting Accord
+/// transactions. We use `t.time` directly (saturating into `i64`) so that two
+/// LWTs whose Accord order is `t1 < t2` always persist cell timestamps in the
+/// same order — independent of any coordinator wall-clock skew.
+fn accord_cell_timestamp(t: Timestamp) -> i64 {
+    i64::try_from(t.time).unwrap_or(i64::MAX)
+}
+
+/// Re-stamp every conflict-resolution timestamp carried by `row` to `cell_ts`.
+///
+/// Touches only the last-write-wins timestamps (live + tombstone cell stamps,
+/// primary-key liveness, row deletion marker) — never `ttl` or
+/// `local_deletion_time`, which encode TTL/expiry semantics that are
+/// independent of write ordering and must survive unchanged.
+fn restamp_row(row: &mut ferrosa_sstable::types::Row, cell_ts: i64) {
+    for (_, cell) in &mut row.cells {
+        cell.timestamp = cell_ts;
+    }
+    if row.primary_key_liveness.has_timestamp() {
+        row.primary_key_liveness.timestamp = cell_ts;
+    }
+    if !row.deletion.is_live() {
+        row.deletion.marked_for_delete_at = cell_ts;
+    }
+}
+
 /// Production [`StorageApplier`] that durably persists a committed mutation to
 /// the local [`StorageEngine`].
 ///
@@ -147,11 +177,18 @@ impl StorageApplier for NoopStorageApplier {
 ///
 /// Accord delivers `Apply` at-least-once, and recovery may re-drive it. The
 /// applier records every `(txn_id, t)` it has applied and treats a repeat as a
-/// no-op. This is required for correctness: re-decoding and re-writing an old
-/// mutation would resurrect a stale value over a newer write to the same key
-/// (last-write-wins would normally protect us, but a re-applied mutation
-/// re-uses its *original* cell timestamp, so a naive re-write is a lost-update
-/// hazard). Tracking applied transactions makes re-apply a true no-op.
+/// no-op. This is required for correctness: cells are persisted at the agreed
+/// `t` (see [`accord_cell_timestamp`]), so a re-applied old mutation re-uses
+/// its *original* `t` and a naive re-write would resurrect a stale value over a
+/// newer write to the same key (a lost-update hazard, since LWW cannot tell the
+/// re-write apart from the first). Tracking applied transactions makes re-apply
+/// a true no-op.
+///
+/// # Last-write-wins vs the Accord total order
+///
+/// Cell timestamps are re-stamped to the agreed `t` at apply time, never the
+/// coordinator's materialize-time wall clock — so LWW resolves against Accord's
+/// agreed order even under coordinator clock skew.
 pub struct EngineStorageApplier {
     engine: Arc<StorageEngine>,
     /// `(txn_id, t.time)` pairs already persisted — for idempotent re-apply.
@@ -184,20 +221,33 @@ impl StorageApplier for EngineStorageApplier {
         }
 
         // Decode the self-describing commit-log mutation. Fail loud on garbage.
-        let decoded = Mutation::deserialize_from(&mutation.data).map_err(|e| ApplyError {
+        let mut decoded = Mutation::deserialize_from(&mutation.data).map_err(|e| ApplyError {
             txn_id,
             reason: format!("failed to decode apply mutation: {e}"),
         })?;
 
         let table_id = TableId::new(&decoded.keyspace, &decoded.table);
 
-        // Persist every row at the mutation's timestamp. `StorageEngine::write`
+        // Re-stamp every cell to the Accord-agreed execution timestamp `t`.
+        //
+        // The coordinator stamps cells at materialize time with its own wall
+        // clock, BEFORE consensus picks `t`. Honoring that wall clock for LWW
+        // would let coordinator clock skew invert the Accord total order
+        // (lost update / non-linearizable). The agreed `t` exists precisely to
+        // order conflicting writes, so it — not the wall clock — must drive the
+        // last-write-wins cell timestamp.
+        let cell_ts = accord_cell_timestamp(mutation.t);
+        for row in &mut decoded.rows {
+            restamp_row(row, cell_ts);
+        }
+
+        // Persist every row at the agreed timestamp. `StorageEngine::write`
         // appends to the commit log (durable) before the memtable, and returns
         // an error if the table is unregistered or admission is denied — we
         // propagate that as `ApplyError` (never fake success).
         for row in decoded.rows {
             self.engine
-                .write(&table_id, &decoded.key, row, decoded.timestamp)
+                .write(&table_id, &decoded.key, row, cell_ts)
                 .map_err(|e| ApplyError {
                     txn_id,
                     reason: format!("storage write failed for {table_id}: {e}"),
@@ -610,6 +660,13 @@ mod engine_applier_tests {
         row.cells.first().and_then(|(_, c)| c.value.clone())
     }
 
+    /// Read the LWW cell timestamp persisted for column 0 of the first row.
+    fn read_cell0_ts(engine: &StorageEngine, key: &DecoratedKey) -> Option<i64> {
+        let partition = engine.read(&TableId::new(KS, TABLE), key).unwrap()?;
+        let row = partition.rows.first()?;
+        row.cells.first().map(|(_, c)| c.timestamp)
+    }
+
     // -----------------------------------------------------------------------
     // RED: applying persists a row that is then readable via the engine.
     // -----------------------------------------------------------------------
@@ -726,5 +783,82 @@ mod engine_applier_tests {
             .apply(txn(1, 1000), mutation)
             .expect_err("malformed mutation bytes must fail loud");
         assert!(!err.reason.is_empty(), "decode error must carry a reason");
+    }
+
+    // -----------------------------------------------------------------------
+    // LWW honors the Accord-agreed order, NOT the coordinator wall clock.
+    //
+    // The coordinator stamps the Mutation's cells at materialize time with its
+    // own `SystemTime::now()` micros, BEFORE consensus picks the execution
+    // timestamp `t`. Under coordinator clock skew the wall-clock cell stamps can
+    // invert the Accord order. The applier MUST persist cells at a timestamp
+    // derived from the agreed `t` so last-write-wins resolves against Accord's
+    // total order — otherwise a lost update / non-linearizable result occurs.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn apply_restamps_cells_to_accord_timestamp_not_wall_clock() {
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine.clone());
+
+        let key = make_key("pk1");
+
+        // Txn A: Accord order t=100 (earlier), but coordinator wall clock is
+        // SKEWED HIGH so its cell stamp is 9_000 (later than B's wall clock).
+        let a = encoded_mutation(key.clone(), b"A", 9_000, accord_ts(100), vec![]);
+        applier.apply(txn(1, 100), a).unwrap();
+
+        // Txn B: Accord order t=200 (later), coordinator wall clock SKEWED LOW
+        // so its cell stamp is 1_000 (earlier than A's wall clock).
+        let b = encoded_mutation(key.clone(), b"B", 1_000, accord_ts(200), vec![]);
+        applier.apply(txn(2, 200), b).unwrap();
+
+        // If the applier wrote at the wall-clock cell stamp (9_000 vs 1_000),
+        // A would win LWW and we'd read "A" — the lost-update bug. With the
+        // agreed `t` (100 < 200) driving the cell timestamp, B wins.
+        assert_eq!(
+            read_cell0(&engine, &key).as_deref(),
+            Some(b"B".as_slice()),
+            "later Accord-agreed txn must win LWW regardless of coordinator clock skew"
+        );
+        // And the persisted cell timestamp must derive from B's agreed t (200),
+        // not its wall-clock stamp (1_000).
+        assert_eq!(
+            read_cell0_ts(&engine, &key),
+            Some(200),
+            "persisted cell timestamp must be the Accord-agreed t, not wall clock"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end serialize round-trip: a Mutation carrying realistic cells
+    // (whose own stamp differs from `t`) survives serialize -> deserialize and
+    // is persisted readable, with the cell timestamp re-stamped to `t`. Guards
+    // the router serialize_into -> applier deserialize_from contract.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn apply_round_trips_serialized_mutation_and_restamps() {
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine.clone());
+
+        let key = make_key("pk-roundtrip");
+        // Cell stamped with a wall-clock micros value far from the agreed t.
+        let wall = 1_700_000_000_000_000_i64;
+        let agreed = accord_ts(42);
+        let mutation = encoded_mutation(key.clone(), b"payload", wall, agreed, vec![]);
+
+        applier
+            .apply(txn(7, 42), mutation)
+            .expect("serialized mutation must round-trip and persist");
+
+        assert_eq!(
+            read_cell0(&engine, &key).as_deref(),
+            Some(b"payload".as_slice()),
+            "round-tripped mutation value must be readable"
+        );
+        assert_eq!(
+            read_cell0_ts(&engine, &key),
+            Some(42),
+            "cell timestamp must be re-stamped to the agreed t, not the wall clock"
+        );
     }
 }

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -168,7 +168,7 @@ fn restamp_row(row: &mut ferrosa_sstable::types::Row, cell_ts: i64) {
 /// the local [`StorageEngine`].
 ///
 /// `ApplyMutation.data` is decoded as a self-describing commit-log
-/// [`Mutation`], which carries the `(keyspace, table)` → [`TableId`], the
+/// [`Mutation`], which carries the `(keyspace, table)` → `TableId`, the
 /// [`DecoratedKey`](ferrosa_common::DecoratedKey), the row data, and the
 /// write timestamp. Each row is written via [`StorageEngine::write`], which
 /// appends to the commit log and the memtable (persist-before-return).
@@ -178,7 +178,7 @@ fn restamp_row(row: &mut ferrosa_sstable::types::Row, cell_ts: i64) {
 /// Accord delivers `Apply` at-least-once, and recovery may re-drive it. The
 /// applier records every `(txn_id, t)` it has applied and treats a repeat as a
 /// no-op. This is required for correctness: cells are persisted at the agreed
-/// `t` (see [`accord_cell_timestamp`]), so a re-applied old mutation re-uses
+/// `t` (see `accord_cell_timestamp`), so a re-applied old mutation re-uses
 /// its *original* `t` and a naive re-write would resurrect a stale value over a
 /// newer write to the same key (a lost-update hazard, since LWW cannot tell the
 /// re-write apart from the first). Tracking applied transactions makes re-apply

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -26,7 +26,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use ferrosa_common::accord::{Timestamp, TxnId};
-use ferrosa_storage::{Mutation, StorageEngine, TableId};
+use ferrosa_storage::{BatchOp, Mutation, StorageEngine};
 use parking_lot::Mutex;
 
 use crate::accord::dep_wait::DepWaitGraph;
@@ -226,8 +226,6 @@ impl StorageApplier for EngineStorageApplier {
             reason: format!("failed to decode apply mutation: {e}"),
         })?;
 
-        let table_id = TableId::new(&decoded.keyspace, &decoded.table);
-
         // Re-stamp every cell to the Accord-agreed execution timestamp `t`.
         //
         // The coordinator stamps cells at materialize time with its own wall
@@ -241,18 +239,30 @@ impl StorageApplier for EngineStorageApplier {
             restamp_row(row, cell_ts);
         }
 
-        // Persist every row at the agreed timestamp. `StorageEngine::write`
-        // appends to the commit log (durable) before the memtable, and returns
-        // an error if the table is unregistered or admission is denied — we
-        // propagate that as `ApplyError` (never fake success).
-        for row in decoded.rows {
-            self.engine
-                .write(&table_id, &decoded.key, row, cell_ts)
-                .map_err(|e| ApplyError {
-                    txn_id,
-                    reason: format!("storage write failed for {table_id}: {e}"),
-                })?;
-        }
+        // Persist all rows atomically via the batch primitive. `apply_batch`
+        // preflights every target table BEFORE appending any commit-log record,
+        // so either all rows land durably or none do — no partial apply.
+        // Returns an error if any table is unregistered or the append fails;
+        // propagated as `ApplyError` (never fake success).
+        let ops: Vec<BatchOp> = decoded
+            .rows
+            .into_iter()
+            .map(|row| BatchOp::Write {
+                keyspace: decoded.keyspace.clone(),
+                table: decoded.table.clone(),
+                key: decoded.key.clone(),
+                row,
+                timestamp: cell_ts,
+            })
+            .collect();
+
+        self.engine.apply_batch(ops).map_err(|e| ApplyError {
+            txn_id,
+            reason: format!(
+                "storage apply_batch failed for {}.{}: {e}",
+                decoded.keyspace, decoded.table
+            ),
+        })?;
 
         // Record only after all rows are durable, so a mid-apply failure leaves
         // the txn re-appliable rather than falsely marked applied.

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -22,9 +22,11 @@
 //! `DepWaitApplier` uses a `parking_lot::Mutex` for the dep-wait graph so it
 //! can be shared across the coordinator thread and the replica handler thread.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use ferrosa_common::accord::{Timestamp, TxnId};
+use ferrosa_storage::{Mutation, StorageEngine, TableId};
 use parking_lot::Mutex;
 
 use crate::accord::dep_wait::DepWaitGraph;
@@ -124,6 +126,87 @@ impl Default for NoopStorageApplier {
 impl StorageApplier for NoopStorageApplier {
     fn apply(&self, txn_id: TxnId, mutation: ApplyMutation) -> Result<(), ApplyError> {
         self.applied.lock().push((txn_id, mutation.t));
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EngineStorageApplier — real persistence via StorageEngine
+// ---------------------------------------------------------------------------
+
+/// Production [`StorageApplier`] that durably persists a committed mutation to
+/// the local [`StorageEngine`].
+///
+/// `ApplyMutation.data` is decoded as a self-describing commit-log
+/// [`Mutation`], which carries the `(keyspace, table)` → [`TableId`], the
+/// [`DecoratedKey`](ferrosa_common::DecoratedKey), the row data, and the
+/// write timestamp. Each row is written via [`StorageEngine::write`], which
+/// appends to the commit log and the memtable (persist-before-return).
+///
+/// # Idempotency
+///
+/// Accord delivers `Apply` at-least-once, and recovery may re-drive it. The
+/// applier records every `(txn_id, t)` it has applied and treats a repeat as a
+/// no-op. This is required for correctness: re-decoding and re-writing an old
+/// mutation would resurrect a stale value over a newer write to the same key
+/// (last-write-wins would normally protect us, but a re-applied mutation
+/// re-uses its *original* cell timestamp, so a naive re-write is a lost-update
+/// hazard). Tracking applied transactions makes re-apply a true no-op.
+pub struct EngineStorageApplier {
+    engine: Arc<StorageEngine>,
+    /// `(txn_id, t.time)` pairs already persisted — for idempotent re-apply.
+    applied: Mutex<HashSet<(TxnId, u64)>>,
+}
+
+impl EngineStorageApplier {
+    /// Create an applier backed by the live storage engine.
+    pub fn new(engine: Arc<StorageEngine>) -> Self {
+        Self {
+            engine,
+            applied: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// Number of distinct `(txn_id, t)` pairs persisted (for assertions/metrics).
+    pub fn applied_count(&self) -> usize {
+        self.applied.lock().len()
+    }
+}
+
+impl StorageApplier for EngineStorageApplier {
+    fn apply(&self, txn_id: TxnId, mutation: ApplyMutation) -> Result<(), ApplyError> {
+        let key = (txn_id, mutation.t.time);
+
+        // Idempotency gate: an already-applied (txn_id, t) is a no-op. Checked
+        // before decode so a duplicate Apply never re-writes a stale value.
+        if self.applied.lock().contains(&key) {
+            return Ok(());
+        }
+
+        // Decode the self-describing commit-log mutation. Fail loud on garbage.
+        let decoded = Mutation::deserialize_from(&mutation.data).map_err(|e| ApplyError {
+            txn_id,
+            reason: format!("failed to decode apply mutation: {e}"),
+        })?;
+
+        let table_id = TableId::new(&decoded.keyspace, &decoded.table);
+
+        // Persist every row at the mutation's timestamp. `StorageEngine::write`
+        // appends to the commit log (durable) before the memtable, and returns
+        // an error if the table is unregistered or admission is denied — we
+        // propagate that as `ApplyError` (never fake success).
+        for row in decoded.rows {
+            self.engine
+                .write(&table_id, &decoded.key, row, decoded.timestamp)
+                .map_err(|e| ApplyError {
+                    txn_id,
+                    reason: format!("storage write failed for {table_id}: {e}"),
+                })?;
+        }
+
+        // Record only after all rows are durable, so a mid-apply failure leaves
+        // the txn re-appliable rather than falsely marked applied.
+        self.applied.lock().insert(key);
         Ok(())
     }
 }
@@ -427,5 +510,221 @@ mod tests {
             log_a_pos < log_b_pos,
             "txn_a must be applied before txn_b in the log"
         );
+    }
+}
+
+// ===========================================================================
+// EngineStorageApplier tests — real persistence via StorageEngine
+// ===========================================================================
+//
+// Increment 3 of the Accord LWT data-path plan: a `StorageApplier` that
+// decodes `ApplyMutation.data` as a self-describing commit-log `Mutation`
+// (TableId via keyspace/table, DecoratedKey, Row, ts) and persists it through
+// `StorageEngine::write`. These tests use a REAL engine (not a Noop) and
+// assert the row is durably readable afterwards — closing the phantom-write
+// gap at the storage seam.
+
+#[cfg(test)]
+mod engine_applier_tests {
+    use super::*;
+    use ferrosa_common::accord::{Timestamp, TxnId};
+    use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+    use ferrosa_common::{CellValue, DecoratedKey, PartitionKey};
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+    use ferrosa_storage::{Mutation, StorageEngine, StorageEngineConfig, TableId};
+
+    const KS: &str = "lwt_ks";
+    const TABLE: &str = "lwt_table";
+
+    fn accord_ts(micros: u64) -> Timestamp {
+        Timestamp::synthetic(micros)
+    }
+
+    fn txn(node: u64, micros: u64) -> TxnId {
+        TxnId::new(node, accord_ts(micros))
+    }
+
+    fn test_schema() -> TableSchema {
+        TableSchema {
+            keyspace: KS.to_string(),
+            table: TABLE.to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![ColumnDefinition {
+                name: "ck".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+            }],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "val".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: Default::default(),
+        }
+    }
+
+    fn make_engine() -> (Arc<StorageEngine>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        (Arc::new(engine), dir)
+    }
+
+    fn make_key(s: &str) -> DecoratedKey {
+        DecoratedKey::new(PartitionKey::new(s.as_bytes().to_vec()))
+    }
+
+    fn make_row(value: &[u8], cell_ts: i64) -> Row {
+        Row {
+            clustering: vec![0x00, 0x00, 0x00, 0x01],
+            cells: vec![(0, CellValue::live(value.to_vec(), cell_ts))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(cell_ts),
+        }
+    }
+
+    /// Encode an `ApplyMutation` whose `data` is a serialized commit-log
+    /// `Mutation` — the wire format the production applier must decode.
+    fn encoded_mutation(
+        key: DecoratedKey,
+        value: &[u8],
+        cell_ts: i64,
+        t: Timestamp,
+        deps: Vec<TxnId>,
+    ) -> ApplyMutation {
+        let m = Mutation::new(
+            KS.to_string(),
+            TABLE.to_string(),
+            key,
+            vec![make_row(value, cell_ts)],
+            cell_ts,
+        );
+        let mut buf = vec![0u8; m.serialized_size()];
+        m.serialize_into(&mut buf);
+        ApplyMutation { data: buf, t, deps }
+    }
+
+    fn read_cell0(engine: &StorageEngine, key: &DecoratedKey) -> Option<Vec<u8>> {
+        let partition = engine.read(&TableId::new(KS, TABLE), key).unwrap()?;
+        let row = partition.rows.first()?;
+        row.cells.first().and_then(|(_, c)| c.value.clone())
+    }
+
+    // -----------------------------------------------------------------------
+    // RED: applying persists a row that is then readable via the engine.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn apply_persists_row_readable_via_engine() {
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine.clone());
+
+        let key = make_key("pk1");
+        let t = accord_ts(1000);
+        let mutation = encoded_mutation(key.clone(), b"hello", 1000, t, vec![]);
+
+        applier
+            .apply(txn(1, 1000), mutation)
+            .expect("apply must persist the mutation to the engine");
+
+        assert_eq!(
+            read_cell0(&engine, &key).as_deref(),
+            Some(b"hello".as_slice()),
+            "the row written by apply must be readable via the engine — \
+             not a phantom write"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Idempotent on (txn_id, t): re-applying the same txn is a safe no-op and
+    // must NOT clobber a newer value written under a different txn/timestamp.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn apply_is_idempotent_on_txn_and_timestamp() {
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine.clone());
+
+        let key = make_key("pk1");
+        let id = txn(1, 1000);
+        let t = accord_ts(1000);
+
+        // First apply writes "v1".
+        applier
+            .apply(id, encoded_mutation(key.clone(), b"v1", 1000, t, vec![]))
+            .unwrap();
+
+        // A later txn writes "v2" with a higher cell timestamp.
+        applier
+            .apply(
+                txn(2, 2000),
+                encoded_mutation(key.clone(), b"v2", 2000, accord_ts(2000), vec![]),
+            )
+            .unwrap();
+        assert_eq!(read_cell0(&engine, &key).as_deref(), Some(b"v2".as_slice()));
+
+        // Re-applying the FIRST txn (same txn_id + t) must be a no-op: it must
+        // not resurrect "v1" over the newer "v2".
+        applier
+            .apply(id, encoded_mutation(key.clone(), b"v1", 1000, t, vec![]))
+            .unwrap();
+        assert_eq!(
+            read_cell0(&engine, &key).as_deref(),
+            Some(b"v2".as_slice()),
+            "re-applying an already-applied (txn_id, t) must not re-write"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fail loud: a write to an unregistered table must return ApplyError,
+    // never a silent success.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn apply_to_unregistered_table_fails_loud() {
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine.clone());
+
+        // Build a mutation targeting a table that was never registered.
+        let m = Mutation::new(
+            KS.to_string(),
+            "no_such_table".to_string(),
+            make_key("pk1"),
+            vec![make_row(b"x", 1000)],
+            1000,
+        );
+        let mut buf = vec![0u8; m.serialized_size()];
+        m.serialize_into(&mut buf);
+        let mutation = ApplyMutation {
+            data: buf,
+            t: accord_ts(1000),
+            deps: vec![],
+        };
+
+        let err = applier
+            .apply(txn(1, 1000), mutation)
+            .expect_err("apply to an unregistered table must fail loud, not fake success");
+        assert!(
+            err.reason.contains("no_such_table") || err.reason.contains("not registered"),
+            "error must name the failure: {}",
+            err.reason
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Decode failure: malformed mutation bytes must return ApplyError.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn apply_with_malformed_data_fails_loud() {
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine);
+
+        let mutation = ApplyMutation {
+            data: vec![0xFF, 0x00, 0x01], // truncated / not a valid Mutation
+            t: accord_ts(1000),
+            deps: vec![],
+        };
+
+        let err = applier
+            .apply(txn(1, 1000), mutation)
+            .expect_err("malformed mutation bytes must fail loud");
+        assert!(!err.reason.is_empty(), "decode error must carry a reason");
     }
 }

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -417,6 +417,15 @@ pub struct AccordCoordinatorDriver {
     /// coordinator itself as an implicit ack for Commit and Apply (the
     /// coordinator drove the protocol and counts as one replica).
     self_id: uuid::Uuid,
+    /// Encoded mutation to apply on commit: a self-describing commit-log
+    /// `Mutation` (keyspace/table, `DecoratedKey`, rows, timestamp).
+    ///
+    /// This is what each replica decodes and writes to storage in the Apply
+    /// phase — it is carried as the Apply payload's `result_data`. It is
+    /// distinct from `coordinator.key` (the raw partition-key bytes used only
+    /// for Accord conflict ordering). An empty vector means "no mutation"
+    /// (read-only / protocol-only transactions).
+    mutation: Vec<u8>,
 }
 
 impl AccordCoordinatorDriver {
@@ -429,7 +438,9 @@ impl AccordCoordinatorDriver {
     /// - `peers`: the peer connection manager for RPC fanout.
     /// - `is_leaseholder`: whether this node is the token-range leaseholder.
     /// - `clock`: HLC for generating the coordinator timestamp `t0`.
-    /// - `key`: raw partition key bytes.
+    /// - `key`: raw partition key bytes (used for Accord conflict ordering).
+    /// - `mutation`: encoded commit-log `Mutation` to apply on commit, carried
+    ///   as the Apply payload's `result_data`. Empty for read-only txns.
     pub fn new(
         node_id: u64,
         replica_ids: Vec<uuid::Uuid>,
@@ -437,6 +448,7 @@ impl AccordCoordinatorDriver {
         is_leaseholder: bool,
         clock: &HybridLogicalClock,
         key: Vec<u8>,
+        mutation: Vec<u8>,
     ) -> Self {
         let rf = replica_ids.len();
         assert!(rf > 0, "replica_ids must be non-empty");
@@ -464,7 +476,24 @@ impl AccordCoordinatorDriver {
             peers,
             replica_ids,
             self_id,
+            mutation,
         }
+    }
+
+    /// Build the Apply-phase payload bytes for this transaction.
+    ///
+    /// The payload carries the encoded **mutation** as `result_data` — NOT the
+    /// Accord partition key. Each replica decodes `result_data` as a commit-log
+    /// `Mutation` and writes it to local storage; passing the key here would be
+    /// a phantom write (storage applier would fail to decode, or worse, persist
+    /// nothing). See `state_machine::handle_apply` for the consuming side.
+    fn apply_payload_bytes(&self) -> Result<Vec<u8>, AccordDriverError> {
+        use crate::accord::wire::ApplyPayload;
+        let apply_payload = ApplyPayload {
+            txn_id: self.coordinator.txn_id,
+            result_data: self.mutation.clone(),
+        };
+        bincode::serialize(&apply_payload).map_err(|e| AccordDriverError::Codec(e.to_string()))
     }
 
     /// Run the full Accord protocol for this transaction.
@@ -794,15 +823,7 @@ impl AccordCoordinatorDriver {
         // to reach F+1 total before returning the LWT result.
         // ------------------------------------------------------------------
 
-        let apply_bytes = {
-            use crate::accord::wire::ApplyPayload;
-            let apply_payload = ApplyPayload {
-                txn_id,
-                result_data: key.clone(),
-            };
-            bincode::serialize(&apply_payload)
-                .map_err(|e| AccordDriverError::Codec(e.to_string()))?
-        };
+        let apply_bytes = self.apply_payload_bytes()?;
         let apply_msg = Message::AccordApply(Bytes::from(apply_bytes));
 
         // Coordinator itself counts as 1 implicit apply ack.
@@ -1605,6 +1626,75 @@ mod tests {
         assert!(
             has_accord_span,
             "expected at least one 'accord.*' span, got: {recorded:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Apply payload carries the real MUTATION, not the partition key.
+    //
+    // Increment 3 of the LWT data path: the coordinator's Apply phase must hand
+    // each replica the encoded commit-log `Mutation` (`result_data`), which the
+    // storage applier decodes and writes. Carrying the raw partition key here is
+    // the phantom-write bug — the applier cannot decode a bare key as a
+    // `Mutation`, so nothing durable is written even though `[applied]=true` is
+    // returned. This test pins `result_data == mutation` (and `!= key`).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn apply_payload_carries_mutation_not_key() {
+        use crate::accord::wire::ApplyPayload;
+        use ferrosa_common::accord::HybridLogicalClock;
+        use ferrosa_net::config::NetConfig;
+        use ferrosa_net::peer::{PeerEventListener, PeerManager};
+        use std::sync::Arc;
+
+        struct NoopListener;
+        impl PeerEventListener for NoopListener {
+            fn on_peer_connected(&self, _: ferrosa_net::rpc::handler::PeerId) {}
+            fn on_peer_disconnected(&self, _: ferrosa_net::rpc::handler::PeerId) {}
+            fn on_peer_suspected(&self, _: ferrosa_net::rpc::handler::PeerId) {}
+            fn on_peer_recovered(&self, _: uuid::Uuid) {}
+            fn on_peer_failed(&self, _: uuid::Uuid) {}
+        }
+
+        let self_uuid = uuid::Uuid::new_v4();
+        let node_id =
+            u64::from_be_bytes(self_uuid.as_bytes()[..8].try_into().expect("uuid 16 bytes"));
+        let peers = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            self_uuid,
+            Arc::new(NoopListener),
+        ));
+        let clock = HybridLogicalClock::new(node_id, 0);
+
+        // A partition key distinct from the encoded mutation bytes.
+        let key = b"pk-bytes".to_vec();
+        let mutation = b"ENCODED-MUTATION-BYTES".to_vec();
+
+        let driver = AccordCoordinatorDriver::new(
+            node_id,
+            vec![self_uuid],
+            peers,
+            true,
+            &clock,
+            key.clone(),
+            mutation.clone(),
+        );
+
+        let bytes = driver
+            .apply_payload_bytes()
+            .expect("apply payload must serialize");
+        let decoded: ApplyPayload =
+            bincode::deserialize(&bytes).expect("apply payload must round-trip");
+
+        assert_eq!(
+            decoded.result_data, mutation,
+            "Apply result_data MUST be the encoded mutation (not the partition key) — \
+             a replica decodes result_data as a commit-log Mutation and writes it"
+        );
+        assert_ne!(
+            decoded.result_data, key,
+            "Apply result_data must NOT be the raw partition key — that is the \
+             phantom-write bug this increment closes"
         );
     }
 }

--- a/ferrosa-cluster/src/accord/mod.rs
+++ b/ferrosa-cluster/src/accord/mod.rs
@@ -35,7 +35,10 @@ pub mod two_phase_ddl;
 pub mod uda_integration;
 pub(crate) mod wire;
 
-pub use apply::{ApplyError, ApplyMutation, DepWaitApplier, NoopStorageApplier, StorageApplier};
+pub use apply::{
+    ApplyError, ApplyMutation, DepWaitApplier, EngineStorageApplier, NoopStorageApplier,
+    StorageApplier,
+};
 pub use clock::{ClockError, ClockValidator};
 pub use clock_validation::{
     validate_timestamp_drift, ClockDriftRejection, DEFAULT_MAX_CLOCK_DRIFT_NS,

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -554,11 +554,42 @@ impl TxnPhaseExt for TxnPhase {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::accord::apply::{ApplyError, ApplyMutation, StorageApplier};
     use ferrosa_storage::accord::sync_writer::{MockSyncWriter, SyncWriteCall};
+    use parking_lot::Mutex;
 
     // -----------------------------------------------------------------------
     // Test helpers
     // -----------------------------------------------------------------------
+
+    /// A `StorageApplier` that captures the full mutation payload (not just
+    /// `(txn_id, t)` like `NoopStorageApplier`) so a test can assert the exact
+    /// mutation bytes that reached the storage seam.
+    struct CapturingApplier {
+        captured: Mutex<Vec<(TxnId, Vec<u8>, Timestamp)>>,
+    }
+
+    impl CapturingApplier {
+        fn new() -> Self {
+            Self {
+                captured: Mutex::new(Vec::new()),
+            }
+        }
+
+        /// All `(txn_id, mutation_data, t)` triples captured, in apply order.
+        fn captured(&self) -> Vec<(TxnId, Vec<u8>, Timestamp)> {
+            self.captured.lock().clone()
+        }
+    }
+
+    impl StorageApplier for CapturingApplier {
+        fn apply(&self, txn_id: TxnId, mutation: ApplyMutation) -> Result<(), ApplyError> {
+            self.captured
+                .lock()
+                .push((txn_id, mutation.data, mutation.t));
+            Ok(())
+        }
+    }
 
     fn ts(micros: u64) -> Timestamp {
         Timestamp::synthetic(micros)
@@ -1189,6 +1220,53 @@ mod tests {
             state.phase,
             TxnPhase::Applied,
             "replay after crash must successfully apply"
+        );
+    }
+
+    /// RED (inc1 of accord-lwt-real-data-path): the apply seam must invoke a
+    /// `StorageApplier` with the mutation payload. Today `handle_apply` only
+    /// writes `"Applied:{t}"` to the protocol log and NEVER writes the row —
+    /// the phantom-write bug (`bug-accord-lwt-acks-phantom-write.md`). This
+    /// test drives a committed txn to `handle_apply` carrying mutation bytes
+    /// and a capturing applier, then asserts the applier received exactly those
+    /// bytes. It does not compile today: `AccordStateMachine` has no
+    /// `StorageApplier` field and no `with_applier` constructor. inc2 adds the
+    /// field + wiring to turn this GREEN; inc1+inc2 are committed together.
+    #[test]
+    fn sm_apply_invokes_storage_applier_with_mutation() {
+        let writer = Arc::new(MockSyncWriter::new());
+        let applier = Arc::new(CapturingApplier::new());
+        // inc2 adds `with_applier`; until then this line fails to compile,
+        // which is the intended RED state for this commit.
+        let mut sm = AccordStateMachine::with_applier(1, writer.clone(), applier.clone());
+
+        let txn_id = txn(1, 1000);
+        let t0 = ts(1000);
+        let t = ts(1001);
+        let mutation_bytes = b"real-row-mutation".to_vec();
+
+        // Drive a full lifecycle up to Apply.
+        sm.handle_preaccept(txn_id, t0, b"key1", BallotNumber(0), 0);
+        sm.handle_accept(txn_id, t0, t, vec![], BallotNumber(1));
+        sm.handle_commit(txn_id, t0, t, vec![]);
+        sm.handle_apply(txn_id, mutation_bytes.clone());
+
+        // The applier must have been invoked with the mutation payload.
+        let captured = applier.captured();
+        assert_eq!(
+            captured.len(),
+            1,
+            "handle_apply must invoke the StorageApplier exactly once"
+        );
+        let (got_txn, got_data, got_t) = &captured[0];
+        assert_eq!(*got_txn, txn_id, "applier must receive the txn id");
+        assert_eq!(
+            *got_data, mutation_bytes,
+            "applier must receive the mutation bytes (no phantom write)"
+        );
+        assert_eq!(
+            *got_t, t,
+            "applier must receive the agreed execution timestamp"
         );
     }
 

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -33,6 +33,8 @@ use ferrosa_common::accord::{
 use ferrosa_storage::accord::conflict_index::{ConflictIndex, InFlightWrite, TxnStatus};
 use ferrosa_storage::accord::sync_writer::SyncWriter;
 
+use crate::accord::apply::{ApplyMutation, NoopStorageApplier, StorageApplier};
+
 // ---------------------------------------------------------------------------
 // Response types
 // ---------------------------------------------------------------------------
@@ -85,10 +87,19 @@ pub struct AccordStateMachine {
     committed_txns: HashSet<TxnId>,
     /// Notified waiters from the last commit (for test inspection).
     last_notified: Vec<TxnId>,
+    /// Storage integration seam: persists the committed mutation to the local
+    /// `StorageEngine` during `handle_apply`. Defaults to [`NoopStorageApplier`]
+    /// for protocol-only tests; production wires a real engine-backed applier
+    /// via [`AccordStateMachine::with_applier`].
+    applier: Arc<dyn StorageApplier>,
 }
 
 impl AccordStateMachine {
     /// Create a new state machine for the given node.
+    ///
+    /// Uses a [`NoopStorageApplier`]: the apply seam records `(txn_id, t)` but
+    /// does NOT persist the row. Production must use [`Self::with_applier`] to
+    /// supply a real engine-backed applier.
     pub fn new(node_id: u64, sync_writer: Arc<dyn SyncWriter>) -> Self {
         Self {
             node_id,
@@ -98,10 +109,13 @@ impl AccordStateMachine {
             dep_waiters: HashMap::new(),
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
+            applier: Arc::new(NoopStorageApplier::new()),
         }
     }
 
     /// Create with a custom conflict index capacity.
+    ///
+    /// Uses a [`NoopStorageApplier`] (see [`Self::new`]).
     pub fn with_capacity(
         node_id: u64,
         sync_writer: Arc<dyn SyncWriter>,
@@ -115,6 +129,29 @@ impl AccordStateMachine {
             dep_waiters: HashMap::new(),
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
+            applier: Arc::new(NoopStorageApplier::new()),
+        }
+    }
+
+    /// Create with a real [`StorageApplier`] (production wiring).
+    ///
+    /// The applier persists each committed mutation to the local storage engine
+    /// during [`Self::handle_apply`], closing the phantom-write gap
+    /// (`bug-accord-lwt-acks-phantom-write.md`).
+    pub fn with_applier(
+        node_id: u64,
+        sync_writer: Arc<dyn SyncWriter>,
+        applier: Arc<dyn StorageApplier>,
+    ) -> Self {
+        Self {
+            node_id,
+            txn_states: HashMap::new(),
+            conflict_index: ConflictIndex::new(100_000),
+            sync_writer,
+            dep_waiters: HashMap::new(),
+            committed_txns: HashSet::new(),
+            last_notified: Vec::new(),
+            applier,
         }
     }
 
@@ -357,29 +394,56 @@ impl AccordStateMachine {
 
     /// Handle an Apply (fire-and-forget).
     ///
-    /// 1. Transition to Applied phase.
-    /// 2. Persist to main log BEFORE setting the applied flag.
+    /// 1. Idempotent no-op if already Applied.
+    /// 2. Persist the protocol-log marker BEFORE applying (recovery ordering).
+    /// 3. Persist the real mutation to local storage via the [`StorageApplier`]
+    ///    — closes the phantom-write gap (`bug-accord-lwt-acks-phantom-write.md`):
+    ///    the row must be durably written to the engine, not merely logged.
+    /// 4. Only after the mutation is durable do we set the Applied flag and mark
+    ///    the conflict index — so a crash before the storage write leaves the txn
+    ///    recoverable (re-Apply), never falsely Applied (persist-before-Applied).
     pub fn handle_apply(&mut self, txn_id: TxnId, result_data: Vec<u8>) -> SmResponse {
-        if let Some(state) = self.txn_states.get_mut(&txn_id) {
-            // Already applied: idempotent.
-            if state.phase == TxnPhase::Applied {
-                return SmResponse::None;
+        // Read the agreed timestamp + deps from committed state BEFORE mutating,
+        // so the mutation we hand to storage carries the real `(t, deps)`.
+        let (t, deps): (Timestamp, Vec<TxnId>) = match self.txn_states.get(&txn_id) {
+            Some(state) => {
+                // Already applied: idempotent — do not re-persist or re-apply.
+                if state.phase == TxnPhase::Applied {
+                    return SmResponse::None;
+                }
+                (state.t, state.deps.iter().copied().collect())
             }
+            // No state for this txn: nothing to apply.
+            None => return SmResponse::None,
+        };
 
-            // Persist to main log BEFORE setting applied flag.
-            let data = format!("Applied:{}", txn_id.0.time);
-            let sync_result = self.sync_writer.write_and_sync(data.as_bytes());
-            if !sync_result.is_ok() {
-                // Fsync failed: do NOT set applied flag.
-                return SmResponse::None;
-            }
-
-            // Now safe to set applied flag.
-            state.apply(result_data);
-
-            // Mark applied in conflict index for later GC.
-            self.conflict_index.mark_applied(&txn_id);
+        // Persist the protocol-log marker BEFORE applying the mutation.
+        let data = format!("Applied:{}", txn_id.0.time);
+        if !self.sync_writer.write_and_sync(data.as_bytes()).is_ok() {
+            // Fsync failed: do NOT apply or set the applied flag.
+            return SmResponse::None;
         }
+
+        // Persist the real mutation to local storage. The applier is idempotent
+        // on (txn_id, t) and must durably write before returning Ok. If it
+        // fails we MUST NOT advance to Applied — fail loud, never fake success:
+        // the coordinator gets no implicit ack and the Apply can be retried.
+        let mutation = ApplyMutation {
+            data: result_data.clone(),
+            t,
+            deps,
+        };
+        if let Err(e) = self.applier.apply(txn_id, mutation) {
+            tracing::error!(%e, "accord: storage applier failed — not advancing to Applied");
+            return SmResponse::None;
+        }
+
+        // Durable in storage — now safe to mark Applied and GC the conflict index.
+        if let Some(state) = self.txn_states.get_mut(&txn_id) {
+            state.apply(result_data);
+        }
+        self.conflict_index.mark_applied(&txn_id);
+
         SmResponse::None
     }
 

--- a/ferrosa-cluster/tests/accord_lwt_concurrent.rs
+++ b/ferrosa-cluster/tests/accord_lwt_concurrent.rs
@@ -163,6 +163,7 @@ async fn two_coordinators_concurrent_insert_if_not_exists() {
         false, // not leaseholder
         &clock_a,
         key.clone(),
+        Vec::new(), // protocol-only test: no mutation payload
     );
     let mut driver_b = AccordCoordinatorDriver::new(
         node_b.node_id,
@@ -171,6 +172,7 @@ async fn two_coordinators_concurrent_insert_if_not_exists() {
         false, // not leaseholder
         &clock_b,
         key.clone(),
+        Vec::new(), // protocol-only test: no mutation payload
     );
 
     // Fire both transactions concurrently (real RPC over TCP).
@@ -308,6 +310,7 @@ async fn single_coordinator_round_trips_to_remote_replica() {
         false,
         &clock,
         b"round-trip-key".to_vec(),
+        Vec::new(), // protocol-only test: no mutation payload
     );
 
     let result = driver.run_transaction().await;
@@ -389,6 +392,7 @@ async fn gap4_gap5_read_vote_and_apply_round_trip() {
         false,
         &clock1,
         key.clone(),
+        Vec::new(), // protocol-only test: no mutation payload
     );
 
     let result1 = driver1.run_transaction().await;
@@ -445,6 +449,7 @@ async fn gap4_gap5_read_vote_and_apply_round_trip() {
         false,
         &clock2,
         key.clone(),
+        Vec::new(), // protocol-only test: no mutation payload
     );
 
     let result2 = driver2.run_transaction().await;

--- a/ferrosa-cluster/tests/accord_nemesis.rs
+++ b/ferrosa-cluster/tests/accord_nemesis.rs
@@ -244,6 +244,7 @@ async fn packet_reorder_linearizability() {
             false,
             &clock_a,
             key_round.clone(),
+            Vec::new(), // protocol-only test: no mutation payload
         );
         let mut driver_b = AccordCoordinatorDriver::new(
             node_b.node_id,
@@ -252,6 +253,7 @@ async fn packet_reorder_linearizability() {
             false,
             &clock_b,
             key_round.clone(),
+            Vec::new(), // protocol-only test: no mutation payload
         );
 
         // Inject delay nemesis: a pre-transaction sleep shifts one coordinator's
@@ -428,6 +430,7 @@ async fn run_batch_atomicity_round(nemesis_name: &str) {
             false,
             &clock_a,
             key_a,
+            Vec::new(), // protocol-only test: no mutation payload
         );
 
         // For partition-halves: skip node_b's driver entirely (it would panic on empty replicas).
@@ -444,6 +447,7 @@ async fn run_batch_atomicity_round(nemesis_name: &str) {
                 false,
                 &clock_b,
                 key_b,
+                Vec::new(), // protocol-only test: no mutation payload
             );
             BatchAtomicityResult::from_driver_result(driver_b.run_transaction().await)
         };
@@ -578,6 +582,7 @@ async fn disk_fail_no_phantom_commits() {
         true, // leaseholder — implicit local PreAccept vote
         &clock,
         key.clone(),
+        Vec::new(), // protocol-only test: no mutation payload
     );
 
     let failed_result = tokio::time::timeout(TXN_TIMEOUT, driver.run_transaction())
@@ -657,6 +662,7 @@ async fn disk_fail_no_phantom_commits() {
         true,
         &clock2,
         key.clone(),
+        Vec::new(), // protocol-only test: no mutation payload
     );
 
     let healed_result = tokio::time::timeout(TXN_TIMEOUT, driver2.run_transaction())

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -21449,4 +21449,107 @@ mod tests {
             "point read needs no continuation"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Cross-crate roundtrip: the router's `build_lwt_mutation` serialize_into
+    // output is EXACTLY what the real `EngineStorageApplier` deserialize_from
+    // can decode and persist — with real partition-key extraction and real
+    // cell values from the INSERT, and the persisted cell timestamp honoring
+    // the Accord-agreed `t` (not the coordinator's materialize-time wall clock).
+    //
+    // This guards two production-correctness contracts that no in-crate test
+    // can cover, because the producer (`build_lwt_mutation`, ferrosa-cql) and
+    // the consumer (`EngineStorageApplier`, ferrosa-cluster) live in different
+    // crates:
+    //   1. SERIALIZATION SKEW: if the router's `Mutation::serialize_into` and
+    //      the applier's `Mutation::deserialize_from` ever drift apart, the
+    //      decode fails (or yields a wrong key/row) and this test fails loud.
+    //   2. LINEARIZABILITY: the router stamps cells with `SystemTime::now()`
+    //      micros; under clock skew that wall-clock stamp can invert the
+    //      Accord order. The applier MUST re-stamp to `t`, so the persisted
+    //      cell timestamp equals the agreed `t`, not the wall clock.
+    // -----------------------------------------------------------------------
+    #[tokio::test]
+    async fn build_lwt_mutation_round_trips_through_engine_storage_applier() {
+        use ferrosa_cluster::accord::apply::{ApplyMutation, EngineStorageApplier, StorageApplier};
+        use ferrosa_common::accord::{Timestamp, TxnId};
+        use ferrosa_storage::TableId;
+
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let no_ks: Option<String> = None;
+        let ctx = test_ctx(&auth, &no_ks);
+
+        // Real keyspace + table.
+        let stmt = crate::parser::parse(
+            "CREATE KEYSPACE lwt_rt WITH REPLICATION = \
+             {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+        )
+        .unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+        let stmt =
+            crate::parser::parse("CREATE TABLE lwt_rt.accts (id text PRIMARY KEY, balance text)")
+                .unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        // Parse a real LWT INSERT. `build_lwt_mutation` ignores the IF clause
+        // (that is the read-phase predicate); it materializes the write.
+        let stmt = crate::parser::parse(
+            "INSERT INTO lwt_rt.accts (id, balance) VALUES ('acct-1', '100') IF NOT EXISTS",
+        )
+        .unwrap();
+
+        // PRODUCER: the router builds the (key, mutation) wire payload exactly
+        // as the Accord coordinator would ship it in the Apply phase.
+        let (key_bytes, mutation_bytes) =
+            build_lwt_mutation(&state, &ctx, &stmt).expect("router must build the LWT mutation");
+
+        // The conflict-ordering key must be the real partition-key bytes —
+        // proving real key extraction (not the old `b"lwt-placeholder-key"`).
+        assert_eq!(
+            key_bytes,
+            b"acct-1".to_vec(),
+            "Accord key must be the real partition-key bytes, not a placeholder"
+        );
+
+        // CONSUMER: a real applier over the SAME engine decodes those exact
+        // bytes and persists. The agreed `t` is deliberately a tiny value
+        // (777), far below the wall-clock micros the router stamped cells with,
+        // so a successful read at ts==777 proves the applier re-stamped to `t`.
+        let agreed = Timestamp::synthetic(777);
+        let applier = EngineStorageApplier::new(state.engine.clone());
+        applier
+            .apply(
+                TxnId::new(1, agreed),
+                ApplyMutation {
+                    data: mutation_bytes,
+                    t: agreed,
+                    deps: vec![],
+                },
+            )
+            .expect("applier must decode the router's bytes and persist (no skew)");
+
+        // The row the router serialized must now be readable via the engine,
+        // with the REAL cell value from the INSERT.
+        let key = ferrosa_common::DecoratedKey::new(ferrosa_common::PartitionKey::new(key_bytes));
+        let partition = state
+            .engine
+            .read(&TableId::new("lwt_rt", "accts"), &key)
+            .unwrap()
+            .expect("the round-tripped row must be persisted and readable");
+        let row = partition.rows.first().expect("one row");
+        let (_, balance_cell) = row
+            .cells
+            .iter()
+            .find(|(_, c)| c.value.as_deref() == Some(b"100".as_slice()))
+            .expect("the real INSERT cell value must survive the roundtrip");
+
+        // The persisted LWW cell timestamp must equal the Accord-agreed `t`
+        // (777), NOT the router's materialize-time wall clock. If the applier
+        // honored the wall clock, this would be ~1.7e15 micros and fail.
+        assert_eq!(
+            balance_cell.timestamp, 777,
+            "persisted cell timestamp must be the Accord-agreed t, not the coordinator wall clock"
+        );
+    }
 }

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -967,6 +967,73 @@ pub enum RouteResult {
 
 // ── Accord LWT dispatch ──────────────────────────────────────────────────
 
+/// Materialize an LWT statement into the real partition key and the encoded
+/// mutation that Accord must replicate and apply.
+///
+/// Returns `(decorated_key_bytes, mutation_bytes)` where:
+/// - `decorated_key_bytes` is the partition-key token+bytes used by Accord for
+///   conflict ordering (the transaction's "key").
+/// - `mutation_bytes` is a self-describing commit-log [`Mutation`]
+///   (keyspace/table, `DecoratedKey`, rows, timestamp) serialized with
+///   `serialize_into`, replacing the former `b"lwt-placeholder-key"` stub that
+///   carried nothing. The mutation is now threaded across the wire so the Apply
+///   phase has the real bytes to persist.
+///
+///   NOTE: a replica only *persists* these bytes once it is constructed with an
+///   [`EngineStorageApplier`](ferrosa_cluster::accord::apply). Production today
+///   still builds `AccordStateMachine` with the default `NoopStorageApplier`
+///   (see `controller/cluster.rs`), so on a live replica the decode-and-write
+///   step is a no-op pending the inc6 startup-wiring increment — no client path
+///   reaches `route_lwt_via_accord` yet, so this is not user-visible.
+///
+/// Reuses the same `materialize_insert`/`materialize_update`/`materialize_delete`
+/// path as logged batches, so an Accord-routed INSERT/UPDATE/DELETE produces
+/// byte-identical storage writes to the local path.
+///
+/// # Errors
+///
+/// Fails loud (`CqlError::Invalid`) for any statement that is not an
+/// INSERT/UPDATE/DELETE — never silently fabricates a mutation.
+fn build_lwt_mutation(
+    state: &SharedState,
+    ctx: &RequestContext<'_>,
+    stmt: &Statement,
+) -> Result<(Vec<u8>, Vec<u8>), CqlError> {
+    use ferrosa_storage::Mutation;
+
+    let now_micros = || -> Result<i64, CqlError> {
+        Ok(std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| CqlError::ServerError(format!("system clock error: {e}")))?
+            .as_micros() as i64)
+    };
+
+    let (table_id, key, row, ts) = match stmt {
+        Statement::Insert(s) => materialize_insert(state, ctx, s, now_micros()?)?,
+        Statement::Update(s) => materialize_update(state, ctx, s, now_micros()?)?,
+        Statement::Delete(s) => materialize_delete(state, ctx, s, now_micros()?)?,
+        _ => {
+            return Err(CqlError::Invalid(
+                "LWT via Accord supports only INSERT/UPDATE/DELETE statements".into(),
+            ));
+        }
+    };
+
+    let key_bytes = key.key.as_bytes().to_vec();
+
+    let mutation = Mutation::new(
+        table_id.keyspace.clone(),
+        table_id.table.clone(),
+        key,
+        vec![row],
+        ts,
+    );
+    let mut mutation_bytes = vec![0u8; mutation.serialized_size()];
+    mutation.serialize_into(&mut mutation_bytes);
+
+    Ok((key_bytes, mutation_bytes))
+}
+
 /// Route a LWT statement through the Accord consensus protocol.
 ///
 /// Constructs an `AccordCoordinatorDriver`, runs the full PreAccept → Commit
@@ -983,8 +1050,8 @@ pub enum RouteResult {
 /// - The Accord quorum cannot be reached (network failure / too few replicas).
 async fn route_lwt_via_accord(
     state: &SharedState,
-    _ctx: &RequestContext<'_>,
-    _stmt: &Statement,
+    ctx: &RequestContext<'_>,
+    stmt: &Statement,
     peers: Arc<ferrosa_net::peer::PeerManager>,
     clock: Arc<ferrosa_common::accord::HybridLogicalClock>,
 ) -> Result<RouteResult, CqlError> {
@@ -1010,10 +1077,12 @@ async fn route_lwt_via_accord(
     let host_bytes = host_id.as_bytes();
     let node_id = u64::from_be_bytes(host_bytes[..8].try_into().expect("uuid has 16 bytes"));
 
-    // Use a simple key derived from the statement type for now.
-    // Full partition key bytes will replace this once the CQL planner is
-    // integrated with the Accord execution path.
-    let key = b"lwt-placeholder-key".to_vec();
+    // Extract the REAL partition key + serialized mutation from the statement.
+    // `key` is the Accord conflict-ordering key (partition-key bytes); `mutation`
+    // is the encoded commit-log Mutation that each replica decodes and writes in
+    // the Apply phase. This replaces the former `b"lwt-placeholder-key"` stub
+    // that persisted nothing (the phantom-write bug).
+    let (key, mutation) = build_lwt_mutation(state, ctx, stmt)?;
 
     let mut driver = AccordCoordinatorDriver::new(
         node_id,
@@ -1022,6 +1091,7 @@ async fn route_lwt_via_accord(
         false, // not leaseholder (derive from TokenRing in future)
         &clock,
         key,
+        mutation,
     );
 
     match driver.run_transaction().await {

--- a/specs/todo/accord-lwt-real-data-path-plan.md
+++ b/specs/todo/accord-lwt-real-data-path-plan.md
@@ -1,0 +1,65 @@
+# Accord LWT — full production data path (TDD implementation plan)
+
+**Status:** in-process. Branch `fix/accord-lwt-real-data-path`.
+**Closes:** `specs/bug-accord-lwt-acks-phantom-write.md` (P0 fake-success / silent data loss).
+**Decision:** the FULL fix (real linearizable LWT through Accord), not the interim fail-loud/flag-off.
+
+## Where it stands (verified map)
+The Accord PROTOCOL layer is real and tested over TCP: PreAccept / Accept / Commit /
+ReadVote / Apply all fan out via `PeerManager`, F+1 quorums, persist-before-reply via
+`SyncWriter`, idempotent state-machine transitions, dep-wait orchestration
+(`DepWaitApplier`). The 7 protocol "Gaps" are closed.
+
+What is STUBBED is the **semantic layer + production wiring**:
+- `ferrosa-cql/src/router.rs:1016` — `key = b"lwt-placeholder-key"` (no real partition key).
+- `route_lwt_via_accord` discards `_stmt` — no mutation cells, no IF predicate carried.
+- `coordinator.rs:797` Apply payload `result_data = key.clone()` — no mutation.
+- `state_machine.rs:362 handle_apply` — persists `"Applied:{t}"` to the protocol log but
+  **never writes the row**; `AccordStateMachine` has a `sync_writer` but **no `StorageApplier`**.
+- `apply.rs` — `StorageApplier` trait + `NoopStorageApplier` (test-only) + `DepWaitApplier`
+  exist, but **no real applier writes to `StorageEngine`**, and none is constructed in prod.
+- `state_machine.rs:451 read_condition_holds_at` — hardcoded `INSERT IF NOT EXISTS` (conflict
+  index), not a generic `IF col=val` evaluated against the stored row; ReadVoteOk returns no row.
+- `ferrosa/src/main.rs` — `peer_manager: None` in `SharedState`; no applier wired → real clients
+  can't even reach the path.
+
+## TDD increments (red → green → verify → commit, in order)
+
+1. **RED: prove the phantom write.** State-machine/handler test: drive a txn to `handle_apply`
+   with mutation bytes + a capturing `StorageApplier`; assert the applier receives the mutation.
+   Fails today (no applier on the state machine). *(Anchors the bug at the apply seam.)*
+2. **Real persist seam.** Add `applier: Arc<dyn StorageApplier>` to `AccordStateMachine`
+   (constructors default to `NoopStorageApplier`; `with_applier` for prod). In `handle_apply`,
+   after the protocol-log sync, build `ApplyMutation { data: result_data, t, deps }` (t/deps from
+   `TxnState`) and call `applier.apply(...)` (idempotent, persist-before-Applied). GREEN on #1.
+3. **Real `StorageApplier` impl.** `EngineStorageApplier` decoding `data` as
+   `(TableId, DecoratedKey, Row, ts)` → `StorageEngine::write(...)`. Idempotent on (txn_id,t).
+   Test: applying persists a row readable via the engine.
+4. **Mutation flow router→Apply.** `route_lwt_via_accord` extracts the real `DecoratedKey` and
+   serializes the mutation from the `Insert/Update/Delete` AST; thread it through the
+   coordinator's Apply payload (`result_data` = encoded mutation, not key). Test: coordinator
+   Apply carries + applies the real mutation.
+5. **Generic IF read + evaluation.** Send the IF predicate(s) `(col, op, val)` in
+   `ReadVotePayload`; replica evaluates against the stored row (reuse the local LWT condition
+   logic), returns `condition_holds` + the current row bytes. Coordinator maps to
+   `[applied]=false` + `current_values`. Test: `IF col=val` true/false paths + current-row return.
+6. **Production wiring.** Thread `PeerManager` + an `EngineStorageApplier` into `SharedState` /
+   `AccordHandler` in `main.rs` (replace `peer_manager: None`). Construct the applier from the
+   live `StorageEngine`. Replica ids from the cluster ring.
+7. **End-to-end cluster test.** Real CQL `INSERT … IF NOT EXISTS` / `UPDATE … IF col=val` in
+   cluster mode: persists, returns correct `[applied]`/`current_values`, survives a node restart;
+   concurrent contenders → exactly one applies. Extend `accord_lwt_concurrent.rs`.
+8. **Multi-statement (optional follow-on).** `BEGIN/COMMIT TRANSACTION` currently no-op
+   (`router.rs:1343`, `session.rs TransactionState` unused) — wire atomic multi-statement or keep
+   rejecting honestly. Track separately.
+
+## Verification each increment
+`cargo fmt --check`, `cargo clippy --all-targets`, `cargo test -p ferrosa-cluster -p ferrosa-cql`;
+full-cluster integration for #7. No `#[ignore]`, no fake success — a stubbed sub-path must return
+`Unavailable`/`ServerError`, never `[applied]=true`.
+
+## Key files
+- `ferrosa-cluster/src/accord/{state_machine.rs, apply.rs, coordinator.rs, handlers.rs}`
+- `ferrosa-cql/src/router.rs` (`route_lwt_via_accord`, the local LWT condition logic to reuse)
+- `ferrosa/src/main.rs` (SharedState wiring), `ferrosa-net/src/accord_messages.rs` (payloads)
+- Tests: `ferrosa-cluster/tests/accord_lwt_concurrent.rs`


### PR DESCRIPTION
## Train PR #2 (stacks on #117 the batch primitive) — DRAFT/WIP

Closes `specs/bug-accord-lwt-acks-phantom-write.md` when complete.

### Done (green, ~60% of the data path)
- Real `StorageApplier` persist seam in `handle_apply` (was protocol-log only).
- `EngineStorageApplier` that decodes the mutation and persists to the engine.
- Real `DecoratedKey` + serialized mutation threaded router → coordinator Apply (replaces `b"lwt-placeholder-key"`).
- **Linearizability fix:** LWT cells now stamped with the **Accord-agreed HLC `t`**, not coordinator wall-clock (was a lost-update bug under clock skew) + a cross-crate serialize↔persist roundtrip test.

### Remaining (the hard correctness core — being hand-driven)
- **#31 production applier wiring** — `controller/cluster.rs:1129` still builds the state machine with `NoopStorageApplier`, so a real replica returns `ApplyOK` **without persisting** (the live phantom write). Must wire `EngineStorageApplier` (via the primitive's `apply_batch`) into the production state machine + `main.rs` SharedState.
- **#30 generic `IF` evaluation** across replicas (currently hardcoded INSERT IF NOT EXISTS).
- **e2e** cluster proof that the phantom write is gone (persist + correct `[applied]`, concurrent contenders, survives restart).

Built on the batch primitive (#117). Not for merge until the remaining items land + an e2e proof is green.