### PR TITLE
fix(accord): complete LWT production data path — kill the phantom write

### DIFF
--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -595,6 +595,34 @@ impl AccordStateMachine {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Production wiring: construct a state machine with a real storage applier
+// ---------------------------------------------------------------------------
+
+/// Build the production [`AccordStateMachine`] wired to durably persist
+/// applied LWT mutations to the live
+/// [`StorageEngine`](ferrosa_storage::engine::StorageEngine).
+///
+/// This is the single construction seam used by the cluster controller
+/// (`controller/cluster.rs`). It wires an
+/// [`EngineStorageApplier`](crate::accord::apply::EngineStorageApplier) so that
+/// `handle_apply` writes the row to storage BEFORE marking the transaction
+/// `Applied` — closing the production phantom-write gap
+/// (`bug-accord-lwt-acks-phantom-write.md`), where a replica recorded
+/// `(txn_id, t)` and returned `ApplyOK` while nothing was persisted.
+///
+/// `node_id` is the Accord node identifier, `sync_writer` the protocol-log
+/// fsync writer, and `storage` the live engine handle whose write/batch path
+/// the applier persists through.
+pub fn build_accord_state_machine(
+    node_id: u64,
+    sync_writer: Arc<dyn SyncWriter>,
+    storage: Arc<ferrosa_storage::engine::StorageEngine>,
+) -> AccordStateMachine {
+    let applier = Arc::new(crate::accord::apply::EngineStorageApplier::new(storage));
+    AccordStateMachine::with_applier(node_id, sync_writer, applier)
+}
+
 // Helper extension for TxnPhase to expose rank for comparison.
 trait TxnPhaseExt {
     fn rank(&self) -> u8;
@@ -1788,6 +1816,182 @@ mod tests {
         assert!(
             sm.get_state(&applied).is_none(),
             "applied transaction must be pruned"
+        );
+    }
+}
+
+// ===========================================================================
+// Production-wiring tests — the state machine built for production
+// (`build_accord_state_machine`) MUST durably persist an applied LWT mutation
+// to the live StorageEngine. This is the headline proof that the PRODUCTION
+// construction path (controller/cluster.rs) is not a phantom write: a replica
+// that returns ApplyOK must have actually written the row.
+//
+// These tests exercise the SAME factory the controller calls (not just the
+// apply unit seam covered in apply.rs), driving a real serialized commit-log
+// Mutation through the full PreAccept -> Accept -> Commit -> Apply lifecycle
+// and then reading the row back through the engine.
+// ===========================================================================
+
+#[cfg(test)]
+mod production_wiring_tests {
+    use super::*;
+    use ferrosa_common::accord::{BallotNumber, Timestamp, TxnId};
+    use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+    use ferrosa_common::{CellValue, DecoratedKey, PartitionKey};
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+    use ferrosa_storage::accord::sync_writer::MockSyncWriter;
+    use ferrosa_storage::engine::StorageEngine;
+    use ferrosa_storage::{Mutation, StorageEngineConfig, TableId};
+
+    const KS: &str = "lwt_ks";
+    const TABLE: &str = "lwt_table";
+
+    fn ts(micros: u64) -> Timestamp {
+        Timestamp::synthetic(micros)
+    }
+
+    fn txn(src: u64, micros: u64) -> TxnId {
+        TxnId::new(src, ts(micros))
+    }
+
+    fn test_schema() -> TableSchema {
+        TableSchema {
+            keyspace: KS.to_string(),
+            table: TABLE.to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![ColumnDefinition {
+                name: "ck".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+            }],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "val".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: Default::default(),
+        }
+    }
+
+    fn make_engine() -> (Arc<StorageEngine>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        (Arc::new(engine), dir)
+    }
+
+    fn make_key(s: &str) -> DecoratedKey {
+        DecoratedKey::new(PartitionKey::new(s.as_bytes().to_vec()))
+    }
+
+    fn make_row(value: &[u8], cell_ts: i64) -> Row {
+        Row {
+            clustering: vec![0x00, 0x00, 0x00, 0x01],
+            cells: vec![(0, CellValue::live(value.to_vec(), cell_ts))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(cell_ts),
+        }
+    }
+
+    /// Serialize a commit-log `Mutation` — the apply-payload wire format the
+    /// production applier decodes.
+    fn serialized_mutation(key: DecoratedKey, value: &[u8], cell_ts: i64) -> Vec<u8> {
+        let m = Mutation::new(
+            KS.to_string(),
+            TABLE.to_string(),
+            key,
+            vec![make_row(value, cell_ts)],
+            cell_ts,
+        );
+        let mut buf = vec![0u8; m.serialized_size()];
+        m.serialize_into(&mut buf);
+        buf
+    }
+
+    fn read_cell0(engine: &StorageEngine, key: &DecoratedKey) -> Option<Vec<u8>> {
+        let partition = engine.read(&TableId::new(KS, TABLE), key).unwrap()?;
+        let row = partition.rows.first()?;
+        row.cells.first().and_then(|(_, c)| c.value.clone())
+    }
+
+    /// RED (inc6 / task #31): the PRODUCTION state machine built by
+    /// `build_accord_state_machine` must durably persist an applied LWT to the
+    /// live engine. With the old wiring (`AccordStateMachine::new`, a
+    /// `NoopStorageApplier`) `handle_apply` records `(txn_id, t)` and returns
+    /// without writing the row — the engine read below returns `None` and this
+    /// assertion FAILS. With the engine-backed applier it persists and the row
+    /// is readable: the phantom write is gone.
+    #[test]
+    fn production_state_machine_persists_applied_lwt_to_engine() {
+        let (engine, _dir) = make_engine();
+
+        // Build EXACTLY as the controller does: the production factory.
+        let writer = Arc::new(MockSyncWriter::new());
+        let mut sm = build_accord_state_machine(7, writer, engine.clone());
+
+        let key = make_key("pk-prod");
+        let txn_id = txn(1, 1000);
+        let t0 = ts(1000);
+        let t = ts(1001);
+        let payload = serialized_mutation(key.clone(), b"durable", 1001);
+
+        // Full lifecycle to Apply, carrying the real serialized mutation.
+        sm.handle_preaccept(txn_id, t0, key.key.as_bytes(), BallotNumber(0), 0);
+        sm.handle_accept(txn_id, t0, t, vec![], BallotNumber(1));
+        sm.handle_commit(txn_id, t0, t, vec![]);
+        sm.handle_apply(txn_id, payload);
+
+        // The replica returned (would return) ApplyOK only after marking Applied;
+        // Applied is reached ONLY if the engine write succeeded. Prove the row is
+        // actually durable and readable — not a phantom write.
+        assert_eq!(
+            sm.get_state(&txn_id).map(|s| s.phase),
+            Some(TxnPhase::Applied),
+            "production apply must reach Applied (engine write succeeded)"
+        );
+        assert_eq!(
+            read_cell0(&engine, &key).as_deref(),
+            Some(b"durable".as_slice()),
+            "applied LWT must be durably persisted + readable via the engine — \
+             the production phantom write must be gone"
+        );
+    }
+
+    /// Fail loud: if the production applier cannot persist (target table not
+    /// registered), `handle_apply` must NOT advance to Applied — so the replica
+    /// does NOT emit a spurious ApplyOK for a write that never landed.
+    #[test]
+    fn production_apply_failure_does_not_fake_applied() {
+        let (engine, _dir) = make_engine();
+        let writer = Arc::new(MockSyncWriter::new());
+        let mut sm = build_accord_state_machine(7, writer, engine.clone());
+
+        let key = make_key("pk-missing-table");
+        let txn_id = txn(2, 2000);
+        let t0 = ts(2000);
+        let t = ts(2001);
+
+        // Mutation targets a table that was never registered on the engine.
+        let m = Mutation::new(
+            KS.to_string(),
+            "unregistered_table".to_string(),
+            key.clone(),
+            vec![make_row(b"x", 2001)],
+            2001,
+        );
+        let mut payload = vec![0u8; m.serialized_size()];
+        m.serialize_into(&mut payload);
+
+        sm.handle_preaccept(txn_id, t0, key.key.as_bytes(), BallotNumber(0), 0);
+        sm.handle_accept(txn_id, t0, t, vec![], BallotNumber(1));
+        sm.handle_commit(txn_id, t0, t, vec![]);
+        sm.handle_apply(txn_id, payload);
+
+        assert_ne!(
+            sm.get_state(&txn_id).map(|s| s.phase),
+            Some(TxnPhase::Applied),
+            "a failed engine apply must NOT mark the txn Applied (no fake ApplyOK)"
         );
     }
 }

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -1108,7 +1108,7 @@ impl ModeController {
         let accord_state_for_maintenance;
         {
             use crate::accord::handlers::{AccordHandler, AccordState};
-            use crate::accord::state_machine::AccordStateMachine;
+            use crate::accord::state_machine::build_accord_state_machine;
             use ferrosa_storage::accord::sync_writer::FileSyncWriter;
 
             let accord_dir = std::env::var("FERROSA_DATA_DIR")
@@ -1125,9 +1125,18 @@ impl ModeController {
                 }
             };
             let sync_writer = Arc::new(FileSyncWriter::new(accord_dir));
-            let accord_state: AccordState = Arc::new(parking_lot::Mutex::new(
-                AccordStateMachine::new(uuid_to_node_id(self.local_host_id), sync_writer),
-            ));
+            // Wire the live StorageEngine into the Accord state machine so an
+            // applied LWT is durably persisted BEFORE the replica returns
+            // ApplyOK — closing the production phantom-write gap
+            // (bug-accord-lwt-acks-phantom-write.md). Previously this used
+            // `AccordStateMachine::new`, which carries a NoopStorageApplier:
+            // a replica recorded (txn_id, t) and acked while nothing landed.
+            let accord_state: AccordState =
+                Arc::new(parking_lot::Mutex::new(build_accord_state_machine(
+                    uuid_to_node_id(self.local_host_id),
+                    sync_writer,
+                    self.storage.clone(),
+                )));
             accord_state_for_maintenance = accord_state.clone();
 
             let accord_handler = Arc::new(AccordHandler::new(


### PR DESCRIPTION
## Summary

Kills the **production phantom write** in the Accord LWT data path — the P0 silent-data-loss bug in \`specs/bug-accord-lwt-acks-phantom-write.md\`. A real replica used to record \`(txn_id, t)\`, advance to \`Applied\`, and let the coordinator count F+1 and return \`[applied]=true\` to the client **while nothing was persisted to the \`StorageEngine\`**.

**DRAFT** — the headline phantom-write fix and the full write path are landed and green; the generic \`IF col=val\` evaluation path (#30) and its end-to-end cluster proof are deliberately **not** in this PR (see *Deferred / where this stops*). Per fail-loud policy I am not claiming green on a hand-written read-at-timestamp seam without an e2e linearizability proof.

## What landed (green)

Increments 1–4 + 6 of \`specs/todo/accord-lwt-real-data-path-plan.md\`:

- **Real persist seam** in \`AccordStateMachine::handle_apply\` — \`applier: Arc<dyn StorageApplier>\` (constructors default to \`NoopStorageApplier\`; \`with_applier\` for prod). Persist-before-Applied: the row is written **before** the txn advances to \`Applied\` / the coordinator gets \`ApplyOK\`.
- **\`EngineStorageApplier\`** — decodes \`ApplyMutation.data\` as a self-describing commit-log \`Mutation\` and persists via \`StorageEngine::apply_batch\` (atomic preflight, no partial apply). Idempotent on \`(txn_id, t)\`.
- **Linearizability fix (lost-update):** LWT cells are re-stamped to the **Accord-agreed HLC \`t\`**, never the coordinator's materialize-time wall clock — so LWW resolves *with* Accord's total order even under coordinator clock skew. Cross-crate serialize↔persist roundtrip test.
- **Real key + mutation flow:** \`route_lwt_via_accord\` extracts the real \`DecoratedKey\` and serializes the mutation from the AST; threaded through the coordinator Apply payload (\`result_data\` = encoded mutation, replacing the \`b\"lwt-placeholder-key\"\` stub).
- **Production wiring (closes #31):** \`build_accord_state_machine(node_id, sync_writer, storage)\` is the single production construction seam, wiring \`EngineStorageApplier(storage)\` into \`controller/cluster.rs\` (was \`NoopStorageApplier\` — the live phantom write). RED-first \`production_wiring_tests\` drive a real serialized \`Mutation\` through the production factory + full PreAccept→Accept→Commit→Apply and assert (a) the applied LWT is durably readable via the engine, and (b) a **failed** engine apply does NOT advance to \`Applied\` (no fake \`ApplyOK\`). Audited all other \`AccordStateMachine::new\` sites — all test/bench-only.

## What this closes

- **#31** Accord LWT production startup wiring — closed.
- The **production phantom write** (the live silent-data-loss path) in \`specs/bug-accord-lwt-acks-phantom-write.md\` — the headline correctness defect. The bug spec is **not fully closed** until #30 + e2e land (see below).

## Deferred / where this stops (NOT in this PR)

- **#30 — generic \`IF col=val\` evaluation across replicas.** The replica-side \`read_condition_holds_at\` still infers existence from the in-memory \`conflict_index\` (correct for \`INSERT IF NOT EXISTS\`), and \`ReadVotePayload\` carries only the partition key — no \`(col, op, val)\` predicate, and \`ReadVoteOkPayload.current_row\` is never populated from storage. Implementing a generic \`IF\` correctly requires a **new linearizable read seam**: the replica must read the actual stored row from \`StorageEngine\` at the agreed \`t\` **after dep-wait**, evaluate the predicate with the same semantics as the local LWT path (\`accord_router::eval_if_conditions\`), and return the real current-row bytes. Getting the read-timestamp ordering wrong reintroduces a non-linearizable read / lost-update. I am not shipping that seam without an e2e proof.
- **e2e (#7) — \`UPDATE … IF col=val\` + node-restart durability through the production applier.** The existing \`accord_lwt_concurrent.rs\` (3 tests, green) proves protocol-level concurrency + read-vote/apply round-trip for \`INSERT IF NOT EXISTS\`, but runs the protocol state machines without a live \`StorageEngine\` — it does **not** exercise \`EngineStorageApplier\` end-to-end, nor generic \`IF\`, nor restart durability. The headline e2e proof that the phantom write is gone through the real wiring is still owed.

These two are the distributed-linearizability correctness core; per fail-loud policy they are tracked, not faked.

## Green gate

\`cargo fmt --check\`, \`cargo clippy -p ferrosa-cluster -p ferrosa-cql --all-targets\`, \`cargo test -p ferrosa-cluster -p ferrosa-cql\` (220 accord lib + 3 e2e + 929 cql, all pass), and the workspace doc gate \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --workspace\` — all green. Rebased on \`origin/main\`.