### PR TITLE
fix(storage): close read-vs-compaction window 1 (degenerate/deleted Filter.db -> Ok(None)/panic)

### DIFF
--- a/ferrosa-sstable/src/bloom.rs
+++ b/ferrosa-sstable/src/bloom.rs
@@ -63,6 +63,12 @@ impl BloomFilter {
     /// increment: `hash_i = h2 + i * h1`. See `BloomFilter.java` line 101-103.
     pub fn add(&mut self, h1: i64, h2: i64) {
         let num_bits = (self.bits.len() * 64) as i64;
+        // A zero-bit filter has no storage; there is nothing to set. Probing
+        // `hash % num_bits` would divide by zero, so skip (matches the
+        // "may contain everything" semantics enforced in `is_present`).
+        if num_bits == 0 {
+            return;
+        }
         for i in 0..self.hash_count as i64 {
             let hash = h2.wrapping_add(i.wrapping_mul(h1));
             let bit_index = (hash % num_bits).unsigned_abs() as usize;
@@ -75,6 +81,14 @@ impl BloomFilter {
     /// Test if a key might be present (false positives possible).
     pub fn is_present(&self, h1: i64, h2: i64) -> bool {
         let num_bits = (self.bits.len() * 64) as i64;
+        // A zero-bit filter carries no information. Treat it as "may contain"
+        // (conservative true) instead of computing `hash % 0` (which panics).
+        // A false positive only forces a real read; a false negative here would
+        // prune the only SSTable holding the key -> spurious `Ok(None)` =
+        // silent data loss. Safety over precision.
+        if num_bits == 0 {
+            return true;
+        }
         for i in 0..self.hash_count as i64 {
             let hash = h2.wrapping_add(i.wrapping_mul(h1));
             let bit_index = (hash % num_bits).unsigned_abs() as usize;
@@ -230,6 +244,44 @@ mod tests {
     #[test]
     fn read_too_short() {
         assert!(BloomFilter::read(&[0; 4]).is_err());
+    }
+
+    /// A validly-serialized zero-word filter (8-byte header, `word_count == 0`)
+    /// has `num_bits == 0`. Probing it must NOT divide-by-zero (`hash % 0`
+    /// panics) and must report "may contain" (`true`) rather than a false
+    /// "absent" — a false negative here would prune the only SSTable holding a
+    /// key and surface as a spurious `Ok(None)` (silent data loss). A
+    /// "may contain" only forces a real read, which is always safe.
+    #[test]
+    fn zero_bit_filter_is_present_returns_true_and_does_not_panic() {
+        // hash_count = 3, word_count = 0 -> bits is empty, num_bits == 0.
+        let mut serialized = Vec::new();
+        serialized.extend_from_slice(&3i32.to_be_bytes());
+        serialized.extend_from_slice(&0i32.to_be_bytes());
+        let bf = BloomFilter::read(&serialized).expect("zero-word filter parses");
+        assert!(bf.bits().is_empty(), "fixture must have zero bits");
+
+        // Must not panic, and must conservatively report "present".
+        assert!(
+            bf.is_present(12345, 67890),
+            "empty/zero-bit filter must report may-contain, never a false absent"
+        );
+        assert!(
+            bf.is_present(-1, i64::MIN),
+            "empty/zero-bit filter must report may-contain for extreme hashes too"
+        );
+    }
+
+    /// Adding to a zero-bit filter must also be a no-op rather than panicking
+    /// on `hash % 0`, so constructing/writing such a filter never crashes.
+    #[test]
+    fn zero_bit_filter_add_does_not_panic() {
+        let mut serialized = Vec::new();
+        serialized.extend_from_slice(&3i32.to_be_bytes());
+        serialized.extend_from_slice(&0i32.to_be_bytes());
+        let mut bf = BloomFilter::read(&serialized).expect("zero-word filter parses");
+        bf.add(12345, 67890); // must not panic
+        assert!(bf.is_present(12345, 67890));
     }
 
     #[test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -6867,6 +6867,15 @@ impl StorageEngine {
             .unwrap_or(0)
     }
 
+    /// Test-only: drop a generation's pooled (already-open) reader so the next
+    /// read reopens it from its on-disk component files. Used to exercise the
+    /// disk-reopen path (e.g. a corrupt/degenerate `Filter.db`) instead of a
+    /// cache hit on the reader the flush seeded.
+    #[cfg(test)]
+    pub(crate) fn evict_pooled_reader_for_test(&self, table_id: &TableId, gen: u64) {
+        self.reader_pool.remove(&(table_id.to_string(), gen));
+    }
+
     /// Returns the count of SSTable read errors for a table.
     pub fn sstable_read_errors(&self, table_id: &TableId) -> u64 {
         self.tables
@@ -12521,6 +12530,192 @@ mod tests {
             "t2 must remain readable via read_clustering_row across a concurrent compaction \
              that deleted its SSTable (no spurious Ok(None) on the point-read hot path)"
         );
+    }
+
+    /// Window (1), DELETED-`Filter.db` variant — fail-loud + retry path.
+    ///
+    /// A read snapshots a view referencing the sole-survivor input SSTable
+    /// (gen2). Compaction deletes gen2 and swaps in a merged output holding the
+    /// key; gen2's `Data.db` is then restored on disk WITHOUT its `Filter.db`,
+    /// so the stale view reopens a Filter-less SSTable. `open_file_sstable` must
+    /// FAIL LOUD on the absent `Filter.db` (FIX A) — converting the window into
+    /// an open `Err` that engages the existing view-retry, which reopens against
+    /// the merged view and finds the key. Asserts the read returns `Some`.
+    ///
+    /// (Note: the bare empty-filter case is also caught by `BloomFilter::read`'s
+    /// length check; this test pins the *diagnosable* fail-loud behavior and
+    /// guards against a future change that would make that check tolerant.)
+    #[tokio::test]
+    async fn read_during_compaction_filter_db_deleted_retries_against_new_view() {
+        use crate::store::read_race_test_hook::{ReadViewBarrier, ARMED};
+        use std::sync::Arc;
+
+        let dir = std::mem::ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let data_dir = dir.path().to_path_buf();
+        let (engine, tid, gen2_dir, gen2, backups) = setup_window1_compaction(&dir);
+
+        // Submit a compaction merging gen1+gen2; control when the swap applies.
+        {
+            let tables = engine.tables.read();
+            let state = tables.get(&tid).unwrap();
+            let metadata = engine.collect_sstable_metadata(&tid, state);
+            drop(tables);
+            let task = crate::compaction::metadata::CompactionTask {
+                inputs: metadata,
+                output_dir: data_dir.join("compaction"),
+                schema: test_schema(),
+                table_id: tid.clone(),
+            };
+            engine.compaction_executor.submit(task).unwrap();
+        }
+
+        let barrier = ReadViewBarrier::new();
+        let b_reader = Arc::clone(&barrier);
+        let eng = Arc::clone(&engine);
+        let rtid = tid.clone();
+        let reader = std::thread::spawn(move || {
+            ARMED.with(|c| *c.borrow_mut() = Some(b_reader));
+            eng.read(&rtid, &make_key("t2"))
+                .expect("read must not error")
+        });
+
+        barrier.wait_reached();
+        let mut swapped = false;
+        for _ in 0..1500 {
+            engine.poll_compactions().await;
+            if engine.sstable_count(&tid) == 1 {
+                swapped = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            swapped,
+            "compaction swap should merge the two inputs into one"
+        );
+
+        // Restore gen2's Data/Partitions/Rows (NOT Filter.db).
+        std::fs::create_dir_all(&gen2_dir).unwrap();
+        for (path, bytes) in &backups {
+            std::fs::write(path, bytes).unwrap();
+        }
+        assert!(
+            !gen2_dir.join(format!("{gen2}-Filter.db")).exists(),
+            "gen2 Filter.db must remain DELETED to exercise window-1"
+        );
+        assert!(
+            gen2_dir.join(format!("{gen2}-Data.db")).exists(),
+            "gen2 Data.db must be present (only Filter.db is missing)"
+        );
+
+        barrier.release();
+        let got = reader.join().unwrap();
+        assert!(
+            got.is_some(),
+            "t2 must remain readable when gen2's Filter.db was concurrently \
+             deleted mid-open (no spurious Ok(None) / no panic)"
+        );
+    }
+
+    /// Window (1), DEGENERATE-`Filter.db` variant — the genuinely-silent case.
+    ///
+    /// A truncated/corrupt `Filter.db` consisting of just a valid 8-byte header
+    /// with `word_count == 0` parses successfully (it passes `BloomFilter::read`)
+    /// into a zero-bit filter. Before the fix, probing that filter executed
+    /// `hash % 0` and PANICKED inside the read — crashing the point read. The
+    /// `num_bits == 0 => may-contain` guard (FIX B) makes the probe return
+    /// `true` instead, so the real SSTable read runs and the key is found.
+    /// Asserts the read neither panics nor returns a spurious `Ok(None)`.
+    #[tokio::test]
+    async fn read_with_zero_bit_filter_db_does_not_panic_or_lose_row() {
+        use std::sync::Arc;
+
+        let dir = std::mem::ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let (engine, tid, gen2_dir, gen2, _backups) = setup_window1_compaction(&dir);
+
+        // Overwrite gen2's Filter.db with a degenerate 0-word filter: a valid
+        // 8-byte header (hash_count=3, word_count=0). This parses OK and yields
+        // num_bits == 0 — the `% 0` panic / false-negative window.
+        let mut degenerate = Vec::new();
+        degenerate.extend_from_slice(&3i32.to_be_bytes());
+        degenerate.extend_from_slice(&0i32.to_be_bytes());
+        std::fs::write(gen2_dir.join(format!("{gen2}-Filter.db")), &degenerate).unwrap();
+
+        // Drop gen2's pooled reader (the flush seeded it with the original,
+        // valid in-memory filter) so the next read REOPENS gen2 from disk and
+        // actually parses the degenerate Filter.db we just wrote.
+        engine.evict_pooled_reader_for_test(&tid, gen2);
+
+        // No compaction: gen2 still holds t2 and is still in the live view. The
+        // read opens gen2, probes the zero-bit filter, and must find t2.
+        let eng = Arc::clone(&engine);
+        let rtid = tid.clone();
+        let got = std::thread::spawn(move || {
+            eng.read(&rtid, &make_key("t2"))
+                .expect("read must not error")
+        })
+        .join()
+        .expect("read thread must not panic on a zero-bit filter");
+
+        assert!(
+            got.is_some(),
+            "t2 must remain readable through a degenerate zero-bit Filter.db \
+             (no `% 0` panic, no false-negative prune to Ok(None))"
+        );
+    }
+
+    /// Shared setup for the window-1 tests: t1 -> gen1, t2 -> gen2 (t2 lives
+    /// ONLY in gen2). Returns the engine, table id, gen2's directory + number,
+    /// and a backup of gen2's non-filter components (for the deletion variant).
+    #[allow(clippy::type_complexity)]
+    fn setup_window1_compaction(
+        dir: &tempfile::TempDir,
+    ) -> (
+        std::sync::Arc<StorageEngine>,
+        TableId,
+        std::path::PathBuf,
+        u64,
+        Vec<(std::path::PathBuf, Vec<u8>)>,
+    ) {
+        use std::sync::Arc;
+        let mut config = StorageEngineConfig::test_config(dir.path());
+        config.compaction.min_threshold = 2;
+        let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        engine
+            .write(&tid, &make_key("t1"), make_row(b"v1", 1000), 1000)
+            .unwrap();
+        engine.flush(&tid).unwrap();
+        engine
+            .write(&tid, &make_key("t2"), make_row(b"v2", 2000), 2000)
+            .unwrap();
+        engine.flush(&tid).unwrap();
+        assert_eq!(engine.sstable_count(&tid), 2);
+
+        let table_dir = dir.path().join("sstables").join(tid.to_string());
+        let gens = StorageEngine::list_generations_in_dir(&table_dir);
+        let gen2 = *gens.iter().max().expect("a gen2 must exist");
+        let gen2_dir = StorageEngine::generation_dir_path(&table_dir, gen2)
+            .expect("gen2 directory must resolve");
+
+        let mut backups: Vec<(std::path::PathBuf, Vec<u8>)> = Vec::new();
+        for comp in [
+            "Data.db",
+            "Partitions.db",
+            "Rows.db",
+            "Statistics.db",
+            "TOC.txt",
+            "CompressionInfo.db",
+        ] {
+            let p = gen2_dir.join(format!("{gen2}-{comp}"));
+            if let Ok(bytes) = std::fs::read(&p) {
+                backups.push((p, bytes));
+            }
+        }
+        assert!(!backups.is_empty(), "gen2 must have at least Data.db");
+        (engine, tid, gen2_dir, gen2, backups)
     }
 
     #[test]

--- a/ferrosa-storage/src/flush.rs
+++ b/ferrosa-storage/src/flush.rs
@@ -905,9 +905,11 @@ struct FileComponentPaths {
 /// in `dir`. Shared by [`FileFlushTarget::open_reader`] and the engine's
 /// startup/load path so on-demand reopens go through one code path.
 ///
-/// Required components (`Data.db`, `Partitions.db`, `Rows.db`) must exist;
-/// optional components (`Filter.db`, `Statistics.db`, `CompressionInfo.db`)
-/// default to empty/absent when missing, matching the historical engine loader.
+/// Required components (`Data.db`, `Partitions.db`, `Rows.db`, `Filter.db`) must
+/// exist — `Filter.db` is always written for a live SSTable, so its absence while
+/// `Data.db` is present means a concurrent compaction/eviction deleted it and we
+/// fail loud (see the inline comment at the read). Genuinely-optional components
+/// (`Statistics.db`, `CompressionInfo.db`) default to empty/absent when missing.
 pub fn open_file_sstable(dir: &Path, gen: &str) -> Result<SSTableReader<FileReadAt>> {
     let required = |suffix: &str| -> Result<PathBuf> {
         let p = dir.join(format!("{gen}-{suffix}"));
@@ -925,7 +927,18 @@ pub fn open_file_sstable(dir: &Path, gen: &str) -> Result<SSTableReader<FileRead
     let partitions = FileReadAt::open(required("Partitions.db")?)?;
     let rows = FileReadAt::open(required("Rows.db")?)?;
 
-    let filter = std::fs::read(dir.join(format!("{gen}-Filter.db"))).unwrap_or_default();
+    // `Filter.db` is ALWAYS written for a live SSTable (flush and compaction
+    // both emit it unconditionally — see `file_flush_target_creates_component_files`).
+    // So unlike a legitimately-optional component, an *absent* `Filter.db` while
+    // `Data.db` is present means a concurrent compaction/eviction deleted it out
+    // from under this open. Substituting an empty filter (the old
+    // `unwrap_or_default()`) would build a DEGRADED reader whose bloom rejects
+    // every key, silently pruning the only SSTable holding a row and surfacing
+    // as a spurious `Ok(None)` (silent data loss) with NO open error — so the
+    // read-path view-retry would never fire. Fail loud instead: this converts
+    // the window into an open `Err`, engaging the existing `with_retried_view`
+    // retry which reopens against the freshly-compacted view that holds the key.
+    let filter = std::fs::read(required("Filter.db")?)?;
     let statistics = std::fs::read(dir.join(format!("{gen}-Statistics.db"))).unwrap_or_default();
     let compression_info = std::fs::read(dir.join(format!("{gen}-CompressionInfo.db"))).ok();
 
@@ -1580,6 +1593,66 @@ mod tests {
             .path()
             .join(format!("{gen}-CompressionInfo.db"))
             .exists());
+    }
+
+    /// Window-1 fail-loud: `Filter.db` is always written for a live SSTable, so
+    /// its absence while `Data.db` is still present means a concurrent
+    /// compaction/eviction deleted it mid-open. Silently substituting an empty
+    /// filter (`unwrap_or_default()`) builds a DEGRADED reader whose bloom
+    /// rejects every key — pruning the only SSTable holding a row and surfacing
+    /// as a spurious `Ok(None)` (silent data loss) with NO open error, so the
+    /// read-path view-retry never fires. `open_file_sstable` must instead return
+    /// `Err` so the retry reopens against the freshly-compacted view.
+    #[test]
+    fn open_file_sstable_errors_when_filter_db_deleted_mid_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let schema = test_schema();
+        let mut partitions = vec![make_partition("k1", b"v1", 5000)];
+        partitions.sort_by(|a, b| a.key.cmp(&b.key));
+        let header = build_serialization_header(&schema, &partitions);
+        let options = WriteOptions {
+            compression: None,
+            ..WriteOptions::default()
+        };
+        let mut writer = SSTableWriter::new(options, header);
+        for p in &partitions {
+            writer.add_partition(p).unwrap();
+        }
+        let output = writer.finish().unwrap();
+
+        let target = FileFlushTarget::new(dir.path().to_path_buf()).unwrap();
+        let _reader = target.flush(output).unwrap();
+        let gen = target.generation();
+
+        // Sanity: a healthy SSTable opens fine.
+        open_file_sstable(dir.path(), &gen.to_string())
+            .expect("healthy sstable with Filter.db must open");
+
+        // Simulate a concurrent compaction deleting ONLY Filter.db while
+        // Data/Partitions/Rows are still on disk and still referenced by a
+        // stale read view.
+        let filter = dir.path().join(format!("{gen}-Filter.db"));
+        assert!(filter.exists(), "fixture must have a Filter.db to delete");
+        std::fs::remove_file(&filter).unwrap();
+        assert!(dir.path().join(format!("{gen}-Data.db")).exists());
+
+        let err = match open_file_sstable(dir.path(), &gen.to_string()) {
+            Ok(_) => panic!(
+                "open must FAIL LOUD when Filter.db is absent but Data.db is present \
+                 (concurrent delete) — never build a degraded empty-bloom reader"
+            ),
+            Err(e) => e,
+        };
+        // The error must explicitly name the missing Filter.db so the cause is
+        // diagnosable, rather than relying on a downstream "bloom filter too
+        // short" parse error from feeding empty bytes to BloomFilter::read
+        // (which `unwrap_or_default()` masks the *reason* for). This pins the
+        // fail-loud point to the genuine cause: a concurrently-deleted filter.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Filter.db"),
+            "error must name the absent Filter.db (got: {msg:?})"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context — completes the read-vs-compaction trilogy (follow-up to #129)

PR #129 closed **windows 2 and 3** of the read-during-compaction `Ok(None)` data-loss bug (sibling read paths routed through `with_retried_view`; `Arc::ptr_eq` false-negative dropped). It listed **window 1** as "known remaining — tracked, NOT closed here (forge `t_b367c166`)". #129 has since merged. This PR closes **window 1**, so all three read-vs-compaction windows are now closed across #129 + this PR.

## Window 1 — missing/degenerate `Filter.db`

A read snapshots the store view, then a concurrent compaction/eviction deletes the input SSTable's `Filter.db` before the read opens it. Two reachable failure modes, both now **fail-loud**:

- **FIX B — `ferrosa-sstable/src/bloom.rs` (the genuinely silent/crash window).** A truncated/corrupt `Filter.db` of a valid 8-byte header with `word_count == 0` parses successfully into a zero-bit filter. Probing it computed `hash % 0` and **panicked inside the point read**. `is_present`/`add` now treat `num_bits == 0` as "may contain" (return `true` / no-op). A false positive only forces a real read; a false negative or panic is data loss.
- **FIX A — `ferrosa-storage/src/flush.rs` `open_file_sstable` (fail-loud + diagnosable).** `Filter.db` is *always* written for a live SSTable (it is in the always-written component list emitted by every flush/compaction). Its absence while `Data.db` is present therefore means a concurrent delete. Replaced `unwrap_or_default()` — which built a **degraded empty-bloom reader** that rejects every key, silently pruning the only SSTable holding the row into a spurious `Ok(None)` **with no open error**, so the read-path view-retry never fired — with `required("Filter.db")?`. This converts the window into an explicit open `Err` that engages the existing `with_retried_view` retry (reopening against the freshly-compacted view that holds the key), and names the genuine cause.

## Proof (deterministic, RED before / GREEN after — verified)

- `ferrosa-sstable` unit: `zero_bit_filter_is_present_returns_true_and_does_not_panic`, `zero_bit_filter_add_does_not_panic` — **RED = `attempt to calculate the remainder with a divisor of zero`** before FIX B, GREEN after.
- `ferrosa-storage` `flush::tests::open_file_sstable_errors_when_filter_db_deleted_mid_open` — **RED = error was `"bloom filter too short"` (masked cause)** before FIX A, GREEN after (error now names `Filter.db`).
- `ferrosa-storage` `engine::tests::read_with_zero_bit_filter_db_does_not_panic_or_lose_row` — **RED = panic in the read thread** before FIX B, GREEN after; asserts the row stays `Some` (no `Ok(None)`, no panic).
- `engine::tests::read_during_compaction_filter_db_deleted_retries_against_new_view` — ReadViewBarrier harness: arms the barrier, deletes **only** `Filter.db` of the sole-survivor input before release, asserts the read returns `Some`.

## Gate

`cargo fmt --check`; `cargo clippy -p ferrosa-storage -p ferrosa-sstable --all-targets` (0 warnings); `cargo test -p ferrosa-storage -p ferrosa-sstable` (all pass); `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` clean. Stress: `concurrent_read_during_compaction` 100× serial + 60× under core saturation + window-1 tests 100×, **zero failures**.

Closes forge task `t_b367c166` (window 1). Same data-loss severity class as #125 / #129.
