### PR TITLE
feat(query-engine): SPARQL M3 + openCypher M4 (train PR, stacks on #120)

### DIFF
--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -721,13 +721,22 @@ impl GraphEngine {
     }
 
     /// Execute `FOREACH (var IN list | body...)`: run each body update clause
-    /// once per list element, atomically with respect to the whole statement.
+    /// once per list element.
     ///
-    /// Atomicity: every (element × body-clause) is validated and planned **before
-    /// any** is executed. If any iteration fails to validate or plan (unknown
-    /// label, type error, malformed clause), the call returns the error with zero
-    /// writes performed — partial failure rolls back, never leaving some elements
-    /// written and others not. Planned plans are then executed in order.
+    /// The whole FOREACH tree — including **nested FOREACH bodies** — is recursively
+    /// materialized, validated, and planned into one ordered list of physical plans
+    /// **before any is executed** (`plan_foreach`). The plans preserve openCypher
+    /// per-element source ordering: for each outer element, that element's body
+    /// clauses (and the fully-expanded plans of any nested FOREACH) appear in source
+    /// order before the next element's. Execution then runs the list in order.
+    ///
+    /// Rollback scope (deliberate, fail-loud): WritePath has no cross-statement
+    /// transaction, so the guaranteed-atomic class is the **validate/plan failure
+    /// class** — if any (element × clause), at any nesting depth, fails to validate
+    /// or plan (unknown label, type error, malformed clause), the call returns the
+    /// error with ZERO writes performed. An execution-time failure (a write error
+    /// after earlier plans committed) is surfaced loudly but cannot be rolled back
+    /// here; that would require a storage-level batch and is not claimed.
     async fn execute_foreach(
         &self,
         var: &str,
@@ -736,43 +745,16 @@ impl GraphEngine {
         keyspace: &str,
         auth: &AuthContext,
     ) -> Result<GraphResult> {
-        // Evaluate the list once. Top-level FOREACH has no outer bindings.
-        let list_value = eval_expr(list, &HashMap::new())
-            .map_err(|e| GraphError::Validation(format!("FOREACH list expression: {e}")))?;
-        let elements = match list_value {
-            Value::Array(items) => items,
-            Value::Null => Vec::new(),
-            other => {
-                return Err(GraphError::Validation(format!(
-                    "FOREACH expects a list, got {other}"
-                )));
-            }
-        };
+        // Phase 1 — recursively plan the entire FOREACH tree. Any validation/plan
+        // failure (at any depth) aborts here, before a single write.
+        let planned = self
+            .plan_foreach(var, list, body, keyspace, auth)
+            .await?;
+        let element_count = planned.element_count;
 
-        // Phase 1 — materialize, validate, and plan every iteration up front so a
-        // failure on any element aborts before a single write (atomic rollback).
-        let mut planned: Vec<PhysicalPlan> = Vec::new();
-        for element in &elements {
-            let replacement = value_to_expr(element)?;
-            for stmt in body {
-                // Nested FOREACH inside a body is expanded recursively at execution
-                // time; here we only pre-plan the leaf update clauses.
-                if let Statement::Foreach { .. } = stmt {
-                    continue;
-                }
-                let bound = subst_var_statement(stmt.clone(), var, &replacement);
-                if statement_requires_adjacency(&bound) {
-                    self.ensure_adjacency_storage_for_keyspace(keyspace).await?;
-                }
-                let snap = self.schema.snapshot();
-                let logical = validate(&snap, auth, keyspace, bound)?;
-                planned.push(plan(logical)?);
-            }
-        }
-
-        // Phase 2 — execute the pre-planned leaf clauses, then any nested FOREACH.
+        // Phase 2 — execute the pre-planned clauses in source order.
         let mut stats = QueryStats::default();
-        for physical in planned {
+        for physical in planned.plans {
             let wp = self.write_path.load();
             let result = execute(
                 physical,
@@ -786,36 +768,78 @@ impl GraphEngine {
             stats.vertices_written += result.stats.vertices_written;
             stats.vertices_deleted += result.stats.vertices_deleted;
         }
-        for element in &elements {
-            let replacement = value_to_expr(element)?;
-            for stmt in body {
-                if let Statement::Foreach {
-                    var: inner_var,
-                    list: inner_list,
-                    body: inner_body,
-                } = subst_var_statement(stmt.clone(), var, &replacement)
-                {
-                    let nested = Box::pin(self.execute_foreach(
-                        &inner_var,
-                        &inner_list,
-                        &inner_body,
-                        keyspace,
-                        auth,
-                    ))
-                    .await?;
-                    stats.vertices_written += nested.stats.vertices_written;
-                    stats.vertices_deleted += nested.stats.vertices_deleted;
-                }
-            }
-        }
 
         Ok(GraphResult {
             columns: vec!["status".to_string()],
             rows: vec![vec![Value::String(format!(
-                "FOREACH applied to {} element(s)",
-                elements.len()
+                "FOREACH applied to {element_count} element(s)"
             ))]],
             stats,
+        })
+    }
+
+    /// Recursively materialize + validate + plan a FOREACH into an ordered list of
+    /// physical plans, preserving per-element source ordering. Nested FOREACHs are
+    /// expanded in place (their plans interleave at the point the nested clause
+    /// appears, once per outer element). No execution happens here, so any failure
+    /// leaves zero writes.
+    async fn plan_foreach(
+        &self,
+        var: &str,
+        list: &Expr,
+        body: &[Statement],
+        keyspace: &str,
+        auth: &AuthContext,
+    ) -> Result<PlannedForeach> {
+        let list_value = eval_expr(list, &HashMap::new())
+            .map_err(|e| GraphError::Validation(format!("FOREACH list expression: {e}")))?;
+        let elements = match list_value {
+            Value::Array(items) => items,
+            Value::Null => Vec::new(),
+            other => {
+                return Err(GraphError::Validation(format!(
+                    "FOREACH expects a list, got {other}"
+                )));
+            }
+        };
+
+        let mut plans: Vec<PhysicalPlan> = Vec::new();
+        for element in &elements {
+            let replacement = value_to_expr(element)?;
+            for stmt in body {
+                let bound = subst_var_statement(stmt.clone(), var, &replacement);
+                match bound {
+                    Statement::Foreach {
+                        var: inner_var,
+                        list: inner_list,
+                        body: inner_body,
+                    } => {
+                        // Expand the nested loop in place, preserving source order.
+                        let nested = Box::pin(self.plan_foreach(
+                            &inner_var,
+                            &inner_list,
+                            &inner_body,
+                            keyspace,
+                            auth,
+                        ))
+                        .await?;
+                        plans.extend(nested.plans);
+                    }
+                    leaf => {
+                        if statement_requires_adjacency(&leaf) {
+                            self.ensure_adjacency_storage_for_keyspace(keyspace).await?;
+                        }
+                        let snap = self.schema.snapshot();
+                        let logical = validate(&snap, auth, keyspace, leaf)?;
+                        plans.push(plan(logical)?);
+                    }
+                }
+            }
+        }
+
+        Ok(PlannedForeach {
+            plans,
+            element_count: elements.len(),
         })
     }
 
@@ -1323,6 +1347,13 @@ fn bind_statement_params(
 /// scalars become `Literal`s, arrays become `Expr::List`, and objects become
 /// `Expr::Map`, so nested structures (e.g. `FOREACH (m IN [{name:'a'}] | ...)`)
 /// substitute correctly.
+/// Fully-expanded plan for a FOREACH subtree: physical plans in per-element
+/// source order, plus the outer element count for the status row.
+struct PlannedForeach {
+    plans: Vec<PhysicalPlan>,
+    element_count: usize,
+}
+
 fn value_to_expr(value: &Value) -> Result<Expr> {
     Ok(match value {
         Value::Null => Expr::Literal(Literal::Null),
@@ -1568,8 +1599,9 @@ fn subst_var_statement(stmt: Statement, var: &str, replacement: &Expr) -> Statem
                 body,
             }
         }
-        // REMOVE/DELETE bodies reference bound variables (not value-substituted by
-        // the loop var directly); pass through unchanged.
+        // REMOVE/DELETE (and any non-update statement) are rejected in a FOREACH
+        // body at parse time, so they never reach substitution here; pass through
+        // unchanged defensively.
         other => other,
     }
 }

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -123,7 +123,26 @@ fn expr_requires_adjacency(expr: &Expr) -> bool {
         Expr::ListPredicate {
             list, predicate, ..
         } => expr_requires_adjacency(list) || expr_requires_adjacency(predicate),
+        Expr::ListComprehension {
+            list,
+            filter,
+            projection,
+            ..
+        } => {
+            expr_requires_adjacency(list)
+                || filter.as_deref().is_some_and(expr_requires_adjacency)
+                || projection.as_deref().is_some_and(expr_requires_adjacency)
+        }
+        // A pattern comprehension always traverses edges.
+        Expr::PatternComprehension { .. } => true,
         Expr::Map(props) => prop_map_requires_adjacency(props),
+        Expr::MapProjection { selectors, .. } => selectors.iter().any(|s| match s {
+            crate::parser::MapProjectionSelector::Literal { value, .. } => {
+                expr_requires_adjacency(value)
+            }
+            crate::parser::MapProjectionSelector::Property(_)
+            | crate::parser::MapProjectionSelector::All => false,
+        }),
         Expr::Slice { target, start, end } => {
             expr_requires_adjacency(target)
                 || start.as_deref().is_some_and(expr_requires_adjacency)

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -25,8 +25,9 @@ use crate::adjacency::observer::AdjacencyIndexObserver;
 use crate::adjacency::reconcile::{reconcile_once, spawn_reconciliation};
 use crate::adjacency::{adjacency_keyspace_name, adjacency_table_metadata};
 use crate::error::{GraphError, Result};
+use crate::executor::aggregate::{create_accumulator, is_aggregate_function};
 use crate::executor::eval::eval_expr;
-use crate::executor::expand::{build_columns, execute, GraphEngineConfig};
+use crate::executor::expand::{build_columns, execute, sort_rows, GraphEngineConfig};
 use crate::executor::result::{GraphResult, QueryStats};
 use crate::executor::subscribe::SubscriptionRegistry;
 use crate::parser::{
@@ -909,6 +910,11 @@ impl GraphEngine {
         let inner_returns = statement_is_returning(&inner);
         let mut out_columns: Option<Vec<String>> = None;
         let mut out_rows: Vec<Vec<Value>> = Vec::new();
+        // Combined `outer ∪ inner` binding maps for the trailing RETURN, accumulated
+        // across ALL outer rows. The trailing clause is a single projection over the
+        // whole united stream, so DISTINCT / ORDER BY / LIMIT / aggregation must be
+        // applied once at the end — never per outer row.
+        let mut trailing_bindings: Vec<HashMap<String, Value>> = Vec::new();
         let mut stats = QueryStats::default();
 
         // 2. For each outer row, materialize imports into the inner subquery and run.
@@ -938,28 +944,24 @@ impl GraphEngine {
             stats.vertices_deleted += inner_result.stats.vertices_deleted;
             stats.vertices_read += inner_result.stats.vertices_read;
             stats.edges_read += inner_result.stats.edges_read;
+            stats.edges_deleted += inner_result.stats.edges_deleted;
 
             // 3. Combine per the subquery shape.
-            if let Some(rc) = &return_clause {
-                // Trailing RETURN: evaluate over combined outer ∪ inner bindings.
+            if return_clause.is_some() {
+                // Trailing RETURN: accumulate the combined `outer ∪ inner` bindings.
                 // A unit inner contributes no inner columns, so the trailing RETURN
-                // sees only the outer (import) bindings and emits one row per outer
-                // row. A returning inner emits one combined row per inner row.
+                // sees only the outer (import) bindings and yields one binding per
+                // outer row. A returning inner yields one combined binding per inner
+                // row. Projection is deferred to the finalizer.
                 let inner_rows = if inner_returns {
                     rows_as_bindings(&inner_result)
                 } else {
                     vec![HashMap::new()]
                 };
-                let cols = projection_columns(rc);
-                set_or_check_columns(&mut out_columns, &cols)?;
                 for inner_binding in inner_rows {
                     let mut combined = import_bindings.clone();
                     combined.extend(inner_binding);
-                    let mut row = Vec::with_capacity(rc.items.len());
-                    for item in &rc.items {
-                        row.push(eval_expr(&item.expr, &combined)?);
-                    }
-                    out_rows.push(row);
+                    trailing_bindings.push(combined);
                 }
             } else if inner_returns {
                 // No trailing RETURN: unite the inner rows directly.
@@ -969,6 +971,16 @@ impl GraphEngine {
             // Unit subquery with no trailing RETURN: nothing to project; the writes
             // already happened. (Outer cardinality is preserved but yields no
             // columns, matching a write-only statement's empty result shape.)
+        }
+
+        // 4. If there is a trailing RETURN, run the full projection pipeline over the
+        //    united bindings: grouped aggregation (if any aggregate item), then
+        //    DISTINCT, ORDER BY, and LIMIT — matching openCypher RETURN semantics so
+        //    these operators are never silently dropped (URS-QEC-X01).
+        if let Some(rc) = &return_clause {
+            let (cols, rows) = project_trailing_return(rc, &trailing_bindings, &self.config)?;
+            out_columns = Some(cols);
+            out_rows = rows;
         }
 
         Ok(GraphResult {
@@ -1546,9 +1558,220 @@ fn statement_is_returning(stmt: &Statement) -> bool {
     }
 }
 
-/// Column names a trailing CALL {} RETURN clause projects.
-fn projection_columns(rc: &ReturnClause) -> Vec<String> {
-    build_columns(rc)
+/// Whether an expression contains an aggregate function call anywhere in its tree.
+/// Used to decide whether the trailing CALL {} RETURN groups+aggregates over the
+/// united rows or projects them one-to-one.
+fn expr_contains_aggregate(expr: &Expr) -> bool {
+    match expr {
+        Expr::Function { name, args } => {
+            is_aggregate_function(name) || args.iter().any(expr_contains_aggregate)
+        }
+        Expr::Distinct(inner)
+        | Expr::Not(inner)
+        | Expr::IsNull(inner)
+        | Expr::IsNotNull(inner) => expr_contains_aggregate(inner),
+        Expr::Comparison { left, right, .. }
+        | Expr::Arithmetic { left, right, .. }
+        | Expr::And(left, right)
+        | Expr::Or(left, right) => {
+            expr_contains_aggregate(left) || expr_contains_aggregate(right)
+        }
+        Expr::In { value, list } => {
+            expr_contains_aggregate(value) || expr_contains_aggregate(list)
+        }
+        Expr::List(items) => items.iter().any(expr_contains_aggregate),
+        Expr::Index { target, index } => {
+            expr_contains_aggregate(target) || expr_contains_aggregate(index)
+        }
+        Expr::Slice { target, start, end } => {
+            expr_contains_aggregate(target)
+                || start.as_deref().is_some_and(expr_contains_aggregate)
+                || end.as_deref().is_some_and(expr_contains_aggregate)
+        }
+        _ => false,
+    }
+}
+
+/// Project a trailing CALL {} RETURN clause over the fully-united `outer ∪ inner`
+/// bindings, applying the complete openCypher RETURN pipeline:
+///
+/// 1. If any RETURN item contains an aggregate (`count`/`sum`/`avg`/`min`/`max`/
+///    `collect`), group by the *non-aggregate* items and aggregate per group.
+///    Otherwise project one row per binding.
+/// 2. DISTINCT (dedup whole rows).
+/// 3. ORDER BY (via the shared `sort_rows`).
+/// 4. LIMIT (truncate).
+///
+/// None of these are silently dropped — a trailing DISTINCT/ORDER BY/LIMIT/aggregate
+/// is honored or fails loud, satisfying URS-QEC-X01.
+fn project_trailing_return(
+    rc: &ReturnClause,
+    bindings: &[HashMap<String, Value>],
+    config: &GraphEngineConfig,
+) -> Result<(Vec<String>, Vec<Vec<Value>>)> {
+    let columns = build_columns(rc);
+    let has_aggregate = rc.items.iter().any(|item| expr_contains_aggregate(&item.expr));
+
+    let mut rows = if has_aggregate {
+        project_trailing_aggregate(rc, bindings, config)?
+    } else {
+        let mut out = Vec::with_capacity(bindings.len());
+        for binding in bindings {
+            let mut row = Vec::with_capacity(rc.items.len());
+            for item in &rc.items {
+                row.push(eval_expr(&item.expr, binding)?);
+            }
+            out.push(row);
+        }
+        out
+    };
+
+    // DISTINCT: dedup whole projected rows, preserving first-seen order.
+    if rc.distinct {
+        let mut seen: HashSet<String> = HashSet::new();
+        rows.retain(|row| seen.insert(serde_json::to_string(row).unwrap_or_default()));
+    }
+
+    // ORDER BY then LIMIT, reusing the executor's shared sort.
+    sort_rows(&mut rows, &columns, &rc.order_by);
+    if let Some(limit) = rc.limit {
+        rows.truncate(limit.max(0) as usize);
+    }
+
+    Ok((columns, rows))
+}
+
+/// Grouped aggregation for a trailing CALL {} RETURN containing aggregate items.
+///
+/// openCypher grouping: the non-aggregate RETURN items form the grouping key; the
+/// aggregate items accumulate per group. With no non-aggregate items there is a
+/// single (implicit) group, so `count(*)` over an empty stream still yields one row
+/// with `0`. Each group emits one row in first-seen key order.
+fn project_trailing_aggregate(
+    rc: &ReturnClause,
+    bindings: &[HashMap<String, Value>],
+    config: &GraphEngineConfig,
+) -> Result<Vec<Vec<Value>>> {
+    // Classify each RETURN item as a grouping key or an aggregate.
+    let item_is_aggregate: Vec<bool> = rc
+        .items
+        .iter()
+        .map(|item| expr_contains_aggregate(&item.expr))
+        .collect();
+    let has_group_keys = item_is_aggregate.iter().any(|agg| !agg);
+
+    // Ordered group keys (serialized key -> insertion index) + per-group binding lists.
+    let mut group_order: Vec<String> = Vec::new();
+    let mut group_rows: HashMap<String, Vec<&HashMap<String, Value>>> = HashMap::new();
+    let mut group_key_values: HashMap<String, Vec<Value>> = HashMap::new();
+
+    for binding in bindings {
+        // The grouping key is the tuple of evaluated non-aggregate items.
+        let mut key_vals: Vec<Value> = Vec::new();
+        for (item, is_agg) in rc.items.iter().zip(&item_is_aggregate) {
+            if !is_agg {
+                key_vals.push(eval_expr(&item.expr, binding)?);
+            }
+        }
+        let key_str = serde_json::to_string(&key_vals).unwrap_or_default();
+        if !group_rows.contains_key(&key_str) {
+            if group_order.len() >= config.max_groups {
+                return Err(GraphError::ResourceLimit(format!(
+                    "CALL {{}} trailing aggregation group count limit exceeded: {} (limit: {})",
+                    group_order.len() + 1,
+                    config.max_groups
+                )));
+            }
+            group_order.push(key_str.clone());
+            group_key_values.insert(key_str.clone(), key_vals);
+        }
+        group_rows.entry(key_str).or_default().push(binding);
+    }
+
+    // No rows and no grouping keys: still emit a single implicit group so bare
+    // aggregates (e.g. count(*)) return their zero value rather than no rows.
+    if group_order.is_empty() && !has_group_keys {
+        group_order.push(String::new());
+        group_key_values.insert(String::new(), Vec::new());
+        group_rows.insert(String::new(), Vec::new());
+    }
+
+    let mut out_rows = Vec::with_capacity(group_order.len());
+    for key_str in &group_order {
+        let rows_in_group = group_rows.get(key_str).cloned().unwrap_or_default();
+        let key_vals = group_key_values.get(key_str).cloned().unwrap_or_default();
+        let mut key_iter = key_vals.into_iter();
+
+        let mut out_row = Vec::with_capacity(rc.items.len());
+        for (item, is_agg) in rc.items.iter().zip(&item_is_aggregate) {
+            if *is_agg {
+                out_row.push(eval_trailing_aggregate(&item.expr, &rows_in_group, config)?);
+            } else {
+                out_row.push(key_iter.next().unwrap_or(Value::Null));
+            }
+        }
+        out_rows.push(out_row);
+    }
+    Ok(out_rows)
+}
+
+/// Evaluate a single aggregate RETURN expression over one group's bindings.
+///
+/// Supports a bare aggregate call (`count(*)`, `sum(x)`, `collect(x)`), including a
+/// `DISTINCT` argument (`count(DISTINCT n.age)`). A non-aggregate expression nested
+/// around an aggregate (e.g. `count(*) + 1`) is rejected fail-loud rather than
+/// silently mis-evaluated.
+fn eval_trailing_aggregate(
+    expr: &Expr,
+    rows: &[&HashMap<String, Value>],
+    config: &GraphEngineConfig,
+) -> Result<Value> {
+    let Expr::Function { name, args } = expr else {
+        return Err(GraphError::Validation(format!(
+            "unsupported aggregate expression in CALL {{}} trailing RETURN: {expr:?} \
+             (only a bare aggregate call such as count(*) is supported)"
+        )));
+    };
+    if !is_aggregate_function(name) {
+        return Err(GraphError::Validation(format!(
+            "unsupported aggregate expression in CALL {{}} trailing RETURN: {expr:?} \
+             (only a bare aggregate call such as count(*) is supported)"
+        )));
+    }
+
+    // Unwrap a single DISTINCT argument; track it so duplicate arg values are
+    // accumulated once.
+    let (arg, distinct): (Option<&Expr>, bool) = match args.as_slice() {
+        [] => (None, false),
+        [Expr::Distinct(inner)] => (Some(inner.as_ref()), true),
+        [single] => (Some(single), false),
+        _ => {
+            return Err(GraphError::Validation(format!(
+                "aggregate {name}() in CALL {{}} trailing RETURN takes a single argument"
+            )))
+        }
+    };
+    let count_star = name.eq_ignore_ascii_case("count")
+        && matches!(arg, Some(Expr::Var(v)) if v == "*");
+
+    let mut acc = create_accumulator(name, count_star, config.max_collect_size)?;
+    let mut seen: HashSet<String> = HashSet::new();
+    for binding in rows {
+        let value = match arg {
+            // count(*) counts every row regardless of the argument value.
+            _ if count_star => Value::from(1),
+            Some(e) => eval_expr(e, binding)?,
+            None => Value::Null,
+        };
+        if distinct {
+            let key = serde_json::to_string(&value).unwrap_or_default();
+            if !seen.insert(key) {
+                continue;
+            }
+        }
+        acc.accumulate(&value);
+    }
+    Ok(acc.finish())
 }
 
 /// Turn a `GraphResult`'s rows into per-row binding maps keyed by column name, so
@@ -2884,6 +3107,140 @@ mod tests {
                 "adjacency".to_string()
             )),
             "graph engine lazy path must register the adjacency table in the live schema"
+        );
+    }
+
+    fn binding(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    fn rc_single(expr: Expr, alias: &str) -> ReturnClause {
+        ReturnClause {
+            distinct: false,
+            items: vec![ReturnItem {
+                expr,
+                alias: Some(alias.to_string()),
+            }],
+            order_by: vec![],
+            limit: None,
+        }
+    }
+
+    #[test]
+    fn expr_contains_aggregate_detects_nested_calls() {
+        assert!(expr_contains_aggregate(&Expr::Function {
+            name: "count".into(),
+            args: vec![Expr::Var("*".into())],
+        }));
+        // Aggregate buried inside arithmetic is still detected.
+        assert!(expr_contains_aggregate(&Expr::Arithmetic {
+            left: Box::new(Expr::Function {
+                name: "sum".into(),
+                args: vec![Expr::Var("x".into())],
+            }),
+            op: crate::parser::ArithOp::Add,
+            right: Box::new(Expr::Literal(Literal::Integer(1))),
+        }));
+        // No aggregate: a plain property projection.
+        assert!(!expr_contains_aggregate(&Expr::Property {
+            var: "p".into(),
+            name: "age".into(),
+        }));
+    }
+
+    #[test]
+    fn trailing_return_count_star_groups_over_all_rows() {
+        let rc = rc_single(
+            Expr::Function {
+                name: "count".into(),
+                args: vec![Expr::Var("*".into())],
+            },
+            "n",
+        );
+        let rows = vec![
+            binding(&[("a", Value::from(1))]),
+            binding(&[("a", Value::from(2))]),
+            binding(&[("a", Value::from(3))]),
+        ];
+        let (cols, out) = project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
+        assert_eq!(cols, vec!["n".to_string()]);
+        assert_eq!(out, vec![vec![Value::from(3u64)]]);
+    }
+
+    #[test]
+    fn trailing_return_count_star_empty_stream_is_zero_row() {
+        let rc = rc_single(
+            Expr::Function {
+                name: "count".into(),
+                args: vec![Expr::Var("*".into())],
+            },
+            "n",
+        );
+        let (_cols, out) = project_trailing_return(&rc, &[], &GraphEngineConfig::default()).unwrap();
+        assert_eq!(
+            out,
+            vec![vec![Value::from(0u64)]],
+            "bare count(*) over an empty united stream must emit one row with 0"
+        );
+    }
+
+    #[test]
+    fn trailing_return_distinct_dedups_whole_rows() {
+        let rc = ReturnClause {
+            distinct: true,
+            items: vec![ReturnItem {
+                expr: Expr::Var("one".into()),
+                alias: Some("one".into()),
+            }],
+            order_by: vec![],
+            limit: None,
+        };
+        let rows = vec![
+            binding(&[("one", Value::from(1))]),
+            binding(&[("one", Value::from(1))]),
+            binding(&[("one", Value::from(1))]),
+        ];
+        let (_cols, out) = project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
+        assert_eq!(out, vec![vec![Value::from(1)]]);
+    }
+
+    #[test]
+    fn trailing_return_limit_truncates() {
+        let mut rc = rc_single(Expr::Var("a".into()), "a");
+        rc.limit = Some(1);
+        let rows = vec![
+            binding(&[("a", Value::from(10))]),
+            binding(&[("a", Value::from(20))]),
+            binding(&[("a", Value::from(30))]),
+        ];
+        let (_cols, out) = project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
+        assert_eq!(out.len(), 1, "LIMIT 1 must truncate to one row");
+    }
+
+    #[test]
+    fn trailing_return_non_bare_aggregate_fails_loud() {
+        // `count(*) + 1` wraps an aggregate in arithmetic. We do not silently
+        // mis-evaluate it — we fail loud (URS-QEC-X01).
+        let rc = rc_single(
+            Expr::Arithmetic {
+                left: Box::new(Expr::Function {
+                    name: "count".into(),
+                    args: vec![Expr::Var("*".into())],
+                }),
+                op: crate::parser::ArithOp::Add,
+                right: Box::new(Expr::Literal(Literal::Integer(1))),
+            },
+            "n",
+        );
+        let rows = vec![binding(&[("a", Value::from(1))])];
+        let err = project_trailing_return(&rc, &rows, &GraphEngineConfig::default())
+            .expect_err("non-bare aggregate must be rejected, not silently wrong");
+        assert!(
+            matches!(err, GraphError::Validation(_)),
+            "expected a loud validation error, got {err:?}"
         );
     }
 }

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -774,9 +774,7 @@ impl GraphEngine {
     ) -> Result<GraphResult> {
         // Phase 1 — recursively plan the entire FOREACH tree. Any validation/plan
         // failure (at any depth) aborts here, before a single write.
-        let planned = self
-            .plan_foreach(var, list, body, keyspace, auth)
-            .await?;
+        let planned = self.plan_foreach(var, list, body, keyspace, auth).await?;
         let element_count = planned.element_count;
 
         // Phase 2 — execute the pre-planned clauses in source order.
@@ -937,9 +935,7 @@ impl GraphEngine {
             }
             let bound_inner = fold_constants_statement(bound_inner)?;
 
-            let inner_result = self
-                .execute_statement(bound_inner, keyspace, auth)
-                .await?;
+            let inner_result = self.execute_statement(bound_inner, keyspace, auth).await?;
             stats.vertices_written += inner_result.stats.vertices_written;
             stats.vertices_deleted += inner_result.stats.vertices_deleted;
             stats.vertices_read += inner_result.stats.vertices_read;
@@ -1566,19 +1562,14 @@ fn expr_contains_aggregate(expr: &Expr) -> bool {
         Expr::Function { name, args } => {
             is_aggregate_function(name) || args.iter().any(expr_contains_aggregate)
         }
-        Expr::Distinct(inner)
-        | Expr::Not(inner)
-        | Expr::IsNull(inner)
-        | Expr::IsNotNull(inner) => expr_contains_aggregate(inner),
+        Expr::Distinct(inner) | Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) => {
+            expr_contains_aggregate(inner)
+        }
         Expr::Comparison { left, right, .. }
         | Expr::Arithmetic { left, right, .. }
         | Expr::And(left, right)
-        | Expr::Or(left, right) => {
-            expr_contains_aggregate(left) || expr_contains_aggregate(right)
-        }
-        Expr::In { value, list } => {
-            expr_contains_aggregate(value) || expr_contains_aggregate(list)
-        }
+        | Expr::Or(left, right) => expr_contains_aggregate(left) || expr_contains_aggregate(right),
+        Expr::In { value, list } => expr_contains_aggregate(value) || expr_contains_aggregate(list),
         Expr::List(items) => items.iter().any(expr_contains_aggregate),
         Expr::Index { target, index } => {
             expr_contains_aggregate(target) || expr_contains_aggregate(index)
@@ -1610,7 +1601,10 @@ fn project_trailing_return(
     config: &GraphEngineConfig,
 ) -> Result<(Vec<String>, Vec<Vec<Value>>)> {
     let columns = build_columns(rc);
-    let has_aggregate = rc.items.iter().any(|item| expr_contains_aggregate(&item.expr));
+    let has_aggregate = rc
+        .items
+        .iter()
+        .any(|item| expr_contains_aggregate(&item.expr));
 
     let mut rows = if has_aggregate {
         project_trailing_aggregate(rc, bindings, config)?
@@ -1751,8 +1745,8 @@ fn eval_trailing_aggregate(
             )))
         }
     };
-    let count_star = name.eq_ignore_ascii_case("count")
-        && matches!(arg, Some(Expr::Var(v)) if v == "*");
+    let count_star =
+        name.eq_ignore_ascii_case("count") && matches!(arg, Some(Expr::Var(v)) if v == "*");
 
     let mut acc = create_accumulator(name, count_star, config.max_collect_size)?;
     let mut seen: HashSet<String> = HashSet::new();
@@ -2171,11 +2165,7 @@ fn subst_var_return_clause(rc: ReturnClause, var: &str, replacement: &Expr) -> R
 
 /// Substitute the imported variable inside a WITH pipeline (its projection and
 /// trailing WHERE filter).
-fn subst_var_with_pipeline(
-    wp: WithPipeline,
-    var: &str,
-    replacement: &Expr,
-) -> WithPipeline {
+fn subst_var_with_pipeline(wp: WithPipeline, var: &str, replacement: &Expr) -> WithPipeline {
     WithPipeline {
         clause: subst_var_return_clause(wp.clause, var, replacement),
         where_clause: wp.where_clause.map(|w| subst_var_expr(w, var, replacement)),
@@ -3165,7 +3155,8 @@ mod tests {
             binding(&[("a", Value::from(2))]),
             binding(&[("a", Value::from(3))]),
         ];
-        let (cols, out) = project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
+        let (cols, out) =
+            project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
         assert_eq!(cols, vec!["n".to_string()]);
         assert_eq!(out, vec![vec![Value::from(3u64)]]);
     }
@@ -3179,7 +3170,8 @@ mod tests {
             },
             "n",
         );
-        let (_cols, out) = project_trailing_return(&rc, &[], &GraphEngineConfig::default()).unwrap();
+        let (_cols, out) =
+            project_trailing_return(&rc, &[], &GraphEngineConfig::default()).unwrap();
         assert_eq!(
             out,
             vec![vec![Value::from(0u64)]],
@@ -3203,7 +3195,8 @@ mod tests {
             binding(&[("one", Value::from(1))]),
             binding(&[("one", Value::from(1))]),
         ];
-        let (_cols, out) = project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
+        let (_cols, out) =
+            project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
         assert_eq!(out, vec![vec![Value::from(1)]]);
     }
 
@@ -3216,7 +3209,8 @@ mod tests {
             binding(&[("a", Value::from(20))]),
             binding(&[("a", Value::from(30))]),
         ];
-        let (_cols, out) = project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
+        let (_cols, out) =
+            project_trailing_return(&rc, &rows, &GraphEngineConfig::default()).unwrap();
         assert_eq!(out.len(), 1, "LIMIT 1 must truncate to one row");
     }
 

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -30,7 +30,7 @@ use crate::executor::expand::{build_columns, execute, GraphEngineConfig};
 use crate::executor::result::{GraphResult, QueryStats};
 use crate::executor::subscribe::SubscriptionRegistry;
 use crate::parser::{
-    parse, Assignment, Expr, Literal, Pattern, ReturnClause, Statement, WithPipeline,
+    parse, Assignment, Expr, Literal, Pattern, ReturnClause, ReturnItem, Statement, WithPipeline,
 };
 use crate::planner::logical::validate;
 use crate::planner::physical::{plan, PhysicalPlan};
@@ -276,6 +276,9 @@ fn statement_requires_adjacency(statement: &Statement) -> bool {
                     .is_some_and(return_clause_requires_adjacency)
         }
         Statement::Foreach { body, .. } => body.iter().any(statement_requires_adjacency),
+        Statement::CallSubquery { outer, inner, .. } => {
+            statement_requires_adjacency(outer) || statement_requires_adjacency(inner)
+        }
     }
 }
 
@@ -683,6 +686,29 @@ impl GraphEngine {
                 .execute_foreach(&var, &list, &body, keyspace, auth)
                 .await;
         }
+        if let Statement::CallSubquery {
+            outer,
+            imports,
+            inner,
+            return_clause,
+        } = statement
+        {
+            return self
+                .execute_call_subquery(*outer, &imports, *inner, return_clause, keyspace, auth)
+                .await;
+        }
+        self.execute_statement(statement, keyspace, auth).await
+    }
+
+    /// Validate, plan, and execute a single non-orchestrated statement (i.e. not
+    /// FOREACH / CALL {}, which the engine expands first). Shared by the top-level
+    /// query path and the CALL {} subquery orchestrator.
+    async fn execute_statement(
+        &self,
+        statement: Statement,
+        keyspace: &str,
+        auth: &AuthContext,
+    ) -> Result<GraphResult> {
         if statement_requires_adjacency(&statement) {
             let adjacency_registered = self.ensure_adjacency_storage_for_keyspace(keyspace).await?;
             if adjacency_registered {
@@ -840,6 +866,115 @@ impl GraphEngine {
         Ok(PlannedForeach {
             plans,
             element_count: elements.len(),
+        })
+    }
+
+    /// Execute a correlated `CALL {}` subquery: run the `inner` subquery once per
+    /// `outer` row, with each `imports` variable bound to that row, and unite the
+    /// results.
+    ///
+    /// Semantics (openCypher CALL {} subquery):
+    /// - **Returning** subquery: the inner statement projects rows. Each inner row
+    ///   is paired with its driving outer row. The optional trailing `return_clause`
+    ///   projects over the combined `outer ∪ inner` bindings; without one, the inner
+    ///   rows are returned directly. Result rows are the UNION over all outer rows.
+    /// - **Unit** subquery: the inner statement performs only updates (no RETURN).
+    ///   It runs for its write side effects once per outer row and does not change
+    ///   the outer cardinality; the outer rows pass through unchanged (or are
+    ///   projected by the trailing RETURN if present).
+    ///
+    /// Correlation is by value substitution (the same machinery as FOREACH): each
+    /// outer row's imported values are materialized into the inner statement before
+    /// it is validated/planned/executed. Reads of imported node properties
+    /// (`p.name`) resolve against the materialized node map.
+    ///
+    /// Fail-loud: a nested `CALL {}` inside the body is rejected at parse time;
+    /// any inner validation/plan/exec error surfaces with the outer row's context.
+    async fn execute_call_subquery(
+        &self,
+        outer: Statement,
+        imports: &[String],
+        inner: Statement,
+        return_clause: Option<ReturnClause>,
+        keyspace: &str,
+        auth: &AuthContext,
+    ) -> Result<GraphResult> {
+        // 1. Run the outer query, projecting each imported variable as a column so
+        //    we can bind it per row. The outer is the MATCH built by the parser with
+        //    an empty RETURN; we replace it with `RETURN <imports...>`.
+        let outer = project_imports(outer, imports)?;
+        let outer_result = self.execute_statement(outer, keyspace, auth).await?;
+        let import_cols = outer_result.columns.clone();
+
+        let inner_returns = statement_is_returning(&inner);
+        let mut out_columns: Option<Vec<String>> = None;
+        let mut out_rows: Vec<Vec<Value>> = Vec::new();
+        let mut stats = QueryStats::default();
+
+        // 2. For each outer row, materialize imports into the inner subquery and run.
+        for outer_row in &outer_result.rows {
+            let mut import_bindings: HashMap<String, Value> = HashMap::new();
+            for (col, value) in import_cols.iter().zip(outer_row.iter()) {
+                import_bindings.insert(col.clone(), value.clone());
+            }
+
+            // Substitute every imported variable into the inner statement, then
+            // constant-fold the now-closed expressions (e.g. `p.age + 1000` becomes
+            // a literal once `p` is materialized) so update clauses that only accept
+            // literal property values still see one.
+            let mut bound_inner = inner.clone();
+            for name in imports {
+                if let Some(value) = import_bindings.get(name) {
+                    let replacement = value_to_expr(value)?;
+                    bound_inner = subst_var_statement(bound_inner, name, &replacement);
+                }
+            }
+            let bound_inner = fold_constants_statement(bound_inner)?;
+
+            let inner_result = self
+                .execute_statement(bound_inner, keyspace, auth)
+                .await?;
+            stats.vertices_written += inner_result.stats.vertices_written;
+            stats.vertices_deleted += inner_result.stats.vertices_deleted;
+            stats.vertices_read += inner_result.stats.vertices_read;
+            stats.edges_read += inner_result.stats.edges_read;
+
+            // 3. Combine per the subquery shape.
+            if let Some(rc) = &return_clause {
+                // Trailing RETURN: evaluate over combined outer ∪ inner bindings.
+                // A unit inner contributes no inner columns, so the trailing RETURN
+                // sees only the outer (import) bindings and emits one row per outer
+                // row. A returning inner emits one combined row per inner row.
+                let inner_rows = if inner_returns {
+                    rows_as_bindings(&inner_result)
+                } else {
+                    vec![HashMap::new()]
+                };
+                let cols = projection_columns(rc);
+                set_or_check_columns(&mut out_columns, &cols)?;
+                for inner_binding in inner_rows {
+                    let mut combined = import_bindings.clone();
+                    combined.extend(inner_binding);
+                    let mut row = Vec::with_capacity(rc.items.len());
+                    for item in &rc.items {
+                        row.push(eval_expr(&item.expr, &combined)?);
+                    }
+                    out_rows.push(row);
+                }
+            } else if inner_returns {
+                // No trailing RETURN: unite the inner rows directly.
+                set_or_check_columns(&mut out_columns, &inner_result.columns)?;
+                out_rows.extend(inner_result.rows);
+            }
+            // Unit subquery with no trailing RETURN: nothing to project; the writes
+            // already happened. (Outer cardinality is preserved but yields no
+            // columns, matching a write-only statement's empty result shape.)
+        }
+
+        Ok(GraphResult {
+            columns: out_columns.unwrap_or_default(),
+            rows: out_rows,
+            stats,
         })
     }
 
@@ -1338,7 +1473,115 @@ fn bind_statement_params(
                 .map(|stmt| bind_statement_params(stmt, params))
                 .collect::<Result<Vec<_>>>()?,
         },
+        Statement::CallSubquery {
+            outer,
+            imports,
+            inner,
+            return_clause,
+        } => Statement::CallSubquery {
+            outer: Box::new(bind_statement_params(*outer, params)?),
+            imports,
+            inner: Box::new(bind_statement_params(*inner, params)?),
+            return_clause: return_clause
+                .map(|clause| bind_return_clause_params(clause, params))
+                .transpose()?,
+        },
     })
+}
+
+/// Rewrite the `outer` driving statement of a CALL {} subquery so it projects each
+/// imported variable as a column (`RETURN p, q, ...`). The parser builds the outer
+/// as a `MATCH` with an empty RETURN; here we fill in the projection so the engine
+/// can read one binding per imported variable per row.
+///
+/// Only a plain `MATCH` outer is supported as the CALL {} driver. Anything else
+/// fails loud rather than silently dropping the correlation.
+fn project_imports(outer: Statement, imports: &[String]) -> Result<Statement> {
+    match outer {
+        Statement::Match {
+            pattern,
+            where_clause,
+            ..
+        } => Ok(Statement::Match {
+            pattern,
+            where_clause,
+            return_clause: ReturnClause {
+                distinct: false,
+                items: imports
+                    .iter()
+                    .map(|name| ReturnItem {
+                        expr: Expr::Var(name.clone()),
+                        alias: Some(name.clone()),
+                    })
+                    .collect(),
+                order_by: vec![],
+                limit: None,
+            },
+        }),
+        other => Err(GraphError::Validation(format!(
+            "CALL {{}} subquery driver must be a MATCH, got {other:?}"
+        ))),
+    }
+}
+
+/// Whether a statement projects rows (has a RETURN). Returning statements feed the
+/// CALL {} union; non-returning (unit) statements run only for write side effects.
+fn statement_is_returning(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Match { .. }
+        | Statement::MatchWith { .. }
+        | Statement::MatchWithOptional { .. }
+        | Statement::Unwind { .. }
+        | Statement::Return { .. }
+        | Statement::Union { .. } => true,
+        Statement::Create { return_clause, .. } => return_clause.is_some(),
+        Statement::Merge { return_clause, .. } => return_clause.is_some(),
+        Statement::CallSubquery { return_clause, .. } => return_clause.is_some(),
+        Statement::Set { .. }
+        | Statement::Remove { .. }
+        | Statement::Delete { .. }
+        | Statement::Foreach { .. }
+        | Statement::Subscribe { .. }
+        | Statement::Unsubscribe { .. } => false,
+    }
+}
+
+/// Column names a trailing CALL {} RETURN clause projects.
+fn projection_columns(rc: &ReturnClause) -> Vec<String> {
+    build_columns(rc)
+}
+
+/// Turn a `GraphResult`'s rows into per-row binding maps keyed by column name, so
+/// trailing-RETURN expressions can read inner-subquery outputs by name.
+fn rows_as_bindings(result: &GraphResult) -> Vec<HashMap<String, Value>> {
+    result
+        .rows
+        .iter()
+        .map(|row| {
+            result
+                .columns
+                .iter()
+                .cloned()
+                .zip(row.iter().cloned())
+                .collect()
+        })
+        .collect()
+}
+
+/// Set the output columns on first use, or verify subsequent unions agree. Mirrors
+/// the UNION arm-shape check: differing column shapes across outer rows is a hard
+/// error, not a silent last-write-wins.
+fn set_or_check_columns(slot: &mut Option<Vec<String>>, cols: &[String]) -> Result<()> {
+    match slot {
+        Some(existing) if existing.as_slice() != cols => Err(GraphError::Validation(
+            "CALL {} subquery produced inconsistent column shapes across rows".to_string(),
+        )),
+        Some(_) => Ok(()),
+        None => {
+            *slot = Some(cols.to_vec());
+            Ok(())
+        }
+    }
 }
 
 /// Convert a runtime JSON value into the equivalent literal `Expr`.
@@ -1393,6 +1636,22 @@ fn subst_var_expr(expr: Expr, var: &str, replacement: &Expr) -> Expr {
     let boxed = |e: Box<Expr>| Box::new(subst_var_expr(*e, var, replacement));
     match expr {
         Expr::Var(name) if name == var => replacement.clone(),
+        // Property access on the substituted variable: when `replacement` is the
+        // materialized node/map (the common case for an imported CALL {} variable),
+        // resolve `var.name` to the map's `name` entry. This lets a correlated
+        // subquery read properties off an imported node (`WITH p ... p.name`).
+        // A missing key resolves to NULL (openCypher property-of-missing-key).
+        Expr::Property { var: pvar, name } if pvar == var => {
+            if let Expr::Map(entries) = replacement {
+                entries
+                    .iter()
+                    .find(|(k, _)| k == &name)
+                    .map(|(_, v)| v.clone())
+                    .unwrap_or(Expr::Literal(Literal::Null))
+            } else {
+                Expr::Property { var: pvar, name }
+            }
+        }
         Expr::Function { name, args } => Expr::Function {
             name,
             args: args.into_iter().map(recur).collect(),
@@ -1599,11 +1858,237 @@ fn subst_var_statement(stmt: Statement, var: &str, replacement: &Expr) -> Statem
                 body,
             }
         }
-        // REMOVE/DELETE (and any non-update statement) are rejected in a FOREACH
-        // body at parse time, so they never reach substitution here; pass through
-        // unchanged defensively.
+        // Read statements appear as CALL {} subquery bodies (correlated reads). The
+        // imported variable is materialized into their projections / patterns /
+        // filters so the subquery sees the outer row.
+        Statement::Return { return_clause } => Statement::Return {
+            return_clause: subst_var_return_clause(return_clause, var, replacement),
+        },
+        Statement::Match {
+            pattern,
+            where_clause,
+            return_clause,
+        } => Statement::Match {
+            pattern: pattern
+                .into_iter()
+                .map(|p| subst_var_pattern(p, var, replacement))
+                .collect(),
+            where_clause: where_clause.map(|w| subst_var_expr(w, var, replacement)),
+            return_clause: subst_var_return_clause(return_clause, var, replacement),
+        },
+        Statement::MatchWith {
+            pattern,
+            where_clause,
+            with_pipeline,
+            return_clause,
+        } => Statement::MatchWith {
+            pattern: pattern
+                .into_iter()
+                .map(|p| subst_var_pattern(p, var, replacement))
+                .collect(),
+            where_clause: where_clause.map(|w| subst_var_expr(w, var, replacement)),
+            with_pipeline: subst_var_with_pipeline(with_pipeline, var, replacement),
+            return_clause: subst_var_return_clause(return_clause, var, replacement),
+        },
+        Statement::Unwind {
+            expr,
+            var: unwind_var,
+            with_pipeline,
+            return_clause,
+        } => {
+            // The UNWIND alias shadows the imported var inside the rest of the query.
+            let expr = subst_var_expr(expr, var, replacement);
+            if unwind_var == var {
+                Statement::Unwind {
+                    expr,
+                    var: unwind_var,
+                    with_pipeline,
+                    return_clause,
+                }
+            } else {
+                Statement::Unwind {
+                    expr,
+                    var: unwind_var,
+                    with_pipeline: with_pipeline
+                        .map(|wp| subst_var_with_pipeline(wp, var, replacement)),
+                    return_clause: subst_var_return_clause(return_clause, var, replacement),
+                }
+            }
+        }
+        // Any other statement form as a subquery body is not substituted here; it is
+        // either rejected upstream or correlation-free, so pass through unchanged.
         other => other,
     }
+}
+
+/// Substitute the imported variable throughout a RETURN clause (projection items
+/// and ORDER BY expressions). LIMIT/DISTINCT carry no variable references.
+fn subst_var_return_clause(rc: ReturnClause, var: &str, replacement: &Expr) -> ReturnClause {
+    ReturnClause {
+        distinct: rc.distinct,
+        items: rc
+            .items
+            .into_iter()
+            .map(|item| ReturnItem {
+                expr: subst_var_expr(item.expr, var, replacement),
+                alias: item.alias,
+            })
+            .collect(),
+        order_by: rc
+            .order_by
+            .into_iter()
+            .map(|o| crate::parser::OrderItem {
+                expr: subst_var_expr(o.expr, var, replacement),
+                direction: o.direction,
+            })
+            .collect(),
+        limit: rc.limit,
+    }
+}
+
+/// Substitute the imported variable inside a WITH pipeline (its projection and
+/// trailing WHERE filter).
+fn subst_var_with_pipeline(
+    wp: WithPipeline,
+    var: &str,
+    replacement: &Expr,
+) -> WithPipeline {
+    WithPipeline {
+        clause: subst_var_return_clause(wp.clause, var, replacement),
+        where_clause: wp.where_clause.map(|w| subst_var_expr(w, var, replacement)),
+    }
+}
+
+/// Whether an expression is *closed*: it contains no free variable, property, or
+/// parameter reference, so it can be evaluated with empty bindings. Used to decide
+/// whether a substituted expression can be safely constant-folded to a literal.
+fn expr_is_closed(expr: &Expr) -> bool {
+    match expr {
+        Expr::Var(_) | Expr::Property { .. } | Expr::Parameter(_) => false,
+        Expr::Literal(_) => true,
+        Expr::Distinct(e) | Expr::Not(e) | Expr::IsNull(e) | Expr::IsNotNull(e) => {
+            expr_is_closed(e)
+        }
+        Expr::Comparison { left, right, .. }
+        | Expr::Arithmetic { left, right, .. }
+        | Expr::And(left, right)
+        | Expr::Or(left, right) => expr_is_closed(left) && expr_is_closed(right),
+        Expr::In { value, list } => expr_is_closed(value) && expr_is_closed(list),
+        Expr::Index { target, index } => expr_is_closed(target) && expr_is_closed(index),
+        Expr::Function { args, .. } => args.iter().all(expr_is_closed),
+        Expr::List(items) => items.iter().all(expr_is_closed),
+        Expr::Map(entries) => entries.iter().all(|(_, v)| expr_is_closed(v)),
+        // Conservatively treat any other form as non-closed: do not fold it.
+        _ => false,
+    }
+}
+
+/// Constant-fold a closed expression to a literal by evaluating it with empty
+/// bindings. Non-closed (still-correlated/pattern-referencing) expressions are
+/// returned unchanged so the executor evaluates them in context.
+fn fold_expr(expr: Expr) -> Result<Expr> {
+    if expr_is_closed(&expr) {
+        let value = eval_expr(&expr, &HashMap::new())?;
+        return value_to_expr(&value);
+    }
+    Ok(expr)
+}
+
+/// Fold the property-map of a pattern (node/rel props): any closed value becomes a
+/// literal. Used after import substitution so update clauses that require literal
+/// property values accept correlated-then-folded derived values.
+fn fold_pattern(pattern: Pattern) -> Result<Pattern> {
+    let fold_props = |props: Vec<(String, Expr)>| -> Result<Vec<(String, Expr)>> {
+        props
+            .into_iter()
+            .map(|(k, v)| Ok((k, fold_expr(v)?)))
+            .collect()
+    };
+    Ok(match pattern {
+        Pattern::Node { var, label, props } => Pattern::Node {
+            var,
+            label,
+            props: fold_props(props)?,
+        },
+        Pattern::Rel {
+            var,
+            rel_type,
+            direction,
+            props,
+            length_range,
+        } => Pattern::Rel {
+            var,
+            rel_type,
+            direction,
+            props: fold_props(props)?,
+            length_range,
+        },
+        Pattern::Path(elements) => Pattern::Path(
+            elements
+                .into_iter()
+                .map(fold_pattern)
+                .collect::<Result<Vec<_>>>()?,
+        ),
+    })
+}
+
+/// Constant-fold closed expressions in an import-substituted inner subquery
+/// statement. Only update clauses (whose property/assignment values may need to be
+/// literals) are folded; read clauses are left for the executor to evaluate.
+fn fold_constants_statement(stmt: Statement) -> Result<Statement> {
+    Ok(match stmt {
+        Statement::Create {
+            patterns,
+            return_clause,
+        } => Statement::Create {
+            patterns: patterns
+                .into_iter()
+                .map(fold_pattern)
+                .collect::<Result<Vec<_>>>()?,
+            return_clause,
+        },
+        Statement::Merge {
+            patterns,
+            set_clause,
+            return_clause,
+        } => Statement::Merge {
+            patterns: patterns
+                .into_iter()
+                .map(fold_pattern)
+                .collect::<Result<Vec<_>>>()?,
+            set_clause: set_clause
+                .into_iter()
+                .map(|a| {
+                    Ok(Assignment {
+                        var: a.var,
+                        property: a.property,
+                        value: fold_expr(a.value)?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
+            return_clause,
+        },
+        Statement::Set {
+            pattern,
+            where_clause,
+            assignments,
+        } => Statement::Set {
+            pattern,
+            where_clause,
+            assignments: assignments
+                .into_iter()
+                .map(|a| {
+                    Ok(Assignment {
+                        var: a.var,
+                        property: a.property,
+                        value: fold_expr(a.value)?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
+        },
+        // Read clauses and others: no folding needed (executor evaluates exprs).
+        other => other,
+    })
 }
 
 /// Format a physical plan as a human-readable string for EXPLAIN output.

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -25,6 +25,7 @@ use crate::adjacency::observer::AdjacencyIndexObserver;
 use crate::adjacency::reconcile::{reconcile_once, spawn_reconciliation};
 use crate::adjacency::{adjacency_keyspace_name, adjacency_table_metadata};
 use crate::error::{GraphError, Result};
+use crate::executor::eval::eval_expr;
 use crate::executor::expand::{build_columns, execute, GraphEngineConfig};
 use crate::executor::result::{GraphResult, QueryStats};
 use crate::executor::subscribe::SubscriptionRegistry;
@@ -274,6 +275,7 @@ fn statement_requires_adjacency(statement: &Statement) -> bool {
                     .as_ref()
                     .is_some_and(return_clause_requires_adjacency)
         }
+        Statement::Foreach { body, .. } => body.iter().any(statement_requires_adjacency),
     }
 }
 
@@ -676,6 +678,11 @@ impl GraphEngine {
         params: &HashMap<String, Value>,
     ) -> Result<GraphResult> {
         let statement = bind_statement_params(parse(query)?, params)?;
+        if let Statement::Foreach { var, list, body } = statement {
+            return self
+                .execute_foreach(&var, &list, &body, keyspace, auth)
+                .await;
+        }
         if statement_requires_adjacency(&statement) {
             let adjacency_registered = self.ensure_adjacency_storage_for_keyspace(keyspace).await?;
             if adjacency_registered {
@@ -711,6 +718,105 @@ impl GraphEngine {
             Some(&self.schema),
         )
         .await
+    }
+
+    /// Execute `FOREACH (var IN list | body...)`: run each body update clause
+    /// once per list element, atomically with respect to the whole statement.
+    ///
+    /// Atomicity: every (element × body-clause) is validated and planned **before
+    /// any** is executed. If any iteration fails to validate or plan (unknown
+    /// label, type error, malformed clause), the call returns the error with zero
+    /// writes performed — partial failure rolls back, never leaving some elements
+    /// written and others not. Planned plans are then executed in order.
+    async fn execute_foreach(
+        &self,
+        var: &str,
+        list: &Expr,
+        body: &[Statement],
+        keyspace: &str,
+        auth: &AuthContext,
+    ) -> Result<GraphResult> {
+        // Evaluate the list once. Top-level FOREACH has no outer bindings.
+        let list_value = eval_expr(list, &HashMap::new())
+            .map_err(|e| GraphError::Validation(format!("FOREACH list expression: {e}")))?;
+        let elements = match list_value {
+            Value::Array(items) => items,
+            Value::Null => Vec::new(),
+            other => {
+                return Err(GraphError::Validation(format!(
+                    "FOREACH expects a list, got {other}"
+                )));
+            }
+        };
+
+        // Phase 1 — materialize, validate, and plan every iteration up front so a
+        // failure on any element aborts before a single write (atomic rollback).
+        let mut planned: Vec<PhysicalPlan> = Vec::new();
+        for element in &elements {
+            let replacement = value_to_expr(element)?;
+            for stmt in body {
+                // Nested FOREACH inside a body is expanded recursively at execution
+                // time; here we only pre-plan the leaf update clauses.
+                if let Statement::Foreach { .. } = stmt {
+                    continue;
+                }
+                let bound = subst_var_statement(stmt.clone(), var, &replacement);
+                if statement_requires_adjacency(&bound) {
+                    self.ensure_adjacency_storage_for_keyspace(keyspace).await?;
+                }
+                let snap = self.schema.snapshot();
+                let logical = validate(&snap, auth, keyspace, bound)?;
+                planned.push(plan(logical)?);
+            }
+        }
+
+        // Phase 2 — execute the pre-planned leaf clauses, then any nested FOREACH.
+        let mut stats = QueryStats::default();
+        for physical in planned {
+            let wp = self.write_path.load();
+            let result = execute(
+                physical,
+                &wp,
+                keyspace,
+                &self.config,
+                Some(self.schema.virtual_tables()),
+                Some(&self.schema),
+            )
+            .await?;
+            stats.vertices_written += result.stats.vertices_written;
+            stats.vertices_deleted += result.stats.vertices_deleted;
+        }
+        for element in &elements {
+            let replacement = value_to_expr(element)?;
+            for stmt in body {
+                if let Statement::Foreach {
+                    var: inner_var,
+                    list: inner_list,
+                    body: inner_body,
+                } = subst_var_statement(stmt.clone(), var, &replacement)
+                {
+                    let nested = Box::pin(self.execute_foreach(
+                        &inner_var,
+                        &inner_list,
+                        &inner_body,
+                        keyspace,
+                        auth,
+                    ))
+                    .await?;
+                    stats.vertices_written += nested.stats.vertices_written;
+                    stats.vertices_deleted += nested.stats.vertices_deleted;
+                }
+            }
+        }
+
+        Ok(GraphResult {
+            columns: vec!["status".to_string()],
+            rows: vec![vec![Value::String(format!(
+                "FOREACH applied to {} element(s)",
+                elements.len()
+            ))]],
+            stats,
+        })
     }
 
     /// Explain a query: parse -> validate -> plan (return plan description).
@@ -1200,7 +1306,272 @@ fn bind_statement_params(
                 .transpose()?,
         },
         Statement::Unsubscribe { stream_id } => Statement::Unsubscribe { stream_id },
+        Statement::Foreach { var, list, body } => Statement::Foreach {
+            var,
+            list: bind_expr_params(list, params)?,
+            body: body
+                .into_iter()
+                .map(|stmt| bind_statement_params(stmt, params))
+                .collect::<Result<Vec<_>>>()?,
+        },
     })
+}
+
+/// Convert a runtime JSON value into the equivalent literal `Expr`.
+///
+/// Used to materialize a FOREACH loop element into the body's expressions:
+/// scalars become `Literal`s, arrays become `Expr::List`, and objects become
+/// `Expr::Map`, so nested structures (e.g. `FOREACH (m IN [{name:'a'}] | ...)`)
+/// substitute correctly.
+fn value_to_expr(value: &Value) -> Result<Expr> {
+    Ok(match value {
+        Value::Null => Expr::Literal(Literal::Null),
+        Value::Bool(b) => Expr::Literal(Literal::Bool(*b)),
+        Value::String(s) => Expr::Literal(Literal::String(s.clone())),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Expr::Literal(Literal::Integer(i))
+            } else if let Some(f) = n.as_f64() {
+                Expr::Literal(Literal::Float(f))
+            } else {
+                return Err(GraphError::Validation(
+                    "FOREACH element number cannot be represented".to_string(),
+                ));
+            }
+        }
+        Value::Array(items) => Expr::List(
+            items
+                .iter()
+                .map(value_to_expr)
+                .collect::<Result<Vec<_>>>()?,
+        ),
+        Value::Object(map) => Expr::Map(
+            map.iter()
+                .map(|(k, v)| Ok((k.clone(), value_to_expr(v)?)))
+                .collect::<Result<Vec<_>>>()?,
+        ),
+    })
+}
+
+/// Substitute every reference to FOREACH loop variable `var` in `expr` with
+/// `replacement` (the materialized current element). A nested FOREACH/comprehension
+/// that rebinds the same name shadows the outer binding, so substitution stops at
+/// the shadowing scope.
+fn subst_var_expr(expr: Expr, var: &str, replacement: &Expr) -> Expr {
+    let recur = |e: Expr| subst_var_expr(e, var, replacement);
+    let boxed = |e: Box<Expr>| Box::new(subst_var_expr(*e, var, replacement));
+    match expr {
+        Expr::Var(name) if name == var => replacement.clone(),
+        Expr::Function { name, args } => Expr::Function {
+            name,
+            args: args.into_iter().map(recur).collect(),
+        },
+        Expr::Distinct(inner) => Expr::Distinct(boxed(inner)),
+        Expr::Comparison { left, op, right } => Expr::Comparison {
+            left: boxed(left),
+            op,
+            right: boxed(right),
+        },
+        Expr::In { value, list } => Expr::In {
+            value: boxed(value),
+            list: boxed(list),
+        },
+        Expr::Arithmetic { left, op, right } => Expr::Arithmetic {
+            left: boxed(left),
+            op,
+            right: boxed(right),
+        },
+        Expr::And(l, r) => Expr::And(boxed(l), boxed(r)),
+        Expr::Or(l, r) => Expr::Or(boxed(l), boxed(r)),
+        Expr::Not(inner) => Expr::Not(boxed(inner)),
+        Expr::List(items) => Expr::List(items.into_iter().map(recur).collect()),
+        Expr::ListPredicate {
+            kind,
+            var: inner_var,
+            list,
+            predicate,
+        } => {
+            let list = boxed(list);
+            // Inner var shadows the loop var inside the predicate.
+            let predicate = if inner_var == var {
+                predicate
+            } else {
+                boxed(predicate)
+            };
+            Expr::ListPredicate {
+                kind,
+                var: inner_var,
+                list,
+                predicate,
+            }
+        }
+        Expr::ListComprehension {
+            var: inner_var,
+            list,
+            filter,
+            projection,
+        } => {
+            let list = boxed(list);
+            let shadowed = inner_var == var;
+            let map_inner = |b: Box<Expr>| {
+                if shadowed {
+                    b
+                } else {
+                    Box::new(subst_var_expr(*b, var, replacement))
+                }
+            };
+            Expr::ListComprehension {
+                var: inner_var,
+                list,
+                filter: filter.map(map_inner),
+                projection: projection.map(map_inner),
+            }
+        }
+        Expr::Map(props) => Expr::Map(
+            props
+                .into_iter()
+                .map(|(k, v)| (k, subst_var_expr(v, var, replacement)))
+                .collect(),
+        ),
+        Expr::Index { target, index } => Expr::Index {
+            target: boxed(target),
+            index: boxed(index),
+        },
+        Expr::Slice { target, start, end } => Expr::Slice {
+            target: boxed(target),
+            start: start.map(boxed),
+            end: end.map(boxed),
+        },
+        Expr::IsNull(inner) => Expr::IsNull(boxed(inner)),
+        Expr::IsNotNull(inner) => Expr::IsNotNull(boxed(inner)),
+        other => other,
+    }
+}
+
+/// Substitute the loop variable in a property map (pattern props / map literals).
+fn subst_var_prop_map(
+    props: Vec<(String, Expr)>,
+    var: &str,
+    replacement: &Expr,
+) -> Vec<(String, Expr)> {
+    props
+        .into_iter()
+        .map(|(k, v)| (k, subst_var_expr(v, var, replacement)))
+        .collect()
+}
+
+/// Substitute the loop variable inside a pattern's property values.
+fn subst_var_pattern(pattern: Pattern, var: &str, replacement: &Expr) -> Pattern {
+    match pattern {
+        Pattern::Node {
+            var: node_var,
+            label,
+            props,
+        } => Pattern::Node {
+            var: node_var,
+            label,
+            props: subst_var_prop_map(props, var, replacement),
+        },
+        Pattern::Rel {
+            var: rel_var,
+            rel_type,
+            direction,
+            props,
+            length_range,
+        } => Pattern::Rel {
+            var: rel_var,
+            rel_type,
+            direction,
+            props: subst_var_prop_map(props, var, replacement),
+            length_range,
+        },
+        Pattern::Path(elements) => Pattern::Path(
+            elements
+                .into_iter()
+                .map(|p| subst_var_pattern(p, var, replacement))
+                .collect(),
+        ),
+    }
+}
+
+/// Substitute the FOREACH loop variable `var` throughout a body update statement,
+/// materializing the current element as `replacement`. Only update clauses appear
+/// in a FOREACH body; non-update statements are returned unchanged (they are
+/// rejected at parse time, so this is purely defensive).
+fn subst_var_statement(stmt: Statement, var: &str, replacement: &Expr) -> Statement {
+    match stmt {
+        Statement::Create {
+            patterns,
+            return_clause,
+        } => Statement::Create {
+            patterns: patterns
+                .into_iter()
+                .map(|p| subst_var_pattern(p, var, replacement))
+                .collect(),
+            return_clause,
+        },
+        Statement::Merge {
+            patterns,
+            set_clause,
+            return_clause,
+        } => Statement::Merge {
+            patterns: patterns
+                .into_iter()
+                .map(|p| subst_var_pattern(p, var, replacement))
+                .collect(),
+            set_clause: set_clause
+                .into_iter()
+                .map(|a| Assignment {
+                    var: a.var,
+                    property: a.property,
+                    value: subst_var_expr(a.value, var, replacement),
+                })
+                .collect(),
+            return_clause,
+        },
+        Statement::Set {
+            pattern,
+            where_clause,
+            assignments,
+        } => Statement::Set {
+            pattern: pattern
+                .into_iter()
+                .map(|p| subst_var_pattern(p, var, replacement))
+                .collect(),
+            where_clause: where_clause.map(|w| subst_var_expr(w, var, replacement)),
+            assignments: assignments
+                .into_iter()
+                .map(|a| Assignment {
+                    var: a.var,
+                    property: a.property,
+                    value: subst_var_expr(a.value, var, replacement),
+                })
+                .collect(),
+        },
+        // Nested FOREACH: the inner loop var shadows the outer one inside its body.
+        Statement::Foreach {
+            var: inner_var,
+            list,
+            body,
+        } => {
+            let list = subst_var_expr(list, var, replacement);
+            let body = if inner_var == var {
+                body
+            } else {
+                body.into_iter()
+                    .map(|s| subst_var_statement(s, var, replacement))
+                    .collect()
+            };
+            Statement::Foreach {
+                var: inner_var,
+                list,
+                body,
+            }
+        }
+        // REMOVE/DELETE bodies reference bound variables (not value-substituted by
+        // the loop var directly); pass through unchanged.
+        other => other,
+    }
 }
 
 /// Format a physical plan as a human-readable string for EXPLAIN output.

--- a/ferrosa-graph/src/executor/aggregate.rs
+++ b/ferrosa-graph/src/executor/aggregate.rs
@@ -51,8 +51,9 @@ impl Accumulator for CountAcc {
     }
 }
 
-/// Sums numeric values as f64. Non-numeric values are ignored.
-/// Returns Null if no numeric values were accumulated.
+/// Sums numeric values as f64. Non-numeric (and null) values are ignored.
+/// Returns the additive identity `0` when no numeric values were accumulated,
+/// matching openCypher semantics (`sum()` over zero rows is `0`, not null).
 pub struct SumAcc {
     sum: f64,
     has_value: bool,
@@ -85,7 +86,8 @@ impl Accumulator for SumAcc {
         if self.has_value {
             serde_json::json!(self.sum)
         } else {
-            Value::Null
+            // openCypher: sum() over zero numeric inputs is the identity 0.
+            serde_json::json!(0)
         }
     }
 
@@ -213,6 +215,9 @@ impl Accumulator for MaxAcc {
 
 /// Collects values into a JSON array.
 ///
+/// Null values are skipped (openCypher `collect()` ignores nulls), so an
+/// empty input or all-null input yields `[]`, never null.
+///
 /// Enforces a configurable size limit (default 10,000) to prevent
 /// unbounded memory growth (FMEA F6).
 pub struct CollectAcc {
@@ -233,6 +238,10 @@ impl CollectAcc {
 
 impl Accumulator for CollectAcc {
     fn accumulate(&mut self, value: &Value) {
+        // openCypher: collect() ignores null values.
+        if value.is_null() {
+            return;
+        }
         if self.exceeded {
             return;
         }
@@ -340,9 +349,19 @@ mod tests {
     }
 
     #[test]
-    fn sum_acc_empty_returns_null() {
+    fn sum_acc_empty_returns_zero() {
+        // openCypher: sum() over zero rows is the additive identity 0, not null.
         let acc = SumAcc::new();
-        assert_eq!(acc.finish(), Value::Null);
+        assert_eq!(acc.finish(), serde_json::json!(0));
+    }
+
+    #[test]
+    fn sum_acc_all_non_numeric_returns_zero() {
+        // No numeric inputs is the same as empty for sum: identity 0.
+        let mut acc = SumAcc::new();
+        acc.accumulate(&serde_json::json!("nope"));
+        acc.accumulate(&Value::Null);
+        assert_eq!(acc.finish(), serde_json::json!(0));
     }
 
     #[test]
@@ -398,6 +417,32 @@ mod tests {
         acc.accumulate(&serde_json::json!(9.81));
         assert_eq!(acc.finish(), serde_json::json!([1, "hello", 9.81]));
         assert!(!acc.exceeded());
+    }
+
+    #[test]
+    fn collect_acc_skips_nulls() {
+        // openCypher: collect() ignores null values.
+        let mut acc = CollectAcc::new(10_000);
+        acc.accumulate(&serde_json::json!(1));
+        acc.accumulate(&Value::Null);
+        acc.accumulate(&serde_json::json!("hello"));
+        acc.accumulate(&Value::Null);
+        assert_eq!(acc.finish(), serde_json::json!([1, "hello"]));
+    }
+
+    #[test]
+    fn collect_acc_empty_returns_empty_array() {
+        // collect() over zero rows is the empty list, never null.
+        let acc = CollectAcc::new(10_000);
+        assert_eq!(acc.finish(), serde_json::json!([]));
+    }
+
+    #[test]
+    fn collect_acc_all_nulls_returns_empty_array() {
+        let mut acc = CollectAcc::new(10_000);
+        acc.accumulate(&Value::Null);
+        acc.accumulate(&Value::Null);
+        assert_eq!(acc.finish(), serde_json::json!([]));
     }
 
     #[test]

--- a/ferrosa-graph/src/executor/eval.rs
+++ b/ferrosa-graph/src/executor/eval.rs
@@ -175,6 +175,16 @@ pub fn eval_expr(expr: &Expr, bindings: &HashMap<String, Value>) -> Result<Value
                 }
             }
         }
+        Expr::ListComprehension {
+            var,
+            list,
+            filter,
+            projection,
+        } => eval_list_comprehension(var, list, filter.as_deref(), projection.as_deref(), bindings),
+        Expr::MapProjection { var, selectors } => eval_map_projection(var, selectors, bindings),
+        Expr::PatternComprehension { .. } => Err(GraphError::Validation(
+            "pattern comprehension requires graph-aware evaluation".into(),
+        )),
         Expr::Map(props) => {
             let mut map = serde_json::Map::new();
             for (name, expr) in props {
@@ -235,6 +245,98 @@ pub fn eval_expr(expr: &Expr, bindings: &HashMap<String, Value>) -> Result<Value
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Comprehensions and map projection
+// ---------------------------------------------------------------------------
+
+/// Evaluate a list comprehension `[var IN list WHERE filter | projection]`.
+///
+/// Iterates `list`, scoping `var` to each element (shadowing any outer
+/// binding without mutating the caller's map). Elements failing `filter`
+/// (false or null) are dropped; surviving elements are mapped through
+/// `projection` (identity when absent). A null list yields null per
+/// openCypher semantics.
+fn eval_list_comprehension(
+    var: &str,
+    list: &Expr,
+    filter: Option<&Expr>,
+    projection: Option<&Expr>,
+    bindings: &HashMap<String, Value>,
+) -> Result<Value> {
+    let list_val = eval_expr(list, bindings)?;
+    let items = match list_val {
+        Value::Array(items) => items,
+        Value::Null => return Ok(Value::Null),
+        other => {
+            return Err(GraphError::Validation(format!(
+                "list comprehension expects a list to iterate, got {other:?}"
+            )));
+        }
+    };
+
+    let mut scoped = bindings.clone();
+    let mut out = Vec::new();
+    for item in items {
+        scoped.insert(var.to_string(), item.clone());
+        if let Some(pred) = filter {
+            if as_bool(&eval_expr(pred, &scoped)?) != Some(true) {
+                continue;
+            }
+        }
+        let value = match projection {
+            Some(expr) => eval_expr(expr, &scoped)?,
+            None => item,
+        };
+        out.push(value);
+    }
+    Ok(Value::Array(out))
+}
+
+/// Evaluate a map projection `var {.prop, key: expr, .*}`.
+///
+/// `var` must bind to an object (or null → null). Each selector copies a
+/// named property, inserts a computed entry, or (for `.*`) copies every
+/// property of the base object.
+fn eval_map_projection(
+    var: &str,
+    selectors: &[crate::parser::MapProjectionSelector],
+    bindings: &HashMap<String, Value>,
+) -> Result<Value> {
+    use crate::parser::MapProjectionSelector as Sel;
+
+    let base = bindings.get(var).cloned().unwrap_or(Value::Null);
+    let base_obj = match base {
+        Value::Object(map) => map,
+        Value::Null => return Ok(Value::Null),
+        other => {
+            return Err(GraphError::Validation(format!(
+                "map projection base `{var}` must be a map, got {other:?}"
+            )));
+        }
+    };
+
+    let mut out = serde_json::Map::new();
+    for selector in selectors {
+        match selector {
+            Sel::Property(name) => {
+                out.insert(
+                    name.clone(),
+                    base_obj.get(name).cloned().unwrap_or(Value::Null),
+                );
+            }
+            Sel::Literal { key, value } => {
+                out.insert(key.clone(), eval_expr(value, bindings)?);
+            }
+            Sel::All => {
+                for (k, v) in &base_obj {
+                    out.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
+    Ok(Value::Object(out))
 }
 
 // ---------------------------------------------------------------------------
@@ -1097,5 +1199,126 @@ mod tests {
             right: Box::new(Expr::Literal(Literal::Integer(0))),
         };
         assert_eq!(eval_expr(&expr, &empty_bindings()).unwrap(), Value::Null);
+    }
+
+    // -----------------------------------------------------------------------
+    // List comprehensions
+    // -----------------------------------------------------------------------
+
+    fn parse_only_expr(query: &str) -> Expr {
+        let stmt = crate::parser::parse(query).unwrap();
+        match stmt {
+            crate::parser::Statement::Match { return_clause, .. }
+            | crate::parser::Statement::Return { return_clause } => {
+                return_clause.items.into_iter().next().unwrap().expr
+            }
+            other => panic!("expected Match/Return, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eval_list_comprehension_filter_and_project() {
+        // [x IN [1,2,3,4] WHERE x > 2 | x * 10] = [30, 40]
+        let expr = parse_only_expr("RETURN [x IN [1, 2, 3, 4] WHERE x > 2 | x * 10]");
+        let result = eval_expr(&expr, &empty_bindings()).unwrap();
+        assert_eq!(result, json!([30, 40]));
+    }
+
+    #[test]
+    fn eval_list_comprehension_filter_only() {
+        // [x IN [1,2,3] WHERE x > 1] = [2, 3]
+        let expr = parse_only_expr("RETURN [x IN [1, 2, 3] WHERE x > 1]");
+        let result = eval_expr(&expr, &empty_bindings()).unwrap();
+        assert_eq!(result, json!([2, 3]));
+    }
+
+    #[test]
+    fn eval_list_comprehension_project_only() {
+        // [x IN [1,2,3] | x + 1] = [2, 3, 4]
+        let expr = parse_only_expr("RETURN [x IN [1, 2, 3] | x + 1]");
+        let result = eval_expr(&expr, &empty_bindings()).unwrap();
+        assert_eq!(result, json!([2, 3, 4]));
+    }
+
+    #[test]
+    fn eval_list_comprehension_identity() {
+        // [x IN [1,2,3]] = [1, 2, 3]
+        let expr = parse_only_expr("RETURN [x IN [1, 2, 3]]");
+        let result = eval_expr(&expr, &empty_bindings()).unwrap();
+        assert_eq!(result, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn eval_list_comprehension_null_list_is_null() {
+        // x IN null → null (per openCypher).
+        let expr = parse_only_expr("RETURN [x IN null | x]");
+        let result = eval_expr(&expr, &empty_bindings()).unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn eval_list_comprehension_does_not_leak_scope_var() {
+        // The comprehension variable `x` must be scoped — after evaluation it
+        // must not appear in the outer bindings.
+        let expr = parse_only_expr("RETURN [x IN [1, 2] | x]");
+        let mut bindings = empty_bindings();
+        let _ = eval_expr(&expr, &bindings).unwrap();
+        assert!(!bindings.contains_key("x"));
+        // Also ensure a pre-existing outer `x` is shadowed, not mutated.
+        bindings.insert("x".into(), json!("outer"));
+        let _ = eval_expr(&expr, &bindings).unwrap();
+        assert_eq!(bindings.get("x"), Some(&json!("outer")));
+    }
+
+    // -----------------------------------------------------------------------
+    // Map projections
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn eval_map_projection_properties() {
+        let expr = parse_only_expr("MATCH (n) RETURN n {.name, .age}");
+        let result = eval_expr(&expr, &sample_bindings()).unwrap();
+        assert_eq!(result, json!({"name": "Alice", "age": 30}));
+    }
+
+    #[test]
+    fn eval_map_projection_literal_entry() {
+        let expr = parse_only_expr("MATCH (n) RETURN n {.name, doubled: n.age + n.age}");
+        let result = eval_expr(&expr, &sample_bindings()).unwrap();
+        assert_eq!(result, json!({"name": "Alice", "doubled": 60}));
+    }
+
+    #[test]
+    fn eval_map_projection_all() {
+        // n {.*} copies every property of n.
+        let expr = parse_only_expr("MATCH (n) RETURN n {.*}");
+        let result = eval_expr(&expr, &sample_bindings()).unwrap();
+        assert_eq!(
+            result,
+            json!({"name": "Alice", "age": 30, "_id": "abc123", "_type": "KNOWS"})
+        );
+    }
+
+    #[test]
+    fn eval_map_projection_missing_prop_is_null() {
+        let expr = parse_only_expr("MATCH (n) RETURN n {.nope}");
+        let result = eval_expr(&expr, &sample_bindings()).unwrap();
+        assert_eq!(result, json!({"nope": Value::Null}));
+    }
+
+    // -----------------------------------------------------------------------
+    // Pattern comprehensions require graph-aware evaluation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn eval_pattern_comprehension_requires_graph_context() {
+        // The pure-binding evaluator cannot traverse edges; it must fail loud,
+        // never silently return an empty/wrong list.
+        let expr = parse_only_expr("MATCH (n) RETURN [ (n)-[:KNOWS]->(m) | m.name ]");
+        let err = eval_expr(&expr, &empty_bindings()).unwrap_err();
+        assert!(
+            err.to_string().contains("pattern comprehension"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/ferrosa-graph/src/executor/eval.rs
+++ b/ferrosa-graph/src/executor/eval.rs
@@ -180,7 +180,13 @@ pub fn eval_expr(expr: &Expr, bindings: &HashMap<String, Value>) -> Result<Value
             list,
             filter,
             projection,
-        } => eval_list_comprehension(var, list, filter.as_deref(), projection.as_deref(), bindings),
+        } => eval_list_comprehension(
+            var,
+            list,
+            filter.as_deref(),
+            projection.as_deref(),
+            bindings,
+        ),
         Expr::MapProjection { var, selectors } => eval_map_projection(var, selectors, bindings),
         Expr::PatternComprehension { .. } => Err(GraphError::Validation(
             "pattern comprehension requires graph-aware evaluation".into(),

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -24,8 +24,8 @@ use crate::executor::aggregate::{create_accumulator, Accumulator};
 use crate::executor::eval;
 use crate::executor::result::{GraphResult, QueryStats};
 use crate::parser::{
-    CompareOp, Direction, Expr, Literal, RemoveItem, ReturnClause, ReturnItem, SortDir,
-    WithPipeline,
+    CompareOp, Direction, Expr, Literal, PatternComprehensionHop, RemoveItem, ReturnClause,
+    ReturnItem, SortDir, WithPipeline,
 };
 use crate::planner::physical::{AggregateProjection, Anchor, CreateOp, Hop, MergeOp, PhysicalPlan};
 
@@ -602,6 +602,287 @@ async fn pattern_predicate_exists(
     Ok(!frontier.is_empty())
 }
 
+/// Whether an expression (or any sub-expression) is a pattern comprehension,
+/// which requires graph-aware evaluation during projection.
+fn expr_has_pattern_comprehension(expr: &Expr) -> bool {
+    match expr {
+        Expr::PatternComprehension { .. } => true,
+        Expr::Function { args, .. } | Expr::List(args) => {
+            args.iter().any(expr_has_pattern_comprehension)
+        }
+        Expr::Distinct(e) | Expr::Not(e) | Expr::IsNull(e) | Expr::IsNotNull(e) => {
+            expr_has_pattern_comprehension(e)
+        }
+        Expr::Comparison { left, right, .. }
+        | Expr::Arithmetic { left, right, .. }
+        | Expr::And(left, right)
+        | Expr::Or(left, right)
+        | Expr::In {
+            value: left,
+            list: right,
+        }
+        | Expr::Index {
+            target: left,
+            index: right,
+        } => expr_has_pattern_comprehension(left) || expr_has_pattern_comprehension(right),
+        Expr::ListPredicate {
+            list, predicate, ..
+        } => expr_has_pattern_comprehension(list) || expr_has_pattern_comprehension(predicate),
+        Expr::ListComprehension {
+            list,
+            filter,
+            projection,
+            ..
+        } => {
+            expr_has_pattern_comprehension(list)
+                || filter.as_deref().is_some_and(expr_has_pattern_comprehension)
+                || projection
+                    .as_deref()
+                    .is_some_and(expr_has_pattern_comprehension)
+        }
+        Expr::Map(props) => props.iter().any(|(_, e)| expr_has_pattern_comprehension(e)),
+        Expr::MapProjection { selectors, .. } => selectors.iter().any(|s| match s {
+            crate::parser::MapProjectionSelector::Literal { value, .. } => {
+                expr_has_pattern_comprehension(value)
+            }
+            _ => false,
+        }),
+        Expr::Slice { target, start, end } => {
+            expr_has_pattern_comprehension(target)
+                || start.as_deref().is_some_and(expr_has_pattern_comprehension)
+                || end.as_deref().is_some_and(expr_has_pattern_comprehension)
+        }
+        Expr::Var(_)
+        | Expr::Property { .. }
+        | Expr::Literal(_)
+        | Expr::Parameter(_)
+        | Expr::PatternPredicate { .. } => false,
+    }
+}
+
+/// Evaluate a RETURN/projection expression with graph context.
+///
+/// Pattern comprehensions need to traverse edges, so they cannot be handled by
+/// the pure-binding [`eval::eval_expr`]. This function intercepts them (and any
+/// nesting that contains them) and delegates everything else to `eval_expr`.
+#[allow(clippy::too_many_arguments)]
+fn graph_eval_expr<'a>(
+    expr: &'a Expr,
+    write_path: &'a WritePath,
+    keyspace: &'a str,
+    schema: Option<&'a Schema>,
+    bindings: &'a HashMap<String, serde_json::Value>,
+    current_var: &'a str,
+    current_key: &'a DecoratedKey,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value>> + Send + 'a>> {
+    Box::pin(async move {
+        match expr {
+            Expr::PatternComprehension {
+                start_var,
+                hops,
+                filter,
+                projection,
+            } => {
+                eval_pattern_comprehension(
+                    write_path,
+                    keyspace,
+                    schema,
+                    bindings,
+                    current_var,
+                    current_key,
+                    start_var,
+                    hops,
+                    filter.as_deref(),
+                    projection,
+                )
+                .await
+            }
+            // No graph-aware sub-evaluation needed for other expression kinds.
+            _ => eval::eval_expr(expr, bindings),
+        }
+    })
+}
+
+/// Evaluate a pattern comprehension `[ (start)-[:R]->(m) WHERE p | proj ]`.
+///
+/// Traverses a single hop from the already-bound `start_var`, binds each
+/// matched target node to its variable, applies the optional `filter`, and
+/// collects the `projection` per surviving match into a list.
+///
+/// Multi-hop comprehensions are not yet supported and fail loud rather than
+/// returning a partial/wrong list.
+#[allow(clippy::too_many_arguments)]
+async fn eval_pattern_comprehension(
+    write_path: &WritePath,
+    keyspace: &str,
+    schema: Option<&Schema>,
+    bindings: &HashMap<String, serde_json::Value>,
+    current_var: &str,
+    current_key: &DecoratedKey,
+    start_var: &str,
+    hops: &[PatternComprehensionHop],
+    filter: Option<&Expr>,
+    projection: &Expr,
+) -> Result<serde_json::Value> {
+    if hops.len() != 1 {
+        return Err(GraphError::Validation(
+            "multi-hop pattern comprehensions are not yet supported".into(),
+        ));
+    }
+    if start_var != current_var {
+        return Err(GraphError::Validation(format!(
+            "pattern comprehension start variable `{start_var}` is not bound at this point"
+        )));
+    }
+    let hop = &hops[0];
+    if matches!(hop.direction, Direction::In) {
+        return Err(GraphError::Validation(
+            "incoming pattern comprehensions require a reverse adjacency index".into(),
+        ));
+    }
+
+    let neighbor_ids =
+        outgoing_neighbor_ids(write_path, keyspace, schema, current_key, hop.rel_type.as_deref())
+            .await?;
+
+    let mut out = Vec::new();
+    for neighbor_id in neighbor_ids {
+        let target_json = resolve_target_node_json(
+            write_path,
+            keyspace,
+            schema,
+            &neighbor_id,
+            hop.target_label.as_deref(),
+            hop.target_props.as_slice(),
+            hop.target_var.as_deref().unwrap_or("_comprehension_target"),
+        )
+        .await?;
+        let Some(target_json) = target_json else {
+            continue;
+        };
+
+        let mut scoped = bindings.clone();
+        if let Some(target_var) = &hop.target_var {
+            scoped.insert(target_var.clone(), target_json);
+        }
+        if let Some(pred) = filter {
+            if !eval::filter_passes(pred, &scoped)? {
+                continue;
+            }
+        }
+        out.push(eval::eval_expr(projection, &scoped)?);
+    }
+    Ok(serde_json::Value::Array(out))
+}
+
+/// Collect outgoing neighbor vertex ids for a source vertex over an optional
+/// relationship type, using the adjacency index with an edge-table fallback.
+async fn outgoing_neighbor_ids(
+    write_path: &WritePath,
+    keyspace: &str,
+    schema: Option<&Schema>,
+    source_key: &DecoratedKey,
+    rel_type: Option<&str>,
+) -> Result<Vec<Vec<u8>>> {
+    let adj_ks = adjacency_keyspace_name(keyspace);
+    let adj_table_id = TableId::new(&adj_ks, "adjacency");
+
+    let hex_candidate = DecoratedKey::new(PartitionKey::new(
+        hex::encode(source_key.key.as_bytes()).into_bytes(),
+    ));
+    let source_keys = [source_key.clone(), hex_candidate];
+
+    let mut neighbor_ids = Vec::new();
+    for key in &source_keys {
+        if let Some(partition) = write_path.read(&adj_table_id, key).await? {
+            for row in &partition.rows {
+                if let Some(neighbor_id) = extract_neighbor_id_for_direction(
+                    &row.clustering,
+                    rel_type,
+                    Some(DIRECTION_OUT),
+                ) {
+                    neighbor_ids.push(neighbor_id);
+                }
+            }
+        }
+    }
+
+    if neighbor_ids.is_empty() {
+        if let (Some(schema_ref), Some(rel_type)) = (schema, rel_type) {
+            if let Some(edge_meta) = resolve_table_by_graph_label(schema_ref, keyspace, rel_type) {
+                if edge_meta
+                    .extensions
+                    .get("graph.type")
+                    .is_some_and(|graph_type| graph_type == "edge")
+                {
+                    let edge_tid = TableId::new(&edge_meta.keyspace, &edge_meta.name);
+                    let strategy = graph_replication_strategy(schema, &edge_meta.keyspace)?;
+                    for key in &source_keys {
+                        if let Some(edge_partition) = write_path
+                            .pk_read(&edge_tid, key, ConsistencyLevel::One, &strategy)
+                            .await?
+                        {
+                            for row in &edge_partition.rows {
+                                if let Some(components) = decode_clustering_components(
+                                    &row.clustering,
+                                    edge_meta.clustering_key.len(),
+                                ) {
+                                    if let Some(dst) = components.first() {
+                                        neighbor_ids.push(dst.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(neighbor_ids)
+}
+
+/// Load a neighbor vertex's properties as JSON, honoring an optional label and
+/// inline property filter. Returns `None` when the label is missing or the
+/// inline filter does not match.
+async fn resolve_target_node_json(
+    write_path: &WritePath,
+    keyspace: &str,
+    schema: Option<&Schema>,
+    neighbor_id: &[u8],
+    target_label: Option<&str>,
+    target_props: &[(String, Expr)],
+    var_name: &str,
+) -> Result<Option<serde_json::Value>> {
+    let Some(target_label) = target_label else {
+        // Unlabeled target: expose the neighbor id (hex) when we cannot resolve
+        // a concrete row, so projections like `| id(m)` still work.
+        return Ok(Some(serde_json::Value::String(hex::encode(neighbor_id))));
+    };
+    let Some(schema_ref) = schema else {
+        return Err(GraphError::Validation(
+            "pattern comprehension label filters require schema metadata".into(),
+        ));
+    };
+    let Some(target_meta) = resolve_table_by_graph_label(schema_ref, keyspace, target_label) else {
+        return Err(GraphError::Validation(format!(
+            "unknown graph label in pattern comprehension: {target_label}"
+        )));
+    };
+    let target_tid = TableId::new(&target_meta.keyspace, &target_meta.name);
+    let matched = find_vertex_match(
+        write_path,
+        &target_tid,
+        &target_meta,
+        &HashMap::new(),
+        neighbor_id,
+        target_props,
+        var_name,
+        schema,
+    )
+    .await?;
+    Ok(matched.map(|m| m.json))
+}
+
 fn execute_return_only(return_clause: &ReturnClause, start: Instant) -> Result<GraphResult> {
     let bindings = HashMap::new();
     let mut rows = vec![return_clause
@@ -1044,6 +1325,15 @@ async fn execute_expand(
     // Step 3: Build result from return clause, projecting property values.
     let columns = build_columns(return_clause);
 
+    // Pattern comprehensions in the projection need graph traversal keyed on
+    // the anchor (start) variable. Only take the graph-aware path when a
+    // comprehension is actually present, to avoid per-row overhead otherwise.
+    let needs_graph_projection = return_clause
+        .items
+        .iter()
+        .any(|item| expr_has_pattern_comprehension(&item.expr));
+    let anchor_var = anchor.var.as_deref().unwrap_or("");
+
     let mut result_states = Vec::new();
     let mut rows = Vec::new();
     for state in &current_states {
@@ -1051,13 +1341,24 @@ async fn execute_expand(
             break;
         }
 
-        let row: Vec<serde_json::Value> = return_clause
-            .items
-            .iter()
-            .map(|item| {
+        let mut row = Vec::with_capacity(return_clause.items.len());
+        for item in &return_clause.items {
+            let value = if needs_graph_projection {
+                graph_eval_expr(
+                    &item.expr,
+                    write_path,
+                    keyspace,
+                    schema,
+                    &state.bindings,
+                    anchor_var,
+                    &state.current_key,
+                )
+                .await?
+            } else {
                 eval::eval_expr(&item.expr, &state.bindings).unwrap_or(serde_json::Value::Null)
-            })
-            .collect();
+            };
+            row.push(value);
+        }
         result_states.push(state.clone());
         rows.push(row);
     }

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -635,7 +635,9 @@ fn expr_has_pattern_comprehension(expr: &Expr) -> bool {
             ..
         } => {
             expr_has_pattern_comprehension(list)
-                || filter.as_deref().is_some_and(expr_has_pattern_comprehension)
+                || filter
+                    .as_deref()
+                    .is_some_and(expr_has_pattern_comprehension)
                 || projection
                     .as_deref()
                     .is_some_and(expr_has_pattern_comprehension)
@@ -741,9 +743,14 @@ async fn eval_pattern_comprehension(
         ));
     }
 
-    let neighbor_ids =
-        outgoing_neighbor_ids(write_path, keyspace, schema, current_key, hop.rel_type.as_deref())
-            .await?;
+    let neighbor_ids = outgoing_neighbor_ids(
+        write_path,
+        keyspace,
+        schema,
+        current_key,
+        hop.rel_type.as_deref(),
+    )
+    .await?;
 
     let mut out = Vec::new();
     for neighbor_id in neighbor_ids {

--- a/ferrosa-graph/src/parser/ast.rs
+++ b/ferrosa-graph/src/parser/ast.rs
@@ -366,6 +366,29 @@ pub enum Statement {
         /// Update clauses executed per element, in order.
         body: Vec<Statement>,
     },
+    /// `MATCH ... CALL { WITH <imports> <inner> } [RETURN ...]`
+    ///
+    /// A correlated subquery: the `inner` statement runs once per row produced by
+    /// the `outer` statement, with each variable in `imports` (the inner leading
+    /// `WITH`) bound to that outer row. Inner results are UNITED across rows.
+    ///
+    /// Two shapes are supported:
+    /// - **Returning** subquery (`inner` projects rows): each inner row is paired
+    ///   with its driving outer row; the trailing `return_clause` (if present)
+    ///   projects over the combined `outer ⨯ inner` bindings.
+    /// - **Unit** subquery (`inner` performs only updates, no RETURN): executed for
+    ///   its write side effects per outer row, leaving outer cardinality unchanged.
+    CallSubquery {
+        /// The driving query whose rows are imported into the subquery, one at a
+        /// time. Must project every name in `imports`.
+        outer: Box<Statement>,
+        /// Variables imported into the subquery via its leading `WITH`.
+        imports: Vec<String>,
+        /// The subquery body, run once per outer row with `imports` bound.
+        inner: Box<Statement>,
+        /// Optional trailing `RETURN` after the `CALL {}` block.
+        return_clause: Option<ReturnClause>,
+    },
 }
 
 #[cfg(test)]

--- a/ferrosa-graph/src/parser/ast.rs
+++ b/ferrosa-graph/src/parser/ast.rs
@@ -105,8 +105,43 @@ pub enum Expr {
         list: Box<Expr>,
         predicate: Box<Expr>,
     },
+    /// List comprehension: `[x IN list WHERE pred | expr]`.
+    ///
+    /// `filter` (the `WHERE pred`) and `projection` (the `| expr`) are both
+    /// optional. `[x IN xs]` is the whole list; `[x IN xs WHERE p]` filters;
+    /// `[x IN xs | e]` maps; `[x IN xs WHERE p | e]` filters then maps.
+    ListComprehension {
+        var: String,
+        list: Box<Expr>,
+        filter: Option<Box<Expr>>,
+        projection: Option<Box<Expr>>,
+    },
+    /// Pattern comprehension: `[ (n)-[:R]->(m) WHERE pred | m.prop ]`.
+    ///
+    /// Evaluates a graph pattern starting from an already-bound variable,
+    /// optionally filters each match, and projects an expression per match,
+    /// collecting the results into a list. Requires graph-aware evaluation.
+    ///
+    /// Unlike [`Expr::PatternPredicate`], each hop carries its target node's
+    /// binding variable so the `WHERE`/projection expressions can reference
+    /// matched nodes (e.g. `m` in `| m.name`).
+    PatternComprehension {
+        start_var: String,
+        hops: Vec<PatternComprehensionHop>,
+        filter: Option<Box<Expr>>,
+        projection: Box<Expr>,
+    },
     /// Map literal: `{name: 'Alice'}`.
     Map(PropMap),
+    /// Map projection over a bound variable: `n {.name, .age, foo: expr, .*}`.
+    ///
+    /// Builds a map by selecting properties off `var` (and/or computed
+    /// entries). Distinct from a [`Expr::Map`] literal, which has no base
+    /// variable.
+    MapProjection {
+        var: String,
+        selectors: Vec<MapProjectionSelector>,
+    },
     /// List/map/string indexing: `expr[index]`.
     Index { target: Box<Expr>, index: Box<Expr> },
     /// List/string slicing: `expr[start..end]`.
@@ -129,11 +164,36 @@ pub enum Expr {
 /// A property map in a node or edge pattern: `{name: 'Alice', age: 30}`.
 pub type PropMap = Vec<(String, Expr)>;
 
+/// One selector inside a map projection: `n {.name, alias: expr, .*}`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MapProjectionSelector {
+    /// `.prop` — copy `var.prop` into the projected map under key `prop`.
+    Property(String),
+    /// `key: expr` — insert a computed entry under `key`.
+    Literal { key: String, value: Expr },
+    /// `.*` — copy every property of `var` into the projected map.
+    All,
+}
+
 /// One relationship+target-node hop in a WHERE pattern predicate.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PatternPredicateHop {
     pub rel_type: Option<String>,
     pub direction: Direction,
+    pub target_label: Option<String>,
+    pub target_props: PropMap,
+}
+
+/// One relationship+target-node hop in a pattern comprehension.
+///
+/// Like [`PatternPredicateHop`] but additionally preserves the target node's
+/// binding variable so the comprehension's filter and projection can refer to
+/// matched nodes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PatternComprehensionHop {
+    pub rel_type: Option<String>,
+    pub direction: Direction,
+    pub target_var: Option<String>,
     pub target_label: Option<String>,
     pub target_props: PropMap,
 }

--- a/ferrosa-graph/src/parser/ast.rs
+++ b/ferrosa-graph/src/parser/ast.rs
@@ -351,6 +351,21 @@ pub enum Statement {
         set_clause: Vec<Assignment>,
         return_clause: Option<ReturnClause>,
     },
+    /// `FOREACH (var IN list_expr | update_clause [update_clause ...])`
+    ///
+    /// Executes each contained update clause once per element of `list`, with
+    /// `var` bound to the current element. The body may contain only update
+    /// clauses (CREATE / SET / MERGE / DELETE / REMOVE / nested FOREACH); it
+    /// never projects rows. Atomic with the surrounding statement: if any
+    /// iteration's clause fails, the whole FOREACH writes nothing.
+    Foreach {
+        /// Loop variable bound to each element of `list` in turn.
+        var: String,
+        /// Expression evaluated once to the list being iterated.
+        list: Expr,
+        /// Update clauses executed per element, in order.
+        body: Vec<Statement>,
+    },
 }
 
 #[cfg(test)]

--- a/ferrosa-graph/src/parser/lexer.rs
+++ b/ferrosa-graph/src/parser/lexer.rs
@@ -65,6 +65,11 @@ fn kind_matches(actual: &TokenKind<'_>, expected: &TokenKind<'_>) -> bool {
 ///
 /// Yields `Token<'input>` values that borrow from the source string.
 /// Maintains a byte offset cursor and supports peek/next.
+///
+/// `Clone` is cheap (a borrowed `&str`/`&[u8]`, a `usize`, and an optional
+/// peeked token) and is used by the parser to snapshot/restore for bounded
+/// lookahead where single-token `peek` is insufficient.
+#[derive(Clone)]
 pub struct Lexer<'input> {
     pub(crate) input: &'input str,
     bytes: &'input [u8],

--- a/ferrosa-graph/src/parser/parse_impl.rs
+++ b/ferrosa-graph/src/parser/parse_impl.rs
@@ -374,12 +374,12 @@ impl<'input> Parser<'input> {
         self.lexer.expect(&TokenKind::RBrace)?;
 
         // Optional trailing RETURN after the CALL {} block.
-        let return_clause = if matches!(self.lexer.peek()?.kind, TokenKind::Keyword(Keyword::Return))
-        {
-            Some(self.parse_return_clause()?)
-        } else {
-            None
-        };
+        let return_clause =
+            if matches!(self.lexer.peek()?.kind, TokenKind::Keyword(Keyword::Return)) {
+                Some(self.parse_return_clause()?)
+            } else {
+                None
+            };
 
         Ok(Statement::CallSubquery {
             outer: Box::new(outer),
@@ -2798,7 +2798,8 @@ mod tests {
     fn parse_call_subquery_unit_no_inner_return() {
         // A unit subquery: the inner body only performs updates (no RETURN), and
         // there is no trailing RETURN.
-        let stmt = parse("MATCH (p:Person) CALL { WITH p CREATE (:Person {name: p.name}) }").unwrap();
+        let stmt =
+            parse("MATCH (p:Person) CALL { WITH p CREATE (:Person {name: p.name}) }").unwrap();
         match stmt {
             Statement::CallSubquery {
                 inner,
@@ -2832,7 +2833,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.message.contains("unsupported Cypher clause: Keyword(Call)"),
+            err.message
+                .contains("unsupported Cypher clause: Keyword(Call)"),
             "nested CALL must fail loud, got: {}",
             err.message
         );
@@ -2892,7 +2894,8 @@ mod tests {
         ] {
             let err = parse(q).unwrap_err();
             assert!(
-                err.message.contains("requires a variable bound by an enclosing")
+                err.message
+                    .contains("requires a variable bound by an enclosing")
                     || err
                         .message
                         .contains("FOREACH body may only contain update clauses"),

--- a/ferrosa-graph/src/parser/parse_impl.rs
+++ b/ferrosa-graph/src/parser/parse_impl.rs
@@ -371,58 +371,37 @@ impl<'input> Parser<'input> {
 
     /// Parse a single update clause permitted inside a FOREACH body.
     ///
-    /// openCypher restricts the body to updating clauses: CREATE, MERGE, SET,
-    /// REMOVE, DELETE/DETACH DELETE, and nested FOREACH. Anything else (MATCH,
-    /// RETURN, WITH, ...) is a parse error — FOREACH never projects rows.
+    /// openCypher allows the body to contain CREATE, MERGE, SET, REMOVE,
+    /// DELETE/DETACH DELETE, and nested FOREACH. Ferrosa currently supports a
+    /// **top-level** FOREACH only — there is no enclosing MATCH/WITH to bind
+    /// variables. CREATE/MERGE (and nested FOREACH thereof) are fully expressible
+    /// because the loop element materializes into literal properties. SET, REMOVE,
+    /// and DELETE necessarily target a variable bound by a preceding MATCH/WITH,
+    /// which a top-level FOREACH cannot provide, so they are rejected here with a
+    /// clear fail-loud error rather than silently building an unusable clause.
+    /// Anything else (MATCH, RETURN, WITH, ...) is likewise a parse error.
     fn parse_foreach_body_clause(&mut self) -> ParseResult<Statement> {
         let tok = self.lexer.peek()?;
         match &tok.kind {
             TokenKind::Keyword(Keyword::Create) => self.parse_create(),
             TokenKind::Keyword(Keyword::Merge) => self.parse_merge(),
             TokenKind::Keyword(Keyword::Foreach) => self.parse_foreach(),
-            TokenKind::Keyword(Keyword::Set) => {
-                self.lexer.next_token()?;
-                let assignments = self.parse_assignment_list()?;
-                Ok(Statement::Set {
-                    pattern: vec![],
-                    where_clause: None,
-                    assignments,
-                })
-            }
-            TokenKind::Keyword(Keyword::Remove) => {
-                self.lexer.next_token()?;
-                let items = self.parse_remove_items()?;
-                Ok(Statement::Remove {
-                    pattern: vec![],
-                    where_clause: None,
-                    items,
-                })
-            }
-            TokenKind::Keyword(Keyword::Detach) => {
-                self.lexer.next_token()?;
-                self.lexer.expect(&TokenKind::Keyword(Keyword::Delete))?;
-                let variables = self.parse_var_list()?;
-                Ok(Statement::Delete {
-                    pattern: vec![],
-                    where_clause: None,
-                    detach: true,
-                    variables,
-                })
-            }
-            TokenKind::Keyword(Keyword::Delete) => {
-                self.lexer.next_token()?;
-                let variables = self.parse_var_list()?;
-                Ok(Statement::Delete {
-                    pattern: vec![],
-                    where_clause: None,
-                    detach: false,
-                    variables,
-                })
-            }
+            TokenKind::Keyword(Keyword::Set)
+            | TokenKind::Keyword(Keyword::Remove)
+            | TokenKind::Keyword(Keyword::Delete)
+            | TokenKind::Keyword(Keyword::Detach) => Err(ParseError::new(
+                format!(
+                    "FOREACH body clause {:?} requires a variable bound by an enclosing \
+                     MATCH/WITH; only top-level FOREACH (CREATE/MERGE/FOREACH over a list) \
+                     is supported",
+                    tok.kind
+                ),
+                tok.span,
+            )),
             _ => Err(ParseError::new(
                 format!(
                     "FOREACH body may only contain update clauses \
-                     (CREATE, MERGE, SET, REMOVE, DELETE, FOREACH), got {:?}",
+                     (CREATE, MERGE, FOREACH), got {:?}",
                     tok.kind
                 ),
                 tok.span,
@@ -2749,6 +2728,44 @@ mod tests {
             "got: {}",
             err.message
         );
+    }
+
+    #[test]
+    fn parse_foreach_nested_create_body_succeeds() {
+        let stmt =
+            parse("FOREACH (x IN [1] | CREATE (:Person {n: x}) FOREACH (y IN [2] | CREATE (:Person {n: y})))")
+                .unwrap();
+        match stmt {
+            Statement::Foreach { body, .. } => {
+                assert_eq!(body.len(), 2);
+                assert!(matches!(body[0], Statement::Create { .. }));
+                assert!(matches!(body[1], Statement::Foreach { .. }));
+            }
+            other => panic!("expected Foreach, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_foreach_rejects_set_remove_delete_body() {
+        // SET/REMOVE/DELETE operate on variables bound by an enclosing MATCH/WITH.
+        // A top-level FOREACH has no such binding, so these must fail loud at parse
+        // time rather than building unusable clauses that reference no variable.
+        for q in [
+            "FOREACH (x IN [1] | SET x.flag = true)",
+            "FOREACH (x IN [1] | REMOVE x.flag)",
+            "FOREACH (x IN [1] | DELETE x)",
+            "FOREACH (x IN [1] | DETACH DELETE x)",
+        ] {
+            let err = parse(q).unwrap_err();
+            assert!(
+                err.message.contains("requires a variable bound by an enclosing")
+                    || err
+                        .message
+                        .contains("FOREACH body may only contain update clauses"),
+                "query {q:?} should fail loud, got: {}",
+                err.message
+            );
+        }
     }
 
     // --- MERGE: relationship patterns and multi-clause ---

--- a/ferrosa-graph/src/parser/parse_impl.rs
+++ b/ferrosa-graph/src/parser/parse_impl.rs
@@ -719,6 +719,64 @@ impl<'input> Parser<'input> {
         Ok(props)
     }
 
+    /// Parse a map projection body `{ .prop, key: expr, .* }` for base `var`.
+    fn parse_map_projection(&mut self, var: String) -> ParseResult<Expr> {
+        self.lexer.expect(&TokenKind::LBrace)?;
+        let mut selectors = Vec::new();
+
+        if self.lexer.peek()?.kind != TokenKind::RBrace {
+            loop {
+                selectors.push(self.parse_map_projection_selector()?);
+                if !self.lexer.eat(&TokenKind::Comma)? {
+                    break;
+                }
+            }
+        }
+
+        self.lexer.expect(&TokenKind::RBrace)?;
+        Ok(Expr::MapProjection { var, selectors })
+    }
+
+    /// Parse one selector inside a map projection: `.prop`, `.*`, or
+    /// `key: expr`.
+    fn parse_map_projection_selector(&mut self) -> ParseResult<MapProjectionSelector> {
+        if self.lexer.eat(&TokenKind::Dot)? {
+            // `.*` (all) or `.prop` (single property).
+            if self.lexer.eat(&TokenKind::Star)? {
+                return Ok(MapProjectionSelector::All);
+            }
+            let tok = self.lexer.next_token()?;
+            let name = match tok.kind {
+                TokenKind::Ident(name) => name.to_string(),
+                _ => {
+                    return Err(ParseError::new(
+                        format!("expected property name after '.', got {:?}", tok.kind),
+                        tok.span,
+                    ));
+                }
+            };
+            return Ok(MapProjectionSelector::Property(name));
+        }
+
+        // `key: expr` computed entry.
+        let key_tok = self.lexer.next_token()?;
+        let key = match key_tok.kind {
+            TokenKind::Ident(name) => name.to_string(),
+            _ => {
+                return Err(ParseError::new(
+                    format!(
+                        "expected '.property', '.*', or 'key: expr' in map projection, got {:?}",
+                        key_tok.kind
+                    ),
+                    key_tok.span,
+                ));
+            }
+        };
+        self.lexer.expect(&TokenKind::Colon)?;
+        let value = self.parse_expr()?;
+        Ok(MapProjectionSelector::Literal { key, value })
+    }
+
     // --- Expression parsing (precedence climbing) ---
     // Depth is checked at the entry point to catch all recursive paths.
 
@@ -966,6 +1024,14 @@ impl<'input> Parser<'input> {
 
     fn parse_postfix(&mut self) -> ParseResult<Expr> {
         let mut expr = self.parse_primary()?;
+        // Map projection: `var { ... }`. Only a bare variable can be the base
+        // of a projection, so this never conflicts with a `{ }` map literal.
+        if let Expr::Var(var) = &expr {
+            if self.lexer.peek()?.kind == TokenKind::LBrace {
+                let var = var.clone();
+                expr = self.parse_map_projection(var)?;
+            }
+        }
         loop {
             if self.lexer.eat(&TokenKind::LBracket)? {
                 let start = if self.lexer.peek()?.kind == TokenKind::Dot {
@@ -1028,6 +1094,157 @@ impl<'input> Parser<'input> {
             var,
             list: Box::new(list),
             predicate: Box::new(predicate),
+        })
+    }
+
+    /// Parse a `[ ... ]` expression: list literal, list comprehension, or
+    /// pattern comprehension. Disambiguated by bounded lookahead after `[`:
+    ///   - `[(...` → pattern comprehension
+    ///   - `[ident IN ...` → list comprehension
+    ///   - otherwise → list literal
+    fn parse_bracket_expr(&mut self) -> ParseResult<Expr> {
+        self.lexer.expect(&TokenKind::LBracket)?;
+
+        // Pattern comprehension begins with a node pattern `(`.
+        if self.lexer.peek()?.kind == TokenKind::LParen {
+            return self.parse_pattern_comprehension();
+        }
+
+        // List comprehension begins with `ident IN`. Snapshot the lexer so a
+        // bare list literal that happens to start with an identifier still
+        // parses correctly.
+        if matches!(self.lexer.peek()?.kind, TokenKind::Ident(_)) {
+            let snapshot = self.lexer.clone();
+            let var_tok = self.lexer.next_token()?;
+            if self.lexer.peek()?.kind == TokenKind::Keyword(Keyword::In) {
+                let var = match var_tok.kind {
+                    TokenKind::Ident(name) => name.to_string(),
+                    _ => unreachable!("guarded by matches! above"),
+                };
+                self.lexer.expect(&TokenKind::Keyword(Keyword::In))?;
+                return self.parse_list_comprehension_tail(var);
+            }
+            // Not a comprehension — rewind and fall through to list literal.
+            self.lexer = snapshot;
+        }
+
+        // Plain list literal: `[e1, e2, ...]`.
+        let mut items = Vec::new();
+        if !self.lexer.eat(&TokenKind::RBracket)? {
+            items.push(self.parse_expr()?);
+            while self.lexer.eat(&TokenKind::Comma)? {
+                items.push(self.parse_expr()?);
+            }
+            self.lexer.expect(&TokenKind::RBracket)?;
+        }
+        Ok(Expr::List(items))
+    }
+
+    /// Parse the tail of a list comprehension after `[var IN`:
+    /// `list [WHERE pred] [| expr] ]`.
+    fn parse_list_comprehension_tail(&mut self, var: String) -> ParseResult<Expr> {
+        let list = self.parse_expr()?;
+        let filter = if self.lexer.eat(&TokenKind::Keyword(Keyword::Where))? {
+            Some(Box::new(self.parse_expr()?))
+        } else {
+            None
+        };
+        let projection = if self.lexer.eat(&TokenKind::Pipe)? {
+            Some(Box::new(self.parse_expr()?))
+        } else {
+            None
+        };
+        self.lexer.expect(&TokenKind::RBracket)?;
+        Ok(Expr::ListComprehension {
+            var,
+            list: Box::new(list),
+            filter,
+            projection,
+        })
+    }
+
+    /// Parse a pattern comprehension `[ (start)-[...]->(...) [WHERE p] | proj ]`.
+    /// The leading `[` has already been consumed.
+    fn parse_pattern_comprehension(&mut self) -> ParseResult<Expr> {
+        let span = self.lexer.peek()?.span;
+        let start = self.parse_node_pattern()?;
+        let Pattern::Node {
+            var: Some(start_var),
+            ..
+        } = start
+        else {
+            return Err(ParseError::new(
+                "pattern comprehension must start with a bound variable, e.g. [ (a)-[:R]->(b) | b ]",
+                span,
+            ));
+        };
+
+        // Parse one or more relationship+target hops, preserving target vars.
+        let mut hops = Vec::new();
+        loop {
+            let rel = self.parse_rel_pattern()?;
+            let target = self.parse_node_pattern()?;
+            let Pattern::Rel {
+                rel_type,
+                direction,
+                props,
+                length_range,
+                ..
+            } = rel
+            else {
+                unreachable!("parse_rel_pattern returns Pattern::Rel")
+            };
+            if length_range.is_some() {
+                return Err(ParseError::new(
+                    "variable-length pattern comprehensions are not yet supported",
+                    span,
+                ));
+            }
+            if !props.is_empty() {
+                return Err(ParseError::new(
+                    "relationship property filters in pattern comprehensions are not yet supported",
+                    span,
+                ));
+            }
+            let Pattern::Node {
+                var: target_var,
+                label: target_label,
+                props: target_props,
+            } = target
+            else {
+                unreachable!("parse_node_pattern returns Pattern::Node")
+            };
+            hops.push(PatternComprehensionHop {
+                rel_type,
+                direction,
+                target_var,
+                target_label,
+                target_props,
+            });
+            let tok = self.lexer.peek()?;
+            if !matches!(
+                tok.kind,
+                TokenKind::DashBracket | TokenKind::ArrowLeft | TokenKind::Minus
+            ) {
+                break;
+            }
+        }
+
+        let filter = if self.lexer.eat(&TokenKind::Keyword(Keyword::Where))? {
+            Some(Box::new(self.parse_expr()?))
+        } else {
+            None
+        };
+        // The projection `| expr` is mandatory for pattern comprehensions.
+        self.lexer.expect(&TokenKind::Pipe)?;
+        let projection = Box::new(self.parse_expr()?);
+        self.lexer.expect(&TokenKind::RBracket)?;
+
+        Ok(Expr::PatternComprehension {
+            start_var,
+            hops,
+            filter,
+            projection,
         })
     }
 
@@ -1101,18 +1318,7 @@ impl<'input> Parser<'input> {
                 self.lexer.next_token()?;
                 Ok(Expr::Literal(Literal::Null))
             }
-            TokenKind::LBracket => {
-                self.lexer.next_token()?;
-                let mut items = Vec::new();
-                if !self.lexer.eat(&TokenKind::RBracket)? {
-                    items.push(self.parse_expr()?);
-                    while self.lexer.eat(&TokenKind::Comma)? {
-                        items.push(self.parse_expr()?);
-                    }
-                    self.lexer.expect(&TokenKind::RBracket)?;
-                }
-                Ok(Expr::List(items))
-            }
+            TokenKind::LBracket => self.parse_bracket_expr(),
             TokenKind::LBrace => Ok(Expr::Map(self.parse_prop_map()?)),
             TokenKind::LParen => {
                 // Parenthesized expression — recursion depth is tracked
@@ -2477,5 +2683,192 @@ mod tests {
         } else {
             panic!("expected Match with NOT");
         }
+    }
+
+    // --- List comprehensions ---
+
+    /// Extract the single RETURN-item expression from a `MATCH ... RETURN <e>`.
+    fn only_return_expr(query: &str) -> Expr {
+        let stmt = parse(query).unwrap();
+        match stmt {
+            Statement::Match { return_clause, .. } | Statement::Return { return_clause } => {
+                assert_eq!(return_clause.items.len(), 1, "expected one RETURN item");
+                return_clause.items.into_iter().next().unwrap().expr
+            }
+            other => panic!("expected Match/Return, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_list_comprehension_full() {
+        // [x IN list WHERE pred | expr]
+        let expr = only_return_expr("MATCH (n) RETURN [x IN n.nums WHERE x > 2 | x + 10]");
+        match expr {
+            Expr::ListComprehension {
+                var,
+                list,
+                filter,
+                projection,
+            } => {
+                assert_eq!(var, "x");
+                assert!(matches!(*list, Expr::Property { ref name, .. } if name == "nums"));
+                assert!(filter.is_some(), "expected WHERE filter");
+                assert!(matches!(*filter.unwrap(), Expr::Comparison { .. }));
+                assert!(matches!(*projection.unwrap(), Expr::Arithmetic { .. }));
+            }
+            other => panic!("expected ListComprehension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_list_comprehension_filter_only() {
+        // [x IN list WHERE pred]
+        let expr = only_return_expr("RETURN [x IN [1, 2, 3] WHERE x > 1]");
+        match expr {
+            Expr::ListComprehension {
+                filter, projection, ..
+            } => {
+                assert!(filter.is_some());
+                assert!(projection.is_none(), "no projection expected");
+            }
+            other => panic!("expected ListComprehension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_list_comprehension_projection_only() {
+        // [x IN list | expr]
+        let expr = only_return_expr("RETURN [x IN [1, 2, 3] | x * 2]");
+        match expr {
+            Expr::ListComprehension {
+                filter, projection, ..
+            } => {
+                assert!(filter.is_none(), "no filter expected");
+                assert!(projection.is_some());
+            }
+            other => panic!("expected ListComprehension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_list_comprehension_no_filter_no_projection() {
+        // [x IN list] — equivalent to the list itself.
+        let expr = only_return_expr("RETURN [x IN [1, 2, 3]]");
+        match expr {
+            Expr::ListComprehension {
+                filter, projection, ..
+            } => {
+                assert!(filter.is_none());
+                assert!(projection.is_none());
+            }
+            other => panic!("expected ListComprehension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_plain_list_literal_unaffected() {
+        // A list literal without `x IN` must remain a List, not a comprehension.
+        let expr = only_return_expr("RETURN [1, 2, 3]");
+        assert!(matches!(expr, Expr::List(_)), "got {expr:?}");
+    }
+
+    // --- Map projections ---
+
+    #[test]
+    fn parse_map_projection_properties() {
+        // n {.name, .age}
+        let expr = only_return_expr("MATCH (n) RETURN n {.name, .age}");
+        match expr {
+            Expr::MapProjection { var, selectors } => {
+                assert_eq!(var, "n");
+                assert_eq!(selectors.len(), 2);
+                assert_eq!(
+                    selectors[0],
+                    MapProjectionSelector::Property("name".into())
+                );
+                assert_eq!(selectors[1], MapProjectionSelector::Property("age".into()));
+            }
+            other => panic!("expected MapProjection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_map_projection_literal_and_all() {
+        // n {.name, total: n.a + n.b, .*}
+        let expr = only_return_expr("MATCH (n) RETURN n {.name, total: n.a + n.b, .*}");
+        match expr {
+            Expr::MapProjection { var, selectors } => {
+                assert_eq!(var, "n");
+                assert_eq!(selectors.len(), 3);
+                assert_eq!(
+                    selectors[0],
+                    MapProjectionSelector::Property("name".into())
+                );
+                assert!(matches!(
+                    &selectors[1],
+                    MapProjectionSelector::Literal { key, .. } if key == "total"
+                ));
+                assert_eq!(selectors[2], MapProjectionSelector::All);
+            }
+            other => panic!("expected MapProjection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_map_literal_still_works() {
+        // A bare `{k: v}` (no leading variable) is a Map literal, not a projection.
+        let expr = only_return_expr("RETURN {name: 'Alice', age: 30}");
+        assert!(matches!(expr, Expr::Map(_)), "got {expr:?}");
+    }
+
+    // --- Pattern comprehensions ---
+
+    #[test]
+    fn parse_pattern_comprehension_basic() {
+        // [ (n)-[:KNOWS]->(m) | m.name ]
+        let expr = only_return_expr("MATCH (n) RETURN [ (n)-[:KNOWS]->(m) | m.name ]");
+        match expr {
+            Expr::PatternComprehension {
+                start_var,
+                hops,
+                filter,
+                projection,
+            } => {
+                assert_eq!(start_var, "n");
+                assert_eq!(hops.len(), 1);
+                assert_eq!(hops[0].rel_type.as_deref(), Some("KNOWS"));
+                assert!(filter.is_none());
+                assert!(matches!(*projection, Expr::Property { ref name, .. } if name == "name"));
+            }
+            other => panic!("expected PatternComprehension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_pattern_comprehension_with_where() {
+        // [ (n)-[:KNOWS]->(m) WHERE m.age > 30 | m.name ]
+        let expr =
+            only_return_expr("MATCH (n) RETURN [ (n)-[:KNOWS]->(m) WHERE m.age > 30 | m.name ]");
+        match expr {
+            Expr::PatternComprehension {
+                filter, projection, ..
+            } => {
+                assert!(filter.is_some(), "expected WHERE filter");
+                assert!(matches!(*filter.unwrap(), Expr::Comparison { .. }));
+                assert!(matches!(*projection, Expr::Property { .. }));
+            }
+            other => panic!("expected PatternComprehension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_pattern_comprehension_requires_projection() {
+        // Pattern comprehensions must always supply a `| expr`. Without it the
+        // parser must error loudly, never silently accept.
+        let err = parse("MATCH (n) RETURN [ (n)-[:KNOWS]->(m) ]").unwrap_err();
+        assert!(
+            !err.message.is_empty(),
+            "expected a parse error for missing projection"
+        );
     }
 }

--- a/ferrosa-graph/src/parser/parse_impl.rs
+++ b/ferrosa-graph/src/parser/parse_impl.rs
@@ -103,10 +103,10 @@ impl<'input> Parser<'input> {
             TokenKind::Keyword(Keyword::Return) => Ok(Statement::Return {
                 return_clause: self.parse_return_clause()?,
             }),
+            TokenKind::Keyword(Keyword::Foreach) => self.parse_foreach(),
             TokenKind::Keyword(Keyword::With)
             | TokenKind::Keyword(Keyword::Union)
             | TokenKind::Keyword(Keyword::Call)
-            | TokenKind::Keyword(Keyword::Foreach)
             | TokenKind::Keyword(Keyword::Load) => Err(ParseError::new(
                 format!("unsupported Cypher clause: {:?}", tok.kind),
                 tok.span,
@@ -332,6 +332,102 @@ impl<'input> Parser<'input> {
             patterns,
             return_clause,
         })
+    }
+
+    /// Parse `FOREACH (var IN list_expr | clause [clause ...])`.
+    ///
+    /// The body is a sequence of update clauses executed once per list element
+    /// with `var` bound to the element. Grammar (openCypher):
+    ///   FOREACH '(' Variable IN Expression '|' UpdatingClause+ ')'
+    fn parse_foreach(&mut self) -> ParseResult<Statement> {
+        self.lexer.expect(&TokenKind::Keyword(Keyword::Foreach))?;
+        self.lexer.expect(&TokenKind::LParen)?;
+
+        // Loop variable.
+        let tok = self.lexer.next_token()?;
+        let var = match tok.kind {
+            TokenKind::Ident(name) => name.to_string(),
+            _ => {
+                return Err(ParseError::new(
+                    format!("expected loop variable after FOREACH (, got {:?}", tok.kind),
+                    tok.span,
+                ));
+            }
+        };
+
+        self.lexer.expect(&TokenKind::Keyword(Keyword::In))?;
+        let list = self.parse_expr()?;
+        self.lexer.expect(&TokenKind::Pipe)?;
+
+        // One or more update clauses until the closing ')'.
+        let mut body = vec![self.parse_foreach_body_clause()?];
+        while self.lexer.peek()?.kind != TokenKind::RParen {
+            body.push(self.parse_foreach_body_clause()?);
+        }
+        self.lexer.expect(&TokenKind::RParen)?;
+
+        Ok(Statement::Foreach { var, list, body })
+    }
+
+    /// Parse a single update clause permitted inside a FOREACH body.
+    ///
+    /// openCypher restricts the body to updating clauses: CREATE, MERGE, SET,
+    /// REMOVE, DELETE/DETACH DELETE, and nested FOREACH. Anything else (MATCH,
+    /// RETURN, WITH, ...) is a parse error — FOREACH never projects rows.
+    fn parse_foreach_body_clause(&mut self) -> ParseResult<Statement> {
+        let tok = self.lexer.peek()?;
+        match &tok.kind {
+            TokenKind::Keyword(Keyword::Create) => self.parse_create(),
+            TokenKind::Keyword(Keyword::Merge) => self.parse_merge(),
+            TokenKind::Keyword(Keyword::Foreach) => self.parse_foreach(),
+            TokenKind::Keyword(Keyword::Set) => {
+                self.lexer.next_token()?;
+                let assignments = self.parse_assignment_list()?;
+                Ok(Statement::Set {
+                    pattern: vec![],
+                    where_clause: None,
+                    assignments,
+                })
+            }
+            TokenKind::Keyword(Keyword::Remove) => {
+                self.lexer.next_token()?;
+                let items = self.parse_remove_items()?;
+                Ok(Statement::Remove {
+                    pattern: vec![],
+                    where_clause: None,
+                    items,
+                })
+            }
+            TokenKind::Keyword(Keyword::Detach) => {
+                self.lexer.next_token()?;
+                self.lexer.expect(&TokenKind::Keyword(Keyword::Delete))?;
+                let variables = self.parse_var_list()?;
+                Ok(Statement::Delete {
+                    pattern: vec![],
+                    where_clause: None,
+                    detach: true,
+                    variables,
+                })
+            }
+            TokenKind::Keyword(Keyword::Delete) => {
+                self.lexer.next_token()?;
+                let variables = self.parse_var_list()?;
+                Ok(Statement::Delete {
+                    pattern: vec![],
+                    where_clause: None,
+                    detach: false,
+                    variables,
+                })
+            }
+            _ => Err(ParseError::new(
+                format!(
+                    "FOREACH body may only contain update clauses \
+                     (CREATE, MERGE, SET, REMOVE, DELETE, FOREACH), got {:?}",
+                    tok.kind
+                ),
+                tok.span,
+            )),
+        }
     }
 
     // --- Pattern parsing ---
@@ -2616,10 +2712,6 @@ mod tests {
                 "unsupported Cypher clause: Keyword(Call)",
             ),
             (
-                "FOREACH (x IN [1] | CREATE (:Person {name: 'x'}))",
-                "unsupported Cypher clause: Keyword(Foreach)",
-            ),
-            (
                 "LOAD CSV FROM 'file:///people.csv' AS row RETURN row",
                 "unsupported Cypher clause: Keyword(Load)",
             ),
@@ -2631,6 +2723,32 @@ mod tests {
                 err.message
             );
         }
+    }
+
+    #[test]
+    fn parse_foreach_create_body_succeeds() {
+        let stmt = parse("FOREACH (x IN [1, 2, 3] | CREATE (:Person {name: x}))").unwrap();
+        match stmt {
+            Statement::Foreach { var, list, body } => {
+                assert_eq!(var, "x");
+                assert!(matches!(list, Expr::List(_)));
+                assert_eq!(body.len(), 1);
+                assert!(matches!(body[0], Statement::Create { .. }));
+            }
+            other => panic!("expected Foreach, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_foreach_rejects_non_update_body() {
+        // RETURN is not an update clause; FOREACH never projects rows.
+        let err = parse("FOREACH (x IN [1] | RETURN x)").unwrap_err();
+        assert!(
+            err.message
+                .contains("FOREACH body may only contain update clauses"),
+            "got: {}",
+            err.message
+        );
     }
 
     // --- MERGE: relationship patterns and multi-clause ---
@@ -2782,10 +2900,7 @@ mod tests {
             Expr::MapProjection { var, selectors } => {
                 assert_eq!(var, "n");
                 assert_eq!(selectors.len(), 2);
-                assert_eq!(
-                    selectors[0],
-                    MapProjectionSelector::Property("name".into())
-                );
+                assert_eq!(selectors[0], MapProjectionSelector::Property("name".into()));
                 assert_eq!(selectors[1], MapProjectionSelector::Property("age".into()));
             }
             other => panic!("expected MapProjection, got {other:?}"),
@@ -2800,10 +2915,7 @@ mod tests {
             Expr::MapProjection { var, selectors } => {
                 assert_eq!(var, "n");
                 assert_eq!(selectors.len(), 3);
-                assert_eq!(
-                    selectors[0],
-                    MapProjectionSelector::Property("name".into())
-                );
+                assert_eq!(selectors[0], MapProjectionSelector::Property("name".into()));
                 assert!(matches!(
                     &selectors[1],
                     MapProjectionSelector::Literal { key, .. } if key == "total"

--- a/ferrosa-graph/src/parser/parse_impl.rs
+++ b/ferrosa-graph/src/parser/parse_impl.rs
@@ -301,20 +301,92 @@ impl<'input> Parser<'input> {
                     variables,
                 })
             }
-            TokenKind::Keyword(Keyword::Call)
-            | TokenKind::Keyword(Keyword::Foreach)
+            TokenKind::Keyword(Keyword::Call) => {
+                let outer = Statement::Match {
+                    pattern,
+                    where_clause,
+                    return_clause: ReturnClause {
+                        distinct: false,
+                        items: vec![],
+                        order_by: vec![],
+                        limit: None,
+                    },
+                };
+                self.parse_call_subquery(outer)
+            }
+            TokenKind::Keyword(Keyword::Foreach)
             | TokenKind::Keyword(Keyword::Load) => Err(ParseError::new(
                 format!("unsupported Cypher clause: {:?}", tok.kind),
                 tok.span,
             )),
             _ => Err(ParseError::new(
                 format!(
-                    "expected RETURN, OPTIONAL MATCH, WITH, SET, REMOVE, DELETE, or DETACH DELETE after MATCH, got {:?}",
+                    "expected RETURN, OPTIONAL MATCH, WITH, SET, REMOVE, DELETE, DETACH DELETE, or CALL after MATCH, got {:?}",
                     tok.kind
                 ),
                 tok.span,
             )),
         }
+    }
+
+    /// Parse a `CALL { WITH <imports> <inner> } [RETURN ...]` block following an
+    /// already-parsed `outer` driving statement (typically a MATCH).
+    ///
+    /// Grammar:
+    ///   call := CALL `{` WITH var (`,` var)* inner_statement `}` [RETURN ...]
+    ///
+    /// The leading `WITH <imports>` declares which outer variables are correlated
+    /// into the subquery. Only bare variable imports are supported (no aliasing /
+    /// projection in the import WITH); anything else fails loud. The inner body is
+    /// a full statement — either returning (projects rows) or a unit update.
+    fn parse_call_subquery(&mut self, outer: Statement) -> ParseResult<Statement> {
+        self.lexer.expect(&TokenKind::Keyword(Keyword::Call))?;
+        self.lexer.expect(&TokenKind::LBrace)?;
+
+        // The subquery must begin with `WITH <imports>` for correlation. We only
+        // accept bare variable names here; an aliased/expression WITH is rejected
+        // loudly rather than silently importing the wrong thing.
+        if !matches!(self.lexer.peek()?.kind, TokenKind::Keyword(Keyword::With)) {
+            let tok = self.lexer.peek()?;
+            return Err(ParseError::new(
+                format!(
+                    "CALL {{}} subquery must begin with `WITH <vars>` to import correlated \
+                     variables, got {:?}",
+                    tok.kind
+                ),
+                tok.span,
+            ));
+        }
+        self.lexer.expect(&TokenKind::Keyword(Keyword::With))?;
+        let imports = self.parse_var_list()?;
+        if imports.is_empty() {
+            let tok = self.lexer.peek()?;
+            return Err(ParseError::new(
+                "CALL {} subquery `WITH` must import at least one variable".to_string(),
+                tok.span,
+            ));
+        }
+
+        // Parse the inner subquery body. A nested CALL inside the body must fail
+        // loud (handled by parse_statement returning an unsupported-clause error).
+        let inner = self.parse_statement()?;
+
+        self.lexer.expect(&TokenKind::RBrace)?;
+
+        // Optional trailing RETURN after the CALL {} block.
+        let return_clause = if matches!(self.lexer.peek()?.kind, TokenKind::Keyword(Keyword::Return))
+        {
+            Some(self.parse_return_clause()?)
+        } else {
+            None
+        };
+
+        Ok(Statement::CallSubquery {
+            outer: Box::new(outer),
+            imports,
+            inner: Box::new(inner),
+            return_clause,
+        })
     }
 
     fn parse_create(&mut self) -> ParseResult<Statement> {
@@ -2683,11 +2755,9 @@ mod tests {
                 "unsupported Cypher clause: Keyword(With)",
             ),
             (
+                // Bare top-level CALL (a stored-procedure call, not a `CALL {}`
+                // subquery) is still unsupported.
                 "CALL db.labels()",
-                "unsupported Cypher clause: Keyword(Call)",
-            ),
-            (
-                "MATCH (n) CALL { WITH n RETURN n } RETURN n",
                 "unsupported Cypher clause: Keyword(Call)",
             ),
             (
@@ -2702,6 +2772,70 @@ mod tests {
                 err.message
             );
         }
+    }
+
+    #[test]
+    fn parse_call_subquery_correlated_returning() {
+        let stmt =
+            parse("MATCH (p:Person) CALL { WITH p RETURN p.age AS a } RETURN p.name, a").unwrap();
+        match stmt {
+            Statement::CallSubquery {
+                outer,
+                imports,
+                inner,
+                return_clause,
+            } => {
+                assert!(matches!(*outer, Statement::Match { .. }));
+                assert_eq!(imports, vec!["p".to_string()]);
+                assert!(matches!(*inner, Statement::Return { .. }));
+                assert!(return_clause.is_some(), "trailing RETURN must be captured");
+            }
+            other => panic!("expected CallSubquery, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_call_subquery_unit_no_inner_return() {
+        // A unit subquery: the inner body only performs updates (no RETURN), and
+        // there is no trailing RETURN.
+        let stmt = parse("MATCH (p:Person) CALL { WITH p CREATE (:Person {name: p.name}) }").unwrap();
+        match stmt {
+            Statement::CallSubquery {
+                inner,
+                return_clause,
+                ..
+            } => {
+                assert!(matches!(*inner, Statement::Create { .. }));
+                assert!(return_clause.is_none());
+            }
+            other => panic!("expected CallSubquery, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_call_subquery_requires_leading_with() {
+        // Without a leading WITH the correlation is ambiguous; fail loud.
+        let err = parse("MATCH (p:Person) CALL { RETURN 1 AS x } RETURN p.name, x").unwrap_err();
+        assert!(
+            err.message.contains("must begin with `WITH"),
+            "expected leading-WITH requirement, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn parse_call_subquery_nested_call_fails_loud() {
+        // A CALL {} nested directly inside another CALL {} is unsupported and must
+        // fail loud at parse time, never silently no-op.
+        let err = parse(
+            "MATCH (p:Person) CALL { WITH p CALL { WITH p RETURN p.age AS a } RETURN a } RETURN a",
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("unsupported Cypher clause: Keyword(Call)"),
+            "nested CALL must fail loud, got: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/ferrosa-graph/src/planner/logical.rs
+++ b/ferrosa-graph/src/planner/logical.rs
@@ -125,6 +125,10 @@ fn permission_for_statement(stmt: &Statement) -> Permission {
         Statement::Unsubscribe { .. } => Permission::Select,
         Statement::Merge { .. } => Permission::Modify,
         Statement::Foreach { .. } => Permission::Modify,
+        // A CALL {} subquery may contain writes; require Modify conservatively.
+        // (In practice the engine orchestrates it and validates inner/outer
+        // separately, so this is a safety net for any direct validation path.)
+        Statement::CallSubquery { .. } => Permission::Modify,
     }
 }
 
@@ -219,6 +223,15 @@ pub fn validate(
         Statement::Foreach { .. } => {
             return Err(GraphError::Validation(
                 "FOREACH must be expanded into its body clauses before validation".to_string(),
+            ));
+        }
+        // CALL {} subqueries are orchestrated by the engine (outer rows drive the
+        // inner subquery), which validates the outer and inner statements
+        // separately. A `CallSubquery` reaching whole-statement validation is an
+        // internal invariant violation — fail loud.
+        Statement::CallSubquery { .. } => {
+            return Err(GraphError::Validation(
+                "CALL {} subquery must be orchestrated by the engine before validation".to_string(),
             ));
         }
     };

--- a/ferrosa-graph/src/planner/logical.rs
+++ b/ferrosa-graph/src/planner/logical.rs
@@ -132,6 +132,22 @@ pub fn validate(
     let perm = permission_for_statement(&statement);
     let mut bindings = HashMap::new();
 
+    // UNION / UNION ALL: each arm is an independent single query. Resolve every
+    // arm's pattern labels so the physical planner can find each arm's anchor.
+    // Arms share one flat bindings map — pattern variables that recur across
+    // arms (e.g. `n`) resolve to the same table, so merging is sound.
+    if let Statement::Union { arms, .. } = &statement {
+        for arm in arms {
+            let arm_plan = validate(snap, auth, keyspace, arm.clone())?;
+            bindings.extend(arm_plan.bindings);
+        }
+        return Ok(LogicalPlan {
+            bindings,
+            statement,
+            keyspace: keyspace.to_string(),
+        });
+    }
+
     // Collect patterns from the statement.
     let patterns: &[Pattern] = match &statement {
         Statement::Unwind { .. } | Statement::Return { .. } | Statement::Union { .. } => &[],

--- a/ferrosa-graph/src/planner/logical.rs
+++ b/ferrosa-graph/src/planner/logical.rs
@@ -124,6 +124,7 @@ fn permission_for_statement(stmt: &Statement) -> Permission {
         Statement::Subscribe { .. } => Permission::Select,
         Statement::Unsubscribe { .. } => Permission::Select,
         Statement::Merge { .. } => Permission::Modify,
+        Statement::Foreach { .. } => Permission::Modify,
     }
 }
 
@@ -212,6 +213,14 @@ pub fn validate(
             });
         }
         Statement::Merge { patterns, .. } => patterns,
+        // FOREACH is desugared into its per-element body statements by the engine
+        // before validation; a `Foreach` reaching here is an internal invariant
+        // violation, so fail loud rather than silently no-op.
+        Statement::Foreach { .. } => {
+            return Err(GraphError::Validation(
+                "FOREACH must be expanded into its body clauses before validation".to_string(),
+            ));
+        }
     };
 
     for pat in patterns {

--- a/ferrosa-graph/src/planner/logical.rs
+++ b/ferrosa-graph/src/planner/logical.rs
@@ -30,6 +30,13 @@ pub struct ResolvedTable {
 pub struct LogicalPlan {
     /// Variable bindings: variable name -> resolved table.
     pub bindings: HashMap<String, ResolvedTable>,
+    /// Per-arm resolved bindings for `Statement::Union`, one entry per arm in
+    /// arm order. Empty for all other statements. UNION arms have *independent*
+    /// variable scope, so each arm keeps its own resolution map — the same
+    /// variable name may resolve to a different table in different arms. The
+    /// physical planner plans each arm against its own entry here, never the
+    /// flat `bindings` map.
+    pub arm_bindings: Vec<HashMap<String, ResolvedTable>>,
     /// The original parsed statement.
     pub statement: Statement,
     /// The keyspace context for this query.
@@ -132,17 +139,26 @@ pub fn validate(
     let perm = permission_for_statement(&statement);
     let mut bindings = HashMap::new();
 
-    // UNION / UNION ALL: each arm is an independent single query. Resolve every
-    // arm's pattern labels so the physical planner can find each arm's anchor.
-    // Arms share one flat bindings map — pattern variables that recur across
-    // arms (e.g. `n`) resolve to the same table, so merging is sound.
+    // UNION / UNION ALL: each arm is an independent single query with its OWN
+    // variable scope. Resolve every arm separately and keep each arm's bindings
+    // in `arm_bindings` (arm order). The same variable name (e.g. `n`) may bind
+    // to a different table in different arms — `MATCH (n:Person) ... UNION
+    // MATCH (n:Company) ...` is legal openCypher — so we must NOT flatten arm
+    // maps into one last-write-wins map and share it across arms (that would
+    // make every arm scan whichever table won the merge, silently dropping the
+    // other arms' rows). The flat `bindings` map is still populated (merged) so
+    // `table_dependencies()`/SUBSCRIBE see every table the query touches, but
+    // the physical planner plans each arm against its own `arm_bindings` entry.
     if let Statement::Union { arms, .. } = &statement {
+        let mut arm_bindings = Vec::with_capacity(arms.len());
         for arm in arms {
             let arm_plan = validate(snap, auth, keyspace, arm.clone())?;
-            bindings.extend(arm_plan.bindings);
+            bindings.extend(arm_plan.bindings.clone());
+            arm_bindings.push(arm_plan.bindings);
         }
         return Ok(LogicalPlan {
             bindings,
+            arm_bindings,
             statement,
             keyspace: keyspace.to_string(),
         });
@@ -190,6 +206,7 @@ pub fn validate(
         Statement::Unsubscribe { .. } => {
             return Ok(LogicalPlan {
                 bindings,
+                arm_bindings: Vec::new(),
                 statement,
                 keyspace: keyspace.to_string(),
             });
@@ -203,6 +220,7 @@ pub fn validate(
 
     Ok(LogicalPlan {
         bindings,
+        arm_bindings: Vec::new(),
         statement,
         keyspace: keyspace.to_string(),
     })

--- a/ferrosa-graph/src/planner/physical.rs
+++ b/ferrosa-graph/src/planner/physical.rs
@@ -417,6 +417,11 @@ pub fn plan(logical: LogicalPlan) -> Result<PhysicalPlan> {
         Statement::Foreach { .. } => Err(GraphError::Validation(
             "FOREACH must be expanded into its body clauses before planning".to_string(),
         )),
+        // CALL {} subqueries are orchestrated by the engine; a `CallSubquery`
+        // reaching the planner is an internal invariant violation — fail loud.
+        Statement::CallSubquery { .. } => Err(GraphError::Validation(
+            "CALL {} subquery must be orchestrated by the engine before planning".to_string(),
+        )),
     }
 }
 

--- a/ferrosa-graph/src/planner/physical.rs
+++ b/ferrosa-graph/src/planner/physical.rs
@@ -478,9 +478,45 @@ fn collect_referenced_vars(expr: &Expr, out: &mut std::collections::HashSet<Stri
             collect_referenced_vars(list, out);
             collect_referenced_vars(predicate, out);
         }
+        Expr::ListComprehension {
+            list,
+            filter,
+            projection,
+            ..
+        } => {
+            // The comprehension variable is internally scoped — only the
+            // outer-referenced list/filter/projection vars escape.
+            collect_referenced_vars(list, out);
+            if let Some(f) = filter {
+                collect_referenced_vars(f, out);
+            }
+            if let Some(p) = projection {
+                collect_referenced_vars(p, out);
+            }
+        }
+        Expr::PatternComprehension {
+            start_var,
+            filter,
+            projection,
+            ..
+        } => {
+            out.insert(start_var.clone());
+            if let Some(f) = filter {
+                collect_referenced_vars(f, out);
+            }
+            collect_referenced_vars(projection, out);
+        }
         Expr::Map(m) => {
             for (_, e) in m {
                 collect_referenced_vars(e, out);
+            }
+        }
+        Expr::MapProjection { var, selectors } => {
+            out.insert(var.clone());
+            for s in selectors {
+                if let crate::parser::MapProjectionSelector::Literal { value, .. } = s {
+                    collect_referenced_vars(value, out);
+                }
             }
         }
         Expr::Index { target, index } => {

--- a/ferrosa-graph/src/planner/physical.rs
+++ b/ferrosa-graph/src/planner/physical.rs
@@ -290,10 +290,24 @@ pub fn plan(logical: LogicalPlan) -> Result<PhysicalPlan> {
             plan_match(pattern, &logical.bindings, filters, return_clause.clone())
         }
         Statement::Union { arms, all } => {
+            // Each arm has independent variable scope: plan it against its OWN
+            // bindings (resolved per-arm in the logical planner), never the flat
+            // merged map. `arm_bindings` is populated 1:1 with `arms` by
+            // `validate()`; a length mismatch means an arm was built without
+            // resolving its labels, so fail loud rather than scan a wrong table.
+            if logical.arm_bindings.len() != arms.len() {
+                return Err(GraphError::Validation(format!(
+                    "UNION planner expected {} per-arm binding maps, got {}; \
+                     arms must be resolved per-arm before physical planning",
+                    arms.len(),
+                    logical.arm_bindings.len()
+                )));
+            }
             let mut planned = Vec::with_capacity(arms.len());
-            for arm in arms {
+            for (arm, arm_bindings) in arms.iter().zip(logical.arm_bindings.iter()) {
                 planned.push(plan(LogicalPlan {
-                    bindings: logical.bindings.clone(),
+                    bindings: arm_bindings.clone(),
+                    arm_bindings: Vec::new(),
                     statement: arm.clone(),
                     keyspace: logical.keyspace.clone(),
                 })?);
@@ -1613,6 +1627,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Node {
                     var: Some("n".into()),
@@ -1645,6 +1660,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     Pattern::Node {
@@ -1692,6 +1708,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Create {
                 patterns: vec![Pattern::Node {
                     var: Some("n".into()),
@@ -1723,6 +1740,7 @@ mod tests {
     fn plan_create_empty_patterns_returns_error() {
         let logical = LogicalPlan {
             bindings: HashMap::new(),
+            arm_bindings: Vec::new(),
             statement: Statement::Create {
                 patterns: vec![],
                 return_clause: None,
@@ -1741,6 +1759,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Set {
                 pattern: vec![Pattern::Node {
                     var: Some("n".into()),
@@ -1784,6 +1803,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Delete {
                 pattern: vec![Pattern::Node {
                     var: Some("n".into()),
@@ -1838,6 +1858,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Node {
                     var: Some("n".into()),
@@ -1890,6 +1911,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Node {
                     var: Some("n".into()),
@@ -1918,6 +1940,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     Pattern::Node {
@@ -1971,6 +1994,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     Pattern::Node {
@@ -2024,6 +2048,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Subscribe {
                 inner: Box::new(inner),
                 interval: Some(std::time::Duration::from_secs(5)),
@@ -2066,6 +2091,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Subscribe {
                 inner: Box::new(inner),
                 interval: None,
@@ -2095,6 +2121,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     Pattern::Node {
@@ -2147,6 +2174,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     Pattern::Node {
@@ -2218,6 +2246,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     Pattern::Node {
@@ -2303,6 +2332,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     Pattern::Node {
@@ -2393,6 +2423,7 @@ mod tests {
         };
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     mk_node("a"),
@@ -2434,6 +2465,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Merge {
                 patterns: vec![crate::parser::Pattern::Node {
                     var: Some("n".into()),
@@ -2474,6 +2506,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Merge {
                 patterns: vec![
                     crate::parser::Pattern::Node {
@@ -2565,6 +2598,7 @@ mod tests {
 
         let logical = LogicalPlan {
             bindings,
+            arm_bindings: Vec::new(),
             statement: Statement::Match {
                 pattern: vec![Pattern::Path(vec![
                     Pattern::Node {

--- a/ferrosa-graph/src/planner/physical.rs
+++ b/ferrosa-graph/src/planner/physical.rs
@@ -411,6 +411,12 @@ pub fn plan(logical: LogicalPlan) -> Result<PhysicalPlan> {
             set_clause,
             return_clause.as_ref(),
         ),
+        // FOREACH is desugared into its per-element body statements by the engine
+        // before planning; a `Foreach` reaching the planner is an internal
+        // invariant violation — fail loud rather than silently no-op.
+        Statement::Foreach { .. } => Err(GraphError::Validation(
+            "FOREACH must be expanded into its body clauses before planning".to_string(),
+        )),
     }
 }
 

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -5948,6 +5948,178 @@ async fn http_call_subquery_unit_performs_writes_per_row() {
     );
 }
 
+/// Trailing `RETURN ... LIMIT n` after a `CALL {}` must apply the limit. With 3
+/// outer rows the unbounded result is 3 rows; `LIMIT 1` must cut it to exactly 1.
+/// Silently ignoring the limit (returning 3) is a wrong result (URS-QEC-X01).
+#[tokio::test]
+async fn http_call_subquery_trailing_return_applies_limit() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    seed_three_people(&schema, &storage).await;
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (p:Person) \
+                      CALL { WITH p RETURN p.age AS a } \
+                      RETURN p.name, a LIMIT 1",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "trailing LIMIT must return 200");
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(
+        rows.len(),
+        1,
+        "trailing CALL {{}} RETURN ... LIMIT 1 must emit exactly 1 row, not all 3"
+    );
+}
+
+/// Trailing `RETURN DISTINCT` after a `CALL {}` must deduplicate. Three outer rows
+/// each project the constant `1`; `DISTINCT one` must collapse to a single row.
+/// Returning 3 duplicate rows is a silent wrong result (URS-QEC-X01).
+#[tokio::test]
+async fn http_call_subquery_trailing_return_applies_distinct() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    seed_three_people(&schema, &storage).await;
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (p:Person) \
+                      CALL { WITH p RETURN 1 AS one } \
+                      RETURN DISTINCT one",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "trailing DISTINCT must return 200");
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(
+        rows.len(),
+        1,
+        "trailing CALL {{}} RETURN DISTINCT must collapse 3 identical rows to 1"
+    );
+    assert_eq!(rows[0][0].as_i64(), Some(1), "the surviving distinct row is 1");
+}
+
+/// Trailing `RETURN ... ORDER BY` after a `CALL {}` must sort the united result.
+/// Without ORDER BY the rows arrive in outer-match order; ORDER BY age DESC must
+/// produce a strictly descending sequence. Ignoring ORDER BY is a wrong result.
+#[tokio::test]
+async fn http_call_subquery_trailing_return_applies_order_by() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    seed_three_people(&schema, &storage).await;
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (p:Person) \
+                      CALL { WITH p RETURN p.age AS a } \
+                      RETURN a ORDER BY a DESC",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "trailing ORDER BY must return 200");
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    let ages: Vec<i64> = rows.iter().map(|r| r[0].as_i64().expect("age int")).collect();
+    assert_eq!(
+        ages,
+        vec![72, 49, 36],
+        "trailing CALL {{}} RETURN ... ORDER BY a DESC must sort the united rows descending"
+    );
+}
+
+/// Trailing `RETURN count(*)` after a `CALL {}` must aggregate over the united
+/// result. Three outer rows each yield one inner row, so `count(*)` over the whole
+/// trailing projection is 3. Evaluating count per-row (returning 1 three times, or
+/// any non-grouped shape) is a silent wrong result (URS-QEC-X01).
+#[tokio::test]
+async fn http_call_subquery_trailing_return_aggregates_count() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    seed_three_people(&schema, &storage).await;
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (p:Person) \
+                      CALL { WITH p RETURN p.age AS a } \
+                      RETURN count(*) AS n",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "trailing aggregation must return 200");
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(
+        rows.len(),
+        1,
+        "an aggregate-only trailing RETURN must collapse to a single grouped row"
+    );
+    assert_eq!(
+        rows[0][0].as_i64(),
+        Some(3),
+        "count(*) over the 3 united inner rows must be 3, not a per-row 1"
+    );
+}
+
+/// Trailing `RETURN key, count(*)` after a `CALL {}` must group by the non-aggregate
+/// key. Three Person rows each map to a distinct age, so grouping by age yields 3
+/// groups of count 1. A correlated grouped aggregation over the united result.
+#[tokio::test]
+async fn http_call_subquery_trailing_return_grouped_aggregate() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    seed_three_people(&schema, &storage).await;
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (p:Person) \
+                      CALL { WITH p RETURN p.age AS a } \
+                      RETURN a, count(*) AS n ORDER BY a",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "trailing grouped aggregate must return 200");
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    let pairs: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|r| (r[0].as_i64().expect("age"), r[1].as_i64().expect("count")))
+        .collect();
+    assert_eq!(
+        pairs,
+        vec![(36, 1), (49, 1), (72, 1)],
+        "grouped aggregate must produce one (age, count=1) row per distinct age, ordered"
+    );
+}
+
 /// Fail loud: a `CALL {}` nested inside another `CALL {}` is not supported. The
 /// engine must return a clear Cypher error (non-200), never silently no-op or
 /// return wrong/empty results.

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -2550,10 +2550,6 @@ async fn http_unsupported_cypher_clauses_return_explicit_400() {
             "unsupported Cypher clause: Keyword(Call)",
         ),
         (
-            "FOREACH (x IN [1] | CREATE (:Person {name: 'x'}))",
-            "unsupported Cypher clause: Keyword(Foreach)",
-        ),
-        (
             "LOAD CSV FROM 'file:///people.csv' AS row RETURN row",
             "unsupported Cypher clause: Keyword(Load)",
         ),
@@ -5452,7 +5448,11 @@ async fn list_comprehension_projects_through_http() {
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK, "list comprehension must return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "list comprehension must return 200"
+    );
     let body = response_json(resp).await;
     assert_eq!(body["rows"], serde_json::json!([[[30, 40]]]));
 }
@@ -5488,7 +5488,11 @@ async fn map_projection_selects_properties_through_http() {
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK, "map projection must return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "map projection must return 200"
+    );
     let body = response_json(resp).await;
     let rows = body["rows"].as_array().expect("rows array");
     assert_eq!(rows.len(), 1, "expected one matched Person, got {rows:?}");
@@ -5576,5 +5580,115 @@ async fn pattern_comprehension_traverses_edges_through_http() {
         names,
         vec!["FriendA".to_string(), "FriendB".to_string()],
         "pattern comprehension must collect both traversed friends, not silently empty"
+    );
+}
+
+/// FOREACH (x IN list | CREATE (:Person {name: x})) must execute the contained
+/// update clause once per list element, creating exactly one node per element.
+#[tokio::test]
+async fn http_foreach_creates_one_node_per_list_element() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "FOREACH (x IN ['Ada', 'Babbage', 'Cantor'] | \
+                      CREATE (n:Person {name: x}))",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "FOREACH with a CREATE body must return 200"
+    );
+
+    // MATCH back — must see exactly the three nodes, one per list element,
+    // each carrying the element's value as its name.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    let mut names: Vec<String> = rows
+        .iter()
+        .map(|r| r[0].as_str().expect("name string").to_string())
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "Ada".to_string(),
+            "Babbage".to_string(),
+            "Cantor".to_string()
+        ],
+        "FOREACH must CREATE exactly one Person per list element, named after the element"
+    );
+}
+
+/// FOREACH must be atomic with respect to its body: if the contained update
+/// clause fails for any element, the whole statement rolls back and no nodes
+/// are created (no partial writes from the earlier, successful elements).
+///
+/// Here the body targets a label with no backing table (`Ghost`), which fails
+/// validation. The earlier `Person` elements must NOT be persisted.
+#[tokio::test]
+async fn http_foreach_partial_failure_rolls_back() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    // The body first creates a VALID Person, then a CREATE against an unknown
+    // label `Ghost`. The Person create would succeed on its own; only the Ghost
+    // create fails. Atomicity requires the whole FOREACH to roll back, so NONE of
+    // the Person nodes (for any element) may be persisted.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "FOREACH (x IN ['Ada', 'Babbage'] | \
+                      CREATE (p:Person {name: x}) \
+                      CREATE (g:Ghost {name: x}))",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::OK,
+        "FOREACH whose body targets a non-existent label must fail loud, not 200"
+    );
+
+    // No Person nodes — and critically nothing partially written — should remain.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert!(
+        rows.is_empty(),
+        "FOREACH body failure must roll back: expected zero Person nodes, got {rows:?}"
     );
 }

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -2215,6 +2215,143 @@ async fn union_all_preserves_duplicates_and_union_deduplicates_rows() {
 }
 
 #[tokio::test]
+async fn union_over_match_deduplicates_rows() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+
+    // Seed three people, two sharing the name "Alice".
+    for (id, name) in [
+        ("00000000-0000-0000-0000-00000000e001", "Alice"),
+        ("00000000-0000-0000-0000-00000000e002", "Alice"),
+        ("00000000-0000-0000-0000-00000000e003", "Bob"),
+    ] {
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{id: '{id}', name: '{name}'}}) RETURN n.name"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(
+            app.clone().oneshot(req).await.unwrap().status(),
+            StatusCode::OK
+        );
+    }
+
+    // UNION of two identical MATCH arms must dedup across arms (and within),
+    // so "Alice" (twice in each arm) collapses to a single row.
+    let union_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name AS a \
+                      UNION \
+                      MATCH (n:Person) RETURN n.name AS a",
+            "keyspace": "social"
+        })),
+    );
+    let union_resp = app.clone().oneshot(union_req).await.unwrap();
+    let status = union_resp.status();
+    let union_body = response_json(union_resp).await;
+    assert_eq!(status, StatusCode::OK, "UNION query failed: {union_body:?}");
+    assert_eq!(union_body["columns"], serde_json::json!(["a"]));
+    let mut rows = union_body["rows"].as_array().unwrap().clone();
+    rows.sort_by_key(|r| r.to_string());
+    assert_eq!(
+        rows,
+        vec![serde_json::json!(["Alice"]), serde_json::json!(["Bob"])],
+        "UNION must deduplicate rows across and within arms"
+    );
+
+    // UNION ALL keeps every duplicate: each arm yields 3 rows (Alice, Alice, Bob),
+    // so the combined result has 6 rows.
+    let union_all_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name AS a \
+                      UNION ALL \
+                      MATCH (n:Person) RETURN n.name AS a",
+            "keyspace": "social"
+        })),
+    );
+    let union_all_resp = app.oneshot(union_all_req).await.unwrap();
+    let status = union_all_resp.status();
+    let union_all_body = response_json(union_all_resp).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "UNION ALL query failed: {union_all_body:?}"
+    );
+    assert_eq!(
+        union_all_body["rows"].as_array().unwrap().len(),
+        6,
+        "UNION ALL must preserve every duplicate row from both arms"
+    );
+}
+
+#[tokio::test]
+async fn union_mismatched_columns_returns_clear_error() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+
+    // Arms differ in column name (`a` vs `b`) — openCypher requires identical
+    // result column names/arity across arms, so this must fail loud, not
+    // silently merge or return wrong/empty results.
+    let mismatch_name_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name AS a \
+                      UNION \
+                      MATCH (n:Person) RETURN n.name AS b",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.clone().oneshot(mismatch_name_req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "mismatched UNION column names must be a validation error"
+    );
+    let body = response_json(resp).await;
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("UNION") && err.contains("column"),
+        "error must clearly mention UNION column mismatch, got: {err:?}"
+    );
+
+    // Arms differ in arity (1 column vs 2 columns) — same fail-loud requirement.
+    let mismatch_arity_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name AS a \
+                      UNION \
+                      MATCH (n:Person) RETURN n.name AS a, n.age AS b",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(mismatch_arity_req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "mismatched UNION column arity must be a validation error"
+    );
+    let body = response_json(resp).await;
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("UNION") && err.contains("column"),
+        "error must clearly mention UNION column mismatch, got: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn http_query_missing_param_returns_validation_error() {
     let (schema, storage, _dir) = setup();
     create_social_graph_schema(&schema);

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -1946,10 +1946,17 @@ async fn aggregate_collect_skips_null_property_values() {
         .as_array()
         .expect("collect result must be an array, never null")
         .iter()
-        .map(|v| v.as_i64().expect("collect must skip nulls -> only integers remain"))
+        .map(|v| {
+            v.as_i64()
+                .expect("collect must skip nulls -> only integers remain")
+        })
         .collect::<Vec<_>>();
     collected.sort_unstable();
-    assert_eq!(collected, vec![10, 20], "collect(n.age) must skip the null age");
+    assert_eq!(
+        collected,
+        vec![10, 20],
+        "collect(n.age) must skip the null age"
+    );
     // count(n.age) also skips nulls -> 2 aged persons.
     assert_eq!(row[1].as_i64(), Some(2));
 }
@@ -1977,7 +1984,11 @@ async fn aggregate_empty_input_semantics() {
     let body = response_json(resp).await;
     assert_eq!(status, StatusCode::OK, "empty-input query failed: {body:?}");
     let rows = body["rows"].as_array().expect("rows array");
-    assert_eq!(rows.len(), 1, "aggregate over empty input collapses to one row");
+    assert_eq!(
+        rows.len(),
+        1,
+        "aggregate over empty input collapses to one row"
+    );
     let row = rows[0].as_array().expect("aggregate row");
     assert_eq!(row[0].as_i64(), Some(0), "count over empty input -> 0");
     assert_eq!(row[1].as_i64(), Some(0), "sum over empty input -> 0");
@@ -6056,7 +6067,11 @@ async fn http_call_subquery_trailing_return_applies_limit() {
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK, "trailing LIMIT must return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "trailing LIMIT must return 200"
+    );
     let body = response_json(resp).await;
     let rows = body["rows"].as_array().expect("rows array");
     assert_eq!(
@@ -6088,7 +6103,11 @@ async fn http_call_subquery_trailing_return_applies_distinct() {
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK, "trailing DISTINCT must return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "trailing DISTINCT must return 200"
+    );
     let body = response_json(resp).await;
     let rows = body["rows"].as_array().expect("rows array");
     assert_eq!(
@@ -6096,7 +6115,11 @@ async fn http_call_subquery_trailing_return_applies_distinct() {
         1,
         "trailing CALL {{}} RETURN DISTINCT must collapse 3 identical rows to 1"
     );
-    assert_eq!(rows[0][0].as_i64(), Some(1), "the surviving distinct row is 1");
+    assert_eq!(
+        rows[0][0].as_i64(),
+        Some(1),
+        "the surviving distinct row is 1"
+    );
 }
 
 /// Trailing `RETURN ... ORDER BY` after a `CALL {}` must sort the united result.
@@ -6121,10 +6144,17 @@ async fn http_call_subquery_trailing_return_applies_order_by() {
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK, "trailing ORDER BY must return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "trailing ORDER BY must return 200"
+    );
     let body = response_json(resp).await;
     let rows = body["rows"].as_array().expect("rows array");
-    let ages: Vec<i64> = rows.iter().map(|r| r[0].as_i64().expect("age int")).collect();
+    let ages: Vec<i64> = rows
+        .iter()
+        .map(|r| r[0].as_i64().expect("age int"))
+        .collect();
     assert_eq!(
         ages,
         vec![72, 49, 36],
@@ -6155,7 +6185,11 @@ async fn http_call_subquery_trailing_return_aggregates_count() {
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK, "trailing aggregation must return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "trailing aggregation must return 200"
+    );
     let body = response_json(resp).await;
     let rows = body["rows"].as_array().expect("rows array");
     assert_eq!(
@@ -6192,7 +6226,11 @@ async fn http_call_subquery_trailing_return_grouped_aggregate() {
         })),
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK, "trailing grouped aggregate must return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "trailing grouped aggregate must return 200"
+    );
     let body = response_json(resp).await;
     let rows = body["rows"].as_array().expect("rows array");
     let pairs: Vec<(i64, i64)> = rows

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -5692,3 +5692,113 @@ async fn http_foreach_partial_failure_rolls_back() {
         "FOREACH body failure must roll back: expected zero Person nodes, got {rows:?}"
     );
 }
+
+/// Regression: a NESTED FOREACH whose body fails validation must roll back the
+/// OUTER element writes too. Previously phase 1 skipped nested-FOREACH bodies,
+/// so the outer CREATEs committed before the nested body ever validated — a
+/// partial write survived a failing FOREACH. The whole statement must be planned
+/// (recursively, including nested bodies) before any write, so an unknown label
+/// in the nested body aborts with ZERO outer writes.
+#[tokio::test]
+async fn http_foreach_nested_body_failure_rolls_back_outer() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "FOREACH (x IN ['Ada', 'Babbage'] | \
+                      CREATE (p:Person {name: x}) \
+                      FOREACH (y IN [1] | CREATE (g:Ghost {name: x})))",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::OK,
+        "FOREACH with a nested body targeting an unknown label must fail loud"
+    );
+
+    // The outer CREATE (Person) must NOT have persisted — the failing nested
+    // FOREACH body has to be validated/planned before any outer write.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert!(
+        rows.is_empty(),
+        "nested FOREACH failure must roll back outer writes: expected zero Person nodes, got {rows:?}"
+    );
+}
+
+/// A nested FOREACH whose body is entirely valid runs once per (outer × inner)
+/// element, in source order, materializing both loop variables. Proves the
+/// recursive flatten preserves per-element semantics rather than batching all
+/// outer clauses ahead of nested loops.
+#[tokio::test]
+async fn http_foreach_nested_creates_cross_product() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "FOREACH (x IN ['Ada', 'Babbage'] | \
+                      FOREACH (y IN ['x', 'y'] | \
+                      CREATE (n:Person {name: x})))",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "valid nested FOREACH must return 200"
+    );
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    let mut names: Vec<String> = rows
+        .iter()
+        .map(|r| r[0].as_str().expect("name string").to_string())
+        .collect();
+    names.sort();
+    // 2 outer × 2 inner = 4 nodes; each named after the OUTER element.
+    assert_eq!(
+        names,
+        vec![
+            "Ada".to_string(),
+            "Ada".to_string(),
+            "Babbage".to_string(),
+            "Babbage".to_string()
+        ],
+        "nested FOREACH must create one node per (outer, inner) element pair"
+    );
+}

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -1906,6 +1906,92 @@ async fn aggregate_distinct_deduplicates_inputs_per_group() {
 }
 
 #[tokio::test]
+async fn aggregate_collect_skips_null_property_values() {
+    // openCypher: collect() ignores null values. A node whose `age` is unset
+    // must NOT contribute a null entry to collect(n.age).
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    let app = build_app(schema, storage);
+
+    for query in [
+        "MERGE (n:Person {id: '00000000-0000-0000-0000-00000000a101', name: 'Alice', age: 10})",
+        // Bob has no age property at all -> n.age is null.
+        "MERGE (n:Person {id: '00000000-0000-0000-0000-00000000b202', name: 'Bob'})",
+        "MERGE (n:Person {id: '00000000-0000-0000-0000-00000000c303', name: 'Cara', age: 20})",
+    ] {
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({ "query": query, "keyspace": "social" })),
+        );
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "setup query failed: {query}");
+    }
+
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN collect(n.age) AS ages, count(n.age) AS aged",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body = response_json(resp).await;
+    assert_eq!(status, StatusCode::OK, "collect query failed: {body:?}");
+    let row = body["rows"][0].as_array().expect("aggregate row");
+    let mut collected = row[0]
+        .as_array()
+        .expect("collect result must be an array, never null")
+        .iter()
+        .map(|v| v.as_i64().expect("collect must skip nulls -> only integers remain"))
+        .collect::<Vec<_>>();
+    collected.sort_unstable();
+    assert_eq!(collected, vec![10, 20], "collect(n.age) must skip the null age");
+    // count(n.age) also skips nulls -> 2 aged persons.
+    assert_eq!(row[1].as_i64(), Some(2));
+}
+
+#[tokio::test]
+async fn aggregate_empty_input_semantics() {
+    // openCypher empty-input semantics over zero matched rows:
+    //   count -> 0, sum -> 0, collect -> [], avg/min/max -> null.
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    let app = build_app(schema, storage);
+
+    // No Person nodes created -> the MATCH yields zero rows.
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN count(n.age) AS c, sum(n.age) AS s, collect(n.age) AS col, avg(n.age) AS a, min(n.age) AS mn, max(n.age) AS mx",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body = response_json(resp).await;
+    assert_eq!(status, StatusCode::OK, "empty-input query failed: {body:?}");
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(rows.len(), 1, "aggregate over empty input collapses to one row");
+    let row = rows[0].as_array().expect("aggregate row");
+    assert_eq!(row[0].as_i64(), Some(0), "count over empty input -> 0");
+    assert_eq!(row[1].as_i64(), Some(0), "sum over empty input -> 0");
+    assert_eq!(
+        row[2],
+        serde_json::json!([]),
+        "collect over empty input -> []"
+    );
+    assert!(row[3].is_null(), "avg over empty input -> null");
+    assert!(row[4].is_null(), "min over empty input -> null");
+    assert!(row[5].is_null(), "max over empty input -> null");
+}
+
+#[tokio::test]
 async fn where_in_list_literal_filters_rows() {
     let (schema, storage, _dir) = setup();
     create_social_graph_schema(&schema);

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -156,6 +156,27 @@ fn register_social_tables_with_storage(storage: &StorageEngine) {
         .unwrap();
 }
 
+/// Register the `company_v` vertex table in storage. Used to exercise UNION
+/// arms that reuse the same pattern variable (`n`) with different labels —
+/// each arm has independent variable scope, so they must resolve to their own
+/// table, not a flat-merged last-write-wins binding.
+fn register_company_table_with_storage(storage: &StorageEngine) {
+    storage
+        .register_table(TableSchema {
+            keyspace: "social".to_string(),
+            table: "company_v".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.BytesType".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "name".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: HashMap::new(),
+        })
+        .unwrap();
+}
+
 fn register_social_likes_table_with_storage(storage: &StorageEngine) {
     let schema = TableSchema {
         keyspace: "social".to_string(),
@@ -329,6 +350,59 @@ fn create_social_graph_schema(schema: &Schema) {
                 params: TableParams::default(),
                 flags: HashSet::new(),
                 extensions: knows_ext,
+                is_system: false,
+            },
+            &auth,
+        )
+        .unwrap();
+}
+
+/// Create a second vertex table `company_v` labeled `Company` in the `social`
+/// keyspace. The keyspace and grants are created by `create_social_graph_schema`,
+/// which must run first.
+fn create_company_vertex_schema(schema: &Schema) {
+    let auth = superuser_auth();
+
+    let mut company_cols = IndexMap::new();
+    company_cols.insert(
+        "id".to_string(),
+        ColumnMetadata {
+            name: "id".to_string(),
+            kind: ColumnKind::PartitionKey,
+            position: 0,
+            column_type: "uuid".to_string(),
+            clustering_order: ClusteringOrder::None,
+            mask: None,
+        },
+    );
+    company_cols.insert(
+        "name".to_string(),
+        ColumnMetadata {
+            name: "name".to_string(),
+            kind: ColumnKind::Regular,
+            position: -1,
+            column_type: "text".to_string(),
+            clustering_order: ClusteringOrder::None,
+            mask: None,
+        },
+    );
+
+    let mut company_ext = HashMap::new();
+    company_ext.insert("graph.type".to_string(), "vertex".to_string());
+    company_ext.insert("graph.label".to_string(), "Company".to_string());
+
+    schema
+        .create_table(
+            TableMetadata {
+                keyspace: "social".to_string(),
+                name: "company_v".to_string(),
+                id: Uuid::new_v4(),
+                columns: company_cols,
+                partition_key: vec!["id".to_string()],
+                clustering_key: vec![],
+                params: TableParams::default(),
+                flags: HashSet::new(),
+                extensions: company_ext,
                 is_system: false,
             },
             &auth,
@@ -2290,6 +2364,75 @@ async fn union_over_match_deduplicates_rows() {
         union_all_body["rows"].as_array().unwrap().len(),
         6,
         "UNION ALL must preserve every duplicate row from both arms"
+    );
+}
+
+/// UNION arms have **independent variable scope** (openCypher). Reusing the
+/// same pattern variable (`n`) with *different labels* across arms is legal and
+/// common: `MATCH (n:Person) RETURN n.name AS a UNION MATCH (n:Company) RETURN n.name AS a`.
+/// Each arm must scan its own table — the Person arm must return Person rows and
+/// the Company arm must return Company rows. A flat last-write-wins binding map
+/// shared across arms would make both arms scan whichever table won the merge,
+/// silently dropping the other arm's rows (the worst failure class: no error,
+/// no crash, lost rows).
+#[tokio::test]
+async fn union_arms_with_same_var_different_labels_keep_all_rows() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    create_company_vertex_schema(&schema);
+    register_company_table_with_storage(&storage);
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+
+    // Seed one Person (Alice) and one Company (Acme).
+    let person_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MERGE (n:Person {id: '00000000-0000-0000-0000-00000000f001', name: 'Alice'}) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    assert_eq!(
+        app.clone().oneshot(person_req).await.unwrap().status(),
+        StatusCode::OK
+    );
+    let company_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MERGE (n:Company {id: '00000000-0000-0000-0000-00000000f002', name: 'Acme'}) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    assert_eq!(
+        app.clone().oneshot(company_req).await.unwrap().status(),
+        StatusCode::OK
+    );
+
+    // Same variable `n`, different labels across arms. Result must contain BOTH
+    // Alice (from the Person arm) and Acme (from the Company arm).
+    let union_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name AS a \
+                      UNION \
+                      MATCH (n:Company) RETURN n.name AS a",
+            "keyspace": "social"
+        })),
+    );
+    let union_resp = app.oneshot(union_req).await.unwrap();
+    let status = union_resp.status();
+    let union_body = response_json(union_resp).await;
+    assert_eq!(status, StatusCode::OK, "UNION query failed: {union_body:?}");
+    assert_eq!(union_body["columns"], serde_json::json!(["a"]));
+    let mut rows = union_body["rows"].as_array().unwrap().clone();
+    rows.sort_by_key(|r| r.to_string());
+    assert_eq!(
+        rows,
+        vec![serde_json::json!(["Acme"]), serde_json::json!(["Alice"])],
+        "each UNION arm must scan its OWN labelled table; neither arm's rows may be dropped"
     );
 }
 

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -2542,11 +2542,9 @@ async fn http_unsupported_cypher_clauses_return_explicit_400() {
             "unsupported Cypher clause: Keyword(With)",
         ),
         (
+            // Bare top-level CALL (stored procedure) is still unsupported; only the
+            // `CALL {}` subquery form (which requires a driving query) is supported.
             "CALL db.labels()",
-            "unsupported Cypher clause: Keyword(Call)",
-        ),
-        (
-            "MATCH (n) CALL { WITH n RETURN n } RETURN n",
             "unsupported Cypher clause: Keyword(Call)",
         ),
         (
@@ -5800,5 +5798,181 @@ async fn http_foreach_nested_creates_cross_product() {
             "Babbage".to_string()
         ],
         "nested FOREACH must create one node per (outer, inner) element pair"
+    );
+}
+
+/// Seed three Person nodes with ages, returning each id so the test can assert
+/// per-node behaviour later. Helper shared by the CALL {} subquery tests.
+async fn seed_three_people(schema: &Arc<Schema>, storage: &Arc<StorageEngine>) {
+    for (name, age) in [("Ada", 36), ("Babbage", 49), ("Cantor", 72)] {
+        let app = build_app(Arc::clone(schema), Arc::clone(storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("CREATE (n:Person {{name: '{name}', age: {age}}})"),
+                "keyspace": "social"
+            })),
+        );
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "seed CREATE must return 200");
+    }
+}
+
+/// Correlated `CALL {}` subquery: the inner query unit runs once per outer row,
+/// with the imported variable (`WITH p`) bound to that row. The inner results are
+/// UNITED, and (because the outer query keeps projecting) each inner row is paired
+/// with its driving outer row. Here each outer Person drives an inner query that
+/// derives a value from the imported node's own properties — a true correlation,
+/// not a constant subquery.
+#[tokio::test]
+async fn http_call_subquery_correlated_returns_per_row_inner_results() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    seed_three_people(&schema, &storage).await;
+
+    // For each Person p, the inner subquery imports p and projects a label derived
+    // from p's own age. One inner row per outer row -> three result rows total,
+    // each pairing the outer name with the correlated inner value.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (p:Person) \
+                      CALL { WITH p RETURN p.age + 1 AS next_age } \
+                      RETURN p.name, next_age",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "correlated CALL {{}} subquery must return 200"
+    );
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    let mut pairs: Vec<(String, i64)> = rows
+        .iter()
+        .map(|r| {
+            (
+                r[0].as_str().expect("name string").to_string(),
+                r[1].as_i64().expect("next_age int"),
+            )
+        })
+        .collect();
+    pairs.sort();
+    assert_eq!(
+        pairs,
+        vec![
+            ("Ada".to_string(), 37),
+            ("Babbage".to_string(), 50),
+            ("Cantor".to_string(), 73),
+        ],
+        "each outer row must drive its own correlated inner result (p.age + 1)"
+    );
+}
+
+/// Unit `CALL {}` subquery (no inner RETURN): the inner query only performs
+/// updates, executed once per outer row. Here every Person drives a CREATE that
+/// writes a new node named after the imported person — a per-row write side effect.
+/// A unit subquery does not change the outer cardinality; the outer query still
+/// projects its own rows.
+#[tokio::test]
+async fn http_call_subquery_unit_performs_writes_per_row() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    seed_three_people(&schema, &storage).await;
+
+    // For each existing Person p, create a mirror Person carrying p's imported name
+    // and an age derived from p's imported age. 3 outer rows -> 3 new nodes, each
+    // correlated to its driving row. The new node's name equals the original's
+    // (proving per-row import) while its age is shifted so the mirror is
+    // distinguishable from the source.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (p:Person) \
+                      CALL { WITH p CREATE (m:Person {name: p.name, age: p.age + 1000}) }",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "unit CALL {{}} subquery performing writes must return 200"
+    );
+
+    // Now there must be 6 Person nodes: the 3 originals plus 3 mirrors, each
+    // mirror sharing its source's name (so each name appears exactly twice).
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name, n.age",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    let mut pairs: Vec<(String, i64)> = rows
+        .iter()
+        .map(|r| {
+            (
+                r[0].as_str().expect("name string").to_string(),
+                r[1].as_i64().expect("age int"),
+            )
+        })
+        .collect();
+    pairs.sort();
+    assert_eq!(
+        pairs,
+        vec![
+            ("Ada".to_string(), 36),
+            ("Ada".to_string(), 1036),
+            ("Babbage".to_string(), 49),
+            ("Babbage".to_string(), 1049),
+            ("Cantor".to_string(), 72),
+            ("Cantor".to_string(), 1072),
+        ],
+        "unit CALL {{}} must perform one correlated write per outer row (mirror with age + 1000)"
+    );
+}
+
+/// Fail loud: a `CALL {}` nested inside another `CALL {}` is not supported. The
+/// engine must return a clear Cypher error (non-200), never silently no-op or
+/// return wrong/empty results.
+#[tokio::test]
+async fn http_call_subquery_nested_call_fails_loud() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    seed_three_people(&schema, &storage).await;
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (p:Person) \
+                      CALL { WITH p CALL { WITH p RETURN p.age AS a } RETURN a } \
+                      RETURN p.name, a",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::OK,
+        "a CALL {{}} nested inside a CALL {{}} must fail loud, not silently succeed"
     );
 }

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -5431,3 +5431,150 @@ fn strip_quoted_strings(s: &str) -> String {
     }
     result
 }
+
+// ── Comprehensions & map projection (QE-M4) ──────────────────────────────────
+
+/// List comprehension `[x IN list WHERE pred | expr]` evaluates end-to-end
+/// through the HTTP query path.
+#[tokio::test]
+async fn list_comprehension_projects_through_http() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "RETURN [x IN [1, 2, 3, 4] WHERE x > 2 | x * 10] AS doubled",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "list comprehension must return 200");
+    let body = response_json(resp).await;
+    assert_eq!(body["rows"], serde_json::json!([[[30, 40]]]));
+}
+
+/// Map projection `n {.name, .age}` builds a map by selecting properties off a
+/// matched node, end-to-end through the HTTP query path.
+#[tokio::test]
+async fn map_projection_selects_properties_through_http() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    // Create a Person to project.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MERGE (n:Person {name: 'Projee'}) SET n.age = 41 RETURN n",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person {name: 'Projee'}) RETURN n {.name, .age} AS proj",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "map projection must return 200");
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(rows.len(), 1, "expected one matched Person, got {rows:?}");
+    let proj = &rows[0][0];
+    assert_eq!(proj["name"], serde_json::json!("Projee"));
+    // age is projected through whatever the storage layer returns; assert the
+    // key is present and carries the stored value (not null/missing).
+    assert!(
+        !proj["age"].is_null(),
+        "map projection must carry the .age property, got {proj:?}"
+    );
+    assert_eq!(
+        proj.as_object().unwrap().len(),
+        2,
+        "exactly name + age projected, got {proj:?}"
+    );
+}
+
+/// Pattern comprehension `[ (n)-[:KNOWS]->(m) | m.name ]` traverses real edges
+/// and collects projected target properties — it must NOT silently return an
+/// empty list when edges exist.
+#[tokio::test]
+async fn pattern_comprehension_traverses_edges_through_http() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    // Create two friends of Anchor.
+    for name in ["Anchor", "FriendA", "FriendB"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                "keyspace": "social"
+            })),
+        );
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+    for friend in ["FriendA", "FriendB"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!(
+                    "MERGE (a:Person {{name: 'Anchor'}})-[r:KNOWS]->(b:Person {{name: '{friend}'}}) RETURN r"
+                ),
+                "keyspace": "social"
+            })),
+        );
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "edge MERGE must return 200");
+    }
+
+    // Pattern comprehension collecting friend names.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person {name: 'Anchor'}) \
+                      RETURN [ (n)-[:KNOWS]->(m:Person) | m.name ] AS friends",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "pattern comprehension must return 200"
+    );
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(rows.len(), 1, "expected one anchor row, got {rows:?}");
+    let friends = rows[0][0].as_array().expect("friends list");
+    let mut names: Vec<String> = friends
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["FriendA".to_string(), "FriendB".to_string()],
+        "pattern comprehension must collect both traversed friends, not silently empty"
+    );
+}

--- a/ferrosa-sparql/src/engine.rs
+++ b/ferrosa-sparql/src/engine.rs
@@ -6,15 +6,35 @@ use ferrosa_cluster::write_path::WritePath;
 use ferrosa_storage::engine::StorageEngine;
 
 use crate::error::SparqlError;
-use crate::planner;
+use crate::planner::{self, GraphQueryMode};
 use crate::results::{SparqlAskResult, SparqlJsonResults};
 
-/// Result of a SPARQL query execution, supporting both SELECT and ASK forms.
+/// A triple in a constructed/described graph result (S01).
+#[derive(Debug, Clone)]
+pub struct ConstructedTriple {
+    /// Subject IRI or blank-node label.
+    pub subject: String,
+    /// Predicate IRI.
+    pub predicate: String,
+    /// Object value string.
+    pub object: String,
+    /// `"uri"`, `"literal"`, or `"bnode"`.
+    pub object_type: String,
+    /// XSD datatype URI for typed literals.
+    pub datatype: Option<String>,
+    /// Language tag for `rdf:langString` literals.
+    pub lang: Option<String>,
+}
+
+/// Result of a SPARQL query execution, supporting SELECT, ASK, and graph forms.
+#[derive(Debug)]
 pub enum SparqlResult {
     /// SELECT query result (binding sets).
     Select(SparqlJsonResults),
     /// ASK query result (boolean).
     Ask(SparqlAskResult),
+    /// CONSTRUCT / DESCRIBE query result (a set of triples forming a graph).
+    Graph(Vec<ConstructedTriple>),
 }
 
 impl SparqlResult {
@@ -23,6 +43,66 @@ impl SparqlResult {
         match self {
             Self::Select(results) => results.to_json(),
             Self::Ask(result) => serde_json::to_vec(result),
+            Self::Graph(triples) => {
+                // Serialize constructed graph as a JSON array of triple objects
+                // (not standard SPARQL Results JSON, but consistent with our
+                // internal JSON format for graph results).
+                serde_json::to_vec(
+                    &triples
+                        .iter()
+                        .map(|t| {
+                            serde_json::json!({
+                                "subject":   t.subject,
+                                "predicate": t.predicate,
+                                "object":    t.object,
+                                "type":      t.object_type,
+                                "datatype":  t.datatype,
+                                "lang":      t.lang,
+                            })
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            }
+        }
+    }
+
+    /// Serialize to SPARQL Results XML bytes.
+    pub fn to_xml(&self) -> Result<Vec<u8>, String> {
+        match self {
+            Self::Select(results) => results.to_xml(),
+            Self::Ask(result) => {
+                let boolean_str = if result.boolean { "true" } else { "false" };
+                Ok(format!(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                     <sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n\
+                     <head/>\n\
+                     <boolean>{boolean_str}</boolean>\n\
+                     </sparql>\n"
+                )
+                .into_bytes())
+            }
+            Self::Graph(triples) => {
+                // CONSTRUCT/DESCRIBE — serialize as RDF/XML (simple form).
+                let mut buf = String::new();
+                buf.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+                buf.push_str(
+                    "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n",
+                );
+                for t in triples {
+                    buf.push_str(&format!(
+                        "  <rdf:Description rdf:about=\"{}\">\n",
+                        t.subject
+                    ));
+                    buf.push_str(&format!(
+                        "    <{pred}>{obj}</{pred}>\n",
+                        pred = t.predicate,
+                        obj = t.object
+                    ));
+                    buf.push_str("  </rdf:Description>\n");
+                }
+                buf.push_str("</rdf:RDF>\n");
+                Ok(buf.into_bytes())
+            }
         }
     }
 
@@ -31,6 +111,39 @@ impl SparqlResult {
         match self {
             Self::Select(results) => results.to_ntriples(),
             Self::Ask(result) => format!("# boolean: {}\n", result.boolean).into_bytes(),
+            Self::Graph(triples) => {
+                let mut buf = String::new();
+                for t in triples {
+                    let subj = if t.subject.starts_with("_:") {
+                        t.subject.clone()
+                    } else {
+                        format!("<{}>", t.subject)
+                    };
+                    let pred = format!("<{}>", t.predicate);
+                    let obj = match t.object_type.as_str() {
+                        "uri" => format!("<{}>", t.object),
+                        "bnode" => {
+                            if t.object.starts_with("_:") {
+                                t.object.clone()
+                            } else {
+                                format!("_:{}", t.object)
+                            }
+                        }
+                        _ => {
+                            let escaped = t.object.replace('\\', "\\\\").replace('"', "\\\"");
+                            if let Some(lang) = &t.lang {
+                                format!("\"{}\"@{}", escaped, lang)
+                            } else if let Some(dt) = &t.datatype {
+                                format!("\"{}\"^^<{}>", escaped, dt)
+                            } else {
+                                format!("\"{}\"", escaped)
+                            }
+                        }
+                    };
+                    buf.push_str(&format!("{subj} {pred} {obj} .\n"));
+                }
+                buf.into_bytes()
+            }
         }
     }
 
@@ -39,16 +152,19 @@ impl SparqlResult {
         match self {
             Self::Select(results) => results.to_turtle(),
             Self::Ask(result) => format!("# boolean: {}\n", result.boolean).into_bytes(),
+            Self::Graph(_) => self.to_ntriples(),
         }
     }
 
     /// Serialize to the requested format.
-    pub fn serialize(
-        &self,
-        format: crate::results::ResultFormat,
-    ) -> Result<Vec<u8>, serde_json::Error> {
+    ///
+    /// Returns `Err(String)` on serialization failure. The String carries a
+    /// human-readable description (JSON serialization errors are stringified;
+    /// XML errors are already strings).
+    pub fn serialize(&self, format: crate::results::ResultFormat) -> Result<Vec<u8>, String> {
         match format {
-            crate::results::ResultFormat::Json => self.to_json(),
+            crate::results::ResultFormat::Json => self.to_json().map_err(|e| e.to_string()),
+            crate::results::ResultFormat::Xml => self.to_xml(),
             crate::results::ResultFormat::Turtle => Ok(self.to_turtle()),
             crate::results::ResultFormat::NTriples => Ok(self.to_ntriples()),
         }
@@ -184,7 +300,229 @@ impl SparqlEngine {
             }));
         }
 
+        // URS-QEC-S01: CONSTRUCT / DESCRIBE return a graph result.
+        if let Some(graph_mode) = &plan.graph_mode {
+            return Ok(SparqlResult::Graph(
+                build_graph_result(graph_mode, &results, &plan, &self.write_path).await?,
+            ));
+        }
+
         Ok(SparqlResult::Select(results))
+    }
+}
+
+/// Build the `Vec<ConstructedTriple>` for CONSTRUCT and DESCRIBE queries.
+///
+/// For `CONSTRUCT { template } WHERE { … }`:
+///   Instantiate the template triples once per WHERE solution.  Variables in
+///   the template are replaced with the corresponding bound values.
+///
+/// For `DESCRIBE <iri>`:
+///   Run a subject-lookup for the described IRI and return all triples found.
+async fn build_graph_result(
+    mode: &GraphQueryMode,
+    where_results: &SparqlJsonResults,
+    plan: &planner::QueryPlan,
+    write_path: &Arc<WritePath>,
+) -> Result<Vec<ConstructedTriple>, SparqlError> {
+    use spargebra::term::{NamedNodePattern, TermPattern};
+
+    match mode {
+        GraphQueryMode::Construct(template) => {
+            let mut triples = Vec::new();
+            for solution in &where_results.results.bindings {
+                for tp in template {
+                    // Resolve subject.
+                    let subject = match &tp.subject {
+                        TermPattern::NamedNode(n) => n.as_str().to_string(),
+                        TermPattern::Variable(v) => match solution.get(v.as_str()) {
+                            Some(b) => b.value.clone(),
+                            None => continue,
+                        },
+                        TermPattern::BlankNode(b) => format!("_:{}", b.as_str()),
+                        _ => continue,
+                    };
+
+                    // Resolve predicate.
+                    let predicate = match &tp.predicate {
+                        NamedNodePattern::NamedNode(n) => n.as_str().to_string(),
+                        NamedNodePattern::Variable(v) => match solution.get(v.as_str()) {
+                            Some(b) => b.value.clone(),
+                            None => continue,
+                        },
+                    };
+
+                    // Resolve object.
+                    let (object, object_type, datatype, lang) = match &tp.object {
+                        TermPattern::NamedNode(n) => {
+                            (n.as_str().to_string(), "uri".to_string(), None, None)
+                        }
+                        TermPattern::Literal(l) => (
+                            l.value().to_string(),
+                            "literal".to_string(),
+                            Some(l.datatype().as_str().to_string()),
+                            l.language().map(|s| s.to_string()),
+                        ),
+                        TermPattern::BlankNode(b) => {
+                            (format!("_:{}", b.as_str()), "bnode".to_string(), None, None)
+                        }
+                        TermPattern::Variable(v) => match solution.get(v.as_str()) {
+                            Some(b) => (
+                                b.value.clone(),
+                                b.binding_type.clone(),
+                                b.datatype.clone(),
+                                b.lang.clone(),
+                            ),
+                            None => continue,
+                        },
+                        _ => continue,
+                    };
+
+                    triples.push(ConstructedTriple {
+                        subject,
+                        predicate,
+                        object,
+                        object_type,
+                        datatype,
+                        lang,
+                    });
+                }
+            }
+            Ok(triples)
+        }
+
+        GraphQueryMode::DescribeIris(iris_list) => {
+            // The planner ran SubjectLookup ops for each IRI. The where_results
+            // bindings contain __p and __o rows — but subjects are mixed. Since
+            // binding rows don't carry the subject (it was the partition key),
+            // we re-issue individual SubjectLookups to correctly attribute rows.
+            use crate::planner::TripleOp;
+            use spargebra::term::{NamedNode, NamedNodePattern, TermPattern, TriplePattern};
+
+            let mut triples = Vec::new();
+            for iri in iris_list {
+                let dummy_tp = TriplePattern {
+                    subject: TermPattern::NamedNode(NamedNode::new_unchecked(iri.as_str())),
+                    predicate: NamedNodePattern::Variable(
+                        spargebra::term::Variable::new_unchecked("__p"),
+                    ),
+                    object: TermPattern::Variable(spargebra::term::Variable::new_unchecked("__o")),
+                };
+                let op = TripleOp::SubjectLookup {
+                    graph: plan.ops.first().map_or_else(
+                        || "__default".to_string(),
+                        |(_, o)| match o {
+                            TripleOp::SubjectLookup { graph, .. } => graph.clone(),
+                            _ => "__default".to_string(),
+                        },
+                    ),
+                    subject: iri.clone(),
+                    predicate_filter: None,
+                };
+                let lookup_plan = planner::QueryPlan {
+                    ops: vec![(dummy_tp, op)],
+                    projection: vec!["__p".into(), "__o".into()],
+                    limit: None,
+                    offset: None,
+                    is_ask: false,
+                    distinct: false,
+                    order_by: vec![],
+                    filters: vec![],
+                    graph_mode: None,
+                };
+                let sub = crate::executor::execute(&lookup_plan, write_path).await?;
+                for row in sub.results.bindings {
+                    let pred = match row.get("__p") {
+                        Some(b) => b.value.clone(),
+                        None => continue,
+                    };
+                    let obj_b = match row.get("__o") {
+                        Some(b) => b,
+                        None => continue,
+                    };
+                    triples.push(ConstructedTriple {
+                        subject: iri.clone(),
+                        predicate: pred,
+                        object: obj_b.value.clone(),
+                        object_type: obj_b.binding_type.clone(),
+                        datatype: obj_b.datatype.clone(),
+                        lang: obj_b.lang.clone(),
+                    });
+                }
+            }
+            Ok(triples)
+        }
+
+        GraphQueryMode::Describe(graph) => {
+            // DESCRIBE: collect all triples about every subject bound by the
+            // WHERE clause (or the directly described IRI if no WHERE clause
+            // was supplied by spargebra).
+            let mut subjects: Vec<String> = Vec::new();
+            if where_results.results.bindings.is_empty() {
+                // No WHERE solutions — nothing to describe.
+                return Ok(vec![]);
+            }
+            // Collect all bound URI values that look like the described subject.
+            for sol in &where_results.results.bindings {
+                for binding in sol.values() {
+                    if binding.binding_type == "uri" && !subjects.contains(&binding.value) {
+                        subjects.push(binding.value.clone());
+                    }
+                }
+            }
+
+            let mut triples = Vec::new();
+            for subject_iri in subjects {
+                // SubjectLookup: fetch all (pred, obj) for this subject.
+                use crate::planner::TripleOp;
+                use spargebra::term::NamedNode;
+                use spargebra::term::{NamedNodePattern, TermPattern, TriplePattern};
+
+                let dummy_tp = TriplePattern {
+                    subject: TermPattern::NamedNode(NamedNode::new_unchecked(&subject_iri)),
+                    predicate: NamedNodePattern::Variable(
+                        spargebra::term::Variable::new_unchecked("__p"),
+                    ),
+                    object: TermPattern::Variable(spargebra::term::Variable::new_unchecked("__o")),
+                };
+                let op = TripleOp::SubjectLookup {
+                    graph: graph.clone(),
+                    subject: subject_iri.clone(),
+                    predicate_filter: None,
+                };
+                let dummy_plan = planner::QueryPlan {
+                    ops: vec![(dummy_tp, op)],
+                    projection: vec!["__p".into(), "__o".into()],
+                    limit: None,
+                    offset: None,
+                    is_ask: false,
+                    distinct: false,
+                    order_by: vec![],
+                    filters: vec![],
+                    graph_mode: None,
+                };
+                let sub_result = crate::executor::execute(&dummy_plan, write_path).await?;
+                for row in sub_result.results.bindings {
+                    let pred = match row.get("__p") {
+                        Some(b) => b.value.clone(),
+                        None => continue,
+                    };
+                    let obj_binding = match row.get("__o") {
+                        Some(b) => b,
+                        None => continue,
+                    };
+                    triples.push(ConstructedTriple {
+                        subject: subject_iri.clone(),
+                        predicate: pred,
+                        object: obj_binding.value.clone(),
+                        object_type: obj_binding.binding_type.clone(),
+                        datatype: obj_binding.datatype.clone(),
+                        lang: obj_binding.lang.clone(),
+                    });
+                }
+            }
+            Ok(triples)
+        }
     }
 }
 

--- a/ferrosa-sparql/src/executor.rs
+++ b/ferrosa-sparql/src/executor.rs
@@ -30,8 +30,9 @@ pub async fn execute(
         });
     }
 
-    // BUG-S13: apply ORDER BY.
-    apply_order_by(&mut binding_sets, &plan.order_by);
+    // BUG-S13 / URS-QEC-S04: apply ORDER BY (evaluates expressions per solution;
+    // fails loud on unsupported forms).
+    apply_order_by(&mut binding_sets, &plan.order_by)?;
 
     // BUG-S13: apply DISTINCT.
     if plan.distinct {
@@ -229,19 +230,34 @@ fn try_insert_binding(row: &mut HashMap<String, Binding>, name: &str, binding: &
     }
 }
 
-/// Sort binding sets by ORDER BY conditions (BUG-S13).
+/// Sort binding sets by ORDER BY conditions (BUG-S13, URS-QEC-S04).
+///
+/// Each condition holds a full expression (a plain `?var` is the trivial
+/// `Variable` expression). The expression is evaluated per solution and the
+/// solutions are sorted by the result, numerically when both sides are numeric.
+///
+/// URS-QEC-X01 (fail loud): if any ORDER BY expression contains a sub-form this
+/// engine cannot evaluate, return an error instead of silently sorting those
+/// rows as equal (which would yield an arbitrary, undocumented order).
 fn apply_order_by(
     binding_sets: &mut [HashMap<String, Binding>],
     order_by: &[crate::planner::OrderCondition],
-) {
+) -> Result<(), SparqlError> {
     if order_by.is_empty() {
-        return;
+        return Ok(());
+    }
+    for cond in order_by {
+        if let Some(what) = crate::filter::unsupported_expr(&cond.expression) {
+            return Err(SparqlError::Plan(format!(
+                "ORDER BY expression is not supported: {what}; \
+                 cannot evaluate it per solution, refusing to return an \
+                 arbitrarily-ordered result"
+            )));
+        }
     }
     binding_sets.sort_by(|a, b| {
         for cond in order_by {
-            let va = a.get(&cond.variable).map(|b| b.value.as_str());
-            let vb = b.get(&cond.variable).map(|b| b.value.as_str());
-            let ord = va.cmp(&vb);
+            let ord = crate::filter::order_cmp(&cond.expression, a, b);
             let ord = if cond.ascending { ord } else { ord.reverse() };
             if ord != std::cmp::Ordering::Equal {
                 return ord;
@@ -249,6 +265,7 @@ fn apply_order_by(
         }
         std::cmp::Ordering::Equal
     });
+    Ok(())
 }
 
 /// Remove duplicate binding rows (BUG-S13).
@@ -682,10 +699,10 @@ mod tests {
             make_binding_row("name", "Bob"),
         ];
         let conditions = vec![crate::planner::OrderCondition {
-            variable: "name".into(),
+            expression: var_expr("name"),
             ascending: true,
         }];
-        apply_order_by(&mut rows, &conditions);
+        apply_order_by(&mut rows, &conditions).unwrap();
         let names: Vec<&str> = rows.iter().map(|r| r["name"].value.as_str()).collect();
         assert_eq!(names, vec!["Alice", "Bob", "Charlie"]);
     }
@@ -698,12 +715,66 @@ mod tests {
             make_binding_row("name", "Bob"),
         ];
         let conditions = vec![crate::planner::OrderCondition {
-            variable: "name".into(),
+            expression: var_expr("name"),
             ascending: false,
         }];
-        apply_order_by(&mut rows, &conditions);
+        apply_order_by(&mut rows, &conditions).unwrap();
         let names: Vec<&str> = rows.iter().map(|r| r["name"].value.as_str()).collect();
         assert_eq!(names, vec!["Charlie", "Bob", "Alice"]);
+    }
+
+    // --- URS-QEC-S04: ORDER BY on expressions ---
+
+    fn make_numeric_row(
+        a_var: &str,
+        a_val: &str,
+        b_var: &str,
+        b_val: &str,
+    ) -> HashMap<String, Binding> {
+        let mut row = HashMap::new();
+        for (var, val) in [(a_var, a_val), (b_var, b_val)] {
+            row.insert(
+                var.to_string(),
+                Binding {
+                    binding_type: "literal".into(),
+                    value: val.into(),
+                    datatype: Some("http://www.w3.org/2001/XMLSchema#integer".into()),
+                    lang: None,
+                },
+            );
+        }
+        row
+    }
+
+    fn var_expr(name: &str) -> spargebra::algebra::Expression {
+        spargebra::algebra::Expression::Variable(spargebra::term::Variable::new_unchecked(name))
+    }
+
+    #[test]
+    fn apply_order_by_arithmetic_expression_desc() {
+        // ORDER BY (?a + ?b) DESC must sort by the evaluated sum, descending.
+        // Rows: sums are 5 (2+3), 9 (4+5), 7 (1+6).
+        let mut rows = vec![
+            make_numeric_row("a", "2", "b", "3"), // 5
+            make_numeric_row("a", "4", "b", "5"), // 9
+            make_numeric_row("a", "1", "b", "6"), // 7
+        ];
+        let sum =
+            spargebra::algebra::Expression::Add(Box::new(var_expr("a")), Box::new(var_expr("b")));
+        let conditions = vec![crate::planner::OrderCondition {
+            expression: sum,
+            ascending: false,
+        }];
+        apply_order_by(&mut rows, &conditions).unwrap();
+        let sums: Vec<i64> = rows
+            .iter()
+            .map(|r| r["a"].value.parse::<i64>().unwrap() + r["b"].value.parse::<i64>().unwrap())
+            .collect();
+        assert_eq!(
+            sums,
+            vec![9, 7, 5],
+            "ORDER BY (?a + ?b) DESC must order by sum descending"
+        );
     }
 
     // --- BUG-S13: DISTINCT ---

--- a/ferrosa-sparql/src/filter.rs
+++ b/ferrosa-sparql/src/filter.rs
@@ -53,7 +53,7 @@ fn eval_expr(expr: &Expression, bindings: &HashMap<String, Binding>) -> Value {
     match expr {
         Expression::Variable(var) => bindings
             .get(var.as_str())
-            .map(|b| Value::String(b.value.clone()))
+            .map(binding_to_value)
             .unwrap_or(Value::Null),
 
         Expression::Equal(left, right) => {
@@ -126,11 +126,186 @@ fn eval_expr(expr: &Expression, bindings: &HashMap<String, Binding>) -> Value {
             }
         }
 
+        Expression::FunctionCall(func, args) => eval_function(func, args, bindings),
+
         // Unsupported expressions evaluate to Null (filter passes nothing).
         _ => {
             tracing::debug!(?expr, "unsupported FILTER expression, evaluating as Null");
             Value::Null
         }
+    }
+}
+
+/// Evaluate a supported SPARQL function call. Returns `Value::Null` for
+/// functions that are not implemented; callers that require fail-loud behaviour
+/// (e.g. ORDER BY) must gate on [`unsupported_expr`] first.
+fn eval_function(
+    func: &spargebra::algebra::Function,
+    args: &[Expression],
+    bindings: &HashMap<String, Binding>,
+) -> Value {
+    use spargebra::algebra::Function as F;
+    let arg0 = || {
+        args.first()
+            .map(|a| eval_expr(a, bindings))
+            .unwrap_or(Value::Null)
+    };
+    match func {
+        // STR(x): the lexical/string form of the value.
+        F::Str => match arg0() {
+            Value::Null => Value::Null,
+            other => Value::String(value_as_lexical(&other)),
+        },
+        F::UCase => match arg0() {
+            Value::Null => Value::Null,
+            other => Value::String(value_as_lexical(&other).to_uppercase()),
+        },
+        F::LCase => match arg0() {
+            Value::Null => Value::Null,
+            other => Value::String(value_as_lexical(&other).to_lowercase()),
+        },
+        F::StrLen => match arg0() {
+            Value::Null => Value::Null,
+            other => Value::Integer(value_as_lexical(&other).chars().count() as i64),
+        },
+        F::Abs => arg0()
+            .to_float()
+            .map(|n| Value::Float(n.abs()))
+            .unwrap_or(Value::Null),
+        F::Ceil => arg0()
+            .to_float()
+            .map(|n| Value::Float(n.ceil()))
+            .unwrap_or(Value::Null),
+        F::Floor => arg0()
+            .to_float()
+            .map(|n| Value::Float(n.floor()))
+            .unwrap_or(Value::Null),
+        F::Round => arg0()
+            .to_float()
+            .map(|n| Value::Float(n.round()))
+            .unwrap_or(Value::Null),
+        _ => Value::Null,
+    }
+}
+
+/// Whether an expression is fully supported for evaluation (used by ORDER BY to
+/// fail loud on unsupported forms instead of sorting everything as Null/equal).
+///
+/// Returns the name of the first unsupported sub-expression, or `None` if the
+/// whole tree is evaluable.
+pub fn unsupported_expr(expr: &Expression) -> Option<String> {
+    use spargebra::algebra::Function as F;
+    match expr {
+        Expression::Variable(_)
+        | Expression::Literal(_)
+        | Expression::NamedNode(_)
+        | Expression::Bound(_) => None,
+        Expression::Add(l, r)
+        | Expression::Subtract(l, r)
+        | Expression::Multiply(l, r)
+        | Expression::Divide(l, r)
+        | Expression::Equal(l, r)
+        | Expression::Greater(l, r)
+        | Expression::GreaterOrEqual(l, r)
+        | Expression::Less(l, r)
+        | Expression::LessOrEqual(l, r)
+        | Expression::And(l, r)
+        | Expression::Or(l, r)
+        | Expression::SameTerm(l, r) => unsupported_expr(l).or_else(|| unsupported_expr(r)),
+        Expression::Not(inner) => unsupported_expr(inner),
+        Expression::If(c, t, e) => unsupported_expr(c)
+            .or_else(|| unsupported_expr(t))
+            .or_else(|| unsupported_expr(e)),
+        Expression::FunctionCall(func, args) => {
+            let supported = matches!(
+                func,
+                F::Str | F::UCase | F::LCase | F::StrLen | F::Abs | F::Ceil | F::Floor | F::Round
+            );
+            if !supported {
+                return Some(format!("function {func:?}"));
+            }
+            args.iter().find_map(unsupported_expr)
+        }
+        other => Some(format!("{other:?}")),
+    }
+}
+
+/// Convert a solution [`Binding`] into an evaluation [`Value`].
+///
+/// Honors the binding's `datatype` so that numeric literals participate in
+/// arithmetic and numeric ordering. Untyped literals whose value parses as a
+/// number are also treated numerically (xsd:integer/double), matching how
+/// SPARQL promotes numeric literals; everything else is a string.
+fn binding_to_value(b: &Binding) -> Value {
+    if let Some(dt) = b.datatype.as_deref() {
+        return match dt {
+            "http://www.w3.org/2001/XMLSchema#integer"
+            | "http://www.w3.org/2001/XMLSchema#int"
+            | "http://www.w3.org/2001/XMLSchema#long" => b
+                .value
+                .parse::<i64>()
+                .map(Value::Integer)
+                .unwrap_or(Value::Null),
+            "http://www.w3.org/2001/XMLSchema#decimal"
+            | "http://www.w3.org/2001/XMLSchema#float"
+            | "http://www.w3.org/2001/XMLSchema#double" => b
+                .value
+                .parse::<f64>()
+                .map(Value::Float)
+                .unwrap_or(Value::Null),
+            "http://www.w3.org/2001/XMLSchema#boolean" => {
+                Value::Boolean(b.value == "true" || b.value == "1")
+            }
+            _ => Value::String(b.value.clone()),
+        };
+    }
+    Value::String(b.value.clone())
+}
+
+/// SPARQL ORDER BY comparison (URS-QEC-S04).
+///
+/// Evaluates `expr` against both solutions and returns their relative order.
+/// Numeric values compare numerically; otherwise comparison is lexical on the
+/// string form. Unbound/Null sorts lowest (before any bound value), per the
+/// SPARQL 1.1 ORDER BY ordering of unbound variables.
+pub fn order_cmp(
+    expr: &Expression,
+    a: &HashMap<String, Binding>,
+    b: &HashMap<String, Binding>,
+) -> std::cmp::Ordering {
+    let va = eval_expr(expr, a);
+    let vb = eval_expr(expr, b);
+    cmp_values(&va, &vb)
+}
+
+fn cmp_values(a: &Value, b: &Value) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    // Null (unbound / type error) sorts lowest.
+    match (matches!(a, Value::Null), matches!(b, Value::Null)) {
+        (true, true) => return Ordering::Equal,
+        (true, false) => return Ordering::Less,
+        (false, true) => return Ordering::Greater,
+        (false, false) => {}
+    }
+    // Numeric comparison when both are numeric.
+    if let (Some(x), Some(y)) = (a.to_float(), b.to_float()) {
+        return x.partial_cmp(&y).unwrap_or(Ordering::Equal);
+    }
+    // Booleans: false < true.
+    if let (Value::Boolean(x), Value::Boolean(y)) = (a, b) {
+        return x.cmp(y);
+    }
+    // Fall back to lexical comparison on the string form.
+    value_as_lexical(a).cmp(&value_as_lexical(b))
+}
+
+fn value_as_lexical(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Integer(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Boolean(b) => b.to_string(),
+        Value::Null => String::new(),
     }
 }
 

--- a/ferrosa-sparql/src/planner.rs
+++ b/ferrosa-sparql/src/planner.rs
@@ -34,10 +34,15 @@ pub enum TripleOp {
 }
 
 /// A sort ordering for ORDER BY.
+///
+/// Holds the full ORDER BY expression (which may be a plain variable, an
+/// arithmetic expression like `?a + ?b`, a function call, etc.). The executor
+/// evaluates the expression per solution and sorts by the resulting value
+/// (URS-QEC-S04).
 #[derive(Debug, Clone)]
 pub struct OrderCondition {
-    /// Variable name to sort on.
-    pub variable: String,
+    /// Expression to evaluate per solution and sort on.
+    pub expression: spargebra::algebra::Expression,
     /// True for ascending, false for descending.
     pub ascending: bool,
 }
@@ -285,37 +290,18 @@ fn collect_ops(
         GraphPattern::OrderBy {
             inner, expression, ..
         } => {
+            // URS-QEC-S04: ORDER BY on arbitrary expressions. The executor
+            // evaluates the expression per solution and sorts by the result;
+            // a plain `?var` is just the trivial Variable expression.
             for cond in expression {
-                match cond {
-                    spargebra::algebra::OrderExpression::Asc(
-                        spargebra::algebra::Expression::Variable(v),
-                    ) => {
-                        order_by.push(OrderCondition {
-                            variable: v.as_str().to_string(),
-                            ascending: true,
-                        });
-                    }
-                    spargebra::algebra::OrderExpression::Desc(
-                        spargebra::algebra::Expression::Variable(v),
-                    ) => {
-                        order_by.push(OrderCondition {
-                            variable: v.as_str().to_string(),
-                            ascending: false,
-                        });
-                    }
-                    other => {
-                        // URS-QEC-S04 / URS-QEC-X01: non-variable ORDER BY
-                        // expressions are not implemented.  Silently ignoring
-                        // them would return results in an arbitrary order with
-                        // no indication that the ordering was not applied —
-                        // that is a silent wrong result.  Fail loud instead.
-                        return Err(SparqlError::Plan(format!(
-                            "ORDER BY expression is not implemented: only \
-                             plain variable references (?var) are supported; \
-                             got: {other:?}"
-                        )));
-                    }
-                }
+                let (expr, ascending) = match cond {
+                    spargebra::algebra::OrderExpression::Asc(e) => (e.clone(), true),
+                    spargebra::algebra::OrderExpression::Desc(e) => (e.clone(), false),
+                };
+                order_by.push(OrderCondition {
+                    expression: expr,
+                    ascending,
+                });
             }
             collect_ops(
                 inner,
@@ -676,8 +662,31 @@ mod tests {
             .unwrap();
         let plan = plan_query(&query, "default").unwrap();
         assert_eq!(plan.order_by.len(), 1);
-        assert_eq!(plan.order_by[0].variable, "name");
+        assert!(matches!(
+            &plan.order_by[0].expression,
+            spargebra::algebra::Expression::Variable(v) if v.as_str() == "name"
+        ));
         assert!(plan.order_by[0].ascending);
+    }
+
+    #[test]
+    fn plan_order_by_expression() {
+        // URS-QEC-S04: ORDER BY on an arithmetic expression must plan, not fail.
+        let query = spargebra::SparqlParser::new()
+            .parse_query(
+                "SELECT ?a ?b WHERE { ?s <http://ex/a> ?a ; <http://ex/b> ?b } ORDER BY DESC(?a + ?b)",
+            )
+            .unwrap();
+        let plan = plan_query(&query, "default").unwrap();
+        assert_eq!(plan.order_by.len(), 1);
+        assert!(!plan.order_by[0].ascending);
+        assert!(
+            matches!(
+                &plan.order_by[0].expression,
+                spargebra::algebra::Expression::Add(_, _)
+            ),
+            "ORDER BY (?a + ?b) must capture the Add expression"
+        );
     }
 
     #[test]

--- a/ferrosa-sparql/src/planner.rs
+++ b/ferrosa-sparql/src/planner.rs
@@ -61,9 +61,24 @@ pub struct QueryPlan {
     pub order_by: Vec<OrderCondition>,
     /// FILTER expressions to evaluate against binding sets.
     pub filters: Vec<spargebra::algebra::Expression>,
+    /// Non-None for CONSTRUCT/DESCRIBE query forms; None for SELECT/ASK.
+    pub graph_mode: Option<GraphQueryMode>,
 }
 
-/// Plan a SPARQL SELECT or ASK query.
+/// The template/mode for a query form that produces a graph result.
+#[derive(Debug, Clone)]
+pub enum GraphQueryMode {
+    /// `CONSTRUCT { template }` — the template triples to instantiate per solution.
+    Construct(Vec<TriplePattern>),
+    /// `DESCRIBE <iri> [<iri> …]` — literal IRI(s) to describe; the planner
+    /// has already built SubjectLookup ops and the executor just needs to
+    /// assemble the result from the SELECT output.
+    DescribeIris(Vec<String>),
+    /// `DESCRIBE ?var WHERE { … }` — subjects are derived from WHERE solutions.
+    Describe(String),
+}
+
+/// Plan a SPARQL SELECT, ASK, CONSTRUCT, or DESCRIBE query.
 pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, SparqlError> {
     match query {
         Query::Select {
@@ -79,9 +94,73 @@ pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, Sparq
             plan.limit = Some(1);
             Ok(plan)
         }
-        _ => Err(SparqlError::Plan(
-            "only SELECT and ASK queries are supported in Sprint 1".into(),
-        )),
+        Query::Construct {
+            template,
+            pattern,
+            base_iri: _,
+            ..
+        } => {
+            // Plan the WHERE clause exactly like SELECT so the executor can
+            // bind solutions; then attach the CONSTRUCT template.
+            let mut plan = plan_select(pattern, default_graph, None, false)?;
+            // CONSTRUCT projects all variables — projection is derived from the template.
+            plan.graph_mode = Some(GraphQueryMode::Construct(template.clone()));
+            Ok(plan)
+        }
+        Query::Describe {
+            dataset: _,
+            pattern,
+            base_iri: _,
+        } => {
+            // DESCRIBE <iri> is parsed by spargebra as:
+            //   Extend { inner: Bgp { patterns: [] },
+            //            variable: _freshvar,
+            //            expression: NamedNode(<iri>) }
+            //
+            // Extract all described IRIs from `Extend` nodes, then build a
+            // SELECT-style plan that does a SubjectLookup per IRI.
+            let iris = extract_describe_iris(pattern);
+            if iris.is_empty() {
+                // DESCRIBE ?var WHERE { … } — plan the WHERE clause normally.
+                let mut plan = plan_select(pattern, default_graph, None, false)?;
+                plan.graph_mode = Some(GraphQueryMode::Describe(default_graph.to_string()));
+                return Ok(plan);
+            }
+
+            // Build ops: one SubjectLookup per described IRI.
+            let mut ops = Vec::new();
+            for iri in &iris {
+                let tp = TriplePattern {
+                    subject: spargebra::term::TermPattern::NamedNode(
+                        spargebra::term::NamedNode::new_unchecked(iri.as_str()),
+                    ),
+                    predicate: NamedNodePattern::Variable(
+                        spargebra::term::Variable::new_unchecked("__p"),
+                    ),
+                    object: TermPattern::Variable(spargebra::term::Variable::new_unchecked("__o")),
+                };
+                ops.push((
+                    tp,
+                    TripleOp::SubjectLookup {
+                        graph: default_graph.to_string(),
+                        subject: iri.clone(),
+                        predicate_filter: None,
+                    },
+                ));
+            }
+
+            Ok(QueryPlan {
+                ops,
+                projection: vec!["__p".into(), "__o".into()],
+                limit: None,
+                offset: None,
+                is_ask: false,
+                distinct: false,
+                order_by: vec![],
+                filters: vec![],
+                graph_mode: Some(GraphQueryMode::DescribeIris(iris)),
+            })
+        }
     }
 }
 
@@ -127,6 +206,7 @@ fn plan_select(
         distinct,
         order_by,
         filters,
+        graph_mode: None,
     })
 }
 
@@ -145,7 +225,7 @@ fn collect_ops(
     match pattern {
         GraphPattern::Bgp { patterns } => {
             for tp in patterns {
-                let op = plan_triple_pattern(tp, default_graph);
+                let op = plan_triple_pattern(tp, default_graph)?;
                 ops.push((tp.clone(), op));
             }
         }
@@ -223,11 +303,17 @@ fn collect_ops(
                             ascending: false,
                         });
                     }
-                    _ => {
-                        tracing::warn!(
-                            "ORDER BY expression type not supported; \
-                             only simple variable ordering is implemented"
-                        );
+                    other => {
+                        // URS-QEC-S04 / URS-QEC-X01: non-variable ORDER BY
+                        // expressions are not implemented.  Silently ignoring
+                        // them would return results in an arbitrary order with
+                        // no indication that the ordering was not applied —
+                        // that is a silent wrong result.  Fail loud instead.
+                        return Err(SparqlError::Plan(format!(
+                            "ORDER BY expression is not implemented: only \
+                             plain variable references (?var) are supported; \
+                             got: {other:?}"
+                        )));
                     }
                 }
             }
@@ -286,7 +372,7 @@ fn collect_ops(
                     ),
                     object: object.clone(),
                 };
-                let op = plan_triple_pattern(&tp, default_graph);
+                let op = plan_triple_pattern(&tp, default_graph)?;
                 ops.push((tp, op));
             } else {
                 // Transitive/closure path — emit PropertyPath op for BFS.
@@ -407,7 +493,27 @@ fn extract_predicate_from_path(
 }
 
 /// Choose a storage operation for a single triple pattern.
-fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> TripleOp {
+///
+/// Returns `Err` when the triple pattern contains an embedded quoted triple
+/// (RDF* / SPARQL-star syntax), which is parsed successfully by spargebra but
+/// whose annotation evaluation is not yet implemented (URS-QEC-S03 /
+/// URS-QEC-X01).  Failing loud here prevents silent wrong results.
+fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> Result<TripleOp, SparqlError> {
+    // URS-QEC-S03 / URS-QEC-X01: detect RDF* embedded triple terms and fail loud.
+    if matches!(&tp.subject, TermPattern::Triple(_)) {
+        return Err(SparqlError::Plan(
+            "RDF* (RDF-star) annotation evaluation is not yet implemented. \
+             Quoted triple patterns << ?s ?p ?o >> are parsed but the annotation \
+             variable binding against edge_annotations is not supported."
+                .into(),
+        ));
+    }
+    if matches!(&tp.object, TermPattern::Triple(_)) {
+        return Err(SparqlError::Plan(
+            "RDF* (RDF-star) object quoted triples are not yet implemented.".into(),
+        ));
+    }
+
     let graph = default_graph.to_string();
 
     let subject_bound = matches!(&tp.subject, TermPattern::NamedNode(_));
@@ -417,7 +523,7 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> TripleOp {
         TermPattern::NamedNode(_) | TermPattern::Literal(_)
     );
 
-    if subject_bound {
+    let op = if subject_bound {
         let subject = match &tp.subject {
             TermPattern::NamedNode(n) => n.as_str().to_string(),
             _ => unreachable!(),
@@ -450,6 +556,50 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> TripleOp {
         TripleOp::ObjectScan { graph, object }
     } else {
         TripleOp::FullScan { graph }
+    };
+    Ok(op)
+}
+
+/// Extract literal IRI strings from `DESCRIBE <iri>` patterns.
+///
+/// `DESCRIBE <iri>` is parsed by spargebra as an `Extend` node that binds a
+/// fresh variable to the literal IRI.  This function walks the pattern tree
+/// and collects the IRI strings from such `Extend` nodes.  Returns an empty
+/// `Vec` if the pattern is a WHERE clause (variable describe) rather than
+/// literal IRIs.
+/// Extract literal IRI strings from `DESCRIBE <iri>` patterns.
+///
+/// `DESCRIBE <iri>` is parsed by spargebra as:
+///   `Project { inner: Extend { inner: Bgp { patterns: [] },
+///                              variable: _freshvar,
+///                              expression: NamedNode(<iri>) },
+///              variables: [_freshvar] }`
+///
+/// This function recursively walks the pattern tree and collects the IRI
+/// strings from `Extend` nodes whose `expression` is a literal `NamedNode`.
+/// Returns an empty `Vec` if the pattern is a WHERE clause (variable describe)
+/// rather than literal IRIs.
+pub fn extract_describe_iris(pattern: &spargebra::algebra::GraphPattern) -> Vec<String> {
+    use spargebra::algebra::{Expression, GraphPattern};
+    match pattern {
+        GraphPattern::Extend {
+            inner, expression, ..
+        } => {
+            let mut iris = extract_describe_iris(inner);
+            if let Expression::NamedNode(n) = expression {
+                iris.push(n.as_str().to_string());
+            }
+            iris
+        }
+        // spargebra wraps the Extend in a Project — recurse through wrapper nodes.
+        GraphPattern::Project { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner } => extract_describe_iris(inner),
+        GraphPattern::Slice { inner, .. } => extract_describe_iris(inner),
+        GraphPattern::OrderBy { inner, .. } => extract_describe_iris(inner),
+        GraphPattern::Filter { inner, .. } => extract_describe_iris(inner),
+        GraphPattern::Bgp { .. } => vec![],
+        _ => vec![],
     }
 }
 

--- a/ferrosa-sparql/src/rdf_star.rs
+++ b/ferrosa-sparql/src/rdf_star.rs
@@ -1,28 +1,34 @@
-//! RDF* (RDF-star) annotation query support.
+//! RDF* (RDF-star) annotation query support — **not yet implemented**.
 //!
 //! RDF* extends RDF with statement-about-statement annotations:
 //! ```sparql
 //! << :alice :knows :bob >> :since "2020" .
 //! ```
 //!
-//! In ferrosa, annotations are stored in an `edge_annotations` table:
-//! ```sql
-//! CREATE TABLE edge_annotations (
-//!     tenant_id uuid,
-//!     session_id uuid,
-//!     src_id uuid,
-//!     edge_type text,
-//!     dst_id uuid,
-//!     property_name text,
-//!     property_value text,
-//!     value_type text,
-//!     created_at timestamp,
-//!     PRIMARY KEY ((tenant_id, session_id, src_id, edge_type, dst_id), property_name)
-//! );
-//! ```
+//! ## Current status (URS-QEC-S03a / URS-QEC-X01)
 //!
-//! The SPARQL planner translates RDF* triple patterns into joins between
-//! the main triples table and the edge_annotations table.
+//! Quoted-triple *matching and binding* is **out of scope** for the M3 SPARQL
+//! increment and is therefore **fail-loud**, never silently approximated:
+//!
+//! - The query planner ([`crate::planner`]) rejects any triple pattern with a
+//!   quoted triple in subject or object position with `SparqlError::Plan`, so a
+//!   SELECT/ASK over `<< ?s ?p ?o >> ?prop ?val` returns a 400, not inner
+//!   bindings with the annotation variable silently absent.
+//! - [`evaluate_rdf_star_pattern`] below mirrors that fail-loud contract for any
+//!   future caller.
+//!
+//! ## What real support would require (deliberately not built here)
+//!
+//! Ferrosa's RDF store is the single `rdf_triples` table
+//! (`((graph, subject), predicate, object)`); there is **no** dedicated
+//! annotation/quoted-triple table, and the SPARQL `INSERT` path can only store a
+//! quoted triple as an opaque `<<…>>` string in *object* position — a
+//! quoted-triple *subject* (the annotation case) cannot even be inserted today.
+//! Real evaluation would need: (1) a storage encoding for quoted-triple terms in
+//! key position, (2) parser/insert support for quoted-triple subjects, and
+//! (3) a join planner that decomposes `<< s p o >>` and binds the inner pattern
+//! before binding the outer annotation property. Until that exists, this module
+//! fails loud rather than returning a wrong answer.
 
 use std::collections::HashMap;
 

--- a/ferrosa-sparql/src/rdf_star.rs
+++ b/ferrosa-sparql/src/rdf_star.rs
@@ -56,22 +56,17 @@ pub fn evaluate_rdf_star_pattern(
     _annotation_variable: &str,
     _keyspace: &str,
 ) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
-    // RDF* requires the edge_annotations table to exist in the keyspace.
-    // This is created by ferrosa-memory via CQL DDL.
-    //
-    // Implementation approach:
-    // 1. For each binding in inner_bindings, extract (subject, predicate, object)
-    // 2. Query edge_annotations WHERE src_id=subject AND edge_type=predicate
-    //    AND dst_id=object AND property_name=annotation_property
-    // 3. Bind the annotation value to annotation_variable
-    //
-    // For now, return the inner bindings unmodified with a warning.
-    tracing::warn!(
-        "RDF* annotation queries are not yet fully implemented — \
-         annotations will be empty. Create the edge_annotations table \
-         and re-run to enable."
-    );
-    Ok(_inner_bindings.to_vec())
+    // URS-QEC-S03 / URS-QEC-X01: RDF* annotation evaluation is not yet
+    // implemented.  Returning the inner bindings without the annotation
+    // variable bound would be a silent wrong result — the caller would receive
+    // rows that look valid but are missing the requested annotation data.
+    // Fail loud instead so the HTTP layer can return 400 Bad Request.
+    Err(SparqlError::Plan(
+        "RDF* (RDF-star) annotation evaluation is not yet implemented. \
+         Quoted triple patterns << ?s ?p ?o >> are parsed but annotation \
+         variable binding against edge_annotations is not supported."
+            .into(),
+    ))
 }
 
 #[cfg(test)]
@@ -91,8 +86,11 @@ mod tests {
         assert_eq!(ann.value, "2020");
     }
 
+    /// URS-QEC-S03 / URS-QEC-X01: `evaluate_rdf_star_pattern` must now fail
+    /// loud rather than returning the inner bindings with the annotation variable
+    /// silently absent.
     #[test]
-    fn evaluate_rdf_star_returns_inner_bindings() {
+    fn evaluate_rdf_star_fails_loud_not_silent_inner_bindings() {
         let inner = vec![{
             let mut m = HashMap::new();
             m.insert(
@@ -107,8 +105,20 @@ mod tests {
             m
         }];
 
-        let result = evaluate_rdf_star_pattern(&inner, "since", "when", "test_ks").unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].contains_key("s"));
+        let result = evaluate_rdf_star_pattern(&inner, "since", "when", "test_ks");
+        assert!(
+            result.is_err(),
+            "evaluate_rdf_star_pattern must return Err (fail loud); \
+             returning inner bindings silently would be a wrong result"
+        );
+        let msg = result.unwrap_err().to_string().to_lowercase();
+        assert!(
+            msg.contains("rdf*")
+                || msg.contains("rdf-star")
+                || msg.contains("annotation")
+                || msg.contains("not")
+                || msg.contains("unsupported"),
+            "error must describe the unimplemented RDF* feature: {msg}"
+        );
     }
 }

--- a/ferrosa-sparql/src/results.rs
+++ b/ferrosa-sparql/src/results.rs
@@ -69,6 +69,8 @@ pub struct SparqlAskResult {
 pub enum ResultFormat {
     /// `application/sparql-results+json` (default for SELECT/ASK).
     Json,
+    /// `application/sparql-results+xml` (SPARQL XML Results Format per W3C).
+    Xml,
     /// `text/turtle` (Turtle/N-Triples-like serialization).
     Turtle,
     /// `application/n-triples` (N-Triples format).
@@ -82,7 +84,9 @@ impl ResultFormat {
     /// type is found.
     pub fn from_accept(accept: &str) -> Self {
         // Check for exact or partial matches in priority order.
-        if accept.contains("text/turtle") {
+        if accept.contains("application/sparql-results+xml") {
+            Self::Xml
+        } else if accept.contains("text/turtle") {
             Self::Turtle
         } else if accept.contains("application/n-triples") {
             Self::NTriples
@@ -95,6 +99,7 @@ impl ResultFormat {
     pub fn content_type(self) -> &'static str {
         match self {
             Self::Json => "application/sparql-results+json",
+            Self::Xml => "application/sparql-results+xml",
             Self::Turtle => "text/turtle",
             Self::NTriples => "application/n-triples",
         }
@@ -102,6 +107,46 @@ impl ResultFormat {
 }
 
 impl SparqlJsonResults {
+    /// Serialize to SPARQL Results XML format per W3C.
+    ///
+    /// Produces `application/sparql-results+xml` per the W3C SPARQL 1.1
+    /// Query Results XML Format specification.  The output is well-formed XML
+    /// with the `<sparql>` root, `<head>` with `<variable>` elements, and
+    /// `<results>` with `<result>` / `<binding>` / `<uri>` / `<literal>` /
+    /// `<bnode>` leaves.
+    pub fn to_xml(&self) -> Result<Vec<u8>, String> {
+        let mut buf = String::new();
+        buf.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        buf.push_str("<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n");
+
+        // <head>
+        buf.push_str("  <head>\n");
+        for var in &self.head.vars {
+            buf.push_str(&format!("    <variable name=\"{}\"/>\n", xml_escape(var)));
+        }
+        buf.push_str("  </head>\n");
+
+        // <results>
+        buf.push_str("  <results>\n");
+        for row in &self.results.bindings {
+            buf.push_str("    <result>\n");
+            for var in &self.head.vars {
+                if let Some(binding) = row.get(var) {
+                    buf.push_str(&format!(
+                        "      <binding name=\"{}\">{}</binding>\n",
+                        xml_escape(var),
+                        format_xml_binding(binding)
+                    ));
+                }
+            }
+            buf.push_str("    </result>\n");
+        }
+        buf.push_str("  </results>\n");
+        buf.push_str("</sparql>\n");
+
+        Ok(buf.into_bytes())
+    }
+
     /// Serialize to N-Triples format (one triple per line).
     ///
     /// Produces a simple tabular rendering: each binding row becomes one
@@ -129,6 +174,49 @@ impl SparqlJsonResults {
     /// of N-Triples. Full Turtle grouping/prefixing is deferred.
     pub fn to_turtle(&self) -> Vec<u8> {
         self.to_ntriples()
+    }
+}
+
+/// Escape a string for inclusion in XML text content or attribute values.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+/// Serialize a single binding value as an XML element leaf.
+///
+/// Per W3C SPARQL Results XML:
+/// - URI → `<uri>iri</uri>`
+/// - bnode → `<bnode>label</bnode>`
+/// - literal → `<literal [xml:lang] [datatype]>value</literal>`
+fn format_xml_binding(binding: &Binding) -> String {
+    match binding.binding_type.as_str() {
+        "uri" => format!("<uri>{}</uri>", xml_escape(&binding.value)),
+        "bnode" => {
+            // Strip leading "_:" label prefix if present.
+            let label = binding.value.strip_prefix("_:").unwrap_or(&binding.value);
+            format!("<bnode>{}</bnode>", xml_escape(label))
+        }
+        _ => {
+            // Literal — may carry xml:lang or datatype attributes.
+            let lang_attr = binding
+                .lang
+                .as_deref()
+                .map(|l| format!(" xml:lang=\"{}\"", xml_escape(l)))
+                .unwrap_or_default();
+            let dt_attr = binding
+                .datatype
+                .as_deref()
+                .map(|d| format!(" datatype=\"{}\"", xml_escape(d)))
+                .unwrap_or_default();
+            format!(
+                "<literal{lang_attr}{dt_attr}>{}</literal>",
+                xml_escape(&binding.value)
+            )
+        }
     }
 }
 

--- a/ferrosa-sparql/src/update.rs
+++ b/ferrosa-sparql/src/update.rs
@@ -81,10 +81,23 @@ pub async fn execute_update(
                 total_deleted += exec_clear(graph, keyspace, storage, write_path).await?;
             }
             spargebra::GraphUpdateOperation::Load { .. } => {
-                return Err(SparqlError::Plan("SPARQL LOAD is not implemented".into()));
+                // URS-QEC-X01: LOAD fetches and parses an external RDF document.
+                // This engine has no HTTP fetch + RDF-document parser pipeline,
+                // so it cannot honor LOAD. Fail loud rather than silently
+                // succeed with zero triples.
+                return Err(SparqlError::Plan(
+                    "SPARQL LOAD is not implemented: this endpoint has no RDF \
+                     document fetch/parse pipeline"
+                        .into(),
+                ));
             }
             spargebra::GraphUpdateOperation::Create { .. } => {
-                return Err(SparqlError::Plan("SPARQL CREATE is not implemented".into()));
+                // CREATE GRAPH is a success no-op in the single-graph-per-keyspace
+                // model: graphs are implicit (materialized by the partition-key
+                // graph component on first insert), so the named graph "exists"
+                // after this call with nothing to allocate. Per SPARQL 1.1,
+                // CREATE on a fresh graph succeeds; we cannot cheaply detect
+                // pre-existence, so (with or without SILENT) we report success.
             }
         }
     }
@@ -111,6 +124,24 @@ async fn exec_delete_insert(
     storage: &Arc<StorageEngine>,
     write_path: &Arc<WritePath>,
 ) -> Result<(usize, usize), SparqlError> {
+    // URS-QEC-X01: a delete or insert template whose target graph is a named
+    // graph distinct from this keyspace's default graph is NOT addressable in
+    // the single-graph-per-keyspace model (the read/write path keys the table
+    // by keyspace and does not filter by the graph partition-key component).
+    // Honoring it by writing into the default graph would be a silent wrong
+    // result, so we fail loud BEFORE evaluating the WHERE or applying any
+    // mutation. This is what makes the spargebra ADD/MOVE/COPY desugaring
+    // (which targets named graphs) fail loud instead of silently operating on
+    // the wrong graph. (A named-graph *read* — `GraphPattern::Graph` in the
+    // WHERE clause, produced when COPY/MOVE/ADD source is a named graph — is
+    // separately rejected by the planner.)
+    for tmpl in delete {
+        check_quad_graph_pattern(&tmpl.graph_name, keyspace, "DELETE")?;
+    }
+    for tmpl in insert {
+        check_quad_graph_pattern(&tmpl.graph_name, keyspace, "INSERT")?;
+    }
+
     let plan = crate::planner::plan_where(pattern, keyspace)?;
     let solutions = crate::executor::execute_bindings(&plan, write_path).await?;
 
@@ -207,6 +238,42 @@ struct InsertTriple {
     obj_type: String,
     datatype: Option<String>,
     language: Option<String>,
+}
+
+/// Validate that a quad template's target graph (a [`GraphNamePattern`], as
+/// carried by both INSERT and DELETE templates in a `DeleteInsert`) is
+/// addressable in this single-graph-per-keyspace engine.
+///
+/// `DefaultGraph` maps to the keyspace's default graph (always OK). A
+/// `NamedNode` equal to the keyspace is the same graph (OK). Any other named
+/// graph — or a variable-bound graph — is not addressable: return a fail-loud
+/// error instead of silently operating on the default graph (URS-QEC-X01).
+fn check_quad_graph_pattern(
+    graph: &spargebra::term::GraphNamePattern,
+    keyspace: &str,
+    op: &str,
+) -> Result<(), SparqlError> {
+    match graph {
+        spargebra::term::GraphNamePattern::DefaultGraph => Ok(()),
+        spargebra::term::GraphNamePattern::NamedNode(n) if n.as_str() == keyspace => Ok(()),
+        spargebra::term::GraphNamePattern::NamedNode(n) => {
+            Err(named_graph_unsupported(op, n.as_str(), keyspace))
+        }
+        spargebra::term::GraphNamePattern::Variable(v) => Err(SparqlError::Plan(format!(
+            "{op} into a variable-bound graph (?{}) is not supported: this endpoint \
+             exposes a single graph per keyspace ('{keyspace}')",
+            v.as_str()
+        ))),
+    }
+}
+
+/// Build the standard fail-loud error for an unaddressable named graph.
+fn named_graph_unsupported(op: &str, graph: &str, keyspace: &str) -> SparqlError {
+    SparqlError::Plan(format!(
+        "{op} into named graph <{graph}> is not supported: this endpoint exposes a \
+         single graph per keyspace ('{keyspace}'); named graphs distinct from it \
+         are not addressable (so ADD/MOVE/COPY across graphs cannot be honored)"
+    ))
 }
 
 /// Resolve a `TermPattern` (subject/object position) against a solution into a

--- a/ferrosa-sparql/src/update.rs
+++ b/ferrosa-sparql/src/update.rs
@@ -47,6 +47,15 @@ pub async fn execute_update(
         .parse_update(update_str)
         .map_err(|e| SparqlError::Parse(format!("{e}")))?;
 
+    // SPARQL 1.1 update atomicity (URS-QEC-X01): an update request that errors
+    // must NOT have partially mutated the store. The executor below applies
+    // operations sequentially with no rollback, so we MUST reject the whole
+    // request up-front if ANY operation is unaddressable in this
+    // single-graph-per-keyspace engine. Without this, a desugared
+    // `COPY/MOVE <g> TO DEFAULT` would run its leading `Drop(DEFAULT)` and wipe
+    // the default graph before the later unaddressable named-graph read fails.
+    validate_update(&update, keyspace)?;
+
     let mut total_inserted = 0usize;
     let mut total_deleted = 0usize;
 
@@ -106,6 +115,154 @@ pub async fn execute_update(
         triples_inserted: total_inserted,
         triples_deleted: total_deleted,
     })
+}
+
+/// Validate EVERY operation of a parsed update before any of them runs, so an
+/// update request that contains an unaddressable operation fails loud with zero
+/// mutations (SPARQL 1.1 atomicity / URS-QEC-X01).
+///
+/// This is the single chokepoint that makes the spargebra `COPY/MOVE/ADD`
+/// desugaring safe: those rewrite into a leading `Drop` plus a `DeleteInsert`
+/// that reads from / writes to a named graph this engine cannot address. By
+/// rejecting the whole request here — before the destructive `Drop` executes —
+/// we guarantee no partial side effects.
+fn validate_update(update: &spargebra::Update, keyspace: &str) -> Result<(), SparqlError> {
+    for op in &update.operations {
+        match op {
+            spargebra::GraphUpdateOperation::InsertData { data } => {
+                for quad in data {
+                    check_graph_name(&quad.graph_name, keyspace, "INSERT DATA")?;
+                }
+            }
+            spargebra::GraphUpdateOperation::DeleteData { data } => {
+                for quad in data {
+                    check_graph_name(&quad.graph_name, keyspace, "DELETE DATA")?;
+                }
+            }
+            spargebra::GraphUpdateOperation::DeleteInsert {
+                delete,
+                insert,
+                pattern,
+                ..
+            } => {
+                for tmpl in delete {
+                    check_quad_graph_pattern(&tmpl.graph_name, keyspace, "DELETE")?;
+                }
+                for tmpl in insert {
+                    check_quad_graph_pattern(&tmpl.graph_name, keyspace, "INSERT")?;
+                }
+                // Reject a WHERE clause that reads from a named graph
+                // (`GraphPattern::Graph`), e.g. the COPY/MOVE/ADD source.
+                check_pattern_graph_reads(pattern, keyspace)?;
+            }
+            spargebra::GraphUpdateOperation::Clear { graph, silent }
+            | spargebra::GraphUpdateOperation::Drop { graph, silent } => {
+                check_graph_target(graph, keyspace, *silent)?;
+            }
+            spargebra::GraphUpdateOperation::Load { .. } => {
+                return Err(SparqlError::Plan(
+                    "SPARQL LOAD is not implemented: this endpoint has no RDF \
+                     document fetch/parse pipeline"
+                        .into(),
+                ));
+            }
+            spargebra::GraphUpdateOperation::Create { .. } => {
+                // CREATE is a success no-op (graphs are implicit); nothing to
+                // validate. See the execution loop for the rationale.
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a concrete (`InsertData`/`DeleteData`) quad's graph name.
+fn check_graph_name(
+    graph: &spargebra::term::GraphName,
+    keyspace: &str,
+    op: &str,
+) -> Result<(), SparqlError> {
+    match graph {
+        spargebra::term::GraphName::DefaultGraph => Ok(()),
+        spargebra::term::GraphName::NamedNode(n) if n.as_str() == keyspace => Ok(()),
+        spargebra::term::GraphName::NamedNode(n) => {
+            Err(named_graph_unsupported(op, n.as_str(), keyspace))
+        }
+    }
+}
+
+/// Validate a `CLEAR`/`DROP` target for the atomicity check.
+///
+/// All `CLEAR`/`DROP` targets are *safe* in this engine: `DefaultGraph`,
+/// `NamedGraphs`, and `AllGraphs` resolve to "every triple in this keyspace"
+/// (clearable), a `NamedNode` equal to the keyspace is that same graph, and any
+/// other `NamedNode` simply does not exist here, so `exec_clear` deletes nothing
+/// (a true no-op — it never fakes or mis-targets a deletion, per URS-QEC-X01 and
+/// the M1 `clear_non_matching_named_graph_deletes_nothing` contract).
+///
+/// Because every `CLEAR`/`DROP` is non-destructive-to-other-data, none of them
+/// can violate atomicity, so this validation always passes. It exists so the
+/// up-front pass is exhaustive over operation kinds (and as the place to tighten
+/// non-SILENT semantics later, if the single-graph model ever gains real named
+/// graphs).
+fn check_graph_target(
+    _target: &GraphTarget,
+    _keyspace: &str,
+    _silent: bool,
+) -> Result<(), SparqlError> {
+    Ok(())
+}
+
+/// Recursively reject any `GraphPattern::Graph` reading from a graph other than
+/// the keyspace default graph. Such a named-graph read (produced by the
+/// COPY/MOVE/ADD desugaring, or by an explicit `GRAPH <g> { … }` block in a
+/// WHERE clause) is not addressable here and must fail loud BEFORE any
+/// preceding destructive op runs.
+fn check_pattern_graph_reads(
+    pattern: &spargebra::algebra::GraphPattern,
+    keyspace: &str,
+) -> Result<(), SparqlError> {
+    use spargebra::algebra::GraphPattern as G;
+    match pattern {
+        G::Graph { name, inner } => {
+            match name {
+                NamedNodePattern::NamedNode(n) if n.as_str() == keyspace => {}
+                NamedNodePattern::NamedNode(n) => {
+                    return Err(SparqlError::Plan(format!(
+                        "reading from named graph <{}> is not supported: this endpoint \
+                         exposes a single graph per keyspace ('{keyspace}') — so \
+                         ADD/MOVE/COPY from a named graph cannot be honored",
+                        n.as_str()
+                    )));
+                }
+                NamedNodePattern::Variable(v) => {
+                    return Err(SparqlError::Plan(format!(
+                        "GRAPH ?{} (variable-bound graph read) is not supported: this \
+                         endpoint exposes a single graph per keyspace ('{keyspace}')",
+                        v.as_str()
+                    )));
+                }
+            }
+            check_pattern_graph_reads(inner, keyspace)
+        }
+        G::Bgp { .. } | G::Path { .. } | G::Values { .. } => Ok(()),
+        G::Join { left, right } | G::Union { left, right } | G::Minus { left, right } => {
+            check_pattern_graph_reads(left, keyspace)?;
+            check_pattern_graph_reads(right, keyspace)
+        }
+        G::LeftJoin { left, right, .. } => {
+            check_pattern_graph_reads(left, keyspace)?;
+            check_pattern_graph_reads(right, keyspace)
+        }
+        G::Filter { inner, .. }
+        | G::Extend { inner, .. }
+        | G::OrderBy { inner, .. }
+        | G::Project { inner, .. }
+        | G::Distinct { inner }
+        | G::Reduced { inner }
+        | G::Slice { inner, .. }
+        | G::Group { inner, .. }
+        | G::Service { inner, .. } => check_pattern_graph_reads(inner, keyspace),
+    }
 }
 
 /// Execute `DELETE … INSERT … WHERE` (covers `DELETE WHERE`, where `insert` is

--- a/ferrosa-sparql/tests/sparql_m3_completeness.rs
+++ b/ferrosa-sparql/tests/sparql_m3_completeness.rs
@@ -13,7 +13,6 @@
 //! | URS-QEC-S03 | RDF* eval (silent → fail loud) + SPARQL XML results | annotated var must NOT silently be absent; XML serialization round-trip |
 //! | URS-QEC-S04 | ORDER BY expressions (silent → fail loud) | non-variable ORDER BY must return Err, not silently skip |
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use ferrosa_cluster::write_path::WritePath;
@@ -63,14 +62,6 @@ fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngi
         ..Default::default()
     };
     SparqlEngine::new(storage, write_path, config)
-}
-
-async fn select_count(eng: &SparqlEngine, query: &str) -> usize {
-    match eng.execute(query, KS).await.expect("select must succeed") {
-        SparqlResult::Select(r) => r.results.bindings.len(),
-        SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
-        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
-    }
 }
 
 async fn select_values(eng: &SparqlEngine, query: &str, var: &str) -> Vec<String> {

--- a/ferrosa-sparql/tests/sparql_m3_completeness.rs
+++ b/ferrosa-sparql/tests/sparql_m3_completeness.rs
@@ -1,0 +1,422 @@
+//! M3 completeness tests — URS-QEC-S01/S02/S03/S04.
+//!
+//! RED tests (written before implementation); each must fail until the
+//! corresponding implementation is in place.  Every test documents its
+//! requirement ID and fail-loud expectation.
+//!
+//! ## Summary of requirements
+//!
+//! | ID | What | Fail-loud rule |
+//! |---|---|---|
+//! | URS-QEC-S01 | CONSTRUCT / DESCRIBE query forms | `plan_query` must return Ok for these forms; engine must produce graph output |
+//! | URS-QEC-S02 | Full SPARQL UPDATE beyond M1: INSERT WHERE | INSERT WHERE must persist triples |
+//! | URS-QEC-S03 | RDF* eval (silent → fail loud) + SPARQL XML results | annotated var must NOT silently be absent; XML serialization round-trip |
+//! | URS-QEC-S04 | ORDER BY expressions (silent → fail loud) | non-variable ORDER BY must return Err, not silently skip |
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_sparql::engine::{SparqlConfig, SparqlEngine, SparqlResult};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+};
+use tempfile::TempDir;
+
+const KS: &str = "default";
+
+fn setup() -> (Arc<StorageEngine>, Arc<WritePath>, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let config = StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 4096,
+            max_segment_age: std::time::Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.path().join("commitlog"),
+            checkpoint_dir: dir.path().join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.path().to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let storage = Arc::new(StorageEngine::new(config, None).unwrap());
+    let write_path = Arc::new(WritePath::direct(Arc::clone(&storage)));
+    (storage, write_path, dir)
+}
+
+fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngine {
+    let config = SparqlConfig {
+        default_graph: KS.to_string(),
+        ..Default::default()
+    };
+    SparqlEngine::new(storage, write_path, config)
+}
+
+async fn select_count(eng: &SparqlEngine, query: &str) -> usize {
+    match eng.execute(query, KS).await.expect("select must succeed") {
+        SparqlResult::Select(r) => r.results.bindings.len(),
+        SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
+    }
+}
+
+async fn select_values(eng: &SparqlEngine, query: &str, var: &str) -> Vec<String> {
+    match eng.execute(query, KS).await.expect("select must succeed") {
+        SparqlResult::Select(r) => r
+            .results
+            .bindings
+            .iter()
+            .filter_map(|row| row.get(var).map(|b| b.value.clone()))
+            .collect(),
+        SparqlResult::Ask(_) => panic!("expected SELECT, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT, got Graph"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S01 — CONSTRUCT and DESCRIBE query forms
+// ---------------------------------------------------------------------------
+
+/// S01-a: CONSTRUCT query must succeed and produce graph output (not a Plan error).
+/// The result must serialize without error; the constructed triples must be
+/// present in the serialized graph.
+#[tokio::test]
+async fn construct_query_produces_graph_result() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // Seed some data.
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/alice> <http://ex/name> \"Alice\" . \
+            <http://ex/bob>   <http://ex/name> \"Bob\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    // CONSTRUCT copies matched triples into a new graph template.
+    let result = eng
+        .execute(
+            "CONSTRUCT { ?s <http://ex/name> ?name } \
+             WHERE { ?s <http://ex/name> ?name }",
+            KS,
+        )
+        .await
+        .expect("CONSTRUCT must not return a plan error");
+
+    // The result must be a Graph variant (not Select/Ask).
+    match &result {
+        SparqlResult::Graph(triples) => {
+            assert_eq!(triples.len(), 2, "CONSTRUCT must produce 2 triples");
+        }
+        other => panic!("expected SparqlResult::Graph, got {other:?}"),
+    }
+
+    // Must serialize to N-Triples without error.
+    let nt = String::from_utf8(result.to_ntriples()).unwrap();
+    assert!(
+        nt.contains("Alice") || nt.contains("alice"),
+        "serialized CONSTRUCT result must contain Alice: {nt}"
+    );
+}
+
+/// S01-b: DESCRIBE query must succeed and produce graph output for the
+/// described resource.
+#[tokio::test]
+async fn describe_query_produces_graph_result() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/alice> <http://ex/name>  \"Alice\" . \
+            <http://ex/alice> <http://ex/email> \"alice@ex.com\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    let result = eng
+        .execute("DESCRIBE <http://ex/alice>", KS)
+        .await
+        .expect("DESCRIBE must not return a plan error");
+
+    match &result {
+        SparqlResult::Graph(triples) => {
+            assert_eq!(
+                triples.len(),
+                2,
+                "DESCRIBE must return both triples about :alice"
+            );
+        }
+        other => panic!("expected SparqlResult::Graph for DESCRIBE, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S02 — Full SPARQL UPDATE: INSERT … WHERE
+// ---------------------------------------------------------------------------
+
+/// S02: INSERT … WHERE must evaluate the WHERE clause, instantiate the INSERT
+/// template per solution, and persist the resulting triples.  After the
+/// operation a SELECT must return the newly inserted data.
+#[tokio::test]
+async fn insert_where_persists_new_triples() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // Seed: alice is a Person.
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/type> <http://ex/Person> }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    // INSERT WHERE: for every Person, assert they are also a LegalEntity.
+    let res = eng
+        .execute_update(
+            "INSERT { ?s <http://ex/type> <http://ex/LegalEntity> } \
+             WHERE  { ?s <http://ex/type> <http://ex/Person> }",
+            KS,
+        )
+        .await
+        .expect("INSERT WHERE must succeed");
+
+    assert_eq!(res.triples_inserted, 1, "one triple must be inserted");
+
+    // The new triple must now be visible to SELECT.
+    let types = select_values(
+        &eng,
+        "SELECT ?t WHERE { <http://ex/alice> <http://ex/type> ?t }",
+        "t",
+    )
+    .await;
+    assert!(
+        types.iter().any(|t| t.contains("LegalEntity")),
+        "LegalEntity triple must be visible after INSERT WHERE; got: {types:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S03a — RDF* must fail loud (not return inner bindings silently)
+// ---------------------------------------------------------------------------
+
+/// S03-a (URS-QEC-X01): A SPARQL query using RDF* annotation syntax must
+/// return a clear SPARQL protocol error — NOT return inner bindings as if the
+/// annotation variable is simply absent.
+///
+/// Current (broken) behaviour: `evaluate_rdf_star_pattern` logs a warning and
+/// returns the inner bindings with the annotation variable unbound.  That is a
+/// silent wrong result — the caller gets rows that look valid but are missing
+/// the requested annotation data.
+///
+/// Required behaviour: the engine returns `Err(SparqlError::Plan(…))` so the
+/// HTTP layer returns 400 Bad Request, not a silently incomplete 200.
+#[tokio::test]
+async fn rdf_star_annotation_fails_loud_not_silent_wrong_result() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // We don't need stored data — the query itself must fail loud before
+    // hitting storage.
+    let err = eng
+        .execute(
+            "SELECT ?conf WHERE { \
+                << <http://ex/a> <http://ex/link> <http://ex/b> >> \
+                   <http://ex/confidence> ?conf }",
+            KS,
+        )
+        .await
+        .expect_err(
+            "RDF* annotation query must return Err (fail loud), \
+             not Ok with the annotation variable silently absent",
+        );
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("rdf*")
+            || msg.contains("rdf-star")
+            || msg.contains("annotation")
+            || msg.contains("not implemented")
+            || msg.contains("unsupported"),
+        "error must explain that RDF* evaluation is not implemented: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S03b — SPARQL XML results serialization
+// ---------------------------------------------------------------------------
+
+/// S03-b: The engine must support `application/sparql-results+xml` as a
+/// result format.  The serialized output must be well-formed XML containing
+/// the standard `<sparql>` root and `<results>` element with correct bindings.
+#[tokio::test]
+async fn xml_results_serialization_roundtrip() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/name> \"Alice\" }",
+        KS,
+    )
+    .await
+    .expect("insert");
+
+    let result = eng
+        .execute("SELECT ?s ?name WHERE { ?s <http://ex/name> ?name }", KS)
+        .await
+        .expect("select");
+
+    // Serialize to XML.
+    let xml_bytes = result.to_xml().expect("XML serialization must succeed");
+    let xml = String::from_utf8(xml_bytes).expect("XML must be valid UTF-8");
+
+    // Must be well-formed SPARQL Results XML per W3C.
+    assert!(
+        xml.contains("<sparql") || xml.contains("sparql-results"),
+        "XML must contain <sparql> root element: {xml}"
+    );
+    assert!(
+        xml.contains("<results"),
+        "XML must contain <results>: {xml}"
+    );
+    assert!(
+        xml.contains("Alice"),
+        "XML must include the bound literal: {xml}"
+    );
+}
+
+/// S03-b: `ResultFormat::from_accept` must recognise
+/// `application/sparql-results+xml` and route to XML serialization.
+#[test]
+fn result_format_accepts_xml_content_type() {
+    use ferrosa_sparql::results::ResultFormat;
+    let fmt = ResultFormat::from_accept("application/sparql-results+xml");
+    assert_eq!(
+        fmt,
+        ResultFormat::Xml,
+        "Accept: application/sparql-results+xml must select Xml format"
+    );
+    assert_eq!(
+        fmt.content_type(),
+        "application/sparql-results+xml",
+        "Xml format must advertise the correct Content-Type"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S04 — ORDER BY on expressions must fail loud
+// ---------------------------------------------------------------------------
+
+/// S04 (URS-QEC-X01): ORDER BY with a non-variable expression (e.g. a
+/// function call like `STR(?name)`, or an arithmetic expression) must return a
+/// clear SPARQL protocol error, NOT silently skip the ordering and return
+/// results in arbitrary order.
+///
+/// Current (broken) behaviour: `planner.rs` logs a warning and falls through,
+/// silently discarding the ORDER BY clause.  The caller gets results in an
+/// arbitrary, undocumented order with no indication that the requested ordering
+/// was not applied.
+///
+/// Required behaviour: the engine returns `Err(SparqlError::Plan(…))` so the
+/// HTTP layer returns 400 Bad Request, not a silently unordered 200.
+#[tokio::test]
+async fn order_by_expression_fails_loud_not_silent_ignore() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // The query itself must fail loud at planning time regardless of stored data.
+    let err = eng
+        .execute(
+            "SELECT ?s ?name \
+             WHERE  { ?s <http://ex/name> ?name } \
+             ORDER BY STR(?name)",
+            KS,
+        )
+        .await
+        .expect_err(
+            "ORDER BY on a function expression must return Err (fail loud), \
+             not silently ignore the ordering clause and return Ok",
+        );
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("order")
+            || msg.contains("expression")
+            || msg.contains("not implemented")
+            || msg.contains("unsupported"),
+        "error must explain that ORDER BY expressions are not implemented: {msg}"
+    );
+}
+
+/// S04 (positive case): ORDER BY on a plain variable must still work correctly
+/// after the fail-loud change — we must not regress variable-based ordering.
+#[tokio::test]
+async fn order_by_variable_still_works_after_fail_loud_change() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/b> <http://ex/name> \"Berta\" . \
+            <http://ex/a> <http://ex/name> \"Anna\"  . \
+            <http://ex/c> <http://ex/name> \"Carl\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    let names = select_values(
+        &eng,
+        "SELECT ?name WHERE { ?s <http://ex/name> ?name } ORDER BY ?name",
+        "name",
+    )
+    .await;
+
+    assert_eq!(
+        names,
+        vec!["Anna", "Berta", "Carl"],
+        "ascending ORDER BY ?name must sort correctly"
+    );
+}
+
+/// S04 (negative direction): ORDER BY DESC(expression) must also fail loud.
+#[tokio::test]
+async fn order_by_desc_expression_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let err = eng
+        .execute(
+            "SELECT ?s ?name \
+             WHERE  { ?s <http://ex/name> ?name } \
+             ORDER BY DESC(STR(?name))",
+            KS,
+        )
+        .await
+        .expect_err("ORDER BY DESC(expr) must return Err (fail loud)");
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("order")
+            || msg.contains("expression")
+            || msg.contains("not implemented")
+            || msg.contains("unsupported"),
+        "error must mention unsupported ORDER BY expression: {msg}"
+    );
+}

--- a/ferrosa-sparql/tests/sparql_m3_completeness.rs
+++ b/ferrosa-sparql/tests/sparql_m3_completeness.rs
@@ -411,3 +411,182 @@ async fn order_by_desc_expression_fails_loud() {
         "error must mention unsupported ORDER BY expression: {msg}"
     );
 }
+
+/// S03-a (object position, URS-QEC-X01): an RDF* quoted triple in OBJECT
+/// position (`?s :p << ?a :q ?b >>`) must also fail loud. The planner has a
+/// distinct branch for this; without a test it could silently regress to a
+/// FullScan that ignores the embedded triple and returns wrong rows.
+#[tokio::test]
+async fn rdf_star_object_quoted_triple_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let err = eng
+        .execute(
+            "SELECT ?s WHERE { \
+                ?s <http://ex/states> \
+                   << <http://ex/a> <http://ex/link> <http://ex/b> >> }",
+            KS,
+        )
+        .await
+        .expect_err(
+            "RDF* object-position quoted triple must return Err (fail loud), \
+             not a silent scan that drops the embedded triple",
+        );
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("rdf*")
+            || msg.contains("rdf-star")
+            || msg.contains("quoted")
+            || msg.contains("not implemented")
+            || msg.contains("unsupported"),
+        "error must explain the unimplemented RDF* object triple: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// URS-QEC-S03b — XML results for ASK + structural/escaping correctness
+//
+// Part (b) of S03 names BOTH "SELECT/ASK". ASK→XML was implemented but never
+// tested, and the SELECT XML test only string-`contains`-checks the value. The
+// W3C SPARQL 1.1 Query Results XML Format mandates a specific element shape and
+// well-formedness (escaping). These RED tests pin that contract.
+// ---------------------------------------------------------------------------
+
+/// S03-b (ASK): An ASK query serialized to XML must produce the W3C
+/// `<boolean>true</boolean>` form under the `<sparql>` root — not a SELECT-style
+/// `<results>` body. The `false` case must likewise render `<boolean>false</boolean>`.
+#[tokio::test]
+async fn ask_query_xml_serialization_boolean_form() {
+    use ferrosa_sparql::results::ResultFormat;
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/name> \"Alice\" }",
+        KS,
+    )
+    .await
+    .expect("insert");
+
+    // ASK that matches -> true.
+    let yes = eng
+        .execute("ASK { <http://ex/alice> <http://ex/name> ?n }", KS)
+        .await
+        .expect("ask true");
+    assert!(
+        matches!(yes, SparqlResult::Ask(_)),
+        "ASK must produce an Ask result"
+    );
+    let xml = String::from_utf8(
+        yes.serialize(ResultFormat::Xml)
+            .expect("ASK XML serialization must succeed"),
+    )
+    .expect("XML must be valid UTF-8");
+    assert!(
+        xml.contains("<sparql"),
+        "ASK XML must carry the <sparql> root: {xml}"
+    );
+    assert!(
+        xml.contains("<boolean>true</boolean>"),
+        "matching ASK must serialize <boolean>true</boolean>, not a SELECT body: {xml}"
+    );
+    assert!(
+        !xml.contains("<results"),
+        "ASK XML must NOT contain a <results> element: {xml}"
+    );
+
+    // ASK that does not match -> false.
+    let no = eng
+        .execute("ASK { <http://ex/nobody> <http://ex/name> ?n }", KS)
+        .await
+        .expect("ask false");
+    let xml_no = String::from_utf8(
+        no.serialize(ResultFormat::Xml)
+            .expect("ASK XML serialization must succeed"),
+    )
+    .expect("XML must be valid UTF-8");
+    assert!(
+        xml_no.contains("<boolean>false</boolean>"),
+        "non-matching ASK must serialize <boolean>false</boolean>: {xml_no}"
+    );
+}
+
+/// S03-b (SELECT structure): The SELECT XML must use the W3C element shape —
+/// each bound variable wrapped in `<binding name="...">` with a typed leaf
+/// (`<uri>` for IRIs, `<literal>` for literals) — not just the raw value text.
+#[tokio::test]
+async fn select_xml_uses_w3c_binding_element_shape() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/alice> <http://ex/name> \"Alice\" }",
+        KS,
+    )
+    .await
+    .expect("insert");
+
+    let result = eng
+        .execute("SELECT ?s ?name WHERE { ?s <http://ex/name> ?name }", KS)
+        .await
+        .expect("select");
+    let xml = String::from_utf8(result.to_xml().expect("XML serialization")).unwrap();
+
+    // Head must declare the projected variables.
+    assert!(
+        xml.contains("<variable name=\"s\"") && xml.contains("<variable name=\"name\""),
+        "XML <head> must declare each projected <variable>: {xml}"
+    );
+    // The IRI subject binding must be a <uri> leaf inside a named <binding>.
+    assert!(
+        xml.contains("<binding name=\"s\"><uri>http://ex/alice</uri></binding>"),
+        "subject must serialize as <binding name=\"s\"><uri>…</uri></binding>: {xml}"
+    );
+    // The literal object binding must be a <literal> leaf inside a named <binding>.
+    assert!(
+        xml.contains("<binding name=\"name\">") && xml.contains("<literal"),
+        "literal binding must use a <literal> leaf inside <binding name=\"name\">: {xml}"
+    );
+    // Result rows must be wrapped in <result> under <results>.
+    assert!(
+        xml.contains("<results") && xml.contains("<result>"),
+        "rows must be wrapped in <results>/<result>: {xml}"
+    );
+}
+
+/// S03-b (escaping / well-formedness): A literal value containing XML
+/// metacharacters (`<`, `&`, `>`) must be entity-escaped so the output stays
+/// well-formed XML. An unescaped `<` would corrupt the document and is also an
+/// injection vector — the raw substring must NOT appear, but its escaped form must.
+#[tokio::test]
+async fn select_xml_escapes_special_characters_in_literals() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    // Literal value carries '<', '&', '>'.
+    eng.execute_update(
+        "INSERT DATA { <http://ex/a> <http://ex/note> \"a < b & c > d\" }",
+        KS,
+    )
+    .await
+    .expect("insert");
+
+    let result = eng
+        .execute("SELECT ?note WHERE { ?s <http://ex/note> ?note }", KS)
+        .await
+        .expect("select");
+    let xml = String::from_utf8(result.to_xml().expect("XML serialization")).unwrap();
+
+    // The escaped entities must be present.
+    assert!(
+        xml.contains("a &lt; b &amp; c &gt; d"),
+        "literal metacharacters must be entity-escaped: {xml}"
+    );
+    // The raw, unescaped literal payload must NOT leak into the document body.
+    assert!(
+        !xml.contains("a < b & c > d"),
+        "raw unescaped '<'/'&'/'>' must not appear in the XML body (well-formedness): {xml}"
+    );
+}

--- a/ferrosa-sparql/tests/sparql_m3_completeness.rs
+++ b/ferrosa-sparql/tests/sparql_m3_completeness.rs
@@ -11,7 +11,7 @@
 //! | URS-QEC-S01 | CONSTRUCT / DESCRIBE query forms | `plan_query` must return Ok for these forms; engine must produce graph output |
 //! | URS-QEC-S02 | Full SPARQL UPDATE beyond M1: INSERT WHERE | INSERT WHERE must persist triples |
 //! | URS-QEC-S03 | RDF* eval (silent → fail loud) + SPARQL XML results | annotated var must NOT silently be absent; XML serialization round-trip |
-//! | URS-QEC-S04 | ORDER BY expressions (silent → fail loud) | non-variable ORDER BY must return Err, not silently skip |
+//! | URS-QEC-S04 | ORDER BY expressions | non-variable ORDER BY (e.g. `?a + ?b`, `STR(?x)`) must be evaluated per-solution and sort correctly (ASC/DESC), not be silently ignored |
 
 use std::sync::Arc;
 
@@ -311,52 +311,80 @@ fn result_format_accepts_xml_content_type() {
 }
 
 // ---------------------------------------------------------------------------
-// URS-QEC-S04 — ORDER BY on expressions must fail loud
+// URS-QEC-S04 — ORDER BY on expressions (evaluated per-solution, ASC/DESC)
 // ---------------------------------------------------------------------------
 
-/// S04 (URS-QEC-X01): ORDER BY with a non-variable expression (e.g. a
-/// function call like `STR(?name)`, or an arithmetic expression) must return a
-/// clear SPARQL protocol error, NOT silently skip the ordering and return
-/// results in arbitrary order.
+/// S04 (headline): `ORDER BY (?a + ?b) DESC` must evaluate the arithmetic
+/// expression per solution and sort by the resulting sum, descending — not
+/// silently ignore the clause and return rows in arbitrary order.
 ///
-/// Current (broken) behaviour: `planner.rs` logs a warning and falls through,
-/// silently discarding the ORDER BY clause.  The caller gets results in an
-/// arbitrary, undocumented order with no indication that the requested ordering
-/// was not applied.
-///
-/// Required behaviour: the engine returns `Err(SparqlError::Plan(…))` so the
-/// HTTP layer returns 400 Bad Request, not a silently unordered 200.
+/// Data: three subjects with integer (?a, ?b) pairs whose sums are 5, 9, 7.
+/// DESC ordering by (?a + ?b) must yield subjects in sum order 9, 7, 5.
 #[tokio::test]
-async fn order_by_expression_fails_loud_not_silent_ignore() {
+async fn order_by_arithmetic_expression_desc_orders_correctly() {
     let (storage, wp, _dir) = setup();
     let eng = engine(storage, wp);
 
-    // The query itself must fail loud at planning time regardless of stored data.
-    let err = eng
-        .execute(
-            "SELECT ?s ?name \
-             WHERE  { ?s <http://ex/name> ?name } \
-             ORDER BY STR(?name)",
-            KS,
-        )
-        .await
-        .expect_err(
-            "ORDER BY on a function expression must return Err (fail loud), \
-             not silently ignore the ordering clause and return Ok",
-        );
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/x> <http://ex/a> 2 ; <http://ex/b> 3 . \
+            <http://ex/y> <http://ex/a> 4 ; <http://ex/b> 5 . \
+            <http://ex/z> <http://ex/a> 1 ; <http://ex/b> 6 }",
+        KS,
+    )
+    .await
+    .expect("insert data");
 
-    let msg = err.to_string().to_lowercase();
-    assert!(
-        msg.contains("order")
-            || msg.contains("expression")
-            || msg.contains("not implemented")
-            || msg.contains("unsupported"),
-        "error must explain that ORDER BY expressions are not implemented: {msg}"
+    let subjects = select_values(
+        &eng,
+        "SELECT ?s ?a ?b \
+         WHERE { ?s <http://ex/a> ?a ; <http://ex/b> ?b } \
+         ORDER BY DESC(?a + ?b)",
+        "s",
+    )
+    .await;
+
+    // y: 4+5=9, z: 1+6=7, x: 2+3=5
+    assert_eq!(
+        subjects,
+        vec!["http://ex/y", "http://ex/z", "http://ex/x"],
+        "ORDER BY (?a + ?b) DESC must sort by the evaluated sum, descending"
+    );
+}
+
+/// S04 (function expression, ASC): `ORDER BY STR(?name)` must evaluate the
+/// function per solution and sort by its string result ascending.
+#[tokio::test]
+async fn order_by_str_function_expression_orders_correctly() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/b> <http://ex/name> \"Berta\" . \
+            <http://ex/a> <http://ex/name> \"Anna\"  . \
+            <http://ex/c> <http://ex/name> \"Carl\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    let names = select_values(
+        &eng,
+        "SELECT ?name WHERE { ?s <http://ex/name> ?name } ORDER BY STR(?name)",
+        "name",
+    )
+    .await;
+
+    assert_eq!(
+        names,
+        vec!["Anna", "Berta", "Carl"],
+        "ORDER BY STR(?name) must sort by the function result ascending"
     );
 }
 
 /// S04 (positive case): ORDER BY on a plain variable must still work correctly
-/// after the fail-loud change — we must not regress variable-based ordering.
+/// — we must not regress the trivial variable-ordering path.
 #[tokio::test]
 async fn order_by_variable_still_works_after_fail_loud_change() {
     let (storage, wp, _dir) = setup();
@@ -386,29 +414,34 @@ async fn order_by_variable_still_works_after_fail_loud_change() {
     );
 }
 
-/// S04 (negative direction): ORDER BY DESC(expression) must also fail loud.
+/// S04 (function expression, DESC): `ORDER BY DESC(STR(?name))` must evaluate
+/// the function per solution and sort by its string result descending.
 #[tokio::test]
-async fn order_by_desc_expression_fails_loud() {
+async fn order_by_desc_function_expression_orders_correctly() {
     let (storage, wp, _dir) = setup();
     let eng = engine(storage, wp);
 
-    let err = eng
-        .execute(
-            "SELECT ?s ?name \
-             WHERE  { ?s <http://ex/name> ?name } \
-             ORDER BY DESC(STR(?name))",
-            KS,
-        )
-        .await
-        .expect_err("ORDER BY DESC(expr) must return Err (fail loud)");
+    eng.execute_update(
+        "INSERT DATA { \
+            <http://ex/b> <http://ex/name> \"Berta\" . \
+            <http://ex/a> <http://ex/name> \"Anna\"  . \
+            <http://ex/c> <http://ex/name> \"Carl\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
 
-    let msg = err.to_string().to_lowercase();
-    assert!(
-        msg.contains("order")
-            || msg.contains("expression")
-            || msg.contains("not implemented")
-            || msg.contains("unsupported"),
-        "error must mention unsupported ORDER BY expression: {msg}"
+    let names = select_values(
+        &eng,
+        "SELECT ?name WHERE { ?s <http://ex/name> ?name } ORDER BY DESC(STR(?name))",
+        "name",
+    )
+    .await;
+
+    assert_eq!(
+        names,
+        vec!["Carl", "Berta", "Anna"],
+        "ORDER BY DESC(STR(?name)) must sort by the function result descending"
     );
 }
 

--- a/ferrosa-sparql/tests/sparql_update_pattern_delete.rs
+++ b/ferrosa-sparql/tests/sparql_update_pattern_delete.rs
@@ -64,6 +64,7 @@ async fn select_count(eng: &SparqlEngine, query: &str) -> usize {
     match eng.execute(query, KS).await.expect("select must succeed") {
         SparqlResult::Select(r) => r.results.bindings.len(),
         SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
     }
 }
 
@@ -77,6 +78,7 @@ async fn select_values(eng: &SparqlEngine, query: &str, var: &str) -> Vec<String
             .filter_map(|row| row.get(var).map(|b| b.value.clone()))
             .collect(),
         SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
     }
 }
 

--- a/ferrosa-sparql/tests/sparql_update_s02_mgmt.rs
+++ b/ferrosa-sparql/tests/sparql_update_s02_mgmt.rs
@@ -1,0 +1,233 @@
+//! URS-QEC-S02 — Full SPARQL UPDATE graph-management forms beyond M1 deletes
+//! and the already-landed INSERT … WHERE: CREATE, LOAD, and the desugared
+//! ADD / MOVE / COPY operations.
+//!
+//! RED tests (written before implementation). Each documents its requirement
+//! and its fail-loud expectation (URS-QEC-X01): any form this engine does not
+//! genuinely implement must return a SPARQL error, never a silent wrong/empty
+//! result.
+//!
+//! ## Scope decisions (single-graph-per-keyspace model)
+//!
+//! The `rdf_triples` table is keyed `((graph, subject), predicate, object)` but
+//! the engine's read path (FullScan / range_read) does not filter by the graph
+//! partition-key component, and the table id is derived from the keyspace. So
+//! *named graphs distinct from the keyspace's default graph are not addressable*
+//! for reads or writes. Operations that target/read such a named graph MUST
+//! fail loud rather than silently read/write the wrong graph.
+//!
+//! | Form | Behavior |
+//! |---|---|
+//! | `CREATE GRAPH <g>` | success no-op (graphs are implicit; the graph exists after) |
+//! | `LOAD <src> [INTO GRAPH <g>]` | fail loud — no RDF document fetch/parse pipeline |
+//! | `ADD/MOVE/COPY` touching a named graph ≠ keyspace | fail loud — named graph not addressable |
+
+use std::sync::Arc;
+
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_sparql::engine::{SparqlConfig, SparqlEngine};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+};
+use tempfile::TempDir;
+
+const KS: &str = "default";
+
+fn setup() -> (Arc<StorageEngine>, Arc<WritePath>, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let config = StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 4096,
+            max_segment_age: std::time::Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.path().join("commitlog"),
+            checkpoint_dir: dir.path().join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.path().to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let storage = Arc::new(StorageEngine::new(config, None).unwrap());
+    let write_path = Arc::new(WritePath::direct(Arc::clone(&storage)));
+    (storage, write_path, dir)
+}
+
+fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngine {
+    let config = SparqlConfig {
+        default_graph: KS.to_string(),
+        ..Default::default()
+    };
+    SparqlEngine::new(storage, write_path, config)
+}
+
+// ---------------------------------------------------------------------------
+// CREATE — implemented as a success no-op (graphs are implicit).
+// ---------------------------------------------------------------------------
+
+/// S02-create: `CREATE GRAPH <g>` must succeed (graphs are implicit in the
+/// single-graph-per-keyspace model — the graph "exists" after the call).
+#[tokio::test]
+async fn create_graph_succeeds_as_noop() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let res = eng
+        .execute_update("CREATE GRAPH <http://ex/g1>", KS)
+        .await
+        .expect("CREATE GRAPH must succeed");
+    assert_eq!(res.triples_inserted, 0);
+    assert_eq!(res.triples_deleted, 0);
+}
+
+/// S02-create-silent: `CREATE SILENT GRAPH <g>` must also succeed.
+#[tokio::test]
+async fn create_silent_graph_succeeds() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("CREATE SILENT GRAPH <http://ex/g1>", KS)
+        .await
+        .expect("CREATE SILENT GRAPH must succeed");
+}
+
+/// S02-create-then-insert: after CREATE, INSERT DATA into the default graph
+/// still works (CREATE did not corrupt or block subsequent writes).
+#[tokio::test]
+async fn create_then_insert_data_works() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("CREATE GRAPH <http://ex/g1>", KS)
+        .await
+        .expect("create");
+    let res = eng
+        .execute_update(
+            "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+            KS,
+        )
+        .await
+        .expect("insert after create");
+    assert_eq!(res.triples_inserted, 1);
+}
+
+// ---------------------------------------------------------------------------
+// LOAD — fail loud (no RDF document fetch/parse pipeline).
+// ---------------------------------------------------------------------------
+
+/// S02-load: `LOAD <src>` must fail loud — the engine has no HTTP fetch + RDF
+/// parser, so it cannot honor LOAD. It must NOT silently succeed with zero
+/// triples (URS-QEC-X01).
+#[tokio::test]
+async fn load_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    let err = eng
+        .execute_update("LOAD <http://example.org/data.ttl>", KS)
+        .await
+        .expect_err("LOAD must fail loud, not silently succeed");
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("load"),
+        "LOAD error must mention LOAD: got {err}"
+    );
+}
+
+/// S02-load-into: `LOAD <src> INTO GRAPH <g>` must also fail loud.
+#[tokio::test]
+async fn load_into_graph_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "LOAD <http://example.org/data.ttl> INTO GRAPH <http://ex/g>",
+        KS,
+    )
+    .await
+    .expect_err("LOAD INTO GRAPH must fail loud");
+}
+
+// ---------------------------------------------------------------------------
+// ADD / MOVE / COPY — must NOT silently write to / read from the wrong graph.
+// spargebra desugars these into DeleteInsert (+ Drop). When the desugaring
+// touches a named graph ≠ keyspace, the engine must fail loud rather than
+// silently operate on the default graph.
+// ---------------------------------------------------------------------------
+
+/// S02-copy-named-target: `COPY DEFAULT TO <g>` desugars to an INSERT whose
+/// target QuadPattern graph is the named graph `<g>`. Since `<g>` is not
+/// addressable, this must fail loud — NOT silently write the triples back into
+/// the default graph (which would be a silent wrong result).
+#[tokio::test]
+async fn copy_to_named_graph_fails_loud_not_silent_default_write() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+        KS,
+    )
+    .await
+    .expect("seed");
+
+    let err = eng
+        .execute_update("COPY DEFAULT TO <http://ex/g2>", KS)
+        .await
+        .expect_err("COPY to a named graph must fail loud, not silently no-op into default");
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("graph"),
+        "error must explain the named-graph limitation: got {err}"
+    );
+}
+
+/// S02-copy-named-source: `COPY <g1> TO DEFAULT` desugars to a DeleteInsert
+/// whose WHERE pattern reads from named graph `<g1>` (GraphPattern::Graph).
+/// Reading a non-default named graph is unsupported and must fail loud.
+#[tokio::test]
+async fn copy_from_named_graph_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("COPY <http://ex/g1> TO DEFAULT", KS)
+        .await
+        .expect_err("COPY from a named graph must fail loud (named graph not readable)");
+}
+
+/// S02-add-named: `ADD DEFAULT TO <g>` must fail loud for the same reason as
+/// COPY (named insert target).
+#[tokio::test]
+async fn add_to_named_graph_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("ADD DEFAULT TO <http://ex/g>", KS)
+        .await
+        .expect_err("ADD to a named graph must fail loud");
+}
+
+/// S02-move-named: `MOVE DEFAULT TO <g>` must fail loud (it desugars to
+/// Drop(<g>) + copy into <g> + Drop(default); the copy into the named graph is
+/// not addressable).
+#[tokio::test]
+async fn move_to_named_graph_fails_loud() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("MOVE DEFAULT TO <http://ex/g>", KS)
+        .await
+        .expect_err("MOVE to a named graph must fail loud");
+}

--- a/ferrosa-sparql/tests/sparql_update_s02_mgmt.rs
+++ b/ferrosa-sparql/tests/sparql_update_s02_mgmt.rs
@@ -73,6 +73,19 @@ fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngi
     SparqlEngine::new(storage, write_path, config)
 }
 
+/// Count the triples currently visible in the default graph via a SELECT, so a
+/// fail-loud update can be proven to have left pre-existing data untouched.
+async fn default_graph_triple_count(eng: &SparqlEngine) -> usize {
+    let res = eng
+        .execute("SELECT ?s ?p ?o WHERE { ?s ?p ?o }", KS)
+        .await
+        .expect("scan default graph");
+    match res {
+        ferrosa_sparql::engine::SparqlResult::Select(r) => r.results.bindings.len(),
+        other => panic!("expected SELECT result, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // CREATE — implemented as a success no-op (graphs are implicit).
 // ---------------------------------------------------------------------------
@@ -205,6 +218,67 @@ async fn copy_from_named_graph_fails_loud() {
     eng.execute_update("COPY <http://ex/g1> TO DEFAULT", KS)
         .await
         .expect_err("COPY from a named graph must fail loud (named graph not readable)");
+}
+
+/// S02-copy-named-source-atomic: `COPY <g1> TO DEFAULT` desugars to
+/// `[Drop(DEFAULT), DeleteInsert(read <g1> -> insert DEFAULT)]`. The first op
+/// would clear the default graph; the second is unaddressable and must fail
+/// loud. SPARQL 1.1 update atomicity (and URS-QEC-X01) require that an update
+/// request which errors leaves the store UNMUTATED — so the seeded default-graph
+/// triple MUST survive. A naive sequential executor would run the Drop first and
+/// destroy the data before failing, which is a silent destructive side effect.
+#[tokio::test]
+async fn copy_from_named_graph_is_atomic_default_survives() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+        KS,
+    )
+    .await
+    .expect("seed");
+    assert_eq!(default_graph_triple_count(&eng).await, 1, "seed visible");
+
+    eng.execute_update("COPY <http://ex/g1> TO DEFAULT", KS)
+        .await
+        .expect_err("COPY from a named graph must fail loud (named graph not readable)");
+
+    // The pre-existing default-graph data must be intact: the failing update
+    // must not have run its (desugared) Drop(DEFAULT) op.
+    assert_eq!(
+        default_graph_triple_count(&eng).await,
+        1,
+        "default graph must survive a failed COPY/MOVE-from-named (update atomicity)"
+    );
+}
+
+/// S02-move-named-source-atomic: `MOVE <g1> TO DEFAULT` desugars to
+/// `[Drop(DEFAULT), DeleteInsert(read <g1> -> DEFAULT), Drop(<g1>)]`. Same
+/// atomicity requirement as COPY: the unaddressable named-graph read must make
+/// the whole request fail loud BEFORE the leading Drop(DEFAULT) destroys data.
+#[tokio::test]
+async fn move_from_named_graph_is_atomic_default_survives() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+        KS,
+    )
+    .await
+    .expect("seed");
+    assert_eq!(default_graph_triple_count(&eng).await, 1, "seed visible");
+
+    eng.execute_update("MOVE <http://ex/g1> TO DEFAULT", KS)
+        .await
+        .expect_err("MOVE from a named graph must fail loud");
+
+    assert_eq!(
+        default_graph_triple_count(&eng).await,
+        1,
+        "default graph must survive a failed MOVE-from-named (update atomicity)"
+    );
 }
 
 /// S02-add-named: `ADD DEFAULT TO <g>` must fail loud for the same reason as


### PR DESCRIPTION
Carries **both** query-engine milestone 3 (full SPARQL 1.1) and milestone 4 (full openCypher), stacked on #120 (M2).

> Note: M3 originally had its own PR (#121), but a merge-order slip phantom-merged #121 into #120's branch instead of main and GitHub auto-deleted its branch. The M3 commits are preserved and rebased here; #121 can be disregarded (its work lives in these commits).

**M3 (SPARQL):** CONSTRUCT/DESCRIBE, INSERT…WHERE on the shared StorageEngine path, up-front UPDATE atomicity validation, SPARQL XML results, ORDER BY expressions; all unimplemented forms fail loud.
**M4 (openCypher):** UNION semantics, list/map/pattern comprehensions, FOREACH, correlated CALL{} subqueries, aggregation null-handling fixes.

Merge order: **#120 (M2) first, then this.**