### PR TITLE
Fix fulltext search read-after-write for memtable rows

### DIFF
--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -17070,6 +17070,51 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn fulltext_index_fts_match_reads_unflushed_memtable_row() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        for cql in [
+            "CREATE KEYSPACE fts_mem WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE fts_mem.docs (id int PRIMARY KEY, body text)",
+            "CREATE INDEX docs_fts ON fts_mem.docs (body) USING 'fulltext'",
+            "INSERT INTO fts_mem.docs (id, body) VALUES (1, 'ferrosaftsfresh native fts probe body')",
+        ] {
+            let stmt = crate::parser::parse(cql).unwrap();
+            route(&state, &ctx, stmt)
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        let stmt = crate::parser::parse(
+            "SELECT id FROM fts_mem.docs WHERE body = fts_match('ferrosaftsfresh')",
+        )
+        .unwrap();
+        let result = route(&state, &ctx, stmt).await;
+        assert!(
+            result.is_ok(),
+            "fts_match query errored: {:?}",
+            result.err()
+        );
+        match result.unwrap() {
+            RouteResult::Result(b) => {
+                let count = extract_row_count(&b);
+                assert_eq!(
+                    count, 1,
+                    "fts_match must return a row that is still only in the memtable"
+                );
+            }
+            _ => panic!("expected Result"),
+        }
+    }
+
     /// Phonetic index: equality on regular column (not part of PK) matches
     /// by Double Metaphone. This exercises the index-based scan path.
     #[tokio::test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -5746,6 +5746,19 @@ impl StorageEngine {
             .collect();
 
         let mut score_map: HashMap<Vec<u8>, f64> = HashMap::new();
+        {
+            let tables = self.tables.read();
+            let Some(state) = tables.get(table_id) else {
+                return Ok(vec![]);
+            };
+            for (partition_key, score) in state.store.fulltext_memtable_search(index_name, query)? {
+                let entry = score_map.entry(partition_key).or_insert(0.0);
+                if score > *entry {
+                    *entry = score;
+                }
+            }
+        }
+
         for fti_path in fti_files {
             let bytes = match std::fs::read(&fti_path) {
                 Ok(b) => b,
@@ -17788,6 +17801,40 @@ mod tests {
         assert!(
             !result_keys.contains(&"r3".to_string()),
             "r3 has neither term"
+        );
+    }
+
+    #[test]
+    fn fts_query_sees_unflushed_memtable_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        engine.add_fulltext_index(&tid, "idx_body", 0).unwrap();
+
+        engine
+            .write(
+                &tid,
+                &make_key("fresh"),
+                make_row(b"ferrosaftsfresh native fts probe body", 1000),
+                1000,
+            )
+            .unwrap();
+
+        let results = engine
+            .fulltext_search(&tid, "idx_body", "ferrosaftsfresh")
+            .unwrap();
+        let result_keys: Vec<String> = results
+            .iter()
+            .map(|pk| String::from_utf8_lossy(pk).to_string())
+            .collect();
+
+        assert_eq!(
+            result_keys,
+            vec!["fresh".to_string()],
+            "fts_match must include rows that are still only in the active memtable"
         );
     }
 

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -4232,6 +4232,82 @@ impl<F: FlushTarget> TableStore<F> {
         &self.fulltext_indexes
     }
 
+    /// Search active/flushing memtables for a declared full-text index.
+    ///
+    /// Persisted FTI sidecars are produced only on flush, so read-after-write
+    /// queries must also consult the live memtable tiers. This builds a small
+    /// transient FTI over the current memtable snapshots and runs the same query
+    /// evaluator used by sidecar readers so fresh rows and flushed rows follow
+    /// the same matching semantics.
+    pub fn fulltext_memtable_search(
+        &self,
+        index_name: &str,
+        query: &str,
+    ) -> ferrosa_common::Result<Vec<(Vec<u8>, f64)>> {
+        use ferrosa_index::fulltext::builder::{serialize_fti, FullTextIndexBuilder};
+        use ferrosa_index::fulltext::query::parse_fts_query;
+        use ferrosa_index::fulltext::reader::FullTextIndexReader;
+
+        let Some((_, col_pos)) = self
+            .fulltext_indexes
+            .iter()
+            .find(|(name, _)| name == index_name)
+        else {
+            return Ok(vec![]);
+        };
+
+        let parsed_query = parse_fts_query(query).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!("fts_match query error: {e}"))
+        })?;
+
+        let guard = self.view.load();
+        let mut builder = FullTextIndexBuilder::new();
+        let mut add_partitions = |partitions: Vec<Partition>| {
+            for partition in partitions {
+                let pk_bytes = partition.key.key.as_bytes().to_vec();
+                let mut text = String::new();
+                for row in &partition.rows {
+                    for (col_idx, cell) in &row.cells {
+                        if *col_idx as usize == *col_pos {
+                            if let Some(ref val) = cell.value {
+                                if let Ok(s) = std::str::from_utf8(val) {
+                                    text.push_str(s);
+                                    text.push(' ');
+                                }
+                            }
+                        }
+                    }
+                }
+                if !text.is_empty() {
+                    builder.add_document(pk_bytes, text.trim());
+                }
+            }
+        };
+        add_partitions(guard.active.snapshot());
+        if let Some(ref flushing) = guard.flushing {
+            add_partitions(flushing.snapshot());
+        }
+        drop(guard);
+
+        let fti = builder.build();
+        if fti.doc_count == 0 {
+            return Ok(vec![]);
+        }
+
+        let bytes = serialize_fti(&fti).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!("fts_match memtable index error: {e}"))
+        })?;
+        let reader = FullTextIndexReader::open(bytes).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!("fts_match memtable index error: {e}"))
+        })?;
+
+        Ok(reader
+            .search(&parsed_query)
+            .into_iter()
+            .map(|hit| (hit.partition_key, hit.score))
+            .collect())
+    }
+
     /// Register a full-text index for this table.
     pub fn add_fulltext_index(&mut self, index_name: String, column_position: usize) {
         if !self.fulltext_indexes.iter().any(|(n, _)| n == &index_name) {


### PR DESCRIPTION
## Executive Summary
- Fixes native full-text `fts_match` read-after-write behavior by including active/flushing memtable rows in `StorageEngine::fulltext_search`.
- Keeps memtable and SSTable full-text matching aligned by building a transient FTI over live memtable snapshots and using the same query evaluator as sidecar readers.
- Adds storage and CQL-router regression tests for unflushed rows returned by `fts_match`.

## Test Plan
- [x] `bash .github/scripts/check-actions-pinned.sh`
- [x] `cargo fmt --check`
- [x] `pre-commit run --files ferrosa-storage/src/store.rs ferrosa-storage/src/engine.rs ferrosa-cql/src/router.rs`
- [x] `cargo clippy -p ferrosa-storage -p ferrosa-cql --all-targets -- -D warnings`
- [x] `cargo test -p ferrosa-storage --lib fts_query_sees_unflushed_memtable_rows -- --nocapture`
- [x] `cargo test -p ferrosa-cql --lib fulltext_index_fts_match_reads_unflushed_memtable_row -- --nocapture`
- [x] `bash ferrosa-udf/examples/asc-poc/build-bundle.sh /tmp/asc-host/asc-bundle.mjs`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p ferrosa-storage -p ferrosa-cql`

## Local CI Notes
- Attempted exact `cargo clippy --all-targets -- -D warnings`; it wedged locally on macOS with idle cargo/clippy-driver processes and no diagnostics, so the touched-crate clippy gate above was run instead.
- Attempted the exact CI workspace test command from `.github/workflows/ci.yml`; it similarly wedged locally on macOS with idle cargo/rustc processes and no diagnostics after compiling for a long time.
- Docker is not installed on this machine, so Docker-backed PR jobs such as driver smoke, node image, cluster integration, and containerized Jepsen smoke could not be run locally.