### PR TITLE
fix(jepsen): multi-DC dual-DC topology bring-up failure (#98)

### DIFF
--- a/.github/workflows/jepsen-multi-dc-nightly.yml
+++ b/.github/workflows/jepsen-multi-dc-nightly.yml
@@ -39,16 +39,42 @@ jobs:
                dc_partition_plus_dc_slow_nemesis_registered \
             2>&1 | tee tier-config.log
 
+      # Build the workload binary up front, BEFORE bring-up, so the workload
+      # step does not compile under load alongside the 6 node containers.
+      # The previous runs died ~30s into the workload step with exit 143
+      # (hosted-runner SIGTERM) — a `cargo run` that still had to link the
+      # release binary while 6 containers churned CPU/RAM is a prime OOM/eviction
+      # trigger. Pre-building keeps the heavy compile isolated and cached.
+      - name: Pre-build workload binary (before bring-up, avoids rebuild under load)
+        run: cargo build --release -p ferrosa-jepsen
+
       - name: Bring up T3 (3+3 dual-DC) topology
         run: |
+          set -euo pipefail
           docker compose -f ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml \
             up -d --build
-          # Wait for both DCs to reach Cluster mode.
+          # Wait for the first node in each DC to report ready on /health
+          # (leader-aware: in Forming/Cluster mode this is 503 until a Raft
+          # leader is elected, so a green probe means the DC actually formed).
+          # Fail-loud: if 60 tries (~120s) elapse without both DCs ready, dump
+          # node logs and `exit 1` so a genuine non-formation is caught instead
+          # of silently sailing into the workload step (the old loop's trailing
+          # `sleep` always succeeded, so the step could never fail).
+          ready=0
           for i in $(seq 1 60); do
-            curl -sf http://localhost:29090/health && \
-            curl -sf http://localhost:29190/health && break
+            if curl -sf http://localhost:29090/health >/dev/null \
+               && curl -sf http://localhost:29190/health >/dev/null; then
+              ready=1
+              break
+            fi
             sleep 2
           done
+          if [ "$ready" -ne 1 ]; then
+            echo "::error::T3 dual-DC topology did not reach ready on /health within ~120s"
+            docker compose -f ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml ps
+            docker compose -f ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml logs --tail 200
+            exit 1
+          fi
 
       - name: Run tier-multi-dc 1h bank workload
         env:
@@ -61,6 +87,23 @@ jobs:
             --output-dir ./jepsen-out \
             2>&1 | tee tier-multi-dc.log
 
+      # Capture runner + container resource state on ANY failure so the next
+      # red run proves OOM-vs-other (the exit-143 evidence aged out before this
+      # could be confirmed). Best-effort: never fails the job itself.
+      - name: Diagnostics on failure (resource + container state)
+        if: failure()
+        run: |
+          echo "=== free -m ==="; free -m || true
+          echo "=== docker stats (snapshot) ==="
+          docker stats --no-stream || true
+          echo "=== docker compose ps ==="
+          docker compose -f ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml ps || true
+          echo "=== dmesg tail (OOM killer?) ==="
+          sudo dmesg 2>/dev/null | tail -50 || dmesg 2>/dev/null | tail -50 || true
+          echo "=== node + rustfs logs ==="
+          docker compose -f ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml logs --tail 200 \
+            > compose-logs.txt 2>&1 || true
+
       - name: Upload Jepsen logs
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -69,8 +112,10 @@ jobs:
           path: |
             tier-config.log
             tier-multi-dc.log
+            compose-logs.txt
             jepsen-out/
           retention-days: 30
+          if-no-files-found: ignore
 
       - name: Tear down compose
         if: always()

--- a/ferrosa/src/web/readiness.rs
+++ b/ferrosa/src/web/readiness.rs
@@ -39,9 +39,20 @@ use serde_json::{json, Value};
 
 use super::WebAppState;
 
-/// Register the `/readyz` route on the given router.
+/// Register the readiness routes on the given router.
+///
+/// Both `/readyz` and `/health` are wired to the same leader-aware handler.
+/// `/health` is an alias kept for orchestrator probes (docker-compose
+/// healthchecks, the Jepsen multi-DC bring-up workflow, k8s) that historically
+/// expect a `/health` path. Before this alias existed, those probes hit the
+/// static-file fallback and always received `404`, so the healthchecks were a
+/// no-op (they could never gate on the cluster actually forming). Routing
+/// `/health` through the readiness handler makes the bring-up fail-loud: in
+/// Forming/Cluster mode it returns `503` until a Raft leader is elected.
 pub fn readiness_route() -> Router<WebAppState> {
-    Router::new().route("/readyz", get(readyz_handler))
+    Router::new()
+        .route("/readyz", get(readyz_handler))
+        .route("/health", get(readyz_handler))
 }
 
 /// `GET /readyz` — leader-aware readiness probe.
@@ -191,6 +202,40 @@ mod tests {
             StatusCode::NOT_FOUND,
             "GET /readyz must not return 404"
         );
+    }
+
+    /// `/health` is an alias of `/readyz` and must be routable — not a 404.
+    /// This is what the docker-compose healthchecks and the Jepsen multi-DC
+    /// bring-up workflow probe; before the alias existed it hit the static
+    /// fallback and 404'd, making those probes a silent no-op.
+    #[tokio::test]
+    async fn health_alias_is_routable() {
+        let state = make_state();
+        let router = build_router(state);
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "GET /health must not return 404 — orchestrators probe it"
+        );
+    }
+
+    /// `/health` must behave identically to `/readyz`: standalone returns 200.
+    #[tokio::test]
+    async fn health_alias_standalone_returns_200() {
+        let state = make_state();
+        assert_eq!(state.mode_controller.mode(), DeploymentMode::Standalone);
+        let router = build_router(state);
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     /// Standalone mode (the default for a new `ModeController`) must return 200.


### PR DESCRIPTION
## Summary

The nightly `tier-multi-dc` Jepsen job (`tier-multi-dc 1h bank workload (T3)`) has filed a failure issue every night since 06-09, dying at the **"Bring up T3 (3+3 dual-DC) topology"** step before the bank workload ever runs. This PR makes the bring-up **fail-loud**, removes two latent bugs that masked the real failure, and adds diagnostics to confirm the root cause on the next red run.

**This is a DRAFT.** The latent bugs below are genuinely fixed and tested, but the *actual* nightly red has not yet been proven green — see "Why draft" at the bottom. It does **not** claim `Closes #98`.

## Root cause (diagnosis)

The issue's cited failing line — the `rustup.rs | sh ... --default-toolchain none` inside `dtolnay/rust-toolchain` — is boilerplate that always passes; it is not the failure. The real failure was the **workload step dying ~30s in with exit 143** (hosted-runner SIGTERM), strongly consistent with an **OOM / runner eviction** while `cargo run --release` still had to *link* the `ferrosa-jepsen` binary under the load of 6 node containers.

Two latent bugs hid this and made the bring-up step unable to fail honestly:

1. **ferrosa had no `/health` route.** `build_router` registered `/readyz`, `/metrics`, and `/api/*` with a 404 static fallback. The 8 compose healthchecks and the workflow bring-up probe all `curl :9090/health`, which always 404'd — so the healthchecks were a silent no-op and could never gate on the cluster actually forming.
2. **The bring-up wait loop ended in `sleep 2`.** Its success made the whole step exit 0 even when `/health` never came up, so a genuine non-formation would sail straight into the workload step undetected.

### Evidence (exact failing command)

- Failing step: `Bring up T3 (3+3 dual-DC) topology` in `.github/workflows/jepsen-multi-dc-nightly.yml` (probe: `curl -sf http://localhost:29090/health && curl -sf http://localhost:29190/health`).
- The probed path `/health` was not registered by `ferrosa/src/web/mod.rs` `build_router` (only `/readyz` was), so the probe always received `404` and the trailing `sleep 2` made the step exit 0 regardless.
- The 06-09/06-12 exit-143 detail logs aged out before they could be re-pulled, which is why the diagnostics step (below) is included to confirm OOM-vs-other on the next red run.

## What changed

- **`ferrosa/src/web/readiness.rs`** — add a `/health` alias wired to the existing leader-aware `readyz_handler`. In `Forming`/`Cluster` mode it returns `503` until a Raft leader is elected, so a green probe now means the DC genuinely formed. Purely additive (sits outside `/api/*` auth). +2 tests (`health_alias_is_routable`, `health_alias_standalone_returns_200`).
- **`.github/workflows/jepsen-multi-dc-nightly.yml`**:
  - Pre-build `cargo build --release -p ferrosa-jepsen` **before** bring-up, so the workload step no longer links the binary under container load (the likely exit-143 trigger).
  - Rewrite the bring-up wait to **fail-loud** (`set -euo pipefail`, explicit `ready` flag): on exhausting ~120s it dumps `compose ps` + node logs and `exit 1` instead of passing silently.
  - Add an `if: failure()` diagnostics step (`free -m`, `docker stats`, `dmesg` OOM-killer tail, `compose logs`) uploaded as an artifact to prove OOM-vs-other next run.

The nightly is **not** disabled or marked ignore.

## Validation (green gate)

Run in `/tmp/ferrosa-jepsen98/ferrosa`:

- `cargo fmt --check` — clean
- `cargo clippy -p ferrosa --all-targets` (forced recompile of touched file) — no warnings/errors
- `cargo test -p ferrosa --bins web::readiness` — **9 passed, 0 failed** (7 existing + 2 new `/health` alias tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — clean

Compose wiring verified: `jepsen-cluster-t3.yml` maps `29090:9090` (DC1 leader) and `29190:9090` (DC2 leader); all 6 node healthchecks `curl -sf http://localhost:9090/health`.

## Why draft / what is NOT yet proven

- The OOM/exit-143 root cause is a **strongly-supported hypothesis**, not yet confirmed by current logs (the originals aged out). The `if: failure()` diagnostics step exists precisely to confirm OOM over the next 1–2 nightly runs.
- The `/health` + fail-loud changes are real fixes for real latent bugs, but the end-to-end nightly cannot be proven green from a unit-test gate alone — it requires a passing nightly run.
- Accordingly this PR intentionally does **not** state `Closes #98`. Promote to ready and close #98 once a nightly run is green (or once the diagnostics confirm OOM and the pre-build mitigation holds).

Refs #98
