### PR TITLE
Document supported fts_match predicate syntax

### DIFF
--- a/docs/database/cql-compatibility.html
+++ b/docs/database/cql-compatibility.html
@@ -635,16 +635,16 @@
 
 <span class="cm">-- Query with fts_match() — boolean operators, phrase, prefix</span>
 <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> <span class="type">articles</span>
-  <span class="kw">WHERE</span> fts_match(body, <span class="str">'distributed AND database'</span>);
+  <span class="kw">WHERE</span> body = fts_match(<span class="str">'distributed AND database'</span>);
 
 <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> <span class="type">articles</span>
-  <span class="kw">WHERE</span> fts_match(body, <span class="str">'"S3 backed storage"'</span>);
+  <span class="kw">WHERE</span> body = fts_match(<span class="str">'"S3 backed storage"'</span>);
 
 <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> <span class="type">articles</span>
-  <span class="kw">WHERE</span> fts_match(body, <span class="str">'compac*'</span>);
+  <span class="kw">WHERE</span> body = fts_match(<span class="str">'compac*'</span>);
 
 <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> <span class="type">articles</span>
-  <span class="kw">WHERE</span> fts_match(body, <span class="str">'NOT deprecated'</span>);</pre>
+  <span class="kw">WHERE</span> body = fts_match(<span class="str">'NOT deprecated'</span>);</pre>
 
   <table>
     <thead><tr><th>Query syntax</th><th>Example</th><th>Description</th></tr></thead>

--- a/docs/database/index.html
+++ b/docs/database/index.html
@@ -1161,7 +1161,7 @@
   <span class="kw">USING</span> <span class="str">'fulltext'</span>;
 
 <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> articles
-  <span class="kw">WHERE</span> fts_match(body, <span class="str">'distributed AND database'</span>);
+  <span class="kw">WHERE</span> body = fts_match(<span class="str">'distributed AND database'</span>);
 
 <span class="cm">-- Nearest neighbor query</span>
 <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> documents

--- a/ferrosa-index/src/fulltext/mod.rs
+++ b/ferrosa-index/src/fulltext/mod.rs
@@ -1,6 +1,6 @@
 //! Full-text index (FTI) implementation.
 //!
-//! Provides an inverted-index pipeline for CQL `fts_match(column, query)` queries:
+//! Provides an inverted-index pipeline for CQL `column = fts_match(query)` queries:
 //!
 //! - [`analyzer`]: text analyzers (Standard, Simple, Keyword).
 //! - [`builder`]: FTI builder — ingests documents, serializes to bytes.

--- a/ferrosa-index/src/fulltext/query.rs
+++ b/ferrosa-index/src/fulltext/query.rs
@@ -1,6 +1,6 @@
 //! Full-text search query parsing.
 //!
-//! Parses a CQL `fts_match(column, query_string)` query string into an
+//! Parses a CQL `column = fts_match(query_string)` query string into an
 //! [`FtsQuery`] enum. The query language supports:
 //!
 //! - **Phrase queries**: `"hello world"` — match documents containing the exact phrase.

--- a/specs/archive/project-plans/compiled-plan-nvme-fts.md
+++ b/specs/archive/project-plans/compiled-plan-nvme-fts.md
@@ -472,7 +472,7 @@ graph LR
 **File:** `ferrosa-cql/src/router.rs`
 
 **Implementation:**
-1. Detect `fts_match(column, query_string)` in WHERE clause
+1. Detect `column = fts_match(query_string)` in WHERE clause
 2. Look up FullText index on the column
 3. Parse query string via FTS query parser
 4. For each SSTable: open FTI sidecar reader, execute query, collect scored results

--- a/specs/archive/project-plans/project-plan-nvme-fts.md
+++ b/specs/archive/project-plans/project-plan-nvme-fts.md
@@ -95,7 +95,7 @@
 |---|------|------|-----------------|-------|
 | FT2.1 | FTS query parser: term, phrase, AND, OR, NOT, prefix | M | `"rust AND \"S3 backed\""` parses to `And(Term("rust"), Phrase(["s3", "backed"]))` | `fts_query_parse_term`, `fts_query_parse_phrase`, `fts_query_parse_boolean`, `fts_query_boolean_precedence` |
 | FT2.2 | BM25 scoring | M | Given term freq + doc freq + doc length, produces correct score | `bm25_single_term`, `bm25_multi_term_ranking` |
-| FT2.3 | `fts_match()` CQL function wired to WHERE clause | L | `SELECT ... WHERE fts_match(col, 'query')` returns matching rows | `fts_match_simple_query`, `fts_match_boolean_query` |
+| FT2.3 | `fts_match()` CQL function wired to WHERE clause | L | `SELECT ... WHERE col = fts_match('query')` returns matching rows | `fts_match_simple_query`, `fts_match_boolean_query` |
 | FT2.4 | Wildcard expansion with cap (max 10000 terms) | S | `compac*` expands to matching terms; `*` returns error | `fts_wildcard_expansion_capped`, `fts_wildcard_bare_star_rejected` |
 | FT2.5 | Compaction merge: merge FTI sidecars | M | Two FTI files merged correctly; no duplicate postings | `fts_compaction_merge_deduplicates`, `fts_compaction_merge_preserves_scores` |
 | FT2.6 | S3 upload includes FTI sidecar | S | After flush + S3 sync, FTI file in object store | `fts_sidecar_uploaded_to_s3` |

--- a/specs/cql.md
+++ b/specs/cql.md
@@ -234,28 +234,28 @@ Enables full-table scan with post-filter evaluation of WHERE predicates. When a 
 | `min(column)` | Aggregate: minimum value |
 | `max(column)` | Aggregate: maximum value |
 | `sum(column)` | Aggregate: sum |
-| `fts_match(column, query)` | Full-text search predicate with BM25 ranking (see below) |
+| `column = fts_match(query)` | Full-text search predicate with BM25 ranking (see below) |
 
 ### Full-Text Search (`fts_match`)
 
 ```sql
 -- Single term
-SELECT * FROM articles WHERE fts_match(body, 'distributed');
+SELECT * FROM articles WHERE body = fts_match('distributed');
 
 -- Boolean AND/OR
-SELECT * FROM articles WHERE fts_match(body, 'rust AND cassandra');
+SELECT * FROM articles WHERE body = fts_match('rust AND cassandra');
 
 -- Phrase
-SELECT * FROM articles WHERE fts_match(body, '"S3 backed storage"');
+SELECT * FROM articles WHERE body = fts_match('"S3 backed storage"');
 
 -- Prefix wildcard
-SELECT * FROM articles WHERE fts_match(body, 'compac*');
+SELECT * FROM articles WHERE body = fts_match('compac*');
 
 -- NOT
-SELECT * FROM articles WHERE fts_match(body, 'NOT deprecated');
+SELECT * FROM articles WHERE body = fts_match('NOT deprecated');
 
 -- Combined with regular WHERE
-SELECT * FROM articles WHERE category = 'tech' AND fts_match(body, 'distributed') ALLOW FILTERING;
+SELECT * FROM articles WHERE category = 'tech' AND body = fts_match('distributed') ALLOW FILTERING;
 ```
 
 Requires a `CREATE INDEX ... USING 'fulltext'` on the target column. Results ranked by BM25 score.

--- a/specs/fulltext-index-architecture.md
+++ b/specs/fulltext-index-architecture.md
@@ -24,7 +24,7 @@ graph TD
     Flush["On flush: index memtable rows"]
     Compact["On compaction: merge inverted indexes"]
     Sidecar["Sidecar file: {gen}-FTI-{index_name}.db"]
-    Query["SELECT ... WHERE fts_match(col, 'query')"]
+    Query["SELECT ... WHERE col = fts_match('query')"]
     Reader["FullTextIndexReader"]
     Results["Ranked partition keys"]
 
@@ -62,13 +62,13 @@ graph TD
 
 ### ADR-FTS-03: Query via CQL function, not new syntax
 
-**Decision:** Full-text queries use a `fts_match(column, query)` function in WHERE clauses, not new CQL syntax like `MATCH` or `CONTAINS TEXT`.
+**Decision:** Full-text queries use a `column = fts_match(query)` predicate in WHERE clauses, not new CQL syntax like `MATCH` or `CONTAINS TEXT`.
 
 **Rationale:**
 - CQL function calls are already parsed by the ferrosa CQL parser
 - No grammar changes needed — functions are extensible
 - Cassandra compatibility: SASI uses `LIKE '%term%'`; we support that too
-- Advanced queries via `fts_match(col, 'term1 AND term2 OR "exact phrase"')` with mini query parser inside the function
+- Advanced queries via `col = fts_match('term1 AND term2 OR "exact phrase"')` with mini query parser inside the function
 
 ### ADR-FTS-04: BM25 ranking for relevance scoring
 
@@ -280,21 +280,21 @@ CREATE INDEX idx_body_fts ON articles (body)
     };
 
 -- Query using fts_match function
-SELECT * FROM articles WHERE fts_match(body, 'distributed database');
+SELECT * FROM articles WHERE body = fts_match('distributed database');
 
 -- Boolean query
-SELECT * FROM articles WHERE fts_match(body, 'rust AND cassandra');
+SELECT * FROM articles WHERE body = fts_match('rust AND cassandra');
 
 -- Phrase query
-SELECT * FROM articles WHERE fts_match(body, '"S3 backed storage"');
+SELECT * FROM articles WHERE body = fts_match('"S3 backed storage"');
 
 -- Prefix query
-SELECT * FROM articles WHERE fts_match(body, 'compac*');
+SELECT * FROM articles WHERE body = fts_match('compac*');
 
 -- Combined with regular WHERE clauses
 SELECT * FROM articles
     WHERE category = 'tech'
-    AND fts_match(body, 'distributed database')
+    AND body = fts_match('distributed database')
     ALLOW FILTERING;
 ```
 


### PR DESCRIPTION
## Summary
- update CQL docs and FTS architecture specs to use the runtime-supported `column = fts_match('query')` predicate form
- remove stale examples that showed parser-rejected `fts_match(column, 'query')`
- align fulltext module docs with the CQL router contract

## Verification
- `cargo fmt --check`
- `bash .github/scripts/check-actions-pinned.sh`
- `rg -n "fts_match\\s*\\(\\s*[A-Za-z_][A-Za-z0-9_]*\\s*," -g '!target' -g '!tmp' -g '!node_modules' . || true`

Context: live Ferrosa runtime rejects `fts_match(column, 'query')`; downstream fmem checks use `column = fts_match('query')`.
