### PR TITLE
feat(bolt): explicit transactions — query-engine milestone 2 (train PR #4, stacks on #119)

### DIFF
--- a/ferrosa-cql/src/error.rs
+++ b/ferrosa-cql/src/error.rs
@@ -54,6 +54,11 @@ pub enum CqlError {
     /// The connection handler should reply with an ERROR frame using the
     /// supported version so the driver falls back.
     ProtocolVersionMismatch { requested: u8, supported: u8 },
+    /// An explicit transaction exceeded its configured timeout and was aborted
+    /// (URS-QEC-B03). Reported as a write-timeout class error so drivers
+    /// classify it as a transient timeout; the message carries the budget and
+    /// the elapsed time. The transaction is aborted: nothing was persisted.
+    TransactionTimeout { timeout_ms: u64, elapsed_ms: u64 },
 }
 
 impl CqlError {
@@ -65,7 +70,7 @@ impl CqlError {
             Self::BadCredentials => 0x0100,
             Self::Unavailable { .. } => 0x1000,
             Self::Overloaded(_) => 0x1001,
-            Self::WriteTimeout { .. } => 0x1100,
+            Self::WriteTimeout { .. } | Self::TransactionTimeout { .. } => 0x1100,
             Self::ReadTimeout { .. } => 0x1200,
             Self::SyntaxError(_) => 0x2000,
             Self::Unauthorized(_) => 0x2100,
@@ -213,7 +218,23 @@ impl std::fmt::Display for CqlError {
                 "Invalid or unsupported protocol version ({requested}); \
                  the lowest supported version is 3 and the greatest is {supported}"
             ),
+            Self::TransactionTimeout {
+                timeout_ms,
+                elapsed_ms,
+            } => write!(
+                f,
+                "transaction timed out and was aborted: budget={timeout_ms}ms, \
+                 elapsed={elapsed_ms}ms; nothing was persisted"
+            ),
         }
+    }
+}
+
+impl CqlError {
+    /// `true` if this is a transaction-timeout error (URS-QEC-B03). Lets a
+    /// transport map a timed-out, aborted transaction to its own FAILURE class.
+    pub fn is_transaction_timeout(&self) -> bool {
+        matches!(self, Self::TransactionTimeout { .. })
     }
 }
 

--- a/ferrosa-cql/src/session.rs
+++ b/ferrosa-cql/src/session.rs
@@ -100,7 +100,7 @@ impl Default for TransactionState {
 ///   FAILS LOUD.
 /// * Reads inside the tx see the connection's own staged writes via
 ///   [`staged_ops`](Self::staged_ops).
-/// * [`commit`](Self::commit) materializes a [`BatchTxn`] from the engine's
+/// * [`commit`](Self::commit) materializes a `BatchTxn` from the engine's
 ///   `begin_batch()`, stages every queued op onto it, and calls
 ///   `BatchTxn::commit` — an **atomic, durable, all-or-nothing** apply. On any
 ///   engine error it returns `Err` and the connection has persisted *nothing*
@@ -228,7 +228,7 @@ impl ConnTxn {
 
     /// Atomically commit the staged batch via the storage primitive.
     ///
-    /// Opens a [`BatchTxn`] from `engine.begin_batch()`, stages every queued op,
+    /// Opens a `BatchTxn` from `engine.begin_batch()`, stages every queued op,
     /// and calls `BatchTxn::commit` (single atomic, durable apply). On engine
     /// error the connection state is still reset (the tx is over) but the `Err`
     /// is returned so the caller emits a Bolt `FAILURE` — the transaction is

--- a/ferrosa-cql/src/session.rs
+++ b/ferrosa-cql/src/session.rs
@@ -4,6 +4,8 @@
 //! transitions. Nested transactions are rejected. DDL inside transactions
 //! is rejected.
 
+use std::time::{Duration, Instant};
+
 use crate::ast::Statement;
 use crate::error::CqlError;
 use ferrosa_storage::{BatchOp, StorageEngine};
@@ -106,6 +108,18 @@ impl Default for TransactionState {
 /// * [`rollback`](Self::rollback) discards the staged ops (`BatchTxn::abort`
 ///   semantics — nothing was ever written).
 ///
+/// ## Timeout enforcement (URS-QEC-B03)
+///
+/// A transaction may be opened with a deadline via
+/// [`begin_with_timeout`](Self::begin_with_timeout) (Bolt's `tx_timeout`
+/// metadata). Once the deadline passes, the next [`stage`](Self::stage) or
+/// [`commit`](Self::commit) **aborts** the transaction (discards every staged
+/// write, closes the tx) and FAILS LOUD with [`CqlError::TransactionTimeout`].
+/// A timed-out `COMMIT` therefore persists *nothing* — the server never acks a
+/// transaction whose budget it blew (URS-QEC-X01, fail-loud, never fake). A
+/// transaction opened via plain [`begin`](Self::begin) has no deadline and
+/// never expires.
+///
 /// Staging holds an owned `Vec<BatchOp>` rather than a live `BatchTxn` so the
 /// machine does not borrow the engine across `RUN` round-trips; the borrowing
 /// `BatchTxn` is materialized only for the duration of `commit`.
@@ -115,6 +129,9 @@ pub struct ConnTxn {
     open: Option<u64>,
     /// Writes staged by `RUN`/`PULL` since `begin`, in submission order.
     staged: Vec<BatchOp>,
+    /// Per-transaction deadline. `Some((deadline, budget))` when the open tx was
+    /// started with a timeout; `None` for an unbounded transaction.
+    deadline: Option<(Instant, Duration)>,
 }
 
 impl ConnTxn {
@@ -133,8 +150,21 @@ impl ConnTxn {
         self.open
     }
 
-    /// Open an explicit transaction. FAILS LOUD on a nested `BEGIN`.
+    /// Open an explicit transaction with **no timeout** (unbounded). FAILS LOUD
+    /// on a nested `BEGIN`.
     pub fn begin(&mut self, tx_id: u64) -> Result<(), CqlError> {
+        self.begin_inner(tx_id, None)
+    }
+
+    /// Open an explicit transaction with a per-transaction `timeout`
+    /// (URS-QEC-B03; Bolt `tx_timeout`). After `timeout` elapses, the next
+    /// `stage`/`commit` aborts the tx and FAILS LOUD with
+    /// [`CqlError::TransactionTimeout`]. FAILS LOUD on a nested `BEGIN`.
+    pub fn begin_with_timeout(&mut self, tx_id: u64, timeout: Duration) -> Result<(), CqlError> {
+        self.begin_inner(tx_id, Some(timeout))
+    }
+
+    fn begin_inner(&mut self, tx_id: u64, timeout: Option<Duration>) -> Result<(), CqlError> {
         if self.open.is_some() {
             return Err(CqlError::Invalid(
                 "BEGIN received while a transaction is already open (nested transactions \
@@ -144,17 +174,49 @@ impl ConnTxn {
         }
         self.open = Some(tx_id);
         self.staged.clear();
+        self.deadline = timeout.map(|budget| (Instant::now() + budget, budget));
         Ok(())
     }
 
+    /// If the open transaction has a deadline that has passed, ABORT it (discard
+    /// staged writes, close the tx) and return the timeout error. Otherwise
+    /// `Ok(())`. This is the single enforcement point shared by `stage` and
+    /// `commit` so a timed-out transaction can never make progress.
+    fn check_deadline(&mut self) -> Result<(), CqlError> {
+        if let Some((deadline, budget)) = self.deadline {
+            let now = Instant::now();
+            if now >= deadline {
+                let elapsed = now.duration_since(deadline) + budget;
+                self.abort_state();
+                return Err(CqlError::TransactionTimeout {
+                    timeout_ms: budget.as_millis() as u64,
+                    elapsed_ms: elapsed.as_millis() as u64,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Reset the machine to the no-open-transaction state, discarding any staged
+    /// writes. Used by abort/commit/rollback — nothing staged is ever persisted
+    /// by this call.
+    fn abort_state(&mut self) {
+        self.staged.clear();
+        self.open = None;
+        self.deadline = None;
+    }
+
     /// Stage a write onto the open transaction's batch. FAILS LOUD if no
-    /// transaction is open (a `RUN` write must not silently escape the tx).
+    /// transaction is open (a `RUN` write must not silently escape the tx) or if
+    /// the transaction's timeout has already elapsed (URS-QEC-B03) — in which
+    /// case the transaction is aborted and nothing is staged.
     pub fn stage(&mut self, op: BatchOp) -> Result<(), CqlError> {
         if self.open.is_none() {
             return Err(CqlError::Invalid(
                 "write staged with no open explicit transaction".to_string(),
             ));
         }
+        self.check_deadline()?;
         self.staged.push(op);
         Ok(())
     }
@@ -179,10 +241,15 @@ impl ConnTxn {
                 "COMMIT received with no open explicit transaction".to_string(),
             ));
         }
+        // Enforce the per-tx timeout BEFORE persisting: a transaction whose
+        // budget has elapsed is aborted and FAILS LOUD — nothing is committed
+        // (URS-QEC-B03, fail-loud, never fake).
+        self.check_deadline()?;
         // Take ownership of the staged ops and close the tx regardless of
         // outcome — a commit attempt ends the transaction either way.
         let ops = std::mem::take(&mut self.staged);
         self.open = None;
+        self.deadline = None;
 
         let mut batch = engine.begin_batch();
         for op in ops {
@@ -203,8 +270,7 @@ impl ConnTxn {
                 "ROLLBACK received with no open explicit transaction".to_string(),
             ));
         }
-        self.staged.clear();
-        self.open = None;
+        self.abort_state();
         Ok(())
     }
 }

--- a/ferrosa-cql/src/session.rs
+++ b/ferrosa-cql/src/session.rs
@@ -6,6 +6,7 @@
 
 use crate::ast::Statement;
 use crate::error::CqlError;
+use ferrosa_storage::{BatchOp, StorageEngine};
 
 /// Transaction state for a CQL session.
 ///
@@ -80,6 +81,131 @@ impl TransactionState {
 impl Default for TransactionState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Per-connection **explicit-transaction state machine** (spec URS-QEC-B02).
+///
+/// This is the connection-level machine that backs Bolt
+/// `BEGIN` / `RUN` / `COMMIT` / `ROLLBACK` (and, in future, an analogous CQL
+/// explicit-transaction surface). It deliberately separates *staging* from
+/// *durability*:
+///
+/// * [`begin`](Self::begin) opens a transaction (assigns a `tx_id`, defers all
+///   execution); a second `begin` while open FAILS LOUD (no nested tx).
+/// * [`stage`](Self::stage) queues a [`BatchOp`] produced by a `RUN`/`PULL`
+///   write **without** touching durable storage. Staging outside an open tx
+///   FAILS LOUD.
+/// * Reads inside the tx see the connection's own staged writes via
+///   [`staged_ops`](Self::staged_ops).
+/// * [`commit`](Self::commit) materializes a [`BatchTxn`] from the engine's
+///   `begin_batch()`, stages every queued op onto it, and calls
+///   `BatchTxn::commit` — an **atomic, durable, all-or-nothing** apply. On any
+///   engine error it returns `Err` and the connection has persisted *nothing*
+///   (URS-QEC-X01: never ack a transaction we didn't persist).
+/// * [`rollback`](Self::rollback) discards the staged ops (`BatchTxn::abort`
+///   semantics — nothing was ever written).
+///
+/// Staging holds an owned `Vec<BatchOp>` rather than a live `BatchTxn` so the
+/// machine does not borrow the engine across `RUN` round-trips; the borrowing
+/// `BatchTxn` is materialized only for the duration of `commit`.
+#[derive(Debug, Default)]
+pub struct ConnTxn {
+    /// `Some(tx_id)` while a transaction is open; `None` otherwise.
+    open: Option<u64>,
+    /// Writes staged by `RUN`/`PULL` since `begin`, in submission order.
+    staged: Vec<BatchOp>,
+}
+
+impl ConnTxn {
+    /// A fresh connection with no open transaction.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `true` while a transaction is open.
+    pub fn is_open(&self) -> bool {
+        self.open.is_some()
+    }
+
+    /// The open transaction's id, if any.
+    pub fn tx_id(&self) -> Option<u64> {
+        self.open
+    }
+
+    /// Open an explicit transaction. FAILS LOUD on a nested `BEGIN`.
+    pub fn begin(&mut self, tx_id: u64) -> Result<(), CqlError> {
+        if self.open.is_some() {
+            return Err(CqlError::Invalid(
+                "BEGIN received while a transaction is already open (nested transactions \
+                 are not supported)"
+                    .to_string(),
+            ));
+        }
+        self.open = Some(tx_id);
+        self.staged.clear();
+        Ok(())
+    }
+
+    /// Stage a write onto the open transaction's batch. FAILS LOUD if no
+    /// transaction is open (a `RUN` write must not silently escape the tx).
+    pub fn stage(&mut self, op: BatchOp) -> Result<(), CqlError> {
+        if self.open.is_none() {
+            return Err(CqlError::Invalid(
+                "write staged with no open explicit transaction".to_string(),
+            ));
+        }
+        self.staged.push(op);
+        Ok(())
+    }
+
+    /// The connection's own staged writes (read-your-own-writes inside the tx).
+    pub fn staged_ops(&self) -> &[BatchOp] {
+        &self.staged
+    }
+
+    /// Atomically commit the staged batch via the storage primitive.
+    ///
+    /// Opens a [`BatchTxn`] from `engine.begin_batch()`, stages every queued op,
+    /// and calls `BatchTxn::commit` (single atomic, durable apply). On engine
+    /// error the connection state is still reset (the tx is over) but the `Err`
+    /// is returned so the caller emits a Bolt `FAILURE` — the transaction is
+    /// **not** acknowledged as committed (URS-QEC-X01, fail-loud, no partial).
+    ///
+    /// FAILS LOUD if no transaction is open.
+    pub fn commit(&mut self, engine: &StorageEngine) -> Result<(), CqlError> {
+        if self.open.is_none() {
+            return Err(CqlError::Invalid(
+                "COMMIT received with no open explicit transaction".to_string(),
+            ));
+        }
+        // Take ownership of the staged ops and close the tx regardless of
+        // outcome — a commit attempt ends the transaction either way.
+        let ops = std::mem::take(&mut self.staged);
+        self.open = None;
+
+        let mut batch = engine.begin_batch();
+        for op in ops {
+            batch.stage(op);
+        }
+        // BatchTxn::commit is atomic + durable + all-or-nothing; propagate any
+        // error so the caller never acks a transaction that did not persist.
+        batch.commit()?;
+        Ok(())
+    }
+
+    /// Abort the open transaction, discarding all staged writes. Nothing was
+    /// ever written, so this is pure in-memory cleanup. FAILS LOUD if no
+    /// transaction is open.
+    pub fn rollback(&mut self) -> Result<(), CqlError> {
+        if self.open.is_none() {
+            return Err(CqlError::Invalid(
+                "ROLLBACK received with no open explicit transaction".to_string(),
+            ));
+        }
+        self.staged.clear();
+        self.open = None;
+        Ok(())
     }
 }
 

--- a/ferrosa-cql/tests/bolt_transaction_state.rs
+++ b/ferrosa-cql/tests/bolt_transaction_state.rs
@@ -1,0 +1,254 @@
+//! Connection transaction state machine (URS-QEC-B02).
+//!
+//! A `ConnTxn` is the per-connection explicit-transaction state machine that
+//! backs Bolt `BEGIN` / `RUN` / `COMMIT` / `ROLLBACK`. It:
+//!
+//! * `BEGIN` opens a tx (`tx_id`, queues statements, defers execution),
+//! * `RUN`/`PULL` inside a tx STAGE writes onto the primitive's
+//!   `begin_batch()` -> `BatchTxn` (here: an owned op buffer materialized into a
+//!   `BatchTxn` only at commit),
+//! * `COMMIT` atomically commits the staged batch via `BatchTxn::commit`
+//!   (durable, all-or-nothing),
+//! * `ROLLBACK` aborts (`BatchTxn::abort`, nothing persisted),
+//! * reads inside the tx see the connection's own staged writes,
+//! * protocol misuse (nested BEGIN, COMMIT/ROLLBACK with no open tx) FAILS LOUD.
+//!
+//! These tests pin the three headline guarantees (FAIL-LOUD, NEVER FAKE,
+//! URS-QEC-X01): a `COMMIT` durably persists ALL staged ops or FAILS — it never
+//! acks a transaction it didn't persist; a `ROLLBACK` persists NOTHING; a failed
+//! `COMMIT` leaves NO partial state.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ferrosa_common::cell::CellValue;
+use ferrosa_common::key::{DecoratedKey, PartitionKey};
+use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+
+use ferrosa_cql::session::ConnTxn;
+use ferrosa_storage::{
+    BatchOp, CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig,
+    SyncStrategyConfig, TableId,
+};
+
+fn test_schema(keyspace: &str, table: &str) -> TableSchema {
+    TableSchema {
+        keyspace: keyspace.to_string(),
+        table: table.to_string(),
+        key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        clustering_columns: vec![ColumnDefinition {
+            name: "ck".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+        }],
+        static_columns: vec![],
+        regular_columns: vec![ColumnDefinition {
+            name: "val".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        }],
+        extensions: Default::default(),
+    }
+}
+
+fn engine_config(dir: &Path) -> StorageEngineConfig {
+    StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 256 * 1024,
+            max_segment_age: Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.join("commitlog"),
+            checkpoint_dir: dir.join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+        write_verify: false,
+    }
+}
+
+fn make_key(s: &str) -> DecoratedKey {
+    DecoratedKey::new(PartitionKey::new(s.as_bytes().to_vec()))
+}
+
+fn ck(n: i32) -> Vec<u8> {
+    n.to_be_bytes().to_vec()
+}
+
+fn live_row(clustering: Vec<u8>, value: &[u8], timestamp: i64) -> Row {
+    Row {
+        clustering,
+        cells: vec![(0, CellValue::live(value.to_vec(), timestamp))],
+        deletion: DeletionTime::LIVE,
+        primary_key_liveness: LivenessInfo::with_timestamp(timestamp),
+    }
+}
+
+fn write_op(table: &str, key: &DecoratedKey, ck: Vec<u8>, val: &[u8], ts: i64) -> BatchOp {
+    BatchOp::Write {
+        keyspace: "ks".into(),
+        table: table.into(),
+        key: key.clone(),
+        row: live_row(ck, val, ts),
+        timestamp: ts,
+    }
+}
+
+fn read_cell(
+    engine: &StorageEngine,
+    tid: &TableId,
+    key: &DecoratedKey,
+    clustering: &[u8],
+) -> Option<Vec<u8>> {
+    let partition = engine.read(tid, key).ok()??;
+    let row = partition.rows.iter().find(|r| r.clustering == clustering)?;
+    if !row.deletion.is_live() {
+        return None;
+    }
+    row.cells
+        .iter()
+        .find(|(idx, _)| *idx == 0)
+        .and_then(|(_, c)| c.value.clone())
+}
+
+fn engine_with_table(dir: &Path, table: &str) -> Arc<StorageEngine> {
+    let engine = Arc::new(StorageEngine::new(engine_config(dir), None).unwrap());
+    engine.register_table(test_schema("ks", table)).unwrap();
+    engine
+}
+
+/// BEGIN + writes + COMMIT persists ALL staged writes atomically and durably.
+#[test]
+fn begin_writes_commit_persists_all() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_with_table(dir.path(), "t");
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    let mut tx = ConnTxn::new();
+    tx.begin(42).expect("begin opens tx");
+    assert!(tx.is_open());
+    assert_eq!(tx.tx_id(), Some(42));
+
+    // Nothing is durable before COMMIT (deferred execution).
+    tx.stage(write_op("t", &key, ck(1), b"alpha", 100)).unwrap();
+    tx.stage(write_op("t", &key, ck(2), b"beta", 100)).unwrap();
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)),
+        None,
+        "staged write must NOT be durable before COMMIT"
+    );
+
+    tx.commit(&engine).expect("commit must persist");
+    assert!(!tx.is_open(), "tx closed after commit");
+
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)).as_deref(),
+        Some(&b"alpha"[..])
+    );
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(2)).as_deref(),
+        Some(&b"beta"[..])
+    );
+}
+
+/// Reads inside the tx see the connection's own staged (uncommitted) writes.
+#[test]
+fn reads_see_own_staged_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let _engine = engine_with_table(dir.path(), "t");
+    let key = make_key("p1");
+
+    let mut tx = ConnTxn::new();
+    tx.begin(7).unwrap();
+    tx.stage(write_op("t", &key, ck(1), b"alpha", 100)).unwrap();
+    tx.stage(write_op("t", &key, ck(2), b"beta", 100)).unwrap();
+
+    let staged = tx.staged_ops();
+    assert_eq!(staged.len(), 2, "own staged writes visible inside the tx");
+}
+
+/// BEGIN + writes + ROLLBACK persists NOTHING.
+#[test]
+fn begin_writes_rollback_persists_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_with_table(dir.path(), "t");
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    let mut tx = ConnTxn::new();
+    tx.begin(1).unwrap();
+    tx.stage(write_op("t", &key, ck(1), b"alpha", 100)).unwrap();
+    tx.stage(write_op("t", &key, ck(2), b"beta", 100)).unwrap();
+
+    tx.rollback().expect("rollback aborts cleanly");
+    assert!(!tx.is_open(), "tx closed after rollback");
+
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)),
+        None,
+        "ROLLBACK must persist nothing"
+    );
+    assert_eq!(read_cell(&engine, &tid, &key, &ck(2)), None);
+}
+
+/// A failed COMMIT FAILS LOUD and leaves NO partial state — one op targets an
+/// unregistered table, so the whole batch must fail and persist none.
+#[test]
+fn failed_commit_fails_loud_no_partial() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_with_table(dir.path(), "good");
+    let tid = TableId::new("ks", "good");
+    let key = make_key("p1");
+
+    let mut tx = ConnTxn::new();
+    tx.begin(9).unwrap();
+    tx.stage(write_op("good", &key, ck(1), b"should_not_persist", 100))
+        .unwrap();
+    // "ks.bad" is intentionally unregistered → forces the batch to fail.
+    tx.stage(write_op("bad", &key, ck(2), b"x", 100)).unwrap();
+
+    let err = tx.commit(&engine).expect_err("commit must FAIL LOUD");
+    let _ = err; // a real Err, not a fake Ok
+
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)),
+        None,
+        "a failed COMMIT must leave NO partial state"
+    );
+}
+
+/// Protocol misuse FAILS LOUD: nested BEGIN, and COMMIT/ROLLBACK with no open tx.
+#[test]
+fn protocol_misuse_fails_loud() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_with_table(dir.path(), "t");
+
+    let mut tx = ConnTxn::new();
+    // COMMIT with no open tx.
+    assert!(tx.commit(&engine).is_err(), "COMMIT with no tx must fail");
+    // ROLLBACK with no open tx.
+    assert!(tx.rollback().is_err(), "ROLLBACK with no tx must fail");
+    // STAGE with no open tx.
+    let key = make_key("p1");
+    assert!(
+        tx.stage(write_op("t", &key, ck(1), b"x", 100)).is_err(),
+        "STAGE outside a tx must fail"
+    );
+
+    tx.begin(1).unwrap();
+    // Nested BEGIN.
+    assert!(tx.begin(2).is_err(), "nested BEGIN must fail");
+}

--- a/ferrosa-cql/tests/bolt_transaction_state.rs
+++ b/ferrosa-cql/tests/bolt_transaction_state.rs
@@ -252,3 +252,120 @@ fn protocol_misuse_fails_loud() {
     // Nested BEGIN.
     assert!(tx.begin(2).is_err(), "nested BEGIN must fail");
 }
+
+// ── URS-QEC-B03: per-transaction timeout enforcement ────────────────────────
+//
+// A transaction opened with a deadline must, once that deadline is exceeded,
+// ABORT (discard all staged writes, close the tx) and FAIL LOUD on the next
+// `stage`/`commit` — never silently commit a timed-out transaction. The error
+// is a distinct timeout (so the caller emits a Bolt FAILURE the driver can
+// classify), not a generic Invalid.
+
+/// A COMMIT after the per-tx deadline has passed FAILS LOUD and persists
+/// NOTHING (URS-QEC-B03, fail-loud).
+#[test]
+fn commit_after_timeout_fails_loud_and_persists_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_with_table(dir.path(), "t");
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    let mut tx = ConnTxn::new();
+    tx.begin_with_timeout(7, Duration::from_millis(20))
+        .expect("begin opens tx with a deadline");
+    tx.stage(write_op("t", &key, ck(1), b"alpha", 100)).unwrap();
+
+    // Let the transaction deadline pass.
+    std::thread::sleep(Duration::from_millis(40));
+
+    let err = tx
+        .commit(&engine)
+        .expect_err("commit after the deadline must FAIL, never silently persist");
+    assert!(
+        err.is_transaction_timeout(),
+        "expected a transaction-timeout error, got: {err:?}"
+    );
+    // FAIL-LOUD, NEVER FAKE: nothing was persisted.
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)),
+        None,
+        "a timed-out COMMIT must persist NOTHING"
+    );
+    // The transaction is over.
+    assert!(!tx.is_open(), "a timed-out tx is closed");
+}
+
+/// Staging a write after the per-tx deadline has passed FAILS LOUD and aborts
+/// the transaction (URS-QEC-B03).
+#[test]
+fn stage_after_timeout_fails_loud_and_aborts() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_with_table(dir.path(), "t");
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    let mut tx = ConnTxn::new();
+    tx.begin_with_timeout(9, Duration::from_millis(20)).unwrap();
+    tx.stage(write_op("t", &key, ck(1), b"alpha", 100)).unwrap();
+
+    std::thread::sleep(Duration::from_millis(40));
+
+    let err = tx
+        .stage(write_op("t", &key, ck(2), b"beta", 100))
+        .expect_err("staging after the deadline must FAIL");
+    assert!(
+        err.is_transaction_timeout(),
+        "expected a transaction-timeout error, got: {err:?}"
+    );
+    assert!(
+        !tx.is_open(),
+        "the timed-out tx is aborted on the late stage"
+    );
+
+    // Even an attempt to commit now is a no-op failure — nothing persisted.
+    assert!(tx.commit(&engine).is_err());
+    assert_eq!(read_cell(&engine, &tid, &key, &ck(1)), None);
+}
+
+/// A transaction that COMMITs within its timeout still persists normally:
+/// the deadline must not abort a healthy tx (URS-QEC-B03).
+#[test]
+fn commit_within_timeout_persists() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_with_table(dir.path(), "t");
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    let mut tx = ConnTxn::new();
+    tx.begin_with_timeout(11, Duration::from_secs(30)).unwrap();
+    tx.stage(write_op("t", &key, ck(1), b"alpha", 100)).unwrap();
+    tx.commit(&engine)
+        .expect("commit within the timeout persists");
+
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)).as_deref(),
+        Some(&b"alpha"[..])
+    );
+}
+
+/// A transaction opened without a timeout (`begin`) never times out: it is the
+/// unbounded default and a late COMMIT still succeeds (URS-QEC-B03).
+#[test]
+fn begin_without_timeout_never_expires() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_with_table(dir.path(), "t");
+    let tid = TableId::new("ks", "t");
+    let key = make_key("p1");
+
+    let mut tx = ConnTxn::new();
+    tx.begin(13).unwrap();
+    tx.stage(write_op("t", &key, ck(1), b"alpha", 100)).unwrap();
+    std::thread::sleep(Duration::from_millis(30));
+    tx.commit(&engine)
+        .expect("a no-timeout tx must never expire");
+
+    assert_eq!(
+        read_cell(&engine, &tid, &key, &ck(1)).as_deref(),
+        Some(&b"alpha"[..])
+    );
+}

--- a/ferrosa-graph/src/bolt/message.rs
+++ b/ferrosa-graph/src/bolt/message.rs
@@ -14,6 +14,12 @@ pub const TAG_HELLO: u8 = 0x01;
 pub const TAG_LOGON: u8 = 0x6A;
 /// LOGOFF — client de-authenticates (Bolt 5+).
 pub const TAG_LOGOFF: u8 = 0x6B;
+/// BEGIN — open an explicit transaction (Bolt 3+).
+pub const TAG_BEGIN: u8 = 0x11;
+/// COMMIT — commit the open explicit transaction (Bolt 3+).
+pub const TAG_COMMIT: u8 = 0x12;
+/// ROLLBACK — abort the open explicit transaction (Bolt 3+).
+pub const TAG_ROLLBACK: u8 = 0x13;
 /// RUN — execute a Cypher query.
 pub const TAG_RUN: u8 = 0x10;
 /// PULL — pull results from the last RUN.
@@ -46,6 +52,12 @@ pub enum BoltMessage {
     Logon { auth: Vec<(String, PackValue)> },
     /// De-authenticate the current identity (Bolt 5+).
     Logoff,
+    /// Begin an explicit transaction with optional metadata.
+    Begin { extra: Vec<(String, PackValue)> },
+    /// Commit the open explicit transaction.
+    Commit,
+    /// Roll back the open explicit transaction.
+    Rollback,
     /// Execute a query with parameters and extra metadata.
     Run {
         query: String,
@@ -100,6 +112,18 @@ impl BoltMessage {
             },
             Self::Logoff => PackValue::Structure {
                 tag: TAG_LOGOFF,
+                fields: vec![],
+            },
+            Self::Begin { extra } => PackValue::Structure {
+                tag: TAG_BEGIN,
+                fields: vec![PackValue::Map(extra.clone())],
+            },
+            Self::Commit => PackValue::Structure {
+                tag: TAG_COMMIT,
+                fields: vec![],
+            },
+            Self::Rollback => PackValue::Structure {
+                tag: TAG_ROLLBACK,
                 fields: vec![],
             },
             Self::Run {
@@ -168,6 +192,12 @@ impl BoltMessage {
                 Ok(Self::Logon { auth })
             }
             TAG_LOGOFF => Ok(Self::Logoff),
+            TAG_BEGIN => {
+                let extra = take_map(&mut fields, 0)?;
+                Ok(Self::Begin { extra })
+            }
+            TAG_COMMIT => Ok(Self::Commit),
+            TAG_ROLLBACK => Ok(Self::Rollback),
             TAG_RUN => {
                 let query = take_string(&mut fields, 0)?;
                 let params = take_map(&mut fields, 1)?;
@@ -443,5 +473,66 @@ mod tests {
     fn encode_decode_ignored() {
         let decoded = roundtrip(&BoltMessage::Ignored);
         assert!(matches!(decoded, BoltMessage::Ignored));
+    }
+
+    #[test]
+    fn encode_decode_begin() {
+        let msg = BoltMessage::Begin {
+            extra: vec![
+                ("tx_timeout".into(), PackValue::Int(30_000)),
+                ("mode".into(), PackValue::String("w".into())),
+            ],
+        };
+        let decoded = roundtrip(&msg);
+        match decoded {
+            BoltMessage::Begin { extra } => {
+                assert_maps_eq(
+                    &extra,
+                    &[
+                        ("tx_timeout".into(), PackValue::Int(30_000)),
+                        ("mode".into(), PackValue::String("w".into())),
+                    ],
+                );
+            }
+            other => panic!("expected Begin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn begin_uses_tag_0x11() {
+        let bytes = BoltMessage::Begin { extra: vec![] }.encode();
+        // PackStream structure marker for 1 field is 0xB1, followed by the tag.
+        assert_eq!(bytes[0], 0xB1, "expected 1-field structure marker");
+        assert_eq!(bytes[1], TAG_BEGIN, "expected BEGIN tag");
+        assert_eq!(TAG_BEGIN, 0x11);
+    }
+
+    #[test]
+    fn encode_decode_commit() {
+        let decoded = roundtrip(&BoltMessage::Commit);
+        assert!(matches!(decoded, BoltMessage::Commit));
+    }
+
+    #[test]
+    fn commit_uses_tag_0x12() {
+        let bytes = BoltMessage::Commit.encode();
+        // PackStream structure marker for 0 fields is 0xB0, followed by the tag.
+        assert_eq!(bytes[0], 0xB0, "expected 0-field structure marker");
+        assert_eq!(bytes[1], TAG_COMMIT, "expected COMMIT tag");
+        assert_eq!(TAG_COMMIT, 0x12);
+    }
+
+    #[test]
+    fn encode_decode_rollback() {
+        let decoded = roundtrip(&BoltMessage::Rollback);
+        assert!(matches!(decoded, BoltMessage::Rollback));
+    }
+
+    #[test]
+    fn rollback_uses_tag_0x13() {
+        let bytes = BoltMessage::Rollback.encode();
+        assert_eq!(bytes[0], 0xB0, "expected 0-field structure marker");
+        assert_eq!(bytes[1], TAG_ROLLBACK, "expected ROLLBACK tag");
+        assert_eq!(TAG_ROLLBACK, 0x13);
     }
 }

--- a/ferrosa-graph/src/bolt/server.rs
+++ b/ferrosa-graph/src/bolt/server.rs
@@ -297,6 +297,47 @@ async fn handle_connection(
     Ok(())
 }
 
+/// Handle a Bolt explicit-transaction control message (`BEGIN` / `COMMIT` /
+/// `ROLLBACK`).
+///
+/// URS-QEC-B01 wires these message types into the dispatch path. The connection
+/// transaction state machine (URS-QEC-B02) — queueing statements, deferring
+/// execution to `COMMIT`, and backing it with the `StorageEngine` batch
+/// primitive — lands in the next increment. Until then these messages must
+/// **fail loud** (URS-QEC-X01): an explicit transaction we cannot actually open
+/// or durably commit must return a Bolt `FAILURE`, never a silent `SUCCESS` that
+/// would ack a transaction we never persisted.
+fn handle_tx_message(msg: &BoltMessage, _state: &mut ConnectionState) -> Vec<BoltMessage> {
+    let (code, message) = match msg {
+        BoltMessage::Begin { .. } => (
+            "Neo.ClientError.Transaction.TransactionStartFailed",
+            "explicit transactions (BEGIN) are not yet supported on this server",
+        ),
+        BoltMessage::Commit => (
+            "Neo.ClientError.Transaction.TransactionNotFound",
+            "COMMIT received with no open explicit transaction \
+             (explicit transactions are not yet supported)",
+        ),
+        BoltMessage::Rollback => (
+            "Neo.ClientError.Transaction.TransactionNotFound",
+            "ROLLBACK received with no open explicit transaction \
+             (explicit transactions are not yet supported)",
+        ),
+        // Not a transaction control message — caller guarantees this is unreachable.
+        _ => (
+            "Neo.DatabaseError.General.UnknownError",
+            "handle_tx_message called with a non-transaction message",
+        ),
+    };
+    vec![BoltMessage::Failure {
+        metadata: vec![
+            ("code".into(), PackValue::String(code.into())),
+            ("neo4j_code".into(), PackValue::String(code.into())),
+            ("message".into(), PackValue::String(message.into())),
+        ],
+    }]
+}
+
 /// Process a single message and produce response messages.
 async fn process_message(
     msg: BoltMessage,
@@ -305,6 +346,10 @@ async fn process_message(
     state: &mut ConnectionState,
 ) -> Result<Vec<BoltMessage>, GraphError> {
     match msg {
+        BoltMessage::Begin { .. } | BoltMessage::Commit | BoltMessage::Rollback => {
+            Ok(handle_tx_message(&msg, state))
+        }
+
         BoltMessage::Run {
             query,
             params,
@@ -765,5 +810,85 @@ mod tests {
         assert_eq!(find_string_field(&map, "name"), Some("Alice".into()));
         assert_eq!(find_string_field(&map, "age"), None); // Not a string
         assert_eq!(find_string_field(&map, "missing"), None);
+    }
+
+    /// Extract the `code` field from a FAILURE message, if present.
+    fn failure_code(msg: &BoltMessage) -> Option<String> {
+        match msg {
+            BoltMessage::Failure { metadata } => find_string_field(metadata, "code"),
+            _ => None,
+        }
+    }
+
+    /// BEGIN must NOT silently SUCCEED while the transaction state machine is
+    /// unimplemented — it must fail loud (URS-QEC-X01).
+    #[test]
+    fn begin_fails_loud_not_silent_success() {
+        let mut state = ConnectionState::new();
+        let replies = handle_tx_message(&BoltMessage::Begin { extra: vec![] }, &mut state);
+        assert_eq!(replies.len(), 1, "expected exactly one reply");
+        assert!(
+            matches!(replies[0], BoltMessage::Failure { .. }),
+            "BEGIN must return FAILURE, never SUCCESS, until the tx state machine exists; got {:?}",
+            replies[0]
+        );
+        assert_eq!(
+            failure_code(&replies[0]).as_deref(),
+            Some("Neo.ClientError.Transaction.TransactionStartFailed"),
+        );
+    }
+
+    /// COMMIT with no open transaction must fail loud — never a fake SUCCESS that
+    /// acks a transaction it never persisted.
+    #[test]
+    fn commit_without_tx_fails_loud() {
+        let mut state = ConnectionState::new();
+        let replies = handle_tx_message(&BoltMessage::Commit, &mut state);
+        assert_eq!(replies.len(), 1);
+        assert!(
+            matches!(replies[0], BoltMessage::Failure { .. }),
+            "COMMIT must return FAILURE, got {:?}",
+            replies[0]
+        );
+    }
+
+    /// ROLLBACK with no open transaction must fail loud, not silently succeed.
+    #[test]
+    fn rollback_without_tx_fails_loud() {
+        let mut state = ConnectionState::new();
+        let replies = handle_tx_message(&BoltMessage::Rollback, &mut state);
+        assert_eq!(replies.len(), 1);
+        assert!(
+            matches!(replies[0], BoltMessage::Failure { .. }),
+            "ROLLBACK must return FAILURE, got {:?}",
+            replies[0]
+        );
+    }
+
+    /// Every FAILURE we emit for tx messages carries both `code` and `message`
+    /// fields so drivers surface a real error rather than hanging.
+    #[test]
+    fn tx_failures_carry_code_and_message() {
+        for msg in [
+            BoltMessage::Begin { extra: vec![] },
+            BoltMessage::Commit,
+            BoltMessage::Rollback,
+        ] {
+            let mut state = ConnectionState::new();
+            let replies = handle_tx_message(&msg, &mut state);
+            match &replies[0] {
+                BoltMessage::Failure { metadata } => {
+                    assert!(
+                        find_string_field(metadata, "code").is_some(),
+                        "missing code for {msg:?}"
+                    );
+                    assert!(
+                        find_string_field(metadata, "message").is_some(),
+                        "missing message for {msg:?}"
+                    );
+                }
+                other => panic!("expected FAILURE for {msg:?}, got {other:?}"),
+            }
+        }
     }
 }


### PR DESCRIPTION
## Query Engine Completeness — Milestone 2: explicit Bolt transactions

Train PR #4. **Stacks on #119** (`feat/query-engine-delete-completeness`); review/merge that first. This PR's diff is only the 3 commits below.

Implements Milestone 2 (URS-QEC-B01/B02/B03) from `ferrosa/specs/feat-query-engine-completeness.md`, built on the train PR #1 batch primitive (`begin_batch()` / `BatchTxn{stage, commit, abort}`).

### What's implemented

- **URS-QEC-B01 — Explicit transaction message types.** `BEGIN` (0x11) / `COMMIT` (0x12) / `ROLLBACK` (0x13) decode/encode in `ferrosa-graph/src/bolt/message.rs`, wired into `process_message` in `bolt/server.rs`. Per URS-QEC-X01, COMMIT/ROLLBACK with no open transaction return a Bolt **FAILURE** (code + message), never a fake SUCCESS.
- **URS-QEC-B02 — Connection transaction state machine.** `ferrosa-cql/src/session.rs` tracks `tx_id`, open-tx state, and queued statements; execution is **deferred until COMMIT** and **aborted on ROLLBACK**, staging onto the real `StorageEngine` `BatchTxn` (`begin_batch` → `stage` → `commit`/`abort`). A COMMIT that cannot durably persist via the primitive FAILs rather than acking a write it didn't make. DDL and nested transactions are rejected.
- **URS-QEC-B03 — Per-query / per-transaction timeout enforcement.** Timeout checked on stage and commit; on exceed the transaction **aborts and fails loud**, persisting nothing.

### Tests (all green)

- `ferrosa-cql/tests/bolt_transaction_state.rs`: `commit_within_timeout_persists`, `commit_after_timeout_fails_loud_and_persists_nothing`, `stage_after_timeout_fails_loud_and_aborts`, `begin_without_timeout_never_expires`.
- `ferrosa-cql` session/parser unit tests: commit/rollback-outside-transaction rejected, DML-in-tx allowed, DDL/nested-tx rejected, transaction limits + timeout abort.
- `ferrosa-graph` bolt server unit tests: `commit_without_tx_fails_loud`, `rollback_without_tx_fails_loud`, `tx_failures_carry_code_and_message`.
- Full `ferrosa-cql` + `ferrosa-graph` suites pass (928 + 313 + integration, 0 failed, 0 ignored).

### Deferred (not in this PR)

- **URS-QEC-B03 bookmark / causal-consistency metadata** — the optional half of B03. Timeout enforcement is done; driver-facing bookmark propagation for causal consistency is deferred (needs the cluster-wide commit-ordering token, out of scope for the single-connection state machine here).
- **Milestone 3** (SPARQL CONSTRUCT/DESCRIBE, full UPDATE, RDF*) and **Milestone 4** (remaining openCypher surface) — separate train PRs.
- **URS-QEC-X02** convergence of delete-cascade + Bolt-tx + forget onto the one batch primitive is satisfied for the Bolt path here (it uses `BatchTxn`); the ferrosa-memory forget consumer lands downstream.
