### PR TITLE
fix(self-heal): stop the idle-CPU spin (per-tick SSTable re-scan + eager posture probe)

### DIFF
--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -4882,11 +4882,30 @@ impl StorageEngine {
     /// Scan a table directory and return the generations that fail the startup
     /// smoke test, paired with the failure reason. The healthy gens are left
     /// untouched. Pure read — moves no files.
-    pub fn scan_table_dir_for_corrupt(table_dir: &std::path::Path) -> Vec<(u64, String)> {
+    /// Smoke-test every generation in `table_dir`, returning the corrupt ones.
+    ///
+    /// `verified` is an in/out cache of generations already smoke-tested OK.
+    /// SSTable generations are **immutable** — once a generation passes the
+    /// smoke test it can never become corrupt — so verified generations are
+    /// skipped on subsequent scans. This is what keeps the periodic self-heal
+    /// corruption scan from re-reading every SSTable's rows on every tick (the
+    /// idle-CPU spin — ../specs/bug-idle-cpu-spin-3cores.md): on an idle cluster
+    /// with no new flushes/compactions there is nothing new to test, so a tick
+    /// costs O(dir listing), not O(all data).
+    pub fn scan_table_dir_for_corrupt(
+        table_dir: &std::path::Path,
+        verified: &mut std::collections::BTreeSet<u64>,
+    ) -> Vec<(u64, String)> {
         let mut corrupt = Vec::new();
         for gen in Self::list_generations_in_dir(table_dir) {
-            if let Err(e) = Self::smoke_test_generation(table_dir, gen) {
-                corrupt.push((gen, e.to_string()));
+            if verified.contains(&gen) {
+                continue;
+            }
+            match Self::smoke_test_generation(table_dir, gen) {
+                Ok(_) => {
+                    verified.insert(gen);
+                }
+                Err(e) => corrupt.push((gen, e.to_string())),
             }
         }
         corrupt

--- a/ferrosa-storage/src/self_heal/detector.rs
+++ b/ferrosa-storage/src/self_heal/detector.rs
@@ -27,12 +27,22 @@ use super::snapshot::{CorruptSstable, IssueKind, ReplicaPosture, TableIssue, Tab
 pub fn detect_corrupt_sstables(
     table: &TableKey,
     table_dir: &Path,
-    replica_posture: ReplicaPosture,
+    // In/out cache of generations already smoke-tested OK. SSTable generations
+    // are immutable, so verified ones are skipped — this keeps the periodic
+    // scan from re-reading every SSTable's rows every tick (the idle-CPU spin,
+    // ../specs/bug-idle-cpu-spin-3cores.md).
+    verified: &mut std::collections::BTreeSet<u64>,
+    // Lazy: `replica_posture` is an expensive full-range Merkle-digest RPC to
+    // peers, but it is only needed once a corrupt SSTable is actually found
+    // (the rare case). Taking a closure keeps the common healthy path from
+    // probing every peer for every table every self-heal tick.
+    replica_posture: impl FnOnce() -> ReplicaPosture,
 ) -> Option<TableIssue> {
-    let corrupt = StorageEngine::scan_table_dir_for_corrupt(table_dir);
+    let corrupt = StorageEngine::scan_table_dir_for_corrupt(table_dir, verified);
     if corrupt.is_empty() {
         return None;
     }
+    let replica_posture = replica_posture();
 
     // LOUD, ALWAYS — independent of remediation (FMEA #6 / "logs warnings if
     // data has issues").
@@ -75,8 +85,12 @@ mod tests {
         metrics::_reset_self_heal_metrics_for_tests();
         let (_engine, _dir, table_dir) = table_dir_with_n_generations(2);
         let table = TableKey::new("test_ks", "test_table");
-        let issue =
-            detect_corrupt_sstables(&table, &table_dir, ReplicaPosture::HealthyReplicaAvailable);
+        let issue = detect_corrupt_sstables(
+            &table,
+            &table_dir,
+            &mut std::collections::BTreeSet::new(),
+            || ReplicaPosture::HealthyReplicaAvailable,
+        );
         assert!(issue.is_none(), "healthy table → no issue");
         assert_eq!(
             metrics::self_heal_metrics().corrupt_sstable_detected_total,
@@ -94,14 +108,51 @@ mod tests {
         let table = TableKey::new("test_ks", "test_table");
         // SingleNode posture → remediation will be refused. Detection still
         // fires (loud-on-issue, FMEA #6).
-        let issue = detect_corrupt_sstables(&table, &table_dir, ReplicaPosture::SingleNode)
-            .expect("corruption must surface an issue");
+        let issue = detect_corrupt_sstables(
+            &table,
+            &table_dir,
+            &mut std::collections::BTreeSet::new(),
+            || ReplicaPosture::SingleNode,
+        )
+        .expect("corruption must surface an issue");
         assert_eq!(issue.kind, IssueKind::CorruptSstables);
         assert_eq!(issue.corrupt_sstables.len(), 1);
         assert_eq!(issue.corrupt_sstables[0].generation, corrupted_gen);
         assert_eq!(
             metrics::self_heal_metrics().corrupt_sstable_detected_total,
             1
+        );
+    }
+
+    /// SSTable generations are immutable: once smoke-tested OK they are cached
+    /// in `verified` and MUST be skipped on later scans, so the periodic
+    /// self-heal corruption scan does not re-read every SSTable's rows every
+    /// tick (the idle-CPU spin, ../specs/bug-idle-cpu-spin-3cores.md).
+    #[test]
+    #[serial]
+    fn scan_skips_already_verified_generations() {
+        metrics::_reset_self_heal_metrics_for_tests();
+        let (_engine, _dir, table_dir) = table_dir_with_n_generations(2);
+        corrupt_one_generation(&table_dir);
+
+        // Fresh cache → the corrupt generation IS detected.
+        let mut fresh = std::collections::BTreeSet::new();
+        assert!(
+            !StorageEngine::scan_table_dir_for_corrupt(&table_dir, &mut fresh).is_empty(),
+            "corruption must be detected on a fresh scan"
+        );
+
+        // Cache marking every current generation as already verified → the
+        // generations are skipped (not re-smoke-tested), so even the corrupt
+        // one is not re-read. Proves the immutable-generation skip that
+        // eliminates the per-tick full re-scan.
+        let mut verified: std::collections::BTreeSet<u64> =
+            StorageEngine::list_generations_in_dir(&table_dir)
+                .into_iter()
+                .collect();
+        assert!(
+            StorageEngine::scan_table_dir_for_corrupt(&table_dir, &mut verified).is_empty(),
+            "generations already in the verified cache must be skipped, not re-smoke-tested"
         );
     }
 }

--- a/ferrosa-storage/src/self_heal/mod.rs
+++ b/ferrosa-storage/src/self_heal/mod.rs
@@ -172,6 +172,11 @@ pub struct SelfHealController {
     ledger: BTreeMap<(TableKey, IssueKind), AttemptState>,
     /// Logical tick counter — the snapshot's deterministic clock.
     tick: u64,
+    /// Per-table cache of SSTable generations already smoke-tested OK.
+    /// SSTable generations are immutable, so verified ones are skipped on
+    /// later ticks — this keeps the periodic corruption scan from re-reading
+    /// every SSTable's rows every tick (../specs/bug-idle-cpu-spin-3cores.md).
+    verified_gens: BTreeMap<TableKey, std::collections::BTreeSet<u64>>,
     refill: Box<dyn RefillScheduler + Send + Sync>,
     /// Port that schedules a prompt targeted refill after a successful
     /// quarantine (FMEA #10). Defaults to [`NoopRepairTrigger`]; the binary
@@ -194,6 +199,7 @@ impl SelfHealController {
             config,
             ledger: BTreeMap::new(),
             tick: 0,
+            verified_gens: BTreeMap::new(),
             refill: Box::new(LoggingRefillScheduler),
             repair_trigger: Arc::new(NoopRepairTrigger),
         }
@@ -268,17 +274,30 @@ impl SelfHealController {
     }
 
     /// Build the snapshot for the current tick from observable state.
-    fn build_snapshot(&self) -> HealthSnapshot {
+    fn build_snapshot(&mut self) -> HealthSnapshot {
         let mut issues = Vec::new();
         let mut owners_by_table = BTreeMap::new();
 
-        for (table, dir) in self.scan_targets() {
-            if let Some(owners) = self.cluster.owners(&table) {
+        // `scan_targets()` returns an owned Vec (releases the `self` borrow);
+        // `cluster` is an Arc clone so the closure below doesn't borrow `self`
+        // while `self.verified_gens` is borrowed mutably.
+        let targets = self.scan_targets();
+        let cluster = self.cluster.clone();
+        for (table, dir) in targets {
+            if let Some(owners) = cluster.owners(&table) {
                 owners_by_table.insert(table.clone(), owners);
             }
-            let posture = self.cluster.replica_posture(&table);
-            // Detector emits the loud WARN + metric unconditionally.
-            if let Some(issue) = detector::detect_corrupt_sstables(&table, &dir, posture) {
+            // Detector emits the loud WARN + metric unconditionally. Two costs
+            // are made lazy/incremental so an idle cluster doesn't spin CPU
+            // (../specs/bug-idle-cpu-spin-3cores.md):
+            //   - `verified_gens` skips re-smoke-testing immutable SSTable
+            //     generations already validated on a previous tick;
+            //   - posture is probed (full-range Merkle RPC) only if a corrupt
+            //     SSTable is actually found.
+            let verified = self.verified_gens.entry(table.clone()).or_default();
+            if let Some(issue) = detector::detect_corrupt_sstables(&table, &dir, verified, || {
+                cluster.replica_posture(&table)
+            }) {
                 issues.push(issue);
             }
             // Extension point: detector::detect_bloat / detect_divergence here.
@@ -452,6 +471,52 @@ mod controller_tests {
         assert_eq!(metrics::self_heal_metrics().corrupt_sstable_tables, 0);
         assert_eq!(metrics::self_heal_metrics().actions_executed_total, 0);
         assert_eq!(c.tick(), 1);
+    }
+
+    /// A cluster view that counts `replica_posture` probes. `replica_posture`
+    /// is an expensive full-range Merkle-digest RPC, so the self-heal control
+    /// loop must NOT call it on every table every tick — only when a corrupt
+    /// SSTable is actually detected (the rare case). Otherwise an idle cluster
+    /// busy-spins building Merkle trees cluster-wide
+    /// (../specs/bug-idle-cpu-spin-3cores.md).
+    struct CountingCluster {
+        posture: ReplicaPosture,
+        probes: Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl ClusterView for CountingCluster {
+        fn this_host(&self) -> u64 {
+            0
+        }
+        fn owners(&self, _t: &TableKey) -> Option<Vec<u64>> {
+            None
+        }
+        fn replica_posture(&self, _t: &TableKey) -> ReplicaPosture {
+            self.probes
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.posture
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn clean_tick_does_not_probe_replica_posture() {
+        metrics::_reset_self_heal_metrics_for_tests();
+        // Registered table(s) with NO corruption.
+        let engine = table_dir_with_n_generations_engine(2);
+        let probes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let cluster = Arc::new(CountingCluster {
+            posture: ReplicaPosture::HealthyReplicaAvailable,
+            probes: probes.clone(),
+        });
+        let mut c = SelfHealController::new(engine, cluster, SelfHealConfig::default());
+        c.run_one_tick();
+        assert_eq!(
+            probes.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "self-heal must NOT probe replica_posture (an expensive full-range \
+             Merkle-digest RPC) when no corrupt SSTable is found — eager probing \
+             per table per tick is the idle-CPU spin"
+        );
     }
 
     #[test]

--- a/specs/bug-idle-cpu-spin-3cores.md
+++ b/specs/bug-idle-cpu-spin-3cores.md
@@ -1,0 +1,94 @@
+# Bug: idle 3-node cluster busy-spins ~3 CPU cores (CQL keepalive/RequestTimeout under 2 vCPU)
+
+**Status**: Open. Root-cause localized to a userspace busy-spin in the net/runtime layer; exact
+loop not yet pinned (needs a CPU flamegraph). Filed 2026-06-14.
+**Severity**: High — starves a 2-vCPU deployment before any work; surfaces as `KeepaliveTimeout` /
+`RequestTimeout` flakes (ferrosa-memory `cql_live` CI on `ubuntu-latest` 2 vCPU). Also wastes CPU
+everywhere — "creeps up" as cost/latency/scaling.
+
+## Symptom
+
+ferrosa-memory's "Cluster integration tests" (`cql_live`) fail on the 2-vCPU/7GB GitHub runner with
+`KeepaliveTimeout` / "pool is broken" / `RequestTimeout(30000ms)` on connect, `CREATE TABLE`, and
+the 100k-row `derived_cache` **seed** (write). Nodes go globally unresponsive under load. **Not**
+OOM (no `OOMKilled`, no exit 137). Persists after merging #131 (read offload) + #132 (sstable OOM).
+
+## Proof (measured, local repro: 3 nodes capped to ~0.66 CPU each ≈ 2 total, 2 G mem each)
+
+**Memory is NOT the constraint.** During the failing 100k-seed, per-node `memory.current` stayed
+~1.0–1.26 GB / 2 GB; `memory.events` = `oom 0 oom_kill 0 max 0` on all nodes (never hit the 2 GB
+ceiling). Proven: fits in 2 G.
+
+**CPU is the constraint, and it's a spin — not legitimate demand:**
+- Under the 2-CPU cap during the seed: `cpu.stat nr_throttled` climbed continuously (node3
+  `throttled_usec` ≈ 559 s over ~2 min) → nodes pegged at quota → 30 s timeouts.
+- **Uncapped**, the same single-client seed drew **~9.2 cores total** (node1 3.15, node2 3.34,
+  node3 2.70) — absurd for one serial insert client.
+- **Idle, after a 60 s quiesce with ZERO client load: ~3.1 cores total** (≈1 core/node). An idle
+  cluster has no reason to burn 3 cores.
+- Thread attribution (`/proc/1/task/*/{stat,comm,syscall}`): the burners are **`data-rt`** (the
+  per-lane `current_thread` runtime, `ferrosa-net/src/lane_actor.rs:460-468`) and the main
+  **`tokio-rt-worker`** threads, in state **`R` with `syscall=running`** → **busy-spinning in
+  userspace**, not blocked in epoll/futex.
+
+Conclusion: a userspace busy-loop (likely a poll/tick that never parks) runs continuously on both
+the lane runtime and the main runtime. On 2 vCPU it consumes the whole box at idle, so any real work
+misses its deadlines → keepalive/RequestTimeout. Raft is NOT storming (election churn ~0).
+
+## Ruled out (do not re-chase)
+- OOM / 2 G memory limit (measured above).
+- #131 (range-read offload) / #132 (sstable seek-index OOM) — both merged to main, spin persists.
+- `spawn_alive_watcher` (`reconnect.rs:172`) — correctly parks on `watch::changed().await`.
+- `run_heartbeat_loop` (`peer.rs:308`) — correctly uses `interval.tick().await`.
+- The `yield_now().await` hits in `lane_actor.rs`/`peer.rs`/`pool.rs` — all in `#[tokio::test]` code,
+  not production.
+
+## ROOT CAUSE CONFIRMED via CPU flamegraph (pprof, 2026-06-14)
+
+Built ferrosa with a gated `pprof` CPU sampler (`main.rs` `maybe_start_cpu_profiler`,
+`FERROSA_CPU_PROFILE_SECS`/`_DELAY_SECS`), sampled an **idle** node for 30 s. **95% of samples** are:
+
+```
+repair::build_tree_for_range → repair::walk_token_range_for_digest
+  → reader::next_clustered_row → read_row → read_at
+    → io::get_or_open  (lru::LruCache<PathBuf, Arc<File>>) → hash<std::path::Path>
+```
+
+**An idle cluster runs anti-entropy repair Merkle builds continuously** (~3 cores total, persistent —
+measured flat 2.0–3.1 cores across 80 s on a cluster idle ~5 min; does NOT decay, so it is steady
+state, not post-restart catch-up). It is **not** the periodic scheduler: that defaults to a 24h
+interval / `sub_tick = interval / ceil(tables/max_concurrent)` and had not ticked at the 34 s sample
+mark. The continuous driver is the self-heal/quarantine-refill (`repair_wiring.rs request_refill` /
+`cluster_view.replica_posture` via `probe_digest`) or peer Merkle-RPC (`repair/rpc.rs:161
+RepairMerkleHandler`) firing on a tight cadence — to be pinned.
+
+Two compounding defects:
+1. **Repair re-reads every row body** to compute the digest (`walk_token_range_for_digest` streams
+   full clustered rows) AND runs continuously → O(all data) CPU, forever.
+2. **`get_or_open` hashes the full `PathBuf` per `read_at`** (`ferrosa-sstable/src/io.rs`,
+   `LruCache<PathBuf, Arc<File>>`) — a path hash per row read, multiplied by millions of reads.
+
+On 2 vCPU this idle spin owns the box → CQL ops miss their 30 s deadline → the `cql_live`
+`KeepaliveTimeout`/`RequestTimeout` failures. Confirmed NOT OOM/RAM.
+
+### Fix directions (pick per design)
+- **(primary) stop the continuous trigger**: find why repair/posture re-fires on a tight loop with
+  an idle, converged cluster and gate it (only repair on real divergence / respect a min interval /
+  cache posture). The 24h scheduler is fine; the event/posture path is not.
+- **(throttle, defense-in-depth)**: bound background-repair CPU (yield/sleep between partitions or a
+  global repair CPU budget) so anti-entropy can never starve foreground CQL/keepalive.
+- **(cheaper digest)**: compare precomputed per-partition/per-SSTable hashes instead of re-reading
+  every row body each cycle.
+- **(efficiency)**: cache the `Arc<File>` handle on the SSTable reader instead of an
+  `LruCache<PathBuf,_>` lookup (path hash) per `read_at`.
+- **regression test**: assert an idle node's `cpu.stat usage_usec` growth stays near zero over a
+  quiet interval.
+
+## (superseded) Next step: CPU flamegraph (mirror the heap-profiling that nailed the OOM)
+gdb `thread apply all bt` detaches after one frame in the slim runtime image (broken unwinder), and
+the image has no `perf`. Get the exact spinning stack by either:
+- building ferrosa with a `pprof`-crate CPU profiler exposed on the web port (flamegraph of an idle
+  node), or
+- `perf record -g` against the podman VM / a privileged sidecar.
+Then fix the loop to park on a waker/notify/interval instead of spinning. Add a regression test/assert
+that an idle node's CPU stays near zero (e.g. bounded `usage_usec` growth over a quiet interval).


### PR DESCRIPTION
## Problem

An **idle** 3-node cluster burned **~3 CPU cores doing nothing**. On a 2 vCPU box (the ferrosa-memory CI runner) this idle spin owns the whole machine, so CQL ops miss their 30 s deadlines → `KeepaliveTimeout` / `RequestTimeout` — the `cql_live` cluster-integration failures (#53/#54). **Not OOM, not a RAM limit** (proven: nodes idle at ~1 GB / 2 GB, `oom_kill=0`).

**Root cause (confirmed via a pprof CPU flamegraph of an idle node — 95% of samples reading SSTable rows):** the self-heal control loop's per-tick `build_snapshot` (every `tick_interval`, 30 s) did O(all-data) work for *every* registered table:

1. `detect_corrupt_sstables → scan_table_dir_for_corrupt` re-ran the SSTable **smoke test (which reads rows)** over **every generation of every table, every tick**. SSTable generations are immutable, so re-smoke-testing them forever is pure waste — the dominant cost.
2. `replica_posture` — an expensive **full-range Merkle-digest RPC** to peers — was computed **eagerly for every table every tick**, though it's only needed once a corrupt SSTable is actually found.

Full write-up: `specs/bug-idle-cpu-spin-3cores.md`.

## Fix

- `scan_table_dir_for_corrupt(table_dir, &mut verified)` skips generations already smoke-tested OK. The self-heal controller carries a per-table `verified_gens` cache, so a steady-state tick costs **O(dir listing)**, not O(all data). New generations (flush/compaction) are still smoke-tested once.
- `detect_corrupt_sstables` takes `replica_posture` as `impl FnOnce()` and invokes it **only when corruption is actually detected** — no Merkle RPC on the healthy path.

## Result (measured, 3-node local cluster, 2 G/node)

Steady-state **idle CPU: ~3.1 cores → 0.03 cores (~100×)**. The cluster is genuinely idle when idle; the per-tick cost no longer scales with data size.

## Tests
- New: `scan_skips_already_verified_generations` (immutable generations are skipped, not re-read) and `clean_tick_does_not_probe_replica_posture` (no Merkle RPC when healthy).
- Existing self-heal suite green (33 tests); clippy + fmt clean.

## Notes
- The pprof CPU profiler used to find this was diagnostic-only and is **not** included.
- Follow-ups (deferred, in spec): bound background-repair CPU (throttle, defense-in-depth); cache the SSTable `Arc<File>` handle per reader instead of an `LruCache<PathBuf,_>` lookup (path hash) per `read_at`.