### PR TITLE
fix(storage): close read-vs-compaction Ok(None) data-loss window (flaky concurrent_read_during_compaction)

### DIFF
--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -12439,6 +12439,90 @@ mod tests {
         );
     }
 
+    /// Window (3): the same read-vs-compaction data-loss race, but exercised
+    /// through `read_clustering_row` — the production full-primary-key point-read
+    /// hot path (write_path.rs routes CQL `=` point reads here). Before the fix
+    /// this path had NO view-retry loop at all: a stale-view open failure just
+    /// `continue`d and the read returned a spurious `Ok(None)` = silent data loss.
+    /// It must now retry against the freshly-swapped view like the partition read.
+    #[tokio::test]
+    async fn clustering_read_during_compaction_retries_against_new_view() {
+        use crate::store::read_race_test_hook::{ReadViewBarrier, ARMED};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = StorageEngineConfig::test_config(dir.path());
+        config.compaction.min_threshold = 2;
+        let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        // t1 -> gen1, t2 -> gen2. t2 lives ONLY in gen2 (no survivor SSTable).
+        // Both use clustering [0,0,0,1] (see make_row).
+        engine
+            .write(&tid, &make_key("t1"), make_row(b"v1", 1000), 1000)
+            .unwrap();
+        engine.flush(&tid).unwrap();
+        engine
+            .write(&tid, &make_key("t2"), make_row(b"v2", 2000), 2000)
+            .unwrap();
+        engine.flush(&tid).unwrap();
+        assert_eq!(engine.sstable_count(&tid), 2);
+
+        // Submit a compaction merging gen1+gen2; control exactly when the swap
+        // (view -> merged, input files deleted) is applied via poll_compactions.
+        {
+            let tables = engine.tables.read();
+            let state = tables.get(&tid).unwrap();
+            let metadata = engine.collect_sstable_metadata(&tid, state);
+            drop(tables);
+            let task = crate::compaction::metadata::CompactionTask {
+                inputs: metadata,
+                output_dir: dir.path().join("compaction"),
+                schema: test_schema(),
+                table_id: tid.clone(),
+            };
+            engine.compaction_executor.submit(task).unwrap();
+        }
+
+        // Reader thread issues a full-primary-key clustering read; arm it so the
+        // read pauses right after snapshotting the still-unswapped view (gen2).
+        let barrier = ReadViewBarrier::new();
+        let b_reader = Arc::clone(&barrier);
+        let eng = Arc::clone(&engine);
+        let rtid = tid.clone();
+        let clustering = vec![0x00, 0x00, 0x00, 0x01];
+        let reader = std::thread::spawn(move || {
+            ARMED.with(|c| *c.borrow_mut() = Some(b_reader));
+            eng.read_clustering_row(&rtid, &make_key("t2"), &clustering)
+                .expect("read must not error")
+        });
+
+        // Drive the swap to completion under the paused read.
+        barrier.wait_reached();
+        let mut swapped = false;
+        for _ in 0..1500 {
+            engine.poll_compactions().await;
+            if engine.sstable_count(&tid) == 1 {
+                swapped = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            swapped,
+            "compaction swap should merge the two inputs into one (background merge never completed)"
+        );
+        barrier.release();
+
+        let got = reader.join().unwrap();
+        assert!(
+            got.is_some(),
+            "t2 must remain readable via read_clustering_row across a concurrent compaction \
+             that deleted its SSTable (no spurious Ok(None) on the point-read hot path)"
+        );
+    }
+
     #[test]
     fn commit_log_position_exposed() {
         let dir = tempfile::tempdir().unwrap();

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -424,6 +424,11 @@ pub struct TableStore<F: FlushTarget> {
     write_barrier: parking_lot::RwLock<()>,
     /// Counter of SSTable read errors during get_partition.
     pub sstable_read_errors: std::sync::atomic::AtomicU64,
+    /// Counter of reads that exhausted the store-view retry bound while an
+    /// SSTable was still failing to open. Non-zero in steady state means a
+    /// genuinely corrupt/missing file (not a transient compaction swap) and a
+    /// read may have returned an incomplete result — alert on it.
+    pub view_retry_exhausted: std::sync::atomic::AtomicU64,
     pub(crate) flush_target: F,
     options: WriteOptions,
     /// Secondary index declarations: `(index_name, column_position)` pairs.
@@ -811,6 +816,7 @@ impl<F: FlushTarget> TableStore<F> {
             vector_index_scopes: parking_lot::Mutex::new(HashMap::new()),
             write_barrier: parking_lot::RwLock::new(()),
             sstable_read_errors: std::sync::atomic::AtomicU64::new(0),
+            view_retry_exhausted: std::sync::atomic::AtomicU64::new(0),
             reader_pool: Arc::new(crate::reader_pool::ReaderPool::new(
                 crate::reader_pool::configured_reader_cache_cap(),
             )),
@@ -1015,6 +1021,7 @@ impl<F: FlushTarget> TableStore<F> {
             vector_index_scopes: parking_lot::Mutex::new(HashMap::new()),
             write_barrier: parking_lot::RwLock::new(()),
             sstable_read_errors: std::sync::atomic::AtomicU64::new(0),
+            view_retry_exhausted: std::sync::atomic::AtomicU64::new(0),
             reader_pool,
             pool_table_key,
         }
@@ -1091,6 +1098,7 @@ impl<F: FlushTarget> TableStore<F> {
             vector_index_scopes: parking_lot::Mutex::new(HashMap::new()),
             write_barrier: parking_lot::RwLock::new(()),
             sstable_read_errors: std::sync::atomic::AtomicU64::new(0),
+            view_retry_exhausted: std::sync::atomic::AtomicU64::new(0),
             reader_pool,
             pool_table_key: String::new(),
         }
@@ -1279,14 +1287,36 @@ impl<F: FlushTarget> TableStore<F> {
         key: &DecoratedKey,
         row_limit: usize,
     ) -> Result<Option<Partition>> {
-        // A read takes an atomic snapshot of the store view. If an SSTable in
-        // that snapshot is concurrently compacted away (its local file deleted)
-        // before we open it, the data has already moved into a new SSTable in a
-        // newer view — so reload and retry instead of returning a partial result
-        // that silently drops the key (a fail-loud violation). Bounded so a
-        // genuinely corrupt/missing file still falls through to tolerant handling.
+        self.with_retried_view("read_limited_rows", |view| {
+            self.read_with_view(view, key, row_limit)
+        })
+    }
+
+    /// Run a single-snapshot read `attempt` under the store-view retry policy.
+    ///
+    /// A read takes an atomic snapshot of the store view. If an SSTable in that
+    /// snapshot is concurrently compacted away (its local file deleted, or a
+    /// component such as `Filter.db` removed) before we open it, the data has
+    /// already moved into a new SSTable in a newer view — so reload and retry
+    /// instead of returning a result that silently drops the key (a fail-loud
+    /// violation). `attempt` returns `(result, stale_view_failed)` where
+    /// `stale_view_failed` means a snapshotted SSTable could not be fully
+    /// consulted; whenever it is set we reload the view and retry.
+    ///
+    /// Retry is **not** gated on the view pointer changing: a deletion that
+    /// leaves the live view referencing the same generation (e.g. S3
+    /// local-cache eviction) must still be retried so the reopen re-resolves /
+    /// re-fetches the file. Bounded by `MAX_VIEW_RETRIES`; if a fresh reopen
+    /// against the current view still fails after the bound, the file is
+    /// genuinely corrupt/missing and the (tolerant) result is returned — but
+    /// the exhaustion is logged and metered so it is never silent.
+    fn with_retried_view<R>(
+        &self,
+        op: &'static str,
+        mut attempt: impl FnMut(&StoreView) -> Result<(Option<R>, bool)>,
+    ) -> Result<Option<R>> {
         const MAX_VIEW_RETRIES: usize = 8;
-        for attempt in 0..=MAX_VIEW_RETRIES {
+        for n in 0..=MAX_VIEW_RETRIES {
             let view = self.view.load_full();
 
             #[cfg(test)]
@@ -1294,12 +1324,21 @@ impl<F: FlushTarget> TableStore<F> {
                 barrier.reach_and_wait();
             }
 
-            let (result, sstable_open_failed) = self.read_with_view(&view, key, row_limit)?;
-            if sstable_open_failed
-                && attempt < MAX_VIEW_RETRIES
-                && !Arc::ptr_eq(&view, &self.view.load_full())
-            {
+            let (result, stale_view_failed) = attempt(&view)?;
+            if stale_view_failed && n < MAX_VIEW_RETRIES {
                 continue;
+            }
+            if stale_view_failed {
+                // Bound exhausted with a still-failing open: fail loud rather
+                // than silently returning a possibly-incomplete result.
+                self.view_retry_exhausted
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                tracing::error!(
+                    op,
+                    retries = MAX_VIEW_RETRIES,
+                    "read exhausted view retries with an SSTable still failing to open — \
+                     result may be incomplete (genuinely corrupt/missing file?)"
+                );
             }
             return Ok(result);
         }
@@ -1447,9 +1486,28 @@ impl<F: FlushTarget> TableStore<F> {
         key: &DecoratedKey,
         clustering: &[u8],
     ) -> Result<Option<Partition>> {
-        let guard = self.view.load();
+        // Route through the shared store-view retry policy so a stale-view
+        // SSTable open failure (compaction swap or local-cache eviction) retries
+        // against a fresh view instead of silently returning `Ok(None)` — the
+        // same data-loss class as a partition read. This path is a production
+        // hot path (full primary-key CQL point reads).
+        self.with_retried_view("read_clustering_row", |view| {
+            self.read_clustering_row_with_view(view, key, clustering)
+        })
+    }
+
+    /// One attempt of [`read_clustering_row`] against a fixed `view` snapshot.
+    /// Returns the matching row (if any) plus whether any SSTable failed to
+    /// open — the signal the caller uses to retry against a fresh view.
+    fn read_clustering_row_with_view(
+        &self,
+        guard: &StoreView,
+        key: &DecoratedKey,
+        clustering: &[u8],
+    ) -> Result<(Option<Partition>, bool)> {
         let schema = self.schema.load();
         let mut sources: Vec<Partition> = Vec::new();
+        let mut sstable_open_failed = false;
 
         if let Some(p) = guard.active.get(key)? {
             if let Some(filtered) = partition_with_matching_clustering(&p, clustering) {
@@ -1476,6 +1534,7 @@ impl<F: FlushTarget> TableStore<F> {
                     tracing::error!(%e, gen = %desc.gen, "clustering read: failed to open SSTable reader");
                     self.sstable_read_errors
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    sstable_open_failed = true;
                     continue;
                 }
             };
@@ -1509,15 +1568,15 @@ impl<F: FlushTarget> TableStore<F> {
         }
 
         if sources.is_empty() {
-            return Ok(None);
+            return Ok((None, sstable_open_failed));
         }
 
         let mut merged = merge::merge_partitions(sources);
         merged.rows.retain(|row| row.clustering == clustering);
         if merged.rows.is_empty() {
-            Ok(None)
+            Ok((None, sstable_open_failed))
         } else {
-            Ok(Some(merged))
+            Ok((Some(merged), sstable_open_failed))
         }
     }
 


### PR DESCRIPTION
## Root cause
A read snapshots the `ArcSwap` store view, then has its SSTable inputs compacted (view swapped + old files deleted) before it opens them → spurious `Ok(None)` = client-visible "row not found" during compaction = silent data loss. PR #104 covered only the partition path's open-error case; an investigation (workflow wrbm62kqp) found **three** residual windows. **Flaky code, not a flaky test** — the "reads must always be readable" assertion is correct and untouched.

## What this PR closes (2 of 3 windows + the demonstrated flake)
- **Window 3 — sibling read paths:** extracted a shared `with_retried_view()` helper and routed `read_limited_rows` **and the production hot path `read_clustering_row`** (CQL point reads via write_path.rs) through it. Previously only `read_limited_rows` retried.
- **Window 2 — Arc::ptr_eq false-negative:** dropped the pointer-equality gate; a stale-view open failure now retries by reopening against the current view (so S3 local-cache eviction re-resolves/re-fetches), bounded by `MAX_VIEW_RETRIES` and **fail-loud** if a fresh reopen still fails.

## Proof (deterministic, not luck)
- New deterministic test `clustering_read_during_compaction_retries_against_new_view` (ReadViewBarrier) — **fails before the fix, passes after**; existing `read_during_compaction_retries_against_new_view` still green.
- `concurrent_read_during_compaction` stress-looped **100× serial + 240× under core saturation, zero failures**; re-verified green on current main after rebase.

## Known remaining — tracked, NOT closed here (forge t_b367c166)
- **Window 1:** a missing `Filter.db` (optional component, `unwrap_or_default()`) deleted mid-open → degraded/empty bloom → key pruned → `Ok(None)` with no open-error, so the retry never fires. Plus a latent `num_bits==0` bloom panic. Needs `flush.rs` (fail-loud on absent Filter.db) + `ferrosa-sstable/reader.rs` (no `% 0`) — narrower window, fast-follow.

Gate: fmt/clippy/`cargo test -p ferrosa-storage`/workspace-doc clean. Same data-loss severity class as #125.