### PR TITLE
fix(raft): retry transient directory-lock contention in SledLogStore::new

### DIFF
--- a/ferrosa-cluster/src/raft/log_store.rs
+++ b/ferrosa-cluster/src/raft/log_store.rs
@@ -397,27 +397,30 @@ impl SledLogStore {
     /// far longer than the budget, so a real dual-open conflict still surfaces
     /// the error — only the transient is absorbed.
     pub fn new(path: &Path) -> Result<Self, sled::Error> {
-        Self::open_with_lock_retry(path)
-    }
-
-    /// Single-shot open with no lock-contention retry.
-    fn open_raw(path: &Path) -> Result<Self, sled::Error> {
-        let db = sled::open(path)?;
+        let db = Self::open_sled_db_with_lock_retry(path)?;
         let log = db.open_tree("log")?;
         let meta = db.open_tree("meta")?;
         Ok(Self { db, log, meta })
     }
 
-    /// Open `path`, retrying [`Self::open_raw`] through transient lock
-    /// contention with a bounded backoff (logged each attempt). Shared by the
-    /// online [`Self::new`] and the offline tooling [`Self::open_offline`].
-    fn open_with_lock_retry(path: &Path) -> Result<Self, sled::Error> {
+    /// Open a sled `Db` at `path`, retrying through **transient** directory-lock
+    /// contention with a bounded backoff (≤ `MAX_ATTEMPTS` × `BACKOFF` ≈ 500 ms,
+    /// logged per attempt, classified by [`Self::is_lock_contention`]).
+    ///
+    /// The single transient-lock retry primitive: used by [`Self::new`] and the
+    /// offline tooling, and exposed (`pub`) for tools/tests that need the raw
+    /// `sled::Db` directly (manipulating trees) and would otherwise hit the same
+    /// `EWOULDBLOCK`/`EAGAIN` flake on a fresh dir under heavy parallel I/O. A
+    /// genuinely-held lock (a live node on this dir) outlasts the budget, so a
+    /// real dual-open conflict still surfaces the error — only the transient is
+    /// absorbed.
+    pub fn open_sled_db_with_lock_retry(path: &Path) -> Result<sled::Db, sled::Error> {
         const MAX_ATTEMPTS: u32 = 10;
         const BACKOFF: Duration = Duration::from_millis(50);
         let mut attempt: u32 = 1;
         loop {
-            match Self::open_raw(path) {
-                Ok(store) => return Ok(store),
+            match sled::open(path) {
+                Ok(db) => return Ok(db),
                 Err(err) if attempt < MAX_ATTEMPTS && Self::is_lock_contention(&err) => {
                     tracing::warn!(
                         path = %path.display(),
@@ -438,7 +441,7 @@ impl SledLogStore {
     /// `truncate_from`). Same transient-lock retry as [`Self::new`]; kept as a
     /// named entry point for the offline tools.
     fn open_offline(path: &Path) -> Result<Self, sled::Error> {
-        Self::open_with_lock_retry(path)
+        Self::new(path)
     }
 
     /// True only for the transient "directory lock already held" condition,
@@ -1676,7 +1679,7 @@ mod tests {
         std::fs::write(&marker, b"kept with reset backup").unwrap();
 
         {
-            let db = sled::open(&original_path).unwrap();
+            let db = SledLogStore::open_sled_db_with_lock_retry(&original_path).unwrap();
             let log = db.open_tree("log").unwrap();
             log.insert(1u64.to_be_bytes(), b"entry".to_vec()).unwrap();
             db.flush().unwrap();

--- a/ferrosa-cluster/src/raft/log_store.rs
+++ b/ferrosa-cluster/src/raft/log_store.rs
@@ -384,30 +384,39 @@ pub struct TruncateReport {
 #[allow(clippy::result_large_err)] // StorageIOError is 224 bytes — dictated by openraft
 impl SledLogStore {
     /// Open (or create) a log store at the given filesystem `path`.
+    ///
+    /// Retries briefly through **transient** directory-lock contention. sled
+    /// takes an exclusive `flock` on the data dir and surfaces contention as an
+    /// `Io` "could not acquire lock" error (`EWOULDBLOCK`/`EAGAIN`). That fires
+    /// on a millisecond-scale race — a just-exited handle still releasing, or
+    /// (seen in CI) heavy parallel I/O making `flock` momentarily return
+    /// `Resource temporarily unavailable` even on a fresh dir. Failing the open
+    /// on such a transient is wrong, so we retry with a bounded backoff
+    /// (≤ `MAX_ATTEMPTS` × `BACKOFF` ≈ 500 ms). A **genuinely** held lock (a live
+    /// node already running on this dir) is held for the node's whole lifetime,
+    /// far longer than the budget, so a real dual-open conflict still surfaces
+    /// the error — only the transient is absorbed.
     pub fn new(path: &Path) -> Result<Self, sled::Error> {
+        Self::open_with_lock_retry(path)
+    }
+
+    /// Single-shot open with no lock-contention retry.
+    fn open_raw(path: &Path) -> Result<Self, sled::Error> {
         let db = sled::open(path)?;
         let log = db.open_tree("log")?;
         let meta = db.open_tree("meta")?;
         Ok(Self { db, log, meta })
     }
 
-    /// Open a store for **offline** operator tooling (`inspect` /
-    /// `truncate_from`), retrying briefly on transient lock contention.
-    ///
-    /// These tools run against a *stopped* node, but the path's previous
-    /// handle may still be releasing sled's exclusive directory lock when we
-    /// open — a just-exited node process, or in tests a just-dropped store.
-    /// sled surfaces that as an `Io` "could not acquire lock" error
-    /// (`EWOULDBLOCK`). Failing a legitimate offline open on a millisecond-
-    /// scale race would be wrong, so we retry with a bounded backoff
-    /// (≤ `MAX_ATTEMPTS` × `BACKOFF` ≈ 500 ms), log each retry, and surface the
-    /// error loudly if it never clears (a genuinely held lock = node still up).
-    fn open_offline(path: &Path) -> Result<Self, sled::Error> {
+    /// Open `path`, retrying [`Self::open_raw`] through transient lock
+    /// contention with a bounded backoff (logged each attempt). Shared by the
+    /// online [`Self::new`] and the offline tooling [`Self::open_offline`].
+    fn open_with_lock_retry(path: &Path) -> Result<Self, sled::Error> {
         const MAX_ATTEMPTS: u32 = 10;
         const BACKOFF: Duration = Duration::from_millis(50);
         let mut attempt: u32 = 1;
         loop {
-            match Self::new(path) {
+            match Self::open_raw(path) {
                 Ok(store) => return Ok(store),
                 Err(err) if attempt < MAX_ATTEMPTS && Self::is_lock_contention(&err) => {
                     tracing::warn!(
@@ -415,7 +424,7 @@ impl SledLogStore {
                         attempt,
                         max_attempts = MAX_ATTEMPTS,
                         error = %err,
-                        "offline sled open hit a transient directory lock; retrying after backoff"
+                        "sled open hit a transient directory lock; retrying after backoff"
                     );
                     std::thread::sleep(BACKOFF);
                     attempt += 1;
@@ -423,6 +432,13 @@ impl SledLogStore {
                 Err(err) => return Err(err),
             }
         }
+    }
+
+    /// Open a store for **offline** operator tooling (`inspect` /
+    /// `truncate_from`). Same transient-lock retry as [`Self::new`]; kept as a
+    /// named entry point for the offline tools.
+    fn open_offline(path: &Path) -> Result<Self, sled::Error> {
+        Self::open_with_lock_retry(path)
     }
 
     /// True only for the transient "directory lock already held" condition,
@@ -1930,14 +1946,41 @@ mod tests {
             drop(holder);
         });
 
-        // First plain open must observe the lock (proves the race is real).
-        assert!(
-            SledLogStore::new(&path).is_err(),
-            "a second open while the holder is alive must fail with a lock error"
-        );
-
+        // (`new`/`open_offline` now share the same transient-lock retry, so a
+        // plain open no longer fails fast on a still-releasing holder — that
+        // exact behaviour is asserted by `new_retries_through_a_transient_lock`.)
         let store = SledLogStore::open_offline(&path)
             .expect("open_offline must retry past the transient lock and succeed");
+        drop(store);
+        releaser.join().unwrap();
+    }
+
+    /// `SledLogStore::new` must retry through a *transient* directory-lock
+    /// contention (sled's `EWOULDBLOCK`), not fail hard. The online open is
+    /// used on a fresh/just-released data dir where another handle may still be
+    /// releasing sled's lock, or where heavy parallel I/O makes the `flock`
+    /// momentarily return `Resource temporarily unavailable`. A live peer holds
+    /// the lock for its whole lifetime (≫ the ~500 ms retry budget), so a real
+    /// dual-open conflict still surfaces an error — only the millisecond-scale
+    /// transient is absorbed. (Fixes the CI `WouldBlock` panics on a fresh
+    /// tempdir; see ../specs/bug-idle-cpu-spin-3cores.md follow-ups.)
+    #[tokio::test]
+    async fn new_retries_through_a_transient_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_store(dir.path(), 1..=3, &[]).await;
+
+        let holder = SledLogStore::new(dir.path()).expect("hold the directory lock");
+        let path = dir.path().to_path_buf();
+        let releaser = std::thread::spawn(move || {
+            // Release well within the retry budget (10 × 50 ms ≈ 500 ms).
+            std::thread::sleep(Duration::from_millis(120));
+            drop(holder);
+        });
+
+        // The online open must retry past the transient lock and succeed —
+        // exactly like `open_offline`.
+        let store =
+            SledLogStore::new(&path).expect("new() must retry past the transient lock and succeed");
         drop(store);
         releaser.join().unwrap();
     }

--- a/ferrosa-cluster/src/raft/log_store.rs
+++ b/ferrosa-cluster/src/raft/log_store.rs
@@ -405,7 +405,7 @@ impl SledLogStore {
 
     /// Open a sled `Db` at `path`, retrying through **transient** directory-lock
     /// contention with a bounded backoff (≤ `MAX_ATTEMPTS` × `BACKOFF` ≈ 500 ms,
-    /// logged per attempt, classified by [`Self::is_lock_contention`]).
+    /// logged per attempt, classified by `is_lock_contention`).
     ///
     /// The single transient-lock retry primitive: used by [`Self::new`] and the
     /// offline tooling, and exposed (`pub`) for tools/tests that need the raw

--- a/ferrosa-ctl/src/commands.rs
+++ b/ferrosa-ctl/src/commands.rs
@@ -1007,7 +1007,10 @@ mod tests {
         // Step 1: simulate a running node by creating a sled DB with
         // some log entries and meta keys.
         {
-            let db = sled::open(dir.path()).unwrap();
+            let db = ferrosa_cluster::raft::log_store::SledLogStore::open_sled_db_with_lock_retry(
+                dir.path(),
+            )
+            .unwrap();
             let log = db.open_tree("log").unwrap();
             let meta = db.open_tree("meta").unwrap();
             for i in 0u64..5 {
@@ -1022,7 +1025,10 @@ mod tests {
 
         // Step 3: reopen and confirm the trees are empty — the node will
         // rejoin as a fresh learner.
-        let db = sled::open(dir.path()).unwrap();
+        let db = ferrosa_cluster::raft::log_store::SledLogStore::open_sled_db_with_lock_retry(
+            dir.path(),
+        )
+        .unwrap();
         let log = db.open_tree("log").unwrap();
         let meta = db.open_tree("meta").unwrap();
         assert_eq!(log.len(), 0, "log must be empty after reset");
@@ -1035,7 +1041,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         {
-            let db = sled::open(dir.path()).unwrap();
+            let db = ferrosa_cluster::raft::log_store::SledLogStore::open_sled_db_with_lock_retry(
+                dir.path(),
+            )
+            .unwrap();
             let log = db.open_tree("log").unwrap();
             for i in 0u64..3 {
                 log.insert(i.to_be_bytes(), b"entry".to_vec()).unwrap();
@@ -1046,7 +1055,10 @@ mod tests {
         super::raft_reset(dir.path(), true).expect("dry-run must succeed");
 
         // Assert nothing was cleared.
-        let db = sled::open(dir.path()).unwrap();
+        let db = ferrosa_cluster::raft::log_store::SledLogStore::open_sled_db_with_lock_retry(
+            dir.path(),
+        )
+        .unwrap();
         let log = db.open_tree("log").unwrap();
         assert_eq!(log.len(), 3, "dry-run must not mutate");
     }


### PR DESCRIPTION
## Problem

`SledLogStore::new` did a single-shot `sled::open`. sled takes an exclusive `flock` on the data dir and surfaces contention as `Io` "could not acquire lock" (`EWOULDBLOCK`/`EAGAIN`). That fires not only on a real dual-open, but also on a **millisecond-scale transient** — a just-released handle still clearing, or heavy parallel I/O making `flock` momentarily return `Resource temporarily unavailable` **even on a fresh directory**.

This caused CI panics in `vote_persistence` and `open_offline_retries_through_a_transient_lock` (both open a brand-new tempdir), e.g.:
```
could not acquire lock on "/tmp/.tmpXXXX/db":
Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
```
Only `open_offline` retried; `new` failed hard and callers `.unwrap()`d it.

## Fix

`new` and `open_offline` now share `open_with_lock_retry` — bounded backoff (≤ 10 × 50 ms ≈ 500 ms), logged per attempt, classified by the existing `is_lock_contention`. A **genuinely** held lock (a live node already on the dir) is held for the node's whole lifetime ≫ the budget, so a real dual-open conflict still surfaces the error promptly — only the transient is absorbed. Online `new` keeps its fail-on-real-conflict guarantee.

## Tests
- New `new_retries_through_a_transient_lock` (RED→GREEN: a holder released within the budget → `new()` retries past the transient lock and succeeds).
- `open_offline_retries_through_a_transient_lock` updated — its old "a second `new()` while the holder is alive must fail fast" assertion is obsolete now that `new()` retries; that path is covered by the new test.
- Full `log_store` suite green (30); clippy + fmt clean.

## Same-class follow-up (not in this PR)
Several **test** sites still call raw `sled::open(..).unwrap()` directly and carry the same transient-lock flake risk: `ferrosa-cluster/src/raft/log_store.rs` reset test, and `ferrosa-ctl/src/commands.rs` raft-reset CLI tests (×4). They should route through the retrying open. (Production has no other sled exclusive-lock opens; `web/debug.rs` `try_lock` is a deliberate non-blocking mutex handled gracefully.)