### PR TITLE
fix: stop blocking work on async worker threads (raft/CQL responsiveness under load)

### DIFF
--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -153,17 +153,37 @@ fn encode_read_request(payload: &ReadRequestPayload) -> Bytes {
     Bytes::from(bincode::serialize(payload).unwrap_or_default())
 }
 
-fn read_local_partition(
-    storage: &ferrosa_storage::StorageEngine,
-    table_id: &TableId,
-    key: &DecoratedKey,
+/// Read a partition from the local storage engine.
+///
+/// The storage read is synchronous and, on an evicted-SSTable miss, performs
+/// blocking I/O (S3 rehydration, `std::fs`, a `std::sync::Mutex` guard). It is
+/// offloaded to a blocking thread via [`TaskPool::spawn_blocking`] — mirroring
+/// the range-scan path in `ferrosa-storage`'s `TableStore` — so it never parks
+/// an async worker thread (raft apply, coordinator, CQL handler). Args are
+/// owned so they can move into the `'static` blocking closure.
+///
+/// A `JoinError` from the blocking pool is mapped to a loud `Storage` error
+/// rather than swallowed, so a panicked read surfaces instead of masquerading
+/// as a missing partition.
+async fn read_local_partition(
+    storage: &std::sync::Arc<ferrosa_storage::StorageEngine>,
+    table_id: TableId,
+    key: DecoratedKey,
     row_limit: usize,
-    clustering: Option<&[u8]>,
+    clustering: Option<Vec<u8>>,
 ) -> ferrosa_common::Result<Option<Partition>> {
-    match clustering {
-        Some(clustering) => storage.read_clustering_row(table_id, key, clustering),
-        None => storage.read_limited_rows(table_id, key, row_limit),
-    }
+    let storage = std::sync::Arc::clone(storage);
+    ferrosa_common::task_pool::TaskPool::current("coordinator-local-read")
+        .spawn_blocking(move || match clustering {
+            Some(clustering) => storage.read_clustering_row(&table_id, &key, &clustering),
+            None => storage.read_limited_rows(&table_id, &key, row_limit),
+        })
+        .await
+        .map_err(|e| {
+            ferrosa_common::Error::Io(std::io::Error::other(format!(
+                "local partition read task failed: {e}"
+            )))
+        })?
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -179,7 +199,7 @@ async fn digest_read_attempt(
     clustering: Option<Vec<u8>>,
 ) -> ReplicaRead {
     if replica_id == local_node_id {
-        match read_local_partition(&storage, &table_id, &key, row_limit, clustering.as_deref()) {
+        match read_local_partition(&storage, table_id, key, row_limit, clustering).await {
             Ok(Some(p)) => {
                 use crate::raft::handlers::compute_partition_digest;
                 let ts = p
@@ -515,13 +535,9 @@ impl ClusterCoordinator {
                 async move {
                     if full_replica == local_node_id {
                         // Local full read.
-                        match read_local_partition(
-                            &storage,
-                            &table_id,
-                            &key,
-                            row_limit,
-                            clustering.as_deref(),
-                        ) {
+                        match read_local_partition(&storage, table_id, key, row_limit, clustering)
+                            .await
+                        {
                             Ok(opt) => ReplicaRead::Full(opt),
                             Err(_) => ReplicaRead::Failed,
                         }
@@ -833,9 +849,16 @@ impl ClusterCoordinator {
 
         for &target in &candidates {
             if target == self.local_node_id {
-                match read_local_partition(&self.storage, table_id, key, row_limit, clustering)
-                    .map(|opt| opt.map(|p| p.rows))
-                    .map_err(ClusterError::Storage)
+                match read_local_partition(
+                    &self.storage,
+                    table_id.clone(),
+                    key.clone(),
+                    row_limit,
+                    clustering.map(<[u8]>::to_vec),
+                )
+                .await
+                .map(|opt| opt.map(|p| p.rows))
+                .map_err(ClusterError::Storage)
                 {
                     Ok(Some(rows)) if !rows.is_empty() => return Ok(Some(rows)),
                     Ok(_) => continue, // no data on this replica, try next
@@ -1799,6 +1822,124 @@ mod tests {
     // -----------------------------------------------------------------------
 
     /// CL=ONE, local replica: should read directly from storage.
+    /// RED for the point-read worker-thread offload.
+    ///
+    /// `read_local_partition` must run the (synchronous, potentially blocking)
+    /// storage read on a tokio blocking thread, not inline on the async runtime
+    /// worker. We make the read deterministically exercise the blocking
+    /// evicted-SSTable miss path by deleting the `Data.db` after flush and
+    /// serving the addressed range from a backup via a path-scoped
+    /// `file_read_range_hook`. The hook records the OS thread it runs on; with
+    /// the fix that thread differs from the single async worker, proving the
+    /// read was offloaded. With the pre-fix inline call it equals the worker
+    /// thread.
+    #[test]
+    fn local_read_runs_off_the_async_worker_thread() {
+        use std::sync::Mutex as StdMutex;
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        let key = test_key();
+        storage
+            .write(&table_id, &key, test_row(1000), 1000)
+            .unwrap();
+        storage.flush(&table_id).unwrap();
+
+        // Locate the flushed Data.db component(s) for this table and back them
+        // up, then evict (delete) them so reads fall through to the range hook.
+        let table_sstable_dir = dir.path().join("sstables").join(table_id.to_string());
+        let backup_dir = dir.path().join("backup");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+        let mut evicted_data: std::collections::HashMap<std::path::PathBuf, Vec<u8>> =
+            std::collections::HashMap::new();
+        for entry in std::fs::read_dir(&table_sstable_dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.to_string_lossy().ends_with("-Data.db") {
+                let bytes = std::fs::read(&path).unwrap();
+                evicted_data.insert(path.clone(), bytes);
+                std::fs::remove_file(&path).unwrap();
+            }
+        }
+        assert!(
+            !evicted_data.is_empty(),
+            "test setup: expected at least one Data.db to evict"
+        );
+
+        // Path-scoped hooks that record the executing thread and serve the
+        // evicted Data.db from the in-memory backup. All three read hooks are
+        // registered so we capture whichever the read path exercises; each
+        // returns a pass-through (`Ok(None)`/`Ok(false)`) for paths it does not
+        // own, so it never interferes with other tests.
+        let observed_thread: Arc<StdMutex<Option<std::thread::ThreadId>>> =
+            Arc::new(StdMutex::new(None));
+        {
+            let observed = observed_thread.clone();
+            let data = evicted_data.clone();
+            ferrosa_sstable::io::register_file_read_range_hook(Arc::new(
+                move |path, offset, len| {
+                    let Some(bytes) = data.get(path) else {
+                        return Ok(None);
+                    };
+                    *observed.lock().unwrap() = Some(std::thread::current().id());
+                    let start = (offset as usize).min(bytes.len());
+                    let end = (start + len).min(bytes.len());
+                    Ok(Some(bytes[start..end].to_vec()))
+                },
+            ));
+        }
+        {
+            let observed = observed_thread.clone();
+            let data = evicted_data.clone();
+            ferrosa_sstable::io::register_file_read_len_hook(Arc::new(move |path| {
+                let Some(bytes) = data.get(path) else {
+                    return Ok(None);
+                };
+                *observed.lock().unwrap() = Some(std::thread::current().id());
+                Ok(Some(bytes.len() as u64))
+            }));
+        }
+        {
+            let observed = observed_thread.clone();
+            let data = evicted_data.clone();
+            ferrosa_sstable::io::register_file_read_rehydration_hook(Arc::new(move |path| {
+                let Some(bytes) = data.get(path) else {
+                    return Ok(false);
+                };
+                *observed.lock().unwrap() = Some(std::thread::current().id());
+                std::fs::write(path, bytes)?;
+                Ok(true)
+            }));
+        }
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let (worker_thread, result_rows) = rt.block_on(async move {
+            let worker = std::thread::current().id();
+            let result = read_local_partition(&storage, table_id.clone(), key.clone(), 0, None)
+                .await
+                .unwrap();
+            (worker, result.map(|p| p.rows.len()).unwrap_or(0))
+        });
+
+        assert_eq!(result_rows, 1, "read should return the written row");
+        let read_thread = observed_thread
+            .lock()
+            .unwrap()
+            .expect("range hook must have served the evicted Data.db read");
+        assert_ne!(
+            read_thread, worker_thread,
+            "local read ran inline on the async worker thread instead of \
+             being offloaded to a blocking thread"
+        );
+    }
+
     #[tokio::test]
     async fn coordinate_read_local_replica_returns_data() {
         let dir = tempfile::tempdir().unwrap();

--- a/ferrosa-cluster/src/raft/state_machine.rs
+++ b/ferrosa-cluster/src/raft/state_machine.rs
@@ -108,6 +108,37 @@ impl std::fmt::Display for ApplyError {
 }
 
 // ---------------------------------------------------------------------------
+// Deferred system-table writes
+// ---------------------------------------------------------------------------
+
+/// Severity for the log line emitted if a deferred system-table write fails.
+///
+/// `WarnReplay` is used for the create-DDL sites where a failure is expected
+/// during Raft log replay on startup (the `system_schema.*` tables are not yet
+/// registered); everything else is a genuine `Error`.
+#[derive(Debug, Clone, Copy)]
+enum SystemWriteLogLevel {
+    WarnReplay,
+    Error,
+}
+
+/// A `SystemTableMutation` collected during `apply_command` to be executed
+/// **after** the in-memory state mutation, on a blocking thread.
+///
+/// `apply_command` runs on the openraft apply task (a runtime worker). The
+/// `engine.write` calls inside `SystemTableWriter::apply` are synchronous and
+/// touch the memtable/commit-log, which previously parked the raft worker and
+/// delayed heartbeat responses. Collecting the mutations and draining them via
+/// `spawn_blocking` (awaited before the next entry, preserving openraft's
+/// sequential apply ordering) keeps that blocking work off the worker.
+struct PendingSystemWrite {
+    mutation: SystemTableMutation,
+    level: SystemWriteLogLevel,
+    /// Static context string mirroring the original inline log message.
+    context: &'static str,
+}
+
+// ---------------------------------------------------------------------------
 // RaftState
 // ---------------------------------------------------------------------------
 
@@ -797,10 +828,16 @@ impl FerrosStateMachine {
 
     /// Apply a single [`RaftCommand`] to `self.state`, updating BTreeMaps
     /// and optionally propagating side effects.
-    fn apply_command(&mut self, cmd: RaftCommand) -> RaftResponse {
+    /// Apply the in-memory state mutation for `cmd` and collect any
+    /// system-table writes to be executed off the raft worker by the caller.
+    ///
+    /// Returns the `RaftResponse` plus the deferred `system_schema.*`/
+    /// `system_auth.*` writes; the caller drains them via `spawn_blocking`.
+    fn apply_command(&mut self, cmd: RaftCommand) -> (RaftResponse, Vec<PendingSystemWrite>) {
         let RaftCommand { op, schema_version } = cmd;
         let mut schema_changed = true;
         let mut apply_errors: Vec<ApplyError> = Vec::new();
+        let mut pending_system_writes: Vec<PendingSystemWrite> = Vec::new();
         match op {
             // ---- DDL: Keyspaces ----------------------------------------
             RaftOp::CreateKeyspace(ks) => {
@@ -818,11 +855,12 @@ impl FerrosStateMachine {
                             tracing::error!(%e, "Raft apply: create_keyspace_internal failed — schema diverged from Raft state");
                         }
                     }
-                    if let Some(writer) = &self.system_writer {
-                        if let Err(e) = writer.apply(SystemTableMutation::KeyspaceCreated(ks_clone))
-                        {
-                            tracing::warn!(%e, "Raft apply: system table write skipped for CreateKeyspace (expected during log replay)");
-                        }
+                    if self.system_writer.is_some() {
+                        pending_system_writes.push(PendingSystemWrite {
+                            mutation: SystemTableMutation::KeyspaceCreated(ks_clone),
+                            level: SystemWriteLogLevel::WarnReplay,
+                            context: "Raft apply: system table write skipped for CreateKeyspace (expected during log replay)",
+                        });
                     }
                 }
             }
@@ -865,11 +903,12 @@ impl FerrosStateMachine {
                         }
                     }
                 }
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::KeyspaceDropped(name.clone()))
-                    {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::KeyspaceDropped(name.clone()),
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
             }
             RaftOp::AlterKeyspace { name, updates } => {
@@ -886,13 +925,13 @@ impl FerrosStateMachine {
                         tracing::error!(%e, "Raft apply: alter_keyspace_internal failed");
                     }
                 }
-                if let Some(writer) = &self.system_writer {
+                if self.system_writer.is_some() {
                     if let Some(ks) = self.state.keyspaces.get(&name) {
-                        if let Err(e) =
-                            writer.apply(SystemTableMutation::KeyspaceCreated(ks.clone()))
-                        {
-                            tracing::error!(%e, "Raft apply: system table write failed for AlterKeyspace");
-                        }
+                        pending_system_writes.push(PendingSystemWrite {
+                            mutation: SystemTableMutation::KeyspaceCreated(ks.clone()),
+                            level: SystemWriteLogLevel::Error,
+                            context: "Raft apply: system table write failed for AlterKeyspace",
+                        });
                     }
                 }
             }
@@ -925,13 +964,15 @@ impl FerrosStateMachine {
                             });
                         }
                     }
-                    if let Some(writer) = &self.system_writer {
-                        if let Err(e) = writer.apply(SystemTableMutation::TableCreated(table)) {
-                            // Warn, not error: during Raft log replay on startup,
-                            // system_schema tables may not be registered yet.  The
-                            // schema bootstrap populates them once loading completes.
-                            tracing::warn!(%e, "Raft apply: system table write skipped for CreateTable (expected during log replay)");
-                        }
+                    if self.system_writer.is_some() {
+                        // Warn, not error: during Raft log replay on startup,
+                        // system_schema tables may not be registered yet.  The
+                        // schema bootstrap populates them once loading completes.
+                        pending_system_writes.push(PendingSystemWrite {
+                            mutation: SystemTableMutation::TableCreated(table),
+                            level: SystemWriteLogLevel::WarnReplay,
+                            context: "Raft apply: system table write skipped for CreateTable (expected during log replay)",
+                        });
                     }
                 }
             }
@@ -960,13 +1001,15 @@ impl FerrosStateMachine {
                         });
                     }
                 }
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::TableDropped {
-                        keyspace: keyspace.clone(),
-                        table: table.clone(),
-                    }) {
-                        tracing::error!(%e, "Raft apply: system table write failed for DropTable");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::TableDropped {
+                            keyspace: keyspace.clone(),
+                            table: table.clone(),
+                        },
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed for DropTable",
+                    });
                 }
             }
             RaftOp::AlterTable {
@@ -1048,10 +1091,12 @@ impl FerrosStateMachine {
                             .or_insert(IndexNodeStatus::Building);
                     }
                 }
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::IndexCreated(index.clone())) {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::IndexCreated(index.clone()),
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.create_index_internal(index) {
@@ -1073,14 +1118,16 @@ impl FerrosStateMachine {
                     table.clone(),
                     index.clone(),
                 ));
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::IndexDropped {
-                        keyspace: keyspace.clone(),
-                        table: table.clone(),
-                        name: index.clone(),
-                    }) {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::IndexDropped {
+                            keyspace: keyspace.clone(),
+                            table: table.clone(),
+                            name: index.clone(),
+                        },
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.drop_index_internal(&keyspace, &table, &index) {
@@ -1108,10 +1155,12 @@ impl FerrosStateMachine {
             RaftOp::CreateType(udt) => {
                 let key = (udt.keyspace.clone(), udt.name.clone());
                 self.state.types.entry(key).or_insert_with(|| udt.clone());
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::TypeCreated(udt.clone())) {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::TypeCreated(udt.clone()),
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.create_type_internal(&udt) {
@@ -1121,13 +1170,15 @@ impl FerrosStateMachine {
             }
             RaftOp::DropType { keyspace, name } => {
                 self.state.types.remove(&(keyspace.clone(), name.clone()));
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::TypeDropped {
-                        keyspace: keyspace.clone(),
-                        name: name.clone(),
-                    }) {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::TypeDropped {
+                            keyspace: keyspace.clone(),
+                            name: name.clone(),
+                        },
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.drop_type_internal(&keyspace, &name) {
@@ -1147,11 +1198,12 @@ impl FerrosStateMachine {
                     .functions
                     .entry(key)
                     .or_insert_with(|| func.clone());
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::FunctionCreated(func.clone()))
-                    {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::FunctionCreated(func.clone()),
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.create_function_internal(&func) {
@@ -1166,14 +1218,16 @@ impl FerrosStateMachine {
             } => {
                 let key = (keyspace.clone(), name.clone(), arg_types.clone());
                 self.state.functions.remove(&key);
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::FunctionDropped {
-                        keyspace: keyspace.clone(),
-                        name: name.clone(),
-                        arg_types: arg_types.clone(),
-                    }) {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::FunctionDropped {
+                            keyspace: keyspace.clone(),
+                            name: name.clone(),
+                            arg_types: arg_types.clone(),
+                        },
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.drop_function_internal(&keyspace, &name, &arg_types) {
@@ -1219,10 +1273,12 @@ impl FerrosStateMachine {
                     .roles
                     .entry(role.name.clone())
                     .or_insert_with(|| role.clone());
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::RoleCreated(role.clone())) {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::RoleCreated(role.clone()),
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.create_role_internal(role) {
@@ -1245,12 +1301,13 @@ impl FerrosStateMachine {
                         role.member_of = member_of.clone();
                     }
                 }
-                if let Some(writer) = &self.system_writer {
+                if self.system_writer.is_some() {
                     if let Some(role) = self.state.roles.get(&name) {
-                        if let Err(e) = writer.apply(SystemTableMutation::RoleCreated(role.clone()))
-                        {
-                            tracing::error!(%e, "Raft apply: system table write failed");
-                        }
+                        pending_system_writes.push(PendingSystemWrite {
+                            mutation: SystemTableMutation::RoleCreated(role.clone()),
+                            level: SystemWriteLogLevel::Error,
+                            context: "Raft apply: system table write failed",
+                        });
                     }
                 }
                 if let Some(schema) = &self.schema {
@@ -1267,10 +1324,12 @@ impl FerrosStateMachine {
                         tracing::error!(%e, "Raft apply: schema.drop_role_internal failed");
                     }
                 }
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::RoleDropped(name.clone())) {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::RoleDropped(name.clone()),
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
             }
             RaftOp::Grant(entry) => {
@@ -1282,10 +1341,12 @@ impl FerrosStateMachine {
                 } else {
                     grants.push(entry.clone());
                 }
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::GrantUpdated(entry.clone())) {
-                        tracing::error!(%e, "Raft apply: system table write failed");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::GrantUpdated(entry.clone()),
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.grant_internal(entry) {
@@ -1307,14 +1368,16 @@ impl FerrosStateMachine {
                         self.state.grants.remove(&role);
                     }
                 }
-                if let Some(writer) = &self.system_writer {
-                    if let Err(e) = writer.apply(SystemTableMutation::PermissionRevoked {
-                        role: role.clone(),
-                        resource: resource.clone(),
-                        permission,
-                    }) {
-                        tracing::error!(%e, "Raft apply: system table write failed for PermissionRevoked");
-                    }
+                if self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::PermissionRevoked {
+                            role: role.clone(),
+                            resource: resource.clone(),
+                            permission,
+                        },
+                        level: SystemWriteLogLevel::Error,
+                        context: "Raft apply: system table write failed for PermissionRevoked",
+                    });
                 }
                 if let Some(schema) = &self.schema {
                     if let Err(e) = schema.revoke_internal(&role, &resource, &permission) {
@@ -1342,13 +1405,13 @@ impl FerrosStateMachine {
                     if let Some(role) = self.state.roles.get_mut(&member) {
                         role.member_of.insert(granted_role.clone());
                     }
-                    if let Some(writer) = &self.system_writer {
+                    if self.system_writer.is_some() {
                         if let Some(role) = self.state.roles.get(&member) {
-                            if let Err(e) =
-                                writer.apply(SystemTableMutation::RoleCreated(role.clone()))
-                            {
-                                tracing::error!(%e, "Raft apply: system table write failed for GrantRole");
-                            }
+                            pending_system_writes.push(PendingSystemWrite {
+                                mutation: SystemTableMutation::RoleCreated(role.clone()),
+                                level: SystemWriteLogLevel::Error,
+                                context: "Raft apply: system table write failed for GrantRole",
+                            });
                         }
                     }
                     if let Some(schema) = &self.schema {
@@ -1365,12 +1428,13 @@ impl FerrosStateMachine {
                 if let Some(role) = self.state.roles.get_mut(&member) {
                     role.member_of.remove(&granted_role);
                 }
-                if let Some(writer) = &self.system_writer {
+                if self.system_writer.is_some() {
                     if let Some(role) = self.state.roles.get(&member) {
-                        if let Err(e) = writer.apply(SystemTableMutation::RoleCreated(role.clone()))
-                        {
-                            tracing::error!(%e, "Raft apply: system table write failed for RevokeRole");
-                        }
+                        pending_system_writes.push(PendingSystemWrite {
+                            mutation: SystemTableMutation::RoleCreated(role.clone()),
+                            level: SystemWriteLogLevel::Error,
+                            context: "Raft apply: system table write failed for RevokeRole",
+                        });
                     }
                 }
                 if let Some(schema) = &self.schema {
@@ -1514,7 +1578,7 @@ impl FerrosStateMachine {
         // W1.7 — surface accumulated sub-errors instead of silently
         // returning Ok.  Callers can detect engine/schema/system_writer
         // failures and decide whether to retry, alert, or escalate.
-        if apply_errors.is_empty() {
+        let response = if apply_errors.is_empty() {
             RaftResponse::Ok
         } else {
             let summary = apply_errors
@@ -1523,6 +1587,57 @@ impl FerrosStateMachine {
                 .collect::<Vec<_>>()
                 .join("; ");
             RaftResponse::Error(summary)
+        };
+        (response, pending_system_writes)
+    }
+
+    /// Execute the system-table writes collected by `apply_command` on a
+    /// blocking thread, then emit the per-mutation log lines on the worker.
+    ///
+    /// The `engine.write` calls inside `SystemTableWriter::apply` are
+    /// synchronous and would otherwise park the raft apply worker, delaying
+    /// heartbeat responses (1s lane deadline). Running them under
+    /// `spawn_blocking` isolates that work; awaiting the handle here preserves
+    /// openraft's sequential apply ordering. A `JoinError` is surfaced loudly
+    /// rather than swallowed.
+    async fn flush_pending_system_writes(&self, pending: Vec<PendingSystemWrite>) {
+        if pending.is_empty() {
+            return;
+        }
+        let Some(writer) = self.system_writer.clone() else {
+            return;
+        };
+
+        let outcomes = ferrosa_net::task_pool::TaskPool::current("raft-system-table-apply")
+            .spawn_blocking(move || {
+                pending
+                    .into_iter()
+                    .map(|p| {
+                        let result = writer.apply(p.mutation);
+                        (p.level, p.context, result.err())
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .await;
+
+        let outcomes = match outcomes {
+            Ok(outcomes) => outcomes,
+            Err(e) => {
+                tracing::error!(
+                    %e,
+                    "Raft apply: system-table write task panicked or was cancelled"
+                );
+                return;
+            }
+        };
+
+        for (level, context, err) in outcomes {
+            if let Some(e) = err {
+                match level {
+                    SystemWriteLogLevel::WarnReplay => tracing::warn!(%e, "{context}"),
+                    SystemWriteLogLevel::Error => tracing::error!(%e, "{context}"),
+                }
+            }
         }
     }
 }
@@ -1609,7 +1724,12 @@ impl RaftStateMachine<FerrosRaftConfig> for FerrosStateMachine {
                     responses.push(RaftResponse::Ok);
                 }
                 EntryPayload::Normal(cmd) => {
-                    let resp = self.apply_command(cmd);
+                    let (resp, pending) = self.apply_command(cmd);
+                    // Drain the collected system-table writes off the raft
+                    // worker. Awaiting here (before the next entry) preserves
+                    // openraft's sequential apply ordering while keeping the
+                    // blocking `engine.write` calls off the worker thread.
+                    self.flush_pending_system_writes(pending).await;
                     responses.push(resp);
                 }
                 EntryPayload::Membership(membership) => {
@@ -3561,6 +3681,61 @@ mod tests {
         assert!(
             partition.is_some(),
             "CreateTable should write to system_schema.tables"
+        );
+    }
+
+    /// RED for the raft-apply offload: the synchronous `engine.write` in
+    /// `SystemTableWriter::apply` must run on a tokio blocking thread, not
+    /// inline on the raft apply worker (where it parks raft core and delays
+    /// heartbeat responses). We drive `apply()` on a single-worker multi-thread
+    /// runtime, capture that worker's thread id, and assert the system-table
+    /// write recorded a *different* thread.
+    #[test]
+    fn system_table_apply_runs_off_the_raft_worker_thread() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = test_engine(dir.path());
+        engine.register_system_tables().unwrap();
+        let schema = test_schema_instance();
+        let mut sm = FerrosStateMachine::with_side_effects(Arc::new(schema), Arc::clone(&engine));
+
+        let apply_thread_handle = sm
+            .system_writer
+            .as_ref()
+            .expect("with_side_effects installs a system writer")
+            .last_apply_thread_handle();
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let worker_thread = rt.block_on(async move {
+            let worker = std::thread::current().id();
+            let ks = simple_keyspace("offload_ks");
+            let entry = make_entry(1, 1, RaftOp::CreateKeyspace(ks));
+            sm.apply(vec![entry]).await.unwrap();
+            worker
+        });
+
+        // The CreateKeyspace must have written to system_schema.keyspaces.
+        let tid = TableId::new("system_schema", "keyspaces");
+        let key = ferrosa_common::DecoratedKey::new(ferrosa_common::PartitionKey::new(
+            b"offload_ks".to_vec(),
+        ));
+        assert!(
+            engine.read(&tid, &key).unwrap().is_some(),
+            "CreateKeyspace should write to system_schema.keyspaces"
+        );
+
+        let apply_thread = apply_thread_handle
+            .lock()
+            .unwrap()
+            .expect("SystemTableWriter::apply must have run");
+        assert_ne!(
+            apply_thread, worker_thread,
+            "system-table apply ran inline on the raft worker thread instead of \
+             being offloaded to a blocking thread"
         );
     }
 

--- a/ferrosa-cluster/src/system_table_writer.rs
+++ b/ferrosa-cluster/src/system_table_writer.rs
@@ -29,18 +29,42 @@ fn now_micros() -> i64 {
 /// Holds an `Arc<StorageEngine>` and translates `SystemTableMutation` values
 /// into `StorageEngine::write()` calls. Each mutation writes to the appropriate
 /// system table (`system_schema.*` or `system_auth.*`).
+#[derive(Clone)]
 pub struct SystemTableWriter {
     engine: Arc<StorageEngine>,
+    /// Test-only observability seam: records the OS thread on which the most
+    /// recent [`SystemTableWriter::apply`] ran. The raft apply-offload
+    /// regression test uses this to prove the synchronous system-table write
+    /// executes on a blocking thread rather than inline on the raft worker.
+    /// Per-instance (not global) so parallel tests cannot race the recording.
+    #[cfg(test)]
+    last_apply_thread: Arc<std::sync::Mutex<Option<std::thread::ThreadId>>>,
 }
 
 impl SystemTableWriter {
     /// Create a new writer backed by the given storage engine.
     pub fn new(engine: Arc<StorageEngine>) -> Self {
-        Self { engine }
+        Self {
+            engine,
+            #[cfg(test)]
+            last_apply_thread: Arc::new(std::sync::Mutex::new(None)),
+        }
+    }
+
+    /// Test-only handle to the thread recorder; see [`Self::last_apply_thread`].
+    #[cfg(test)]
+    pub(crate) fn last_apply_thread_handle(
+        &self,
+    ) -> Arc<std::sync::Mutex<Option<std::thread::ThreadId>>> {
+        Arc::clone(&self.last_apply_thread)
     }
 
     /// Apply a system table mutation by writing to the storage engine.
     pub fn apply(&self, mutation: SystemTableMutation) -> ferrosa_common::Result<()> {
+        #[cfg(test)]
+        {
+            *self.last_apply_thread.lock().unwrap() = Some(std::thread::current().id());
+        }
         match mutation {
             SystemTableMutation::KeyspaceCreated(ks) => {
                 let (key, row, ts) = keyspace_to_row(&ks);

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -781,6 +781,14 @@ pub struct StorageEngine {
     /// maintenance loop consumes this flag to run an urgent S3 upload/eviction
     /// pass instead of waiting for the next normal flush tick.
     s3_sync_requested: AtomicBool,
+    /// Last observed free bytes on `config.data_dir`, refreshed by
+    /// `disk_free_bytes_cached()` at most ~once per second. Reading this on the
+    /// per-write admission path keeps the blocking `statvfs` syscall off the
+    /// async worker threads (raft apply, coordinator, CQL handlers).
+    cached_disk_free_bytes: AtomicU64,
+    /// Milliseconds since [`reference_instant`] of the last successful disk-free
+    /// refresh. `u64::MAX` is the sentinel for "never checked".
+    disk_free_checked_at_ms: AtomicU64,
     /// Set when the write path observes a memtable at/near the flush threshold.
     /// The process maintenance loop consumes this flag to run an urgent flush
     /// outside request handling.
@@ -1624,16 +1632,65 @@ impl StorageEngine {
         Ok(count)
     }
 
+    /// Free bytes on `config.data_dir`, served from a time-gated cache so the
+    /// blocking `statvfs` syscall runs at most ~once per second instead of on
+    /// every write. The cache is at most ~1s stale, which is well within the
+    /// tolerance of the disk-reserve guard.
+    ///
+    /// Refresh is single-flight: a `compare_exchange` on the timestamp elects
+    /// exactly one caller to run `statvfs` per ~1s window; everyone else reads
+    /// the last cached value. On `statvfs` error we log and return the cached
+    /// value rather than clobbering it (fail-visible, not fail-silent).
+    fn disk_free_bytes_cached(&self) -> u64 {
+        let now_ms = reference_instant().elapsed().as_millis() as u64;
+        let last = self.disk_free_checked_at_ms.load(Ordering::Acquire);
+        let stale = last == u64::MAX || now_ms.saturating_sub(last) >= 1000;
+        if stale
+            && self
+                .disk_free_checked_at_ms
+                .compare_exchange(last, now_ms, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            match fs2::available_space(&self.config.data_dir) {
+                Ok(available) => {
+                    self.cached_disk_free_bytes
+                        .store(available, Ordering::Release);
+                    if available < self.local_disk_eviction_low_water_bytes() {
+                        self.request_s3_sync();
+                    }
+                    return available;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        path = %self.config.data_dir.display(),
+                        error = %e,
+                        "statvfs failed during disk-free refresh; serving cached value"
+                    );
+                }
+            }
+        }
+        self.cached_disk_free_bytes.load(Ordering::Acquire)
+    }
+
+    /// Test-only override of the disk-free cache. Marks the cache fresh so the
+    /// admission gate reads the injected value instead of immediately running a
+    /// live `statvfs` that would overwrite it.
+    #[cfg(test)]
+    pub(crate) fn set_disk_free_cache_for_test(&self, bytes: u64) {
+        self.cached_disk_free_bytes.store(bytes, Ordering::Release);
+        self.disk_free_checked_at_ms.store(
+            reference_instant().elapsed().as_millis() as u64,
+            Ordering::Release,
+        );
+    }
+
     pub fn check_write_admission(&self) -> ferrosa_common::Result<()> {
         let reserve = self.config.local_disk_free_reserve_bytes;
         if reserve == 0 {
             return Ok(());
         }
 
-        let available = fs2::available_space(&self.config.data_dir)?;
-        if available < self.local_disk_eviction_low_water_bytes() {
-            self.request_s3_sync();
-        }
+        let available = self.disk_free_bytes_cached();
         if available < reserve {
             return Err(ferrosa_common::Error::InvalidData(format!(
                 "local disk free space below write reserve: available={available} reserve={reserve} path={}",
@@ -1773,6 +1830,8 @@ impl StorageEngine {
             s3_cas_supported: std::sync::atomic::AtomicBool::new(true),
             s3_sync_running: AtomicBool::new(false),
             s3_sync_requested: AtomicBool::new(false),
+            cached_disk_free_bytes: AtomicU64::new(0),
+            disk_free_checked_at_ms: AtomicU64::new(u64::MAX),
             flush_requested: AtomicBool::new(false),
             s3_manifest_stats: RwLock::new(HashMap::new()),
             reader_pool,
@@ -1940,6 +1999,8 @@ impl StorageEngine {
             s3_cas_supported: std::sync::atomic::AtomicBool::new(true),
             s3_sync_running: AtomicBool::new(false),
             s3_sync_requested: AtomicBool::new(false),
+            cached_disk_free_bytes: AtomicU64::new(0),
+            disk_free_checked_at_ms: AtomicU64::new(u64::MAX),
             flush_requested: AtomicBool::new(false),
             s3_manifest_stats: RwLock::new(HashMap::new()),
             reader_pool,
@@ -2084,6 +2145,8 @@ impl StorageEngine {
             s3_cas_supported: std::sync::atomic::AtomicBool::new(true),
             s3_sync_running: AtomicBool::new(false),
             s3_sync_requested: AtomicBool::new(false),
+            cached_disk_free_bytes: AtomicU64::new(0),
+            disk_free_checked_at_ms: AtomicU64::new(u64::MAX),
             flush_requested: AtomicBool::new(false),
             s3_manifest_stats: RwLock::new(HashMap::new()),
             reader_pool,
@@ -8019,6 +8082,8 @@ impl StorageEngine {
             s3_cas_supported: std::sync::atomic::AtomicBool::new(true),
             s3_sync_running: AtomicBool::new(false),
             s3_sync_requested: AtomicBool::new(false),
+            cached_disk_free_bytes: AtomicU64::new(0),
+            disk_free_checked_at_ms: AtomicU64::new(u64::MAX),
             flush_requested: AtomicBool::new(false),
             s3_manifest_stats: RwLock::new(HashMap::new()),
             reader_pool,
@@ -8798,6 +8863,30 @@ mod tests {
                 path.display()
             );
         }
+    }
+
+    #[test]
+    fn check_write_admission_reads_cached_disk_free_not_live_statvfs() {
+        // RED: the admission gate must consult the time-gated disk-free cache,
+        // not run a live statvfs on every write. With a real writable temp
+        // data_dir (which has free space) a live statvfs would always pass;
+        // this test forces the cache below the reserve and expects a failure.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = StorageEngineConfig::test_config(dir.path());
+        config.local_disk_free_reserve_bytes = 1024;
+        let engine = StorageEngine::new(config, None).unwrap();
+
+        engine.set_disk_free_cache_for_test(10);
+        assert!(
+            engine.check_write_admission().is_err(),
+            "cached free space below reserve must reject the write"
+        );
+
+        engine.set_disk_free_cache_for_test(1_000_000_000);
+        assert!(
+            engine.check_write_admission().is_ok(),
+            "cached free space above reserve must admit the write"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Under load on small/shared hosts, ferrosa nodes go unresponsive: Raft heartbeat RPCs miss the 1s lane deadline (→ peer `Unreachable`, replication stalls, transient `LOCAL_QUORUM received=1 required=2`), and CQL session builds miss the driver's 10s deadline (→ `pool is broken` / `KeepaliveTimeout`). Reproduces reliably on the 2-vCPU CI runner used by ferrosa-memory's cluster-integration job; invisible on big dev boxes.

## Root cause: blocking work on tokio async worker threads

Not CPU under-provisioning — a worker that **parks in a blocking syscall** stalls everything sharing the runtime (heartbeats, CQL accept) for the full I/O duration, regardless of thread count. Three such paths:

1. **`statvfs` on every write** — `StorageEngine::check_write_admission()` called `fs2::available_space()` (blocking) on every `engine.write()`, which runs inline on async workers (raft apply, coordinator, CQL handlers).
2. **Synchronous point-read storage access** — `coordinator::read::read_local_partition` ran the sync storage read inline in async futures on the worker (range scans already offloaded; point reads didn't).
3. **Synchronous `engine.write()` in raft apply** — `RaftStateMachine::apply` (on the raft runtime, serialized with the raft core) ran ~20 synchronous system-table writes, parking the raft worker and delaying heartbeat responses.

## Fix (TDD, one commit each — RED test proving the work ran *on* the worker thread, then GREEN)

- **6ef9d313** — disk-free check served from a time-gated (≤1s), single-flight (CAS-elected) cache; `statvfs` now runs ≤~1×/s off the per-write path. Guard stays accurate; errors log + return cached value (no clobber).
- **a6cf1ed5** — `read_local_partition` offloaded via the existing `TaskPool::spawn_blocking` mechanism; `JoinError` propagated loudly.
- **57ba8ec3** — raft system-table apply collected and drained through `spawn_blocking`, preserving openraft's sequential apply ordering; in-memory state mutation stays on the worker.

## Verification
- New RED→GREEN tests: `check_write_admission_reads_cached_disk_free_not_live_statvfs` (ferrosa-storage), `local_read_runs_off_the_async_worker_thread` + `system_table_apply_runs_off_the_raft_worker_thread` (ferrosa-cluster).
- `cargo test -p ferrosa-storage` and `cargo test -p ferrosa-cluster` green (cluster lib 961 passed, 0 failed); clippy 0 warnings; fmt clean. No existing test weakened.
- End-to-end: ferrosa-memory CI (branch `fix/ci-cluster-test-threads`) builds this branch and runs the cluster-integration job at full parallelism against the fixed engine.