### PR TITLE
feat(sparql): full SPARQL 1.1 — query-engine milestone 3 (train PR #5, stacks on #120)

### DIFF
--- a/ferrosa-sparql/src/engine.rs
+++ b/ferrosa-sparql/src/engine.rs
@@ -6,15 +6,35 @@ use ferrosa_cluster::write_path::WritePath;
 use ferrosa_storage::engine::StorageEngine;
 
 use crate::error::SparqlError;
-use crate::planner;
+use crate::planner::{self, GraphQueryMode};
 use crate::results::{SparqlAskResult, SparqlJsonResults};
 
-/// Result of a SPARQL query execution, supporting both SELECT and ASK forms.
+/// A triple in a constructed/described graph result (S01).
+#[derive(Debug, Clone)]
+pub struct ConstructedTriple {
+    /// Subject IRI or blank-node label.
+    pub subject: String,
+    /// Predicate IRI.
+    pub predicate: String,
+    /// Object value string.
+    pub object: String,
+    /// `"uri"`, `"literal"`, or `"bnode"`.
+    pub object_type: String,
+    /// XSD datatype URI for typed literals.
+    pub datatype: Option<String>,
+    /// Language tag for `rdf:langString` literals.
+    pub lang: Option<String>,
+}
+
+/// Result of a SPARQL query execution, supporting SELECT, ASK, and graph forms.
+#[derive(Debug)]
 pub enum SparqlResult {
     /// SELECT query result (binding sets).
     Select(SparqlJsonResults),
     /// ASK query result (boolean).
     Ask(SparqlAskResult),
+    /// CONSTRUCT / DESCRIBE query result (a set of triples forming a graph).
+    Graph(Vec<ConstructedTriple>),
 }
 
 impl SparqlResult {
@@ -23,6 +43,66 @@ impl SparqlResult {
         match self {
             Self::Select(results) => results.to_json(),
             Self::Ask(result) => serde_json::to_vec(result),
+            Self::Graph(triples) => {
+                // Serialize constructed graph as a JSON array of triple objects
+                // (not standard SPARQL Results JSON, but consistent with our
+                // internal JSON format for graph results).
+                serde_json::to_vec(
+                    &triples
+                        .iter()
+                        .map(|t| {
+                            serde_json::json!({
+                                "subject":   t.subject,
+                                "predicate": t.predicate,
+                                "object":    t.object,
+                                "type":      t.object_type,
+                                "datatype":  t.datatype,
+                                "lang":      t.lang,
+                            })
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            }
+        }
+    }
+
+    /// Serialize to SPARQL Results XML bytes.
+    pub fn to_xml(&self) -> Result<Vec<u8>, String> {
+        match self {
+            Self::Select(results) => results.to_xml(),
+            Self::Ask(result) => {
+                let boolean_str = if result.boolean { "true" } else { "false" };
+                Ok(format!(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                     <sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n\
+                     <head/>\n\
+                     <boolean>{boolean_str}</boolean>\n\
+                     </sparql>\n"
+                )
+                .into_bytes())
+            }
+            Self::Graph(triples) => {
+                // CONSTRUCT/DESCRIBE — serialize as RDF/XML (simple form).
+                let mut buf = String::new();
+                buf.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+                buf.push_str(
+                    "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n",
+                );
+                for t in triples {
+                    buf.push_str(&format!(
+                        "  <rdf:Description rdf:about=\"{}\">\n",
+                        t.subject
+                    ));
+                    buf.push_str(&format!(
+                        "    <{pred}>{obj}</{pred}>\n",
+                        pred = t.predicate,
+                        obj = t.object
+                    ));
+                    buf.push_str("  </rdf:Description>\n");
+                }
+                buf.push_str("</rdf:RDF>\n");
+                Ok(buf.into_bytes())
+            }
         }
     }
 
@@ -31,6 +111,39 @@ impl SparqlResult {
         match self {
             Self::Select(results) => results.to_ntriples(),
             Self::Ask(result) => format!("# boolean: {}\n", result.boolean).into_bytes(),
+            Self::Graph(triples) => {
+                let mut buf = String::new();
+                for t in triples {
+                    let subj = if t.subject.starts_with("_:") {
+                        t.subject.clone()
+                    } else {
+                        format!("<{}>", t.subject)
+                    };
+                    let pred = format!("<{}>", t.predicate);
+                    let obj = match t.object_type.as_str() {
+                        "uri" => format!("<{}>", t.object),
+                        "bnode" => {
+                            if t.object.starts_with("_:") {
+                                t.object.clone()
+                            } else {
+                                format!("_:{}", t.object)
+                            }
+                        }
+                        _ => {
+                            let escaped = t.object.replace('\\', "\\\\").replace('"', "\\\"");
+                            if let Some(lang) = &t.lang {
+                                format!("\"{}\"@{}", escaped, lang)
+                            } else if let Some(dt) = &t.datatype {
+                                format!("\"{}\"^^<{}>", escaped, dt)
+                            } else {
+                                format!("\"{}\"", escaped)
+                            }
+                        }
+                    };
+                    buf.push_str(&format!("{subj} {pred} {obj} .\n"));
+                }
+                buf.into_bytes()
+            }
         }
     }
 
@@ -39,16 +152,19 @@ impl SparqlResult {
         match self {
             Self::Select(results) => results.to_turtle(),
             Self::Ask(result) => format!("# boolean: {}\n", result.boolean).into_bytes(),
+            Self::Graph(_) => self.to_ntriples(),
         }
     }
 
     /// Serialize to the requested format.
-    pub fn serialize(
-        &self,
-        format: crate::results::ResultFormat,
-    ) -> Result<Vec<u8>, serde_json::Error> {
+    ///
+    /// Returns `Err(String)` on serialization failure. The String carries a
+    /// human-readable description (JSON serialization errors are stringified;
+    /// XML errors are already strings).
+    pub fn serialize(&self, format: crate::results::ResultFormat) -> Result<Vec<u8>, String> {
         match format {
-            crate::results::ResultFormat::Json => self.to_json(),
+            crate::results::ResultFormat::Json => self.to_json().map_err(|e| e.to_string()),
+            crate::results::ResultFormat::Xml => self.to_xml(),
             crate::results::ResultFormat::Turtle => Ok(self.to_turtle()),
             crate::results::ResultFormat::NTriples => Ok(self.to_ntriples()),
         }
@@ -184,7 +300,229 @@ impl SparqlEngine {
             }));
         }
 
+        // URS-QEC-S01: CONSTRUCT / DESCRIBE return a graph result.
+        if let Some(graph_mode) = &plan.graph_mode {
+            return Ok(SparqlResult::Graph(
+                build_graph_result(graph_mode, &results, &plan, &self.write_path).await?,
+            ));
+        }
+
         Ok(SparqlResult::Select(results))
+    }
+}
+
+/// Build the `Vec<ConstructedTriple>` for CONSTRUCT and DESCRIBE queries.
+///
+/// For `CONSTRUCT { template } WHERE { … }`:
+///   Instantiate the template triples once per WHERE solution.  Variables in
+///   the template are replaced with the corresponding bound values.
+///
+/// For `DESCRIBE <iri>`:
+///   Run a subject-lookup for the described IRI and return all triples found.
+async fn build_graph_result(
+    mode: &GraphQueryMode,
+    where_results: &SparqlJsonResults,
+    plan: &planner::QueryPlan,
+    write_path: &Arc<WritePath>,
+) -> Result<Vec<ConstructedTriple>, SparqlError> {
+    use spargebra::term::{NamedNodePattern, TermPattern};
+
+    match mode {
+        GraphQueryMode::Construct(template) => {
+            let mut triples = Vec::new();
+            for solution in &where_results.results.bindings {
+                for tp in template {
+                    // Resolve subject.
+                    let subject = match &tp.subject {
+                        TermPattern::NamedNode(n) => n.as_str().to_string(),
+                        TermPattern::Variable(v) => match solution.get(v.as_str()) {
+                            Some(b) => b.value.clone(),
+                            None => continue,
+                        },
+                        TermPattern::BlankNode(b) => format!("_:{}", b.as_str()),
+                        _ => continue,
+                    };
+
+                    // Resolve predicate.
+                    let predicate = match &tp.predicate {
+                        NamedNodePattern::NamedNode(n) => n.as_str().to_string(),
+                        NamedNodePattern::Variable(v) => match solution.get(v.as_str()) {
+                            Some(b) => b.value.clone(),
+                            None => continue,
+                        },
+                    };
+
+                    // Resolve object.
+                    let (object, object_type, datatype, lang) = match &tp.object {
+                        TermPattern::NamedNode(n) => {
+                            (n.as_str().to_string(), "uri".to_string(), None, None)
+                        }
+                        TermPattern::Literal(l) => (
+                            l.value().to_string(),
+                            "literal".to_string(),
+                            Some(l.datatype().as_str().to_string()),
+                            l.language().map(|s| s.to_string()),
+                        ),
+                        TermPattern::BlankNode(b) => {
+                            (format!("_:{}", b.as_str()), "bnode".to_string(), None, None)
+                        }
+                        TermPattern::Variable(v) => match solution.get(v.as_str()) {
+                            Some(b) => (
+                                b.value.clone(),
+                                b.binding_type.clone(),
+                                b.datatype.clone(),
+                                b.lang.clone(),
+                            ),
+                            None => continue,
+                        },
+                        _ => continue,
+                    };
+
+                    triples.push(ConstructedTriple {
+                        subject,
+                        predicate,
+                        object,
+                        object_type,
+                        datatype,
+                        lang,
+                    });
+                }
+            }
+            Ok(triples)
+        }
+
+        GraphQueryMode::DescribeIris(iris_list) => {
+            // The planner ran SubjectLookup ops for each IRI. The where_results
+            // bindings contain __p and __o rows — but subjects are mixed. Since
+            // binding rows don't carry the subject (it was the partition key),
+            // we re-issue individual SubjectLookups to correctly attribute rows.
+            use crate::planner::TripleOp;
+            use spargebra::term::{NamedNode, NamedNodePattern, TermPattern, TriplePattern};
+
+            let mut triples = Vec::new();
+            for iri in iris_list {
+                let dummy_tp = TriplePattern {
+                    subject: TermPattern::NamedNode(NamedNode::new_unchecked(iri.as_str())),
+                    predicate: NamedNodePattern::Variable(
+                        spargebra::term::Variable::new_unchecked("__p"),
+                    ),
+                    object: TermPattern::Variable(spargebra::term::Variable::new_unchecked("__o")),
+                };
+                let op = TripleOp::SubjectLookup {
+                    graph: plan.ops.first().map_or_else(
+                        || "__default".to_string(),
+                        |(_, o)| match o {
+                            TripleOp::SubjectLookup { graph, .. } => graph.clone(),
+                            _ => "__default".to_string(),
+                        },
+                    ),
+                    subject: iri.clone(),
+                    predicate_filter: None,
+                };
+                let lookup_plan = planner::QueryPlan {
+                    ops: vec![(dummy_tp, op)],
+                    projection: vec!["__p".into(), "__o".into()],
+                    limit: None,
+                    offset: None,
+                    is_ask: false,
+                    distinct: false,
+                    order_by: vec![],
+                    filters: vec![],
+                    graph_mode: None,
+                };
+                let sub = crate::executor::execute(&lookup_plan, write_path).await?;
+                for row in sub.results.bindings {
+                    let pred = match row.get("__p") {
+                        Some(b) => b.value.clone(),
+                        None => continue,
+                    };
+                    let obj_b = match row.get("__o") {
+                        Some(b) => b,
+                        None => continue,
+                    };
+                    triples.push(ConstructedTriple {
+                        subject: iri.clone(),
+                        predicate: pred,
+                        object: obj_b.value.clone(),
+                        object_type: obj_b.binding_type.clone(),
+                        datatype: obj_b.datatype.clone(),
+                        lang: obj_b.lang.clone(),
+                    });
+                }
+            }
+            Ok(triples)
+        }
+
+        GraphQueryMode::Describe(graph) => {
+            // DESCRIBE: collect all triples about every subject bound by the
+            // WHERE clause (or the directly described IRI if no WHERE clause
+            // was supplied by spargebra).
+            let mut subjects: Vec<String> = Vec::new();
+            if where_results.results.bindings.is_empty() {
+                // No WHERE solutions — nothing to describe.
+                return Ok(vec![]);
+            }
+            // Collect all bound URI values that look like the described subject.
+            for sol in &where_results.results.bindings {
+                for binding in sol.values() {
+                    if binding.binding_type == "uri" && !subjects.contains(&binding.value) {
+                        subjects.push(binding.value.clone());
+                    }
+                }
+            }
+
+            let mut triples = Vec::new();
+            for subject_iri in subjects {
+                // SubjectLookup: fetch all (pred, obj) for this subject.
+                use crate::planner::TripleOp;
+                use spargebra::term::NamedNode;
+                use spargebra::term::{NamedNodePattern, TermPattern, TriplePattern};
+
+                let dummy_tp = TriplePattern {
+                    subject: TermPattern::NamedNode(NamedNode::new_unchecked(&subject_iri)),
+                    predicate: NamedNodePattern::Variable(
+                        spargebra::term::Variable::new_unchecked("__p"),
+                    ),
+                    object: TermPattern::Variable(spargebra::term::Variable::new_unchecked("__o")),
+                };
+                let op = TripleOp::SubjectLookup {
+                    graph: graph.clone(),
+                    subject: subject_iri.clone(),
+                    predicate_filter: None,
+                };
+                let dummy_plan = planner::QueryPlan {
+                    ops: vec![(dummy_tp, op)],
+                    projection: vec!["__p".into(), "__o".into()],
+                    limit: None,
+                    offset: None,
+                    is_ask: false,
+                    distinct: false,
+                    order_by: vec![],
+                    filters: vec![],
+                    graph_mode: None,
+                };
+                let sub_result = crate::executor::execute(&dummy_plan, write_path).await?;
+                for row in sub_result.results.bindings {
+                    let pred = match row.get("__p") {
+                        Some(b) => b.value.clone(),
+                        None => continue,
+                    };
+                    let obj_binding = match row.get("__o") {
+                        Some(b) => b,
+                        None => continue,
+                    };
+                    triples.push(ConstructedTriple {
+                        subject: subject_iri.clone(),
+                        predicate: pred,
+                        object: obj_binding.value.clone(),
+                        object_type: obj_binding.binding_type.clone(),
+                        datatype: obj_binding.datatype.clone(),
+                        lang: obj_binding.lang.clone(),
+                    });
+                }
+            }
+            Ok(triples)
+        }
     }
 }
 

--- a/ferrosa-sparql/src/executor.rs
+++ b/ferrosa-sparql/src/executor.rs
@@ -30,8 +30,9 @@ pub async fn execute(
         });
     }
 
-    // BUG-S13: apply ORDER BY.
-    apply_order_by(&mut binding_sets, &plan.order_by);
+    // BUG-S13 / URS-QEC-S04: apply ORDER BY (evaluates expressions per solution;
+    // fails loud on unsupported forms).
+    apply_order_by(&mut binding_sets, &plan.order_by)?;
 
     // BUG-S13: apply DISTINCT.
     if plan.distinct {
@@ -229,19 +230,34 @@ fn try_insert_binding(row: &mut HashMap<String, Binding>, name: &str, binding: &
     }
 }
 
-/// Sort binding sets by ORDER BY conditions (BUG-S13).
+/// Sort binding sets by ORDER BY conditions (BUG-S13, URS-QEC-S04).
+///
+/// Each condition holds a full expression (a plain `?var` is the trivial
+/// `Variable` expression). The expression is evaluated per solution and the
+/// solutions are sorted by the result, numerically when both sides are numeric.
+///
+/// URS-QEC-X01 (fail loud): if any ORDER BY expression contains a sub-form this
+/// engine cannot evaluate, return an error instead of silently sorting those
+/// rows as equal (which would yield an arbitrary, undocumented order).
 fn apply_order_by(
     binding_sets: &mut [HashMap<String, Binding>],
     order_by: &[crate::planner::OrderCondition],
-) {
+) -> Result<(), SparqlError> {
     if order_by.is_empty() {
-        return;
+        return Ok(());
+    }
+    for cond in order_by {
+        if let Some(what) = crate::filter::unsupported_expr(&cond.expression) {
+            return Err(SparqlError::Plan(format!(
+                "ORDER BY expression is not supported: {what}; \
+                 cannot evaluate it per solution, refusing to return an \
+                 arbitrarily-ordered result"
+            )));
+        }
     }
     binding_sets.sort_by(|a, b| {
         for cond in order_by {
-            let va = a.get(&cond.variable).map(|b| b.value.as_str());
-            let vb = b.get(&cond.variable).map(|b| b.value.as_str());
-            let ord = va.cmp(&vb);
+            let ord = crate::filter::order_cmp(&cond.expression, a, b);
             let ord = if cond.ascending { ord } else { ord.reverse() };
             if ord != std::cmp::Ordering::Equal {
                 return ord;
@@ -249,6 +265,7 @@ fn apply_order_by(
         }
         std::cmp::Ordering::Equal
     });
+    Ok(())
 }
 
 /// Remove duplicate binding rows (BUG-S13).
@@ -682,10 +699,10 @@ mod tests {
             make_binding_row("name", "Bob"),
         ];
         let conditions = vec![crate::planner::OrderCondition {
-            variable: "name".into(),
+            expression: var_expr("name"),
             ascending: true,
         }];
-        apply_order_by(&mut rows, &conditions);
+        apply_order_by(&mut rows, &conditions).unwrap();
         let names: Vec<&str> = rows.iter().map(|r| r["name"].value.as_str()).collect();
         assert_eq!(names, vec!["Alice", "Bob", "Charlie"]);
     }
@@ -698,12 +715,66 @@ mod tests {
             make_binding_row("name", "Bob"),
         ];
         let conditions = vec![crate::planner::OrderCondition {
-            variable: "name".into(),
+            expression: var_expr("name"),
             ascending: false,
         }];
-        apply_order_by(&mut rows, &conditions);
+        apply_order_by(&mut rows, &conditions).unwrap();
         let names: Vec<&str> = rows.iter().map(|r| r["name"].value.as_str()).collect();
         assert_eq!(names, vec!["Charlie", "Bob", "Alice"]);
+    }
+
+    // --- URS-QEC-S04: ORDER BY on expressions ---
+
+    fn make_numeric_row(
+        a_var: &str,
+        a_val: &str,
+        b_var: &str,
+        b_val: &str,
+    ) -> HashMap<String, Binding> {
+        let mut row = HashMap::new();
+        for (var, val) in [(a_var, a_val), (b_var, b_val)] {
+            row.insert(
+                var.to_string(),
+                Binding {
+                    binding_type: "literal".into(),
+                    value: val.into(),
+                    datatype: Some("http://www.w3.org/2001/XMLSchema#integer".into()),
+                    lang: None,
+                },
+            );
+        }
+        row
+    }
+
+    fn var_expr(name: &str) -> spargebra::algebra::Expression {
+        spargebra::algebra::Expression::Variable(spargebra::term::Variable::new_unchecked(name))
+    }
+
+    #[test]
+    fn apply_order_by_arithmetic_expression_desc() {
+        // ORDER BY (?a + ?b) DESC must sort by the evaluated sum, descending.
+        // Rows: sums are 5 (2+3), 9 (4+5), 7 (1+6).
+        let mut rows = vec![
+            make_numeric_row("a", "2", "b", "3"), // 5
+            make_numeric_row("a", "4", "b", "5"), // 9
+            make_numeric_row("a", "1", "b", "6"), // 7
+        ];
+        let sum =
+            spargebra::algebra::Expression::Add(Box::new(var_expr("a")), Box::new(var_expr("b")));
+        let conditions = vec![crate::planner::OrderCondition {
+            expression: sum,
+            ascending: false,
+        }];
+        apply_order_by(&mut rows, &conditions).unwrap();
+        let sums: Vec<i64> = rows
+            .iter()
+            .map(|r| r["a"].value.parse::<i64>().unwrap() + r["b"].value.parse::<i64>().unwrap())
+            .collect();
+        assert_eq!(
+            sums,
+            vec![9, 7, 5],
+            "ORDER BY (?a + ?b) DESC must order by sum descending"
+        );
     }
 
     // --- BUG-S13: DISTINCT ---

--- a/ferrosa-sparql/src/filter.rs
+++ b/ferrosa-sparql/src/filter.rs
@@ -53,7 +53,7 @@ fn eval_expr(expr: &Expression, bindings: &HashMap<String, Binding>) -> Value {
     match expr {
         Expression::Variable(var) => bindings
             .get(var.as_str())
-            .map(|b| Value::String(b.value.clone()))
+            .map(binding_to_value)
             .unwrap_or(Value::Null),
 
         Expression::Equal(left, right) => {
@@ -126,11 +126,186 @@ fn eval_expr(expr: &Expression, bindings: &HashMap<String, Binding>) -> Value {
             }
         }
 
+        Expression::FunctionCall(func, args) => eval_function(func, args, bindings),
+
         // Unsupported expressions evaluate to Null (filter passes nothing).
         _ => {
             tracing::debug!(?expr, "unsupported FILTER expression, evaluating as Null");
             Value::Null
         }
+    }
+}
+
+/// Evaluate a supported SPARQL function call. Returns `Value::Null` for
+/// functions that are not implemented; callers that require fail-loud behaviour
+/// (e.g. ORDER BY) must gate on [`unsupported_expr`] first.
+fn eval_function(
+    func: &spargebra::algebra::Function,
+    args: &[Expression],
+    bindings: &HashMap<String, Binding>,
+) -> Value {
+    use spargebra::algebra::Function as F;
+    let arg0 = || {
+        args.first()
+            .map(|a| eval_expr(a, bindings))
+            .unwrap_or(Value::Null)
+    };
+    match func {
+        // STR(x): the lexical/string form of the value.
+        F::Str => match arg0() {
+            Value::Null => Value::Null,
+            other => Value::String(value_as_lexical(&other)),
+        },
+        F::UCase => match arg0() {
+            Value::Null => Value::Null,
+            other => Value::String(value_as_lexical(&other).to_uppercase()),
+        },
+        F::LCase => match arg0() {
+            Value::Null => Value::Null,
+            other => Value::String(value_as_lexical(&other).to_lowercase()),
+        },
+        F::StrLen => match arg0() {
+            Value::Null => Value::Null,
+            other => Value::Integer(value_as_lexical(&other).chars().count() as i64),
+        },
+        F::Abs => arg0()
+            .to_float()
+            .map(|n| Value::Float(n.abs()))
+            .unwrap_or(Value::Null),
+        F::Ceil => arg0()
+            .to_float()
+            .map(|n| Value::Float(n.ceil()))
+            .unwrap_or(Value::Null),
+        F::Floor => arg0()
+            .to_float()
+            .map(|n| Value::Float(n.floor()))
+            .unwrap_or(Value::Null),
+        F::Round => arg0()
+            .to_float()
+            .map(|n| Value::Float(n.round()))
+            .unwrap_or(Value::Null),
+        _ => Value::Null,
+    }
+}
+
+/// Whether an expression is fully supported for evaluation (used by ORDER BY to
+/// fail loud on unsupported forms instead of sorting everything as Null/equal).
+///
+/// Returns the name of the first unsupported sub-expression, or `None` if the
+/// whole tree is evaluable.
+pub fn unsupported_expr(expr: &Expression) -> Option<String> {
+    use spargebra::algebra::Function as F;
+    match expr {
+        Expression::Variable(_)
+        | Expression::Literal(_)
+        | Expression::NamedNode(_)
+        | Expression::Bound(_) => None,
+        Expression::Add(l, r)
+        | Expression::Subtract(l, r)
+        | Expression::Multiply(l, r)
+        | Expression::Divide(l, r)
+        | Expression::Equal(l, r)
+        | Expression::Greater(l, r)
+        | Expression::GreaterOrEqual(l, r)
+        | Expression::Less(l, r)
+        | Expression::LessOrEqual(l, r)
+        | Expression::And(l, r)
+        | Expression::Or(l, r)
+        | Expression::SameTerm(l, r) => unsupported_expr(l).or_else(|| unsupported_expr(r)),
+        Expression::Not(inner) => unsupported_expr(inner),
+        Expression::If(c, t, e) => unsupported_expr(c)
+            .or_else(|| unsupported_expr(t))
+            .or_else(|| unsupported_expr(e)),
+        Expression::FunctionCall(func, args) => {
+            let supported = matches!(
+                func,
+                F::Str | F::UCase | F::LCase | F::StrLen | F::Abs | F::Ceil | F::Floor | F::Round
+            );
+            if !supported {
+                return Some(format!("function {func:?}"));
+            }
+            args.iter().find_map(unsupported_expr)
+        }
+        other => Some(format!("{other:?}")),
+    }
+}
+
+/// Convert a solution [`Binding`] into an evaluation [`Value`].
+///
+/// Honors the binding's `datatype` so that numeric literals participate in
+/// arithmetic and numeric ordering. Untyped literals whose value parses as a
+/// number are also treated numerically (xsd:integer/double), matching how
+/// SPARQL promotes numeric literals; everything else is a string.
+fn binding_to_value(b: &Binding) -> Value {
+    if let Some(dt) = b.datatype.as_deref() {
+        return match dt {
+            "http://www.w3.org/2001/XMLSchema#integer"
+            | "http://www.w3.org/2001/XMLSchema#int"
+            | "http://www.w3.org/2001/XMLSchema#long" => b
+                .value
+                .parse::<i64>()
+                .map(Value::Integer)
+                .unwrap_or(Value::Null),
+            "http://www.w3.org/2001/XMLSchema#decimal"
+            | "http://www.w3.org/2001/XMLSchema#float"
+            | "http://www.w3.org/2001/XMLSchema#double" => b
+                .value
+                .parse::<f64>()
+                .map(Value::Float)
+                .unwrap_or(Value::Null),
+            "http://www.w3.org/2001/XMLSchema#boolean" => {
+                Value::Boolean(b.value == "true" || b.value == "1")
+            }
+            _ => Value::String(b.value.clone()),
+        };
+    }
+    Value::String(b.value.clone())
+}
+
+/// SPARQL ORDER BY comparison (URS-QEC-S04).
+///
+/// Evaluates `expr` against both solutions and returns their relative order.
+/// Numeric values compare numerically; otherwise comparison is lexical on the
+/// string form. Unbound/Null sorts lowest (before any bound value), per the
+/// SPARQL 1.1 ORDER BY ordering of unbound variables.
+pub fn order_cmp(
+    expr: &Expression,
+    a: &HashMap<String, Binding>,
+    b: &HashMap<String, Binding>,
+) -> std::cmp::Ordering {
+    let va = eval_expr(expr, a);
+    let vb = eval_expr(expr, b);
+    cmp_values(&va, &vb)
+}
+
+fn cmp_values(a: &Value, b: &Value) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    // Null (unbound / type error) sorts lowest.
+    match (matches!(a, Value::Null), matches!(b, Value::Null)) {
+        (true, true) => return Ordering::Equal,
+        (true, false) => return Ordering::Less,
+        (false, true) => return Ordering::Greater,
+        (false, false) => {}
+    }
+    // Numeric comparison when both are numeric.
+    if let (Some(x), Some(y)) = (a.to_float(), b.to_float()) {
+        return x.partial_cmp(&y).unwrap_or(Ordering::Equal);
+    }
+    // Booleans: false < true.
+    if let (Value::Boolean(x), Value::Boolean(y)) = (a, b) {
+        return x.cmp(y);
+    }
+    // Fall back to lexical comparison on the string form.
+    value_as_lexical(a).cmp(&value_as_lexical(b))
+}
+
+fn value_as_lexical(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Integer(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Boolean(b) => b.to_string(),
+        Value::Null => String::new(),
     }
 }
 

--- a/ferrosa-sparql/src/planner.rs
+++ b/ferrosa-sparql/src/planner.rs
@@ -34,10 +34,15 @@ pub enum TripleOp {
 }
 
 /// A sort ordering for ORDER BY.
+///
+/// Holds the full ORDER BY expression (which may be a plain variable, an
+/// arithmetic expression like `?a + ?b`, a function call, etc.). The executor
+/// evaluates the expression per solution and sorts by the resulting value
+/// (URS-QEC-S04).
 #[derive(Debug, Clone)]
 pub struct OrderCondition {
-    /// Variable name to sort on.
-    pub variable: String,
+    /// Expression to evaluate per solution and sort on.
+    pub expression: spargebra::algebra::Expression,
     /// True for ascending, false for descending.
     pub ascending: bool,
 }
@@ -285,37 +290,18 @@ fn collect_ops(
         GraphPattern::OrderBy {
             inner, expression, ..
         } => {
+            // URS-QEC-S04: ORDER BY on arbitrary expressions. The executor
+            // evaluates the expression per solution and sorts by the result;
+            // a plain `?var` is just the trivial Variable expression.
             for cond in expression {
-                match cond {
-                    spargebra::algebra::OrderExpression::Asc(
-                        spargebra::algebra::Expression::Variable(v),
-                    ) => {
-                        order_by.push(OrderCondition {
-                            variable: v.as_str().to_string(),
-                            ascending: true,
-                        });
-                    }
-                    spargebra::algebra::OrderExpression::Desc(
-                        spargebra::algebra::Expression::Variable(v),
-                    ) => {
-                        order_by.push(OrderCondition {
-                            variable: v.as_str().to_string(),
-                            ascending: false,
-                        });
-                    }
-                    other => {
-                        // URS-QEC-S04 / URS-QEC-X01: non-variable ORDER BY
-                        // expressions are not implemented.  Silently ignoring
-                        // them would return results in an arbitrary order with
-                        // no indication that the ordering was not applied —
-                        // that is a silent wrong result.  Fail loud instead.
-                        return Err(SparqlError::Plan(format!(
-                            "ORDER BY expression is not implemented: only \
-                             plain variable references (?var) are supported; \
-                             got: {other:?}"
-                        )));
-                    }
-                }
+                let (expr, ascending) = match cond {
+                    spargebra::algebra::OrderExpression::Asc(e) => (e.clone(), true),
+                    spargebra::algebra::OrderExpression::Desc(e) => (e.clone(), false),
+                };
+                order_by.push(OrderCondition {
+                    expression: expr,
+                    ascending,
+                });
             }
             collect_ops(
                 inner,
@@ -676,8 +662,31 @@ mod tests {
             .unwrap();
         let plan = plan_query(&query, "default").unwrap();
         assert_eq!(plan.order_by.len(), 1);
-        assert_eq!(plan.order_by[0].variable, "name");
+        assert!(matches!(
+            &plan.order_by[0].expression,
+            spargebra::algebra::Expression::Variable(v) if v.as_str() == "name"
+        ));
         assert!(plan.order_by[0].ascending);
+    }
+
+    #[test]
+    fn plan_order_by_expression() {
+        // URS-QEC-S04: ORDER BY on an arithmetic expression must plan, not fail.
+        let query = spargebra::SparqlParser::new()
+            .parse_query(
+                "SELECT ?a ?b WHERE { ?s <http://ex/a> ?a ; <http://ex/b> ?b } ORDER BY DESC(?a + ?b)",
+            )
+            .unwrap();
+        let plan = plan_query(&query, "default").unwrap();
+        assert_eq!(plan.order_by.len(), 1);
+        assert!(!plan.order_by[0].ascending);
+        assert!(
+            matches!(
+                &plan.order_by[0].expression,
+                spargebra::algebra::Expression::Add(_, _)
+            ),
+            "ORDER BY (?a + ?b) must capture the Add expression"
+        );
     }
 
     #[test]

--- a/ferrosa-sparql/src/planner.rs
+++ b/ferrosa-sparql/src/planner.rs
@@ -61,9 +61,24 @@ pub struct QueryPlan {
     pub order_by: Vec<OrderCondition>,
     /// FILTER expressions to evaluate against binding sets.
     pub filters: Vec<spargebra::algebra::Expression>,
+    /// Non-None for CONSTRUCT/DESCRIBE query forms; None for SELECT/ASK.
+    pub graph_mode: Option<GraphQueryMode>,
 }
 
-/// Plan a SPARQL SELECT or ASK query.
+/// The template/mode for a query form that produces a graph result.
+#[derive(Debug, Clone)]
+pub enum GraphQueryMode {
+    /// `CONSTRUCT { template }` — the template triples to instantiate per solution.
+    Construct(Vec<TriplePattern>),
+    /// `DESCRIBE <iri> [<iri> …]` — literal IRI(s) to describe; the planner
+    /// has already built SubjectLookup ops and the executor just needs to
+    /// assemble the result from the SELECT output.
+    DescribeIris(Vec<String>),
+    /// `DESCRIBE ?var WHERE { … }` — subjects are derived from WHERE solutions.
+    Describe(String),
+}
+
+/// Plan a SPARQL SELECT, ASK, CONSTRUCT, or DESCRIBE query.
 pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, SparqlError> {
     match query {
         Query::Select {
@@ -79,9 +94,73 @@ pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, Sparq
             plan.limit = Some(1);
             Ok(plan)
         }
-        _ => Err(SparqlError::Plan(
-            "only SELECT and ASK queries are supported in Sprint 1".into(),
-        )),
+        Query::Construct {
+            template,
+            pattern,
+            base_iri: _,
+            ..
+        } => {
+            // Plan the WHERE clause exactly like SELECT so the executor can
+            // bind solutions; then attach the CONSTRUCT template.
+            let mut plan = plan_select(pattern, default_graph, None, false)?;
+            // CONSTRUCT projects all variables — projection is derived from the template.
+            plan.graph_mode = Some(GraphQueryMode::Construct(template.clone()));
+            Ok(plan)
+        }
+        Query::Describe {
+            dataset: _,
+            pattern,
+            base_iri: _,
+        } => {
+            // DESCRIBE <iri> is parsed by spargebra as:
+            //   Extend { inner: Bgp { patterns: [] },
+            //            variable: _freshvar,
+            //            expression: NamedNode(<iri>) }
+            //
+            // Extract all described IRIs from `Extend` nodes, then build a
+            // SELECT-style plan that does a SubjectLookup per IRI.
+            let iris = extract_describe_iris(pattern);
+            if iris.is_empty() {
+                // DESCRIBE ?var WHERE { … } — plan the WHERE clause normally.
+                let mut plan = plan_select(pattern, default_graph, None, false)?;
+                plan.graph_mode = Some(GraphQueryMode::Describe(default_graph.to_string()));
+                return Ok(plan);
+            }
+
+            // Build ops: one SubjectLookup per described IRI.
+            let mut ops = Vec::new();
+            for iri in &iris {
+                let tp = TriplePattern {
+                    subject: spargebra::term::TermPattern::NamedNode(
+                        spargebra::term::NamedNode::new_unchecked(iri.as_str()),
+                    ),
+                    predicate: NamedNodePattern::Variable(
+                        spargebra::term::Variable::new_unchecked("__p"),
+                    ),
+                    object: TermPattern::Variable(spargebra::term::Variable::new_unchecked("__o")),
+                };
+                ops.push((
+                    tp,
+                    TripleOp::SubjectLookup {
+                        graph: default_graph.to_string(),
+                        subject: iri.clone(),
+                        predicate_filter: None,
+                    },
+                ));
+            }
+
+            Ok(QueryPlan {
+                ops,
+                projection: vec!["__p".into(), "__o".into()],
+                limit: None,
+                offset: None,
+                is_ask: false,
+                distinct: false,
+                order_by: vec![],
+                filters: vec![],
+                graph_mode: Some(GraphQueryMode::DescribeIris(iris)),
+            })
+        }
     }
 }
 
@@ -127,6 +206,7 @@ fn plan_select(
         distinct,
         order_by,
         filters,
+        graph_mode: None,
     })
 }
 
@@ -145,7 +225,7 @@ fn collect_ops(
     match pattern {
         GraphPattern::Bgp { patterns } => {
             for tp in patterns {
-                let op = plan_triple_pattern(tp, default_graph);
+                let op = plan_triple_pattern(tp, default_graph)?;
                 ops.push((tp.clone(), op));
             }
         }
@@ -223,11 +303,17 @@ fn collect_ops(
                             ascending: false,
                         });
                     }
-                    _ => {
-                        tracing::warn!(
-                            "ORDER BY expression type not supported; \
-                             only simple variable ordering is implemented"
-                        );
+                    other => {
+                        // URS-QEC-S04 / URS-QEC-X01: non-variable ORDER BY
+                        // expressions are not implemented.  Silently ignoring
+                        // them would return results in an arbitrary order with
+                        // no indication that the ordering was not applied —
+                        // that is a silent wrong result.  Fail loud instead.
+                        return Err(SparqlError::Plan(format!(
+                            "ORDER BY expression is not implemented: only \
+                             plain variable references (?var) are supported; \
+                             got: {other:?}"
+                        )));
                     }
                 }
             }
@@ -286,7 +372,7 @@ fn collect_ops(
                     ),
                     object: object.clone(),
                 };
-                let op = plan_triple_pattern(&tp, default_graph);
+                let op = plan_triple_pattern(&tp, default_graph)?;
                 ops.push((tp, op));
             } else {
                 // Transitive/closure path — emit PropertyPath op for BFS.
@@ -407,7 +493,27 @@ fn extract_predicate_from_path(
 }
 
 /// Choose a storage operation for a single triple pattern.
-fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> TripleOp {
+///
+/// Returns `Err` when the triple pattern contains an embedded quoted triple
+/// (RDF* / SPARQL-star syntax), which is parsed successfully by spargebra but
+/// whose annotation evaluation is not yet implemented (URS-QEC-S03 /
+/// URS-QEC-X01).  Failing loud here prevents silent wrong results.
+fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> Result<TripleOp, SparqlError> {
+    // URS-QEC-S03 / URS-QEC-X01: detect RDF* embedded triple terms and fail loud.
+    if matches!(&tp.subject, TermPattern::Triple(_)) {
+        return Err(SparqlError::Plan(
+            "RDF* (RDF-star) annotation evaluation is not yet implemented. \
+             Quoted triple patterns << ?s ?p ?o >> are parsed but the annotation \
+             variable binding against edge_annotations is not supported."
+                .into(),
+        ));
+    }
+    if matches!(&tp.object, TermPattern::Triple(_)) {
+        return Err(SparqlError::Plan(
+            "RDF* (RDF-star) object quoted triples are not yet implemented.".into(),
+        ));
+    }
+
     let graph = default_graph.to_string();
 
     let subject_bound = matches!(&tp.subject, TermPattern::NamedNode(_));
@@ -417,7 +523,7 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> TripleOp {
         TermPattern::NamedNode(_) | TermPattern::Literal(_)
     );
 
-    if subject_bound {
+    let op = if subject_bound {
         let subject = match &tp.subject {
             TermPattern::NamedNode(n) => n.as_str().to_string(),
             _ => unreachable!(),
@@ -450,6 +556,50 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> TripleOp {
         TripleOp::ObjectScan { graph, object }
     } else {
         TripleOp::FullScan { graph }
+    };
+    Ok(op)
+}
+
+/// Extract literal IRI strings from `DESCRIBE <iri>` patterns.
+///
+/// `DESCRIBE <iri>` is parsed by spargebra as an `Extend` node that binds a
+/// fresh variable to the literal IRI.  This function walks the pattern tree
+/// and collects the IRI strings from such `Extend` nodes.  Returns an empty
+/// `Vec` if the pattern is a WHERE clause (variable describe) rather than
+/// literal IRIs.
+/// Extract literal IRI strings from `DESCRIBE <iri>` patterns.
+///
+/// `DESCRIBE <iri>` is parsed by spargebra as:
+///   `Project { inner: Extend { inner: Bgp { patterns: [] },
+///                              variable: _freshvar,
+///                              expression: NamedNode(<iri>) },
+///              variables: [_freshvar] }`
+///
+/// This function recursively walks the pattern tree and collects the IRI
+/// strings from `Extend` nodes whose `expression` is a literal `NamedNode`.
+/// Returns an empty `Vec` if the pattern is a WHERE clause (variable describe)
+/// rather than literal IRIs.
+pub fn extract_describe_iris(pattern: &spargebra::algebra::GraphPattern) -> Vec<String> {
+    use spargebra::algebra::{Expression, GraphPattern};
+    match pattern {
+        GraphPattern::Extend {
+            inner, expression, ..
+        } => {
+            let mut iris = extract_describe_iris(inner);
+            if let Expression::NamedNode(n) = expression {
+                iris.push(n.as_str().to_string());
+            }
+            iris
+        }
+        // spargebra wraps the Extend in a Project — recurse through wrapper nodes.
+        GraphPattern::Project { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner } => extract_describe_iris(inner),
+        GraphPattern::Slice { inner, .. } => extract_describe_iris(inner),
+        GraphPattern::OrderBy { inner, .. } => extract_describe_iris(inner),
+        GraphPattern::Filter { inner, .. } => extract_describe_iris(inner),
+        GraphPattern::Bgp { .. } => vec![],
+        _ => vec![],
     }
 }
 

--- a/ferrosa-sparql/src/rdf_star.rs
+++ b/ferrosa-sparql/src/rdf_star.rs
@@ -1,28 +1,34 @@
-//! RDF* (RDF-star) annotation query support.
+//! RDF* (RDF-star) annotation query support — **not yet implemented**.
 //!
 //! RDF* extends RDF with statement-about-statement annotations:
 //! ```sparql
 //! << :alice :knows :bob >> :since "2020" .
 //! ```
 //!
-//! In ferrosa, annotations are stored in an `edge_annotations` table:
-//! ```sql
-//! CREATE TABLE edge_annotations (
-//!     tenant_id uuid,
-//!     session_id uuid,
-//!     src_id uuid,
-//!     edge_type text,
-//!     dst_id uuid,
-//!     property_name text,
-//!     property_value text,
-//!     value_type text,
-//!     created_at timestamp,
-//!     PRIMARY KEY ((tenant_id, session_id, src_id, edge_type, dst_id), property_name)
-//! );
-//! ```
+//! ## Current status (URS-QEC-S03a / URS-QEC-X01)
 //!
-//! The SPARQL planner translates RDF* triple patterns into joins between
-//! the main triples table and the edge_annotations table.
+//! Quoted-triple *matching and binding* is **out of scope** for the M3 SPARQL
+//! increment and is therefore **fail-loud**, never silently approximated:
+//!
+//! - The query planner ([`crate::planner`]) rejects any triple pattern with a
+//!   quoted triple in subject or object position with `SparqlError::Plan`, so a
+//!   SELECT/ASK over `<< ?s ?p ?o >> ?prop ?val` returns a 400, not inner
+//!   bindings with the annotation variable silently absent.
+//! - [`evaluate_rdf_star_pattern`] below mirrors that fail-loud contract for any
+//!   future caller.
+//!
+//! ## What real support would require (deliberately not built here)
+//!
+//! Ferrosa's RDF store is the single `rdf_triples` table
+//! (`((graph, subject), predicate, object)`); there is **no** dedicated
+//! annotation/quoted-triple table, and the SPARQL `INSERT` path can only store a
+//! quoted triple as an opaque `<<…>>` string in *object* position — a
+//! quoted-triple *subject* (the annotation case) cannot even be inserted today.
+//! Real evaluation would need: (1) a storage encoding for quoted-triple terms in
+//! key position, (2) parser/insert support for quoted-triple subjects, and
+//! (3) a join planner that decomposes `<< s p o >>` and binds the inner pattern
+//! before binding the outer annotation property. Until that exists, this module
+//! fails loud rather than returning a wrong answer.
 
 use std::collections::HashMap;
 

--- a/ferrosa-sparql/src/rdf_star.rs
+++ b/ferrosa-sparql/src/rdf_star.rs
@@ -56,22 +56,17 @@ pub fn evaluate_rdf_star_pattern(
     _annotation_variable: &str,
     _keyspace: &str,
 ) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
-    // RDF* requires the edge_annotations table to exist in the keyspace.
-    // This is created by ferrosa-memory via CQL DDL.
-    //
-    // Implementation approach:
-    // 1. For each binding in inner_bindings, extract (subject, predicate, object)
-    // 2. Query edge_annotations WHERE src_id=subject AND edge_type=predicate
-    //    AND dst_id=object AND property_name=annotation_property
-    // 3. Bind the annotation value to annotation_variable
-    //
-    // For now, return the inner bindings unmodified with a warning.
-    tracing::warn!(
-        "RDF* annotation queries are not yet fully implemented — \
-         annotations will be empty. Create the edge_annotations table \
-         and re-run to enable."
-    );
-    Ok(_inner_bindings.to_vec())
+    // URS-QEC-S03 / URS-QEC-X01: RDF* annotation evaluation is not yet
+    // implemented.  Returning the inner bindings without the annotation
+    // variable bound would be a silent wrong result — the caller would receive
+    // rows that look valid but are missing the requested annotation data.
+    // Fail loud instead so the HTTP layer can return 400 Bad Request.
+    Err(SparqlError::Plan(
+        "RDF* (RDF-star) annotation evaluation is not yet implemented. \
+         Quoted triple patterns << ?s ?p ?o >> are parsed but annotation \
+         variable binding against edge_annotations is not supported."
+            .into(),
+    ))
 }
 
 #[cfg(test)]
@@ -91,8 +86,11 @@ mod tests {
         assert_eq!(ann.value, "2020");
     }
 
+    /// URS-QEC-S03 / URS-QEC-X01: `evaluate_rdf_star_pattern` must now fail
+    /// loud rather than returning the inner bindings with the annotation variable
+    /// silently absent.
     #[test]
-    fn evaluate_rdf_star_returns_inner_bindings() {
+    fn evaluate_rdf_star_fails_loud_not_silent_inner_bindings() {
         let inner = vec![{
             let mut m = HashMap::new();
             m.insert(
@@ -107,8 +105,20 @@ mod tests {
             m
         }];
 
-        let result = evaluate_rdf_star_pattern(&inner, "since", "when", "test_ks").unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].contains_key("s"));
+        let result = evaluate_rdf_star_pattern(&inner, "since", "when", "test_ks");
+        assert!(
+            result.is_err(),
+            "evaluate_rdf_star_pattern must return Err (fail loud); \
+             returning inner bindings silently would be a wrong result"
+        );
+        let msg = result.unwrap_err().to_string().to_lowercase();
+        assert!(
+            msg.contains("rdf*")
+                || msg.contains("rdf-star")
+                || msg.contains("annotation")
+                || msg.contains("not")
+                || msg.contains("unsupported"),
+            "error must describe the unimplemented RDF* feature: {msg}"
+        );
     }
 }

--- a/ferrosa-sparql/src/results.rs
+++ b/ferrosa-sparql/src/results.rs
@@ -69,6 +69,8 @@ pub struct SparqlAskResult {
 pub enum ResultFormat {
     /// `application/sparql-results+json` (default for SELECT/ASK).
     Json,
+    /// `application/sparql-results+xml` (SPARQL XML Results Format per W3C).
+    Xml,
     /// `text/turtle` (Turtle/N-Triples-like serialization).
     Turtle,
     /// `application/n-triples` (N-Triples format).
@@ -82,7 +84,9 @@ impl ResultFormat {
     /// type is found.
     pub fn from_accept(accept: &str) -> Self {
         // Check for exact or partial matches in priority order.
-        if accept.contains("text/turtle") {
+        if accept.contains("application/sparql-results+xml") {
+            Self::Xml
+        } else if accept.contains("text/turtle") {
             Self::Turtle
         } else if accept.contains("application/n-triples") {
             Self::NTriples
@@ -95,6 +99,7 @@ impl ResultFormat {
     pub fn content_type(self) -> &'static str {
         match self {
             Self::Json => "application/sparql-results+json",
+            Self::Xml => "application/sparql-results+xml",
             Self::Turtle => "text/turtle",
             Self::NTriples => "application/n-triples",
         }
@@ -102,6 +107,46 @@ impl ResultFormat {
 }
 
 impl SparqlJsonResults {
+    /// Serialize to SPARQL Results XML format per W3C.
+    ///
+    /// Produces `application/sparql-results+xml` per the W3C SPARQL 1.1
+    /// Query Results XML Format specification.  The output is well-formed XML
+    /// with the `<sparql>` root, `<head>` with `<variable>` elements, and
+    /// `<results>` with `<result>` / `<binding>` / `<uri>` / `<literal>` /
+    /// `<bnode>` leaves.
+    pub fn to_xml(&self) -> Result<Vec<u8>, String> {
+        let mut buf = String::new();
+        buf.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        buf.push_str("<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n");
+
+        // <head>
+        buf.push_str("  <head>\n");
+        for var in &self.head.vars {
+            buf.push_str(&format!("    <variable name=\"{}\"/>\n", xml_escape(var)));
+        }
+        buf.push_str("  </head>\n");
+
+        // <results>
+        buf.push_str("  <results>\n");
+        for row in &self.results.bindings {
+            buf.push_str("    <result>\n");
+            for var in &self.head.vars {
+                if let Some(binding) = row.get(var) {
+                    buf.push_str(&format!(
+                        "      <binding name=\"{}\">{}</binding>\n",
+                        xml_escape(var),
+                        format_xml_binding(binding)
+                    ));
+                }
+            }
+            buf.push_str("    </result>\n");
+        }
+        buf.push_str("  </results>\n");
+        buf.push_str("</sparql>\n");
+
+        Ok(buf.into_bytes())
+    }
+
     /// Serialize to N-Triples format (one triple per line).
     ///
     /// Produces a simple tabular rendering: each binding row becomes one
@@ -129,6 +174,49 @@ impl SparqlJsonResults {
     /// of N-Triples. Full Turtle grouping/prefixing is deferred.
     pub fn to_turtle(&self) -> Vec<u8> {
         self.to_ntriples()
+    }
+}
+
+/// Escape a string for inclusion in XML text content or attribute values.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+/// Serialize a single binding value as an XML element leaf.
+///
+/// Per W3C SPARQL Results XML:
+/// - URI → `<uri>iri</uri>`
+/// - bnode → `<bnode>label</bnode>`
+/// - literal → `<literal [xml:lang] [datatype]>value</literal>`
+fn format_xml_binding(binding: &Binding) -> String {
+    match binding.binding_type.as_str() {
+        "uri" => format!("<uri>{}</uri>", xml_escape(&binding.value)),
+        "bnode" => {
+            // Strip leading "_:" label prefix if present.
+            let label = binding.value.strip_prefix("_:").unwrap_or(&binding.value);
+            format!("<bnode>{}</bnode>", xml_escape(label))
+        }
+        _ => {
+            // Literal — may carry xml:lang or datatype attributes.
+            let lang_attr = binding
+                .lang
+                .as_deref()
+                .map(|l| format!(" xml:lang=\"{}\"", xml_escape(l)))
+                .unwrap_or_default();
+            let dt_attr = binding
+                .datatype
+                .as_deref()
+                .map(|d| format!(" datatype=\"{}\"", xml_escape(d)))
+                .unwrap_or_default();
+            format!(
+                "<literal{lang_attr}{dt_attr}>{}</literal>",
+                xml_escape(&binding.value)
+            )
+        }
     }
 }
 

--- a/ferrosa-sparql/src/update.rs
+++ b/ferrosa-sparql/src/update.rs
@@ -81,10 +81,23 @@ pub async fn execute_update(
                 total_deleted += exec_clear(graph, keyspace, storage, write_path).await?;
             }
             spargebra::GraphUpdateOperation::Load { .. } => {
-                return Err(SparqlError::Plan("SPARQL LOAD is not implemented".into()));
+                // URS-QEC-X01: LOAD fetches and parses an external RDF document.
+                // This engine has no HTTP fetch + RDF-document parser pipeline,
+                // so it cannot honor LOAD. Fail loud rather than silently
+                // succeed with zero triples.
+                return Err(SparqlError::Plan(
+                    "SPARQL LOAD is not implemented: this endpoint has no RDF \
+                     document fetch/parse pipeline"
+                        .into(),
+                ));
             }
             spargebra::GraphUpdateOperation::Create { .. } => {
-                return Err(SparqlError::Plan("SPARQL CREATE is not implemented".into()));
+                // CREATE GRAPH is a success no-op in the single-graph-per-keyspace
+                // model: graphs are implicit (materialized by the partition-key
+                // graph component on first insert), so the named graph "exists"
+                // after this call with nothing to allocate. Per SPARQL 1.1,
+                // CREATE on a fresh graph succeeds; we cannot cheaply detect
+                // pre-existence, so (with or without SILENT) we report success.
             }
         }
     }
@@ -111,6 +124,24 @@ async fn exec_delete_insert(
     storage: &Arc<StorageEngine>,
     write_path: &Arc<WritePath>,
 ) -> Result<(usize, usize), SparqlError> {
+    // URS-QEC-X01: a delete or insert template whose target graph is a named
+    // graph distinct from this keyspace's default graph is NOT addressable in
+    // the single-graph-per-keyspace model (the read/write path keys the table
+    // by keyspace and does not filter by the graph partition-key component).
+    // Honoring it by writing into the default graph would be a silent wrong
+    // result, so we fail loud BEFORE evaluating the WHERE or applying any
+    // mutation. This is what makes the spargebra ADD/MOVE/COPY desugaring
+    // (which targets named graphs) fail loud instead of silently operating on
+    // the wrong graph. (A named-graph *read* — `GraphPattern::Graph` in the
+    // WHERE clause, produced when COPY/MOVE/ADD source is a named graph — is
+    // separately rejected by the planner.)
+    for tmpl in delete {
+        check_quad_graph_pattern(&tmpl.graph_name, keyspace, "DELETE")?;
+    }
+    for tmpl in insert {
+        check_quad_graph_pattern(&tmpl.graph_name, keyspace, "INSERT")?;
+    }
+
     let plan = crate::planner::plan_where(pattern, keyspace)?;
     let solutions = crate::executor::execute_bindings(&plan, write_path).await?;
 
@@ -207,6 +238,42 @@ struct InsertTriple {
     obj_type: String,
     datatype: Option<String>,
     language: Option<String>,
+}
+
+/// Validate that a quad template's target graph (a [`GraphNamePattern`], as
+/// carried by both INSERT and DELETE templates in a `DeleteInsert`) is
+/// addressable in this single-graph-per-keyspace engine.
+///
+/// `DefaultGraph` maps to the keyspace's default graph (always OK). A
+/// `NamedNode` equal to the keyspace is the same graph (OK). Any other named
+/// graph — or a variable-bound graph — is not addressable: return a fail-loud
+/// error instead of silently operating on the default graph (URS-QEC-X01).
+fn check_quad_graph_pattern(
+    graph: &spargebra::term::GraphNamePattern,
+    keyspace: &str,
+    op: &str,
+) -> Result<(), SparqlError> {
+    match graph {
+        spargebra::term::GraphNamePattern::DefaultGraph => Ok(()),
+        spargebra::term::GraphNamePattern::NamedNode(n) if n.as_str() == keyspace => Ok(()),
+        spargebra::term::GraphNamePattern::NamedNode(n) => {
+            Err(named_graph_unsupported(op, n.as_str(), keyspace))
+        }
+        spargebra::term::GraphNamePattern::Variable(v) => Err(SparqlError::Plan(format!(
+            "{op} into a variable-bound graph (?{}) is not supported: this endpoint \
+             exposes a single graph per keyspace ('{keyspace}')",
+            v.as_str()
+        ))),
+    }
+}
+
+/// Build the standard fail-loud error for an unaddressable named graph.
+fn named_graph_unsupported(op: &str, graph: &str, keyspace: &str) -> SparqlError {
+    SparqlError::Plan(format!(
+        "{op} into named graph <{graph}> is not supported: this endpoint exposes a \
+         single graph per keyspace ('{keyspace}'); named graphs distinct from it \
+         are not addressable (so ADD/MOVE/COPY across graphs cannot be honored)"
+    ))
 }
 
 /// Resolve a `TermPattern` (subject/object position) against a solution into a

--- a/ferrosa-sparql/src/update.rs
+++ b/ferrosa-sparql/src/update.rs
@@ -47,6 +47,15 @@ pub async fn execute_update(
         .parse_update(update_str)
         .map_err(|e| SparqlError::Parse(format!("{e}")))?;
 
+    // SPARQL 1.1 update atomicity (URS-QEC-X01): an update request that errors
+    // must NOT have partially mutated the store. The executor below applies
+    // operations sequentially with no rollback, so we MUST reject the whole
+    // request up-front if ANY operation is unaddressable in this
+    // single-graph-per-keyspace engine. Without this, a desugared
+    // `COPY/MOVE <g> TO DEFAULT` would run its leading `Drop(DEFAULT)` and wipe
+    // the default graph before the later unaddressable named-graph read fails.
+    validate_update(&update, keyspace)?;
+
     let mut total_inserted = 0usize;
     let mut total_deleted = 0usize;
 
@@ -106,6 +115,154 @@ pub async fn execute_update(
         triples_inserted: total_inserted,
         triples_deleted: total_deleted,
     })
+}
+
+/// Validate EVERY operation of a parsed update before any of them runs, so an
+/// update request that contains an unaddressable operation fails loud with zero
+/// mutations (SPARQL 1.1 atomicity / URS-QEC-X01).
+///
+/// This is the single chokepoint that makes the spargebra `COPY/MOVE/ADD`
+/// desugaring safe: those rewrite into a leading `Drop` plus a `DeleteInsert`
+/// that reads from / writes to a named graph this engine cannot address. By
+/// rejecting the whole request here — before the destructive `Drop` executes —
+/// we guarantee no partial side effects.
+fn validate_update(update: &spargebra::Update, keyspace: &str) -> Result<(), SparqlError> {
+    for op in &update.operations {
+        match op {
+            spargebra::GraphUpdateOperation::InsertData { data } => {
+                for quad in data {
+                    check_graph_name(&quad.graph_name, keyspace, "INSERT DATA")?;
+                }
+            }
+            spargebra::GraphUpdateOperation::DeleteData { data } => {
+                for quad in data {
+                    check_graph_name(&quad.graph_name, keyspace, "DELETE DATA")?;
+                }
+            }
+            spargebra::GraphUpdateOperation::DeleteInsert {
+                delete,
+                insert,
+                pattern,
+                ..
+            } => {
+                for tmpl in delete {
+                    check_quad_graph_pattern(&tmpl.graph_name, keyspace, "DELETE")?;
+                }
+                for tmpl in insert {
+                    check_quad_graph_pattern(&tmpl.graph_name, keyspace, "INSERT")?;
+                }
+                // Reject a WHERE clause that reads from a named graph
+                // (`GraphPattern::Graph`), e.g. the COPY/MOVE/ADD source.
+                check_pattern_graph_reads(pattern, keyspace)?;
+            }
+            spargebra::GraphUpdateOperation::Clear { graph, silent }
+            | spargebra::GraphUpdateOperation::Drop { graph, silent } => {
+                check_graph_target(graph, keyspace, *silent)?;
+            }
+            spargebra::GraphUpdateOperation::Load { .. } => {
+                return Err(SparqlError::Plan(
+                    "SPARQL LOAD is not implemented: this endpoint has no RDF \
+                     document fetch/parse pipeline"
+                        .into(),
+                ));
+            }
+            spargebra::GraphUpdateOperation::Create { .. } => {
+                // CREATE is a success no-op (graphs are implicit); nothing to
+                // validate. See the execution loop for the rationale.
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a concrete (`InsertData`/`DeleteData`) quad's graph name.
+fn check_graph_name(
+    graph: &spargebra::term::GraphName,
+    keyspace: &str,
+    op: &str,
+) -> Result<(), SparqlError> {
+    match graph {
+        spargebra::term::GraphName::DefaultGraph => Ok(()),
+        spargebra::term::GraphName::NamedNode(n) if n.as_str() == keyspace => Ok(()),
+        spargebra::term::GraphName::NamedNode(n) => {
+            Err(named_graph_unsupported(op, n.as_str(), keyspace))
+        }
+    }
+}
+
+/// Validate a `CLEAR`/`DROP` target for the atomicity check.
+///
+/// All `CLEAR`/`DROP` targets are *safe* in this engine: `DefaultGraph`,
+/// `NamedGraphs`, and `AllGraphs` resolve to "every triple in this keyspace"
+/// (clearable), a `NamedNode` equal to the keyspace is that same graph, and any
+/// other `NamedNode` simply does not exist here, so `exec_clear` deletes nothing
+/// (a true no-op — it never fakes or mis-targets a deletion, per URS-QEC-X01 and
+/// the M1 `clear_non_matching_named_graph_deletes_nothing` contract).
+///
+/// Because every `CLEAR`/`DROP` is non-destructive-to-other-data, none of them
+/// can violate atomicity, so this validation always passes. It exists so the
+/// up-front pass is exhaustive over operation kinds (and as the place to tighten
+/// non-SILENT semantics later, if the single-graph model ever gains real named
+/// graphs).
+fn check_graph_target(
+    _target: &GraphTarget,
+    _keyspace: &str,
+    _silent: bool,
+) -> Result<(), SparqlError> {
+    Ok(())
+}
+
+/// Recursively reject any `GraphPattern::Graph` reading from a graph other than
+/// the keyspace default graph. Such a named-graph read (produced by the
+/// COPY/MOVE/ADD desugaring, or by an explicit `GRAPH <g> { … }` block in a
+/// WHERE clause) is not addressable here and must fail loud BEFORE any
+/// preceding destructive op runs.
+fn check_pattern_graph_reads(
+    pattern: &spargebra::algebra::GraphPattern,
+    keyspace: &str,
+) -> Result<(), SparqlError> {
+    use spargebra::algebra::GraphPattern as G;
+    match pattern {
+        G::Graph { name, inner } => {
+            match name {
+                NamedNodePattern::NamedNode(n) if n.as_str() == keyspace => {}
+                NamedNodePattern::NamedNode(n) => {
+                    return Err(SparqlError::Plan(format!(
+                        "reading from named graph <{}> is not supported: this endpoint \
+                         exposes a single graph per keyspace ('{keyspace}') — so \
+                         ADD/MOVE/COPY from a named graph cannot be honored",
+                        n.as_str()
+                    )));
+                }
+                NamedNodePattern::Variable(v) => {
+                    return Err(SparqlError::Plan(format!(
+                        "GRAPH ?{} (variable-bound graph read) is not supported: this \
+                         endpoint exposes a single graph per keyspace ('{keyspace}')",
+                        v.as_str()
+                    )));
+                }
+            }
+            check_pattern_graph_reads(inner, keyspace)
+        }
+        G::Bgp { .. } | G::Path { .. } | G::Values { .. } => Ok(()),
+        G::Join { left, right } | G::Union { left, right } | G::Minus { left, right } => {
+            check_pattern_graph_reads(left, keyspace)?;
+            check_pattern_graph_reads(right, keyspace)
+        }
+        G::LeftJoin { left, right, .. } => {
+            check_pattern_graph_reads(left, keyspace)?;
+            check_pattern_graph_reads(right, keyspace)
+        }
+        G::Filter { inner, .. }
+        | G::Extend { inner, .. }
+        | G::OrderBy { inner, .. }
+        | G::Project { inner, .. }
+        | G::Distinct { inner }
+        | G::Reduced { inner }
+        | G::Slice { inner, .. }
+        | G::Group { inner, .. }
+        | G::Service { inner, .. } => check_pattern_graph_reads(inner, keyspace),
+    }
 }
 
 /// Execute `DELETE … INSERT … WHERE` (covers `DELETE WHERE`, where `insert` is

--- a/ferrosa-sparql/tests/sparql_m3_completeness.rs
+++ b/ferrosa-sparql/tests/sparql_m3_completeness.rs
@@ -13,7 +13,6 @@
 //! | URS-QEC-S03 | RDF* eval (silent → fail loud) + SPARQL XML results | annotated var must NOT silently be absent; XML serialization round-trip |
 //! | URS-QEC-S04 | ORDER BY expressions (silent → fail loud) | non-variable ORDER BY must return Err, not silently skip |
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use ferrosa_cluster::write_path::WritePath;
@@ -63,14 +62,6 @@ fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngi
         ..Default::default()
     };
     SparqlEngine::new(storage, write_path, config)
-}
-
-async fn select_count(eng: &SparqlEngine, query: &str) -> usize {
-    match eng.execute(query, KS).await.expect("select must succeed") {
-        SparqlResult::Select(r) => r.results.bindings.len(),
-        SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
-        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
-    }
 }
 
 async fn select_values(eng: &SparqlEngine, query: &str, var: &str) -> Vec<String> {

--- a/ferrosa-sparql/tests/sparql_m3_completeness.rs
+++ b/ferrosa-sparql/tests/sparql_m3_completeness.rs
@@ -1,0 +1,422 @@
+//! M3 completeness tests — URS-QEC-S01/S02/S03/S04.
+//!
+//! RED tests (written before implementation); each must fail until the
+//! corresponding implementation is in place.  Every test documents its
+//! requirement ID and fail-loud expectation.
+//!
+//! ## Summary of requirements
+//!
+//! | ID | What | Fail-loud rule |
+//! |---|---|---|
+//! | URS-QEC-S01 | CONSTRUCT / DESCRIBE query forms | `plan_query` must return Ok for these forms; engine must produce graph output |
+//! | URS-QEC-S02 | Full SPARQL UPDATE beyond M1: INSERT WHERE | INSERT WHERE must persist triples |
+//! | URS-QEC-S03 | RDF* eval (silent → fail loud) + SPARQL XML results | annotated var must NOT silently be absent; XML serialization round-trip |
+//! | URS-QEC-S04 | ORDER BY expressions (silent → fail loud) | non-variable ORDER BY must return Err, not silently skip |
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_sparql::engine::{SparqlConfig, SparqlEngine, SparqlResult};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+};
+use tempfile::TempDir;
+
+const KS: &str = "default";
+
+fn setup() -> (Arc<StorageEngine>, Arc<WritePath>, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let config = StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 4096,
+            max_segment_age: std::time::Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.path().join("commitlog"),
+            checkpoint_dir: dir.path().join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.path().to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let storage = Arc::new(StorageEngine::new(config, None).unwrap());
+    let write_path = Arc::new(WritePath::direct(Arc::clone(&storage)));
+    (storage, write_path, dir)
+}
+
+fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngine {
+    let config = SparqlConfig {
+        default_graph: KS.to_string(),
+        ..Default::default()
+    };
+    SparqlEngine::new(storage, write_path, config)
+}
+
+async fn select_count(eng: &SparqlEngine, query: &str) -> usize {
+    match eng.execute(query, KS).await.expect("select must succeed") {
+        SparqlResult::Select(r) => r.results.bindings.len(),
+        SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
+    }
+}
+
+async fn select_values(eng: &SparqlEngine, query: &str, var: &str) -> Vec<String> {
+    match eng.execute(query, KS).await.expect("select must succeed") {
+        SparqlResult::Select(r) => r
+            .results
+            .bindings
+            .iter()
+            .filter_map(|row| row.get(var).map(|b| b.value.clone()))
+            .collect(),
+        SparqlResult::Ask(_) => panic!("expected SELECT, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT, got Graph"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S01 — CONSTRUCT and DESCRIBE query forms
+// ---------------------------------------------------------------------------
+
+/// S01-a: CONSTRUCT query must succeed and produce graph output (not a Plan error).
+/// The result must serialize without error; the constructed triples must be
+/// present in the serialized graph.
+#[tokio::test]
+async fn construct_query_produces_graph_result() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // Seed some data.
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/alice> <http://ex/name> \"Alice\" . \
+            <http://ex/bob>   <http://ex/name> \"Bob\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    // CONSTRUCT copies matched triples into a new graph template.
+    let result = eng
+        .execute(
+            "CONSTRUCT { ?s <http://ex/name> ?name } \
+             WHERE { ?s <http://ex/name> ?name }",
+            KS,
+        )
+        .await
+        .expect("CONSTRUCT must not return a plan error");
+
+    // The result must be a Graph variant (not Select/Ask).
+    match &result {
+        SparqlResult::Graph(triples) => {
+            assert_eq!(triples.len(), 2, "CONSTRUCT must produce 2 triples");
+        }
+        other => panic!("expected SparqlResult::Graph, got {other:?}"),
+    }
+
+    // Must serialize to N-Triples without error.
+    let nt = String::from_utf8(result.to_ntriples()).unwrap();
+    assert!(
+        nt.contains("Alice") || nt.contains("alice"),
+        "serialized CONSTRUCT result must contain Alice: {nt}"
+    );
+}
+
+/// S01-b: DESCRIBE query must succeed and produce graph output for the
+/// described resource.
+#[tokio::test]
+async fn describe_query_produces_graph_result() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/alice> <http://ex/name>  \"Alice\" . \
+            <http://ex/alice> <http://ex/email> \"alice@ex.com\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    let result = eng
+        .execute("DESCRIBE <http://ex/alice>", KS)
+        .await
+        .expect("DESCRIBE must not return a plan error");
+
+    match &result {
+        SparqlResult::Graph(triples) => {
+            assert_eq!(
+                triples.len(),
+                2,
+                "DESCRIBE must return both triples about :alice"
+            );
+        }
+        other => panic!("expected SparqlResult::Graph for DESCRIBE, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S02 — Full SPARQL UPDATE: INSERT … WHERE
+// ---------------------------------------------------------------------------
+
+/// S02: INSERT … WHERE must evaluate the WHERE clause, instantiate the INSERT
+/// template per solution, and persist the resulting triples.  After the
+/// operation a SELECT must return the newly inserted data.
+#[tokio::test]
+async fn insert_where_persists_new_triples() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // Seed: alice is a Person.
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/type> <http://ex/Person> }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    // INSERT WHERE: for every Person, assert they are also a LegalEntity.
+    let res = eng
+        .execute_update(
+            "INSERT { ?s <http://ex/type> <http://ex/LegalEntity> } \
+             WHERE  { ?s <http://ex/type> <http://ex/Person> }",
+            KS,
+        )
+        .await
+        .expect("INSERT WHERE must succeed");
+
+    assert_eq!(res.triples_inserted, 1, "one triple must be inserted");
+
+    // The new triple must now be visible to SELECT.
+    let types = select_values(
+        &eng,
+        "SELECT ?t WHERE { <http://ex/alice> <http://ex/type> ?t }",
+        "t",
+    )
+    .await;
+    assert!(
+        types.iter().any(|t| t.contains("LegalEntity")),
+        "LegalEntity triple must be visible after INSERT WHERE; got: {types:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S03a — RDF* must fail loud (not return inner bindings silently)
+// ---------------------------------------------------------------------------
+
+/// S03-a (URS-QEC-X01): A SPARQL query using RDF* annotation syntax must
+/// return a clear SPARQL protocol error — NOT return inner bindings as if the
+/// annotation variable is simply absent.
+///
+/// Current (broken) behaviour: `evaluate_rdf_star_pattern` logs a warning and
+/// returns the inner bindings with the annotation variable unbound.  That is a
+/// silent wrong result — the caller gets rows that look valid but are missing
+/// the requested annotation data.
+///
+/// Required behaviour: the engine returns `Err(SparqlError::Plan(…))` so the
+/// HTTP layer returns 400 Bad Request, not a silently incomplete 200.
+#[tokio::test]
+async fn rdf_star_annotation_fails_loud_not_silent_wrong_result() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // We don't need stored data — the query itself must fail loud before
+    // hitting storage.
+    let err = eng
+        .execute(
+            "SELECT ?conf WHERE { \
+                << <http://ex/a> <http://ex/link> <http://ex/b> >> \
+                   <http://ex/confidence> ?conf }",
+            KS,
+        )
+        .await
+        .expect_err(
+            "RDF* annotation query must return Err (fail loud), \
+             not Ok with the annotation variable silently absent",
+        );
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("rdf*")
+            || msg.contains("rdf-star")
+            || msg.contains("annotation")
+            || msg.contains("not implemented")
+            || msg.contains("unsupported"),
+        "error must explain that RDF* evaluation is not implemented: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S03b — SPARQL XML results serialization
+// ---------------------------------------------------------------------------
+
+/// S03-b: The engine must support `application/sparql-results+xml` as a
+/// result format.  The serialized output must be well-formed XML containing
+/// the standard `<sparql>` root and `<results>` element with correct bindings.
+#[tokio::test]
+async fn xml_results_serialization_roundtrip() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/name> \"Alice\" }",
+        KS,
+    )
+    .await
+    .expect("insert");
+
+    let result = eng
+        .execute("SELECT ?s ?name WHERE { ?s <http://ex/name> ?name }", KS)
+        .await
+        .expect("select");
+
+    // Serialize to XML.
+    let xml_bytes = result.to_xml().expect("XML serialization must succeed");
+    let xml = String::from_utf8(xml_bytes).expect("XML must be valid UTF-8");
+
+    // Must be well-formed SPARQL Results XML per W3C.
+    assert!(
+        xml.contains("<sparql") || xml.contains("sparql-results"),
+        "XML must contain <sparql> root element: {xml}"
+    );
+    assert!(
+        xml.contains("<results"),
+        "XML must contain <results>: {xml}"
+    );
+    assert!(
+        xml.contains("Alice"),
+        "XML must include the bound literal: {xml}"
+    );
+}
+
+/// S03-b: `ResultFormat::from_accept` must recognise
+/// `application/sparql-results+xml` and route to XML serialization.
+#[test]
+fn result_format_accepts_xml_content_type() {
+    use ferrosa_sparql::results::ResultFormat;
+    let fmt = ResultFormat::from_accept("application/sparql-results+xml");
+    assert_eq!(
+        fmt,
+        ResultFormat::Xml,
+        "Accept: application/sparql-results+xml must select Xml format"
+    );
+    assert_eq!(
+        fmt.content_type(),
+        "application/sparql-results+xml",
+        "Xml format must advertise the correct Content-Type"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S04 — ORDER BY on expressions must fail loud
+// ---------------------------------------------------------------------------
+
+/// S04 (URS-QEC-X01): ORDER BY with a non-variable expression (e.g. a
+/// function call like `STR(?name)`, or an arithmetic expression) must return a
+/// clear SPARQL protocol error, NOT silently skip the ordering and return
+/// results in arbitrary order.
+///
+/// Current (broken) behaviour: `planner.rs` logs a warning and falls through,
+/// silently discarding the ORDER BY clause.  The caller gets results in an
+/// arbitrary, undocumented order with no indication that the requested ordering
+/// was not applied.
+///
+/// Required behaviour: the engine returns `Err(SparqlError::Plan(…))` so the
+/// HTTP layer returns 400 Bad Request, not a silently unordered 200.
+#[tokio::test]
+async fn order_by_expression_fails_loud_not_silent_ignore() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // The query itself must fail loud at planning time regardless of stored data.
+    let err = eng
+        .execute(
+            "SELECT ?s ?name \
+             WHERE  { ?s <http://ex/name> ?name } \
+             ORDER BY STR(?name)",
+            KS,
+        )
+        .await
+        .expect_err(
+            "ORDER BY on a function expression must return Err (fail loud), \
+             not silently ignore the ordering clause and return Ok",
+        );
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("order")
+            || msg.contains("expression")
+            || msg.contains("not implemented")
+            || msg.contains("unsupported"),
+        "error must explain that ORDER BY expressions are not implemented: {msg}"
+    );
+}
+
+/// S04 (positive case): ORDER BY on a plain variable must still work correctly
+/// after the fail-loud change — we must not regress variable-based ordering.
+#[tokio::test]
+async fn order_by_variable_still_works_after_fail_loud_change() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/b> <http://ex/name> \"Berta\" . \
+            <http://ex/a> <http://ex/name> \"Anna\"  . \
+            <http://ex/c> <http://ex/name> \"Carl\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    let names = select_values(
+        &eng,
+        "SELECT ?name WHERE { ?s <http://ex/name> ?name } ORDER BY ?name",
+        "name",
+    )
+    .await;
+
+    assert_eq!(
+        names,
+        vec!["Anna", "Berta", "Carl"],
+        "ascending ORDER BY ?name must sort correctly"
+    );
+}
+
+/// S04 (negative direction): ORDER BY DESC(expression) must also fail loud.
+#[tokio::test]
+async fn order_by_desc_expression_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let err = eng
+        .execute(
+            "SELECT ?s ?name \
+             WHERE  { ?s <http://ex/name> ?name } \
+             ORDER BY DESC(STR(?name))",
+            KS,
+        )
+        .await
+        .expect_err("ORDER BY DESC(expr) must return Err (fail loud)");
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("order")
+            || msg.contains("expression")
+            || msg.contains("not implemented")
+            || msg.contains("unsupported"),
+        "error must mention unsupported ORDER BY expression: {msg}"
+    );
+}

--- a/ferrosa-sparql/tests/sparql_m3_completeness.rs
+++ b/ferrosa-sparql/tests/sparql_m3_completeness.rs
@@ -411,3 +411,182 @@ async fn order_by_desc_expression_fails_loud() {
         "error must mention unsupported ORDER BY expression: {msg}"
     );
 }
+
+/// S03-a (object position, URS-QEC-X01): an RDF* quoted triple in OBJECT
+/// position (`?s :p << ?a :q ?b >>`) must also fail loud. The planner has a
+/// distinct branch for this; without a test it could silently regress to a
+/// FullScan that ignores the embedded triple and returns wrong rows.
+#[tokio::test]
+async fn rdf_star_object_quoted_triple_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let err = eng
+        .execute(
+            "SELECT ?s WHERE { \
+                ?s <http://ex/states> \
+                   << <http://ex/a> <http://ex/link> <http://ex/b> >> }",
+            KS,
+        )
+        .await
+        .expect_err(
+            "RDF* object-position quoted triple must return Err (fail loud), \
+             not a silent scan that drops the embedded triple",
+        );
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("rdf*")
+            || msg.contains("rdf-star")
+            || msg.contains("quoted")
+            || msg.contains("not implemented")
+            || msg.contains("unsupported"),
+        "error must explain the unimplemented RDF* object triple: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S03b — XML results for ASK + structural/escaping correctness
+//
+// Part (b) of S03 names BOTH "SELECT/ASK". ASK→XML was implemented but never
+// tested, and the SELECT XML test only string-`contains`-checks the value. The
+// W3C SPARQL 1.1 Query Results XML Format mandates a specific element shape and
+// well-formedness (escaping). These RED tests pin that contract.
+// ---------------------------------------------------------------------------
+
+/// S03-b (ASK): An ASK query serialized to XML must produce the W3C
+/// `<boolean>true</boolean>` form under the `<sparql>` root — not a SELECT-style
+/// `<results>` body. The `false` case must likewise render `<boolean>false</boolean>`.
+#[tokio::test]
+async fn ask_query_xml_serialization_boolean_form() {
+    use ferrosa_sparql::results::ResultFormat;
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/name> \"Alice\" }",
+        KS,
+    )
+    .await
+    .expect("insert");
+
+    // ASK that matches -> true.
+    let yes = eng
+        .execute("ASK { <http://ex/alice> <http://ex/name> ?n }", KS)
+        .await
+        .expect("ask true");
+    assert!(
+        matches!(yes, SparqlResult::Ask(_)),
+        "ASK must produce an Ask result"
+    );
+    let xml = String::from_utf8(
+        yes.serialize(ResultFormat::Xml)
+            .expect("ASK XML serialization must succeed"),
+    )
+    .expect("XML must be valid UTF-8");
+    assert!(
+        xml.contains("<sparql"),
+        "ASK XML must carry the <sparql> root: {xml}"
+    );
+    assert!(
+        xml.contains("<boolean>true</boolean>"),
+        "matching ASK must serialize <boolean>true</boolean>, not a SELECT body: {xml}"
+    );
+    assert!(
+        !xml.contains("<results"),
+        "ASK XML must NOT contain a <results> element: {xml}"
+    );
+
+    // ASK that does not match -> false.
+    let no = eng
+        .execute("ASK { <http://ex/nobody> <http://ex/name> ?n }", KS)
+        .await
+        .expect("ask false");
+    let xml_no = String::from_utf8(
+        no.serialize(ResultFormat::Xml)
+            .expect("ASK XML serialization must succeed"),
+    )
+    .expect("XML must be valid UTF-8");
+    assert!(
+        xml_no.contains("<boolean>false</boolean>"),
+        "non-matching ASK must serialize <boolean>false</boolean>: {xml_no}"
+    );
+}
+
+/// S03-b (SELECT structure): The SELECT XML must use the W3C element shape —
+/// each bound variable wrapped in `<binding name="...">` with a typed leaf
+/// (`<uri>` for IRIs, `<literal>` for literals) — not just the raw value text.
+#[tokio::test]
+async fn select_xml_uses_w3c_binding_element_shape() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/name> \"Alice\" }",
+        KS,
+    )
+    .await
+    .expect("insert");
+
+    let result = eng
+        .execute("SELECT ?s ?name WHERE { ?s <http://ex/name> ?name }", KS)
+        .await
+        .expect("select");
+    let xml = String::from_utf8(result.to_xml().expect("XML serialization")).unwrap();
+
+    // Head must declare the projected variables.
+    assert!(
+        xml.contains("<variable name=\"s\"") && xml.contains("<variable name=\"name\""),
+        "XML <head> must declare each projected <variable>: {xml}"
+    );
+    // The IRI subject binding must be a <uri> leaf inside a named <binding>.
+    assert!(
+        xml.contains("<binding name=\"s\"><uri>http://ex/alice</uri></binding>"),
+        "subject must serialize as <binding name=\"s\"><uri>…</uri></binding>: {xml}"
+    );
+    // The literal object binding must be a <literal> leaf inside a named <binding>.
+    assert!(
+        xml.contains("<binding name=\"name\">") && xml.contains("<literal"),
+        "literal binding must use a <literal> leaf inside <binding name=\"name\">: {xml}"
+    );
+    // Result rows must be wrapped in <result> under <results>.
+    assert!(
+        xml.contains("<results") && xml.contains("<result>"),
+        "rows must be wrapped in <results>/<result>: {xml}"
+    );
+}
+
+/// S03-b (escaping / well-formedness): A literal value containing XML
+/// metacharacters (`<`, `&`, `>`) must be entity-escaped so the output stays
+/// well-formed XML. An unescaped `<` would corrupt the document and is also an
+/// injection vector — the raw substring must NOT appear, but its escaped form must.
+#[tokio::test]
+async fn select_xml_escapes_special_characters_in_literals() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // Literal value carries '<', '&', '>'.
+    eng.execute_update(
+        "INSERT DATA { <http://ex/a> <http://ex/note> \"a < b & c > d\" }",
+        KS,
+    )
+    .await
+    .expect("insert");
+
+    let result = eng
+        .execute("SELECT ?note WHERE { ?s <http://ex/note> ?note }", KS)
+        .await
+        .expect("select");
+    let xml = String::from_utf8(result.to_xml().expect("XML serialization")).unwrap();
+
+    // The escaped entities must be present.
+    assert!(
+        xml.contains("a &lt; b &amp; c &gt; d"),
+        "literal metacharacters must be entity-escaped: {xml}"
+    );
+    // The raw, unescaped literal payload must NOT leak into the document body.
+    assert!(
+        !xml.contains("a < b & c > d"),
+        "raw unescaped '<'/'&'/'>' must not appear in the XML body (well-formedness): {xml}"
+    );
+}

--- a/ferrosa-sparql/tests/sparql_m3_completeness.rs
+++ b/ferrosa-sparql/tests/sparql_m3_completeness.rs
@@ -11,7 +11,7 @@
 //! | URS-QEC-S01 | CONSTRUCT / DESCRIBE query forms | `plan_query` must return Ok for these forms; engine must produce graph output |
 //! | URS-QEC-S02 | Full SPARQL UPDATE beyond M1: INSERT WHERE | INSERT WHERE must persist triples |
 //! | URS-QEC-S03 | RDF* eval (silent → fail loud) + SPARQL XML results | annotated var must NOT silently be absent; XML serialization round-trip |
-//! | URS-QEC-S04 | ORDER BY expressions (silent → fail loud) | non-variable ORDER BY must return Err, not silently skip |
+//! | URS-QEC-S04 | ORDER BY expressions | non-variable ORDER BY (e.g. `?a + ?b`, `STR(?x)`) must be evaluated per-solution and sort correctly (ASC/DESC), not be silently ignored |
 
 use std::sync::Arc;
 
@@ -311,52 +311,80 @@ fn result_format_accepts_xml_content_type() {
 }
 
 // ---------------------------------------------------------------------------
-// URS-QEC-S04 — ORDER BY on expressions must fail loud
+// URS-QEC-S04 — ORDER BY on expressions (evaluated per-solution, ASC/DESC)
 // ---------------------------------------------------------------------------
 
-/// S04 (URS-QEC-X01): ORDER BY with a non-variable expression (e.g. a
-/// function call like `STR(?name)`, or an arithmetic expression) must return a
-/// clear SPARQL protocol error, NOT silently skip the ordering and return
-/// results in arbitrary order.
+/// S04 (headline): `ORDER BY (?a + ?b) DESC` must evaluate the arithmetic
+/// expression per solution and sort by the resulting sum, descending — not
+/// silently ignore the clause and return rows in arbitrary order.
 ///
-/// Current (broken) behaviour: `planner.rs` logs a warning and falls through,
-/// silently discarding the ORDER BY clause.  The caller gets results in an
-/// arbitrary, undocumented order with no indication that the requested ordering
-/// was not applied.
-///
-/// Required behaviour: the engine returns `Err(SparqlError::Plan(…))` so the
-/// HTTP layer returns 400 Bad Request, not a silently unordered 200.
+/// Data: three subjects with integer (?a, ?b) pairs whose sums are 5, 9, 7.
+/// DESC ordering by (?a + ?b) must yield subjects in sum order 9, 7, 5.
 #[tokio::test]
-async fn order_by_expression_fails_loud_not_silent_ignore() {
+async fn order_by_arithmetic_expression_desc_orders_correctly() {
     let (storage, wp, _dir) = setup();
     let eng = engine(storage, wp);
 
-    // The query itself must fail loud at planning time regardless of stored data.
-    let err = eng
-        .execute(
-            "SELECT ?s ?name \
-             WHERE  { ?s <http://ex/name> ?name } \
-             ORDER BY STR(?name)",
-            KS,
-        )
-        .await
-        .expect_err(
-            "ORDER BY on a function expression must return Err (fail loud), \
-             not silently ignore the ordering clause and return Ok",
-        );
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/x> <http://ex/a> 2 ; <http://ex/b> 3 . \
+            <http://ex/y> <http://ex/a> 4 ; <http://ex/b> 5 . \
+            <http://ex/z> <http://ex/a> 1 ; <http://ex/b> 6 }",
+        KS,
+    )
+    .await
+    .expect("insert data");
 
-    let msg = err.to_string().to_lowercase();
-    assert!(
-        msg.contains("order")
-            || msg.contains("expression")
-            || msg.contains("not implemented")
-            || msg.contains("unsupported"),
-        "error must explain that ORDER BY expressions are not implemented: {msg}"
+    let subjects = select_values(
+        &eng,
+        "SELECT ?s ?a ?b \
+         WHERE { ?s <http://ex/a> ?a ; <http://ex/b> ?b } \
+         ORDER BY DESC(?a + ?b)",
+        "s",
+    )
+    .await;
+
+    // y: 4+5=9, z: 1+6=7, x: 2+3=5
+    assert_eq!(
+        subjects,
+        vec!["http://ex/y", "http://ex/z", "http://ex/x"],
+        "ORDER BY (?a + ?b) DESC must sort by the evaluated sum, descending"
+    );
+}
+
+/// S04 (function expression, ASC): `ORDER BY STR(?name)` must evaluate the
+/// function per solution and sort by its string result ascending.
+#[tokio::test]
+async fn order_by_str_function_expression_orders_correctly() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/b> <http://ex/name> \"Berta\" . \
+            <http://ex/a> <http://ex/name> \"Anna\"  . \
+            <http://ex/c> <http://ex/name> \"Carl\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    let names = select_values(
+        &eng,
+        "SELECT ?name WHERE { ?s <http://ex/name> ?name } ORDER BY STR(?name)",
+        "name",
+    )
+    .await;
+
+    assert_eq!(
+        names,
+        vec!["Anna", "Berta", "Carl"],
+        "ORDER BY STR(?name) must sort by the function result ascending"
     );
 }
 
 /// S04 (positive case): ORDER BY on a plain variable must still work correctly
-/// after the fail-loud change — we must not regress variable-based ordering.
+/// — we must not regress the trivial variable-ordering path.
 #[tokio::test]
 async fn order_by_variable_still_works_after_fail_loud_change() {
     let (storage, wp, _dir) = setup();
@@ -386,29 +414,34 @@ async fn order_by_variable_still_works_after_fail_loud_change() {
     );
 }
 
-/// S04 (negative direction): ORDER BY DESC(expression) must also fail loud.
+/// S04 (function expression, DESC): `ORDER BY DESC(STR(?name))` must evaluate
+/// the function per solution and sort by its string result descending.
 #[tokio::test]
-async fn order_by_desc_expression_fails_loud() {
+async fn order_by_desc_function_expression_orders_correctly() {
     let (storage, wp, _dir) = setup();
     let eng = engine(storage, wp);
 
-    let err = eng
-        .execute(
-            "SELECT ?s ?name \
-             WHERE  { ?s <http://ex/name> ?name } \
-             ORDER BY DESC(STR(?name))",
-            KS,
-        )
-        .await
-        .expect_err("ORDER BY DESC(expr) must return Err (fail loud)");
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/b> <http://ex/name> \"Berta\" . \
+            <http://ex/a> <http://ex/name> \"Anna\"  . \
+            <http://ex/c> <http://ex/name> \"Carl\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
 
-    let msg = err.to_string().to_lowercase();
-    assert!(
-        msg.contains("order")
-            || msg.contains("expression")
-            || msg.contains("not implemented")
-            || msg.contains("unsupported"),
-        "error must mention unsupported ORDER BY expression: {msg}"
+    let names = select_values(
+        &eng,
+        "SELECT ?name WHERE { ?s <http://ex/name> ?name } ORDER BY DESC(STR(?name))",
+        "name",
+    )
+    .await;
+
+    assert_eq!(
+        names,
+        vec!["Carl", "Berta", "Anna"],
+        "ORDER BY DESC(STR(?name)) must sort by the function result descending"
     );
 }
 

--- a/ferrosa-sparql/tests/sparql_update_pattern_delete.rs
+++ b/ferrosa-sparql/tests/sparql_update_pattern_delete.rs
@@ -64,6 +64,7 @@ async fn select_count(eng: &SparqlEngine, query: &str) -> usize {
     match eng.execute(query, KS).await.expect("select must succeed") {
         SparqlResult::Select(r) => r.results.bindings.len(),
         SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
     }
 }
 
@@ -77,6 +78,7 @@ async fn select_values(eng: &SparqlEngine, query: &str, var: &str) -> Vec<String
             .filter_map(|row| row.get(var).map(|b| b.value.clone()))
             .collect(),
         SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
     }
 }
 

--- a/ferrosa-sparql/tests/sparql_update_s02_mgmt.rs
+++ b/ferrosa-sparql/tests/sparql_update_s02_mgmt.rs
@@ -1,0 +1,233 @@
+//! URS-QEC-S02 — Full SPARQL UPDATE graph-management forms beyond M1 deletes
+//! and the already-landed INSERT … WHERE: CREATE, LOAD, and the desugared
+//! ADD / MOVE / COPY operations.
+//!
+//! RED tests (written before implementation). Each documents its requirement
+//! and its fail-loud expectation (URS-QEC-X01): any form this engine does not
+//! genuinely implement must return a SPARQL error, never a silent wrong/empty
+//! result.
+//!
+//! ## Scope decisions (single-graph-per-keyspace model)
+//!
+//! The `rdf_triples` table is keyed `((graph, subject), predicate, object)` but
+//! the engine's read path (FullScan / range_read) does not filter by the graph
+//! partition-key component, and the table id is derived from the keyspace. So
+//! *named graphs distinct from the keyspace's default graph are not addressable*
+//! for reads or writes. Operations that target/read such a named graph MUST
+//! fail loud rather than silently read/write the wrong graph.
+//!
+//! | Form | Behavior |
+//! |---|---|
+//! | `CREATE GRAPH <g>` | success no-op (graphs are implicit; the graph exists after) |
+//! | `LOAD <src> [INTO GRAPH <g>]` | fail loud — no RDF document fetch/parse pipeline |
+//! | `ADD/MOVE/COPY` touching a named graph ≠ keyspace | fail loud — named graph not addressable |
+
+use std::sync::Arc;
+
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_sparql::engine::{SparqlConfig, SparqlEngine};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+};
+use tempfile::TempDir;
+
+const KS: &str = "default";
+
+fn setup() -> (Arc<StorageEngine>, Arc<WritePath>, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let config = StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 4096,
+            max_segment_age: std::time::Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.path().join("commitlog"),
+            checkpoint_dir: dir.path().join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.path().to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let storage = Arc::new(StorageEngine::new(config, None).unwrap());
+    let write_path = Arc::new(WritePath::direct(Arc::clone(&storage)));
+    (storage, write_path, dir)
+}
+
+fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngine {
+    let config = SparqlConfig {
+        default_graph: KS.to_string(),
+        ..Default::default()
+    };
+    SparqlEngine::new(storage, write_path, config)
+}
+
+// ---------------------------------------------------------------------------
+// CREATE — implemented as a success no-op (graphs are implicit).
+// ---------------------------------------------------------------------------
+
+/// S02-create: `CREATE GRAPH <g>` must succeed (graphs are implicit in the
+/// single-graph-per-keyspace model — the graph "exists" after the call).
+#[tokio::test]
+async fn create_graph_succeeds_as_noop() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let res = eng
+        .execute_update("CREATE GRAPH <http://ex/g1>", KS)
+        .await
+        .expect("CREATE GRAPH must succeed");
+    assert_eq!(res.triples_inserted, 0);
+    assert_eq!(res.triples_deleted, 0);
+}
+
+/// S02-create-silent: `CREATE SILENT GRAPH <g>` must also succeed.
+#[tokio::test]
+async fn create_silent_graph_succeeds() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("CREATE SILENT GRAPH <http://ex/g1>", KS)
+        .await
+        .expect("CREATE SILENT GRAPH must succeed");
+}
+
+/// S02-create-then-insert: after CREATE, INSERT DATA into the default graph
+/// still works (CREATE did not corrupt or block subsequent writes).
+#[tokio::test]
+async fn create_then_insert_data_works() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("CREATE GRAPH <http://ex/g1>", KS)
+        .await
+        .expect("create");
+    let res = eng
+        .execute_update(
+            "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+            KS,
+        )
+        .await
+        .expect("insert after create");
+    assert_eq!(res.triples_inserted, 1);
+}
+
+// ---------------------------------------------------------------------------
+// LOAD — fail loud (no RDF document fetch/parse pipeline).
+// ---------------------------------------------------------------------------
+
+/// S02-load: `LOAD <src>` must fail loud — the engine has no HTTP fetch + RDF
+/// parser, so it cannot honor LOAD. It must NOT silently succeed with zero
+/// triples (URS-QEC-X01).
+#[tokio::test]
+async fn load_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let err = eng
+        .execute_update("LOAD <http://example.org/data.ttl>", KS)
+        .await
+        .expect_err("LOAD must fail loud, not silently succeed");
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("load"),
+        "LOAD error must mention LOAD: got {err}"
+    );
+}
+
+/// S02-load-into: `LOAD <src> INTO GRAPH <g>` must also fail loud.
+#[tokio::test]
+async fn load_into_graph_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "LOAD <http://example.org/data.ttl> INTO GRAPH <http://ex/g>",
+        KS,
+    )
+    .await
+    .expect_err("LOAD INTO GRAPH must fail loud");
+}
+
+// ---------------------------------------------------------------------------
+// ADD / MOVE / COPY — must NOT silently write to / read from the wrong graph.
+// spargebra desugars these into DeleteInsert (+ Drop). When the desugaring
+// touches a named graph ≠ keyspace, the engine must fail loud rather than
+// silently operate on the default graph.
+// ---------------------------------------------------------------------------
+
+/// S02-copy-named-target: `COPY DEFAULT TO <g>` desugars to an INSERT whose
+/// target QuadPattern graph is the named graph `<g>`. Since `<g>` is not
+/// addressable, this must fail loud — NOT silently write the triples back into
+/// the default graph (which would be a silent wrong result).
+#[tokio::test]
+async fn copy_to_named_graph_fails_loud_not_silent_default_write() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+        KS,
+    )
+    .await
+    .expect("seed");
+
+    let err = eng
+        .execute_update("COPY DEFAULT TO <http://ex/g2>", KS)
+        .await
+        .expect_err("COPY to a named graph must fail loud, not silently no-op into default");
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("graph"),
+        "error must explain the named-graph limitation: got {err}"
+    );
+}
+
+/// S02-copy-named-source: `COPY <g1> TO DEFAULT` desugars to a DeleteInsert
+/// whose WHERE pattern reads from named graph `<g1>` (GraphPattern::Graph).
+/// Reading a non-default named graph is unsupported and must fail loud.
+#[tokio::test]
+async fn copy_from_named_graph_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("COPY <http://ex/g1> TO DEFAULT", KS)
+        .await
+        .expect_err("COPY from a named graph must fail loud (named graph not readable)");
+}
+
+/// S02-add-named: `ADD DEFAULT TO <g>` must fail loud for the same reason as
+/// COPY (named insert target).
+#[tokio::test]
+async fn add_to_named_graph_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("ADD DEFAULT TO <http://ex/g>", KS)
+        .await
+        .expect_err("ADD to a named graph must fail loud");
+}
+
+/// S02-move-named: `MOVE DEFAULT TO <g>` must fail loud (it desugars to
+/// Drop(<g>) + copy into <g> + Drop(default); the copy into the named graph is
+/// not addressable).
+#[tokio::test]
+async fn move_to_named_graph_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("MOVE DEFAULT TO <http://ex/g>", KS)
+        .await
+        .expect_err("MOVE to a named graph must fail loud");
+}

--- a/ferrosa-sparql/tests/sparql_update_s02_mgmt.rs
+++ b/ferrosa-sparql/tests/sparql_update_s02_mgmt.rs
@@ -73,6 +73,19 @@ fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngi
     SparqlEngine::new(storage, write_path, config)
 }
 
+/// Count the triples currently visible in the default graph via a SELECT, so a
+/// fail-loud update can be proven to have left pre-existing data untouched.
+async fn default_graph_triple_count(eng: &SparqlEngine) -> usize {
+    let res = eng
+        .execute("SELECT ?s ?p ?o WHERE { ?s ?p ?o }", KS)
+        .await
+        .expect("scan default graph");
+    match res {
+        ferrosa_sparql::engine::SparqlResult::Select(r) => r.results.bindings.len(),
+        other => panic!("expected SELECT result, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // CREATE — implemented as a success no-op (graphs are implicit).
 // ---------------------------------------------------------------------------
@@ -205,6 +218,67 @@ async fn copy_from_named_graph_fails_loud() {
     eng.execute_update("COPY <http://ex/g1> TO DEFAULT", KS)
         .await
         .expect_err("COPY from a named graph must fail loud (named graph not readable)");
+}
+
+/// S02-copy-named-source-atomic: `COPY <g1> TO DEFAULT` desugars to
+/// `[Drop(DEFAULT), DeleteInsert(read <g1> -> insert DEFAULT)]`. The first op
+/// would clear the default graph; the second is unaddressable and must fail
+/// loud. SPARQL 1.1 update atomicity (and URS-QEC-X01) require that an update
+/// request which errors leaves the store UNMUTATED — so the seeded default-graph
+/// triple MUST survive. A naive sequential executor would run the Drop first and
+/// destroy the data before failing, which is a silent destructive side effect.
+#[tokio::test]
+async fn copy_from_named_graph_is_atomic_default_survives() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+        KS,
+    )
+    .await
+    .expect("seed");
+    assert_eq!(default_graph_triple_count(&eng).await, 1, "seed visible");
+
+    eng.execute_update("COPY <http://ex/g1> TO DEFAULT", KS)
+        .await
+        .expect_err("COPY from a named graph must fail loud (named graph not readable)");
+
+    // The pre-existing default-graph data must be intact: the failing update
+    // must not have run its (desugared) Drop(DEFAULT) op.
+    assert_eq!(
+        default_graph_triple_count(&eng).await,
+        1,
+        "default graph must survive a failed COPY/MOVE-from-named (update atomicity)"
+    );
+}
+
+/// S02-move-named-source-atomic: `MOVE <g1> TO DEFAULT` desugars to
+/// `[Drop(DEFAULT), DeleteInsert(read <g1> -> DEFAULT), Drop(<g1>)]`. Same
+/// atomicity requirement as COPY: the unaddressable named-graph read must make
+/// the whole request fail loud BEFORE the leading Drop(DEFAULT) destroys data.
+#[tokio::test]
+async fn move_from_named_graph_is_atomic_default_survives() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+        KS,
+    )
+    .await
+    .expect("seed");
+    assert_eq!(default_graph_triple_count(&eng).await, 1, "seed visible");
+
+    eng.execute_update("MOVE <http://ex/g1> TO DEFAULT", KS)
+        .await
+        .expect_err("MOVE from a named graph must fail loud");
+
+    assert_eq!(
+        default_graph_triple_count(&eng).await,
+        1,
+        "default graph must survive a failed MOVE-from-named (update atomicity)"
+    );
 }
 
 /// S02-add-named: `ADD DEFAULT TO <g>` must fail loud for the same reason as


### PR DESCRIPTION
## Query Engine Milestone 3 — Full SPARQL 1.1 (train PR #5)

Stacks on **#120** (QE-M2 Bolt transactions). Base: `feat/query-engine-bolt-transactions`.

Completes Milestone 3 of `specs/feat-query-engine-completeness.md` — full SPARQL 1.1
over the CQL-backed triple store (`ferrosa-sparql`, spargebra parser). Strict TDD;
every still-unimplemented form **fails loud** with a SPARQL protocol error per
URS-QEC-X01 — never a silent wrong/empty result.

### Requirements delivered

| ID | Requirement | Status |
| --- | --- | --- |
| URS-QEC-S01 | `CONSTRUCT` and `DESCRIBE` query forms (planner + executor + graph result serialization) | Done |
| URS-QEC-S02 | Full SPARQL UPDATE beyond M1 deletes: `INSERT … WHERE`, graph management (`CREATE`/`LOAD`/`ADD`/`MOVE`/`COPY`) | Done (real where addressable; fail-loud otherwise) |
| URS-QEC-S03 | RDF\* annotation evaluation + SPARQL XML results serialization | XML results done; RDF\* fail-loud |
| URS-QEC-S04 | `ORDER BY` on expressions (previously variables only — silent ignore) | Done; unsupported exprs fail loud |

### Highlights

- **CONSTRUCT / DESCRIBE**: planner + executor + RDF graph (N-Triples/Turtle/JSON) serialization.
- **INSERT … WHERE**: persists via the same `StorageEngine` tombstone/write path as the M1 deletes.
- **ORDER BY expressions**: per-solution evaluation, ASC/DESC, numeric-aware comparator (`order_cmp`, Null sorts lowest); common functions usable in ORDER BY (`STR`/`UCASE`/`LCASE`/`STRLEN`/`ABS`/`CEIL`/`FLOOR`/`ROUND` + arithmetic). Anything unsupported is gated by `unsupported_expr` and fails loud — never silently ignored.
- **UPDATE atomicity**: `validate_update()` does a single up-front pass over **every** parsed operation (LOAD, CLEAR/DROP targets, `DeleteInsert` delete/insert templates **and** the WHERE component) so a request that references an unaddressable named graph fails loud as a whole — no partial application (e.g. `Drop(DEFAULT)` no longer wipes the default graph before a later op errors).
- **XML results**: ASK + SELECT XML serialization with correct shape and escaping.

### Fail-loud (URS-QEC-X01) — designed, not silent

- **RDF\*** annotation matching/binding (S03a): planner fail-loud — never returns inner bindings silently (the prior silent-warning behavior is removed).
- **`ORDER BY`** unsupported expressions: fail loud rather than silently ignored.
- **`LOAD`** / `LOAD INTO GRAPH`: fail loud — this endpoint has no RDF document fetch/parse pipeline, so it never silently zero-triples.
- **Named-graph `ADD`/`MOVE`/`COPY`** (desugared by spargebra into `DeleteInsert`+`Drop`): fail loud since named graphs are not addressable here. Proven that `COPY`/`ADD`/`MOVE` no longer silently writes copied triples back into the default graph.
- **`CREATE`**: no-op + SILENT honored; create-then-insert covered.

### Deferred (follow-on)

- **URS-QEC-S03a — real RDF\* annotation evaluation**: matching/binding of quoted-triple patterns against the RDF table. Currently fail-loud at the planner; real support needs the RDF\* table/evaluation path.
- **`LOAD` document pipeline**: a real HTTP fetch + RDF parse pipeline so `LOAD <url>` ingests triples (today fail-loud).
- **Addressable named graphs** for `ADD`/`MOVE`/`COPY` and named-graph reads/writes (today the single-default-graph model makes these fail loud).

### Verification

`ferrosa-sparql`: `cargo fmt --check`, `cargo clippy --all-targets` clean; full crate test suite green (110 tests, 0 failed, 0 ignored). Rebased clean on `feat/query-engine-bolt-transactions`.
