### PR TITLE
Harden nightly pair-mode smoke startup

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -199,6 +199,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install cqlsh
+        run: pip install cqlsh
+
       - name: Run Docker smoke test
         env:
           PAIR_CQL_TIMEOUT: 180

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -194,19 +194,25 @@ jobs:
     runs-on: ubuntu-latest
     # Was 10 min and timed out nightly (image build + 2-node bring-up + smoke
     # exceeds 10 min on the runner). Give it headroom to complete.
-    timeout-minutes: 20
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Docker smoke test
+        env:
+          PAIR_CQL_TIMEOUT: 180
         run: bash tests/docker-smoke.sh
 
       - name: Collect Docker logs on failure
         if: failure()
         run: |
-          docker compose logs node1 > node1.log 2>&1 || true
-          docker compose logs node2 > node2.log 2>&1 || true
+          docker compose ps > docker-compose-ps.log 2>&1 || true
+          for service in node1 node2 node3 rustfs rustfs-init; do
+            if [ ! -s "${service}.log" ]; then
+              docker compose logs "$service" > "${service}.log" 2>&1 || true
+            fi
+          done
 
       - name: Upload Docker logs
         if: failure()
@@ -214,8 +220,12 @@ jobs:
         with:
           name: docker-smoke-logs
           path: |
+            docker-compose-ps.log
             node1.log
             node2.log
+            node3.log
+            rustfs.log
+            rustfs-init.log
           retention-days: 14
 
       - name: Cleanup

--- a/tests/docker-smoke.sh
+++ b/tests/docker-smoke.sh
@@ -127,6 +127,18 @@ collect_default_compose_logs() {
     done
 }
 
+preflight_fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    exit 1
+}
+
+require_command() {
+    local name=$1
+    if ! command -v "$name" >/dev/null 2>&1; then
+        preflight_fail "Required command not found: $name"
+    fi
+}
+
 pass() { echo -e "${GREEN}PASS${NC}: $1"; }
 fail() {
     echo -e "${RED}FAIL${NC}: $1"
@@ -217,6 +229,10 @@ cleanup() {
     docker compose down -v --remove-orphans 2>/dev/null || true
 }
 trap cleanup EXIT
+
+require_command docker
+require_command cqlsh
+require_command curl
 
 # Helper: run CQL and capture output (suppress cqlsh version warnings)
 cql1() { cqlsh localhost 9042 -e "$1" 2>/dev/null; }

--- a/tests/docker-smoke.sh
+++ b/tests/docker-smoke.sh
@@ -116,8 +116,23 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
+PAIR_CQL_TIMEOUT="${PAIR_CQL_TIMEOUT:-180}"
+
+collect_default_compose_logs() {
+    # Keep failure artifacts before the EXIT trap removes containers. The
+    # workflow's follow-up collection step may run after cleanup has completed.
+    docker compose ps > docker-compose-ps.log 2>&1 || true
+    for service in node1 node2 node3 rustfs rustfs-init; do
+        docker compose logs "$service" > "${service}.log" 2>&1 || true
+    done
+}
+
 pass() { echo -e "${GREEN}PASS${NC}: $1"; }
-fail() { echo -e "${RED}FAIL${NC}: $1"; exit 1; }
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    collect_default_compose_logs
+    exit 1
+}
 info() { echo -e "${YELLOW}INFO${NC}: $1"; }
 
 # Compose file for the cluster suite (trio / quint)
@@ -235,11 +250,11 @@ if $RUN_PAIR; then
 # ============================================================
 info "=== Phase 1: Bidirectional reads and writes ==="
 
-info "Building and starting services..."
-docker compose up -d --build
+info "Building and starting pair services..."
+docker compose up -d --build node1 node2
 
-wait_cql 9042 "node1"
-wait_cql 9043 "node2"
+wait_cql 9042 "node1" "$PAIR_CQL_TIMEOUT"
+wait_cql 9043 "node2" "$PAIR_CQL_TIMEOUT"
 
 info "Waiting for pair mode activation..."
 sleep 5
@@ -377,7 +392,7 @@ info "=== Phase 4: Rejoin and catch-up ==="
 
 info "Restarting node1..."
 docker compose start node1
-wait_cql 9042 "node1" 60
+wait_cql 9042 "node1" "$PAIR_CQL_TIMEOUT"
 
 # Wait for pair mode re-establishment and schema catch-up.
 # Schema should arrive via PairSchemaSync before mutation replay.
@@ -465,8 +480,8 @@ info ""
 info "=== Phase 6: Cluster Formation ==="
 
 info "Starting node3..."
-docker compose up -d node3
-wait_cql 9044 "node3" 60
+docker compose up -d --build node3
+wait_cql 9044 "node3" "$PAIR_CQL_TIMEOUT"
 
 info "Waiting for cluster formation..."
 sleep 15
@@ -608,8 +623,8 @@ info "=== Phase 10: Cluster Recovery ==="
 
 info "Restarting node2 and node3..."
 docker compose start node2 node3
-wait_cql 9043 "node2" 60
-wait_cql 9044 "node3" 60
+wait_cql 9043 "node2" "$PAIR_CQL_TIMEOUT"
+wait_cql 9044 "node3" "$PAIR_CQL_TIMEOUT"
 sleep 10
 
 # Verify cluster re-forms
@@ -703,7 +718,7 @@ docker compose stop node3 >/dev/null 2>&1
 sleep 3
 cql1 "INSERT INTO cluster_test.data (k, v, source) VALUES ('while_n3_down', 'catch_me', 'node1')"
 docker compose start node3 >/dev/null 2>&1
-wait_cql 9044 "node3" 60
+wait_cql 9044 "node3" "$PAIR_CQL_TIMEOUT"
 sleep 10
 RESULT=$(cql3 "SELECT v FROM cluster_test.data WHERE k = 'while_n3_down';" 2>&1) || true
 if echo "$RESULT" | grep -q "catch_me"; then


### PR DESCRIPTION
## Summary
- start only `node1` and `node2` during pair-mode smoke phase 1, then introduce `node3` explicitly in the cluster-formation phase
- raise pair-mode CQL readiness waits to `PAIR_CQL_TIMEOUT=180` and give the nightly smoke job 35 minutes of headroom
- preserve compose status and service logs before the script cleanup trap removes containers, so future smoke failures upload useful artifacts

## Failure Analyzed
- Nightly Fuzz + Smoke Test run: https://github.com/ferrosadb/ferrosa/actions/runs/27535139354
- The property fuzz job passed.
- The `Docker Smoke Test (Pair Mode)` job failed because `node1` CQL did not become ready within 60 seconds after container start.
- Uploaded `node1.log` / `node2.log` artifacts were empty because `tests/docker-smoke.sh` cleaned up the compose stack before the workflow's failure-log step ran.

## Verification
- `bash -n tests/docker-smoke.sh`
- `shellcheck -S error tests/docker-smoke.sh`
- `actionlint .github/workflows/nightly-fuzz.yml`
- `bash .github/scripts/check-actions-pinned.sh`
- `git diff --check`

Local Docker is not installed on this machine, so the Docker-backed smoke run is left to GitHub CI.
