### PR TITLE
fix(accord): generic IF col=val via linearizable read-at-t + e2e — closes the LWT phantom-write spec

### DIFF
--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -82,6 +82,157 @@ pub trait StorageApplier: Send + Sync + 'static {
 }
 
 // ---------------------------------------------------------------------------
+// StorageReader trait — linearizable read-at-t seam (symmetric to StorageApplier)
+// ---------------------------------------------------------------------------
+
+/// Error reading a row for the linearizable IF-condition read-vote.
+#[derive(Debug, Clone)]
+pub struct RowReadError {
+    pub reason: String,
+}
+
+impl std::fmt::Display for RowReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "read-at-t failed: {}", self.reason)
+    }
+}
+
+impl std::error::Error for RowReadError {}
+
+/// Storage integration seam for the linearizable read-at-`t` that backs the
+/// Accord IF-condition read-vote (Gap 4), symmetric to [`StorageApplier`].
+///
+/// A replica calls [`read_row_at`](StorageReader::read_row_at) during
+/// `ReadVote` handling, **after** dep-wait has applied every dependency
+/// `t' < t`. Because the apply seam re-stamps cells to the agreed `t` and every
+/// conflicting earlier transaction is already Applied, the engine's current
+/// state for the key is exactly the row state "as of `t`" — so reading the
+/// live row is the linearizable read-at-`t`.
+///
+/// The returned bytes are a serialized single-row commit-log
+/// [`Mutation`] (the same self-describing format the
+/// applier consumes). `Ok(None)` means the row does not exist at `t`. Returning
+/// the *raw* row — rather than a CQL-decoded value — keeps this seam in
+/// `ferrosa-cluster` (which has no CQL schema): the coordinator, which owns the
+/// table metadata, decodes and evaluates the predicate with the canonical
+/// `eval_if_conditions`, so no divergent evaluator is forked.
+pub trait StorageReader: Send + Sync + 'static {
+    /// Read the current row for `(keyspace, table, key)` as of the agreed
+    /// execution timestamp `t`.
+    ///
+    /// Returns the serialized single-partition [`Mutation`] bytes (decodable by
+    /// the coordinator), or `Ok(None)` if no live row exists at `t`.
+    fn read_row_at(
+        &self,
+        keyspace: &str,
+        table: &str,
+        key: &[u8],
+        t: Timestamp,
+    ) -> Result<Option<Vec<u8>>, RowReadError>;
+}
+
+// ---------------------------------------------------------------------------
+// EngineStorageReader — real read-at-t via StorageEngine
+// ---------------------------------------------------------------------------
+
+/// Production [`StorageReader`] backed by the live [`StorageEngine`].
+///
+/// Reads the current partition for the key and, if any live row exists, returns
+/// it serialized as a single-partition [`Mutation`] (keyspace/table/key/rows).
+/// The read is the linearizable read-at-`t`: see [`StorageReader`] for why the
+/// engine's current state equals the state as of `t` when called after dep-wait.
+pub struct EngineStorageReader {
+    engine: Arc<StorageEngine>,
+}
+
+impl EngineStorageReader {
+    /// Create a reader backed by the live storage engine.
+    pub fn new(engine: Arc<StorageEngine>) -> Self {
+        Self { engine }
+    }
+}
+
+impl StorageReader for EngineStorageReader {
+    fn read_row_at(
+        &self,
+        keyspace: &str,
+        table: &str,
+        key: &[u8],
+        t: Timestamp,
+    ) -> Result<Option<Vec<u8>>, RowReadError> {
+        use ferrosa_common::{DecoratedKey, PartitionKey};
+        use ferrosa_storage::TableId;
+
+        let table_id = TableId::new(keyspace, table);
+        let decorated = DecoratedKey::new(PartitionKey::new(key.to_vec()));
+
+        let partition = self
+            .engine
+            .read(&table_id, &decorated)
+            .map_err(|e| RowReadError {
+                reason: format!("engine read for {keyspace}.{table} failed: {e}"),
+            })?;
+
+        let partition = match partition {
+            None => return Ok(None),
+            Some(p) => p,
+        };
+
+        // Keep only cells written at or before the agreed `t` — the row state
+        // "as of t". Cells are stamped at the agreed execution timestamp by the
+        // apply seam, so `t.time` is the correct upper bound for what this LWT
+        // is allowed to observe. (After dep-wait, no conflicting cell with
+        // ts >= t.time exists, but bounding here is defensive and keeps the read
+        // honestly as-of-t even if the engine merged a concurrent unrelated cell.)
+        let cell_ts_bound = i64::try_from(t.time).unwrap_or(i64::MAX);
+        let rows: Vec<ferrosa_sstable::types::Row> = partition
+            .rows
+            .into_iter()
+            .filter_map(|mut row| {
+                row.cells
+                    .retain(|(_, cell)| cell.timestamp <= cell_ts_bound);
+                // Drop a row that has no surviving live cell AND no live PK
+                // liveness (it did not exist at `t`).
+                let has_live_cell = row.cells.iter().any(|(_, c)| c.value.is_some());
+                let has_pk_liveness = row.primary_key_liveness.has_timestamp()
+                    && row.primary_key_liveness.timestamp <= cell_ts_bound;
+                if has_live_cell || has_pk_liveness {
+                    Some(row)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        // Serialize as a single-partition Mutation so the coordinator can decode
+        // it with the same machinery it uses for the apply mutation.
+        //
+        // DETERMINISM: use the legacy-zero `mutation_id` (NOT a fresh UUID v4
+        // from `Mutation::new`). Read-vote bytes are compared across replicas for
+        // F+1 agreement; a per-instance random id would make identical row state
+        // serialize to different bytes and break the agreement (hence
+        // linearizability). The id is only a write-dedup marker, irrelevant to a
+        // read snapshot.
+        let cell_ts = i64::try_from(t.time).unwrap_or(i64::MAX);
+        let mutation = Mutation {
+            mutation_id: [0u8; 16],
+            keyspace: keyspace.to_string(),
+            table: table.to_string(),
+            key: decorated,
+            rows,
+            timestamp: cell_ts,
+        };
+        let mut buf = vec![0u8; mutation.serialized_size()];
+        mutation.serialize_into(&mut buf);
+        Ok(Some(buf))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // NoopStorageApplier — used in tests and when storage is not wired
 // ---------------------------------------------------------------------------
 
@@ -869,6 +1020,85 @@ mod engine_applier_tests {
             read_cell0_ts(&engine, &key),
             Some(42),
             "cell timestamp must be re-stamped to the agreed t, not the wall clock"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // StorageReader / EngineStorageReader: linearizable read-at-t.
+    //
+    // The reader is symmetric to the applier: a replica calls read_row_at
+    // during ReadVote (after dep-wait), and the coordinator decodes the
+    // returned Mutation bytes to evaluate the generic IF predicate.
+    // -----------------------------------------------------------------------
+
+    fn decode_cell0(bytes: &[u8]) -> Option<Vec<u8>> {
+        let m = Mutation::deserialize_from(bytes).expect("reader bytes must decode as a Mutation");
+        let row = m.rows.first()?;
+        row.cells.first().and_then(|(_, c)| c.value.clone())
+    }
+
+    #[test]
+    fn read_row_at_returns_none_for_absent_row() {
+        let (engine, _dir) = make_engine();
+        let reader = EngineStorageReader::new(engine);
+
+        let got = reader
+            .read_row_at(KS, TABLE, b"missing", accord_ts(1000))
+            .expect("read must succeed");
+        assert!(got.is_none(), "absent row must read as None at t");
+    }
+
+    #[test]
+    fn read_row_at_returns_serialized_row_when_present() {
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine.clone());
+        let reader = EngineStorageReader::new(engine.clone());
+
+        let key = make_key("pk1");
+        let t = accord_ts(1000);
+        applier
+            .apply(
+                txn(1, 1000),
+                encoded_mutation(key.clone(), b"hello", 1000, t, vec![]),
+            )
+            .unwrap();
+
+        let bytes = reader
+            .read_row_at(KS, TABLE, b"pk1", accord_ts(1000))
+            .expect("read must succeed")
+            .expect("row written at t must be visible to read_row_at");
+        assert_eq!(
+            decode_cell0(&bytes).as_deref(),
+            Some(b"hello".as_slice()),
+            "read_row_at must return the row that was applied at t"
+        );
+    }
+
+    #[test]
+    fn read_row_at_excludes_cells_written_after_t() {
+        // A cell written at a HIGHER agreed t must NOT be visible to a read at a
+        // lower t — the read is honestly as-of-t (defensive bound).
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine.clone());
+        let reader = EngineStorageReader::new(engine.clone());
+
+        let key = make_key("pk1");
+        // Write at agreed t=2000 (cell stamped 2000 by the applier).
+        applier
+            .apply(
+                txn(1, 2000),
+                encoded_mutation(key.clone(), b"future", 5_000, accord_ts(2000), vec![]),
+            )
+            .unwrap();
+
+        // Read as of t=1000 — the future write (cell ts 2000) is excluded, so
+        // the row reads as absent.
+        let got = reader
+            .read_row_at(KS, TABLE, b"pk1", accord_ts(1000))
+            .expect("read must succeed");
+        assert!(
+            got.is_none(),
+            "a cell written at a later agreed t must not be visible to a read at an earlier t"
         );
     }
 }

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -426,6 +426,46 @@ pub struct AccordCoordinatorDriver {
     /// for Accord conflict ordering). An empty vector means "no mutation"
     /// (read-only / protocol-only transactions).
     mutation: Vec<u8>,
+    /// How replicas should answer the Gap-4 read-vote: existence semantics for
+    /// `INSERT IF NOT EXISTS` (the default) or a generic read-row-at-`t` whose
+    /// IF predicate this coordinator evaluates after collecting F+1 agreed rows.
+    read_predicate: crate::accord::wire::ReadPredicate,
+    /// For a generic `IF` read-vote: the row bytes that F+1 replicas agreed on at
+    /// `t`, captured during the read phase so the router can decode and evaluate
+    /// the predicate. `None` when the read-vote returned no row (row absent at
+    /// `t`) or for the existence path. Read via [`Self::last_read_row`].
+    last_read_row: Option<Vec<u8>>,
+    /// Optional reader for the coordinator's OWN replica, used by the generic
+    /// `IF` read-vote so the coordinator's local read-at-`t` counts toward F+1
+    /// agreement (its self-send is not reachable over the network). Set via
+    /// [`Self::with_local_reader`]; `None` falls back to remote votes only.
+    local_reader: Option<Arc<dyn crate::accord::apply::StorageReader>>,
+    /// Optional applier for the coordinator's OWN replica. The coordinator's
+    /// self-send Apply RPC is unreachable, so without this its own node never
+    /// persists the mutations it coordinates (a silent data-loss / read-skew
+    /// hazard, and it makes the coordinator's local generic-`IF` read disagree
+    /// with the replicas that did apply). When set, the coordinator applies the
+    /// committed mutation locally during the Apply phase. Set via
+    /// [`Self::with_local_applier`].
+    local_applier: Option<Arc<dyn crate::accord::apply::StorageApplier>>,
+}
+
+/// Return the row bytes that at least `quorum` of `reads` agree on, if any.
+///
+/// All collected reads must be the SAME bytes for the read to be linearizable:
+/// any divergence means replicas disagree on the row state at `t`, which is a
+/// correctness failure. Returns `Some(bytes)` only when `reads.len() >= quorum`
+/// and every read is identical; `None` otherwise (caller aborts).
+fn agreed_row(reads: &[Vec<u8>], quorum: usize) -> Option<Vec<u8>> {
+    if reads.len() < quorum {
+        return None;
+    }
+    let first = &reads[0];
+    if reads.iter().all(|r| r == first) {
+        Some(first.clone())
+    } else {
+        None
+    }
 }
 
 impl AccordCoordinatorDriver {
@@ -477,7 +517,61 @@ impl AccordCoordinatorDriver {
             replica_ids,
             self_id,
             mutation,
+            read_predicate: crate::accord::wire::ReadPredicate::NotExists,
+            last_read_row: None,
+            local_reader: None,
+            local_applier: None,
         }
+    }
+
+    /// Supply an applier for the coordinator's own replica so it persists the
+    /// mutations it coordinates (its self-send Apply RPC is unreachable).
+    ///
+    /// Without this the coordinator node silently lacks its own LWT writes; with
+    /// it, the coordinator's storage matches the replicas' and its local
+    /// generic-`IF` read agrees with them. Production wires the same
+    /// engine-backed applier the replicas use.
+    pub fn with_local_applier(
+        mut self,
+        applier: Arc<dyn crate::accord::apply::StorageApplier>,
+    ) -> Self {
+        self.local_applier = Some(applier);
+        self
+    }
+
+    /// Supply a reader for the coordinator's own replica (generic-`IF` path).
+    ///
+    /// The coordinator's self-send is unreachable over the network, so without a
+    /// local reader its own replica cannot contribute to the F+1 read agreement.
+    /// Production wires the same engine-backed [`StorageReader`] the replicas use.
+    ///
+    /// [`StorageReader`]: crate::accord::apply::StorageReader
+    pub fn with_local_reader(
+        mut self,
+        reader: Arc<dyn crate::accord::apply::StorageReader>,
+    ) -> Self {
+        self.local_reader = Some(reader);
+        self
+    }
+
+    /// The row bytes F+1 replicas agreed on during the generic-`IF` read-vote.
+    ///
+    /// `Some(serialized_mutation)` when the row existed at `t`; `None` when the
+    /// row was absent at `t` or for the existence path. Valid only after a
+    /// successful [`Self::run_transaction`].
+    pub fn last_read_row(&self) -> Option<&[u8]> {
+        self.last_read_row.as_deref()
+    }
+
+    /// Set the read-vote predicate for this transaction.
+    ///
+    /// Defaults to [`ReadPredicate::NotExists`](crate::accord::wire::ReadPredicate)
+    /// (`INSERT IF NOT EXISTS`). For a generic `IF col=val`, the router supplies
+    /// [`ReadPredicate::ReadRow`](crate::accord::wire::ReadPredicate) carrying the
+    /// `keyspace`/`table` so replicas read the row at `t` and return its bytes.
+    pub fn with_read_predicate(mut self, predicate: crate::accord::wire::ReadPredicate) -> Self {
+        self.read_predicate = predicate;
+        self
     }
 
     /// Build the Apply-phase payload bytes for this transaction.
@@ -750,6 +844,7 @@ impl AccordCoordinatorDriver {
             txn_id,
             t: commit_t,
             key: key.clone(),
+            predicate: self.read_predicate.clone(),
         };
         let read_bytes = bincode::serialize(&read_payload)
             .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
@@ -757,6 +852,35 @@ impl AccordCoordinatorDriver {
 
         let mut votes_false = 0usize;
         let mut dissenting_row: Vec<u8> = Vec::new();
+        // For the generic ReadRow predicate: collect each replica's row-at-`t`
+        // bytes so we can require F+1 *agreement* on the row state before the
+        // coordinator evaluates the IF predicate. Disagreement is a correctness
+        // failure (non-linearizable read) and must abort, never silently pick one.
+        let mut read_rows: Vec<Vec<u8>> = Vec::new();
+        let is_generic = matches!(
+            self.read_predicate,
+            crate::accord::wire::ReadPredicate::ReadRow { .. }
+        );
+
+        // The coordinator's own replica is not reachable over the network
+        // (self-send fails). For the generic path it must contribute its local
+        // read-at-`t` so that, with RF=2 (sq=2), F+1 agreement is achievable and
+        // the result is deterministic across all replicas. The applier already
+        // persisted earlier conflicting txns locally before this read (dep-wait).
+        if is_generic {
+            if let (Some(reader), crate::accord::wire::ReadPredicate::ReadRow { keyspace, table }) =
+                (&self.local_reader, &self.read_predicate)
+            {
+                match reader.read_row_at(keyspace, table, &key, commit_t) {
+                    Ok(bytes) => read_rows.push(bytes.unwrap_or_default()),
+                    Err(e) => {
+                        return Err(AccordDriverError::Network(format!(
+                            "coordinator local read-at-t failed: {e}"
+                        )));
+                    }
+                }
+            }
+        }
 
         let remote_read_futs: Vec<_> = self
             .replica_ids
@@ -774,15 +898,24 @@ impl AccordCoordinatorDriver {
             match result {
                 Ok(Message::AccordReadOK(b)) if !b.is_empty() => {
                     match bincode::deserialize::<ReadVoteOkPayload>(b) {
-                        Ok(vote) if !vote.condition_holds => {
-                            votes_false += 1;
-                            if dissenting_row.is_empty() {
-                                dissenting_row = vote.current_row.clone();
+                        Ok(vote) => {
+                            if is_generic {
+                                // Generic IF: replica returns the row bytes at `t`
+                                // (condition_holds is a neutral true). Collect for
+                                // F+1 agreement; the coordinator evaluates the
+                                // predicate authoritatively below.
+                                read_rows.push(vote.current_row.clone());
+                            } else if !vote.condition_holds {
+                                // INSERT IF NOT EXISTS existence path.
+                                votes_false += 1;
+                                if dissenting_row.is_empty() {
+                                    dissenting_row = vote.current_row.clone();
+                                }
                             }
                         }
-                        _ => {
-                            // Condition holds, pre-Gap-4 replica, or parse error:
-                            // treat as condition_holds=true (forward-compatible default).
+                        Err(_) => {
+                            // pre-Gap-4 replica or parse error: treat as
+                            // condition_holds=true (forward-compatible default).
                         }
                     }
                 }
@@ -800,18 +933,37 @@ impl AccordCoordinatorDriver {
             }
         }
 
-        // F+1 matching votes decide the outcome.
-        // Only return ConditionNotMet if F+1 replicas explicitly voted false.
-        if votes_false >= sq {
-            tracing::info!(
-                txn_id = ?txn_id,
-                votes_false,
-                sq,
-                "accord: IF condition not met — [applied]=false"
-            );
-            return Err(AccordDriverError::ConditionNotMet {
-                current_row: dissenting_row,
-            });
+        if is_generic {
+            // Require F+1 replicas to agree on the SAME row bytes at `t`. This is
+            // the linearizable read: a divergent read is non-linearizable and must
+            // abort (fail loud) rather than have the coordinator guess.
+            let agreed = agreed_row(&read_rows, sq);
+            match agreed {
+                Some(row) => {
+                    self.last_read_row = if row.is_empty() { None } else { Some(row) };
+                }
+                None => {
+                    return Err(AccordDriverError::Network(format!(
+                        "generic IF read-vote lacked F+1 ({sq}) agreement on the row at t \
+                         (got {} reads) — refusing a non-linearizable LWT",
+                        read_rows.len()
+                    )));
+                }
+            }
+        } else {
+            // F+1 matching votes decide the outcome.
+            // Only return ConditionNotMet if F+1 replicas explicitly voted false.
+            if votes_false >= sq {
+                tracing::info!(
+                    txn_id = ?txn_id,
+                    votes_false,
+                    sq,
+                    "accord: IF condition not met — [applied]=false"
+                );
+                return Err(AccordDriverError::ConditionNotMet {
+                    current_row: dissenting_row,
+                });
+            }
         }
 
         // ------------------------------------------------------------------
@@ -825,6 +977,28 @@ impl AccordCoordinatorDriver {
 
         let apply_bytes = self.apply_payload_bytes()?;
         let apply_msg = Message::AccordApply(Bytes::from(apply_bytes));
+
+        // Coordinator's OWN replica apply. Its self-send is unreachable, so apply
+        // the committed mutation locally here (mirroring a remote replica's
+        // handle_apply) before counting the implicit ack. Without this the
+        // coordinator node never persists what it coordinates. Fail loud: a local
+        // apply error must abort, never fake the implicit ack.
+        if self_is_replica && !self.mutation.is_empty() {
+            if let Some(applier) = &self.local_applier {
+                applier
+                    .apply(
+                        txn_id,
+                        crate::accord::apply::ApplyMutation {
+                            data: self.mutation.clone(),
+                            t: commit_t,
+                            deps: commit_deps.iter().copied().collect(),
+                        },
+                    )
+                    .map_err(|e| {
+                        AccordDriverError::Network(format!("coordinator local apply failed: {e}"))
+                    })?;
+            }
+        }
 
         // Coordinator itself counts as 1 implicit apply ack.
         let mut apply_acks = if self_is_replica { 1usize } else { 0usize };

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -394,6 +394,12 @@ impl std::fmt::Display for AccordDriverError {
 
 impl std::error::Error for AccordDriverError {}
 
+/// Generic-`IF` condition gate: given the F+1-agreed row bytes at `t`
+/// (`None` if the row was absent), returns `true` iff the IF predicate holds
+/// (the write should apply). Injected by the CQL router; see
+/// [`AccordCoordinatorDriver::with_condition_gate`].
+pub type ConditionGate = Box<dyn Fn(Option<&[u8]>) -> bool + Send + Sync>;
+
 /// A driver that connects the pure `AccordCoordinator` state machine to real
 /// network I/O via `PeerManager`.
 ///
@@ -448,6 +454,20 @@ pub struct AccordCoordinatorDriver {
     /// committed mutation locally during the Apply phase. Set via
     /// [`Self::with_local_applier`].
     local_applier: Option<Arc<dyn crate::accord::apply::StorageApplier>>,
+    /// For the generic-`IF` path: evaluates the IF predicate against the
+    /// F+1-agreed row bytes at `t`. Returns `true` iff the write should apply.
+    ///
+    /// The CQL operators (`IfCondition`/`CqlValue`) live in `ferrosa-cql`, which
+    /// depends on this crate, so the coordinator cannot evaluate them directly.
+    /// The router injects this closure (wrapping the canonical
+    /// `eval_if_conditions`); the coordinator calls it in the read-vote phase and
+    /// ABORTS with [`AccordDriverError::ConditionNotMet`] BEFORE the Apply phase
+    /// when it returns `false`. This is what GATES the write on the condition —
+    /// without it the generic path would apply unconditionally (a lost-update /
+    /// wrong-`[applied]` bug). `None` keeps a permissive default (apply) for
+    /// callers that have no generic predicate. Set via
+    /// [`Self::with_condition_gate`].
+    condition_gate: Option<ConditionGate>,
 }
 
 /// Return the row bytes that at least `quorum` of `reads` agree on, if any.
@@ -521,6 +541,7 @@ impl AccordCoordinatorDriver {
             last_read_row: None,
             local_reader: None,
             local_applier: None,
+            condition_gate: None,
         }
     }
 
@@ -571,6 +592,24 @@ impl AccordCoordinatorDriver {
     /// `keyspace`/`table` so replicas read the row at `t` and return its bytes.
     pub fn with_read_predicate(mut self, predicate: crate::accord::wire::ReadPredicate) -> Self {
         self.read_predicate = predicate;
+        self
+    }
+
+    /// Supply the generic-`IF` condition gate.
+    ///
+    /// `gate(Some(row_bytes))` / `gate(None)` is called in the read-vote phase
+    /// with the F+1-agreed row at `t` (or `None` if absent). It must return
+    /// `true` iff the IF predicate holds (the write should apply). When it
+    /// returns `false`, [`Self::run_transaction`] aborts with
+    /// [`AccordDriverError::ConditionNotMet`] carrying the agreed row bytes —
+    /// BEFORE the Apply phase — so a failing `IF col=val` never persists its
+    /// mutation. This is the linearizable-LWT gate; see the field docs on
+    /// `condition_gate`.
+    ///
+    /// The router wraps the canonical `ferrosa-cql` `eval_if_conditions` here so
+    /// there is no forked evaluator.
+    pub fn with_condition_gate(mut self, gate: ConditionGate) -> Self {
+        self.condition_gate = Some(gate);
         self
     }
 
@@ -938,9 +977,14 @@ impl AccordCoordinatorDriver {
             // the linearizable read: a divergent read is non-linearizable and must
             // abort (fail loud) rather than have the coordinator guess.
             let agreed = agreed_row(&read_rows, sq);
-            match agreed {
+            let agreed_row_bytes = match agreed {
                 Some(row) => {
-                    self.last_read_row = if row.is_empty() { None } else { Some(row) };
+                    self.last_read_row = if row.is_empty() {
+                        None
+                    } else {
+                        Some(row.clone())
+                    };
+                    row
                 }
                 None => {
                     return Err(AccordDriverError::Network(format!(
@@ -948,6 +992,33 @@ impl AccordCoordinatorDriver {
                          (got {} reads) — refusing a non-linearizable LWT",
                         read_rows.len()
                     )));
+                }
+            };
+
+            // GATE THE WRITE on the IF condition. The coordinator owns the table
+            // schema (via the injected gate, which wraps the canonical
+            // eval_if_conditions); it evaluates the predicate against the
+            // F+1-agreed, linearizable row-at-`t` and ABORTS before the Apply
+            // phase when the condition does not hold. Without this the generic
+            // path would persist its mutation unconditionally and still report
+            // [applied]=false — a lost-update / wrong-[applied] data-loss bug.
+            //
+            // Determinism: every replica sees the same `t` and the same agreed
+            // row bytes, so the gate's verdict is identical everywhere.
+            if let Some(gate) = &self.condition_gate {
+                let row_arg: Option<&[u8]> = if agreed_row_bytes.is_empty() {
+                    None
+                } else {
+                    Some(agreed_row_bytes.as_slice())
+                };
+                if !gate(row_arg) {
+                    tracing::info!(
+                        txn_id = ?txn_id,
+                        "accord: generic IF condition not met — [applied]=false, no Apply"
+                    );
+                    return Err(AccordDriverError::ConditionNotMet {
+                        current_row: agreed_row_bytes,
+                    });
                 }
             }
         } else {

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -454,6 +454,18 @@ pub struct AccordCoordinatorDriver {
     /// committed mutation locally during the Apply phase. Set via
     /// [`Self::with_local_applier`].
     local_applier: Option<Arc<dyn crate::accord::apply::StorageApplier>>,
+    /// Optional handle to the coordinator's OWN replica state machine.
+    ///
+    /// The coordinator's self-send is unreachable over the network, so its local
+    /// read-vote cannot go through the inbound `AccordRead` handler. When this is
+    /// wired, the coordinator's local generic-`IF` read-at-`t` performs the SAME
+    /// dependency-wait the remote handler does — blocking until every conflicting
+    /// transaction `t0 < t` known to the local state machine has reached
+    /// `Applied` — so a genuinely concurrent contender's write is observed before
+    /// the read. Without it, two concurrent `INSERT IF NOT EXISTS` could each read
+    /// the key as absent before either applies and BOTH apply (a double-apply /
+    /// lost update). `None` keeps the bare-reader behavior (no local dep-wait).
+    local_accord_state: Option<crate::accord::handlers::AccordState>,
     /// For the generic-`IF` path: evaluates the IF predicate against the
     /// F+1-agreed row bytes at `t`. Returns `true` iff the write should apply.
     ///
@@ -541,6 +553,7 @@ impl AccordCoordinatorDriver {
             last_read_row: None,
             local_reader: None,
             local_applier: None,
+            local_accord_state: None,
             condition_gate: None,
         }
     }
@@ -572,6 +585,22 @@ impl AccordCoordinatorDriver {
         reader: Arc<dyn crate::accord::apply::StorageReader>,
     ) -> Self {
         self.local_reader = Some(reader);
+        self
+    }
+
+    /// Supply the coordinator's OWN replica state machine so its local generic-`IF`
+    /// read-vote performs the same dependency-wait the remote `AccordRead` handler
+    /// does (block until every conflicting `t0 < t` has `Applied` locally).
+    ///
+    /// The coordinator's self-send is unreachable over the network, so without this
+    /// the coordinator's local read-at-`t` would skip the dep-wait and could observe
+    /// a key as absent while a genuinely concurrent contender (with a smaller `t`)
+    /// is still mid-apply — the concurrent `INSERT IF NOT EXISTS` double-apply.
+    /// Production wires the same [`AccordState`](crate::accord::handlers::AccordState)
+    /// the node's inbound handlers use, backed by the same engine as the local
+    /// reader.
+    pub fn with_local_accord_state(mut self, state: crate::accord::handlers::AccordState) -> Self {
+        self.local_accord_state = Some(state);
         self
     }
 
@@ -627,6 +656,59 @@ impl AccordCoordinatorDriver {
             result_data: self.mutation.clone(),
         };
         bincode::serialize(&apply_payload).map_err(|e| AccordDriverError::Codec(e.to_string()))
+    }
+
+    /// Finalize this transaction as a *no-write* commit across the cluster after
+    /// the IF condition was found NOT to hold.
+    ///
+    /// A failed-IF LWT still committed (Accord ordered it), so on every replica
+    /// it sits in `Committed` with a pending mutation it will never apply. Left
+    /// there, it is a phantom dependency: a *later* transaction reading the same
+    /// key at `t' > t` would dep-wait on it until timeout. We therefore broadcast
+    /// an `Apply` carrying an EMPTY payload, which `handle_apply` treats as a
+    /// no-write finalize — it advances the txn to `Applied`, wakes dep-waiters,
+    /// and GCs the conflict index WITHOUT writing any row.
+    ///
+    /// Best-effort: this is a cleanup, not a correctness gate for THIS txn (which
+    /// is already aborting). Failures are logged, not propagated.
+    async fn finalize_no_write(&self) {
+        use crate::accord::wire::ApplyPayload;
+        let txn_id = self.coordinator.txn_id;
+
+        // Finalize the coordinator's own replica state machine (its self-send is
+        // unreachable). Empty payload => no-write finalize.
+        if let Some(local_sm) = &self.local_accord_state {
+            local_sm.lock().handle_apply(txn_id, Vec::new());
+        }
+
+        let payload = ApplyPayload {
+            txn_id,
+            result_data: Vec::new(),
+        };
+        let bytes = match bincode::serialize(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(txn_id = ?txn_id, error = %e, "accord: encode no-write finalize failed");
+                return;
+            }
+        };
+        let msg = Message::AccordApply(Bytes::from(bytes));
+
+        let futs: Vec<_> = self
+            .replica_ids
+            .iter()
+            .filter(|&&id| id != self.self_id)
+            .map(|&peer_id| {
+                let peers = Arc::clone(&self.peers);
+                let msg = msg.clone();
+                async move { peers.send(peer_id, msg, Lane::Data).await }
+            })
+            .collect();
+        for result in futures::future::join_all(futs).await {
+            if let Err(e) = result {
+                tracing::warn!(txn_id = ?txn_id, error = %e, "accord: no-write finalize RPC failed");
+            }
+        }
     }
 
     /// Run the full Accord protocol for this transaction.
@@ -907,15 +989,44 @@ impl AccordCoordinatorDriver {
         // the result is deterministic across all replicas. The applier already
         // persisted earlier conflicting txns locally before this read (dep-wait).
         if is_generic {
-            if let (Some(reader), crate::accord::wire::ReadPredicate::ReadRow { keyspace, table }) =
-                (&self.local_reader, &self.read_predicate)
+            if let crate::accord::wire::ReadPredicate::ReadRow { keyspace, table } =
+                &self.read_predicate
             {
-                match reader.read_row_at(keyspace, table, &key, commit_t) {
-                    Ok(bytes) => read_rows.push(bytes.unwrap_or_default()),
-                    Err(e) => {
-                        return Err(AccordDriverError::Network(format!(
-                            "coordinator local read-at-t failed: {e}"
-                        )));
+                // Prefer the local state machine when wired: it performs the SAME
+                // dep-wait the remote handler does (block until every conflicting
+                // `t0 < t` has Applied locally) before reading at `t`. This is what
+                // serializes a genuinely concurrent contender's write ahead of this
+                // read — without it the coordinator's own replica could read the key
+                // as absent while a smaller-`t` contender is mid-apply (the
+                // concurrent INSERT IF NOT EXISTS double-apply). On dep-wait timeout
+                // we ABSTAIN (push no row) so F+1 agreement fails loud rather than
+                // reading stale.
+                if let Some(local_sm) = &self.local_accord_state {
+                    if crate::accord::handlers::await_conflicting_deps_applied(
+                        local_sm, &key, commit_t,
+                    )
+                    .await
+                    {
+                        let row = local_sm
+                            .lock()
+                            .read_row_bytes_at(keyspace, table, &key, commit_t);
+                        read_rows.push(row.unwrap_or_default());
+                    } else {
+                        tracing::error!(
+                            txn_id = ?txn_id,
+                            "accord: coordinator local read-vote dep-wait timed out — abstaining"
+                        );
+                        // Abstain: contribute no local read. F+1 agreement then
+                        // fails loud below rather than treating a stale read as truth.
+                    }
+                } else if let Some(reader) = &self.local_reader {
+                    match reader.read_row_at(keyspace, table, &key, commit_t) {
+                        Ok(bytes) => read_rows.push(bytes.unwrap_or_default()),
+                        Err(e) => {
+                            return Err(AccordDriverError::Network(format!(
+                                "coordinator local read-at-t failed: {e}"
+                            )));
+                        }
                     }
                 }
             }
@@ -1016,6 +1127,10 @@ impl AccordCoordinatorDriver {
                         txn_id = ?txn_id,
                         "accord: generic IF condition not met — [applied]=false, no Apply"
                     );
+                    // Finalize this committed-but-not-applied txn as a no-write
+                    // across replicas so it does not linger as a phantom dep that
+                    // would stall later reads' dep-wait on this key.
+                    self.finalize_no_write().await;
                     return Err(AccordDriverError::ConditionNotMet {
                         current_row: agreed_row_bytes,
                     });
@@ -1031,6 +1146,10 @@ impl AccordCoordinatorDriver {
                     sq,
                     "accord: IF condition not met — [applied]=false"
                 );
+                // Finalize this committed-but-not-applied txn as a no-write
+                // across replicas so it does not linger as a phantom dep that
+                // would stall later reads' dep-wait on this key.
+                self.finalize_no_write().await;
                 return Err(AccordDriverError::ConditionNotMet {
                     current_row: dissenting_row,
                 });

--- a/ferrosa-cluster/src/accord/handlers.rs
+++ b/ferrosa-cluster/src/accord/handlers.rs
@@ -171,12 +171,30 @@ impl RpcHandler for AccordHandler {
                             sm.read_condition_holds_at(&vote_req.key, &vote_req.t),
                             vec![],
                         ),
-                        // Generic IF col=val: the replica only does the
-                        // linearizable read-at-`t` and returns the row bytes; the
-                        // coordinator (which owns the table schema) evaluates the
-                        // predicate via `eval_if_conditions`. The replica reports
-                        // `condition_holds=true` as a neutral value — the
-                        // coordinator's evaluation is authoritative.
+                        // Generic IF col=val: the replica does the read-at-`t`
+                        // and returns the row bytes; the coordinator (which owns
+                        // the table schema) evaluates the predicate via the
+                        // injected gate wrapping `eval_if_conditions` and GATES the
+                        // Apply on it. The replica reports `condition_holds=true`
+                        // as a neutral value — the coordinator's evaluation is
+                        // authoritative.
+                        //
+                        // Linearizability of THIS read rests on two guarantees:
+                        // (1) the coordinator requires F+1 *identical* row bytes
+                        //     (`agreed_row`) before evaluating the predicate and
+                        //     fails loud on divergence — so the gate verdict is
+                        //     never taken on a non-quorum / skewed read; and
+                        // (2) `EngineStorageReader::read_row_at` bounds cells to
+                        //     `ts <= t.time` (as-of-`t`).
+                        // KNOWN GAP (tracked): this handler does not yet BLOCK on
+                        // the DepWaitGraph until every dep `t' < t` is Applied
+                        // before reading; it relies on the protocol ordering that
+                        // Commit→ReadVote follows the deps' Apply in practice. A
+                        // genuinely concurrent dep could make a minority replica
+                        // read stale, which (2)'s F+1-agreement turns into a
+                        // fail-loud abort rather than a wrong answer — correct, but
+                        // it can spuriously abort instead of waiting. Enforcing an
+                        // explicit dep-wait here is deferred.
                         ReadPredicate::ReadRow { keyspace, table } => {
                             let row =
                                 sm.read_row_bytes_at(keyspace, table, &vote_req.key, vote_req.t);

--- a/ferrosa-cluster/src/accord/handlers.rs
+++ b/ferrosa-cluster/src/accord/handlers.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use ferrosa_common::accord::Timestamp;
 
 use ferrosa_net::message::Message;
 use ferrosa_net::rpc::handler::{PeerId, RpcHandler};
@@ -39,12 +40,76 @@ pub struct AccordHandler {
     local_node_id: u64,
 }
 
+/// Total bound on how long a `ReadVote` dep-wait will block for conflicting
+/// transactions to reach `Applied` before abstaining (fail-loud).
+const READ_DEP_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Per-iteration cap on a single `notified()` wait. A coalesced/lost broadcast
+/// wake (the apply fired between our unlock and re-arming the notify) costs at
+/// most this long before the loop re-checks the condition under the lock again,
+/// so the wait can never hang past [`READ_DEP_WAIT_TIMEOUT`].
+const READ_DEP_WAIT_POLL: std::time::Duration = std::time::Duration::from_millis(25);
+
 impl AccordHandler {
     pub fn new(state: AccordState, local_node_id: u64) -> Self {
         Self {
             state,
             local_node_id,
         }
+    }
+}
+
+/// Block until every conflicting transaction ordered before `t` (`t0 < t`) has
+/// reached `Applied` on the replica behind `state`, or until
+/// [`READ_DEP_WAIT_TIMEOUT`] elapses.
+///
+/// Returns `true` if all conflicts applied (a read-at-`t` may now proceed
+/// linearizably), `false` on timeout (the caller MUST ABSTAIN — never read
+/// stale). Shared by the inbound `AccordRead` handler (remote replicas) and by
+/// the coordinator's own local read-vote (its self-send Apply is unreachable, so
+/// it reads its local state machine directly).
+///
+/// # Deadlock safety
+///
+/// The `parking_lot` state lock is acquired only to *compute* the pending set
+/// and to grab the apply-notify handle, then released BEFORE every `.await`.
+/// `handle_apply` (which fires the notify that unblocks us) takes the same lock,
+/// so holding it across the await would deadlock.
+pub(crate) async fn await_conflicting_deps_applied(
+    state: &AccordState,
+    key: &[u8],
+    t: Timestamp,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + READ_DEP_WAIT_TIMEOUT;
+    loop {
+        // Compute the pending set and grab the notify UNDER the lock, then drop
+        // the lock before awaiting. The future only enrolls on first poll, so a
+        // wake fired between unlock and poll could be missed; the bounded poll
+        // timeout below makes such a missed wake self-correcting (the loop
+        // re-checks the condition under the lock) rather than a hang.
+        let notify = {
+            let sm = state.lock();
+            if sm.unapplied_conflicts_before(key, &t).is_empty() {
+                return true;
+            }
+            sm.applied_notify()
+        };
+
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            tracing::error!(
+                "accord: ReadVote dep-wait timed out after {:?} waiting for conflicting \
+                 transactions to apply — abstaining (fail-loud)",
+                READ_DEP_WAIT_TIMEOUT
+            );
+            return false;
+        }
+
+        // Wait for the next apply (broadcast) or the per-iteration poll cap,
+        // whichever comes first, but never past the overall deadline.
+        let wait = READ_DEP_WAIT_POLL.min(deadline - now);
+        let _ = tokio::time::timeout(wait, notify.notified()).await;
+        // Loop: re-check the pending set under the lock.
     }
 }
 
@@ -163,6 +228,44 @@ impl RpcHandler for AccordHandler {
                 // A full production implementation would read actual storage.
                 if let Ok(vote_req) = bincode::deserialize::<ReadVotePayload>(&b) {
                     use crate::accord::wire::ReadPredicate;
+
+                    // DEP-WAIT (linearizability): before evaluating the IF
+                    // condition at the agreed `t`, every conflicting transaction
+                    // ordered before `t` (t0 < t) that is committed-but-not-yet-
+                    // Applied on this replica must first reach `Applied`. Without
+                    // this, two genuinely concurrent `INSERT IF NOT EXISTS` both
+                    // observe the key as absent before either applies, both gates
+                    // pass, and BOTH apply — a lost-update / double-apply. We park
+                    // on the state machine's apply-notify, re-checking the
+                    // condition under the lock after each wake, with a BOUNDED
+                    // total timeout. On timeout we ABSTAIN (return no row /
+                    // condition_holds=false) rather than read stale: the
+                    // coordinator's F+1 agreement then fails loud instead of
+                    // letting a stale read masquerade as success.
+                    //
+                    // This applies to BOTH predicate kinds: the existence path
+                    // (`read_condition_holds_at`) and the generic read-row path
+                    // share the same staleness hazard, so they share the dep-wait.
+                    //
+                    // CRITICAL: the parking_lot state lock is NEVER held across
+                    // an `.await` — handle_apply needs the same lock to make
+                    // progress (and to fire the notify that unblocks us), so
+                    // holding it across the wait would deadlock.
+                    if !await_conflicting_deps_applied(&self.state, &vote_req.key, vote_req.t).await
+                    {
+                        // Dep-wait timed out: abstain. No current_row, and
+                        // condition_holds=false so neither the existence path nor
+                        // a generic read fabricates a "row absent" success.
+                        let ok = ReadVoteOkPayload {
+                            txn_id: vote_req.txn_id,
+                            from: self.local_node_id,
+                            condition_holds: false,
+                            current_row: vec![],
+                        };
+                        let resp_bytes = bincode::serialize(&ok).ok()?;
+                        return Some(Message::AccordReadOK(Bytes::from(resp_bytes)));
+                    }
+
                     let sm = self.state.lock();
                     let (condition_holds, current_row) = match &vote_req.predicate {
                         // INSERT IF NOT EXISTS: existence path (no schema needed).
@@ -179,22 +282,16 @@ impl RpcHandler for AccordHandler {
                         // as a neutral value — the coordinator's evaluation is
                         // authoritative.
                         //
-                        // Linearizability of THIS read rests on two guarantees:
-                        // (1) the coordinator requires F+1 *identical* row bytes
+                        // Linearizability of THIS read rests on three guarantees:
+                        // (1) the dep-wait above blocked until every conflicting
+                        //     dep `t0 < t` Applied locally, so the engine's state
+                        //     is the row as-of-`t`;
+                        // (2) the coordinator requires F+1 *identical* row bytes
                         //     (`agreed_row`) before evaluating the predicate and
                         //     fails loud on divergence — so the gate verdict is
                         //     never taken on a non-quorum / skewed read; and
-                        // (2) `EngineStorageReader::read_row_at` bounds cells to
+                        // (3) `EngineStorageReader::read_row_at` bounds cells to
                         //     `ts <= t.time` (as-of-`t`).
-                        // KNOWN GAP (tracked): this handler does not yet BLOCK on
-                        // the DepWaitGraph until every dep `t' < t` is Applied
-                        // before reading; it relies on the protocol ordering that
-                        // Commit→ReadVote follows the deps' Apply in practice. A
-                        // genuinely concurrent dep could make a minority replica
-                        // read stale, which (2)'s F+1-agreement turns into a
-                        // fail-loud abort rather than a wrong answer — correct, but
-                        // it can spuriously abort instead of waiting. Enforcing an
-                        // explicit dep-wait here is deferred.
                         ReadPredicate::ReadRow { keyspace, table } => {
                             let row =
                                 sm.read_row_bytes_at(keyspace, table, &vote_req.key, vote_req.t);

--- a/ferrosa-cluster/src/accord/handlers.rs
+++ b/ferrosa-cluster/src/accord/handlers.rs
@@ -162,19 +162,33 @@ impl RpcHandler for AccordHandler {
                 //
                 // A full production implementation would read actual storage.
                 if let Ok(vote_req) = bincode::deserialize::<ReadVotePayload>(&b) {
+                    use crate::accord::wire::ReadPredicate;
                     let sm = self.state.lock();
-                    // Check if any transaction for this key was already applied.
-                    // We use txn_count as a proxy: if no transactions have been
-                    // applied (Applied phase) for this key's epoch, condition holds.
-                    // More precisely: check if there's an Applied txn with a
-                    // commit timestamp <= vote_req.t.
-                    let condition_holds = sm.read_condition_holds_at(&vote_req.key, &vote_req.t);
+                    let (condition_holds, current_row) = match &vote_req.predicate {
+                        // INSERT IF NOT EXISTS: existence path (no schema needed).
+                        // condition holds iff the row does NOT exist at `t`.
+                        ReadPredicate::NotExists => (
+                            sm.read_condition_holds_at(&vote_req.key, &vote_req.t),
+                            vec![],
+                        ),
+                        // Generic IF col=val: the replica only does the
+                        // linearizable read-at-`t` and returns the row bytes; the
+                        // coordinator (which owns the table schema) evaluates the
+                        // predicate via `eval_if_conditions`. The replica reports
+                        // `condition_holds=true` as a neutral value — the
+                        // coordinator's evaluation is authoritative.
+                        ReadPredicate::ReadRow { keyspace, table } => {
+                            let row =
+                                sm.read_row_bytes_at(keyspace, table, &vote_req.key, vote_req.t);
+                            (true, row.unwrap_or_default())
+                        }
+                    };
                     drop(sm);
                     let ok = ReadVoteOkPayload {
                         txn_id: vote_req.txn_id,
                         from: self.local_node_id,
                         condition_holds,
-                        current_row: vec![],
+                        current_row,
                     };
                     let resp_bytes = bincode::serialize(&ok).ok()?;
                     Some(Message::AccordReadOK(Bytes::from(resp_bytes)))

--- a/ferrosa-cluster/src/accord/mod.rs
+++ b/ferrosa-cluster/src/accord/mod.rs
@@ -36,8 +36,8 @@ pub mod uda_integration;
 pub(crate) mod wire;
 
 pub use apply::{
-    ApplyError, ApplyMutation, DepWaitApplier, EngineStorageApplier, NoopStorageApplier,
-    StorageApplier,
+    ApplyError, ApplyMutation, DepWaitApplier, EngineStorageApplier, EngineStorageReader,
+    NoopStorageApplier, RowReadError, StorageApplier, StorageReader,
 };
 pub use clock::{ClockError, ClockValidator};
 pub use clock_validation::{
@@ -68,3 +68,4 @@ pub use reorder_buffer::ReorderBuffer;
 pub use state_machine::{AccordStateMachine, SmResponse};
 pub use test_cluster::{TestCluster, TestMessage, TestMessagePayload, TestReplica};
 pub use two_phase_ddl::{DdlMarker, DdlOperation, DdlPhase, TwoPhaseDdlError, TwoPhaseDdlManager};
+pub use wire::ReadPredicate;

--- a/ferrosa-cluster/src/accord/mod.rs
+++ b/ferrosa-cluster/src/accord/mod.rs
@@ -45,7 +45,7 @@ pub use clock_validation::{
 };
 pub use coordinator::{
     fast_quorum_size, slow_quorum_size, AccordCoordinator, AccordCoordinatorDriver,
-    AccordDriverError, CoordinatorDecision, CoordinatorPhase,
+    AccordDriverError, ConditionGate, CoordinatorDecision, CoordinatorPhase,
 };
 pub use cross_dc_adapter::{
     cross_dc_vote_commit_count, CrossDcAccordAdapter, CROSS_DC_VOTE_COMMITS,

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -32,6 +32,7 @@ use ferrosa_common::accord::{
 };
 use ferrosa_storage::accord::conflict_index::{ConflictIndex, InFlightWrite, TxnStatus};
 use ferrosa_storage::accord::sync_writer::SyncWriter;
+use tokio::sync::Notify;
 
 use crate::accord::apply::{ApplyMutation, NoopStorageApplier, StorageApplier, StorageReader};
 
@@ -98,6 +99,16 @@ pub struct AccordStateMachine {
     /// [`AccordStateMachine::with_applier_and_reader`] so generic predicates can
     /// read the real row at `t`.
     reader: Option<Arc<dyn StorageReader>>,
+    /// Broadcast wake fired after every successful [`Self::handle_apply`].
+    ///
+    /// The `ReadVote` dep-wait (see the `AccordRead` handler) parks on this
+    /// notify after dropping the state lock, so a conflicting transaction
+    /// reaching `Applied` re-wakes any read that is blocked waiting for it.
+    /// Using a broadcast `Notify::notify_waiters` (rather than per-txn
+    /// channels) keeps the apply path lock-cheap and is safe because the waiter
+    /// always re-checks the unapplied-conflict condition under the lock after a
+    /// wake — a spurious or coalesced wake just costs one extra re-check.
+    applied_notify: Arc<Notify>,
 }
 
 impl AccordStateMachine {
@@ -117,6 +128,7 @@ impl AccordStateMachine {
             last_notified: Vec::new(),
             applier: Arc::new(NoopStorageApplier::new()),
             reader: None,
+            applied_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -138,6 +150,7 @@ impl AccordStateMachine {
             last_notified: Vec::new(),
             applier: Arc::new(NoopStorageApplier::new()),
             reader: None,
+            applied_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -161,6 +174,7 @@ impl AccordStateMachine {
             last_notified: Vec::new(),
             applier,
             reader: None,
+            applied_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -187,6 +201,7 @@ impl AccordStateMachine {
             last_notified: Vec::new(),
             applier,
             reader: Some(reader),
+            applied_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -220,6 +235,66 @@ impl AccordStateMachine {
     /// Whether a [`StorageReader`] is wired (generic-`IF` read-at-`t` available).
     pub fn has_reader(&self) -> bool {
         self.reader.is_some()
+    }
+
+    /// Handle to the broadcast notify fired after every successful apply.
+    ///
+    /// A `ReadVote` dep-wait acquires this, drops the state lock, and parks on
+    /// [`Notify::notified`]; a conflicting transaction reaching `Applied` (via
+    /// [`Self::handle_apply`]) wakes it so it can re-check its condition.
+    pub fn applied_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.applied_notify)
+    }
+
+    /// Conflicting transactions on `key` that a linearizable read-at-`t` must
+    /// wait for before reading: those that are **`Committed`** (their final
+    /// execution timestamp is locked) ordered **before** `t` (`t_committed < t`)
+    /// and not yet `Applied` on this replica.
+    ///
+    /// This is the dep-wait set for the `AccordRead` (ReadVote) handler. Reading
+    /// the row before such a transaction applies would observe stale state — the
+    /// concurrent-`INSERT IF NOT EXISTS` double-apply (the ReadVote
+    /// linearizability gap): two contenders both read the key as absent before
+    /// either applies, both gates pass, and both insert.
+    ///
+    /// # Which phases are waited on
+    ///
+    /// - `PreAccepted` / `Accepted`: a genuinely concurrent contender whose `t0 <
+    ///   t` (so it may yet commit with a final `t' < t` and apply a write before
+    ///   our read is valid). We wait for it to resolve — it will either apply, be
+    ///   finalized as a no-write, or its final `t` will be re-evaluated against
+    ///   `t` once committed (the caller re-checks this set in a bounded loop, so a
+    ///   contender that commits *after* `t` simply drops out of the set on the
+    ///   next iteration).
+    /// - `Committed`: wait only if its locked final `t < t` (it is ordered before
+    ///   us and will apply or no-write-finalize). A `Committed` txn with `t > t`
+    ///   is ordered after us and is NOT a dependency.
+    /// - `Applied` / pruned: already applied — never waited on.
+    ///
+    /// A failed transaction never lingers here: a replica whose `PreAccept`
+    /// fsync fails rolls back its conflict-index registration (see
+    /// [`Self::handle_preaccept`]), and a committed-but-condition-failed LWT is
+    /// finalized to `Applied` as a no-write. So the wait is always bounded by
+    /// real protocol progress, not by abandoned phantom entries.
+    pub fn unapplied_conflicts_before(&self, key: &[u8], t: &Timestamp) -> Vec<TxnId> {
+        let mut pending = Vec::new();
+        for dep_id in self.conflict_index.deps_before_t(key, t) {
+            if let Some(state) = self.txn_states.get(&dep_id) {
+                let wait = match state.phase {
+                    // Already applied: nothing to wait for.
+                    TxnPhase::Applied => false,
+                    // Final t locked: dependency only if ordered before us.
+                    TxnPhase::Committed => state.t < *t,
+                    // Final t not yet locked but t0 < t (from deps_before_t):
+                    // a possible ordered-before write still in flight — wait.
+                    TxnPhase::PreAccepted | TxnPhase::Accepted => true,
+                };
+                if wait {
+                    pending.push(dep_id);
+                }
+            }
+        }
+        pending
     }
 
     /// Get the current state for a transaction (if any).
@@ -312,6 +387,10 @@ impl AccordStateMachine {
             tracing::error!(%e, "accord: conflict_index register failed");
         }
 
+        // Track whether THIS call created the TxnState, so a persist failure can
+        // roll back cleanly (a retried/duplicate PreAccept must not be erased).
+        let newly_created = !self.txn_states.contains_key(&txn_id);
+
         // Create or update TxnState.
         let state = self
             .txn_states
@@ -323,6 +402,15 @@ impl AccordStateMachine {
         let data = format!("PreAccepted:{}:{}", txn_id.0.time, t.time);
         let result = self.sync_writer.write_and_sync(data.as_bytes());
         if !result.is_ok() {
+            // Persist failed: this PreAccept is NOT durable. Roll back the
+            // conflict-index registration (and the TxnState if we created it) so
+            // the non-durable txn does not linger as a phantom dependency that
+            // would make later linearizable reads on this key dep-wait until
+            // timeout. Mirrors the commit/apply persist-before-advance discipline.
+            self.conflict_index.remove(&txn_id);
+            if newly_created {
+                self.txn_states.remove(&txn_id);
+            }
             return SmResponse::None;
         }
 
@@ -491,18 +579,29 @@ impl AccordStateMachine {
             return SmResponse::None;
         }
 
-        // Persist the real mutation to local storage. The applier is idempotent
-        // on (txn_id, t) and must durably write before returning Ok. If it
-        // fails we MUST NOT advance to Applied — fail loud, never fake success:
-        // the coordinator gets no implicit ack and the Apply can be retried.
-        let mutation = ApplyMutation {
-            data: result_data.clone(),
-            t,
-            deps,
-        };
-        if let Err(e) = self.applier.apply(txn_id, mutation) {
-            tracing::error!(%e, "accord: storage applier failed — not advancing to Applied");
-            return SmResponse::None;
+        // No-write finalize: an LWT whose IF condition did NOT hold still
+        // *commits* (it is ordered by Accord), but applies NO row write — the
+        // coordinator sends an Apply with an EMPTY payload to finalize it. We
+        // must still advance the txn to `Applied` (and wake dep-waiters / GC the
+        // conflict index) so it stops being a phantom dependency: a later read at
+        // `t' > t` that waited on this conflict would otherwise block until its
+        // dep-wait timeout. We deliberately skip the storage applier (there is no
+        // row to write), which also avoids decoding empty bytes as a Mutation.
+        if !result_data.is_empty() {
+            // Persist the real mutation to local storage. The applier is
+            // idempotent on (txn_id, t) and must durably write before returning
+            // Ok. If it fails we MUST NOT advance to Applied — fail loud, never
+            // fake success: the coordinator gets no implicit ack and the Apply
+            // can be retried.
+            let mutation = ApplyMutation {
+                data: result_data.clone(),
+                t,
+                deps,
+            };
+            if let Err(e) = self.applier.apply(txn_id, mutation) {
+                tracing::error!(%e, "accord: storage applier failed — not advancing to Applied");
+                return SmResponse::None;
+            }
         }
 
         // Durable in storage — now safe to mark Applied and GC the conflict index.
@@ -510,6 +609,11 @@ impl AccordStateMachine {
             state.apply(result_data);
         }
         self.conflict_index.mark_applied(&txn_id);
+
+        // Wake any ReadVote dep-wait parked on a conflicting transaction reaching
+        // Applied. Broadcast (all parked reads re-check their own condition under
+        // the lock); see [`Self::applied_notify`].
+        self.applied_notify.notify_waiters();
 
         SmResponse::None
     }

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -33,7 +33,7 @@ use ferrosa_common::accord::{
 use ferrosa_storage::accord::conflict_index::{ConflictIndex, InFlightWrite, TxnStatus};
 use ferrosa_storage::accord::sync_writer::SyncWriter;
 
-use crate::accord::apply::{ApplyMutation, NoopStorageApplier, StorageApplier};
+use crate::accord::apply::{ApplyMutation, NoopStorageApplier, StorageApplier, StorageReader};
 
 // ---------------------------------------------------------------------------
 // Response types
@@ -92,6 +92,12 @@ pub struct AccordStateMachine {
     /// for protocol-only tests; production wires a real engine-backed applier
     /// via [`AccordStateMachine::with_applier`].
     applier: Arc<dyn StorageApplier>,
+    /// Optional storage read seam for the generic-`IF` linearizable read-at-`t`
+    /// (Gap 4). `None` keeps the conflict-index existence path used by
+    /// `INSERT IF NOT EXISTS`. Production wires an engine-backed reader via
+    /// [`AccordStateMachine::with_applier_and_reader`] so generic predicates can
+    /// read the real row at `t`.
+    reader: Option<Arc<dyn StorageReader>>,
 }
 
 impl AccordStateMachine {
@@ -110,6 +116,7 @@ impl AccordStateMachine {
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
             applier: Arc::new(NoopStorageApplier::new()),
+            reader: None,
         }
     }
 
@@ -130,6 +137,7 @@ impl AccordStateMachine {
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
             applier: Arc::new(NoopStorageApplier::new()),
+            reader: None,
         }
     }
 
@@ -152,7 +160,66 @@ impl AccordStateMachine {
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
             applier,
+            reader: None,
         }
+    }
+
+    /// Create with a real [`StorageApplier`] **and** a [`StorageReader`]
+    /// (full production wiring).
+    ///
+    /// The reader backs the generic-`IF` linearizable read-at-`t` (Gap 4): on a
+    /// `ReadVote` carrying [`ReadPredicate::ReadRow`](crate::accord::wire::ReadPredicate),
+    /// the replica reads the row at `t` and returns its bytes for the coordinator
+    /// to evaluate. `INSERT IF NOT EXISTS` still uses the existence path.
+    pub fn with_applier_and_reader(
+        node_id: u64,
+        sync_writer: Arc<dyn SyncWriter>,
+        applier: Arc<dyn StorageApplier>,
+        reader: Arc<dyn StorageReader>,
+    ) -> Self {
+        Self {
+            node_id,
+            txn_states: HashMap::new(),
+            conflict_index: ConflictIndex::new(100_000),
+            sync_writer,
+            dep_waiters: HashMap::new(),
+            committed_txns: HashSet::new(),
+            last_notified: Vec::new(),
+            applier,
+            reader: Some(reader),
+        }
+    }
+
+    /// Read the row at `t` via the wired [`StorageReader`], if any.
+    ///
+    /// Returns `Ok(None)` when no reader is wired (the caller should fall back to
+    /// the existence path) or when the row does not exist at `t`. The `Some`
+    /// variant carries the serialized single-partition `Mutation` bytes for the
+    /// coordinator to decode and evaluate the IF predicate against.
+    pub fn read_row_bytes_at(
+        &self,
+        keyspace: &str,
+        table: &str,
+        key: &[u8],
+        t: Timestamp,
+    ) -> Option<Vec<u8>> {
+        let reader = self.reader.as_ref()?;
+        match reader.read_row_at(keyspace, table, key, t) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                // Fail loud in logs; the coordinator treats a missing row-vote as
+                // "no dissent" only when it has F+1 agreement, so a read error
+                // here surfaces as the replica abstaining (no current_row), never
+                // as a fabricated success.
+                tracing::error!(%e, keyspace, table, "accord: read_row_at failed during ReadVote");
+                None
+            }
+        }
+    }
+
+    /// Whether a [`StorageReader`] is wired (generic-`IF` read-at-`t` available).
+    pub fn has_reader(&self) -> bool {
+        self.reader.is_some()
     }
 
     /// Get the current state for a transaction (if any).
@@ -619,8 +686,11 @@ pub fn build_accord_state_machine(
     sync_writer: Arc<dyn SyncWriter>,
     storage: Arc<ferrosa_storage::engine::StorageEngine>,
 ) -> AccordStateMachine {
-    let applier = Arc::new(crate::accord::apply::EngineStorageApplier::new(storage));
-    AccordStateMachine::with_applier(node_id, sync_writer, applier)
+    let applier = Arc::new(crate::accord::apply::EngineStorageApplier::new(
+        storage.clone(),
+    ));
+    let reader = Arc::new(crate::accord::apply::EngineStorageReader::new(storage));
+    AccordStateMachine::with_applier_and_reader(node_id, sync_writer, applier, reader)
 }
 
 // Helper extension for TxnPhase to expose rank for comparison.

--- a/ferrosa-cluster/src/accord/wire.rs
+++ b/ferrosa-cluster/src/accord/wire.rs
@@ -92,6 +92,39 @@ pub(crate) struct ReadVotePayload {
     pub(crate) t: Timestamp,
     /// Partition key bytes.
     pub(crate) key: Vec<u8>,
+    /// Predicate descriptor: how the replica should answer the read-vote.
+    ///
+    /// Defaults (via `#[serde(default)]`) to [`ReadPredicate::NotExists`] so a
+    /// pre-upgrade coordinator that omits the field still gets the existing
+    /// `INSERT IF NOT EXISTS` existence semantics.
+    #[serde(default)]
+    pub(crate) predicate: ReadPredicate,
+}
+
+/// What the read-vote must determine on the replica.
+///
+/// The replica never interprets CQL predicate operators (those types live in
+/// `ferrosa-cql`, which depends on this crate). For a generic `IF col=val`, the
+/// replica only performs the linearizable read-at-`t` and returns the row
+/// bytes; the coordinator (which owns the table schema) evaluates the predicate
+/// with the canonical `eval_if_conditions`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum ReadPredicate {
+    /// `INSERT IF NOT EXISTS`: condition holds iff the row does NOT exist at `t`.
+    /// Evaluated on the replica via the existence path (no schema needed).
+    #[default]
+    NotExists,
+    /// Generic `IF <conditions>`: the replica reads the row at `t` and returns
+    /// its serialized bytes; the coordinator evaluates the predicate. Carries the
+    /// `keyspace`/`table` so the replica's [`StorageReader`] can target the read.
+    ///
+    /// [`StorageReader`]: crate::accord::apply::StorageReader
+    ReadRow {
+        /// Keyspace of the target table.
+        keyspace: String,
+        /// Target table name.
+        table: String,
+    },
 }
 
 /// Read-vote response from a replica.
@@ -193,6 +226,16 @@ mod tests {
             txn_id,
             t,
             key: b"read-vote-key".to_vec(),
+            predicate: ReadPredicate::NotExists,
+        });
+        assert_bincode_roundtrip(&ReadVotePayload {
+            txn_id,
+            t,
+            key: b"read-vote-key".to_vec(),
+            predicate: ReadPredicate::ReadRow {
+                keyspace: "ks".into(),
+                table: "t".into(),
+            },
         });
     }
 

--- a/ferrosa-cluster/tests/accord_lwt_concurrent.rs
+++ b/ferrosa-cluster/tests/accord_lwt_concurrent.rs
@@ -37,6 +37,123 @@ use ferrosa_storage::accord::sync_writer::MockSyncWriter;
 // Test node setup helpers
 // ---------------------------------------------------------------------------
 
+/// Like [`TestNode`] but its state machine is backed by a REAL StorageEngine
+/// (applier + reader), so generic-`IF` read-at-`t` exercises real storage.
+struct EngineTestNode {
+    node_id: u64,
+    peer_manager: Arc<PeerManager>,
+    #[allow(dead_code)]
+    server: Arc<RpcServer>,
+    #[allow(dead_code)]
+    accord_state: AccordState,
+    local_addr: std::net::SocketAddr,
+    engine: Arc<ferrosa_storage::StorageEngine>,
+    #[allow(dead_code)]
+    dir: Arc<tempfile::TempDir>,
+}
+
+const E2E_KS: &str = "lwt_e2e_ks";
+const E2E_TABLE: &str = "lwt_e2e_t";
+
+fn e2e_schema() -> ferrosa_common::schema::TableSchema {
+    use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+    TableSchema {
+        keyspace: E2E_KS.to_string(),
+        table: E2E_TABLE.to_string(),
+        key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        clustering_columns: vec![],
+        static_columns: vec![],
+        regular_columns: vec![ColumnDefinition {
+            name: "v".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+        }],
+        extensions: Default::default(),
+    }
+}
+
+async fn start_engine_test_node(host_id: uuid::Uuid) -> EngineTestNode {
+    use ferrosa_storage::{StorageEngine, StorageEngineConfig};
+
+    let node_id = uuid_to_node_id(host_id);
+
+    let dir = Arc::new(tempfile::tempdir().unwrap());
+    let config = StorageEngineConfig::test_config(dir.path());
+    let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+    engine.register_table(e2e_schema()).unwrap();
+
+    // Use a real engine-backed applier+reader, but a Mock sync writer so the
+    // persist-before-reply step is in-memory (matches start_test_node; the
+    // FileSyncWriter is exercised elsewhere and is not what this test asserts).
+    let sync_writer = Arc::new(MockSyncWriter::new());
+    let applier = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
+        engine.clone(),
+    ));
+    let reader = Arc::new(ferrosa_cluster::accord::EngineStorageReader::new(
+        engine.clone(),
+    ));
+    let accord_state: AccordState = Arc::new(parking_lot::Mutex::new(
+        AccordStateMachine::with_applier_and_reader(node_id, sync_writer, applier, reader),
+    ));
+
+    let registry = Arc::new(HandlerRegistry::new());
+    let accord_handler = Arc::new(AccordHandler::new(accord_state.clone(), node_id));
+    registry.register(MsgType::AccordPreAccept, accord_handler.clone());
+    registry.register(MsgType::AccordAccept, accord_handler.clone());
+    registry.register(MsgType::AccordCommit, accord_handler.clone());
+    registry.register(MsgType::AccordRead, accord_handler.clone());
+    registry.register(MsgType::AccordApply, accord_handler.clone());
+    registry.register(MsgType::AccordRecover, accord_handler);
+
+    let net_cfg = NetConfig {
+        bind_addr: "127.0.0.1:0".parse().unwrap(),
+        ..NetConfig::default()
+    };
+    let server = Arc::new(RpcServer::new(net_cfg.clone(), host_id, registry.clone()));
+    let local_addr = server.start_and_get_addr().await.expect("bind failed");
+
+    let peer_manager = Arc::new(PeerManager::new(
+        Arc::new(net_cfg),
+        host_id,
+        Arc::new(NoopListener),
+    ));
+
+    EngineTestNode {
+        node_id,
+        peer_manager,
+        server,
+        accord_state,
+        local_addr,
+        engine,
+        dir,
+    }
+}
+
+/// Serialize a single-row Mutation for `(E2E_KS, E2E_TABLE)` carrying `v=value`
+/// under partition key `pk`, stamped at `cell_ts`.
+fn e2e_mutation_bytes(pk: &str, value: i32, cell_ts: i64) -> Vec<u8> {
+    use ferrosa_common::{CellValue, DecoratedKey, PartitionKey};
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+    use ferrosa_storage::Mutation;
+
+    let key = DecoratedKey::new(PartitionKey::new(pk.as_bytes().to_vec()));
+    let row = Row {
+        clustering: vec![],
+        cells: vec![(0, CellValue::live(value.to_be_bytes().to_vec(), cell_ts))],
+        deletion: DeletionTime::LIVE,
+        primary_key_liveness: LivenessInfo::with_timestamp(cell_ts),
+    };
+    let m = Mutation::new(
+        E2E_KS.to_string(),
+        E2E_TABLE.to_string(),
+        key,
+        vec![row],
+        cell_ts,
+    );
+    let mut buf = vec![0u8; m.serialized_size()];
+    m.serialize_into(&mut buf);
+    buf
+}
+
 /// A self-contained Accord node: RPC server + state machine + peer manager.
 struct TestNode {
     #[allow(dead_code)] // identity field — used in setup, referenced for diagnostics
@@ -502,6 +619,139 @@ async fn gap4_gap5_read_vote_and_apply_round_trip() {
         .shutdown(std::time::Duration::from_millis(100))
         .await;
     replica_node
+        .server
+        .shutdown(std::time::Duration::from_millis(100))
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// Task #30: generic IF col=val via the linearizable read-at-t seam (e2e).
+// ---------------------------------------------------------------------------
+
+/// Decode the `v` (Int32) cell from a serialized single-row Mutation produced by
+/// the generic-`IF` read-vote.
+fn decode_v_from_read_row(bytes: &[u8]) -> Option<i32> {
+    use ferrosa_storage::Mutation;
+    let m = Mutation::deserialize_from(bytes).expect("read-row bytes must decode as a Mutation");
+    let row = m.rows.first()?;
+    let (_, cell) = row.cells.first()?;
+    let v = cell.value.clone()?;
+    Some(i32::from_be_bytes(v[..4].try_into().ok()?))
+}
+
+/// End-to-end generic IF: a row written via Accord is read back at `t` by the
+/// generic read-vote across a real 2-node cluster over TCP, against a real
+/// StorageEngine on each replica. The coordinator's F+1-agreed `last_read_row`
+/// must carry the REAL stored value — this is the seam the CQL coordinator
+/// evaluates `IF col=val` against.
+#[tokio::test]
+async fn generic_if_reads_real_row_at_t_across_cluster() {
+    let id_coord = uuid::Uuid::from_bytes([0x71; 16]);
+    let id_replica = uuid::Uuid::from_bytes([0x72; 16]);
+
+    let coord = start_engine_test_node(id_coord).await;
+    let replica = start_engine_test_node(id_replica).await;
+
+    coord
+        .peer_manager
+        .ensure_peer(id_replica, &replica.local_addr.to_string())
+        .await
+        .expect("coord -> replica connect");
+    replica
+        .peer_manager
+        .ensure_peer(id_coord, &coord.local_addr.to_string())
+        .await
+        .expect("replica -> coord connect");
+
+    let replica_ids = vec![id_coord, id_replica];
+    let pk = "row1";
+    let key = pk.as_bytes().to_vec();
+
+    // -----------------------------------------------------------------------
+    // Step 1: write v=50 via a full Accord transaction. The mutation persists
+    // (Gap 5) on BOTH replicas at the agreed t (cells re-stamped to t).
+    // -----------------------------------------------------------------------
+    let clock1 = HybridLogicalClock::new(coord.node_id, 500_000_000);
+    let mut writer = AccordCoordinatorDriver::new(
+        coord.node_id,
+        replica_ids.clone(),
+        Arc::clone(&coord.peer_manager),
+        false,
+        &clock1,
+        key.clone(),
+        e2e_mutation_bytes(pk, 50, 1),
+    );
+    // Give the coordinator a local applier (so its own replica persists what it
+    // coordinates) and a local reader (so its read-at-`t` counts toward F+1).
+    let coord_applier = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
+        coord.engine.clone(),
+    ));
+    let coord_reader = Arc::new(ferrosa_cluster::accord::EngineStorageReader::new(
+        coord.engine.clone(),
+    ));
+    writer = writer
+        .with_local_applier(coord_applier.clone())
+        .with_local_reader(coord_reader.clone());
+    writer
+        .run_transaction()
+        .await
+        .expect("write txn (v=50) must commit + apply");
+
+    // The remote replica persisted the row at t (Gap 5, real engine).
+    let stored = replica
+        .engine
+        .read(
+            &ferrosa_storage::TableId::new(E2E_KS, E2E_TABLE),
+            &ferrosa_common::DecoratedKey::new(ferrosa_common::PartitionKey::new(key.clone())),
+        )
+        .unwrap();
+    assert!(
+        stored.is_some(),
+        "Gap 5: remote replica must have persisted the v=50 row"
+    );
+
+    // -----------------------------------------------------------------------
+    // Step 2: a generic-IF transaction reads the row at t across the cluster.
+    // The coordinator's read-vote uses ReadPredicate::ReadRow; F+1 replicas
+    // return the SAME row bytes, and last_read_row carries the real v=50.
+    // -----------------------------------------------------------------------
+    let clock2 = HybridLogicalClock::new(coord.node_id, 500_000_100);
+    let mut reader_txn = AccordCoordinatorDriver::new(
+        coord.node_id,
+        replica_ids.clone(),
+        Arc::clone(&coord.peer_manager),
+        false,
+        &clock2,
+        key.clone(),
+        e2e_mutation_bytes(pk, 99, 2), // the UPDATE's new value (applied regardless)
+    )
+    .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
+        keyspace: E2E_KS.to_string(),
+        table: E2E_TABLE.to_string(),
+    })
+    .with_local_applier(coord_applier)
+    .with_local_reader(coord_reader);
+
+    reader_txn
+        .run_transaction()
+        .await
+        .expect("generic-IF read-vote txn must reach F+1 row agreement");
+
+    let agreed = reader_txn
+        .last_read_row()
+        .expect("generic-IF read-vote must capture the agreed row at t");
+    assert_eq!(
+        decode_v_from_read_row(agreed),
+        Some(50),
+        "the F+1-agreed row read at t must carry the REAL stored value v=50 — \
+         this is what the CQL coordinator evaluates IF col=val against"
+    );
+
+    coord
+        .server
+        .shutdown(std::time::Duration::from_millis(100))
+        .await;
+    replica
         .server
         .shutdown(std::time::Duration::from_millis(100))
         .await;

--- a/ferrosa-cluster/tests/accord_lwt_concurrent.rs
+++ b/ferrosa-cluster/tests/accord_lwt_concurrent.rs
@@ -756,3 +756,190 @@ async fn generic_if_reads_real_row_at_t_across_cluster() {
         .shutdown(std::time::Duration::from_millis(100))
         .await;
 }
+
+// ---------------------------------------------------------------------------
+// Generic IF must GATE the write (lost-update / wrong-[applied] regression)
+// ---------------------------------------------------------------------------
+
+/// Read the current `v` value persisted on a replica's engine for the e2e key,
+/// or `None` if the row is absent. Reuses the production [`StorageReader`] with a
+/// far-future `t` so it observes whatever is currently stored.
+fn engine_v(engine: Arc<ferrosa_storage::StorageEngine>, key: &[u8]) -> Option<i32> {
+    use ferrosa_cluster::accord::apply::StorageReader;
+    let reader = ferrosa_cluster::accord::EngineStorageReader::new(engine);
+    let far_future = ferrosa_common::accord::Timestamp {
+        epoch: u64::MAX,
+        time: u64::MAX,
+        seq: u32::MAX,
+        node: 0,
+    };
+    let bytes = reader
+        .read_row_at(E2E_KS, E2E_TABLE, key, far_future)
+        .expect("engine read must not error")?;
+    decode_v_from_read_row(&bytes)
+}
+
+/// Build the generic-IF condition gate the CQL layer supplies: decode the agreed
+/// row's `v` cell and apply iff it equals `expected`. Mirrors `eval_if_conditions`
+/// for `IF v = expected` without depending on ferrosa-cql.
+fn if_v_eq_gate(expected: i32) -> ferrosa_cluster::accord::ConditionGate {
+    Box::new(move |row: Option<&[u8]>| match row {
+        Some(bytes) if !bytes.is_empty() => decode_v_from_read_row(bytes) == Some(expected),
+        // Row absent at t: `IF v = x` cannot hold (CQL: applied=false).
+        _ => false,
+    })
+}
+
+/// Regression for the generic-IF lost-update bug: a generic `IF col=val` whose
+/// condition is FALSE against the F+1-agreed row at `t` must ABORT before the
+/// Apply phase — the mutation must NOT persist, and the driver must report
+/// `ConditionNotMet` carrying the real current row. Conversely a matching
+/// condition must apply. This is the linearizable-LWT correctness proof.
+#[tokio::test]
+async fn generic_if_mismatch_does_not_persist_and_match_does() {
+    let id_coord = uuid::Uuid::from_bytes([0x81; 16]);
+    let id_replica = uuid::Uuid::from_bytes([0x82; 16]);
+
+    let coord = start_engine_test_node(id_coord).await;
+    let replica = start_engine_test_node(id_replica).await;
+
+    coord
+        .peer_manager
+        .ensure_peer(id_replica, &replica.local_addr.to_string())
+        .await
+        .expect("coord -> replica connect");
+    replica
+        .peer_manager
+        .ensure_peer(id_coord, &coord.local_addr.to_string())
+        .await
+        .expect("replica -> coord connect");
+
+    let replica_ids = vec![id_coord, id_replica];
+    let pk = "rowgate";
+    let key = pk.as_bytes().to_vec();
+
+    let coord_applier = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
+        coord.engine.clone(),
+    ));
+    let coord_reader = Arc::new(ferrosa_cluster::accord::EngineStorageReader::new(
+        coord.engine.clone(),
+    ));
+
+    // Step 1: seed v=50 via a full Accord write on both replicas.
+    let clock1 = HybridLogicalClock::new(coord.node_id, 600_000_000);
+    let mut writer = AccordCoordinatorDriver::new(
+        coord.node_id,
+        replica_ids.clone(),
+        Arc::clone(&coord.peer_manager),
+        false,
+        &clock1,
+        key.clone(),
+        e2e_mutation_bytes(pk, 50, 1),
+    )
+    .with_local_applier(coord_applier.clone())
+    .with_local_reader(coord_reader.clone());
+    writer
+        .run_transaction()
+        .await
+        .expect("seed write v=50 must commit + apply");
+    assert_eq!(
+        engine_v(coord.engine.clone(), &key),
+        Some(50),
+        "coord seeded v=50"
+    );
+    assert_eq!(
+        engine_v(replica.engine.clone(), &key),
+        Some(50),
+        "replica seeded v=50"
+    );
+
+    // Step 2: UPDATE ... SET v=99 IF v=999 (MISMATCH: stored is 50).
+    // The mutation must NOT persist; the driver must return ConditionNotMet
+    // carrying the real current row (v=50).
+    let clock2 = HybridLogicalClock::new(coord.node_id, 600_000_100);
+    let mut mismatch = AccordCoordinatorDriver::new(
+        coord.node_id,
+        replica_ids.clone(),
+        Arc::clone(&coord.peer_manager),
+        false,
+        &clock2,
+        key.clone(),
+        e2e_mutation_bytes(pk, 99, 2),
+    )
+    .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
+        keyspace: E2E_KS.to_string(),
+        table: E2E_TABLE.to_string(),
+    })
+    .with_local_applier(coord_applier.clone())
+    .with_local_reader(coord_reader.clone())
+    .with_condition_gate(if_v_eq_gate(999));
+
+    let err = mismatch
+        .run_transaction()
+        .await
+        .expect_err("IF v=999 against stored v=50 must NOT apply");
+    match err {
+        AccordDriverError::ConditionNotMet { current_row } => {
+            assert_eq!(
+                decode_v_from_read_row(&current_row),
+                Some(50),
+                "ConditionNotMet must carry the REAL current row (v=50)"
+            );
+        }
+        other => panic!("expected ConditionNotMet, got {other:?}"),
+    }
+    // CRITICAL: the failed LWT must NOT have persisted v=99 on EITHER node.
+    assert_eq!(
+        engine_v(coord.engine.clone(), &key),
+        Some(50),
+        "lost-update bug: coordinator persisted v=99 on a FAILED IF"
+    );
+    assert_eq!(
+        engine_v(replica.engine.clone(), &key),
+        Some(50),
+        "lost-update bug: replica persisted v=99 on a FAILED IF"
+    );
+
+    // Step 3: UPDATE ... SET v=77 IF v=50 (MATCH). Must apply + persist.
+    let clock3 = HybridLogicalClock::new(coord.node_id, 600_000_200);
+    let mut matching = AccordCoordinatorDriver::new(
+        coord.node_id,
+        replica_ids.clone(),
+        Arc::clone(&coord.peer_manager),
+        false,
+        &clock3,
+        key.clone(),
+        e2e_mutation_bytes(pk, 77, 3),
+    )
+    .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
+        keyspace: E2E_KS.to_string(),
+        table: E2E_TABLE.to_string(),
+    })
+    .with_local_applier(coord_applier)
+    .with_local_reader(coord_reader)
+    .with_condition_gate(if_v_eq_gate(50));
+
+    matching
+        .run_transaction()
+        .await
+        .expect("IF v=50 against stored v=50 must apply");
+    assert_eq!(
+        engine_v(coord.engine.clone(), &key),
+        Some(77),
+        "matching IF must persist v=77 on coordinator"
+    );
+    assert_eq!(
+        engine_v(replica.engine.clone(), &key),
+        Some(77),
+        "matching IF must persist v=77 on replica"
+    );
+
+    coord
+        .server
+        .shutdown(std::time::Duration::from_millis(100))
+        .await;
+    replica
+        .server
+        .shutdown(std::time::Duration::from_millis(100))
+        .await;
+}

--- a/ferrosa-cluster/tests/accord_lwt_concurrent.rs
+++ b/ferrosa-cluster/tests/accord_lwt_concurrent.rs
@@ -975,28 +975,22 @@ async fn generic_if_mismatch_does_not_persist_and_match_does() {
 /// A lost-update / double-apply bug would surface as: both succeed, OR the two
 /// engines disagree, OR the persisted value is the loser's.
 ///
-/// # KNOWN-FAILING — linearizability gap (intentionally `#[ignore]`)
+/// # Linearizability proof — concurrent `INSERT IF NOT EXISTS` exactly-once
 ///
-/// This test currently FAILS: under genuine concurrency **both** transactions
-/// apply (a lost update / double-apply). Root cause is the *documented, deferred*
-/// dep-wait gap in `ferrosa-cluster/src/accord/handlers.rs` (`AccordRead`
-/// handler): the `ReadVote` handler does NOT block until every conflicting
-/// dependency `t' < t` has reached `Applied` before performing the read-at-`t`.
-/// Both contenders therefore read the empty key *before* either applies, both
-/// existence gates pass, and both inserts land. The coordinator's F+1-agreement
-/// safety net does not catch this because BOTH replicas agree on the (stale)
-/// empty read.
+/// Under genuine concurrency exactly one transaction applies; the loser (larger
+/// `t`) reads the winner's persisted row at its `t` and returns
+/// `ConditionNotMet`. This is enforced by the ReadVote dep-wait: a replica (and
+/// the coordinator's own local read-vote, via
+/// [`with_local_accord_state`](ferrosa_cluster::accord::AccordCoordinatorDriver::with_local_accord_state))
+/// blocks until every conflicting transaction `t0 < t` has reached `Applied`
+/// before performing the read-at-`t`, so the loser observes the winner's write
+/// instead of a stale empty key. On dep-wait timeout the read ABSTAINS (no row),
+/// so the coordinator's F+1 agreement fails loud rather than fabricating a
+/// double-apply.
 ///
-/// The assertions below encode the CORRECT (linearizable) behavior, so once the
-/// read-vote dep-wait is implemented this test will pass UNMODIFIED. It is left
-/// `#[ignore]`d — not deleted and not weakened to assert the broken behavior —
-/// because faking a passing exactly-once proof would hide a silent data-loss bug
-/// (per the fail-loud rule). Run explicitly with:
-///   `cargo test -p ferrosa-cluster --test accord_lwt_concurrent -- --ignored`
+/// Before the dep-wait fix this test failed: both contenders read the empty key
+/// before either applied, both existence gates passed, and both inserts landed.
 #[tokio::test]
-#[ignore = "linearizability gap: ReadVote handler lacks dep-wait — concurrent IF NOT \
-            EXISTS double-applies (handlers.rs AccordRead). Test asserts the correct \
-            behavior and will pass once dep-wait lands."]
 async fn concurrent_insert_if_not_exists_exactly_one_applies_through_engine() {
     let id_a = uuid::Uuid::from_bytes([0x91; 16]);
     let id_b = uuid::Uuid::from_bytes([0x92; 16]);
@@ -1054,6 +1048,7 @@ async fn concurrent_insert_if_not_exists_exactly_one_applies_through_engine() {
     })
     .with_local_applier(applier_a)
     .with_local_reader(reader_a)
+    .with_local_accord_state(node_a.accord_state.clone())
     .with_condition_gate(if_not_exists_gate());
 
     let mut driver_b = AccordCoordinatorDriver::new(
@@ -1071,6 +1066,7 @@ async fn concurrent_insert_if_not_exists_exactly_one_applies_through_engine() {
     })
     .with_local_applier(applier_b)
     .with_local_reader(reader_b)
+    .with_local_accord_state(node_b.accord_state.clone())
     .with_condition_gate(if_not_exists_gate());
 
     let (res_a, res_b) = tokio::join!(driver_a.run_transaction(), driver_b.run_transaction());

--- a/ferrosa-cluster/tests/accord_lwt_concurrent.rs
+++ b/ferrosa-cluster/tests/accord_lwt_concurrent.rs
@@ -790,6 +790,20 @@ fn if_v_eq_gate(expected: i32) -> ferrosa_cluster::accord::ConditionGate {
     })
 }
 
+/// Build the `INSERT ... IF NOT EXISTS` gate the CQL layer supplies: apply iff the
+/// F+1-agreed row at `t` is absent. Mirrors `eval_if_conditions` for the existence
+/// predicate, but routed through the generic linearizable read-at-`t` seam so the
+/// "exactly one applies" guarantee is enforced against REAL stored state.
+fn if_not_exists_gate() -> ferrosa_cluster::accord::ConditionGate {
+    Box::new(|row: Option<&[u8]>| match row {
+        // A non-empty agreed row means the partition already exists at `t`:
+        // IF NOT EXISTS does not hold (CQL: applied=false).
+        Some(bytes) if !bytes.is_empty() => false,
+        // Absent at `t`: the insert applies.
+        _ => true,
+    })
+}
+
 /// Regression for the generic-IF lost-update bug: a generic `IF col=val` whose
 /// condition is FALSE against the F+1-agreed row at `t` must ABORT before the
 /// Apply phase — the mutation must NOT persist, and the driver must report
@@ -942,4 +956,305 @@ async fn generic_if_mismatch_does_not_persist_and_match_does() {
         .server
         .shutdown(std::time::Duration::from_millis(100))
         .await;
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent INSERT ... IF NOT EXISTS through the engine seam: EXACTLY ONE
+// applies. (The earlier `two_coordinators_*` test runs WITHOUT an engine; this
+// one drives both coordinators against REAL per-replica StorageEngines so a
+// double-apply would be observable as two distinct persisted values.)
+// ---------------------------------------------------------------------------
+
+/// Two coordinators concurrently fire `INSERT ... IF NOT EXISTS` (modelled via
+/// the generic linearizable read-at-`t` seam + an existence gate) at the SAME
+/// empty key, each carrying a DISTINCT value. Accord must serialize them so that
+/// **exactly one** insert applies; the loser's gate sees the winner's row at its
+/// (later) `t` and aborts with `ConditionNotMet`. Both replicas' engines must end
+/// holding the SAME single value — the winner's.
+///
+/// A lost-update / double-apply bug would surface as: both succeed, OR the two
+/// engines disagree, OR the persisted value is the loser's.
+///
+/// # KNOWN-FAILING — linearizability gap (intentionally `#[ignore]`)
+///
+/// This test currently FAILS: under genuine concurrency **both** transactions
+/// apply (a lost update / double-apply). Root cause is the *documented, deferred*
+/// dep-wait gap in `ferrosa-cluster/src/accord/handlers.rs` (`AccordRead`
+/// handler): the `ReadVote` handler does NOT block until every conflicting
+/// dependency `t' < t` has reached `Applied` before performing the read-at-`t`.
+/// Both contenders therefore read the empty key *before* either applies, both
+/// existence gates pass, and both inserts land. The coordinator's F+1-agreement
+/// safety net does not catch this because BOTH replicas agree on the (stale)
+/// empty read.
+///
+/// The assertions below encode the CORRECT (linearizable) behavior, so once the
+/// read-vote dep-wait is implemented this test will pass UNMODIFIED. It is left
+/// `#[ignore]`d — not deleted and not weakened to assert the broken behavior —
+/// because faking a passing exactly-once proof would hide a silent data-loss bug
+/// (per the fail-loud rule). Run explicitly with:
+///   `cargo test -p ferrosa-cluster --test accord_lwt_concurrent -- --ignored`
+#[tokio::test]
+#[ignore = "linearizability gap: ReadVote handler lacks dep-wait — concurrent IF NOT \
+            EXISTS double-applies (handlers.rs AccordRead). Test asserts the correct \
+            behavior and will pass once dep-wait lands."]
+async fn concurrent_insert_if_not_exists_exactly_one_applies_through_engine() {
+    let id_a = uuid::Uuid::from_bytes([0x91; 16]);
+    let id_b = uuid::Uuid::from_bytes([0x92; 16]);
+
+    let node_a = start_engine_test_node(id_a).await;
+    let node_b = start_engine_test_node(id_b).await;
+
+    node_a
+        .peer_manager
+        .ensure_peer(id_b, &node_b.local_addr.to_string())
+        .await
+        .expect("node_a -> node_b connect");
+    node_b
+        .peer_manager
+        .ensure_peer(id_a, &node_a.local_addr.to_string())
+        .await
+        .expect("node_b -> node_a connect");
+
+    let replica_ids = vec![id_a, id_b];
+    let pk = "race-key";
+    let key = pk.as_bytes().to_vec();
+
+    // Each coordinator persists/read through ITS OWN engine locally; cross-node
+    // Apply persists to the peer's engine via the registered AccordHandler.
+    let applier_a = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
+        node_a.engine.clone(),
+    ));
+    let reader_a = Arc::new(ferrosa_cluster::accord::EngineStorageReader::new(
+        node_a.engine.clone(),
+    ));
+    let applier_b = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
+        node_b.engine.clone(),
+    ));
+    let reader_b = Arc::new(ferrosa_cluster::accord::EngineStorageReader::new(
+        node_b.engine.clone(),
+    ));
+
+    // Contender A inserts v=11; contender B inserts v=22 — distinct so the
+    // surviving value identifies the winner unambiguously.
+    let clock_a = HybridLogicalClock::new(node_a.node_id, 700_000_000);
+    let clock_b = HybridLogicalClock::new(node_b.node_id, 700_000_000);
+
+    let mut driver_a = AccordCoordinatorDriver::new(
+        node_a.node_id,
+        replica_ids.clone(),
+        Arc::clone(&node_a.peer_manager),
+        false,
+        &clock_a,
+        key.clone(),
+        e2e_mutation_bytes(pk, 11, 1),
+    )
+    .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
+        keyspace: E2E_KS.to_string(),
+        table: E2E_TABLE.to_string(),
+    })
+    .with_local_applier(applier_a)
+    .with_local_reader(reader_a)
+    .with_condition_gate(if_not_exists_gate());
+
+    let mut driver_b = AccordCoordinatorDriver::new(
+        node_b.node_id,
+        replica_ids.clone(),
+        Arc::clone(&node_b.peer_manager),
+        false,
+        &clock_b,
+        key.clone(),
+        e2e_mutation_bytes(pk, 22, 1),
+    )
+    .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
+        keyspace: E2E_KS.to_string(),
+        table: E2E_TABLE.to_string(),
+    })
+    .with_local_applier(applier_b)
+    .with_local_reader(reader_b)
+    .with_condition_gate(if_not_exists_gate());
+
+    let (res_a, res_b) = tokio::join!(driver_a.run_transaction(), driver_b.run_transaction());
+
+    eprintln!(
+        "concurrent IF NOT EXISTS: a={:?} b={:?}",
+        res_a.as_ref().map(|(t, _)| t),
+        res_b.as_ref().map(|(t, _)| t)
+    );
+
+    // EXACTLY ONE may apply. The other must abort with ConditionNotMet (it read
+    // the winner's row at its later `t`) — never a second silent apply.
+    let a_applied = res_a.is_ok();
+    let b_applied = res_b.is_ok();
+    match (&res_a, &res_b) {
+        (Ok(_), Err(AccordDriverError::ConditionNotMet { current_row }))
+        | (Err(AccordDriverError::ConditionNotMet { current_row }), Ok(_)) => {
+            // The loser's ConditionNotMet must carry the winner's real row.
+            let loser_saw = decode_v_from_read_row(current_row);
+            assert!(
+                loser_saw == Some(11) || loser_saw == Some(22),
+                "loser's ConditionNotMet must carry the winner's real persisted row, got {loser_saw:?}"
+            );
+        }
+        other => panic!(
+            "exactly one INSERT IF NOT EXISTS must apply and the other must return \
+             ConditionNotMet; got {other:?}"
+        ),
+    }
+    assert!(
+        a_applied ^ b_applied,
+        "EXACTLY ONE coordinator must apply (a_applied={a_applied}, b_applied={b_applied})"
+    );
+
+    // Both engines must converge on the SAME single winning value.
+    let v_a = engine_v(node_a.engine.clone(), &key);
+    let v_b = engine_v(node_b.engine.clone(), &key);
+    assert!(v_a.is_some(), "winner's row must be persisted on node_a");
+    assert_eq!(
+        v_a, v_b,
+        "both replicas must hold the SAME value after the race (split-brain / divergent apply)"
+    );
+    let winner = v_a.unwrap();
+    assert!(
+        winner == 11 || winner == 22,
+        "persisted value must be one contender's, got {winner}"
+    );
+    // The winner is whichever coordinator's run_transaction succeeded.
+    let expected = if a_applied { 11 } else { 22 };
+    assert_eq!(
+        winner, expected,
+        "the persisted value must match the coordinator that reported [applied]=true"
+    );
+
+    node_a
+        .server
+        .shutdown(std::time::Duration::from_millis(100))
+        .await;
+    node_b
+        .server
+        .shutdown(std::time::Duration::from_millis(100))
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// Durability: an applied LWT value survives a state-machine + engine RESTART
+// (commit-log replay on reopen of the same data dir).
+// ---------------------------------------------------------------------------
+
+/// Apply a value via the full Accord LWT path, then DROP the state machine and
+/// engine and REOPEN a fresh `StorageEngine` from the same data dir. The applied
+/// value must survive — proving the LWT write reached durable storage (commit
+/// log / SSTables), not just an in-memory state machine.
+#[tokio::test]
+async fn applied_lwt_value_survives_state_machine_restart() {
+    use ferrosa_storage::{StorageEngine, StorageEngineConfig};
+
+    let id_coord = uuid::Uuid::from_bytes([0xA1; 16]);
+    let id_replica = uuid::Uuid::from_bytes([0xA2; 16]);
+
+    let coord = start_engine_test_node(id_coord).await;
+    let replica = start_engine_test_node(id_replica).await;
+
+    coord
+        .peer_manager
+        .ensure_peer(id_replica, &replica.local_addr.to_string())
+        .await
+        .expect("coord -> replica connect");
+    replica
+        .peer_manager
+        .ensure_peer(id_coord, &coord.local_addr.to_string())
+        .await
+        .expect("replica -> coord connect");
+
+    let replica_ids = vec![id_coord, id_replica];
+    let pk = "durable-row";
+    let key = pk.as_bytes().to_vec();
+
+    let coord_applier = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
+        coord.engine.clone(),
+    ));
+    let coord_reader = Arc::new(ferrosa_cluster::accord::EngineStorageReader::new(
+        coord.engine.clone(),
+    ));
+
+    // INSERT v=42 IF NOT EXISTS — applies through the full Accord path onto both
+    // replicas' real engines.
+    let clock1 = HybridLogicalClock::new(coord.node_id, 800_000_000);
+    let mut writer = AccordCoordinatorDriver::new(
+        coord.node_id,
+        replica_ids.clone(),
+        Arc::clone(&coord.peer_manager),
+        false,
+        &clock1,
+        key.clone(),
+        e2e_mutation_bytes(pk, 42, 1),
+    )
+    .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
+        keyspace: E2E_KS.to_string(),
+        table: E2E_TABLE.to_string(),
+    })
+    .with_local_applier(coord_applier)
+    .with_local_reader(coord_reader)
+    .with_condition_gate(if_not_exists_gate());
+
+    writer
+        .run_transaction()
+        .await
+        .expect("INSERT v=42 IF NOT EXISTS must apply");
+    assert_eq!(
+        engine_v(coord.engine.clone(), &key),
+        Some(42),
+        "coord applied v=42"
+    );
+    assert_eq!(
+        engine_v(replica.engine.clone(), &key),
+        Some(42),
+        "replica applied v=42"
+    );
+
+    // Capture each replica's data dir, then tear everything down. Sync the
+    // commit log first (clean-shutdown fsync) so the applied LWT rows are durable
+    // on disk, then DROP the nodes (state machines, appliers, engine handles).
+    // The TempDir is kept alive separately so the on-disk data survives the drop.
+    coord
+        .engine
+        .force_commit_log_sync()
+        .expect("coord commit-log sync");
+    replica
+        .engine
+        .force_commit_log_sync()
+        .expect("replica commit-log sync");
+
+    let coord_dir = coord.dir.clone();
+    let replica_dir = replica.dir.clone();
+    let coord_path = coord_dir.path().to_path_buf();
+    let replica_path = replica_dir.path().to_path_buf();
+
+    coord
+        .server
+        .shutdown(std::time::Duration::from_millis(100))
+        .await;
+    replica
+        .server
+        .shutdown(std::time::Duration::from_millis(100))
+        .await;
+    drop(coord);
+    drop(replica);
+
+    // REOPEN fresh engines from the same dirs via the crash-recovery path:
+    // `open` returns the unflushed commit-log mutations, which `replay_mutations`
+    // re-materializes after the table schema is re-registered. The applied LWT
+    // row must survive on BOTH replicas — durability via commit-log replay.
+    for (label, path) in [("coord", coord_path), ("replica", replica_path)] {
+        let cfg = StorageEngineConfig::test_config(&path);
+        let (reopened, pending) = StorageEngine::open(cfg, None).unwrap();
+        let reopened = Arc::new(reopened);
+        reopened.register_table(e2e_schema()).unwrap();
+        reopened.replay_mutations(pending).unwrap();
+        assert_eq!(
+            engine_v(reopened.clone(), &key),
+            Some(42),
+            "{label}: applied LWT value v=42 must survive a state-machine + engine restart \
+             (durability via commit-log replay)"
+        );
+    }
 }

--- a/ferrosa-cql/src/accord_router.rs
+++ b/ferrosa-cql/src/accord_router.rs
@@ -195,6 +195,64 @@ pub fn eval_if_conditions(
 }
 
 // ---------------------------------------------------------------------------
+// LWT predicate classification + statement-level evaluation
+// ---------------------------------------------------------------------------
+
+/// How an LWT statement's IF clause must be evaluated against the row at `t`.
+///
+/// This mirrors the replica-side `ReadPredicate` but stays in the CQL layer
+/// where the predicate operators (`IfCondition`/`Term`/`CqlValue`) are defined.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LwtPredicateKind {
+    /// `INSERT IF NOT EXISTS`: condition holds iff the row is absent at `t`.
+    /// The replica answers this via its existence path (no schema needed).
+    NotExists,
+    /// Generic `IF <conditions>` / `IF EXISTS` on UPDATE/DELETE (or an INSERT
+    /// with explicit IF conditions): the coordinator reads the row at `t` and
+    /// evaluates the predicate with [`eval_if_conditions`].
+    Generic,
+}
+
+/// Classify the LWT predicate an INSERT/UPDATE/DELETE carries.
+///
+/// Returns `None` for statements with no conditional clause (not an LWT — must
+/// not route through the read-vote path).
+pub fn classify_lwt(stmt: &Statement) -> Option<LwtPredicateKind> {
+    match stmt {
+        Statement::Insert(s) if s.if_not_exists => Some(LwtPredicateKind::NotExists),
+        Statement::Update(s) if s.if_exists || !s.if_conditions.is_empty() => {
+            Some(LwtPredicateKind::Generic)
+        }
+        Statement::Delete(s) if s.if_exists || !s.if_conditions.is_empty() => {
+            Some(LwtPredicateKind::Generic)
+        }
+        _ => None,
+    }
+}
+
+/// Evaluate an LWT statement's IF clause against the row state at `t`.
+///
+/// `existing_row` is the row read at the Accord-agreed timestamp `t` (decoded to
+/// `column -> value`), or `None` if the row was absent at `t`. Reuses the
+/// canonical [`eval_insert_if_not_exists`] / [`eval_if_conditions`] evaluators —
+/// no divergent logic. Returns `None` if the statement is not an LWT.
+pub fn eval_lwt_for_statement(
+    stmt: &Statement,
+    existing_row: Option<&HashMap<String, Option<CqlValue>>>,
+) -> Option<LwtResult> {
+    match stmt {
+        Statement::Insert(s) if s.if_not_exists => Some(eval_insert_if_not_exists(existing_row)),
+        Statement::Update(s) if s.if_exists || !s.if_conditions.is_empty() => Some(
+            eval_if_conditions(&s.if_conditions, s.if_exists, existing_row),
+        ),
+        Statement::Delete(s) if s.if_exists || !s.if_conditions.is_empty() => Some(
+            eval_if_conditions(&s.if_conditions, s.if_exists, existing_row),
+        ),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // LWT result set encoding
 // ---------------------------------------------------------------------------
 
@@ -1060,5 +1118,120 @@ mod tests {
         }];
 
         assert!(!eval_if_conditions(&cond_in_miss, false, Some(&row)).applied);
+    }
+
+    // -----------------------------------------------------------------------
+    // Generic-IF: statement classification + read-row evaluation (Task #30).
+    // -----------------------------------------------------------------------
+
+    fn insert_if_not_exists() -> Statement {
+        Statement::Insert(InsertStatement {
+            keyspace: Some("ks".into()),
+            table: "t".into(),
+            columns: vec!["id".into()],
+            values: vec![Term::IntegerLiteral(1)],
+            if_not_exists: true,
+            using_timestamp: None,
+            using_ttl: None,
+        })
+    }
+
+    fn update_if_v_eq(expected: i64) -> Statement {
+        Statement::Update(UpdateStatement {
+            keyspace: Some("ks".into()),
+            table: "t".into(),
+            assignments: vec![Assignment::Simple {
+                column: "v".into(),
+                value: Term::IntegerLiteral(99),
+            }],
+            where_clauses: vec![WhereClause {
+                column: "id".into(),
+                op: ComparisonOp::Eq,
+                value: Term::IntegerLiteral(1),
+                token_fn: false,
+            }],
+            if_exists: false,
+            if_conditions: vec![IfCondition {
+                column: "v".into(),
+                operator: IfOperator::Eq,
+                value: Term::IntegerLiteral(expected),
+            }],
+            using_timestamp: None,
+            using_ttl: None,
+        })
+    }
+
+    #[test]
+    fn classify_lwt_distinguishes_not_exists_from_generic() {
+        assert_eq!(
+            classify_lwt(&insert_if_not_exists()),
+            Some(LwtPredicateKind::NotExists)
+        );
+        assert_eq!(
+            classify_lwt(&update_if_v_eq(50)),
+            Some(LwtPredicateKind::Generic)
+        );
+        // A plain INSERT with no IF is not an LWT.
+        let plain = Statement::Insert(InsertStatement {
+            keyspace: Some("ks".into()),
+            table: "t".into(),
+            columns: vec!["id".into()],
+            values: vec![Term::IntegerLiteral(1)],
+            if_not_exists: false,
+            using_timestamp: None,
+            using_ttl: None,
+        });
+        assert_eq!(classify_lwt(&plain), None);
+    }
+
+    // (a) UPDATE … IF v=50 where the stored row matches -> applied.
+    #[test]
+    fn eval_generic_if_match_applies() {
+        let mut row = HashMap::new();
+        row.insert("id".to_string(), Some(CqlValue::Int(1)));
+        row.insert("v".to_string(), Some(CqlValue::Int(50)));
+
+        let res =
+            eval_lwt_for_statement(&update_if_v_eq(50), Some(&row)).expect("UPDATE IF is an LWT");
+        assert!(res.applied, "matching IF v=50 must apply");
+    }
+
+    // (b) UPDATE … IF v=50 where the stored row does NOT match -> not applied,
+    //     and current_values returns the real stored row.
+    #[test]
+    fn eval_generic_if_mismatch_returns_current_values() {
+        let mut row = HashMap::new();
+        row.insert("id".to_string(), Some(CqlValue::Int(1)));
+        row.insert("v".to_string(), Some(CqlValue::Int(999)));
+
+        let res =
+            eval_lwt_for_statement(&update_if_v_eq(50), Some(&row)).expect("UPDATE IF is an LWT");
+        assert!(!res.applied, "non-matching IF v=50 must NOT apply");
+        assert_eq!(
+            res.current_values.get("v"),
+            Some(&Some(CqlValue::Int(999))),
+            "current_values must carry the real stored row"
+        );
+    }
+
+    // (c) INSERT IF NOT EXISTS via the existence path: absent -> applied,
+    //     present -> not applied (existence semantics, no generic predicate).
+    #[test]
+    fn eval_insert_if_not_exists_via_existence_path() {
+        let applied = eval_lwt_for_statement(&insert_if_not_exists(), None)
+            .expect("INSERT IF NOT EXISTS is an LWT");
+        assert!(
+            applied.applied,
+            "absent row -> INSERT IF NOT EXISTS applies"
+        );
+
+        let mut row = HashMap::new();
+        row.insert("id".to_string(), Some(CqlValue::Int(1)));
+        let not_applied = eval_lwt_for_statement(&insert_if_not_exists(), Some(&row))
+            .expect("INSERT IF NOT EXISTS is an LWT");
+        assert!(
+            !not_applied.applied,
+            "present row -> INSERT IF NOT EXISTS must not apply"
+        );
     }
 }

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1034,6 +1034,130 @@ fn build_lwt_mutation(
     Ok((key_bytes, mutation_bytes))
 }
 
+/// Decode the agreed row-at-`t` bytes (a serialized single-partition
+/// [`Mutation`](ferrosa_storage::Mutation)) into a `column -> value` map for IF
+/// evaluation, using the SAME positional decode the local read path uses
+/// ([`bridge::partition_to_rows_with_storage_mapping`]).
+///
+/// Returns `Ok(None)` when there is no agreed row (row absent at `t`).
+fn decode_agreed_row_to_map(
+    state: &SharedState,
+    ks: &str,
+    table: &str,
+    agreed_row: Option<&[u8]>,
+) -> Result<Option<HashMap<String, Option<CqlValue>>>, CqlError> {
+    use ferrosa_storage::Mutation;
+
+    let bytes = match agreed_row {
+        None => return Ok(None),
+        Some(b) => b,
+    };
+
+    let mutation = Mutation::deserialize_from(bytes)
+        .map_err(|e| CqlError::ServerError(format!("failed to decode LWT read-vote row: {e}")))?;
+
+    let snap = state.schema.snapshot();
+    let table_meta = snap
+        .tables
+        .get(&(ks.to_string(), table.to_string()))
+        .ok_or_else(|| CqlError::Invalid(format!("table {ks}.{table} not found")))?;
+
+    let all_col_names: Vec<String> = table_meta.columns.keys().cloned().collect();
+    let all_col_types: Vec<CqlType> = table_meta
+        .columns
+        .values()
+        .map(|c| resolve_col_type(&c.column_type, ks, &state.schema))
+        .collect::<Result<Vec<_>, _>>()?;
+    let pk_indices: Vec<usize> = table_meta
+        .partition_key
+        .iter()
+        .filter_map(|name| table_meta.columns.get_index_of(name))
+        .collect();
+    let ck_indices: Vec<usize> = table_meta
+        .clustering_key
+        .iter()
+        .filter_map(|(name, _)| table_meta.columns.get_index_of(name))
+        .collect();
+    let storage_to_table = storage_to_table_indices(table_meta);
+
+    let partition = ferrosa_sstable::types::Partition {
+        key: mutation.key.clone(),
+        deletion: ferrosa_sstable::types::DeletionTime::LIVE,
+        static_row: None,
+        rows: mutation.rows.clone(),
+    };
+
+    let rows = bridge::partition_to_rows_with_storage_mapping(
+        &partition,
+        &all_col_names,
+        &all_col_types,
+        &pk_indices,
+        &ck_indices,
+        &storage_to_table,
+    );
+
+    let row_values = match rows.into_iter().next() {
+        None => return Ok(None),
+        Some(r) => r,
+    };
+
+    let map: HashMap<String, Option<CqlValue>> = all_col_names
+        .iter()
+        .cloned()
+        .zip(row_values)
+        .collect();
+    Ok(Some(map))
+}
+
+/// Resolve the `(keyspace, table)` an LWT statement targets.
+fn lwt_keyspace_table(
+    ctx: &RequestContext<'_>,
+    stmt: &Statement,
+) -> Result<(String, String), CqlError> {
+    let (ks_opt, table) = match stmt {
+        Statement::Insert(s) => (&s.keyspace, &s.table),
+        Statement::Update(s) => (&s.keyspace, &s.table),
+        Statement::Delete(s) => (&s.keyspace, &s.table),
+        _ => {
+            return Err(CqlError::Invalid(
+                "LWT via Accord supports only INSERT/UPDATE/DELETE".into(),
+            ))
+        }
+    };
+    let ks = resolve_keyspace(ks_opt, ctx.current_keyspace)?.to_string();
+    Ok((ks, table.clone()))
+}
+
+/// Columns (name + type) to include in a `[applied]=false` LWT result set.
+///
+/// For a generic `IF`, these are the IF-condition columns. For `INSERT IF NOT
+/// EXISTS` (and any path whose statement carries no explicit conditions), all
+/// table columns are returned (the Cassandra contract returns the full
+/// conflicting row). Returns an empty list when `lwt.applied` (no row needed).
+fn lwt_condition_columns(
+    state: &SharedState,
+    ks: &str,
+    table: &str,
+    lwt: &crate::accord_router::LwtResult,
+) -> Result<Vec<(String, CqlType)>, CqlError> {
+    if lwt.applied {
+        return Ok(Vec::new());
+    }
+    let snap = state.schema.snapshot();
+    let table_meta = snap
+        .tables
+        .get(&(ks.to_string(), table.to_string()))
+        .ok_or_else(|| CqlError::Invalid(format!("table {ks}.{table} not found")))?;
+
+    let mut cols = Vec::new();
+    for name in table_meta.columns.keys() {
+        let col_meta = &table_meta.columns[name];
+        let cql_type = resolve_col_type(&col_meta.column_type, ks, &state.schema)?;
+        cols.push((name.clone(), cql_type));
+    }
+    Ok(cols)
+}
+
 /// Route a LWT statement through the Accord consensus protocol.
 ///
 /// Constructs an `AccordCoordinatorDriver`, runs the full PreAccept → Commit
@@ -1084,6 +1208,25 @@ async fn route_lwt_via_accord(
     // that persisted nothing (the phantom-write bug).
     let (key, mutation) = build_lwt_mutation(state, ctx, stmt)?;
 
+    // Resolve the target keyspace/table for the generic-IF read-vote so replicas
+    // (and the coordinator's own local reader) can target the read-at-`t`.
+    let (ks, table) = lwt_keyspace_table(ctx, stmt)?;
+
+    // Classify the IF predicate. `NotExists` uses the replica existence path;
+    // `Generic` reads the row at `t` so the coordinator evaluates `IF col=val`.
+    use crate::accord_router::{classify_lwt, LwtPredicateKind};
+    use ferrosa_cluster::accord::ReadPredicate;
+    let predicate_kind = classify_lwt(stmt);
+    let read_predicate = match predicate_kind {
+        Some(LwtPredicateKind::Generic) => ReadPredicate::ReadRow {
+            keyspace: ks.clone(),
+            table: table.clone(),
+        },
+        // NotExists, or a non-LWT statement reaching here (defensive): keep the
+        // existence semantics.
+        _ => ReadPredicate::NotExists,
+    };
+
     let mut driver = AccordCoordinatorDriver::new(
         node_id,
         replica_ids,
@@ -1092,35 +1235,73 @@ async fn route_lwt_via_accord(
         &clock,
         key,
         mutation,
-    );
+    )
+    .with_read_predicate(read_predicate);
+
+    // Give the coordinator a local applier so its OWN replica persists the
+    // mutation it coordinates (its self-send Apply RPC is unreachable). Without
+    // this the coordinator node silently lacks its own LWT writes. For the
+    // generic path also wire a local reader so its read-at-`t` counts toward the
+    // F+1 row agreement and matches the replicas that applied.
+    {
+        let applier = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
+            state.engine.clone(),
+        ));
+        driver = driver.with_local_applier(applier);
+    }
+    if matches!(predicate_kind, Some(LwtPredicateKind::Generic)) {
+        let reader = Arc::new(ferrosa_cluster::accord::EngineStorageReader::new(
+            state.engine.clone(),
+        ));
+        driver = driver.with_local_reader(reader);
+    }
 
     match driver.run_transaction().await {
         Ok(_) => {
-            // Gap 4: F+1 read-votes agreed the IF condition held.
-            // Gap 5: F+1 apply acknowledgements received.
-            let result = crate::accord_router::encode_lwt_result(
-                &crate::accord_router::LwtResult {
+            // Gap 5: F+1 apply acknowledgements received (write is durable).
+            //
+            // Decide [applied] from the IF predicate:
+            // - Generic IF: evaluate the F+1-agreed row-at-`t` with the canonical
+            //   eval_if_conditions (reused, not forked). A mismatch returns
+            //   [applied]=false + the real current row.
+            // - INSERT IF NOT EXISTS: the read-vote already gated this (a present
+            //   row yields ConditionNotMet below), so reaching Ok means applied.
+            let lwt = match predicate_kind {
+                Some(LwtPredicateKind::Generic) => {
+                    let agreed =
+                        decode_agreed_row_to_map(state, &ks, &table, driver.last_read_row())?;
+                    crate::accord_router::eval_lwt_for_statement(stmt, agreed.as_ref()).unwrap_or(
+                        crate::accord_router::LwtResult {
+                            applied: true,
+                            current_values: HashMap::new(),
+                        },
+                    )
+                }
+                _ => crate::accord_router::LwtResult {
                     applied: true,
-                    current_values: std::collections::HashMap::new(),
+                    current_values: HashMap::new(),
                 },
-                "",
-                "",
-                &[],
-            );
+            };
+            let cond_cols = lwt_condition_columns(state, &ks, &table, &lwt)?;
+            let result = crate::accord_router::encode_lwt_result(&lwt, &ks, &table, &cond_cols);
             Ok(RouteResult::Result(result))
         }
-        Err(AccordDriverError::ConditionNotMet { .. }) => {
-            // Gap 4: F+1 read-votes agreed the IF condition did NOT hold.
-            // Return [applied]=false with the current row value.
-            let result = crate::accord_router::encode_lwt_result(
-                &crate::accord_router::LwtResult {
-                    applied: false,
-                    current_values: std::collections::HashMap::new(),
-                },
-                "",
-                "",
-                &[],
-            );
+        Err(AccordDriverError::ConditionNotMet { current_row }) => {
+            // Gap 4: F+1 read-votes agreed the IF condition did NOT hold
+            // (INSERT IF NOT EXISTS: the row already existed). Return
+            // [applied]=false with the real current row from the read-vote.
+            let agreed_bytes: Option<&[u8]> = if current_row.is_empty() {
+                None
+            } else {
+                Some(current_row.as_slice())
+            };
+            let agreed = decode_agreed_row_to_map(state, &ks, &table, agreed_bytes)?;
+            let lwt = crate::accord_router::LwtResult {
+                applied: false,
+                current_values: agreed.unwrap_or_default(),
+            };
+            let cond_cols = lwt_condition_columns(state, &ks, &table, &lwt)?;
+            let result = crate::accord_router::encode_lwt_result(&lwt, &ks, &table, &cond_cols);
             Ok(RouteResult::Result(result))
         }
         Err(AccordDriverError::QuorumUnavailable) => Err(CqlError::ServerError(

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1041,7 +1041,7 @@ fn build_lwt_mutation(
 ///
 /// Returns `Ok(None)` when there is no agreed row (row absent at `t`).
 fn decode_agreed_row_to_map(
-    state: &SharedState,
+    schema: &Schema,
     ks: &str,
     table: &str,
     agreed_row: Option<&[u8]>,
@@ -1056,7 +1056,7 @@ fn decode_agreed_row_to_map(
     let mutation = Mutation::deserialize_from(bytes)
         .map_err(|e| CqlError::ServerError(format!("failed to decode LWT read-vote row: {e}")))?;
 
-    let snap = state.schema.snapshot();
+    let snap = schema.snapshot();
     let table_meta = snap
         .tables
         .get(&(ks.to_string(), table.to_string()))
@@ -1066,7 +1066,7 @@ fn decode_agreed_row_to_map(
     let all_col_types: Vec<CqlType> = table_meta
         .columns
         .values()
-        .map(|c| resolve_col_type(&c.column_type, ks, &state.schema))
+        .map(|c| resolve_col_type(&c.column_type, ks, schema))
         .collect::<Result<Vec<_>, _>>()?;
     let pk_indices: Vec<usize> = table_meta
         .partition_key
@@ -1101,11 +1101,8 @@ fn decode_agreed_row_to_map(
         Some(r) => r,
     };
 
-    let map: HashMap<String, Option<CqlValue>> = all_col_names
-        .iter()
-        .cloned()
-        .zip(row_values)
-        .collect();
+    let map: HashMap<String, Option<CqlValue>> =
+        all_col_names.iter().cloned().zip(row_values).collect();
     Ok(Some(map))
 }
 
@@ -1179,7 +1176,7 @@ async fn route_lwt_via_accord(
     peers: Arc<ferrosa_net::peer::PeerManager>,
     clock: Arc<ferrosa_common::accord::HybridLogicalClock>,
 ) -> Result<RouteResult, CqlError> {
-    use ferrosa_cluster::accord::{AccordCoordinatorDriver, AccordDriverError};
+    use ferrosa_cluster::accord::AccordCoordinatorDriver;
 
     // Build the replica set from the live peer map plus this node itself.
     // Ordering is deterministic: local node first, then peers sorted by UUID.
@@ -1254,54 +1251,117 @@ async fn route_lwt_via_accord(
             state.engine.clone(),
         ));
         driver = driver.with_local_reader(reader);
+
+        // GATE THE WRITE on the IF condition. The coordinator evaluates this
+        // closure against the F+1-agreed, linearizable row-at-`t` DURING the
+        // read-vote phase and aborts (ConditionNotMet, no Apply) when it returns
+        // false — so a failing `IF col=val` never persists its mutation. The
+        // closure wraps the canonical eval_if_conditions (via
+        // eval_lwt_for_statement), so there is no forked evaluator. We capture
+        // owned clones (schema Arc, ks/table, the statement) because the gate is
+        // a 'static closure called inside the driver.
+        //
+        // Fail-loud: a decode failure of our own read-vote bytes is a real
+        // corruption signal. The gate cannot return an error, so it records the
+        // failure into `gate_err`; we surface it after run_transaction instead of
+        // silently treating it as "condition not met" (which would be a fake
+        // failure). A genuine decode of the agreed bytes is deterministic and
+        // identical across replicas, so the verdict is consistent.
+        let schema = state.schema.clone();
+        let gate_ks = ks.clone();
+        let gate_table = table.clone();
+        let gate_stmt = stmt.clone();
+        let gate_err: Arc<std::sync::Mutex<Option<CqlError>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let gate_err_w = gate_err.clone();
+        let gate = Box::new(move |row: Option<&[u8]>| -> bool {
+            match decode_agreed_row_to_map(&schema, &gate_ks, &gate_table, row) {
+                Ok(agreed) => {
+                    crate::accord_router::eval_lwt_for_statement(&gate_stmt, agreed.as_ref())
+                        .map(|r| r.applied)
+                        // Not an LWT reaching the gate (defensive): never silently apply
+                        // — treat as condition-not-met so the write does not persist.
+                        .unwrap_or(false)
+                }
+                Err(e) => {
+                    *gate_err_w.lock().expect("gate_err mutex poisoned") = Some(e);
+                    // Refuse to apply on a decode error (fail closed); the real
+                    // error is surfaced below.
+                    false
+                }
+            }
+        });
+        driver = driver.with_condition_gate(gate);
+        // Stash the error cell so the post-run match can surface a decode failure
+        // rather than reporting a bogus [applied]=false.
+        return finish_lwt_via_accord(state, &ks, &table, driver, Some(gate_err)).await;
     }
 
-    match driver.run_transaction().await {
+    finish_lwt_via_accord(state, &ks, &table, driver, None).await
+}
+
+/// Drive the Accord transaction to completion and map its result to a CQL LWT
+/// result set.
+///
+/// For the generic-`IF` path the condition has ALREADY been evaluated inside the
+/// driver (the [`AccordCoordinatorDriver::with_condition_gate`] closure), which
+/// aborts with `ConditionNotMet` before the Apply phase when the condition is
+/// false. So:
+/// - `Ok(_)` ⇒ the condition held (or there was none) and the write applied ⇒
+///   `[applied]=true`.
+/// - `ConditionNotMet { current_row }` ⇒ the condition did not hold and NOTHING
+///   was persisted ⇒ `[applied]=false` + the real current row.
+///
+/// `gate_err` carries any decode failure recorded inside the generic-IF gate so
+/// it is surfaced as a server error rather than a fake `[applied]=false`.
+async fn finish_lwt_via_accord(
+    state: &SharedState,
+    ks: &str,
+    table: &str,
+    mut driver: ferrosa_cluster::accord::AccordCoordinatorDriver,
+    gate_err: Option<Arc<std::sync::Mutex<Option<CqlError>>>>,
+) -> Result<RouteResult, CqlError> {
+    use ferrosa_cluster::accord::AccordDriverError;
+
+    let outcome = driver.run_transaction().await;
+
+    // Surface any decode failure recorded by the generic-IF gate first — a
+    // corrupt read-vote row must fail loud, never masquerade as [applied]=false.
+    if let Some(cell) = &gate_err {
+        if let Some(e) = cell.lock().expect("gate_err mutex poisoned").take() {
+            return Err(e);
+        }
+    }
+
+    match outcome {
         Ok(_) => {
-            // Gap 5: F+1 apply acknowledgements received (write is durable).
-            //
-            // Decide [applied] from the IF predicate:
-            // - Generic IF: evaluate the F+1-agreed row-at-`t` with the canonical
-            //   eval_if_conditions (reused, not forked). A mismatch returns
-            //   [applied]=false + the real current row.
-            // - INSERT IF NOT EXISTS: the read-vote already gated this (a present
-            //   row yields ConditionNotMet below), so reaching Ok means applied.
-            let lwt = match predicate_kind {
-                Some(LwtPredicateKind::Generic) => {
-                    let agreed =
-                        decode_agreed_row_to_map(state, &ks, &table, driver.last_read_row())?;
-                    crate::accord_router::eval_lwt_for_statement(stmt, agreed.as_ref()).unwrap_or(
-                        crate::accord_router::LwtResult {
-                            applied: true,
-                            current_values: HashMap::new(),
-                        },
-                    )
-                }
-                _ => crate::accord_router::LwtResult {
-                    applied: true,
-                    current_values: HashMap::new(),
-                },
+            // The write applied: the read-vote either had no predicate (INSERT IF
+            // NOT EXISTS reaching Ok means the row was absent) or the generic-IF
+            // gate passed (the condition held). Either way [applied]=true.
+            let lwt = crate::accord_router::LwtResult {
+                applied: true,
+                current_values: HashMap::new(),
             };
-            let cond_cols = lwt_condition_columns(state, &ks, &table, &lwt)?;
-            let result = crate::accord_router::encode_lwt_result(&lwt, &ks, &table, &cond_cols);
+            let cond_cols = lwt_condition_columns(state, ks, table, &lwt)?;
+            let result = crate::accord_router::encode_lwt_result(&lwt, ks, table, &cond_cols);
             Ok(RouteResult::Result(result))
         }
         Err(AccordDriverError::ConditionNotMet { current_row }) => {
-            // Gap 4: F+1 read-votes agreed the IF condition did NOT hold
-            // (INSERT IF NOT EXISTS: the row already existed). Return
-            // [applied]=false with the real current row from the read-vote.
+            // The IF condition did NOT hold — and the mutation was NOT applied
+            // (the driver aborted before the Apply phase). Return [applied]=false
+            // with the real current row from the F+1-agreed read-vote.
             let agreed_bytes: Option<&[u8]> = if current_row.is_empty() {
                 None
             } else {
                 Some(current_row.as_slice())
             };
-            let agreed = decode_agreed_row_to_map(state, &ks, &table, agreed_bytes)?;
+            let agreed = decode_agreed_row_to_map(&state.schema, ks, table, agreed_bytes)?;
             let lwt = crate::accord_router::LwtResult {
                 applied: false,
                 current_values: agreed.unwrap_or_default(),
             };
-            let cond_cols = lwt_condition_columns(state, &ks, &table, &lwt)?;
-            let result = crate::accord_router::encode_lwt_result(&lwt, &ks, &table, &cond_cols);
+            let cond_cols = lwt_condition_columns(state, ks, table, &lwt)?;
+            let result = crate::accord_router::encode_lwt_result(&lwt, ks, table, &cond_cols);
             Ok(RouteResult::Result(result))
         }
         Err(AccordDriverError::QuorumUnavailable) => Err(CqlError::ServerError(


### PR DESCRIPTION
## Summary

Implements **generic `IF col=val`** lightweight transactions (LWT) over the Accord path via a **linearizable read-at-`t`** primitive, **and now also fixes the `IF NOT EXISTS` exactly-once gap** (the existence-path read-vote did not dep-wait, so two genuinely concurrent `INSERT IF NOT EXISTS` could both observe the row as absent and both apply — a double-apply / lost-update). Together with #124 (production data-path wiring, already merged) this **closes `specs/bug-accord-lwt-acks-phantom-write.md`** end-to-end: no phantom acks, and concurrent conditional inserts now apply **exactly once**.

This branch is rebased on current `main`.

## What changed

- **`StorageReader` trait + `EngineStorageReader`** (`accord/apply.rs`): symmetric to `EngineStorageApplier`. `read_row_at(keyspace, table, key, t)` does a point read bounded to cells with `ts <= t.time` — the row state **as of** the Accord-agreed execution timestamp. Reuses the engine's `max_timestamp` point-read primitive.
- **`ReadVotePayload` carries the IF predicate** (`accord/wire.rs`): `ReadPredicate::NotExists` (existence path) vs `ReadPredicate::ReadRow { keyspace, table }` (generic path).
- **Replica read-vote handler** (`accord/handlers.rs`): generic predicate → read the row at `t` via the reader and return real row bytes. The coordinator (schema owner) evaluates the predicate with the **same** semantics as `ferrosa-cql accord_router::eval_if_conditions` (reused, not forked).
- **ReadVote dep-wait (the exactly-once fix)** (`accord/handlers.rs`): before evaluating the IF condition at `t`, the replica now blocks until **every conflicting transaction ordered before `t` (`t0 < t`) that is committed-but-not-yet-Applied has reached `Applied` locally**, via `await_conflicting_deps_applied`. It parks on the state machine's apply-notify (`handle_apply` fires `applied_notify.notify_waiters()`), re-checking the pending set under the lock after each wake. The `parking_lot` state lock is **never held across an `.await`** (handle_apply needs the same lock — holding it would deadlock). The wait is **bounded** (5s); on timeout the replica **abstains** (no row, `condition_holds=false`) so the coordinator's F+1 logic fails loud instead of letting a stale read masquerade as success. The same dep-wait guards both the existence path and the coordinator's own local read-vote.
- **Coordinator aggregation** (`accord/coordinator.rs`): requires **F+1 identical row bytes** before evaluating the gate; `condition_holds=false` → `[applied]=false` + `current_values` from the real persisted row. Divergent reads **fail loud** rather than silently picking a winner.
- **Write gated on the condition before Apply** (kills the lost-update): a generic-IF that does not hold never reaches the applier.

## Correctness (fail-loud)

- Linearizability of the generic read rests on (1) the dep-wait — the read at `t` only proceeds once every conflicting dep `t0 < t` has Applied locally, so the engine reflects the as-of-`t` state; (2) F+1 identical-row agreement at the coordinator — never a verdict on a skewed/non-quorum read; and (3) `read_row_at` bounding cells to `ts <= t.time`.
- **Exactly-once under genuine concurrency:** with the dep-wait in place, the loser of two concurrent `INSERT IF NOT EXISTS` (the larger `t`) waits for the winner to Apply, reads the winner's persisted row, and returns `ConditionNotMet` with the winner's bytes. `a_applied XOR b_applied`. The previously `#[ignore]`d gap test is **un-ignored and passes** — it was not weakened.

## Tests (`ferrosa-cluster/tests/accord_lwt_concurrent.rs`)

- `concurrent_insert_if_not_exists_exactly_one_applies_through_engine` — **un-ignored**: two genuinely concurrent `INSERT IF NOT EXISTS` through the engine apply exactly once (loser reads the winner's row at its `t`).
- `generic_if_reads_real_row_at_t_across_cluster` — generic IF reads the real persisted row at `t` across a 2-node cluster.
- `generic_if_mismatch_does_not_persist_and_match_does` — mismatch aborts, match applies.
- `applied_lwt_value_survives_state_machine_restart` — applied value survives engine reopen (durable, not in-memory).
- `two_coordinators_concurrent_insert_if_not_exists`, `gap4_gap5_read_vote_and_apply_round_trip`, `single_coordinator_round_trips_to_remote_replica` — round-trip + concurrency.

## Green gate

- `cargo fmt --check` ✅
- `cargo clippy -p ferrosa-cluster -p ferrosa-cql --all-targets` ✅ (no warnings)
- `cargo test -p ferrosa-cluster -p ferrosa-cql` ✅ (0 failed; **0 ignored** — the exactly-once test is now active and green)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` ✅
