### PR TITLE
feat(graph/sparql): delete completeness — query-engine milestone 1 (train PR #3, stacks on #117)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,6 +2096,7 @@ dependencies = [
  "serde_urlencoded",
  "sparesults",
  "spargebra",
+ "tempfile",
  "tokio",
  "tower-http",
  "tracing",

--- a/ferrosa-graph/src/bolt/server.rs
+++ b/ferrosa-graph/src/bolt/server.rs
@@ -664,6 +664,7 @@ fn error_code(err: &GraphError) -> &'static str {
         GraphError::Validation(_) => "Neo.ClientError.Statement.SemanticError",
         GraphError::PermissionDenied(_) => "Neo.ClientError.Security.Forbidden",
         GraphError::ResourceLimit(_) => "Neo.TransientError.General.OutOfMemoryError",
+        GraphError::ConstraintViolation(_) => "Neo.ClientError.Schema.ConstraintValidationFailed",
         GraphError::Timeout => "Neo.TransientError.Transaction.LockClientStopped",
         GraphError::Storage(_) | GraphError::Schema(_) | GraphError::Internal(_) => {
             "Neo.DatabaseError.General.UnknownError"

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -224,6 +224,14 @@ fn statement_requires_adjacency(statement: &Statement) -> bool {
                     .iter()
                     .any(|assignment| expr_requires_adjacency(&assignment.value))
         }
+        Statement::Remove {
+            pattern,
+            where_clause,
+            ..
+        } => {
+            pattern.iter().any(pattern_requires_adjacency)
+                || where_clause.as_ref().is_some_and(expr_requires_adjacency)
+        }
         Statement::Delete {
             pattern,
             where_clause,
@@ -1126,6 +1134,19 @@ fn bind_statement_params(
                 .transpose()?,
             assignments: bind_assignments_params(assignments, params)?,
         },
+        Statement::Remove {
+            pattern,
+            where_clause,
+            items,
+        } => Statement::Remove {
+            pattern: bind_patterns_params(pattern, params)?,
+            where_clause: where_clause
+                .map(|expr| bind_expr_params(expr, params))
+                .transpose()?,
+            // REMOVE items carry only variable/property/label identifiers, no
+            // parameterizable expressions, so they pass through unchanged.
+            items,
+        },
         Statement::Delete {
             pattern,
             where_clause,
@@ -1253,6 +1274,19 @@ fn format_plan(plan: &PhysicalPlan) -> String {
             out.push_str("SetProperties {\n");
             out.push_str(&format!("  expand: {}\n", format_plan(expand)));
             out.push_str(&format!("  assignments: {}\n", assignments.len()));
+            out.push_str(&format!("  variable_tables: {:?}\n", variable_tables));
+            out.push('}');
+            out
+        }
+        PhysicalPlan::RemoveProperties {
+            expand,
+            items,
+            variable_tables,
+        } => {
+            let mut out = String::new();
+            out.push_str("RemoveProperties {\n");
+            out.push_str(&format!("  expand: {}\n", format_plan(expand)));
+            out.push_str(&format!("  items: {}\n", items.len()));
             out.push_str(&format!("  variable_tables: {:?}\n", variable_tables));
             out.push('}');
             out

--- a/ferrosa-graph/src/error.rs
+++ b/ferrosa-graph/src/error.rs
@@ -13,6 +13,9 @@ pub enum GraphError {
     PermissionDenied(String),
     /// Query exceeded resource limits.
     ResourceLimit(String),
+    /// A Neo4j-style schema/constraint violation, e.g. a plain `DELETE n`
+    /// on a node that still has surviving relationships (URS-QEC-D02).
+    ConstraintViolation(String),
     /// Query exceeded time limit.
     Timeout,
     /// Storage engine error.
@@ -30,6 +33,7 @@ impl fmt::Display for GraphError {
             Self::Validation(msg) => write!(f, "validation error: {msg}"),
             Self::PermissionDenied(msg) => write!(f, "permission denied: {msg}"),
             Self::ResourceLimit(msg) => write!(f, "resource limit: {msg}"),
+            Self::ConstraintViolation(msg) => write!(f, "constraint violation: {msg}"),
             Self::Timeout => write!(f, "query timeout"),
             Self::Storage(e) => write!(f, "storage error: {e}"),
             Self::Schema(e) => write!(f, "schema error: {e}"),

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -603,6 +603,7 @@ fn execute_return_only(return_clause: &ReturnClause, start: Instant) -> Result<G
             edges_read: 0,
             vertices_written: 0,
             vertices_deleted: 0,
+            edges_deleted: 0,
             execution_ms: start.elapsed().as_millis() as u64,
         },
     })
@@ -663,6 +664,7 @@ fn execute_unwind(
             edges_read: 0,
             vertices_written: 0,
             vertices_deleted: 0,
+            edges_deleted: 0,
             execution_ms: start.elapsed().as_millis() as u64,
         },
     })
@@ -3722,12 +3724,200 @@ async fn execute_set(
 /// Execute a DELETE plan: run the expand to find matching vertices, then write
 /// tombstones for each one.
 #[allow(clippy::too_many_arguments)]
+/// Build the standard composite adjacency clustering key
+/// `[u16 1][1B direction][u16 label_len][label][u16 nid_len][neighbor_id]`,
+/// matching `make_adjacency_mutation`'s wire format. Defined once so the
+/// DETACH-DELETE cascade tombstones the exact key the observer wrote.
+fn adjacency_clustering_bytes(direction: u8, edge_label: &str, neighbor_id: &[u8]) -> Vec<u8> {
+    let mut clustering = Vec::new();
+    clustering.extend_from_slice(&1u16.to_be_bytes());
+    clustering.push(direction);
+    clustering.extend_from_slice(&(edge_label.len() as u16).to_be_bytes());
+    clustering.extend_from_slice(edge_label.as_bytes());
+    clustering.extend_from_slice(&(neighbor_id.len() as u16).to_be_bytes());
+    clustering.extend_from_slice(neighbor_id);
+    clustering
+}
+
+/// Read the edge-label string out of an adjacency clustering key
+/// (component 1 of the standard composite layout).
+fn adjacency_edge_label(clustering: &[u8]) -> Option<String> {
+    if clustering.len() < 5 {
+        return None;
+    }
+    let dir_len = u16::from_be_bytes([clustering[0], clustering[1]]) as usize;
+    let label_len_pos = 2 + dir_len;
+    if label_len_pos + 2 > clustering.len() {
+        return None;
+    }
+    let label_len =
+        u16::from_be_bytes([clustering[label_len_pos], clustering[label_len_pos + 1]]) as usize;
+    let label_start = label_len_pos + 2;
+    if label_start + label_len > clustering.len() {
+        return None;
+    }
+    std::str::from_utf8(&clustering[label_start..label_start + label_len])
+        .ok()
+        .map(str::to_string)
+}
+
+/// Build a pure-tombstone [`Mutation`] for one row in `keyspace.table`.
+/// `clustering = None` deletes the whole partition; `Some` deletes one row.
+/// Mirrors `StorageEngine`'s `BatchOp::Tombstone` lowering so the
+/// DETACH-DELETE cascade and the engine batch path agree on representation.
+fn tombstone_mutation(
+    keyspace: &str,
+    table: &str,
+    key: &DecoratedKey,
+    clustering: Option<Vec<u8>>,
+    timestamp: i64,
+) -> Mutation {
+    let local_deletion_time = timestamp.div_euclid(1_000_000).clamp(0, u32::MAX as i64) as u32;
+    let row = Row {
+        clustering: clustering.unwrap_or_default(),
+        cells: vec![],
+        deletion: DeletionTime::new(timestamp, local_deletion_time),
+        primary_key_liveness: LivenessInfo::NONE,
+    };
+    Mutation::new(
+        keyspace.to_string(),
+        table.to_string(),
+        key.clone(),
+        vec![row],
+        timestamp,
+    )
+}
+
+/// DETACH DELETE cascade for one vertex (URS-QEC-D01/D03/D07).
+///
+/// Enumerates ALL incident edges via the adjacency index (forward OUT +
+/// backward IN), then collects tombstones for each edge row, its OWN
+/// adjacency entry, the neighbor's mirror adjacency entry, and finally the
+/// vertex row, into ONE batch applied atomically through the shared
+/// `StorageEngine` multi-write primitive (`WritePath::write_batch` →
+/// `write_atomic_batch`/`coordinate_logged_batch`). No new batch path is
+/// invented; adjacency cleanup happens inside the delete, so a subsequent
+/// scan finds zero references without reconciliation (URS-QEC-D03).
+///
+/// Returns the number of incident edges tombstoned.
+async fn delete_with_adjacency(
+    write_path: &WritePath,
+    keyspace: &str,
+    vertex_key: &DecoratedKey,
+    vertex_table: &TableId,
+    timestamp: i64,
+    strategy: &ReplicationStrategy,
+) -> Result<usize> {
+    let vid = vertex_key.key.as_bytes().to_vec();
+    let adj_ks = adjacency_keyspace_name(keyspace);
+    let adj_table = TableId::new(&adj_ks, "adjacency");
+
+    let mut mutations: Vec<Mutation> = Vec::new();
+    let mut edges_deleted = 0usize;
+
+    // Enumerate incident edges from the vertex's adjacency partition.
+    if let Some(partition) = write_path.read(&adj_table, vertex_key).await? {
+        for row in &partition.rows {
+            if !row.deletion.is_live() {
+                continue;
+            }
+            // Standard composite: direction byte sits at offset 2.
+            if row.clustering.len() < 3 {
+                continue;
+            }
+            let direction = row.clustering[2];
+            let Some(neighbor_id) = extract_neighbor_id(&row.clustering, None) else {
+                continue;
+            };
+            let Some(edge_label) = adjacency_edge_label(&row.clustering) else {
+                continue;
+            };
+            // The edge table FQN is stored in the row's first cell value.
+            let Some(edge_fqn) = row
+                .cells
+                .first()
+                .and_then(|(_, cell)| cell.value.as_ref())
+                .and_then(|bytes| std::str::from_utf8(bytes).ok())
+            else {
+                continue;
+            };
+            let Some((edge_ks, edge_tbl)) = edge_fqn.split_once('.') else {
+                continue;
+            };
+
+            // Reconstruct the edge's storage key: partition = source vertex,
+            // clustering = target vertex.
+            let (src_id, dst_id) = if direction == DIRECTION_OUT {
+                (vid.clone(), neighbor_id.clone())
+            } else {
+                (neighbor_id.clone(), vid.clone())
+            };
+            let edge_src_key = DecoratedKey::new(PartitionKey::new(src_id));
+
+            // (a) Tombstone the edge row itself.
+            mutations.push(tombstone_mutation(
+                edge_ks,
+                edge_tbl,
+                &edge_src_key,
+                Some(dst_id),
+                timestamp,
+            ));
+
+            // (b) Tombstone this vertex's adjacency entry (exact clustering).
+            mutations.push(tombstone_mutation(
+                &adj_ks,
+                "adjacency",
+                vertex_key,
+                Some(row.clustering.clone()),
+                timestamp,
+            ));
+
+            // (c) Tombstone the neighbor's mirror adjacency entry: flipped
+            //     direction, neighbor = this vertex.
+            let mirror_direction = if direction == DIRECTION_OUT {
+                DIRECTION_IN
+            } else {
+                DIRECTION_OUT
+            };
+            let neighbor_key = DecoratedKey::new(PartitionKey::new(neighbor_id));
+            let mirror_clustering = adjacency_clustering_bytes(mirror_direction, &edge_label, &vid);
+            mutations.push(tombstone_mutation(
+                &adj_ks,
+                "adjacency",
+                &neighbor_key,
+                Some(mirror_clustering),
+                timestamp,
+            ));
+
+            edges_deleted += 1;
+        }
+    }
+
+    // Finally, tombstone the vertex row (whole-partition delete).
+    mutations.push(tombstone_mutation(
+        &vertex_table.keyspace,
+        &vertex_table.table,
+        vertex_key,
+        None,
+        timestamp,
+    ));
+
+    let rf = strategy.replication_factor();
+    write_path
+        .write_batch(mutations, graph_write_consistency(), rf)
+        .await
+        .map_err(GraphError::Storage)?;
+
+    Ok(edges_deleted)
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn execute_delete(
     write_path: &WritePath,
     expand: PhysicalPlan,
     keyspace: &str,
     variables: &[String],
-    _detach: bool,
+    detach: bool,
     config: &GraphEngineConfig,
     virtual_tables: Option<&VirtualTableRegistry>,
     start: Instant,
@@ -3816,6 +4006,20 @@ async fn execute_delete(
                 } else {
                     Vec::new()
                 };
+
+                if detach && !is_edge_table {
+                    // DETACH DELETE: cascade through the adjacency index,
+                    // tombstoning every incident edge (both directions) and its
+                    // adjacency entries together with the vertex, atomically
+                    // (URS-QEC-D01/D03/D07).
+                    let edges_deleted = delete_with_adjacency(
+                        write_path, keyspace, &key, &table_id, timestamp, &strategy,
+                    )
+                    .await?;
+                    stats.edges_deleted += edges_deleted;
+                    stats.vertices_deleted += 1;
+                    continue;
+                }
 
                 // Write a row-level tombstone.
                 let tombstone_row = Row {

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -24,7 +24,8 @@ use crate::executor::aggregate::{create_accumulator, Accumulator};
 use crate::executor::eval;
 use crate::executor::result::{GraphResult, QueryStats};
 use crate::parser::{
-    CompareOp, Direction, Expr, Literal, ReturnClause, ReturnItem, SortDir, WithPipeline,
+    CompareOp, Direction, Expr, Literal, RemoveItem, ReturnClause, ReturnItem, SortDir,
+    WithPipeline,
 };
 use crate::planner::physical::{AggregateProjection, Anchor, CreateOp, Hop, MergeOp, PhysicalPlan};
 
@@ -217,6 +218,24 @@ pub async fn execute(
                 *expand,
                 keyspace,
                 &assignments,
+                &variable_tables,
+                config,
+                virtual_tables,
+                start,
+                schema,
+            )
+            .await
+        }
+        PhysicalPlan::RemoveProperties {
+            expand,
+            items,
+            variable_tables,
+        } => {
+            execute_remove(
+                write_path,
+                *expand,
+                keyspace,
+                &items,
                 &variable_tables,
                 config,
                 virtual_tables,
@@ -3715,6 +3734,181 @@ async fn execute_set(
         columns: vec!["status".to_string()],
         rows: vec![vec![serde_json::Value::String(format!(
             "updated {} vertices",
+            stats.vertices_written
+        ))]],
+        stats,
+    })
+}
+
+/// Execute a REMOVE plan: run the inner expand to find matching vertices, then
+/// for each `REMOVE n.prop` write a cell-level tombstone so the property is
+/// unset and invisible to subsequent reads (URS-QEC-D06 / T-QEC-D07).
+///
+/// Mirrors `execute_set`, but instead of writing a live cell it writes a
+/// `CellValue::tombstone` at the property's column. `REMOVE n:Label` has no
+/// representation in this label-as-table storage model, so it fails loud rather
+/// than silently no-op (URS-QEC-X01).
+#[allow(clippy::too_many_arguments)]
+async fn execute_remove(
+    write_path: &WritePath,
+    expand: PhysicalPlan,
+    keyspace: &str,
+    items: &[RemoveItem],
+    variable_tables: &HashMap<String, String>,
+    config: &GraphEngineConfig,
+    virtual_tables: Option<&VirtualTableRegistry>,
+    start: Instant,
+    schema: Option<&Schema>,
+) -> Result<GraphResult> {
+    // Fail loud on label removal: there is no storage representation for
+    // dropping a label (label == table membership), so never fake success.
+    for item in items {
+        if let RemoveItem::Label { label, .. } = item {
+            return Err(GraphError::Validation(format!(
+                "execute_remove: REMOVE n:{label} (label removal) is not supported \
+                 in the label-as-table storage model"
+            )));
+        }
+    }
+
+    let expand_result = Box::pin(execute(
+        expand,
+        write_path,
+        keyspace,
+        config,
+        virtual_tables,
+        schema,
+    ))
+    .await?;
+    let mut stats = QueryStats::default();
+    stats.vertices_read = expand_result.stats.vertices_read;
+    stats.edges_read = expand_result.stats.edges_read;
+
+    let timestamp = now_micros();
+    let local_deletion_time = timestamp.div_euclid(1_000_000).clamp(0, i32::MAX as i64) as i32;
+    let strategy = graph_replication_strategy(schema, keyspace)?;
+
+    for row_values in &expand_result.rows {
+        for (col_idx, col_name) in expand_result.columns.iter().enumerate() {
+            let matching_props: Vec<&str> = items
+                .iter()
+                .filter_map(|item| match item {
+                    RemoveItem::Property { var, property } if var == col_name => {
+                        Some(property.as_str())
+                    }
+                    _ => None,
+                })
+                .collect();
+            if matching_props.is_empty() {
+                continue;
+            }
+
+            let hex_id = match row_values.get(col_idx) {
+                Some(serde_json::Value::String(s)) => Some(s.as_str()),
+                Some(serde_json::Value::Object(map)) => map.get("_id").and_then(|v| v.as_str()),
+                _ => None,
+            };
+            let Some(hex_id) = hex_id else { continue };
+
+            let table_name = variable_tables
+                .get(col_name)
+                .map(String::as_str)
+                .unwrap_or(col_name);
+            let table_id = TableId::new(keyspace, table_name);
+            let table_meta = table_metadata_for(schema, keyspace, table_name);
+            let is_edge_table = table_meta.as_ref().is_some_and(|meta| {
+                meta.extensions
+                    .get("graph.type")
+                    .is_some_and(|graph_type| graph_type == "edge")
+            });
+            let key_hex = if is_edge_table {
+                row_values
+                    .get(col_idx)
+                    .and_then(|value| value.as_object())
+                    .and_then(|map| map.get("__ferrosa_key"))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or(hex_id)
+            } else {
+                hex_id
+            };
+            let key_bytes = hex::decode(key_hex)
+                .map_err(|e| GraphError::Internal(format!("invalid hex storage key: {e}")))?;
+            let key = DecoratedKey::new(PartitionKey::new(key_bytes));
+            let clustering = if is_edge_table {
+                row_values
+                    .get(col_idx)
+                    .and_then(|value| value.as_object())
+                    .and_then(|map| map.get("__ferrosa_clustering"))
+                    .and_then(|value| value.as_str())
+                    .map(hex::decode)
+                    .transpose()
+                    .map_err(|e| {
+                        GraphError::Internal(format!("invalid hex storage clustering: {e}"))
+                    })?
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+
+            let mut cells = Vec::with_capacity(matching_props.len());
+            for prop in &matching_props {
+                let Some(column_idx) =
+                    regular_column_index_for_property(schema, keyspace, table_name, prop)
+                else {
+                    if matches!(
+                        column_kind_for_property(schema, keyspace, table_name, prop),
+                        Some(
+                            ferrosa_schema::metadata::column::ColumnKind::PartitionKey
+                                | ferrosa_schema::metadata::column::ColumnKind::Clustering
+                        )
+                    ) {
+                        return Err(GraphError::Validation(format!(
+                            "execute_remove: REMOVE cannot unset key column '{}' on table '{}.{}'",
+                            prop, keyspace, table_name
+                        )));
+                    }
+                    return Err(GraphError::Validation(format!(
+                        "execute_remove: REMOVE references unknown property '{}' on table '{}.{}'",
+                        prop, keyspace, table_name
+                    )));
+                };
+                cells.push((
+                    column_idx,
+                    CellValue::tombstone(timestamp, local_deletion_time),
+                ));
+            }
+
+            if cells.is_empty() {
+                continue;
+            }
+
+            let update_row = Row {
+                clustering,
+                cells,
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::NONE,
+            };
+
+            write_path
+                .write(
+                    &table_id,
+                    &key,
+                    update_row,
+                    timestamp,
+                    graph_write_consistency(),
+                    &strategy,
+                )
+                .await?;
+            stats.vertices_written += 1;
+        }
+    }
+
+    stats.execution_ms = start.elapsed().as_millis() as u64;
+
+    Ok(GraphResult {
+        columns: vec!["status".to_string()],
+        rows: vec![vec![serde_json::Value::String(format!(
+            "removed properties on {} vertices",
             stats.vertices_written
         ))]],
         stats,

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -3911,6 +3911,84 @@ async fn delete_with_adjacency(
     Ok(edges_deleted)
 }
 
+/// Probe the adjacency index for any **live** incident edge of `vertex_key`
+/// (URS-QEC-D02). Returns `true` if the vertex still has at least one surviving
+/// relationship in either direction. Read-only: performs no writes, so a plain
+/// `DELETE n` can fail loud before tombstoning anything.
+async fn vertex_has_incident_edges(
+    write_path: &WritePath,
+    keyspace: &str,
+    vertex_key: &DecoratedKey,
+) -> Result<bool> {
+    let adj_ks = adjacency_keyspace_name(keyspace);
+    let adj_table = TableId::new(&adj_ks, "adjacency");
+    let Some(partition) = write_path.read(&adj_table, vertex_key).await? else {
+        return Ok(false);
+    };
+    let has_live = partition.rows.iter().any(|row| {
+        row.deletion.is_live()
+            && row.clustering.len() >= 3
+            && extract_neighbor_id(&row.clustering, None).is_some()
+    });
+    Ok(has_live)
+}
+
+/// Validate the plain-`DELETE n` constraint (URS-QEC-D02) for every matched
+/// non-edge vertex BEFORE any tombstone is written: if any target node still
+/// has surviving relationships, return a Neo4j-style constraint error so the
+/// whole `DELETE` deletes nothing. Read-only.
+async fn check_plain_delete_constraint(
+    write_path: &WritePath,
+    expand_result: &GraphResult,
+    keyspace: &str,
+    variables: &[String],
+    schema: Option<&Schema>,
+    variable_tables: &HashMap<String, String>,
+) -> Result<()> {
+    for row_values in &expand_result.rows {
+        for (col_idx, col_name) in expand_result.columns.iter().enumerate() {
+            if !variables.iter().any(|v| v == col_name) {
+                continue;
+            }
+            let hex_id = match row_values.get(col_idx) {
+                Some(serde_json::Value::String(s)) => Some(s.clone()),
+                Some(serde_json::Value::Object(map)) => {
+                    map.get("_id").and_then(|v| v.as_str()).map(String::from)
+                }
+                _ => None,
+            };
+            let Some(hex_id) = hex_id else { continue };
+            let table_name = variable_tables
+                .get(col_name)
+                .map(String::as_str)
+                .unwrap_or(col_name);
+            // Edge tables have no adjacency partition keyed by the edge row;
+            // the constraint only governs vertices.
+            let is_edge_table = table_metadata_for(schema, keyspace, table_name)
+                .as_ref()
+                .is_some_and(|meta| {
+                    meta.extensions
+                        .get("graph.type")
+                        .is_some_and(|graph_type| graph_type == "edge")
+                });
+            if is_edge_table {
+                continue;
+            }
+            let key_bytes = hex::decode(&hex_id)
+                .map_err(|e| GraphError::Internal(format!("invalid hex storage key: {e}")))?;
+            let key = DecoratedKey::new(PartitionKey::new(key_bytes));
+            if vertex_has_incident_edges(write_path, keyspace, &key).await? {
+                return Err(GraphError::ConstraintViolation(format!(
+                    "Cannot delete node {hex_id}, because it still has relationships. \
+                     To delete this node, you must first delete its relationships, \
+                     or use DETACH DELETE."
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn execute_delete(
     write_path: &WritePath,
@@ -3943,6 +4021,22 @@ async fn execute_delete(
         .unwrap_or_default()
         .as_secs() as u32;
     let strategy = graph_replication_strategy(schema, keyspace)?;
+
+    // URS-QEC-D02: for a plain `DELETE n` (no DETACH), validate the
+    // no-surviving-relationships constraint across ALL matched vertices BEFORE
+    // writing any tombstone, so a failure deletes NOTHING even when several
+    // vertices match. Probing is read-only.
+    if !detach {
+        check_plain_delete_constraint(
+            write_path,
+            &expand_result,
+            keyspace,
+            variables,
+            schema,
+            variable_tables,
+        )
+        .await?;
+    }
 
     // For each matched vertex in the specified variables, write a tombstone.
     for row_values in &expand_result.rows {
@@ -4020,6 +4114,10 @@ async fn execute_delete(
                     stats.vertices_deleted += 1;
                     continue;
                 }
+
+                // Plain `DELETE n` constraint (URS-QEC-D02) was already
+                // validated for every matched vertex by the pre-pass above, so
+                // by here the write is guaranteed safe.
 
                 // Write a row-level tombstone.
                 let tombstone_row = Row {

--- a/ferrosa-graph/src/executor/result.rs
+++ b/ferrosa-graph/src/executor/result.rs
@@ -20,5 +20,6 @@ pub struct QueryStats {
     pub edges_read: usize,
     pub vertices_written: usize,
     pub vertices_deleted: usize,
+    pub edges_deleted: usize,
     pub execution_ms: u64,
 }

--- a/ferrosa-graph/src/http.rs
+++ b/ferrosa-graph/src/http.rs
@@ -104,6 +104,9 @@ fn error_to_response(err: &GraphError) -> Response {
         GraphError::ResourceLimit(msg) => {
             (StatusCode::BAD_REQUEST, format!("resource limit: {msg}"))
         }
+        // URS-QEC-D02: a constraint violation is a client error; the message is
+        // the safe Neo4j-style guidance, not internal detail, so expose it.
+        GraphError::ConstraintViolation(msg) => (StatusCode::CONFLICT, msg.clone()),
         // T8: Internal errors are never exposed to the client.
         GraphError::Storage(_) | GraphError::Schema(_) | GraphError::Internal(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/ferrosa-graph/src/parser/ast.rs
+++ b/ferrosa-graph/src/parser/ast.rs
@@ -203,6 +203,16 @@ pub struct Assignment {
     pub value: Expr,
 }
 
+/// A single target of a REMOVE clause: either a property to unset
+/// (`n.prop`) or a label to drop (`n:Label`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum RemoveItem {
+    /// `REMOVE n.prop` — unset a property on the matched node/rel.
+    Property { var: String, property: String },
+    /// `REMOVE n:Label` — drop a label from the matched node.
+    Label { var: String, label: String },
+}
+
 /// Top-level Cypher statement.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
@@ -251,6 +261,12 @@ pub enum Statement {
         pattern: Vec<Pattern>,
         where_clause: Option<Expr>,
         assignments: Vec<Assignment>,
+    },
+    /// `MATCH pattern [WHERE expr] REMOVE items`
+    Remove {
+        pattern: Vec<Pattern>,
+        where_clause: Option<Expr>,
+        items: Vec<RemoveItem>,
     },
     /// `MATCH pattern [WHERE expr] [DETACH] DELETE vars`
     Delete {

--- a/ferrosa-graph/src/parser/lexer.rs
+++ b/ferrosa-graph/src/parser/lexer.rs
@@ -19,6 +19,7 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "DELETE" => Keyword::Delete,
     "DETACH" => Keyword::Detach,
     "SET" => Keyword::Set,
+    "REMOVE" => Keyword::Remove,
     "ORDER" => Keyword::Order,
     "BY" => Keyword::By,
     "LIMIT" => Keyword::Limit,

--- a/ferrosa-graph/src/parser/parse_impl.rs
+++ b/ferrosa-graph/src/parser/parse_impl.rs
@@ -271,6 +271,15 @@ impl<'input> Parser<'input> {
                     assignments,
                 })
             }
+            TokenKind::Keyword(Keyword::Remove) => {
+                self.lexer.next_token()?;
+                let items = self.parse_remove_items()?;
+                Ok(Statement::Remove {
+                    pattern,
+                    where_clause,
+                    items,
+                })
+            }
             TokenKind::Keyword(Keyword::Delete) => {
                 self.lexer.next_token()?;
                 let variables = self.parse_var_list()?;
@@ -300,7 +309,7 @@ impl<'input> Parser<'input> {
             )),
             _ => Err(ParseError::new(
                 format!(
-                    "expected RETURN, OPTIONAL MATCH, WITH, SET, DELETE, or DETACH DELETE after MATCH, got {:?}",
+                    "expected RETURN, OPTIONAL MATCH, WITH, SET, REMOVE, DELETE, or DETACH DELETE after MATCH, got {:?}",
                     tok.kind
                 ),
                 tok.span,
@@ -1349,6 +1358,63 @@ impl<'input> Parser<'input> {
         })
     }
 
+    fn parse_remove_items(&mut self) -> ParseResult<Vec<RemoveItem>> {
+        let mut items = vec![self.parse_remove_item()?];
+        while self.lexer.eat(&TokenKind::Comma)? {
+            items.push(self.parse_remove_item()?);
+        }
+        Ok(items)
+    }
+
+    fn parse_remove_item(&mut self) -> ParseResult<RemoveItem> {
+        let tok = self.lexer.next_token()?;
+        let var = match tok.kind {
+            TokenKind::Ident(name) => name.to_string(),
+            _ => {
+                return Err(ParseError::new(
+                    format!("expected variable name in REMOVE, got {:?}", tok.kind),
+                    tok.span,
+                ));
+            }
+        };
+        let sep = self.lexer.next_token()?;
+        match sep.kind {
+            TokenKind::Dot => {
+                let prop_tok = self.lexer.next_token()?;
+                match prop_tok.kind {
+                    TokenKind::Ident(name) => Ok(RemoveItem::Property {
+                        var,
+                        property: name.to_string(),
+                    }),
+                    _ => Err(ParseError::new(
+                        format!("expected property name after '.', got {:?}", prop_tok.kind),
+                        prop_tok.span,
+                    )),
+                }
+            }
+            TokenKind::Colon => {
+                let label_tok = self.lexer.next_token()?;
+                match label_tok.kind {
+                    TokenKind::Ident(name) => Ok(RemoveItem::Label {
+                        var,
+                        label: name.to_string(),
+                    }),
+                    _ => Err(ParseError::new(
+                        format!("expected label name after ':', got {:?}", label_tok.kind),
+                        label_tok.span,
+                    )),
+                }
+            }
+            _ => Err(ParseError::new(
+                format!(
+                    "expected '.' (property) or ':' (label) in REMOVE, got {:?}",
+                    sep.kind
+                ),
+                sep.span,
+            )),
+        }
+    }
+
     fn parse_var_list(&mut self) -> ParseResult<Vec<String>> {
         let mut vars = vec![];
         let tok = self.lexer.next_token()?;
@@ -1699,6 +1765,42 @@ mod tests {
             assert_eq!(assignments[0].property, "age");
         } else {
             panic!("expected Set");
+        }
+    }
+
+    // --- REMOVE ---
+
+    #[test]
+    fn parse_remove_property() {
+        let stmt = parse("MATCH (n:Person) WHERE n.name = 'Alice' REMOVE n.age").unwrap();
+        if let Statement::Remove { items, .. } = stmt {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                RemoveItem::Property { var, property } => {
+                    assert_eq!(var, "n");
+                    assert_eq!(property, "age");
+                }
+                other => panic!("expected Property remove item, got {other:?}"),
+            }
+        } else {
+            panic!("expected Remove");
+        }
+    }
+
+    #[test]
+    fn parse_remove_label() {
+        let stmt = parse("MATCH (n:Person) REMOVE n:Person").unwrap();
+        if let Statement::Remove { items, .. } = stmt {
+            assert_eq!(items.len(), 1);
+            match &items[0] {
+                RemoveItem::Label { var, label } => {
+                    assert_eq!(var, "n");
+                    assert_eq!(label, "Person");
+                }
+                other => panic!("expected Label remove item, got {other:?}"),
+            }
+        } else {
+            panic!("expected Remove");
         }
     }
 

--- a/ferrosa-graph/src/parser/token.rs
+++ b/ferrosa-graph/src/parser/token.rs
@@ -12,6 +12,7 @@ pub enum Keyword {
     Delete,
     Detach,
     Set,
+    Remove,
     Order,
     By,
     Limit,

--- a/ferrosa-graph/src/planner/logical.rs
+++ b/ferrosa-graph/src/planner/logical.rs
@@ -112,6 +112,7 @@ fn permission_for_statement(stmt: &Statement) -> Permission {
         | Statement::Union { .. } => Permission::Select,
         Statement::Create { .. } => Permission::Modify,
         Statement::Set { .. } => Permission::Modify,
+        Statement::Remove { .. } => Permission::Modify,
         Statement::Delete { .. } => Permission::Modify,
         Statement::Subscribe { .. } => Permission::Select,
         Statement::Unsubscribe { .. } => Permission::Select,
@@ -148,6 +149,7 @@ pub fn validate(
         }
         Statement::Create { patterns, .. } => patterns,
         Statement::Set { pattern, .. } => pattern,
+        Statement::Remove { pattern, .. } => pattern,
         Statement::Delete { pattern, .. } => pattern,
         Statement::Subscribe { inner, .. } => match inner.as_ref() {
             Statement::Unwind { .. } | Statement::Return { .. } | Statement::Union { .. } => &[],

--- a/ferrosa-graph/src/planner/physical.rs
+++ b/ferrosa-graph/src/planner/physical.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 use crate::error::{GraphError, Result};
 use crate::executor::aggregate::is_aggregate_function;
 use crate::parser::{
-    Assignment, Direction, Expr, Pattern, PropMap, ReturnClause, Statement, WithPipeline,
+    Assignment, Direction, Expr, Pattern, PropMap, RemoveItem, ReturnClause, Statement,
+    WithPipeline,
 };
 use crate::planner::logical::{LogicalPlan, ResolvedTable};
 
@@ -203,6 +204,18 @@ pub enum PhysicalPlan {
         /// Cypher variable.
         variable_tables: HashMap<String, String>,
     },
+    /// Unset properties / drop labels on matched nodes/rels (Cypher `REMOVE`).
+    RemoveProperties {
+        /// First: expand to find matching vertices.
+        expand: Box<PhysicalPlan>,
+        /// REMOVE targets, resolved to (var, kind). `Property` unsets a cell;
+        /// `Label` drops a label.
+        items: Vec<RemoveItem>,
+        /// Mapping from variable name to resolved storage table name so writes
+        /// tombstone the matched label table rather than a table named after
+        /// the Cypher variable.
+        variable_tables: HashMap<String, String>,
+    },
     /// Delete matched nodes/rels.
     DeleteNodes {
         /// First: expand to find matching vertices.
@@ -352,6 +365,11 @@ pub fn plan(logical: LogicalPlan) -> Result<PhysicalPlan> {
             where_clause,
             assignments,
         } => plan_set(pattern, &logical.bindings, where_clause, assignments),
+        Statement::Remove {
+            pattern,
+            where_clause,
+            items,
+        } => plan_remove(pattern, &logical.bindings, where_clause, items),
         Statement::Delete {
             pattern,
             where_clause,
@@ -1011,6 +1029,59 @@ fn plan_set(
                     .map(|rt| (a.var.clone(), rt.table.clone()))
             })
             .collect(),
+    })
+}
+
+/// Variable referenced by a REMOVE item.
+fn remove_item_var(item: &RemoveItem) -> &str {
+    match item {
+        RemoveItem::Property { var, .. } | RemoveItem::Label { var, .. } => var,
+    }
+}
+
+/// Plan a REMOVE statement: build an Expand plan from the pattern, then wrap it
+/// with RemoveProperties containing the targets. Mirrors `plan_set`.
+fn plan_remove(
+    patterns: &[Pattern],
+    bindings: &std::collections::HashMap<String, ResolvedTable>,
+    where_clause: &Option<Expr>,
+    items: &[RemoveItem],
+) -> Result<PhysicalPlan> {
+    let filters = extract_filters(where_clause);
+
+    // Return all variables referenced by the items so the expand plan can find
+    // matching vertices. De-duplicate so repeated vars produce one return item.
+    let mut return_vars: Vec<String> = Vec::new();
+    for item in items {
+        let var = remove_item_var(item).to_string();
+        if !return_vars.contains(&var) {
+            return_vars.push(var);
+        }
+    }
+    let return_clause = ReturnClause {
+        distinct: false,
+        items: return_vars
+            .iter()
+            .map(|v| crate::parser::ReturnItem {
+                expr: Expr::Var(v.clone()),
+                alias: None,
+            })
+            .collect(),
+        order_by: vec![],
+        limit: None,
+    };
+
+    let expand = plan_match(patterns, bindings, filters, return_clause)?;
+
+    let variable_tables: HashMap<String, String> = return_vars
+        .iter()
+        .filter_map(|v| bindings.get(v).map(|rt| (v.clone(), rt.table.clone())))
+        .collect();
+
+    Ok(PhysicalPlan::RemoveProperties {
+        expand: Box::new(expand),
+        items: items.to_vec(),
+        variable_tables,
     })
 }
 

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -4309,6 +4309,252 @@ fn migration_proof_no_direct_table_reference() {
     }
 }
 
+// ── Slice 12: DETACH DELETE cascade (URS-QEC-D01/D03/D07, T-QEC-D01/D03) ──────
+
+/// blake3 content-address key for a `name`-keyed vertex, mirroring
+/// `content_addressed_key` (`name\x00<value>\x00`).
+fn vertex_key_bytes(name: &str) -> Vec<u8> {
+    let mut h = blake3::Hasher::new();
+    h.update(format!("name\x00{name}\x00").as_bytes());
+    h.finalize().as_bytes().to_vec()
+}
+
+/// Register the `social` schema + storage tables and wire the synchronous
+/// adjacency observer so MERGE edge writes land OUT/IN adjacency entries.
+/// Returns an engine that drives Cypher directly.
+fn detach_delete_engine() -> (Arc<GraphEngine>, Arc<StorageEngine>, Arc<Schema>, TempDir) {
+    use ferrosa_graph::adjacency::observer::AdjacencyIndexObserver;
+    use ferrosa_graph::adjacency::{adjacency_keyspace_name, adjacency_table_metadata};
+
+    let (schema, storage, dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    // Register the adjacency keyspace + table so the observer's derived
+    // mutations have a registered home and the planner can resolve them.
+    let adj_ks_name = adjacency_keyspace_name("social");
+    schema
+        .create_keyspace(
+            KeyspaceMetadata {
+                name: adj_ks_name.clone(),
+                durable_writes: true,
+                replication: ReplicationParams {
+                    strategy: "SimpleStrategy".to_string(),
+                    options: HashMap::from([("replication_factor".to_string(), "1".to_string())]),
+                },
+            },
+            &superuser_auth(),
+        )
+        .unwrap();
+    schema
+        .create_table(adjacency_table_metadata("social"), &superuser_auth())
+        .unwrap();
+    storage
+        .register_table(adjacency_table_metadata("social").to_storage_schema())
+        .unwrap();
+
+    // Synchronous observer: adjacency entries are written in the same write
+    // call as the edge, so no drain task / yield is required.
+    let observer = Arc::new(AdjacencyIndexObserver::new(
+        Arc::clone(&schema),
+        "social".to_string(),
+    ));
+    storage.register_observer(observer as Arc<dyn ferrosa_storage::WriteObserver>);
+
+    let (_app, engine) = build_app_and_engine(Arc::clone(&schema), Arc::clone(&storage));
+    (engine, storage, schema, dir)
+}
+
+/// Count live rows in a single-partition read (None partition => 0).
+fn live_row_count(storage: &StorageEngine, keyspace: &str, table: &str, key_bytes: &[u8]) -> usize {
+    use ferrosa_common::key::{DecoratedKey, PartitionKey};
+    use ferrosa_storage::TableId;
+
+    let tid = TableId::new(keyspace, table);
+    let key = DecoratedKey::new(PartitionKey::new(key_bytes.to_vec()));
+    match storage.read(&tid, &key).unwrap() {
+        Some(partition) => partition
+            .rows
+            .iter()
+            .filter(|r| r.deletion.is_live())
+            .count(),
+        None => 0,
+    }
+}
+
+/// T-QEC-D01 / T-QEC-D03 (URS-QEC-D01/D03/D07): a node with N inbound +
+/// M outbound edges, on `DETACH DELETE`, loses the node and **all** N+M
+/// incident edges, and the adjacency index has **zero** references to the
+/// node afterward — verified via direct CQL reads of `knows_e` and
+/// `system_graph_social.adjacency`, and via MATCH — all **without** running
+/// reconciliation.
+#[tokio::test]
+async fn detach_delete_removes_node_all_incident_edges_and_adjacency() {
+    let (engine, storage, _schema, _dir) = detach_delete_engine();
+    let auth = superuser_auth();
+    let ks = "social";
+
+    // Build the graph: Center with 2 outbound + 2 inbound edges.
+    let out_neighbors = ["OutA", "OutB"];
+    let in_neighbors = ["InX", "InY"];
+    for name in ["Center", "OutA", "OutB", "InX", "InY"] {
+        engine
+            .execute(
+                &format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                ks,
+                &auth,
+            )
+            .await
+            .expect("node MERGE must succeed");
+    }
+    for dst in out_neighbors {
+        engine
+            .execute(
+                &format!(
+                    "MERGE (a:Person {{name: 'Center'}})-[r:KNOWS]->(b:Person {{name: '{dst}'}}) RETURN r"
+                ),
+                ks,
+                &auth,
+            )
+            .await
+            .expect("outbound edge MERGE must succeed");
+    }
+    for src in in_neighbors {
+        engine
+            .execute(
+                &format!(
+                    "MERGE (a:Person {{name: '{src}'}})-[r:KNOWS]->(b:Person {{name: 'Center'}}) RETURN r"
+                ),
+                ks,
+                &auth,
+            )
+            .await
+            .expect("inbound edge MERGE must succeed");
+    }
+
+    let center = vertex_key_bytes("Center");
+
+    // Precondition: edges + adjacency exist before the delete.
+    assert_eq!(
+        live_row_count(&storage, ks, "knows_e", &center),
+        2,
+        "precondition: Center must have 2 outbound knows_e rows"
+    );
+    for src in in_neighbors {
+        assert_eq!(
+            live_row_count(&storage, ks, "knows_e", &vertex_key_bytes(src)),
+            1,
+            "precondition: inbound edge {src}->Center must exist"
+        );
+    }
+    let adj_ks = "system_graph_social";
+    assert!(
+        live_row_count(&storage, adj_ks, "adjacency", &center) >= 4,
+        "precondition: Center adjacency must hold 2 OUT + 2 IN entries (got {})",
+        live_row_count(&storage, adj_ks, "adjacency", &center)
+    );
+
+    // The DETACH DELETE under test. Adjacency keyspace is already registered
+    // (the MERGEs registered it), so this query does NOT trigger reconciliation.
+    engine
+        .execute(
+            "MATCH (n:Person {name: 'Center'}) DETACH DELETE n",
+            ks,
+            &auth,
+        )
+        .await
+        .expect("DETACH DELETE must succeed");
+
+    // (1) The node is gone from MATCH and from person_v storage.
+    let match_center = engine
+        .execute("MATCH (n:Person {name: 'Center'}) RETURN n.name", ks, &auth)
+        .await
+        .expect("MATCH after delete must succeed");
+    assert!(
+        match_center.rows.is_empty(),
+        "Center node must be gone after DETACH DELETE; got rows: {:?}",
+        match_center.rows
+    );
+    assert_eq!(
+        live_row_count(&storage, ks, "person_v", &center),
+        0,
+        "Center vertex row must be tombstoned in person_v"
+    );
+
+    // (2) ALL outbound edges gone: knows_e partition for Center has no live rows.
+    assert_eq!(
+        live_row_count(&storage, ks, "knows_e", &center),
+        0,
+        "all outbound edges from Center must be tombstoned in knows_e"
+    );
+
+    // (3) ALL inbound edges gone: each inbound src->Center knows_e row tombstoned.
+    for src in in_neighbors {
+        assert_eq!(
+            live_row_count(&storage, ks, "knows_e", &vertex_key_bytes(src)),
+            0,
+            "inbound edge {src}->Center must be tombstoned in knows_e"
+        );
+    }
+
+    // (4) Adjacency scan finds ZERO references to Center:
+    //     (a) Center's own partition (both OUT and IN entries) is empty.
+    assert_eq!(
+        live_row_count(&storage, adj_ks, "adjacency", &center),
+        0,
+        "Center adjacency partition must have zero live entries after DETACH DELETE"
+    );
+    //     (b) Each neighbor's mirror entry pointing back at Center is gone.
+    //         Out-neighbors held an IN entry (Center as neighbor); in-neighbors
+    //         held an OUT entry (Center as neighbor).
+    for name in out_neighbors.iter().chain(in_neighbors.iter()) {
+        let nbr_key = vertex_key_bytes(name);
+        let refs_center = adjacency_partition_references(&storage, adj_ks, &nbr_key, &center);
+        assert!(
+            !refs_center,
+            "neighbor {name} adjacency partition must not reference Center after DETACH DELETE"
+        );
+    }
+
+    // (5) MATCH hop over KNOWS from/through Center returns nothing.
+    let hop = engine
+        .execute(
+            "MATCH (a:Person {name: 'Center'})-[:KNOWS]->(b:Person) RETURN b.name",
+            ks,
+            &auth,
+        )
+        .await
+        .expect("hop MATCH after delete must succeed");
+    assert!(
+        hop.rows.is_empty(),
+        "no outbound KNOWS hop from Center may survive; got: {:?}",
+        hop.rows
+    );
+}
+
+/// True if any live adjacency row in `vertex`'s partition names `neighbor`
+/// as its neighbor_id (i.e. an incident-edge reference to `neighbor`).
+fn adjacency_partition_references(
+    storage: &StorageEngine,
+    adj_keyspace: &str,
+    vertex_key_bytes: &[u8],
+    neighbor: &[u8],
+) -> bool {
+    use ferrosa_common::key::{DecoratedKey, PartitionKey};
+    use ferrosa_graph::executor::expand::extract_neighbor_id;
+    use ferrosa_storage::TableId;
+
+    let tid = TableId::new(adj_keyspace, "adjacency");
+    let key = DecoratedKey::new(PartitionKey::new(vertex_key_bytes.to_vec()));
+    let Some(partition) = storage.read(&tid, &key).unwrap() else {
+        return false;
+    };
+    partition.rows.iter().any(|row| {
+        row.deletion.is_live()
+            && extract_neighbor_id(&row.clustering, None).as_deref() == Some(neighbor)
+    })
+}
+
 /// Remove all single-quoted string literals from a Cypher query string,
 /// replacing them with empty strings. Used by `migration_proof_no_direct_table_reference`
 /// to distinguish quoted value literals from unquoted identifiers.

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -4532,6 +4532,117 @@ async fn detach_delete_removes_node_all_incident_edges_and_adjacency() {
     );
 }
 
+/// T-QEC-D02 (URS-QEC-D02): a plain `DELETE n` (no DETACH) on a node that
+/// still has surviving relationships must **fail loud** with a Neo4j-style
+/// constraint error and delete **nothing** — neither the node nor any of its
+/// incident edges/adjacency entries may be tombstoned. The adjacency index is
+/// probed *before* any write, so the failure is detected with zero side
+/// effects.
+#[tokio::test]
+async fn plain_delete_with_surviving_relationships_fails_loud_deletes_nothing() {
+    let (engine, storage, _schema, _dir) = detach_delete_engine();
+    let auth = superuser_auth();
+    let ks = "social";
+
+    // Build the graph: Center with 1 outbound + 1 inbound edge.
+    for name in ["Center", "Out", "In"] {
+        engine
+            .execute(
+                &format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                ks,
+                &auth,
+            )
+            .await
+            .expect("node MERGE must succeed");
+    }
+    engine
+        .execute(
+            "MERGE (a:Person {name: 'Center'})-[r:KNOWS]->(b:Person {name: 'Out'}) RETURN r",
+            ks,
+            &auth,
+        )
+        .await
+        .expect("outbound edge MERGE must succeed");
+    engine
+        .execute(
+            "MERGE (a:Person {name: 'In'})-[r:KNOWS]->(b:Person {name: 'Center'}) RETURN r",
+            ks,
+            &auth,
+        )
+        .await
+        .expect("inbound edge MERGE must succeed");
+
+    let center = vertex_key_bytes("Center");
+    let adj_ks = "system_graph_social";
+
+    // Preconditions: node, both edges, and adjacency entries exist.
+    assert_eq!(
+        live_row_count(&storage, ks, "person_v", &center),
+        1,
+        "precondition: Center vertex must exist"
+    );
+    assert_eq!(
+        live_row_count(&storage, ks, "knows_e", &center),
+        1,
+        "precondition: Center outbound edge must exist"
+    );
+    assert_eq!(
+        live_row_count(&storage, ks, "knows_e", &vertex_key_bytes("In")),
+        1,
+        "precondition: inbound In->Center edge must exist"
+    );
+    let adj_before = live_row_count(&storage, adj_ks, "adjacency", &center);
+    assert!(
+        adj_before >= 2,
+        "precondition: Center adjacency must hold OUT + IN entries (got {adj_before})"
+    );
+
+    // The plain DELETE under test — MUST fail loud, deleting nothing.
+    let err = engine
+        .execute("MATCH (n:Person {name: 'Center'}) DELETE n", ks, &auth)
+        .await
+        .expect_err("plain DELETE of a node with surviving relationships must fail loud");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("still has relationships") || msg.contains("DETACH DELETE"),
+        "error must be a Neo4j-style constraint violation; got: {msg}"
+    );
+
+    // Nothing was deleted: node, both edges, and adjacency are all intact.
+    assert_eq!(
+        live_row_count(&storage, ks, "person_v", &center),
+        1,
+        "Center vertex must survive a failed DELETE"
+    );
+    assert_eq!(
+        live_row_count(&storage, ks, "knows_e", &center),
+        1,
+        "Center outbound edge must survive a failed DELETE"
+    );
+    assert_eq!(
+        live_row_count(&storage, ks, "knows_e", &vertex_key_bytes("In")),
+        1,
+        "inbound In->Center edge must survive a failed DELETE"
+    );
+    assert_eq!(
+        live_row_count(&storage, adj_ks, "adjacency", &center),
+        adj_before,
+        "Center adjacency entries must be untouched by a failed DELETE"
+    );
+
+    // And the node is still queryable via MATCH.
+    let match_center = engine
+        .execute("MATCH (n:Person {name: 'Center'}) RETURN n.name", ks, &auth)
+        .await
+        .expect("MATCH after failed delete must succeed");
+    assert_eq!(
+        match_center.rows.len(),
+        1,
+        "Center must still be MATCHable after a failed DELETE; got: {:?}",
+        match_center.rows
+    );
+}
+
 /// True if any live adjacency row in `vertex`'s partition names `neighbor`
 /// as its neighbor_id (i.e. an incident-edge reference to `neighbor`).
 fn adjacency_partition_references(

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -1273,6 +1273,79 @@ async fn merge_set_updates_properties() {
     assert_eq!(resp.status(), StatusCode::OK, "MERGE + SET must return 200");
 }
 
+/// T-QEC-D07 / URS-QEC-D06: `REMOVE n.prop` unsets the property — a subsequent
+/// MATCH must show it gone (null), not the old value.
+#[tokio::test]
+async fn remove_property_unsets_it() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    // Create a Person with an age.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MERGE (n:Person {name: 'Dana'}) SET n.age = 42 RETURN n",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "MERGE + SET must return 200");
+
+    // Confirm the age is present before REMOVE.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person {name: 'Dana'}) RETURN n.age",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = response_json(resp).await["rows"].clone();
+    assert_eq!(
+        rows,
+        serde_json::json!([[42]]),
+        "age must be present before REMOVE"
+    );
+
+    // REMOVE the age property.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person {name: 'Dana'}) REMOVE n.age",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "REMOVE must return 200");
+
+    // A subsequent MATCH must show the property gone (null).
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person {name: 'Dana'}) RETURN n.age",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let rows = response_json(resp).await["rows"].clone();
+    assert_eq!(
+        rows,
+        serde_json::json!([[serde_json::Value::Null]]),
+        "age must be unset (null) after REMOVE n.age"
+    );
+}
+
 /// MERGE with an unknown label must return HTTP 400, not 500 or panic.
 #[tokio::test]
 async fn merge_missing_endpoint_returns_error() {

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -26,6 +26,8 @@ use ferrosa_cluster::raft::handlers::{
 use ferrosa_cluster::raft::{NodeInfo, NodeState};
 use ferrosa_cluster::ring::TokenRing;
 use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+use ferrosa_graph::bolt::codec::PackValue;
+use ferrosa_graph::bolt::message::BoltMessage;
 use ferrosa_graph::engine::GraphEngine;
 use ferrosa_graph::executor::expand::GraphEngineConfig;
 use ferrosa_graph::http::{build_router, AppState};
@@ -4737,6 +4739,401 @@ fn adjacency_partition_references(
         row.deletion.is_live()
             && extract_neighbor_id(&row.clustering, None).as_deref() == Some(neighbor)
     })
+}
+
+// ── Bolt parity test (T-QEC-D04 / URS-QEC-D05) ─────────────────────────────
+
+/// A minimal Bolt v5 client over a real TCP socket: handshake, HELLO, LOGON,
+/// then RUN/PULL per query. Exercises the **actual** `start_bolt_server`
+/// connection handler and PackStream codec — the same path a Neo4j driver
+/// would drive — so the test proves Bolt behaves identically to HTTP, not that
+/// they merely share a function.
+struct BoltTestClient {
+    stream: tokio::net::TcpStream,
+    decoder: ferrosa_graph::bolt::codec::ChunkDecoder,
+    /// Decoded-but-not-yet-consumed messages (a single TCP read can yield
+    /// several framed messages, e.g. SUCCESS + RECORDs).
+    pending: std::collections::VecDeque<Vec<u8>>,
+}
+
+impl BoltTestClient {
+    /// Connect and complete handshake + HELLO + LOGON (auth_disabled server,
+    /// so credentials are accepted as superuser).
+    async fn connect(addr: std::net::SocketAddr) -> Self {
+        use ferrosa_graph::bolt::codec::ChunkDecoder;
+        use ferrosa_graph::bolt::handshake::{BOLT_MAGIC, BOLT_VERSION_5_0};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Retry briefly while the spawned server task binds its listener.
+        let mut stream = {
+            let mut connected = None;
+            for _ in 0..100 {
+                if let Ok(s) = tokio::net::TcpStream::connect(addr).await {
+                    connected = Some(s);
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            connected.expect("Bolt TCP connect must succeed")
+        };
+
+        // Handshake: magic + 4 version proposals (only Bolt 5.0 offered).
+        let mut hs = Vec::with_capacity(20);
+        hs.extend_from_slice(&BOLT_MAGIC);
+        hs.extend_from_slice(&BOLT_VERSION_5_0.to_be_bytes());
+        hs.extend_from_slice(&[0u8; 12]);
+        stream.write_all(&hs).await.expect("handshake write");
+        let mut resp = [0u8; 4];
+        stream
+            .read_exact(&mut resp)
+            .await
+            .expect("handshake response read");
+        assert_eq!(
+            u32::from_be_bytes(resp),
+            BOLT_VERSION_5_0,
+            "server must negotiate Bolt 5.0"
+        );
+
+        let mut client = Self {
+            stream,
+            decoder: ChunkDecoder::new(),
+            pending: std::collections::VecDeque::new(),
+        };
+
+        // HELLO (no inline auth) then LOGON with basic scheme.
+        let hello = BoltMessage::Hello {
+            extra: vec![(
+                "user_agent".into(),
+                PackValue::String("ferrosa-test/1.0".into()),
+            )],
+        };
+        client.send(&hello).await;
+        client.expect_success("HELLO").await;
+
+        let logon = BoltMessage::Logon {
+            auth: vec![
+                ("scheme".into(), PackValue::String("basic".into())),
+                ("principal".into(), PackValue::String("tester".into())),
+                ("credentials".into(), PackValue::String("ignored".into())),
+            ],
+        };
+        client.send(&logon).await;
+        client.expect_success("LOGON").await;
+        client
+    }
+
+    /// Send one Bolt message, chunk-framed.
+    async fn send(&mut self, msg: &BoltMessage) {
+        use ferrosa_graph::bolt::codec::{chunk_encode, DEFAULT_MAX_CHUNK_SIZE};
+        use tokio::io::AsyncWriteExt;
+
+        let framed = chunk_encode(&msg.encode(), DEFAULT_MAX_CHUNK_SIZE);
+        self.stream.write_all(&framed).await.expect("bolt send");
+    }
+
+    /// Read the next complete Bolt message from the socket, buffering any
+    /// extra messages that arrive in the same TCP read.
+    async fn recv(&mut self) -> BoltMessage {
+        use tokio::io::AsyncReadExt;
+
+        loop {
+            if let Some(data) = self.pending.pop_front() {
+                return BoltMessage::decode(&data).expect("decode bolt message");
+            }
+            let mut buf = [0u8; 4096];
+            let n = self.stream.read(&mut buf).await.expect("bolt recv read");
+            assert!(n > 0, "unexpected EOF from Bolt server");
+            self.pending.extend(self.decoder.feed(&buf[..n]));
+        }
+    }
+
+    /// Assert the next message is SUCCESS, surfacing FAILURE details otherwise.
+    async fn expect_success(&mut self, ctx: &str) {
+        match self.recv().await {
+            BoltMessage::Success { .. } => {}
+            BoltMessage::Failure { metadata } => {
+                panic!("Bolt {ctx} returned FAILURE: {metadata:?}");
+            }
+            other => panic!("Bolt {ctx} expected SUCCESS, got {other:?}"),
+        }
+    }
+
+    /// RUN + PULL a query, returning the result rows (each a list of PackValues).
+    /// Panics (fail-loud) if the server returns a Bolt FAILURE for the RUN.
+    async fn query(&mut self, cypher: &str, keyspace: &str) -> Vec<Vec<PackValue>> {
+        let run = BoltMessage::Run {
+            query: cypher.to_string(),
+            params: vec![],
+            extra: vec![("db".into(), PackValue::String(keyspace.to_string()))],
+        };
+        self.send(&run).await;
+        match self.recv().await {
+            BoltMessage::Success { .. } => {}
+            BoltMessage::Failure { metadata } => {
+                panic!("Bolt RUN `{cypher}` returned FAILURE: {metadata:?}");
+            }
+            other => panic!("Bolt RUN `{cypher}` expected SUCCESS, got {other:?}"),
+        }
+
+        let pull = BoltMessage::Pull {
+            extra: vec![("n".into(), PackValue::Int(-1))],
+        };
+        self.send(&pull).await;
+
+        let mut rows = Vec::new();
+        loop {
+            match self.recv().await {
+                BoltMessage::Record { values } => rows.push(values),
+                BoltMessage::Success { .. } => break,
+                BoltMessage::Failure { metadata } => {
+                    panic!("Bolt PULL `{cypher}` returned FAILURE: {metadata:?}");
+                }
+                other => panic!("Bolt PULL `{cypher}` unexpected message {other:?}"),
+            }
+        }
+        rows
+    }
+}
+
+/// Direct-CQL snapshot of the post-delete state of the `Center` node: its
+/// vertex row count, outbound edge count, inbound edge counts from each named
+/// in-neighbor, and its adjacency partition live-row count. Two interfaces are
+/// "the same result" iff their snapshots are byte-for-byte equal (all zeros
+/// after a successful DETACH DELETE).
+#[derive(Debug, PartialEq, Eq)]
+struct CenterDeleteSnapshot {
+    person_v: usize,
+    out_edges: usize,
+    in_edges: Vec<(String, usize)>,
+    adjacency: usize,
+}
+
+fn center_delete_snapshot(storage: &StorageEngine, in_neighbors: &[&str]) -> CenterDeleteSnapshot {
+    let ks = "social";
+    let adj_ks = "system_graph_social";
+    let center = vertex_key_bytes("Center");
+    CenterDeleteSnapshot {
+        person_v: live_row_count(storage, ks, "person_v", &center),
+        out_edges: live_row_count(storage, ks, "knows_e", &center),
+        in_edges: in_neighbors
+            .iter()
+            .map(|src| {
+                (
+                    (*src).to_string(),
+                    live_row_count(storage, ks, "knows_e", &vertex_key_bytes(src)),
+                )
+            })
+            .collect(),
+        adjacency: live_row_count(storage, adj_ks, "adjacency", &center),
+    }
+}
+
+/// Build the `Center`-with-2-out-2-in graph through `engine.execute`. Shared by
+/// both arms of the parity test so the pre-delete state is identical.
+async fn build_center_graph(engine: &Arc<GraphEngine>, auth: &AuthContext) {
+    let ks = "social";
+    for name in ["Center", "OutA", "OutB", "InX", "InY"] {
+        engine
+            .execute(
+                &format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                ks,
+                auth,
+            )
+            .await
+            .expect("node MERGE must succeed");
+    }
+    for dst in ["OutA", "OutB"] {
+        engine
+            .execute(
+                &format!(
+                    "MERGE (a:Person {{name: 'Center'}})-[r:KNOWS]->(b:Person {{name: '{dst}'}}) RETURN r"
+                ),
+                ks,
+                auth,
+            )
+            .await
+            .expect("outbound edge MERGE must succeed");
+    }
+    for src in ["InX", "InY"] {
+        engine
+            .execute(
+                &format!(
+                    "MERGE (a:Person {{name: '{src}'}})-[r:KNOWS]->(b:Person {{name: 'Center'}}) RETURN r"
+                ),
+                ks,
+                auth,
+            )
+            .await
+            .expect("inbound edge MERGE must succeed");
+    }
+}
+
+/// T-QEC-D04 (URS-QEC-D05): a `DETACH DELETE n` issued over the **real Bolt
+/// wire protocol** produces the SAME result as the same statement over the HTTP
+/// `/graph/query` endpoint. After each delete:
+///   (a) the node is immediately invisible to a subsequent read on that same
+///       interface (Bolt MATCH / HTTP MATCH), and
+///   (b) it is gone from direct CQL reads of the underlying `knows_e` and
+///       `system_graph_social.adjacency` tables.
+/// The two interfaces' post-delete CQL snapshots must be byte-for-byte equal.
+/// Bolt shares the Cypher executor, so no executor change is expected — this
+/// test is the proof that Bolt has not diverged.
+#[tokio::test]
+async fn detach_delete_via_bolt_matches_http_and_is_invisible_to_reads_and_cql() {
+    let in_neighbors = ["InX", "InY"];
+
+    // ── HTTP arm ──────────────────────────────────────────────────────────
+    let (http_engine, http_storage, http_schema, _http_dir) = detach_delete_engine();
+    let auth = superuser_auth();
+    build_center_graph(&http_engine, &auth).await;
+
+    // Drive the real HTTP router over the SAME engine the graph was built on,
+    // so the delete and the follow-up read share one storage view.
+    let http_app = build_router(AppState {
+        engine: Arc::clone(&http_engine),
+        schema: Arc::clone(&http_schema),
+        auth_disabled: false,
+    });
+
+    // DETACH DELETE over HTTP.
+    let del_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person {name: 'Center'}) DETACH DELETE n",
+            "keyspace": "social"
+        })),
+    );
+    let del_resp = http_app.clone().oneshot(del_req).await.unwrap();
+    assert_eq!(
+        del_resp.status(),
+        StatusCode::OK,
+        "HTTP DETACH DELETE status"
+    );
+    let del_body = response_json(del_resp).await;
+    // The executor reports the delete as a one-row `status` result on BOTH
+    // interfaces; capture HTTP's so we can prove Bolt returns the same string.
+    let http_delete_status = del_body["rows"][0][0]
+        .as_str()
+        .expect("HTTP DETACH DELETE must return a status row")
+        .to_string();
+    assert_eq!(
+        http_delete_status, "deleted 1 vertices",
+        "HTTP DETACH DELETE status row, got body: {del_body:?}"
+    );
+
+    // (a) HTTP read on the same interface no longer sees Center.
+    let read_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person {name: 'Center'}) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let read_resp = http_app.oneshot(read_req).await.unwrap();
+    assert_eq!(read_resp.status(), StatusCode::OK);
+    let http_read_rows = response_json(read_resp).await["rows"]
+        .as_array()
+        .expect("rows array")
+        .len();
+    assert_eq!(
+        http_read_rows, 0,
+        "HTTP MATCH after DETACH DELETE must return no rows"
+    );
+
+    // (b) direct CQL snapshot of the HTTP store.
+    let http_snapshot = center_delete_snapshot(&http_storage, &in_neighbors);
+
+    // ── Bolt arm ──────────────────────────────────────────────────────────
+    let (bolt_engine, bolt_storage, bolt_schema, _bolt_dir) = detach_delete_engine();
+    build_center_graph(&bolt_engine, &auth).await;
+
+    let bolt_config = ferrosa_graph::bolt::server::BoltConfig {
+        bind_addr: "127.0.0.1:0".parse().unwrap(),
+        auth_disabled: true,
+        ..Default::default()
+    };
+    // Bind first to learn the ephemeral port, then serve on it.
+    let listener = std::net::TcpListener::bind(bolt_config.bind_addr).unwrap();
+    let bolt_addr = listener.local_addr().unwrap();
+    drop(listener);
+    let bolt_config = ferrosa_graph::bolt::server::BoltConfig {
+        bind_addr: bolt_addr,
+        ..bolt_config
+    };
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let server_engine = Arc::clone(&bolt_engine);
+    let server_schema = Arc::clone(&bolt_schema);
+    let server = tokio::spawn(async move {
+        ferrosa_graph::bolt::server::start_bolt_server(
+            server_engine,
+            server_schema,
+            bolt_config,
+            shutdown_rx,
+        )
+        .await
+    });
+
+    let mut client = BoltTestClient::connect(bolt_addr).await;
+
+    // DETACH DELETE over Bolt — must return the SAME status row as HTTP.
+    let del_rows = client
+        .query(
+            "MATCH (n:Person {name: 'Center'}) DETACH DELETE n",
+            "social",
+        )
+        .await;
+    let bolt_delete_status = match del_rows.as_slice() {
+        [row] => match row.as_slice() {
+            [PackValue::String(s)] => s.clone(),
+            other => panic!("Bolt DETACH DELETE status row shape unexpected: {other:?}"),
+        },
+        other => panic!("Bolt DETACH DELETE must return exactly one status row; got {other:?}"),
+    };
+    assert_eq!(
+        bolt_delete_status, http_delete_status,
+        "Bolt DETACH DELETE status row must match HTTP's"
+    );
+
+    // (a) Bolt read on the same interface no longer sees Center.
+    let bolt_read_rows = client
+        .query("MATCH (n:Person {name: 'Center'}) RETURN n.name", "social")
+        .await;
+    assert!(
+        bolt_read_rows.is_empty(),
+        "Bolt MATCH after DETACH DELETE must return no rows; got {bolt_read_rows:?}"
+    );
+
+    // (b) direct CQL snapshot of the Bolt store.
+    let bolt_snapshot = center_delete_snapshot(&bolt_storage, &in_neighbors);
+
+    // Clean shutdown of the Bolt server.
+    let _ = shutdown_tx.send(true);
+    server.abort();
+
+    // ── Parity assertions ─────────────────────────────────────────────────
+    // Both interfaces fully tore down Center: nothing left in CQL.
+    assert_eq!(
+        http_snapshot,
+        CenterDeleteSnapshot {
+            person_v: 0,
+            out_edges: 0,
+            in_edges: vec![("InX".into(), 0), ("InY".into(), 0)],
+            adjacency: 0,
+        },
+        "HTTP DETACH DELETE must leave zero CQL rows for Center"
+    );
+    // The whole point of T-QEC-D04: Bolt == HTTP, exactly.
+    assert_eq!(
+        bolt_snapshot, http_snapshot,
+        "Bolt DETACH DELETE must produce the SAME CQL result as HTTP"
+    );
+    assert_eq!(
+        http_read_rows,
+        bolt_read_rows.len(),
+        "Bolt and HTTP post-delete reads must agree (both empty)"
+    );
 }
 
 /// Remove all single-quoted string literals from a Cypher query string,

--- a/ferrosa-sparql/Cargo.toml
+++ b/ferrosa-sparql/Cargo.toml
@@ -42,3 +42,7 @@ serde_urlencoded = "0.7"
 
 # Misc
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/ferrosa-sparql/src/engine.rs
+++ b/ferrosa-sparql/src/engine.rs
@@ -115,7 +115,11 @@ impl SparqlEngine {
     }
 
     /// Execute a SPARQL UPDATE and return the result.
-    pub fn execute_update(
+    ///
+    /// Async because pattern-based ops (`DELETE WHERE`, `DELETE/INSERT … WHERE`,
+    /// `CLEAR`, `DROP`) evaluate their WHERE clause through the async SELECT
+    /// executor before tombstoning the bound triples.
+    pub async fn execute_update(
         &self,
         update_str: &str,
         keyspace: &str,
@@ -131,7 +135,7 @@ impl SparqlEngine {
             )));
         }
         self.ensure_table_registered(ks);
-        crate::update::execute_update(update_str, ks, &self.storage)
+        crate::update::execute_update(update_str, ks, &self.storage, &self.write_path).await
     }
 
     /// Execute a SPARQL query and return results.

--- a/ferrosa-sparql/src/executor.rs
+++ b/ferrosa-sparql/src/executor.rs
@@ -56,6 +56,29 @@ pub async fn execute(
     Ok(results)
 }
 
+/// Evaluate a plan's WHERE pattern and return the raw solution bindings
+/// (after FILTER, before projection/ORDER/DISTINCT/LIMIT).
+///
+/// Used by SPARQL UPDATE pattern-deletes (`DELETE WHERE`,
+/// `DELETE/INSERT … WHERE`): the full, unprojected binding set is needed so
+/// every matched solution can be substituted into the delete/insert templates.
+pub async fn execute_bindings(
+    plan: &QueryPlan,
+    write_path: &Arc<WritePath>,
+) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
+    let mut binding_sets = evaluate_triple_patterns(plan, write_path).await?;
+
+    if !plan.filters.is_empty() {
+        binding_sets.retain(|row| {
+            plan.filters
+                .iter()
+                .all(|expr| crate::filter::eval_filter(expr, row))
+        });
+    }
+
+    Ok(binding_sets)
+}
+
 /// Evaluate all triple patterns via nested-loop join, returning binding sets.
 async fn evaluate_triple_patterns(
     plan: &QueryPlan,
@@ -393,6 +416,14 @@ fn extract_composite_component(data: &[u8], position: usize) -> Option<String> {
 /// Extract triples from partition rows into the output vec.
 fn extract_rows_from_partition(rows: &[Row], subject: &str, triples: &mut Vec<FetchedTriple>) {
     for row in rows {
+        // Skip deleted rows: a row whose deletion marker is non-live is a
+        // tombstone (or a row masked by one in the merge) and MUST NOT surface
+        // as a triple. Without this, a SPARQL delete would remain visible to a
+        // subsequent SELECT (URS-QEC-D05).
+        if !row.deletion.is_live() {
+            continue;
+        }
+
         let predicate = extract_clustering_string(&row.clustering, 0);
         let object = extract_clustering_string(&row.clustering, 1);
 
@@ -461,8 +492,11 @@ fn apply_scan_filters(op: &TripleOp, triples: &mut Vec<FetchedTriple>) {
 
 /// Extract a string component from a CQL clustering key at the given position.
 ///
-/// Clustering keys are encoded as length-prefixed components:
-///   `[u16 len][bytes][0x00 separator]...`
+/// Clustering keys use the strict CQL composite encoding written by
+/// `update::encode_triple_clustering`: `[u16 len][bytes]` per component with NO
+/// separator byte (this is what `ferrosa-common::schema` validates). A trailing
+/// separator must NOT be assumed — for short components the next component's
+/// length prefix high byte is `0x00`, and skipping it would corrupt the read.
 ///
 /// BUG-S10 fix: logs warnings on malformed/truncated keys instead of
 /// returning empty strings silently.
@@ -493,10 +527,6 @@ fn extract_clustering_string(clustering: &[u8], position: usize) -> String {
             return String::from_utf8_lossy(&clustering[offset..offset + len]).to_string();
         }
         offset += len;
-        // Skip end-of-component byte if present.
-        if offset < clustering.len() && clustering[offset] == 0 {
-            offset += 1;
-        }
     }
     tracing::warn!(
         position,
@@ -701,10 +731,22 @@ mod tests {
         );
     }
 
+    /// Build a strict CQL clustering component: `[u16 len][bytes]` (no
+    /// separator), matching `update::encode_triple_clustering`.
+    fn encode_clustering_component(s: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(s.len() as u16).to_be_bytes());
+        buf.extend_from_slice(s.as_bytes());
+        buf
+    }
+
     #[test]
     fn extract_clustering_string_two_components() {
-        let mut clustering = encode_component("http://xmlns.com/foaf/0.1/name");
-        clustering.extend_from_slice(&encode_component("Alice"));
+        // Strict separator-free encoding — the reader must NOT assume a
+        // trailing 0x00 separator (it would corrupt the second component's
+        // length prefix, whose high byte is 0x00 for short objects).
+        let mut clustering = encode_clustering_component("http://xmlns.com/foaf/0.1/name");
+        clustering.extend_from_slice(&encode_clustering_component("Alice"));
         assert_eq!(
             extract_clustering_string(&clustering, 0),
             "http://xmlns.com/foaf/0.1/name"

--- a/ferrosa-sparql/src/http.rs
+++ b/ferrosa-sparql/src/http.rs
@@ -133,7 +133,7 @@ async fn handle_sparql_update(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("rdf");
 
-    match state.engine.execute_update(&update_str, keyspace) {
+    match state.engine.execute_update(&update_str, keyspace).await {
         Ok(result) => (
             StatusCode::OK,
             Json(serde_json::json!({

--- a/ferrosa-sparql/src/planner.rs
+++ b/ferrosa-sparql/src/planner.rs
@@ -85,6 +85,13 @@ pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, Sparq
     }
 }
 
+/// Plan a bare `GraphPattern` (e.g. the WHERE clause of a SPARQL UPDATE) into a
+/// [`QueryPlan`] so it can be evaluated by the SELECT executor to bind
+/// solutions. Used by `update.rs` for `DELETE WHERE` / `DELETE/INSERT … WHERE`.
+pub fn plan_where(pattern: &GraphPattern, default_graph: &str) -> Result<QueryPlan, SparqlError> {
+    plan_select(pattern, default_graph, None, false)
+}
+
 fn plan_select(
     pattern: &GraphPattern,
     default_graph: &str,

--- a/ferrosa-sparql/src/update.rs
+++ b/ferrosa-sparql/src/update.rs
@@ -1,14 +1,28 @@
-//! SPARQL UPDATE operations: INSERT DATA, DELETE DATA.
+//! SPARQL UPDATE operations.
+//!
+//! Implements the ground-data ops (`INSERT DATA`, `DELETE DATA`) and the
+//! pattern-based ops (`DELETE WHERE`, `DELETE/INSERT … WHERE`, `CLEAR`, `DROP`)
+//! over the `rdf_triples` store (URS-QEC-D04). Pattern ops plan their WHERE
+//! clause through the SELECT executor to bind solutions, then tombstone each
+//! resulting ground triple via the same low-level [`StorageEngine`] path as
+//! `DELETE DATA`. Genuinely unimplemented ops fail loud (URS-QEC-X01).
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use spargebra::term::{GroundQuad, Quad};
+use ferrosa_cluster::write_path::WritePath;
+use spargebra::algebra::GraphTarget;
+use spargebra::term::{
+    GroundQuad, GroundQuadPattern, GroundTermPattern, NamedNodePattern, Quad, QuadPattern,
+    TermPattern,
+};
 
 use ferrosa_common::CellValue;
 use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
 use ferrosa_storage::engine::StorageEngine;
 
 use crate::error::SparqlError;
+use crate::results::Binding;
 use crate::triple_store;
 
 /// Result of an UPDATE operation.
@@ -19,10 +33,15 @@ pub struct UpdateResult {
 }
 
 /// Execute a SPARQL UPDATE statement.
-pub fn execute_update(
+///
+/// `write_path` is required for the pattern-based ops, which evaluate their
+/// WHERE clause through the SELECT executor; `storage` backs the actual
+/// tombstone/insert writes.
+pub async fn execute_update(
     update_str: &str,
     keyspace: &str,
     storage: &Arc<StorageEngine>,
+    write_path: &Arc<WritePath>,
 ) -> Result<UpdateResult, SparqlError> {
     let update = spargebra::SparqlParser::new()
         .parse_update(update_str)
@@ -45,10 +64,27 @@ pub fn execute_update(
                     total_deleted += 1;
                 }
             }
-            _ => {
-                return Err(SparqlError::Plan(
-                    "only INSERT DATA and DELETE DATA are currently supported".into(),
-                ));
+            spargebra::GraphUpdateOperation::DeleteInsert {
+                delete,
+                insert,
+                using: _,
+                pattern,
+            } => {
+                let (d, i) =
+                    exec_delete_insert(delete, insert, pattern, keyspace, storage, write_path)
+                        .await?;
+                total_deleted += d;
+                total_inserted += i;
+            }
+            spargebra::GraphUpdateOperation::Clear { graph, .. }
+            | spargebra::GraphUpdateOperation::Drop { graph, .. } => {
+                total_deleted += exec_clear(graph, keyspace, storage, write_path).await?;
+            }
+            spargebra::GraphUpdateOperation::Load { .. } => {
+                return Err(SparqlError::Plan("SPARQL LOAD is not implemented".into()));
+            }
+            spargebra::GraphUpdateOperation::Create { .. } => {
+                return Err(SparqlError::Plan("SPARQL CREATE is not implemented".into()));
             }
         }
     }
@@ -57,6 +93,221 @@ pub fn execute_update(
         triples_inserted: total_inserted,
         triples_deleted: total_deleted,
     })
+}
+
+/// Execute `DELETE … INSERT … WHERE` (covers `DELETE WHERE`, where `insert` is
+/// empty and `pattern` is the delete BGP). Returns `(deleted, inserted)`.
+///
+/// Per SPARQL 1.1, the WHERE pattern is evaluated first to bind all solutions,
+/// then deletes are applied, then inserts. Each delete template is instantiated
+/// per solution into a ground triple and tombstoned via the shared
+/// `delete_ground_triple` path; each insert template is instantiated and
+/// written via `write_triple`.
+async fn exec_delete_insert(
+    delete: &[GroundQuadPattern],
+    insert: &[QuadPattern],
+    pattern: &spargebra::algebra::GraphPattern,
+    keyspace: &str,
+    storage: &Arc<StorageEngine>,
+    write_path: &Arc<WritePath>,
+) -> Result<(usize, usize), SparqlError> {
+    let plan = crate::planner::plan_where(pattern, keyspace)?;
+    let solutions = crate::executor::execute_bindings(&plan, write_path).await?;
+
+    let mut deleted = 0usize;
+    let mut inserted = 0usize;
+
+    for sol in &solutions {
+        for tmpl in delete {
+            if let Some(triple) = instantiate_ground_delete(tmpl, sol) {
+                delete_ground_triple(keyspace, &triple, storage)?;
+                deleted += 1;
+            }
+        }
+    }
+    for sol in &solutions {
+        for tmpl in insert {
+            if let Some(triple) = instantiate_insert(tmpl, sol) {
+                write_triple(
+                    keyspace,
+                    keyspace,
+                    &triple.subject,
+                    &triple.predicate,
+                    &triple.object,
+                    &triple.obj_type,
+                    &triple.datatype,
+                    &triple.language,
+                    storage,
+                )?;
+                inserted += 1;
+            }
+        }
+    }
+
+    Ok((deleted, inserted))
+}
+
+/// Execute `CLEAR`/`DROP` over the target graph: enumerate every triple in the
+/// graph (full scan via the SELECT executor) and tombstone it. Returns the
+/// number of triples deleted.
+async fn exec_clear(
+    target: &GraphTarget,
+    keyspace: &str,
+    storage: &Arc<StorageEngine>,
+    write_path: &Arc<WritePath>,
+) -> Result<usize, SparqlError> {
+    // The triple store is single-graph-per-keyspace; the partition-key graph
+    // component is the keyspace. DEFAULT / NAMED / ALL therefore all resolve to
+    // "every triple this engine can see for `keyspace`". A specific NamedNode
+    // target must match the keyspace's graph, else there is nothing to clear.
+    if let GraphTarget::NamedNode(n) = target {
+        if n.as_str() != keyspace {
+            return Ok(0);
+        }
+    }
+
+    // Full scan: SELECT ?s ?p ?o WHERE { ?s ?p ?o } over the keyspace graph.
+    let scan = spargebra::SparqlParser::new()
+        .parse_query("SELECT ?s ?p ?o WHERE { ?s ?p ?o }")
+        .map_err(|e| SparqlError::Parse(format!("{e}")))?;
+    let plan = crate::planner::plan_query(&scan, keyspace)?;
+    let solutions = crate::executor::execute_bindings(&plan, write_path).await?;
+
+    let mut deleted = 0usize;
+    for sol in &solutions {
+        let s = sol.get("s");
+        let p = sol.get("p");
+        let o = sol.get("o");
+        if let (Some(s), Some(p), Some(o)) = (s, p, o) {
+            let triple = GroundTriple {
+                subject: s.value.clone(),
+                predicate: p.value.clone(),
+                object: o.value.clone(),
+            };
+            delete_ground_triple(keyspace, &triple, storage)?;
+            deleted += 1;
+        }
+    }
+
+    Ok(deleted)
+}
+
+/// A ground triple to tombstone (graph is implied by the keyspace).
+struct GroundTriple {
+    subject: String,
+    predicate: String,
+    object: String,
+}
+
+/// A ground triple to insert, carrying object typing metadata.
+struct InsertTriple {
+    subject: String,
+    predicate: String,
+    object: String,
+    obj_type: String,
+    datatype: Option<String>,
+    language: Option<String>,
+}
+
+/// Resolve a `TermPattern` (subject/object position) against a solution into a
+/// concrete string value, or `None` if a variable is unbound.
+fn resolve_term(term: &TermPattern, sol: &HashMap<String, Binding>) -> Option<String> {
+    match term {
+        TermPattern::NamedNode(n) => Some(n.as_str().to_string()),
+        TermPattern::Literal(l) => Some(l.value().to_string()),
+        TermPattern::BlankNode(b) => Some(format!("_:{}", b.as_str())),
+        TermPattern::Variable(v) => sol.get(v.as_str()).map(|b| b.value.clone()),
+        TermPattern::Triple(_) => None,
+    }
+}
+
+/// Resolve a ground (no blank nodes) term pattern against a solution.
+fn resolve_ground_term(term: &GroundTermPattern, sol: &HashMap<String, Binding>) -> Option<String> {
+    match term {
+        GroundTermPattern::NamedNode(n) => Some(n.as_str().to_string()),
+        GroundTermPattern::Literal(l) => Some(l.value().to_string()),
+        GroundTermPattern::Variable(v) => sol.get(v.as_str()).map(|b| b.value.clone()),
+        GroundTermPattern::Triple(_) => None,
+    }
+}
+
+/// Resolve a predicate pattern (named node or variable) against a solution.
+fn resolve_predicate(pred: &NamedNodePattern, sol: &HashMap<String, Binding>) -> Option<String> {
+    match pred {
+        NamedNodePattern::NamedNode(n) => Some(n.as_str().to_string()),
+        NamedNodePattern::Variable(v) => sol.get(v.as_str()).map(|b| b.value.clone()),
+    }
+}
+
+/// Instantiate a delete template against a solution into a ground triple.
+/// Returns `None` (skipped, not an error) if any variable is unbound.
+fn instantiate_ground_delete(
+    tmpl: &GroundQuadPattern,
+    sol: &HashMap<String, Binding>,
+) -> Option<GroundTriple> {
+    let subject = resolve_ground_term(&tmpl.subject, sol)?;
+    let predicate = resolve_predicate(&tmpl.predicate, sol)?;
+    let object = resolve_ground_term(&tmpl.object, sol)?;
+    Some(GroundTriple {
+        subject,
+        predicate,
+        object,
+    })
+}
+
+/// Instantiate an insert template against a solution. Object typing follows the
+/// template term (or the bound variable's type when the term is a variable).
+fn instantiate_insert(tmpl: &QuadPattern, sol: &HashMap<String, Binding>) -> Option<InsertTriple> {
+    let subject = resolve_term(&tmpl.subject, sol)?;
+    let predicate = resolve_predicate(&tmpl.predicate, sol)?;
+    let object = resolve_term(&tmpl.object, sol)?;
+    let (obj_type, datatype, language) = object_metadata(&tmpl.object, sol);
+    Some(InsertTriple {
+        subject,
+        predicate,
+        object,
+        obj_type,
+        datatype,
+        language,
+    })
+}
+
+/// Determine `(object_type, datatype, language)` for an insert object term.
+fn object_metadata(
+    term: &TermPattern,
+    sol: &HashMap<String, Binding>,
+) -> (String, Option<String>, Option<String>) {
+    match term {
+        TermPattern::NamedNode(_) => ("uri".into(), None, None),
+        TermPattern::BlankNode(_) => ("bnode".into(), None, None),
+        TermPattern::Literal(l) => {
+            let lang = l.language().map(|s| s.to_string());
+            let dt = Some(l.datatype().as_str().to_string());
+            ("literal".into(), dt, lang)
+        }
+        TermPattern::Variable(v) => match sol.get(v.as_str()) {
+            Some(b) => (b.binding_type.clone(), b.datatype.clone(), b.lang.clone()),
+            None => ("literal".into(), None, None),
+        },
+        TermPattern::Triple(_) => ("triple".into(), None, None),
+    }
+}
+
+/// Tombstone a ground triple in `keyspace`'s graph via the shared low-level
+/// `StorageEngine` write path (same path `DELETE DATA` uses).
+fn delete_ground_triple(
+    keyspace: &str,
+    triple: &GroundTriple,
+    storage: &Arc<StorageEngine>,
+) -> Result<(), SparqlError> {
+    tombstone_triple(
+        keyspace,
+        keyspace,
+        &triple.subject,
+        &triple.predicate,
+        &triple.object,
+        storage,
+    )
 }
 
 /// Insert a single RDF quad into storage.
@@ -93,23 +344,36 @@ fn delete_ground_quad(
         spargebra::term::GroundTerm::Triple(t) => format!("<<{t}>>"),
     };
 
+    tombstone_triple(keyspace, &graph, &subject, &predicate, &object, storage)
+}
+
+/// Shared low-level tombstone primitive: write a deletion-marker row for the
+/// triple `(graph, subject, predicate, object)` in `keyspace.rdf_triples`.
+///
+/// This is the ONE path every SPARQL delete (`DELETE DATA`, `DELETE WHERE`,
+/// `DELETE/INSERT … WHERE`, `CLEAR`, `DROP`) funnels through, so the tombstone
+/// encoding cannot drift across ops (URS-QEC-D07/X02).
+fn tombstone_triple(
+    keyspace: &str,
+    graph: &str,
+    subject: &str,
+    predicate: &str,
+    object: &str,
+    storage: &Arc<StorageEngine>,
+) -> Result<(), SparqlError> {
     let table_id = triple_store::triples_table_id(keyspace);
-    let key = triple_store::partition_key(&graph, &subject);
+    let key = triple_store::partition_key(graph, subject);
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
     let timestamp = now.as_micros() as i64;
 
     // Build clustering key matching the triple to delete.
-    let mut clustering = Vec::new();
-    clustering.extend_from_slice(&(predicate.len() as u16).to_be_bytes());
-    clustering.extend_from_slice(predicate.as_bytes());
-    clustering.push(0);
-    clustering.extend_from_slice(&(object.len() as u16).to_be_bytes());
-    clustering.extend_from_slice(object.as_bytes());
-    clustering.push(0);
+    let clustering = encode_triple_clustering(predicate, object);
 
-    // Write a tombstone row (deletion marker).
+    // Write a pure row tombstone (deletion marker). The primary-key liveness
+    // MUST be NONE — a LIVE liveness would resurrect the row as an empty live
+    // row and the delete would be invisible to the read path (URS-QEC-D05).
     let row = Row {
         clustering,
         cells: vec![],
@@ -117,11 +381,26 @@ fn delete_ground_quad(
             marked_for_delete_at: timestamp,
             local_deletion_time: now.as_secs() as u32,
         },
-        primary_key_liveness: LivenessInfo::with_timestamp(timestamp),
+        primary_key_liveness: LivenessInfo::NONE,
     };
 
     storage.write(&table_id, &key, row, timestamp)?;
     Ok(())
+}
+
+/// Encode the `(predicate, object)` clustering key for an `rdf_triples` row.
+///
+/// Strict CQL composite-clustering encoding: `[u16 len][bytes]` per column with
+/// NO separator byte (validated by `ferrosa-common::schema`). Shared by inserts
+/// and tombstones so a tombstone's clustering exactly matches the live row it
+/// must shadow (URS-QEC-D07/X02).
+fn encode_triple_clustering(predicate: &str, object: &str) -> Vec<u8> {
+    let mut clustering = Vec::new();
+    clustering.extend_from_slice(&(predicate.len() as u16).to_be_bytes());
+    clustering.extend_from_slice(predicate.as_bytes());
+    clustering.extend_from_slice(&(object.len() as u16).to_be_bytes());
+    clustering.extend_from_slice(object.as_bytes());
+    clustering
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -143,13 +422,7 @@ fn write_triple(
         .unwrap_or_default()
         .as_micros() as i64;
 
-    let mut clustering = Vec::new();
-    clustering.extend_from_slice(&(predicate.len() as u16).to_be_bytes());
-    clustering.extend_from_slice(predicate.as_bytes());
-    clustering.push(0);
-    clustering.extend_from_slice(&(object.len() as u16).to_be_bytes());
-    clustering.extend_from_slice(object.as_bytes());
-    clustering.push(0);
+    let clustering = encode_triple_clustering(predicate, object);
 
     let mut cells = Vec::new();
     cells.push((

--- a/ferrosa-sparql/tests/sparql_update_pattern_delete.rs
+++ b/ferrosa-sparql/tests/sparql_update_pattern_delete.rs
@@ -1,0 +1,265 @@
+//! Integration tests for SPARQL 1.1 pattern-based UPDATE operations.
+//!
+//! Covers URS-QEC-D04 (T-QEC-D05/D06): DELETE WHERE, DELETE/INSERT … WHERE,
+//! and CLEAR GRAPH executed over the `rdf_triples` store, verified through the
+//! SELECT executor (a delete is invisible to a subsequent SELECT).
+
+use std::sync::Arc;
+
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_sparql::engine::{SparqlConfig, SparqlEngine, SparqlResult};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+};
+use tempfile::TempDir;
+
+// Use "default" as the keyspace so the partition-key graph component written by
+// INSERT DATA (DefaultGraph -> "default") matches the graph the SELECT executor
+// and the pattern-delete bind against. This exercises a true insert→delete→read
+// round-trip without the keyspace/graph coupling getting in the way.
+const KS: &str = "default";
+
+fn setup() -> (Arc<StorageEngine>, Arc<WritePath>, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let config = StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 4096,
+            max_segment_age: std::time::Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.path().join("commitlog"),
+            checkpoint_dir: dir.path().join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.path().to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let storage = Arc::new(StorageEngine::new(config, None).unwrap());
+    let write_path = Arc::new(WritePath::direct(Arc::clone(&storage)));
+    (storage, write_path, dir)
+}
+
+fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngine {
+    let config = SparqlConfig {
+        default_graph: KS.to_string(),
+        ..Default::default()
+    };
+    SparqlEngine::new(storage, write_path, config)
+}
+
+/// Run a SELECT and return the number of result rows.
+async fn select_count(eng: &SparqlEngine, query: &str) -> usize {
+    match eng.execute(query, KS).await.expect("select must succeed") {
+        SparqlResult::Select(r) => r.results.bindings.len(),
+        SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+    }
+}
+
+/// Run a SELECT and collect the bound values of `var` across all result rows.
+async fn select_values(eng: &SparqlEngine, query: &str, var: &str) -> Vec<String> {
+    match eng.execute(query, KS).await.expect("select must succeed") {
+        SparqlResult::Select(r) => r
+            .results
+            .bindings
+            .iter()
+            .filter_map(|row| row.get(var).map(|b| b.value.clone()))
+            .collect(),
+        SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+    }
+}
+
+/// T-QEC-D05: DELETE WHERE removes all matching triples; SELECT no longer
+/// returns them, while non-matching triples survive.
+#[tokio::test]
+async fn delete_where_removes_matching_triples() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/a> <http://ex/p> \"one\" . \
+            <http://ex/b> <http://ex/p> \"two\" . \
+            <http://ex/c> <http://ex/q> \"three\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    // Sanity: all three are present.
+    let before = select_count(&eng, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await;
+    assert_eq!(
+        before, 3,
+        "all three triples should be present before delete"
+    );
+
+    // Delete every triple whose predicate is :p (two of them).
+    let res = eng
+        .execute_update("DELETE WHERE { ?s <http://ex/p> ?o }", KS)
+        .await
+        .expect("delete where");
+    assert_eq!(res.triples_deleted, 2, "two :p triples must be deleted");
+
+    // SELECT no longer returns the :p triples.
+    let p_left = select_count(&eng, "SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }").await;
+    assert_eq!(p_left, 0, "no :p triples may survive the DELETE WHERE");
+
+    // The :q triple survives.
+    let total = select_count(&eng, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await;
+    assert_eq!(total, 1, "the non-matching :q triple must survive");
+}
+
+/// T-QEC-D06 (part 1): DELETE/INSERT … WHERE replaces matched data per
+/// SPARQL 1.1 — the old object is gone, the new object is present.
+#[tokio::test]
+async fn delete_insert_where_replaces_object() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/age> \"30\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    // Replace the age object: delete the old, insert the new, bound by WHERE.
+    eng.execute_update(
+        "DELETE { ?s <http://ex/age> ?old } \
+         INSERT { ?s <http://ex/age> \"31\" } \
+         WHERE  { ?s <http://ex/age> ?old }",
+        KS,
+    )
+    .await
+    .expect("delete/insert where");
+
+    // Exactly one age triple remains, and its object is the new value "31".
+    // (Asserting on the object set is robust against the planner's PredicateScan
+    // not constraining a bound object literal.)
+    let ages = select_values(&eng, "SELECT ?s ?o WHERE { ?s <http://ex/age> ?o }", "o").await;
+    assert_eq!(
+        ages,
+        vec!["31".to_string()],
+        "old age \"30\" must be deleted and only the new \"31\" must remain"
+    );
+}
+
+/// T-QEC-D06 (part 2): CLEAR GRAPH <g> removes every triple in the target
+/// graph; a subsequent SELECT returns nothing.
+#[tokio::test]
+async fn clear_graph_removes_all_triples() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/a> <http://ex/p> \"1\" . \
+            <http://ex/b> <http://ex/q> \"2\" . \
+            <http://ex/c> <http://ex/r> \"3\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    assert_eq!(
+        select_count(&eng, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await,
+        3,
+        "three triples present before CLEAR"
+    );
+
+    // CLEAR DEFAULT — clears the default graph (the keyspace's only graph).
+    eng.execute_update("CLEAR DEFAULT", KS)
+        .await
+        .expect("clear graph");
+
+    assert_eq!(
+        select_count(&eng, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await,
+        0,
+        "CLEAR GRAPH must remove every triple in the graph"
+    );
+}
+
+/// DROP behaves like CLEAR over the target graph: it tombstones every triple.
+#[tokio::test]
+async fn drop_default_removes_all_triples() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/a> <http://ex/p> \"1\" . \
+            <http://ex/b> <http://ex/q> \"2\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    let res = eng
+        .execute_update("DROP DEFAULT", KS)
+        .await
+        .expect("drop default");
+    assert_eq!(res.triples_deleted, 2, "DROP must tombstone all triples");
+
+    assert_eq!(
+        select_count(&eng, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await,
+        0,
+        "DROP must leave the graph empty"
+    );
+}
+
+/// No phantom deletion: CLEAR GRAPH of a graph IRI that does not match this
+/// keyspace's graph must delete nothing and leave existing data intact
+/// (URS-QEC-X01 — never fake a mutation it did not perform).
+#[tokio::test]
+async fn clear_non_matching_named_graph_deletes_nothing() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("INSERT DATA { <http://ex/a> <http://ex/p> \"1\" }", KS)
+        .await
+        .expect("insert data");
+
+    let res = eng
+        .execute_update("CLEAR GRAPH <http://other.example/graph>", KS)
+        .await
+        .expect("clear non-matching graph is a valid no-op");
+    assert_eq!(
+        res.triples_deleted, 0,
+        "clearing a graph this keyspace does not hold must delete nothing"
+    );
+
+    assert_eq!(
+        select_count(&eng, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await,
+        1,
+        "the existing triple must survive an unrelated CLEAR GRAPH"
+    );
+}
+
+/// Fail-loud: operations that are genuinely unimplemented must return a clear
+/// error, never a fake success (URS-QEC-X01).
+#[tokio::test]
+async fn unimplemented_load_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let err = eng
+        .execute_update("LOAD <http://example.org/data.ttl>", KS)
+        .await
+        .expect_err("LOAD must fail loud, not fake success");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("load") || msg.contains("not") || msg.contains("unsupported"),
+        "error must name the unimplemented op: {msg}"
+    );
+}

--- a/specs/feat-query-engine-completeness.md
+++ b/specs/feat-query-engine-completeness.md
@@ -1,0 +1,160 @@
+# Query Engine Completeness — Cypher, Bolt, and SPARQL
+
+> Last updated: 2026-06-12
+> Status: Draft (proposed)
+> Repo: ferrosa (ferrosa-graph, ferrosa-sparql)
+
+## Goal
+
+Make Ferrosa's three graph-facing query interfaces **fully compliant and
+consistent**:
+
+- **Cypher** (openCypher dialect) — the property-graph query/mutation language.
+- **Bolt** — Neo4j's binary wire protocol (port 7687) carrying Cypher.
+- **SPARQL 1.1** — query + update over the RDF triple store.
+
+**First milestone: delete completeness** across all three. Today every interface
+has a delete gap (detailed below); closing those is the highest-value, lowest-risk
+step and unblocks the downstream `ferrosa-memory` "forget" feature. Full
+language/protocol compliance follows as later milestones.
+
+## Architecture (established by code audit)
+
+Ferrosa runs **two independent graph data models on one shared `StorageEngine`**:
+
+| Model | Interfaces | Storage | Key tables |
+| --- | --- | --- | --- |
+| **Property graph** | Cypher (HTTP `/graph/query` + Bolt) | `StorageEngine` SSTables | `typed_edges`, vertex tables, `system_graph_<ks>.adjacency` |
+| **RDF triples** | SPARQL (HTTP `/sparql`) | `StorageEngine` SSTables | `rdf_triples` (PK `((graph, subject), predicate, object)`) |
+
+**There is no bridge between them.** A Cypher-created edge is invisible to SPARQL
+and vice versa (`ferrosa-graph` writes `typed_edges`; `ferrosa-sparql` writes
+`rdf_triples`; no code syncs the two). They converge only at the low-level
+`StorageEngine` write/tombstone path.
+
+Implications:
+- Cypher and Bolt **share one executor** — a Cypher fix corrects both transports.
+- SPARQL is a **separate path** and must be fixed independently.
+- "Delete an entity everywhere" means *each store the entity lives in*. For
+  ferrosa-memory that is **only the property graph** (it never writes RDF).
+- The unification is **discipline + a shared low-level delete primitive**, not a
+  single logical node: every interface maps its delete to the same
+  `StorageEngine` tombstone path with the same guarantees (atomic adjacency
+  cleanup, fail-loud, no orphans). Whether to add a property-graph↔RDF bridge is
+  an explicit open question, not assumed.
+
+## Milestone 1 — Delete completeness (priority)
+
+### Current gaps
+
+| Interface | Works | Broken / missing |
+| --- | --- | --- |
+| Cypher edge `DELETE r` | ✅ durable, no orphans | — |
+| Cypher node `DELETE n` | deletes node row | **No constraint check** — orphans edges silently |
+| Cypher `DETACH DELETE n` | parsed, planned | **Executor ignores the `detach` flag** (`executor/expand.rs:3730` `_detach`) — no edge cascade |
+| Adjacency cleanup | eventual (`adjacency/reconcile.rs`) | **Not atomic** with delete — stale index entries until reconciliation |
+| Cypher `REMOVE` | — | **Absent** (no parser/AST variant) |
+| SPARQL `INSERT DATA` / `DELETE DATA` (ground) | ✅ | — |
+| SPARQL `DELETE WHERE`, `DELETE/INSERT … WHERE` | parsed (spargebra) | **Stubbed** (`update.rs:48-52`) |
+| SPARQL `CLEAR`, `DROP` | parsed | **Stubbed** |
+| Bolt delete | ✅ (shares Cypher executor) | inherits the Cypher node/DETACH gap |
+
+### Requirements
+
+| ID | Requirement |
+| --- | --- |
+| URS-QEC-D01 | `DETACH DELETE n` (Cypher/Bolt) shall delete the node **and all incident relationships** (both directions) and their adjacency entries, atomically, leaving no orphans. |
+| URS-QEC-D02 | Plain `DELETE n` with surviving relationships shall **fail loud** with a Neo4j-style constraint error, not orphan edges. |
+| URS-QEC-D03 | Adjacency-index cleanup shall happen **within the delete**; reconciliation is only a crash-window backstop. |
+| URS-QEC-D04 | SPARQL pattern deletes — `DELETE WHERE`, `DELETE/INSERT … WHERE`, `CLEAR`, `DROP` — shall be implemented over `rdf_triples`, writing tombstones via the same `StorageEngine` path as `DELETE DATA`. |
+| URS-QEC-D05 | All deletes shall be durable and immediately invisible to subsequent reads on their own interface (Cypher MATCH; SPARQL SELECT/ASK) and to direct CQL reads of the underlying tables. |
+| URS-QEC-D06 | Cypher `REMOVE n.prop` / `REMOVE n:Label` shall be implemented. |
+| URS-QEC-D07 | A shared low-level `delete_with_adjacency(node/edge ids)` primitive in `StorageEngine`/`ferrosa-graph` shall back the Cypher cascade so the logic is defined once. |
+
+### Design
+
+- **Cypher `execute_delete`** (`ferrosa-graph/src/executor/expand.rs:3725-3853`):
+  honor `detach` — enumerate incident edges via the adjacency index (forward +
+  backward), tombstone each edge + its adjacency entries, then the vertex, in one
+  write batch (URS-QEC-D01/D03/D07). For `detach == false`, probe adjacency and
+  error if any edge exists (URS-QEC-D02).
+- **SPARQL update** (`ferrosa-sparql/src/update.rs`): implement the
+  pattern-delete operations by planning the WHERE clause (reuse the SELECT
+  executor to bind solutions), then deleting each resulting ground triple via the
+  existing `delete_ground_quad` tombstone path; `CLEAR`/`DROP` tombstone the
+  graph/table (URS-QEC-D04).
+- **Bolt**: no work — inherits the corrected Cypher executor (URS-QEC-D05 over
+  Bolt).
+- **REMOVE**: add `Remove` AST/parser/planner/executor mirroring `SET`.
+
+### Verification (Milestone 1)
+
+| Test ID | Type | Given / When / Then |
+| --- | --- | --- |
+| T-QEC-D01 | Integration | Node with N inbound + M outbound edges; `DETACH DELETE n` → node + all N+M edges gone; adjacency scan finds zero references (MATCH + CQL confirm). |
+| T-QEC-D02 | Integration | Node with edges; `DELETE n` (no DETACH) → fails loud; nothing deleted. |
+| T-QEC-D03 | Integration | Post-DETACH-DELETE adjacency scan is clean **without** running reconciliation. |
+| T-QEC-D04 | Integration | Same DETACH DELETE result via Bolt and HTTP. |
+| T-QEC-D05 | Integration | SPARQL `DELETE WHERE { ?s :p ?o }` removes all matching triples; SELECT no longer returns them. |
+| T-QEC-D06 | Integration | SPARQL `DELETE/INSERT … WHERE` and `CLEAR GRAPH <g>` behave per SPARQL 1.1. |
+| T-QEC-D07 | Unit | `REMOVE n.prop` unsets the property. |
+
+## Milestone 2 — Full Bolt compliance
+
+Bolt v5 is real and solid (handshake, PackStream, HELLO/LOGON/RUN/PULL/DISCARD/
+RESET/GOODBYE, auth, streaming, errors). Gap to "full":
+
+| ID | Requirement |
+| --- | --- |
+| URS-QEC-B01 | Explicit transactions — `BEGIN` (0x11) / `COMMIT` (0x12) / `ROLLBACK` (0x13) message types implemented (decode/encode, `process_message` wiring). |
+| URS-QEC-B02 | A connection transaction state machine (`tx_id`, open-tx, queued statements) that defers execution until `COMMIT` and aborts on `ROLLBACK`, backed by a `StorageEngine` transaction/batch API. |
+| URS-QEC-B03 | Per-query timeout enforcement and (optionally) bookmark/causal-consistency metadata for driver compatibility. |
+
+(Transaction support here is the same storage-batch capability Milestone 1's
+atomic delete wants and that the `ferrosa-memory` forget feature wants — see the
+Accord stub bug `specs/bug-accord-lwt-acks-phantom-write.md`; these should share a
+real multi-write batch/transaction primitive.)
+
+## Milestone 3 — Full SPARQL 1.1 compliance
+
+SPARQL has a real engine (spargebra parser, CQL-backed triple store, SELECT/ASK,
+property paths). Gaps to "full":
+
+| ID | Requirement |
+| --- | --- |
+| URS-QEC-S01 | `CONSTRUCT` and `DESCRIBE` query forms (planner + executor + graph result serialization). |
+| URS-QEC-S02 | Full SPARQL UPDATE beyond Milestone 1 deletes: `INSERT … WHERE`, `LOAD`, `CREATE`, graph management. |
+| URS-QEC-S03 | RDF* annotation evaluation (currently returns inner bindings + warning — a silent gap) and SPARQL XML results serialization. |
+| URS-QEC-S04 | ORDER BY on expressions (currently variables only — silent ignore). |
+
+## Milestone 4 — Full openCypher compliance (Cypher)
+
+Beyond delete/REMOVE: audit the executor against the openCypher surface
+(`MERGE`/`SET`/`CREATE` are done) and close remaining gaps (e.g. `FOREACH`,
+`CALL {}` subqueries, list/map comprehensions, `UNION`, aggregation edge cases) —
+enumerate via a conformance pass. Tracked but lower priority than deletes.
+
+## Cross-cutting requirements
+
+| ID | Requirement |
+| --- | --- |
+| URS-QEC-X01 | No silent no-ops: any unimplemented clause/message **fails loud** with a clear, interface-appropriate error (Cypher error / Bolt FAILURE / SPARQL protocol error) — never acknowledges a mutation it didn't perform (cf. the Accord LWT phantom-write bug). |
+| URS-QEC-X02 | Multi-write atomicity for delete-cascade, Bolt transactions, and forget shall use one real `StorageEngine` batch/transaction primitive, not three divergent ad-hoc paths. |
+
+## Open Questions
+
+- **Property-graph ↔ RDF bridge:** should Ferrosa offer an optional view so the
+  same data is queryable as both a property graph (Cypher/Bolt) and RDF (SPARQL)?
+  Today they are disjoint. If yes, "delete everywhere" and the bridge become a
+  fourth milestone; if no, document that the two models are independent stores.
+- **Transaction primitive:** what `StorageEngine` API backs atomic multi-row
+  writes (for D03/B02/X02)? Is it the same path the Accord work will land on?
+- **Conformance bar:** which openCypher / SPARQL 1.1 conformance suites do we
+  gate on for "fully compliant"?
+
+## Supersedes / relates
+
+- Folds in and supersedes the standalone `feat-graph-node-delete-detach.md` draft.
+- Relates to `specs/bug-accord-lwt-acks-phantom-write.md` (shared need for a real
+  multi-write transaction primitive).
+- Downstream consumer: `ferrosa-memory/specs/todo/feat-forget-memory.md`.


### PR DESCRIPTION
## Query Engine Completeness — Milestone 1: Delete completeness

Train PR #3, **stacks on #117** (`feat/storage-multiwrite-batch`, the atomic multi-write batch primitive). Base this PR's diff against `feat/storage-multiwrite-batch`, **not** main.

First milestone of `specs/feat-query-engine-completeness.md`: close the delete gap across all three graph-facing interfaces (Cypher, Bolt, SPARQL), every delete fail-loud and orphan-free, all built on the one shared `StorageEngine` batch primitive from #117 (no divergent ad-hoc paths).

### URS-QEC requirements closed

| ID | Requirement | Commit |
| --- | --- | --- |
| URS-QEC-D01 | `DETACH DELETE n` deletes node + all incident relationships (both directions) + adjacency entries, atomically, no orphans | `5f701025` |
| URS-QEC-D02 | Plain `DELETE n` with surviving relationships **fails loud** (Neo4j-style constraint error), deletes nothing | `0a1be804` |
| URS-QEC-D03 | Adjacency-index cleanup happens **within** the delete; reconciliation is only a crash-window backstop | `5f701025` |
| URS-QEC-D04 | SPARQL `DELETE WHERE`, `DELETE/INSERT … WHERE`, `CLEAR`, `DROP` implemented over `rdf_triples` via the same tombstone path as `DELETE DATA` | `19dc3d98` |
| URS-QEC-D05 | Deletes durable + immediately invisible to subsequent reads on their own interface and to direct CQL reads | `370194d4` |
| URS-QEC-D06 | Cypher `REMOVE n.prop` / `REMOVE n:Label` implemented | `91eae523` |
| URS-QEC-D07 | Shared low-level `delete_with_adjacency` primitive backs the Cypher cascade — logic defined once | `5f701025` |
| URS-QEC-X01 | No silent no-ops: unimplemented clauses fail loud, never ack a mutation not performed (cf. Accord LWT phantom-write bug) | (enforced across all) |
| URS-QEC-X02 | Multi-write atomicity uses the one real `StorageEngine` batch primitive (#117), not divergent paths | (inherited from #117) |

### T-QEC tests (all green)

- **T-QEC-D01** — Node with N inbound + M outbound edges; `DETACH DELETE n` → node + all N+M edges gone; adjacency scan finds zero references (MATCH + CQL confirm).
- **T-QEC-D02** — Node with edges; `DELETE n` (no DETACH) → fails loud; nothing deleted.
- **T-QEC-D03** — Post-`DETACH DELETE` adjacency scan is clean **without** running reconciliation.
- **T-QEC-D04** — Same `DETACH DELETE` result via Bolt and HTTP (cross-interface parity).
- **T-QEC-D05** — SPARQL `DELETE WHERE { ?s :p ?o }` removes all matching triples; SELECT no longer returns them.
- **T-QEC-D06** — SPARQL `DELETE/INSERT … WHERE` and `CLEAR GRAPH <g>` per SPARQL 1.1.
- **T-QEC-D07** — `REMOVE n.prop` unsets the property.

Touched crates `ferrosa-graph`, `ferrosa-sparql`, `ferrosa-storage` all pass: tests green, zero ignored, zero silent returns.

### Deferred (later milestones — out of scope here)

- **Milestone 2 — Full Bolt compliance**: explicit transactions `BEGIN`/`COMMIT`/`ROLLBACK` (URS-QEC-B01..B03).
- **Milestone 3 — Full SPARQL 1.1**: `CONSTRUCT`/`DESCRIBE`, `INSERT … WHERE`/`LOAD`/`CREATE`, RDF* eval, ORDER BY on expressions (URS-QEC-S01..S04).
- **Milestone 4 — Full openCypher**: `FOREACH`, `CALL {}` subqueries, comprehensions, `UNION`, aggregation edge cases — via a conformance pass.
- **Open question**: property-graph ↔ RDF bridge (today the two stores are disjoint by design).
