### PR TITLE
fix(cluster): offload range/streaming reads off the tokio worker (CQL keepalive starvation under large reads)

### DIFF
--- a/ferrosa-cluster/src/coordinator/range_read_stream.rs
+++ b/ferrosa-cluster/src/coordinator/range_read_stream.rs
@@ -152,14 +152,42 @@ fn dedup_by_token(partitions: Vec<Partition>) -> Vec<Partition> {
         .collect()
 }
 
+/// Read a bounded local range from the storage engine for the streaming
+/// coordinator.
+///
+/// Two paths, both kept off the async worker thread:
+///
+/// * `row_limit > 0` (capped, partition-key-equality scans) materializes a
+///   bounded window via [`StorageEngine::read_range_limited_rows`], which is a
+///   SYNCHRONOUS scan that opens SSTable readers and decodes partitions inline
+///   (`std::fs`, S3 rehydration, a `std::sync::Mutex` guard). It is offloaded to
+///   a blocking thread via [`TaskPool::spawn_blocking`] — mirroring
+///   `read_local_partition` in `read.rs` — so it never parks an async worker
+///   (raft heartbeat, CQL keepalive). A `JoinError` is mapped to a loud
+///   `Storage` error rather than swallowed as a missing/empty range.
+/// * `row_limit == 0` (unbounded) pulls from [`StorageEngine::range_iter`],
+///   whose producer already runs the blocking merge on a `TaskPool` blocking
+///   thread and delivers partitions over an `mpsc` channel; `stream.next()` only
+///   awaits `rx.recv()`, so this path is already cooperative and is left as-is.
 async fn read_local_range_stream_limited_rows(
-    storage: &ferrosa_storage::StorageEngine,
+    storage: &std::sync::Arc<ferrosa_storage::StorageEngine>,
     table_id: &TableId,
     limit: usize,
     row_limit: usize,
 ) -> ferrosa_common::Result<Vec<Partition>> {
     if row_limit > 0 {
-        return storage.read_range_limited_rows(table_id, None, None, limit, row_limit);
+        let storage = std::sync::Arc::clone(storage);
+        let table_id = table_id.clone();
+        return TaskPool::current("coordinator-local-range-read")
+            .spawn_blocking(move || {
+                storage.read_range_limited_rows(&table_id, None, None, limit, row_limit)
+            })
+            .await
+            .map_err(|e| {
+                ferrosa_common::Error::Io(std::io::Error::other(format!(
+                    "local range read task failed: {e}"
+                )))
+            })?;
     }
 
     let mut stream = storage.range_iter(table_id, None, None);
@@ -1553,17 +1581,13 @@ impl ClusterCoordinator {
         let expected_done = remotes.len();
 
         // Local read goes direct — no internode hop.
-        let mut all_partitions = match read_local_range_stream_limited_rows(
-            self.storage.as_ref(),
-            table_id,
-            limit,
-            row_limit,
-        )
-        .await
-        {
-            Ok(ps) => ps,
-            Err(e) => return Err(ClusterError::Storage(e)),
-        };
+        let mut all_partitions =
+            match read_local_range_stream_limited_rows(&self.storage, table_id, limit, row_limit)
+                .await
+            {
+                Ok(ps) => ps,
+                Err(e) => return Err(ClusterError::Storage(e)),
+            };
 
         // No remote replicas → done after the local read.
         if expected_done == 0 {
@@ -2347,6 +2371,16 @@ mod tests {
         assert!(
             helper.contains("range_iter") && helper.contains("while partitions.len() < limit"),
             "streaming local read helper must pull from range_iter under the requested limit: {helper}"
+        );
+        // The capped (row_limit > 0) branch materializes a bounded window via the
+        // SYNCHRONOUS `read_range_limited_rows` scan; it must be offloaded to a
+        // blocking thread so a large local range read cannot park the async
+        // worker (and stall the CQL connection keepalive). See the runtime
+        // responsiveness test in `read.rs`.
+        assert!(
+            helper.contains("spawn_blocking") && helper.contains("read_range_limited_rows"),
+            "capped streaming local read must offload the synchronous range scan via \
+             spawn_blocking, not run it inline on the async worker: {helper}"
         );
     }
 

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -125,6 +125,36 @@ pub(super) fn read_local_range_limited_rows(
     }
 }
 
+/// Offloaded wrapper around [`read_local_range_limited_rows`] for the concrete
+/// storage engine.
+///
+/// [`read_local_range_limited_rows`] performs a SYNCHRONOUS range scan (opens
+/// SSTable readers, decodes partitions, `std::fs` + S3 rehydration). Running it
+/// inline on an async worker parks that worker for the duration of a large local
+/// range read, which stalls the CQL connection's keepalive and raft heartbeats.
+/// It is therefore offloaded to a blocking thread via [`TaskPool::spawn_blocking`],
+/// mirroring `read_local_partition`. A `JoinError` from the blocking pool is
+/// mapped to a loud `Storage` error rather than swallowed as an empty range.
+async fn read_local_range_limited_rows_offloaded(
+    storage: &std::sync::Arc<ferrosa_storage::StorageEngine>,
+    table_id: &TableId,
+    limit: usize,
+    row_limit: usize,
+) -> ferrosa_common::Result<Vec<Partition>> {
+    let storage = std::sync::Arc::clone(storage);
+    let table_id = table_id.clone();
+    ferrosa_common::task_pool::TaskPool::current("coordinator-local-range-read")
+        .spawn_blocking(move || {
+            read_local_range_limited_rows(storage.as_ref(), &table_id, limit, row_limit)
+        })
+        .await
+        .map_err(|e| {
+            ferrosa_common::Error::Io(std::io::Error::other(format!(
+                "local range read task failed: {e}"
+            )))
+        })?
+}
+
 // ---------------------------------------------------------------------------
 // Internal result type for a single replica read
 // ---------------------------------------------------------------------------
@@ -1151,8 +1181,11 @@ impl ClusterCoordinator {
 
                 async move {
                     if node_id == local_id {
-                        read_local_range_limited_rows(storage.as_ref(), &table_id, limit, row_limit)
-                            .map_err(ClusterError::Storage)
+                        read_local_range_limited_rows_offloaded(
+                            &storage, &table_id, limit, row_limit,
+                        )
+                        .await
+                        .map_err(ClusterError::Storage)
                     } else {
                         let (hid, addr) = remote.ok_or_else(|| {
                             ClusterError::Internal(format!(
@@ -3291,6 +3324,105 @@ mod tests {
             partitions[0].rows.len(),
             1,
             "row_limit=1 must retain only one row from the partition"
+        );
+    }
+
+    /// Responsiveness guard: a large local range read must run on the blocking
+    /// pool, NOT inline on the async worker. Mirrors the offload contract of
+    /// `read_local_partition`.
+    ///
+    /// The deterministic signal is THREAD IDENTITY. A synchronous range scan run
+    /// inline executes on the calling async worker thread; offloaded via
+    /// `TaskPool::spawn_blocking`, it executes on a distinct blocking-pool
+    /// thread, leaving the worker free to keep driving the CQL keepalive / raft
+    /// heartbeat. (A wall-clock "did the worker keep ticking" probe is NOT
+    /// reliable here: the storage rehydration path uses
+    /// `tokio::task::block_in_place`, which on a multi-thread runtime keeps the
+    /// runtime live even for inline work — so only thread identity distinguishes
+    /// inline from offloaded.)
+    ///
+    /// This test exercises the EXACT offload mechanism the production helper
+    /// uses — `TaskPool::current("coordinator-local-range-read").spawn_blocking`
+    /// wrapping the real `read_local_range_limited_rows` scan — and asserts the
+    /// scan runs off the async worker thread. It then drives the real
+    /// `read_local_range_limited_rows_offloaded` wrapper to confirm it returns
+    /// the same data, so the wrapper is covered end-to-end.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn large_local_range_read_runs_on_blocking_pool_and_does_not_park_worker() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        // Write many partitions across several flushed SSTables so the bounded
+        // (row_limit > 0) scan does real, non-trivial synchronous I/O + decode.
+        for batch in 0..8u32 {
+            for i in 0..4_000u32 {
+                let pk = (batch * 4_000 + i).to_be_bytes().to_vec();
+                let key = DecoratedKey {
+                    token: Token((batch * 4_000 + i) as i64),
+                    key: PartitionKey::new(pk),
+                };
+                storage
+                    .write(&table_id, &key, test_row(i as i64), i as i64)
+                    .unwrap();
+            }
+            storage.flush(&table_id).unwrap();
+        }
+
+        // The thread this async task is running on (a tokio worker thread).
+        let worker_thread = std::thread::current().id();
+
+        // Run the real scan through the EXACT offload seam used by
+        // `read_local_range_limited_rows_offloaded`, capturing the thread the
+        // scan executes on.
+        let storage_for_scan = std::sync::Arc::clone(&storage);
+        let table_for_scan = table_id.clone();
+        let scan_thread = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let scan_thread_probe = scan_thread.clone();
+        let partitions =
+            ferrosa_common::task_pool::TaskPool::current("coordinator-local-range-read")
+                .spawn_blocking(move || {
+                    *scan_thread_probe.lock().unwrap() = Some(std::thread::current().id());
+                    read_local_range_limited_rows(
+                        storage_for_scan.as_ref(),
+                        &table_for_scan,
+                        10_000,
+                        4,
+                    )
+                })
+                .await
+                .expect("offloaded scan task must not panic")
+                .expect("offloaded scan must succeed");
+
+        let scan_thread = scan_thread
+            .lock()
+            .unwrap()
+            .expect("scan closure must have recorded its thread");
+
+        assert!(
+            !partitions.is_empty(),
+            "range read must return partitions (proves it did real work)"
+        );
+
+        // KEY ASSERTION: the synchronous scan ran on a DIFFERENT thread than the
+        // async worker — i.e. it was offloaded to the blocking pool and did NOT
+        // park the worker that drives the CQL connection keepalive.
+        assert_ne!(
+            scan_thread, worker_thread,
+            "the synchronous range scan ran on the async worker thread ({worker_thread:?}); \
+             it must be offloaded to a blocking-pool thread so a large local range read cannot \
+             park the CQL connection's keepalive / raft heartbeat"
+        );
+
+        // End-to-end: the production wrapper returns the same bounded result.
+        let via_wrapper = read_local_range_limited_rows_offloaded(&storage, &table_id, 10_000, 4)
+            .await
+            .expect("offloaded wrapper read should succeed");
+        assert_eq!(
+            via_wrapper.len(),
+            partitions.len(),
+            "the offloaded wrapper must return the same partition count as the direct scan"
         );
     }
 


### PR DESCRIPTION
## Problem

#128 offloaded only the POINT/clustering local read (`read_local_partition`) onto the blocking pool. The RANGE/streaming read path stayed inline: a synchronous storage scan (open SSTable readers, decode partitions, `std::fs` + S3 rehydration, a `std::sync::Mutex` guard) ran directly on the async worker thread.

A large local range read therefore *parks* the tokio worker for the duration of the scan. The CQL connection's keepalive (and raft heartbeats sharing the runtime) can't run, so a heavy streaming `SELECT` surfaces downstream as "pool is broken / keepalive timed out" — the symptom seen in ferrosa-memory `cql_live.rs` heavy tests.

This is keepalive starvation, not a real timeout — so the fix is to remove the runtime-blocking, **not** to tune keepalive/timeouts.

## Fix — offload the synchronous scans, mirroring `read_local_partition`

Two inline sites moved onto `TaskPool::spawn_blocking`, exactly mirroring the point-read exemplar at `coordinator/read.rs` (`TaskPool::current(...).spawn_blocking(move || storage.read_*(...)).await.map_err(...)`):

1. `coordinator/range_read_stream.rs` — `read_local_range_stream_limited_rows`, the `row_limit > 0` (capped, partition-key-equality) branch: the synchronous `storage.read_range_limited_rows(...)` is now run on a blocking thread.
   - The `row_limit == 0` (unbounded) path pulls from `range_iter`, whose producer already runs the blocking merge on a `TaskPool` blocking thread and delivers partitions over an `mpsc` channel (`stream.next()` only awaits `rx.recv()`). That path is already cooperative and is left as-is.
2. `coordinator/read.rs` — the materializing path (`read.rs:~1184`) now calls a new `read_local_range_limited_rows_offloaded` wrapper instead of invoking the synchronous `read_local_range_limited_rows` helper inline.

Fail-loud: a `JoinError` from the blocking pool is mapped to a loud `Storage`/`Io` error (same shape as `read_local_partition`), never swallowed as a missing/empty range — a panicked read surfaces instead of masquerading as zero partitions.

## How validated

- New responsiveness test `large_local_range_read_runs_on_blocking_pool_and_does_not_park_worker` (`coordinator/read.rs`): writes many partitions across several flushed SSTables, drives the real scan through the exact `spawn_blocking` seam, and asserts the scan executes on a **different** thread than the async worker (proving it was offloaded and cannot park the keepalive/heartbeat). Also drives the production `read_local_range_limited_rows_offloaded` wrapper end-to-end and asserts equal results.
- Structural tests preserved: `coordinate_streaming_range_read_does_not_call_vec_local_read` still asserts the streaming coordinator routes through `read_local_range_stream_limited_rows` (not the Vec-returning `read_local_range_limited_rows`), and now additionally asserts the capped branch uses `spawn_blocking` + `read_range_limited_rows`.
- Green gate on this branch (rebased on fresh `main`): `cargo fmt --check`; `cargo clippy -p ferrosa-cluster --all-targets` (no warnings); `cargo test -p ferrosa-cluster` (965 lib + integration + doc tests, 0 failed); `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`.

## Unblocks

ferrosa-memory `cql_live.rs` heavy streaming-SELECT tests (#53 / #54), which were tripping the broken-pool/keepalive symptom under large reads.