### PR TITLE
fix(sstable): bound the seek partition-offset index (recovery OOM)

### DIFF
--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -182,6 +182,13 @@ pub struct SSTableComponents<R> {
     pub statistics: Vec<u8>,
 }
 
+/// Hard ceiling on resident `seek_to_token` summary entries per SSTable
+/// reader. The summary is downsampled to at most this many `(token, offset)`
+/// pairs (~16 B each → ~1 MB) regardless of partition count, so a reader's
+/// memory does not scale with table size. Tables with fewer partitions keep a
+/// full (stride-1) index. See `build_token_summary`.
+const PARTITION_TOKEN_SUMMARY_MAX_ENTRIES: usize = 65_536;
+
 /// Composes all SSTable component readers into a single read interface.
 pub struct SSTableReader<R: ReadAt> {
     partition_index: PartitionIndex<CachedReadAt<R>>,
@@ -307,30 +314,62 @@ impl<R: ReadAt> SSTableReader<R> {
     /// linear scan from byte 0.
     pub fn partition_token_offsets(&self) -> std::sync::Arc<Vec<(i64, u64)>> {
         self.partition_token_offsets
-            .get_or_init(|| {
-                let mut out: Vec<(i64, u64)> = Vec::new();
-                let mut iter = match self.partitions_iter() {
-                    Ok(it) => it,
-                    Err(_) => {
-                        // Match `partition_offsets()`: silent empty
-                        // cache; callers detect and fall back.
-                        return std::sync::Arc::new(out);
-                    }
-                };
-                loop {
-                    let pos = iter.pos;
-                    match iter.peek_partition_key() {
-                        Ok(Some(dk)) => out.push((dk.token.0, pos)),
-                        Ok(None) => break,
-                        Err(_) => break,
-                    }
-                    if iter.skip_to_next_partition().is_err() {
-                        break;
+            .get_or_init(|| self.build_token_summary(PARTITION_TOKEN_SUMMARY_MAX_ENTRIES))
+            .clone()
+    }
+
+    /// Build a **bounded, downsampled** `(token, byte-offset)` summary for
+    /// `seek_to_token`: at most `max_entries` samples, taken at an even
+    /// stride derived from the on-disk partition count, so a reader's
+    /// resident seek index is O(max_entries) rather than O(num_partitions).
+    ///
+    /// This is the fix for the recovery OOM where the old full index held
+    /// one entry per partition (tens of millions → ~1 GB live during a
+    /// repair Merkle scan — see
+    /// `../ferrosa/specs/bug-recovery-oom-nonstreaming-snapshot.md`).
+    ///
+    /// Invariants the seek floor-scan relies on: samples are in token
+    /// (== file) order, and the **first partition is always included** as
+    /// the floor anchor. The walk advances with `next_partition_metadata`
+    /// (the index-free advance) — NOT `skip_to_next_partition`, which would
+    /// build the full `partition_offsets` index and reintroduce the OOM.
+    ///
+    /// On error the summary is left empty; callers fall back to a linear
+    /// scan from byte 0 (same contract as before).
+    pub(crate) fn build_token_summary(
+        &self,
+        max_entries: usize,
+    ) -> std::sync::Arc<Vec<(i64, u64)>> {
+        let mut out: Vec<(i64, u64)> = Vec::new();
+        let mut iter = match self.partitions_iter() {
+            Ok(it) => it,
+            Err(_) => return std::sync::Arc::new(out),
+        };
+        let n = self.partition_index.key_count() as usize;
+        let max = max_entries.max(1);
+        // Even downsample to a hard entry ceiling. stride == 1 for tables
+        // with <= max partitions, so small tables keep a full index and
+        // their seek behaviour is byte-identical to the old code.
+        let stride = if n <= max { 1 } else { n.div_ceil(max) };
+        let mut i = 0usize;
+        loop {
+            let pos = iter.pos;
+            match iter.peek_partition_key() {
+                Ok(Some(dk)) => {
+                    if i.is_multiple_of(stride) {
+                        out.push((dk.token.0, pos));
                     }
                 }
-                std::sync::Arc::new(out)
-            })
-            .clone()
+                Ok(None) => break,
+                Err(_) => break,
+            }
+            i += 1;
+            match iter.next_partition_metadata() {
+                Ok(Some(_)) => {}
+                Ok(None) | Err(_) => break,
+            }
+        }
+        std::sync::Arc::new(out)
     }
 
     /// Look up a partition by its decorated key.
@@ -1110,18 +1149,48 @@ impl<'a, R: ReadAt> PartitionIter<'a, R> {
     /// iterator stays at its current position — callers fall back to
     /// the existing linear `next_partition + token-filter` shape.
     pub fn seek_to_token(&mut self, target: i64) -> Result<()> {
-        let tokens = self.sst.partition_token_offsets();
-        if tokens.is_empty() {
+        let summary = self.sst.partition_token_offsets();
+        self.seek_to_token_within(&summary, target)
+    }
+
+    /// Position the iterator at the first partition whose `token >= target`,
+    /// driven by a BOUNDED downsampled `summary` (see
+    /// [`SSTableReader::build_token_summary`]). Binary-search the summary for
+    /// the floor sample (`token < target`), jump there, then forward-scan —
+    /// bounded by the sample stride — to the exact landing.
+    ///
+    /// The scan advances with `next_partition_metadata` (index-free) so it
+    /// never materializes the full `partition_offsets` index. For a stride-1
+    /// summary (small tables) this lands on exactly the same partition as the
+    /// old full-index seek, one metadata decode later.
+    ///
+    /// Empty summary (cache build failed) → no-op; callers fall back to a
+    /// linear `next_partition + token-filter` scan, as before.
+    pub(crate) fn seek_to_token_within(
+        &mut self,
+        summary: &[(i64, u64)],
+        target: i64,
+    ) -> Result<()> {
+        if summary.is_empty() {
             return Ok(());
         }
-        // First entry with `token >= target`. partition_point splits
-        // the slice on the first element NOT satisfying the
-        // predicate; we want the first NOT `< target`.
-        let idx = tokens.partition_point(|(t, _)| *t < target);
-        self.pos = match tokens.get(idx) {
-            Some(&(_, pos)) => pos,
-            None => self.sst.data.len()?, // every token < target → EOF
-        };
+        // Floor sample: last sample with `token < target`, or sample 0 when
+        // target precedes everything. The exact partition is at/after it,
+        // within one stride. `build_token_summary` guarantees sample 0 is the
+        // first partition, so the anchor is always a valid scan start.
+        let idx = summary.partition_point(|(t, _)| *t < target);
+        let anchor = if idx == 0 { 0 } else { idx - 1 };
+        self.pos = summary[anchor].1;
+        loop {
+            match self.peek_partition_key()? {
+                Some(dk) if dk.token.0 < target => {
+                    if self.next_partition_metadata()?.is_none() {
+                        break; // EOF before any token >= target
+                    }
+                }
+                _ => break, // token >= target, or EOF
+            }
+        }
         Ok(())
     }
 
@@ -2218,6 +2287,84 @@ mod tests {
         let mut iter = reader.partitions_iter().expect("partitions_iter");
         iter.seek_to_token(above_max).expect("seek above max");
         assert!(iter.next_partition().expect("next").is_none());
+    }
+
+    /// The seek index must be a BOUNDED, downsampled summary — not a
+    /// full `(token, offset)` entry per partition — so a reader's
+    /// resident memory does not scale with partition count. (Confirmed
+    /// OOM source: ../ferrosa/specs/bug-recovery-oom-nonstreaming-snapshot.md.)
+    /// Downsampling must preserve: token order, inclusion of the first
+    /// partition (the floor-seek anchor), and exact `seek_to_token`
+    /// landing via a bounded forward scan between samples.
+    #[test]
+    fn token_summary_is_downsampled_yet_seek_lands_exactly() {
+        let header = test_header();
+        let n = 64usize;
+        let mut dks: Vec<_> = (0..n)
+            .map(|i| DecoratedKey::new(PartitionKey::from(format!("pk{i:04}").as_bytes())))
+            .collect();
+        dks.sort_by_key(|dk| dk.token.0);
+
+        let mut data_bytes = Vec::new();
+        let mut positions = Vec::new();
+        for dk in &dks {
+            positions.push(data_bytes.len() as u64);
+            data_bytes.extend_from_slice(&build_data_blob(dk.key.as_bytes()));
+        }
+        let dk_pos: Vec<_> = dks.iter().zip(positions.iter().copied()).collect();
+        let partitions_bytes =
+            build_partition_index(&dk_pos.iter().map(|(d, p)| (*d, *p)).collect::<Vec<_>>());
+        let filter_bytes = build_bloom_filter(&dks.iter().collect::<Vec<_>>());
+        let stats_bytes = build_statistics(header);
+        let components = SSTableComponents {
+            data: data_bytes,
+            partitions: partitions_bytes,
+            rows: Vec::new(),
+            filter: filter_bytes,
+            compression_info: None,
+            statistics: stats_bytes,
+        };
+        let reader = SSTableReader::open(components).unwrap();
+
+        // Downsample target smaller than the partition count → the summary
+        // must be bounded by `max`, not equal to `n`.
+        let max = 8usize;
+        let summary = reader.build_token_summary(max);
+        assert!(
+            !summary.is_empty() && summary.len() <= max,
+            "summary len {} must be in 1..={}",
+            summary.len(),
+            max
+        );
+        // Token order preserved.
+        for w in summary.windows(2) {
+            assert!(w[0].0 <= w[1].0, "summary must be token-sorted");
+        }
+        // First partition is always anchored at offset 0 (floor-seek relies on it).
+        assert_eq!(summary[0].1, 0, "summary must include the first partition");
+
+        // seek_to_token, driven by the bounded summary + forward scan, must
+        // still land at the first partition whose token >= target — for an
+        // exact match, the floor anchor, and beyond-last (EOF).
+        for probe in [dks[n / 2].token.0, dks[0].token.0, dks[n - 1].token.0] {
+            let mut iter = reader.partitions_iter().unwrap();
+            iter.seek_to_token_within(&summary, probe).unwrap();
+            let first = iter
+                .next_partition()
+                .unwrap()
+                .expect("a partition exists at or after target");
+            assert_eq!(
+                first.key.token.0, probe,
+                "bounded-summary seek must land on the exact first token >= target"
+            );
+        }
+        let above_max = dks.last().unwrap().token.0.saturating_add(1);
+        let mut iter = reader.partitions_iter().unwrap();
+        iter.seek_to_token_within(&summary, above_max).unwrap();
+        assert!(
+            iter.next_partition().unwrap().is_none(),
+            "seek beyond last token parks at EOF"
+        );
     }
 
     /// After `next_partition_header_only` parks the iterator at

--- a/specs/bug-recovery-oom-nonstreaming-snapshot.md
+++ b/specs/bug-recovery-oom-nonstreaming-snapshot.md
@@ -1,0 +1,204 @@
+# Bug: node OOM during cluster recovery — Raft snapshot install/build materializes the full dataset in memory (non-streaming)
+
+**Status**: Open. Filed from ferrosa-memory cluster rebuild on `main@673f9ada` (2026-06-14).
+**Severity**: High — blocks a 3-node cluster from re-forming under its provisioned per-node memory budget.
+**Component**: `ferrosa-cluster` — Raft snapshot path (`raft/state_machine.rs`, `raft/snapshot_pusher.rs`, `raft/snapshot_transport.rs`), and possibly `repair/cluster_view.rs` / peer bootstrap streaming.
+
+## Contract being violated
+
+A ferrosa node in the ferrosa-memory test deployment is provisioned with a **hard 2 GB per-node
+`mem_limit`** (`ferrosa-memory/docker-compose.yml`, all of node1/node2/node3). Policy: a node must
+**never** need more than 2 GB. If it does, that is a streaming bug — memory use during any operation
+(including recovery) must be bounded and independent of total dataset size, not proportional to it.
+
+## Symptom
+
+During cluster re-formation (any `compose down` + `up`, or a node restart that leaves a peer
+lagging), one node spikes memory to ≥2 GB and is **OOM-killed by the cgroup** (`SIGKILL`, exit
+`137`, `podman inspect … State.OOMKilled=true`). With `on-failure:5` it exhausts retries and stays
+down, so the cluster is stuck at 2/3 and reads/writes that need the down node's replica time out.
+Observed on node1, node2, and node3 across attempts — whichever node is doing the heavy recovery
+work at the time.
+
+Concrete signatures observed:
+
+- `OOMKilled=true ExitCode=137` on multiple nodes after `down`/`up`.
+- Leader (node3) log immediately before a victim OOM:
+  `ferrosa_cluster::raft::snapshot_pusher: snapshot_pusher: triggered snapshot + heartbeat for 1
+  lagging peer(s) (P0-20) lagging_peers=1 leader_committed=5986 INSTALLSNAPSHOT_PUSHES_TOTAL=1`
+  → the victim was the **lagging peer receiving a full `InstallSnapshot`**.
+- Victim startup also runs self-heal scanning **every** table:
+  `ferrosa_cluster::repair::cluster_view: self-heal: no reachable replica peer for table —
+  posture=SingleNode (quarantine will be refused; FMEA #1) keyspace=… table=…` (repeated per table).
+
+## Key evidence: memory use is proportional to dataset, not bounded
+
+- On-disk data is ~equal across nodes: node1 1.8 G, node2 2.0 G, node3 1.8 G SSTables; commit logs
+  are trivial (12–28 KiB). So replay is not the cost.
+- **Steady-state RSS is tiny.** With the cgroup cap temporarily lifted to 10 GB (for measurement
+  only — the cap was restored to 2 GB afterward), node1 and node3 ran a full recovery and settled at
+  **idle ~240–270 MB, peak ~450–500 MB** — ~0.13:1 RSS:data. No OOM when they did **not** need a
+  snapshot install.
+- The OOM only appears on the node that must **receive an `InstallSnapshot`** (lagging peer) or
+  otherwise reconstruct state. That node approaches **~1:1 RSS:data (~1.8 GB)** — i.e. it pulls
+  roughly its entire dataset into memory at once.
+
+A 13-entry lag (committed 5973 → 5986) triggered a full snapshot install that OOM'd the receiver.
+A tiny lag forcing a full-dataset-in-memory transfer is the bug.
+
+## Root cause: CONFIRMED via jemalloc heap profiling (2026-06-14)
+
+Built ferrosa with `tikv-jemallocator` `profiling` feature (branch
+`debug/recovery-oom-heap-profiling`), ran the cluster with
+`MALLOC_CONF=...,prof:true,lg_prof_interval:28,prof_prefix:/var/lib/ferrosa/jeprof` (incremental
+dumps that survive the SIGKILL), reproduced the OOM, and analyzed the near-OOM dump with `jeprof`.
+
+**Result: 1.35 GB live heap, ~82% of it in a single call path:**
+
+```
+ferrosa_net::rpc::server::RpcServer::handle_connection
+ → HandlerRegistry::dispatch
+  → ferrosa_cluster::repair::rpc::RepairMerkleHandler::handle   (repair/rpc.rs:161)
+   → ferrosa_cluster::repair::build_tree_for_range              (repair/mod.rs:126)
+    → StorageEngine::walk_token_range_for_digest                (ferrosa-storage/src/store.rs:3376)
+     → ferrosa_sstable::reader::partition_token_offsets / partition_offsets  (reader.rs:269,308)
+       → OnceLock::get_or_init → Arc<Vec<(i64,u64)>> / Arc<Vec<u64>>  (RawVec::grow_one)
+```
+
+**The allocation is the SSTable reader's per-partition offset indexes**, NOT the memtable, the Raft
+snapshot, or `cluster_view`:
+
+- `reader.rs:308 partition_token_offsets() -> Arc<Vec<(i64, u64)>>` — one `(token, byte-offset)`
+  pair for **every partition** in the SSTable, built by walking the whole file, cached in `OnceLock`
+  for the reader's lifetime. Added as the seek optimization that turns repair's "partitions in token
+  range [a,b)" from O(table_size) into O(log N + matches) — but the **index itself is
+  O(num_partitions) resident memory**.
+- `reader.rs:269 partition_offsets() -> Arc<Vec<u64>>` — same shape for the skip-dedup path.
+- ~24 B/partition × tens of millions of small partitions (agent_memory term/edge tables) ≈ the
+  observed ~1 GB, and it is built **per reader**. `repair::build_tree_for_range` and the storage walk
+  themselves correctly stream rows (one partition in flight); the unbounded memory is purely these
+  cached whole-table offset vectors. `bounded_overlap_readers` bounds the reader *count*, not each
+  reader's offset-index size.
+
+### Fix direction
+
+The partition offset/token index is **already on disk** (Cassandra-style `Index.db` / `Summary.db`
++ `partition_index` trie used by `get_partition`). `seek_to_token` and `skip_to_next_partition`
+should resolve positions via the **on-disk index / a bounded sampled summary** (binary search on
+disk, or a fixed-size sampled in-memory summary à la Cassandra's index summary), instead of
+materializing and caching `Vec`s sized to the whole partition count. Peak memory for a digest scan
+must be O(sample/window), not O(num_partitions). This keeps the O(log N) seek win without the
+O(partitions) resident cost.
+
+### TDD test list (target: ferrosa-sstable reader + storage digest walk)
+- [ ] A reader over an SSTable with N partitions answers `seek_to_token`/range scan **without**
+      retaining an O(N) offset Vec (assert resident structure size is bounded / sampled).
+- [ ] `walk_token_range_for_digest` over a narrow sub-range of a large table touches memory bounded
+      by the sub-range + sample, not the whole table.
+- [ ] Digest output is **byte-identical** to the current full-index implementation (regression
+      guard — the Merkle XOR must not change).
+- [ ] Empty/torn-index fallback path still works (linear scan from byte 0).
+- [ ] Property: for random partition counts and random token sub-ranges, peak resident index memory
+      stays under a fixed bound and the digest equals the reference full-scan digest.
+
+### Chosen plan
+- **Approach 1 (LANDED — branch `fix/sstable-sampled-partition-index`, TDD):** `partition_token_offsets`
+  is now a bounded downsampled summary (`build_token_summary`, ≤ `PARTITION_TOKEN_SUMMARY_MAX_ENTRIES`
+  = 65 536 → ~1 MB hard cap; stride 1 for small tables so behaviour is unchanged). `seek_to_token`
+  binary-searches the summary to the floor anchor then forward-scans (bounded by stride) to the exact
+  landing via `next_partition_metadata` — the **index-free** advance, which also stops the build from
+  calling `skip_to_next_partition`, so a repair seek no longer materializes the full `partition_offsets`
+  either. Same partition landing → byte-identical digest. Tests: `ferrosa-sstable/src/reader.rs`
+  `token_summary_is_downsampled_yet_seek_lands_exactly` (new) + `seek_to_token_starts_at_or_after_target`
+  (regression). Green: ferrosa-sstable lib 247, ferrosa-storage digest 5 / walk_token 1, ferrosa-cluster
+  repair 80; clippy clean. Not yet rebuilt+verified live on the cluster.
+- **Approach 2 (DEFERRED follow-up):** on-disk index seek — resolve `seek_to_token` against the
+  on-disk `Partitions.db` BTI trie + a file-order cursor for `skip_to_next_partition`, for O(1)
+  resident memory. Larger blast radius (needs an ordered range/floor-seek walker on the trie, which
+  is point-lookup only today). Do after Approach 1 lands and re-measure. *(Could not file to the
+  forge task board — its CQL was unreachable while the cluster is degraded; tracked here instead.)*
+- **Also deferred:** apply the same bounding to `partition_offsets` (the `skip_to_next_partition`
+  merge/compaction path) — same O(num_partitions) shape, wider blast radius than repair.
+- **Separate work item:** start/stop **property/fuzz (Jepsen-style) tests** asserting the cluster
+  always re-forms a single stable leader with all voters, no OOM, bounded election churn.
+
+---
+
+## Earlier hypotheses (investigated and disproven — kept for the record)
+
+Two initial hypotheses were investigated and **disproven** (do not fix these without evidence):
+
+1. **Raft snapshot materialization** (`raft/state_machine.rs`) — the snapshot *is* a single
+   in-memory `Vec<u8>` (`current_snapshot: Option<(SnapshotMeta, Vec<u8>)>`,
+   `PersistedSnapshot { bytes: Vec<u8> }`, `bincode` over the whole blob). **But** the snapshotted
+   payload is `SnapshotData { state: RaftState, last_applied, last_membership }` — that is **cluster
+   metadata** (schema, members, config, index-state map, Accord ledgers/buffers), **not** the
+   ~1.8 GB of row data, which lives in SSTables *outside* Raft. For the ferrosa-memory workload this
+   blob should be KB–low-MB, so it is an unlikely source of a ~1.8 GB spike. (Streaming it is still
+   good hygiene, but it is not the confirmed OOM cause.)
+2. **Startup self-heal scan** (`repair/cluster_view.rs`) — uses **repair Merkle/digest RPCs** (root
+   hash per `(table, range)`), not full-table reads. Does not materialize row data. Not the cause.
+
+**What is actually confirmed:**
+- A plain `podman compose down && up` of the 3-node cluster **reliably OOM-kills 1–2 nodes**
+  (`exit 137`, `State.OOMKilled=true`) at the 2 GB cap during recovery. **Which** node(s) OOM is
+  non-deterministic across runs (observed node1; node1+node2; node3) — correlates with whichever
+  node performs the heavier "catch-up / SingleNode" recovery in that run's ordering.
+- It is a **transient spike**, not retained memory: with the cap temporarily lifted to 10 GB the
+  same nodes recover and settle at **idle ~250 MB / peak ~450–500 MB**, and a node that does **not**
+  need catch-up rejoins cleanly under 2 GB.
+- Spike approaches ~1:1 with dataset size (~1.8 GB) on the affected node ⇒ a recovery path pulling
+  ~the full dataset into memory at once (non-streaming), per the original thesis — **but the exact
+  path is not yet identified.**
+
+**Next step (prerequisite to any fix): capture a heap profile of the over-allocation.** ferrosa uses
+`tikv-jemallocator` and honors `MALLOC_CONF` (`ferrosa/src/main.rs:48`) but is built **without** the
+`profiling` feature. To capture:
+1. `ferrosa/Cargo.toml`: add `"profiling"` to `tikv-jemallocator` features; rebuild the image.
+2. Run the node with `MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:17,lg_prof_interval:28,prof_prefix:/var/lib/ferrosa/jeprof/jeprof"`
+   (dumps a profile every ~256 MiB allocated to the mounted volume — survives the SIGKILL).
+3. Reproduce the OOM; analyze the last `jeprof.*.heap` with `jeprof --show_bytes --cum --text
+   /usr/local/bin/ferrosa <heap>` to attribute the allocation by call stack.
+
+Candidate paths to keep on the audit list until the profile points somewhere (all in
+`ferrosa-cluster`): peer bootstrap / catch-up data streaming (sender reading whole tables into a
+`Vec`), the storage-engine startup load on the catch-up node, and any repair path that materializes
+rows (vs digests).
+
+## Related instability (separate, likely same recovery flow)
+
+After recovery a node can enter a **CheckQuorum step-down / re-election loop** ("leader has lost
+quorum contact, stepping down") even with peers reachable (0 TCP refused) — i.e. a node cannot
+re-stabilize into the existing quorum after start/stop. A distributed DB must tolerate individual
+node start/stop and re-converge without destabilizing healthy peers. This needs its own
+investigation and **property-based / fuzz (Jepsen-style) tests** that randomize start/stop/restart
+orderings and assert the cluster always re-forms a single stable leader with all voters, no OOM, and
+bounded election churn.
+
+(Operational note, not a ferrosa bug: `podman restart <one node>` cascades through compose
+`depends_on: service_healthy` and SIGKILLs healthy dependents. Use `podman-compose up/down`, not
+per-container restart, when operating this stack.)
+
+## Fix direction
+
+Make snapshot build and install **streaming and bounded**: serialize/deserialize and persist the
+snapshot to/from disk in bounded chunks (the 3 MiB transport chunk is a natural unit) without ever
+holding the full snapshot as one `Vec<u8>` in RAM. Peak memory for snapshot transfer must be O(chunk
+size), not O(dataset). Same requirement for any repair/bootstrap scan: stream rows to the
+network/disk, never collect a full table into memory.
+
+## Not fixed by PR#131
+
+PR#131 (`fix/cql-range-read-offload`, OPEN) offloads the **CQL range/streaming read** off the tokio
+worker to cure **keepalive starvation** ("pool is broken / keepalive timed out") on heavy
+`SELECT`s. It changes which thread runs the scan but still materializes results into a `Vec` — it
+does not reduce memory, and it touches the CQL read path, not the Raft recovery/snapshot path. PR#131
+is still wanted for the `cql_live.rs` heavy-read timeout symptom, but it will **not** stop these
+recovery OOMs.
+
+## Reproduction
+
+1. 3-node ferrosa cluster on `main@673f9ada`, ~1.8–2 GB data/node, per-node `mem_limit: 2g`.
+2. `podman compose down && podman compose up -d` (or restart one node so it lags by a few entries).
+3. The lagging node receives an `InstallSnapshot`, RSS climbs to ≥2 GB, cgroup OOM-kills it
+   (`ExitCode=137`, `OOMKilled=true`); it cannot rejoin within the 2 GB budget.


### PR DESCRIPTION
## Problem

A 3-node ferrosa-memory cluster OOM-kills nodes (exit 137, `State.OOMKilled=true`) at the 2 GB per-node limit during recovery — a plain `compose down && up` reliably kills 1–2 nodes, blocking the cluster from re-forming.

**Root cause (confirmed via jemalloc heap profiling):** the SSTable reader lazily builds a full in-memory `(token, offset)` index for *every* partition (`partition_token_offsets`, and via the build's `skip_to_next_partition` also `partition_offsets`), cached in `OnceLock` per reader — O(num_partitions) resident (~24 B × tens of millions ≈ ~1 GB). During an anti-entropy repair Merkle scan a lagging node opens these readers and OOMs.

Near-OOM heap profile (1.35 GB live, ~82% one path):
```
RpcServer::handle_connection -> HandlerRegistry::dispatch
 -> repair::rpc::RepairMerkleHandler::handle (repair/rpc.rs:161)
  -> repair::build_tree_for_range -> StorageEngine::walk_token_range_for_digest
   -> sstable::reader::partition_token_offsets / partition_offsets (Arc<Vec<..>>)
```
Full write-up: `specs/bug-recovery-oom-nonstreaming-snapshot.md`.

## Fix

`partition_token_offsets` is now a **bounded, downsampled summary** (`build_token_summary`, ≤ `PARTITION_TOKEN_SUMMARY_MAX_ENTRIES = 65_536` → ~1 MB hard cap), evenly sampled at a stride derived from the on-disk partition count. Tables with ≤ cap partitions keep a full stride-1 index → unchanged behaviour.

`seek_to_token` binary-searches the summary to the floor anchor, then forward-scans (bounded by the sample stride) to the exact landing via `next_partition_metadata` — the **index-free** advance. That also stops the summary build from calling `skip_to_next_partition`, so a repair seek no longer materializes the full `partition_offsets` index either.

Same partition landing ⇒ **byte-identical repair Merkle digest**.

## Validation

- TDD: new `token_summary_is_downsampled_yet_seek_lands_exactly` (bounded size, token order, first-partition anchor, exact seek incl. EOF) + existing `seek_to_token_starts_at_or_after_target` regression.
- Green: ferrosa-sstable **247**, ferrosa-storage digest **5** / walk_token **1**, ferrosa-cluster repair **80**; clippy clean, fmt clean.
- **Live:** rebuilt the cluster image from this branch; clean down/up at 2 GB → **0 OOM**, all 3 nodes healthy, peak ~250–530 MB (vs prior ~1.8 GB), stable leader, memory MCP serving (348 entities / 54k edges).

## Follow-ups (deferred, in spec)
- Approach 2: on-disk `Partitions.db` trie seek for O(1) resident.
- Same bounding for `partition_offsets` / `skip_to_next_partition` (merge/compaction path).
- Start/stop property/fuzz (Jepsen-style) tests for cluster re-formation.