### PR TITLE
docs(memory): refresh Ferrosa Memory marketing site for 0.16

### DIFF
--- a/docs/ferrosa-memory/assets/brand/fm-logo.svg
+++ b/docs/ferrosa-memory/assets/brand/fm-logo.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-labelledby="title desc">
+  <title id="title">Ferrosa Memory Discord logo</title>
+  <desc id="desc">A Ferrosa-family periodic-table monogram mark for Ferrosa Memory, rendered in electric blued-steel tones with an Fm symbol, atomic-number nod, orbital ring, and memory graph nodes.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="42%" r="72%">
+      <stop offset="0%" stop-color="#15243b"/>
+      <stop offset="58%" stop-color="#0b111d"/>
+      <stop offset="100%" stop-color="#05070c"/>
+    </radialGradient>
+    <linearGradient id="steel" x1="18%" y1="8%" x2="88%" y2="92%">
+      <stop offset="0%" stop-color="#d7fbff"/>
+      <stop offset="18%" stop-color="#7ee7ff"/>
+      <stop offset="54%" stop-color="#348cff"/>
+      <stop offset="100%" stop-color="#516d92"/>
+    </linearGradient>
+    <linearGradient id="steel-soft" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7ee7ff" stop-opacity="0.72"/>
+      <stop offset="55%" stop-color="#348cff" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#d7fbff" stop-opacity="0.08"/>
+    </linearGradient>
+    <linearGradient id="node" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f4feff"/>
+      <stop offset="45%" stop-color="#7ee7ff"/>
+      <stop offset="100%" stop-color="#2f7cff"/>
+    </linearGradient>
+    <filter id="glow" x="-45%" y="-45%" width="190%" height="190%">
+      <feGaussianBlur stdDeviation="9" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.20  0 0 0 0 0.58  0 0 0 0 1.00  0 0 0 0.85 0" result="blueGlow"/>
+      <feMerge>
+        <feMergeNode in="blueGlow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="soft-shadow" x="-25%" y="-25%" width="150%" height="150%">
+      <feDropShadow dx="0" dy="22" stdDeviation="24" flood-color="#000000" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <!-- Discord-safe square field. The mark is inset enough for circular avatar crop. -->
+  <rect width="1024" height="1024" rx="228" fill="url(#bg)"/>
+
+  <!-- Subtle blued-steel grain/plate lines. -->
+  <g opacity="0.16" stroke="#7ee7ff" stroke-width="2">
+    <path d="M168 260h148"/>
+    <path d="M728 252h126"/>
+    <path d="M142 763h170"/>
+    <path d="M712 778h164"/>
+  </g>
+
+  <!-- Ferrosa-family orbital ring, shifted to feel like memory retrieval rather than database core. -->
+  <g filter="url(#glow)">
+    <ellipse cx="512" cy="512" rx="402" ry="402" fill="none" stroke="url(#steel-soft)" stroke-width="15" stroke-linecap="round" stroke-dasharray="1260 430" transform="rotate(-22 512 512)"/>
+    <ellipse cx="512" cy="512" rx="352" ry="352" fill="none" stroke="#31577f" stroke-width="3" stroke-opacity="0.55" stroke-dasharray="24 28" transform="rotate(17 512 512)"/>
+  </g>
+
+  <!-- Periodic-table frame, same Ferrosa grammar but cooler and heavier for avatar legibility. -->
+  <g filter="url(#soft-shadow)">
+    <rect x="172" y="172" width="680" height="680" rx="142" fill="#09111f" fill-opacity="0.82" stroke="#172f4b" stroke-width="10"/>
+    <rect x="194" y="194" width="636" height="636" rx="123" fill="none" stroke="url(#steel)" stroke-width="26"/>
+    <rect x="232" y="232" width="560" height="560" rx="94" fill="none" stroke="#d7fbff" stroke-width="3" stroke-opacity="0.28"/>
+  </g>
+
+  <!-- Memory graph motif: intentionally distinct from the base Ferrosa Fe icon. -->
+  <g opacity="0.88" stroke="url(#steel-soft)" stroke-width="9" stroke-linecap="round" filter="url(#glow)">
+    <path d="M291 704 C375 633 432 611 506 621 C600 634 643 578 724 505" fill="none"/>
+    <path d="M305 366 C390 421 458 439 534 401 C603 367 660 381 725 430" fill="none"/>
+    <path d="M308 535 C394 519 447 532 512 584 C586 641 656 651 737 628" fill="none" stroke-opacity="0.58"/>
+  </g>
+  <g filter="url(#glow)">
+    <circle cx="292" cy="704" r="22" fill="url(#node)"/>
+    <circle cx="506" cy="621" r="18" fill="url(#node)"/>
+    <circle cx="724" cy="505" r="22" fill="url(#node)"/>
+    <circle cx="305" cy="366" r="18" fill="url(#node)" opacity="0.95"/>
+    <circle cx="534" cy="401" r="15" fill="url(#node)" opacity="0.82"/>
+    <circle cx="725" cy="430" r="18" fill="url(#node)" opacity="0.95"/>
+    <circle cx="737" cy="628" r="18" fill="url(#node)" opacity="0.88"/>
+  </g>
+
+  <!-- Monogram: Fm = Ferrosa Memory / Fermium nod. -->
+  <text x="512" y="584" text-anchor="middle"
+        font-family="Georgia, 'Times New Roman', serif"
+        font-size="348" font-weight="700" letter-spacing="-20"
+        fill="url(#steel)" filter="url(#glow)">Fm</text>
+
+  <!-- Fermium atomic-number nod. Visually echoes Fe/26 without pretending this is the database logo. -->
+  <text x="275" y="314" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+        font-size="78" font-weight="800" fill="#7d9fca" letter-spacing="-2">100</text>
+
+  <!-- Small persistent-memory cue. -->
+  <g transform="translate(642 692)" opacity="0.9">
+    <path d="M0 0h108a22 22 0 0 1 22 22v34a22 22 0 0 1-22 22H0a22 22 0 0 1-22-22V22A22 22 0 0 1 0 0Z" fill="#07101d" stroke="url(#steel)" stroke-width="7"/>
+    <path d="M12 26h84M12 52h58" stroke="#7ee7ff" stroke-width="8" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/docs/ferrosa-memory/compare.html
+++ b/docs/ferrosa-memory/compare.html
@@ -640,7 +640,7 @@
         <tbody>
           <tr>
             <td>MCP-native tools</td>
-            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">23 tier-1 + 41 tier-2 tools</span></td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">21 tier-1 + 58 tier-2 tools</span></td>
             <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">via OpenMemory / mem0-mcp; OpenMemory deprecated</span></td>
             <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">Graphiti <code>mcp_server</code></span></td>
             <td><span class="cell-verdict v-partial">MCP client only</span><span class="cell-note">uses external MCP tools; no official Letta MCP server</span></td>

--- a/docs/ferrosa-memory/compare.html
+++ b/docs/ferrosa-memory/compare.html
@@ -1,0 +1,844 @@
+<!DOCTYPE html>
+<!-- ferrosadb.com marketing site -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ferrosa Memory — Compare vs Mem0, Zep/Graphiti, Letta &amp; Vector+RAG</title>
+  <meta name="description" content="A fair, source-grounded capability comparison of Ferrosa Memory against Mem0, Zep/Graphiti, Letta, and the vector+RAG baseline: typed bi-temporal graph, hybrid retrieval, explainable derivation, and auditable forgetting — with honest positioning.">
+  <link rel="icon" type="image/svg+xml" href="assets/brand/fm-logo.svg">
+  <style>
+    :root {
+      --bg-primary: #05070c;
+      --bg-secondary: #09111f;
+      --bg-card: #0e1828;
+      --bg-card-hover: #142337;
+      --text-primary: #e8eef7;
+      --text-secondary: #9fb0c6;
+      --text-muted: #647794;
+      --accent: #348cff;
+      --accent-glow: rgba(52, 140, 255, 0.18);
+      --accent-secondary: #7ee7ff;
+      --accent-cool: #7ee7ff;
+      --accent-steel: #516d92;
+      --accent-green: #6bc9a0;
+      --border: #17273d;
+      --border-hover: #25395a;
+      --code-bg: #060b14;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* ── Navigation ── */
+    nav {
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 100;
+      background: rgba(5, 7, 12, 0.85);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border);
+      padding: 0 2rem;
+    }
+
+    nav .nav-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 64px;
+    }
+
+    nav .logo {
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--text-primary);
+      text-decoration: none;
+    }
+
+    nav .logo span { color: var(--accent); }
+
+    nav .nav-links {
+      display: flex;
+      gap: 2rem;
+      list-style: none;
+    }
+
+    nav .nav-links a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav .nav-links a:hover { color: var(--text-primary); }
+
+    nav .nav-cta {
+      background: var(--accent);
+      color: #fff;
+      padding: 0.5rem 1.25rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 600;
+      transition: opacity 0.2s;
+    }
+
+    nav .nav-cta:hover { opacity: 0.9; }
+
+    nav .nav-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      width: 2.5rem;
+      height: 2.5rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+
+    nav .nav-toggle span,
+    nav .nav-toggle span::before,
+    nav .nav-toggle span::after {
+      display: block;
+      width: 1.1rem;
+      height: 2px;
+      border-radius: 2px;
+      background: currentColor;
+      content: '';
+      transition: transform 0.2s, opacity 0.2s;
+    }
+
+    nav .nav-toggle span { position: relative; }
+    nav .nav-toggle span::before { position: absolute; transform: translateY(-6px); }
+    nav .nav-toggle span::after { position: absolute; transform: translateY(6px); }
+
+    nav.nav-open .nav-toggle span { background: transparent; }
+    nav.nav-open .nav-toggle span::before { background: var(--text-primary); transform: rotate(45deg); }
+    nav.nav-open .nav-toggle span::after { background: var(--text-primary); transform: rotate(-45deg); }
+
+    /* ── Sections ── */
+    section {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 6rem 2rem;
+    }
+
+    /* ── Hero ── */
+    .hero {
+      padding-top: 11rem;
+      padding-bottom: 6rem;
+      text-align: center;
+      position: relative;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -60%);
+      width: 600px;
+      height: 600px;
+      background: radial-gradient(circle, var(--accent-glow) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    .hero-logo {
+      width: 88px;
+      height: 88px;
+      border-radius: 22px;
+      margin: 0 auto 1.75rem;
+      display: block;
+      box-shadow: 0 10px 40px rgba(52, 140, 255, 0.25);
+      position: relative;
+    }
+
+    .hero-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 100px;
+      padding: 0.375rem 1rem;
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+      margin-bottom: 2rem;
+    }
+
+    .hero-badge .dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-green);
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+
+    .hero h1 {
+      font-size: clamp(2.5rem, 6vw, 4.5rem);
+      font-weight: 800;
+      line-height: 1.08;
+      letter-spacing: -0.03em;
+      margin-bottom: 1.5rem;
+      position: relative;
+    }
+
+    .hero h1 .gradient {
+      background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero p {
+      font-size: 1.25rem;
+      color: var(--text-secondary);
+      max-width: 680px;
+      margin: 0 auto 2.5rem;
+      line-height: 1.7;
+    }
+
+    .hero-actions {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+      padding: 0.75rem 2rem;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 1rem;
+      transition: transform 0.15s, box-shadow 0.15s;
+    }
+
+    .btn-primary:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 30px var(--accent-glow);
+    }
+
+    .btn-secondary {
+      background: var(--bg-card);
+      color: var(--text-primary);
+      padding: 0.75rem 2rem;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 1rem;
+      border: 1px solid var(--border);
+      transition: border-color 0.2s, background 0.2s;
+    }
+
+    .btn-secondary:hover {
+      border-color: var(--border-hover);
+      background: var(--bg-card-hover);
+    }
+
+    /* ── Section headers ── */
+    .section-label {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+
+    .section-title {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin-bottom: 1rem;
+      line-height: 1.15;
+    }
+
+    .section-subtitle {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      max-width: 680px;
+      line-height: 1.7;
+    }
+
+    .section-subtitle.centered {
+      margin: 0 auto;
+      text-align: center;
+    }
+
+    .section-title.centered { text-align: center; }
+    .section-label.centered { text-align: center; }
+
+    /* ── Problem section ── */
+    .problem {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .problem section { padding: 5rem 2rem; }
+
+    /* ── Feature grid ── */
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+
+    .feature-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 2.25rem;
+      transition: border-color 0.2s, transform 0.15s;
+    }
+
+    .feature-card:hover {
+      border-color: var(--border-hover);
+      transform: translateY(-2px);
+    }
+
+    .feature-icon {
+      width: 44px;
+      height: 44px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.25rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .feature-icon.steel { background: rgba(52, 140, 255, 0.14); }
+    .feature-icon.cyan { background: rgba(126, 231, 255, 0.14); }
+    .feature-icon.cql { background: rgba(124, 156, 245, 0.12); }
+    .feature-icon.graph { background: rgba(107, 201, 160, 0.12); }
+    .feature-icon.lock { background: rgba(200, 130, 240, 0.12); }
+    .feature-icon.index { background: rgba(100, 200, 220, 0.12); }
+    .feature-icon.observe { background: rgba(240, 200, 100, 0.12); }
+
+    .feature-card h3 {
+      font-size: 1.1875rem;
+      font-weight: 700;
+      margin-bottom: 0.625rem;
+    }
+
+    .feature-card p {
+      font-size: 0.9375rem;
+      color: var(--text-secondary);
+      line-height: 1.65;
+    }
+
+    /* ── Comparison table ── */
+    .comparison {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 3rem;
+      font-size: 0.9375rem;
+    }
+
+    .comparison-table th,
+    .comparison-table td {
+      text-align: left;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .comparison-table thead th {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+
+    .comparison-table thead th:first-child { color: var(--text-secondary); }
+
+    .comparison-table thead th.ferrosa-col {
+      color: var(--accent);
+    }
+
+    .comparison-table tbody td:first-child {
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .comparison-table tbody td {
+      color: var(--text-secondary);
+    }
+
+    .comparison-table tbody td.ferrosa-col {
+      color: var(--accent-green);
+      font-weight: 600;
+    }
+
+    .comparison-table tbody tr:hover {
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    .check { color: var(--accent-green); }
+    .cross { color: var(--text-muted); }
+
+    /* ── CTA section ── */
+    .cta-section {
+      text-align: center;
+      padding: 6rem 2rem;
+    }
+
+    .cta-section h2 {
+      font-size: clamp(2rem, 4vw, 3rem);
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin-bottom: 1rem;
+    }
+
+    .cta-section p {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      margin-bottom: 2.5rem;
+      max-width: 520px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    /* ── Beta Banner ── */
+    .beta-banner {
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border);
+      text-align: center;
+      padding: 0.5rem 1rem;
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+      position: fixed;
+      top: 64px;
+      width: 100%;
+      z-index: 99;
+    }
+
+    .beta-tag {
+      display: inline-block;
+      background: var(--accent);
+      color: #fff;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+      vertical-align: middle;
+    }
+
+    /* ── Responsive ── */
+    @media (max-width: 768px) {
+      .features-grid { grid-template-columns: 1fr; }
+      nav { padding: 0 1rem; }
+      nav .nav-inner {
+        height: 64px;
+        min-height: 64px;
+        gap: 0.75rem;
+        padding: 0;
+        position: relative;
+      }
+      body { overflow-x: hidden; }
+      nav .logo { margin-right: auto; }
+      nav .nav-cta {
+        display: inline-flex;
+        flex-shrink: 0;
+        padding: 0.5rem 0.75rem;
+      }
+      nav .nav-toggle { display: inline-flex; }
+      nav .nav-links {
+        position: fixed;
+        top: 64px;
+        left: 0;
+        right: 0;
+        display: none;
+        flex-direction: column;
+        gap: 0;
+        padding: 0.5rem 1rem 1rem;
+        background: rgba(5, 7, 12, 0.98);
+        border-bottom: 1px solid var(--border);
+        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+      }
+      nav.nav-open .nav-links { display: flex; }
+      nav .nav-links li { list-style: none; }
+      nav .nav-links a {
+        display: block;
+        padding: 0.75rem 0;
+        white-space: nowrap;
+      }
+      section {
+        width: 100%;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        overflow-wrap: anywhere;
+      }
+      .hero { padding-top: 11rem; }
+      .hero h1 { font-size: clamp(2rem, 11vw, 3rem); }
+      .hero p { font-size: 1rem; }
+      .hero-actions { flex-direction: column; align-items: stretch; }
+      .btn-primary,
+      .btn-secondary { width: 100%; text-align: center; }
+      .beta-banner { top: 148px; font-size: 0.75rem; }
+      .comparison-table { font-size: 0.8125rem; }
+      .comparison-table th,
+      .comparison-table td { padding: 0.75rem 0.75rem; }
+    }
+  </style>
+
+<style>
+  .suite-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap:1.5rem; margin-top:2.5rem; }
+  .suite-card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:2rem; text-decoration:none; transition:border-color .2s, transform .2s, background .2s; }
+  .suite-card:hover { border-color:var(--accent); transform:translateY(-2px); background:var(--bg-card-hover); }
+  .kicker { color:var(--accent); font-size:.75rem; letter-spacing:.12em; font-weight:800; text-transform:uppercase; margin-bottom:.75rem; }
+  .cool { color:var(--accent-cool); }
+  .pill-row { display:flex; flex-wrap:wrap; gap:.5rem; margin:1.25rem 0; }
+  .pill { border:1px solid var(--border); background:var(--bg-secondary); color:var(--text-secondary); border-radius:999px; padding:.35rem .75rem; font-size:.8125rem; }
+  .doc-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:1rem; margin-top:1.5rem; }
+  .doc-card { background:var(--bg-card); border:1px solid var(--border); border-radius:14px; padding:1.4rem; transition:border-color .2s; }
+  .doc-card:hover { border-color:var(--border-hover); }
+  .doc-card h3 { margin-bottom:.5rem; }
+  .doc-card p, .suite-card p { color:var(--text-secondary); }
+  .doc-card .tag { display:inline-block; font-family:var(--font-mono); font-size:.72rem; color:var(--accent-cool); margin-bottom:.5rem; letter-spacing:.04em; }
+  .code-block { background:var(--code-bg); border:1px solid var(--border); border-radius:14px; padding:1.25rem; overflow:auto; margin:1rem 0; }
+  .code-block code, pre { font-family:var(--font-mono); font-size:.875rem; color:#cfe0f5; }
+  .note { border-left:3px solid var(--accent-cool); background:rgba(126,231,255,.08); padding:1rem 1.25rem; border-radius:0 12px 12px 0; color:var(--text-secondary); margin:1.5rem 0; }
+  .two-col { display:grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap:2rem; align-items:start; }
+
+  .reference-table-wrap { margin-top:1.5rem; border:1px solid var(--border); border-radius:16px; overflow:hidden; background:rgba(255,255,255,.02); }
+  .reference-table { width:100%; border-collapse:collapse; font-size:.875rem; }
+  .reference-table caption { text-align:left; padding:1rem 1.1rem; color:var(--text-secondary); border-bottom:1px solid var(--border); }
+  .reference-table th { text-align:left; padding:.75rem 1rem; color:var(--text-muted); font-size:.72rem; letter-spacing:.08em; text-transform:uppercase; background:rgba(255,255,255,.025); border-bottom:1px solid var(--border); }
+  .reference-table td { padding:.8rem 1rem; color:var(--text-secondary); border-bottom:1px solid rgba(255,255,255,.055); vertical-align:top; }
+  .reference-table tr:last-child td { border-bottom:0; }
+  .reference-table a { color:var(--text-primary); text-decoration:none; border-bottom:1px solid rgba(126,231,255,.35); }
+  .reference-table a:hover { color:var(--accent-cool); border-bottom-color:var(--accent-cool); }
+  .reference-table .ref-id { color:var(--accent-cool); font-family:var(--font-mono); white-space:nowrap; }
+  .reference-table .ref-theme { color:var(--text-muted); white-space:nowrap; }
+  @media (max-width: 760px) { .reference-table th:nth-child(3), .reference-table td:nth-child(3) { display:none; } }
+  @media (max-width: 800px) { .two-col { grid-template-columns:1fr; } }
+</style>
+
+<style>
+  /* compare.html — page-local helpers, existing tokens only */
+  .matrix-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; margin-top: 3rem; border-radius: 12px; }
+  .matrix-scroll .comparison-table { margin-top: 0; min-width: 880px; }
+  .matrix-scroll .comparison-table th,
+  .matrix-scroll .comparison-table td { vertical-align: top; }
+  .matrix-scroll .comparison-table thead th { white-space: nowrap; }
+  .matrix-scroll .comparison-table tbody td { font-size: 0.875rem; line-height: 1.5; }
+  .cell-verdict { display: block; font-weight: 600; color: var(--text-primary); }
+  .cell-note { display: block; color: var(--text-muted); font-size: 0.8125rem; margin-top: 0.15rem; }
+  .comparison-table tbody td.ferrosa-col .cell-verdict { color: var(--accent-green); }
+  .v-yes { color: var(--accent-green); }
+  .v-no { color: var(--text-muted); }
+  .v-partial { color: var(--accent-cool); }
+  .v-unclear { color: var(--accent-steel); }
+  .matrix-legend { margin-top: 1.25rem; font-size: 0.8125rem; color: var(--text-muted); line-height: 1.7; }
+  .matrix-legend strong { color: var(--text-secondary); }
+  .compare-card { display: flex; flex-direction: column; }
+  .compare-card .what-is { color: var(--text-secondary); font-size: 0.9375rem; line-height: 1.65; }
+  .compare-card .differs { margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border); color: var(--text-primary); font-size: 0.9375rem; }
+  .compare-card .differs strong { color: var(--accent); }
+  .compare-card .nuance { margin-top: 0.85rem; font-size: 0.8125rem; color: var(--text-muted); line-height: 1.6; }
+  .sources-list { columns: 2; column-gap: 2.5rem; margin-top: 1.5rem; font-size: 0.8125rem; color: var(--text-muted); line-height: 1.85; }
+  .sources-list a { color: var(--text-muted); text-decoration: none; border-bottom: 1px solid rgba(126,231,255,.2); }
+  .sources-list a:hover { color: var(--accent-cool); border-bottom-color: var(--accent-cool); }
+  .sources-list .src-vendor { color: var(--text-secondary); font-weight: 600; }
+  @media (max-width: 700px) { .sources-list { columns: 1; } }
+</style>
+
+</head>
+<body>
+<!-- ═══════════════════ Navigation ═══════════════════ -->
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="logo" style="display:flex;align-items:center;gap:0.5rem;">
+      <img src="assets/brand/fm-logo.svg" alt="Fm" width="28" height="28" style="border-radius:7px;">
+      ferrosa <span>memory</span>
+    </a>
+    <ul class="nav-links" id="site-nav-links">
+      <li><a href="./">Overview</a></li>
+      <li><a href="how-it-works.html">How it works</a></li>
+      <li><a href="tools.html">Tools</a></li>
+      <li><a href="compare.html">Compare</a></li>
+      <li><a href="getting-started.html">Setup</a></li>
+      <li><a href="../database/">Database</a></li>
+      <li><a href="https://github.com/ferrosadb" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+    </ul>
+    <a href="how-it-works.html" class="nav-cta">How it works</a>
+    <button class="nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="site-nav-links"><span></span></button>
+  </div>
+</nav>
+
+<div class="beta-banner">
+  <span class="beta-tag">Developer Preview</span> Ferrosa Memory 0.15 — structured, linked, auditable memory for agentic systems.
+</div>
+
+<section class="hero">
+  <img class="hero-logo" src="assets/brand/fm-logo.svg" alt="Ferrosa Memory logo">
+  <div class="hero-badge"><span class="dot"></span> Ferrosa Memory · 0.15 · Developer Preview</div>
+  <h1>How Ferrosa Memory <span class="gradient">compares.</span></h1>
+  <p>Most memory layers answer "what's similar?" Ferrosa Memory also answers "what changed, what's connected, why does this exist, and can I safely remove it?" Here's how that differs from Mem0, Zep/Graphiti, Letta, and the vector+RAG baseline — fairly, and grounded in each project's own docs.</p>
+  <div class="hero-actions">
+    <a href="how-it-works.html" class="btn-primary">See how it works</a>
+    <a href="tools.html" class="btn-secondary">Browse the tools</a>
+  </div>
+</section>
+
+<!-- ═══════════════════ Capability matrix ═══════════════════ -->
+<section id="matrix" class="comparison">
+  <section>
+    <div class="section-label cool">The capability matrix</div>
+    <h2 class="section-title">A fair, source-grounded comparison.</h2>
+    <p class="section-subtitle">Each competitor cell is drawn from that project's own public documentation or repository. Where the public docs don't clearly establish a capability, the cell is marked <em>Unclear</em> rather than guessed. This is capability framing only — no benchmark, latency, or scoring numbers.</p>
+
+    <div class="matrix-scroll">
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>Capability</th>
+            <th class="ferrosa-col">Ferrosa Memory</th>
+            <th>Mem0</th>
+            <th>Zep / Graphiti</th>
+            <th>Letta</th>
+            <th>Vector + RAG</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>MCP-native tools</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">23 tier-1 + 41 tier-2 tools</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">via OpenMemory / mem0-mcp; OpenMemory deprecated</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">Graphiti <code>mcp_server</code></span></td>
+            <td><span class="cell-verdict v-partial">MCP client only</span><span class="cell-note">uses external MCP tools; no official Letta MCP server</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">some vector-DB MCP servers; not inherent</span></td>
+          </tr>
+          <tr>
+            <td>Typed knowledge graph</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">typed entities + edges</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">entity linking; standalone graph store being deprecated Apr 2026</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">typed entities / edges / episodes</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">via pluggable graph backend; not core</span></td>
+            <td><span class="cell-verdict v-no">No</span></td>
+          </tr>
+          <tr>
+            <td>Bi-temporal facts (supersession history)</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">timestamped facts, supersession chain stays inspectable</span></td>
+            <td><span class="cell-verdict v-no">No</span><span class="cell-note">no validity-interval model documented</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note"><code>t_valid</code>/<code>t_invalid</code> + ingest timestamps; invalidate-not-delete</span></td>
+            <td><span class="cell-verdict v-unclear">Unclear</span><span class="cell-note">no bi-temporal model documented</span></td>
+            <td><span class="cell-verdict v-no">No</span></td>
+          </tr>
+          <tr>
+            <td>Hybrid retrieval (lexical + vector + graph + recency)</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">RRF over ~11 signals incl. PageRank</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">semantic + BM25 + entity boost; no graph/recency fusion documented</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">semantic + BM25 + graph traversal; recency via temporal metadata</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">tiered vector + recall search; no documented fusion</span></td>
+            <td><span class="cell-verdict v-no">No</span><span class="cell-note">vector similarity, optional keyword</span></td>
+          </tr>
+          <tr>
+            <td>Explainable / derived facts (rules)</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">Datalog-derived facts with proof trace</span></td>
+            <td><span class="cell-verdict v-no">No</span><span class="cell-note">extracted text, no rule engine</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">episode provenance + temporal lineage; no logical rule engine</span></td>
+            <td><span class="cell-verdict v-no">No</span><span class="cell-note">transparent edits, no rule derivation</span></td>
+            <td><span class="cell-verdict v-no">No</span><span class="cell-note">source-traceable chunks, no derivation</span></td>
+          </tr>
+          <tr>
+            <td>Forgetting w/ blast radius + reversible retraction</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">0.15 feature: blast-radius preview + journal</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">delete exists; no blast-radius / reversible audit documented</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">invalidate-not-delete preserves history; no blast-radius UX documented</span></td>
+            <td><span class="cell-verdict v-unclear">Unclear</span><span class="cell-note">block / passage CRUD; no reversible-retraction feature documented</span></td>
+            <td><span class="cell-verdict v-no">No</span><span class="cell-note">delete-by-ID only</span></td>
+          </tr>
+          <tr>
+            <td>Automatic consolidation</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">background "dream cycle"</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">add-pipeline reconciliation / dedup; no consolidation cycle documented</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">incremental graph updates / invalidation; not a scheduled cycle</span></td>
+            <td><span class="cell-verdict v-unclear">Unclear</span><span class="cell-note">agent-driven edits; no automatic consolidation documented</span></td>
+            <td><span class="cell-verdict v-no">No</span><span class="cell-note">manual</span></td>
+          </tr>
+          <tr>
+            <td>Durable storage + tiering</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span><span class="cell-note">Ferrosa DB backend, S3 tiering</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">vector / graph store; cloud-managed; no S3 tiering documented</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">graph DB; cloud-managed; no S3 tiering documented</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">Postgres + pluggable stores; no S3 tiering documented</span></td>
+            <td><span class="cell-verdict v-partial">Partial</span><span class="cell-note">depends on chosen DB</span></td>
+          </tr>
+          <tr>
+            <td>Self-hostable</td>
+            <td class="ferrosa-col"><span class="cell-verdict">Yes</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">library + self-hosted server</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">Graphiti OSS; full Zep CE deprecated Apr 2025</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">with OSS components</span></td>
+          </tr>
+          <tr>
+            <td>Managed cloud</td>
+            <td class="ferrosa-col"><span class="cell-verdict v-no">No</span><span class="cell-note">developer preview / self-host</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">app.mem0.ai</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">Zep Cloud</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">Letta Cloud, app.letta.com</span></td>
+            <td><span class="cell-verdict v-yes">Yes</span><span class="cell-note">e.g. Pinecone, managed Weaviate / Qdrant</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="matrix-legend">
+      <strong>Legend:</strong> <span class="v-yes">Yes</span> = documented / supported ·
+      <span class="v-no">No</span> = documented absence or not applicable ·
+      <span class="v-partial">Partial</span> = exists in limited or indirect form (see cell note) ·
+      <span class="v-unclear">Unclear</span> = public docs do not establish it. Where a capability is available only through an external component, that's noted in the cell. Ferrosa Memory's column reflects the product's stated 0.15 capabilities and is not independently third-party verified here.
+    </p>
+  </section>
+</section>
+
+<!-- ═══════════════════ Per-competitor cards ═══════════════════ -->
+<section id="competitors">
+  <div class="section-label cool">Project by project</div>
+  <h2 class="section-title">What each one is, and how Ferrosa Memory differs.</h2>
+  <p class="section-subtitle">The agent-memory space is moving fast. These summaries reflect each project's current public posture, including notable 2025–2026 shifts — stated neutrally and factually.</p>
+
+  <div class="features-grid">
+    <div class="feature-card compare-card">
+      <div class="feature-icon steel">🧩</div>
+      <h3>Mem0</h3>
+      <p class="what-is">An open-source "memory layer" for AI agents that remembers user preferences and facts across sessions. An LLM extracts memories from conversations and stores them as embeddings with user / session / agent scoping, retrieved by a hybrid of semantic search, BM25 keyword matching, and entity linking. Ships as a Python / JS library, a self-hostable server, and a managed cloud (app.mem0.ai), under Apache-2.0.</p>
+      <p class="differs"><strong>How fmem differs:</strong> Mem0 centers on LLM-extracted free-form memories; Ferrosa Memory keeps a typed bi-temporal graph with rule-derived, explainable facts and auditable forgetting on a durable S3-tiered backend.</p>
+      <p class="nuance">2025–2026 nuance: as of the April 2026 algorithm change, Mem0's standalone <code>graph_store</code> / <code>enable_graph</code> config is being deprecated in favor of vector-centric entity linking; its MCP story (mem0-mcp and OpenMemory) is in flux, with OpenMemory documented as sunset in favor of the unified self-hosted server.</p>
+    </div>
+
+    <div class="feature-card compare-card">
+      <div class="feature-icon graph">🕸️</div>
+      <h3>Zep / Graphiti</h3>
+      <p class="what-is">Graphiti is an open-source temporal knowledge-graph engine (Apache-2.0) that is the core of Zep's commercial Context Graph platform. It ingests conversational and structured data into typed entity nodes, relationship edges, and episodes, and is explicitly bi-temporal: edges carry validity windows (<code>t_valid</code> / <code>t_invalid</code>) plus ingest timestamps, and conflicting facts are invalidated rather than deleted. Retrieval is hybrid — embeddings + BM25 + graph traversal.</p>
+      <p class="differs"><strong>How fmem differs:</strong> Zep/Graphiti is the closest match on the typed bi-temporal graph story. Ferrosa Memory adds a Datalog rule/derivation engine, a dream-cycle consolidation pass, and a blast-radius forgetting UX — none of which Graphiti documents as such.</p>
+      <p class="nuance">Credit where due: Zep has a battle-tested commercial offering and a peer-reviewed temporal-graph architecture paper behind it. 2025 nuance: Zep's self-hostable Community Edition was deprecated (April 2025) and is unmaintained, so self-hosting today means running the Graphiti library yourself.</p>
+    </div>
+
+    <div class="feature-card compare-card">
+      <div class="feature-icon cyan">🧠</div>
+      <h3>Letta</h3>
+      <p class="what-is">An open-source framework (Apache-2.0) for building stateful agents that manage their own memory, descended from the Berkeley MemGPT "LLM-as-OS" work. Memory is organized into labeled in-context "memory blocks" across OS-inspired tiers — core memory (always in-context), archival memory (external vector / graph store), and recall memory (searchable history). The agent actively edits its own memory via tool calls. Available as OSS and as Letta Cloud.</p>
+      <p class="differs"><strong>How fmem differs:</strong> Letta centers on agent-driven self-editing memory blocks; Ferrosa Memory provides a typed graph, bi-temporal supersession, multi-signal fusion retrieval, and rule-based derivation as first-class server features rather than agent-managed state.</p>
+      <p class="nuance">2025–2026 nuance: Letta is documented as an MCP <em>client</em> — its agents attach and call external MCP tools — but it is not itself an official MCP <em>server</em> exposing its memory as tools (a community-built Letta MCP server exists). Letta has a polished managed cloud, a large community, and broad framework integrations.</p>
+    </div>
+
+    <div class="feature-card compare-card">
+      <div class="feature-icon index">📚</div>
+      <h3>Vector + RAG baseline</h3>
+      <p class="what-is">The default "roll-your-own" pattern (a category, not a product): store conversation or document chunks in a vector database — Pinecone, Weaviate, Qdrant, pgvector — and wire retrieval with a framework like LangChain or LlamaIndex, or simply lean on a long context window. Retrieval is vector similarity, optionally plus keyword or metadata filters; some frameworks add reranking. Both OSS components and managed clouds exist.</p>
+      <p class="differs"><strong>How fmem differs:</strong> the baseline answers "what's similar?"; Ferrosa Memory adds a typed graph, bi-temporal history, multi-signal RRF fusion, explainable derivation, automatic consolidation, and auditable forgetting beyond delete-by-ID.</p>
+      <p class="nuance">Credit where due: the vector + RAG baseline wins on ubiquity, simplicity, and ecosystem familiarity — for many teams "Pinecone / pgvector + LangChain" is the fastest path to good-enough memory.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════ Honest positioning ═══════════════════ -->
+<section id="positioning" class="comparison">
+  <section>
+    <div class="section-label cool">Honest positioning</div>
+    <h2 class="section-title">Depth and correctness for teams comfortable self-hosting today.</h2>
+    <p class="section-subtitle">Ferrosa Memory's differentiator is breadth and rigor in one self-hostable package: native MCP tooling, a typed bi-temporal graph, multi-signal RRF retrieval including PageRank, Datalog-derived explainable facts, dream-cycle consolidation, and reversible forgetting with blast radius — all on a durable S3-tiered Ferrosa DB backend. No single competitor combines all of these in one product today.</p>
+    <div class="note">
+      <p><strong>We won't pretend to be more mature than the incumbents.</strong> Mem0 and Letta both offer polished managed cloud platforms, large active communities, and broad framework integrations — while fmem is developer-preview and self-host only, with no managed cloud. Zep has a battle-tested commercial offering and a peer-reviewed temporal-graph architecture paper behind it. The vector + RAG baseline wins on ubiquity, simplicity, and ecosystem familiarity.</p>
+      <p style="margin-top:0.85rem;">fmem's credible pitch is depth and correctness for teams that need <em>explainable, auditable, temporally-correct</em> memory and are comfortable self-hosting today — not "more mature than the incumbents."</p>
+    </div>
+  </section>
+</section>
+
+<!-- ═══════════════════ Sources ═══════════════════ -->
+<section id="sources">
+  <div class="section-label cool">Sources</div>
+  <h2 class="section-title">Every claim is checkable.</h2>
+  <p class="section-subtitle">Competitor capabilities above are grounded in each project's own public docs and repositories. The key vendor sources are linked here so the matrix can be verified independently.</p>
+  <div class="sources-list">
+    <p><span class="src-vendor">Mem0:</span> <a href="https://github.com/mem0ai/mem0" target="_blank" rel="noopener noreferrer">GitHub repo</a>, <a href="https://docs.mem0.ai/platform/features/graph-memory" target="_blank" rel="noopener noreferrer">Graph Memory / migration docs</a>, <a href="https://mem0.ai/openmemory" target="_blank" rel="noopener noreferrer">OpenMemory</a>, <a href="https://github.com/mem0ai/mem0-mcp" target="_blank" rel="noopener noreferrer">mem0-mcp</a>, <a href="https://mem0.ai/blog/what-is-ai-agent-memory" target="_blank" rel="noopener noreferrer">"What is AI Agent Memory"</a>.</p>
+    <p><span class="src-vendor">Zep / Graphiti:</span> <a href="https://github.com/getzep/graphiti" target="_blank" rel="noopener noreferrer">Graphiti repo</a>, <a href="https://www.getzep.com/ai-agents/temporal-knowledge-graph/" target="_blank" rel="noopener noreferrer">"What Is a Temporal Knowledge Graph?"</a>, <a href="https://arxiv.org/abs/2501.13956" target="_blank" rel="noopener noreferrer">Zep paper (arXiv 2501.13956)</a>, <a href="https://blog.getzep.com/announcing-a-new-direction-for-zeps-open-source-strategy/" target="_blank" rel="noopener noreferrer">CE deprecation announcement</a>.</p>
+    <p><span class="src-vendor">Letta:</span> <a href="https://github.com/letta-ai/letta" target="_blank" rel="noopener noreferrer">GitHub repo</a>, <a href="https://docs.letta.com/guides/mcp/overview" target="_blank" rel="noopener noreferrer">MCP overview docs</a>, <a href="https://docs.letta.com/guides/ade/archival-memory/" target="_blank" rel="noopener noreferrer">archival memory docs</a>, <a href="https://www.letta.com/blog/memory-blocks" target="_blank" rel="noopener noreferrer">"Memory Blocks"</a>.</p>
+    <p><span class="src-vendor">Vector + RAG components:</span> Pinecone, Weaviate, Qdrant, pgvector, LangChain, and LlamaIndex — characterized at the category level from their respective public documentation.</p>
+  </div>
+</section>
+
+<!-- ═══════════════════ CTA ═══════════════════ -->
+<section id="get-started" class="cta-section">
+  <h2>See what the structure buys you.</h2>
+  <p>Read how the typed graph, bi-temporal facts, hybrid retrieval, and auditable forgetting fit together — then browse the MCP tools your agents call.</p>
+  <div class="hero-actions">
+    <a href="how-it-works.html" class="btn-primary">How it works</a>
+    <a href="tools.html" class="btn-secondary">Browse the tools</a>
+  </div>
+</section>
+
+<footer>
+  <div style="max-width: 1200px; margin: 0 auto; padding: 3rem 2rem; border-top: 1px solid var(--border); display:flex; justify-content:space-between; gap:2rem; flex-wrap:wrap; color:var(--text-muted);">
+    <div>Ferrosa Memory <span style="color:var(--accent);">0.15</span> · Developer preview</div>
+    <div style="display:flex; gap:1rem; flex-wrap:wrap;">
+      <a href="./" style="color:var(--text-secondary); text-decoration:none;">Overview</a>
+      <a href="how-it-works.html" style="color:var(--text-secondary); text-decoration:none;">How it works</a>
+      <a href="tools.html" style="color:var(--text-secondary); text-decoration:none;">Tools</a>
+      <a href="compare.html" style="color:var(--text-secondary); text-decoration:none;">Compare</a>
+      <a href="getting-started.html" style="color:var(--text-secondary); text-decoration:none;">Setup</a>
+      <a href="../database/" style="color:var(--text-secondary); text-decoration:none;">Database</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll('nav').forEach((nav) => {
+    const toggle = nav.querySelector('.nav-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+      const open = nav.classList.toggle('nav-open');
+      toggle.setAttribute('aria-expanded', String(open));
+      toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Open navigation');
+    });
+    nav.querySelectorAll('.nav-links a').forEach((link) => {
+      link.addEventListener('click', () => {
+        nav.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.setAttribute('aria-label', 'Open navigation');
+      });
+    });
+  });
+</script>
+</body>
+</html>

--- a/docs/ferrosa-memory/getting-started.html
+++ b/docs/ferrosa-memory/getting-started.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ferrosa Memory Getting Started</title>
   <meta name="description" content="Run, configure, and use Ferrosa Memory locally with Ferrosa Database and MCP-compatible agent harnesses.">
-  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="assets/brand/fm-logo.svg">
   <style>
-    :root { --bg:#0a0a0f; --card:#16161f; --card2:#111118; --text:#e8e8ed; --muted:#9494a3; --accent:#7c9cf5; --accent2:#e2725b; --border:#262637; --code:#0d0d14; }
+    :root { --bg:#05070c; --card:#0e1828; --card2:#09111f; --text:#e8eef7; --muted:#9fb0c6; --accent:#348cff; --accent2:#7ee7ff; --border:#17273d; --code:#060b14; }
     * { box-sizing:border-box; }
     body { margin:0; font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; background:var(--bg); color:var(--text); line-height:1.65; }
-    nav { position:sticky; top:0; background:rgba(10,10,15,.9); backdrop-filter:blur(16px); border-bottom:1px solid var(--border); z-index:10; }
+    nav { position:sticky; top:0; background:rgba(5,7,12,.9); backdrop-filter:blur(16px); border-bottom:1px solid var(--border); z-index:10; }
     nav .inner { max-width:1100px; margin:0 auto; padding:1rem 1.5rem; display:flex; align-items:center; justify-content:space-between; gap:1rem; }
     nav a { color:var(--text); text-decoration:none; }
     nav .links { display:flex; gap:1rem; flex-wrap:wrap; }
@@ -30,8 +30,8 @@
     h3 { margin-top:2rem; }
     p, li, td { color:var(--muted); }
     a { color:var(--accent); }
-    .hero { background:linear-gradient(135deg,rgba(124,156,245,.14),rgba(226,114,91,.08)); border:1px solid var(--border); border-radius:22px; padding:2rem; }
-    .pill { display:inline-block; border:1px solid rgba(124,156,245,.35); color:var(--accent); background:rgba(124,156,245,.08); border-radius:999px; padding:.25rem .7rem; font-size:.8rem; font-weight:700; letter-spacing:.06em; text-transform:uppercase; }
+    .hero { background:linear-gradient(135deg,rgba(52,140,255,.16),rgba(126,231,255,.08)); border:1px solid var(--border); border-radius:22px; padding:2rem; }
+    .pill { display:inline-block; border:1px solid rgba(52,140,255,.35); color:var(--accent); background:rgba(52,140,255,.08); border-radius:999px; padding:.25rem .7rem; font-size:.8rem; font-weight:700; letter-spacing:.06em; text-transform:uppercase; }
     .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1rem; margin:1rem 0; }
     .card { background:var(--card); border:1px solid var(--border); border-radius:16px; padding:1.25rem; }
     table { width:100%; border-collapse:collapse; background:var(--card2); border:1px solid var(--border); border-radius:12px; overflow:hidden; display:table; }
@@ -40,7 +40,7 @@
     tr:last-child td { border-bottom:0; }
     pre { background:var(--code); border:1px solid var(--border); border-radius:14px; padding:1rem; overflow:auto; }
     code { font-family:'JetBrains Mono','Fira Code',ui-monospace,monospace; color:#dcdcf0; }
-    .warn { border-left:3px solid var(--accent2); background:rgba(226,114,91,.08); padding:1rem 1.2rem; border-radius:0 12px 12px 0; color:var(--muted); }
+    .warn { border-left:3px solid var(--accent2); background:rgba(126,231,255,.08); padding:1rem 1.2rem; border-radius:0 12px 12px 0; color:var(--muted); }
     footer { max-width:980px; margin:0 auto; padding:2rem 1.5rem; color:#6b6b7a; border-top:1px solid var(--border); }
     @media (max-width: 768px) {
       body { overflow-x:hidden; }
@@ -48,7 +48,7 @@
       nav .inner > a:first-child { margin-right:auto; }
       nav .nav-cta { flex-shrink:0; padding:.5rem .75rem; }
       nav .nav-toggle { display:inline-flex; }
-      nav .links { position:fixed; top:64px; left:0; right:0; display:none; flex-direction:column; gap:0; padding:.5rem 1rem 1rem; background:rgba(10,10,15,.98); border-bottom:1px solid var(--border); box-shadow:0 18px 40px rgba(0,0,0,.35); }
+      nav .links { position:fixed; top:64px; left:0; right:0; display:none; flex-direction:column; gap:0; padding:.5rem 1rem 1rem; background:rgba(5,7,12,.98); border-bottom:1px solid var(--border); box-shadow:0 18px 40px rgba(0,0,0,.35); }
       nav.open .links { display:flex; }
       nav .links a { display:block; padding:.75rem 0; white-space:nowrap; }
       main { width:100%; min-width:0; padding-left:1rem; padding-right:1rem; overflow-wrap:anywhere; }
@@ -58,7 +58,7 @@
   </style>
 </head>
 <body>
-<nav><div class="inner"><a href="./"><strong>Ferrosa <span style="color:var(--accent)">Memory</span></strong></a><div class="links" id="site-nav-links"><a href="../database/">Database</a><a href="./">Memory overview</a><a href="#quickstart">Quickstart</a><a href="#examples">Examples</a><a href="https://github.com/ferrosadb" target="_blank" rel="noopener noreferrer">GitHub</a></div><a href="#quickstart" class="nav-cta">Get Started</a><button class="nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="site-nav-links"><span></span></button></div></nav>
+<nav><div class="inner"><a href="./"><img src="assets/brand/fm-logo.svg" alt="Fm" width="24" height="24" style="border-radius:6px;vertical-align:middle;margin-right:.4rem;"><strong>Ferrosa <span style="color:var(--accent)">Memory</span></strong></a><div class="links" id="site-nav-links"><a href="./">Overview</a><a href="how-it-works.html">How it works</a><a href="tools.html">Tools</a><a href="compare.html">Compare</a><a href="getting-started.html">Setup</a><a href="../database/">Database</a><a href="https://github.com/ferrosadb" target="_blank" rel="noopener noreferrer">GitHub</a></div><a href="#quickstart" class="nav-cta">Get Started</a><button class="nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="site-nav-links"><span></span></button></div></nav>
 <main>
   <section class="hero">
     <span class="pill">Developer preview</span>
@@ -110,8 +110,8 @@ podman compose version        # full Podman stack only</code></pre>
 ollama list | grep nomic-embed-text-v2-moe</code></pre>
   <div class="warn">If embeddings are skipped, lexical/phonetic search still works, but semantic/vector search quality is degraded.</div>
 
-  <h2>0.13 retrieval defaults</h2>
-  <p>The 0.13 preview keeps live agent turns compact while eval runs use wider candidate generation.</p>
+  <h2>Retrieval defaults</h2>
+  <p>Ferrosa Memory keeps live agent turns compact while evaluation runs use wider candidate generation.</p>
   <pre><code>[retrieval]
 default_limit = 10
 
@@ -123,16 +123,15 @@ dimensions = 768
 [eval]
 retrieval_k = 25</code></pre>
   <p><code>default_limit = 10</code> is used when an agent omits <code>limit</code> or <code>k</code>. Lower it with the <code>config</code> MCP tool if memory results are consuming too much context. Eval runs should widen candidate generation in the harness instead of raising the live default.</p>
-  <p>Best-known BRIGHT-Pro support-doc-closed MCP slice profile for 0.13:</p>
+  <p>For evaluation, the harness widens candidate generation rather than raising the live default — for example a wider <code>candidate_limit</code>, a full fusion profile, LLM query decomposition, and embedding variants:</p>
   <pre><code>candidate_limit=50
 fusion_profile=all
 query_decomposition=llm
-query_task=bright_pro
 query_variant_limit=5
 query_embed_variants=true
 chunk_expansion=none
 rerank=false</code></pre>
-  <p>On the 200-document biology support-closed slice this measured alpha_nDCG <code>0.816</code>, NDCG <code>0.799</code>, aspect_recall <code>0.940</code>, and recall <code>0.796</code>. These are preview slice numbers; full-corpus paper comparisons require the full corpus to be ingested through the same MCP path.</p>
+  <p>Tune these in the eval harness for your own corpus; keep the live defaults compact so memory results don't crowd out an agent's working context.</p>
 
   <h3>Optional live judge/reranker</h3>
   <pre><code>[judge]

--- a/docs/ferrosa-memory/how-it-works.html
+++ b/docs/ferrosa-memory/how-it-works.html
@@ -1,0 +1,902 @@
+<!DOCTYPE html>
+<!-- ferrosadb.com marketing site -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How Ferrosa Memory Works — Architecture, Retrieval &amp; Auditable Forgetting</title>
+  <meta name="description" content="How Ferrosa Memory works: the agent → MCP → memory-semantics → Ferrosa DB architecture, the memory primitives, hybrid Reciprocal Rank Fusion retrieval, dream-cycle consolidation, auditable forgetting, and the hook-driven session lifecycle.">
+  <link rel="icon" type="image/svg+xml" href="assets/brand/fm-logo.svg">
+  <style>
+    :root {
+      --bg-primary: #05070c;
+      --bg-secondary: #09111f;
+      --bg-card: #0e1828;
+      --bg-card-hover: #142337;
+      --text-primary: #e8eef7;
+      --text-secondary: #9fb0c6;
+      --text-muted: #647794;
+      --accent: #348cff;
+      --accent-glow: rgba(52, 140, 255, 0.18);
+      --accent-secondary: #7ee7ff;
+      --accent-cool: #7ee7ff;
+      --accent-steel: #516d92;
+      --accent-green: #6bc9a0;
+      --border: #17273d;
+      --border-hover: #25395a;
+      --code-bg: #060b14;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* ── Navigation ── */
+    nav {
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 100;
+      background: rgba(5, 7, 12, 0.85);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border);
+      padding: 0 2rem;
+    }
+
+    nav .nav-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 64px;
+    }
+
+    nav .logo {
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--text-primary);
+      text-decoration: none;
+    }
+
+    nav .logo span { color: var(--accent); }
+
+    nav .nav-links {
+      display: flex;
+      gap: 2rem;
+      list-style: none;
+    }
+
+    nav .nav-links a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav .nav-links a:hover { color: var(--text-primary); }
+
+    nav .nav-cta {
+      background: var(--accent);
+      color: #fff;
+      padding: 0.5rem 1.25rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 600;
+      transition: opacity 0.2s;
+    }
+
+    nav .nav-cta:hover { opacity: 0.9; }
+
+    nav .nav-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      width: 2.5rem;
+      height: 2.5rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+
+    nav .nav-toggle span,
+    nav .nav-toggle span::before,
+    nav .nav-toggle span::after {
+      display: block;
+      width: 1.1rem;
+      height: 2px;
+      border-radius: 2px;
+      background: currentColor;
+      content: '';
+      transition: transform 0.2s, opacity 0.2s;
+    }
+
+    nav .nav-toggle span { position: relative; }
+    nav .nav-toggle span::before { position: absolute; transform: translateY(-6px); }
+    nav .nav-toggle span::after { position: absolute; transform: translateY(6px); }
+
+    nav.nav-open .nav-toggle span { background: transparent; }
+    nav.nav-open .nav-toggle span::before { background: var(--text-primary); transform: rotate(45deg); }
+    nav.nav-open .nav-toggle span::after { background: var(--text-primary); transform: rotate(-45deg); }
+
+    /* ── Sections ── */
+    section {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 6rem 2rem;
+    }
+
+    /* ── Hero ── */
+    .hero {
+      padding-top: 11rem;
+      padding-bottom: 6rem;
+      text-align: center;
+      position: relative;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -60%);
+      width: 600px;
+      height: 600px;
+      background: radial-gradient(circle, var(--accent-glow) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    .hero-logo {
+      width: 88px;
+      height: 88px;
+      border-radius: 22px;
+      margin: 0 auto 1.75rem;
+      display: block;
+      box-shadow: 0 10px 40px rgba(52, 140, 255, 0.25);
+      position: relative;
+    }
+
+    .hero-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 100px;
+      padding: 0.375rem 1rem;
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+      margin-bottom: 2rem;
+    }
+
+    .hero-badge .dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-green);
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+
+    .hero h1 {
+      font-size: clamp(2.5rem, 6vw, 4.5rem);
+      font-weight: 800;
+      line-height: 1.08;
+      letter-spacing: -0.03em;
+      margin-bottom: 1.5rem;
+      position: relative;
+    }
+
+    .hero h1 .gradient {
+      background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero p {
+      font-size: 1.25rem;
+      color: var(--text-secondary);
+      max-width: 680px;
+      margin: 0 auto 2.5rem;
+      line-height: 1.7;
+    }
+
+    .hero-actions {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+      padding: 0.75rem 2rem;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 1rem;
+      transition: transform 0.15s, box-shadow 0.15s;
+    }
+
+    .btn-primary:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 30px var(--accent-glow);
+    }
+
+    .btn-secondary {
+      background: var(--bg-card);
+      color: var(--text-primary);
+      padding: 0.75rem 2rem;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 1rem;
+      border: 1px solid var(--border);
+      transition: border-color 0.2s, background 0.2s;
+    }
+
+    .btn-secondary:hover {
+      border-color: var(--border-hover);
+      background: var(--bg-card-hover);
+    }
+
+    /* ── Section headers ── */
+    .section-label {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+
+    .section-title {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin-bottom: 1rem;
+      line-height: 1.15;
+    }
+
+    .section-subtitle {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      max-width: 680px;
+      line-height: 1.7;
+    }
+
+    .section-subtitle.centered {
+      margin: 0 auto;
+      text-align: center;
+    }
+
+    .section-title.centered { text-align: center; }
+    .section-label.centered { text-align: center; }
+
+    /* ── Problem section ── */
+    .problem {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .problem section { padding: 5rem 2rem; }
+
+    /* ── Feature grid ── */
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+
+    .feature-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 2.25rem;
+      transition: border-color 0.2s, transform 0.15s;
+    }
+
+    .feature-card:hover {
+      border-color: var(--border-hover);
+      transform: translateY(-2px);
+    }
+
+    .feature-icon {
+      width: 44px;
+      height: 44px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.25rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .feature-icon.steel { background: rgba(52, 140, 255, 0.14); }
+    .feature-icon.cyan { background: rgba(126, 231, 255, 0.14); }
+    .feature-icon.cql { background: rgba(124, 156, 245, 0.12); }
+    .feature-icon.graph { background: rgba(107, 201, 160, 0.12); }
+    .feature-icon.lock { background: rgba(200, 130, 240, 0.12); }
+    .feature-icon.index { background: rgba(100, 200, 220, 0.12); }
+    .feature-icon.observe { background: rgba(240, 200, 100, 0.12); }
+
+    .feature-card h3 {
+      font-size: 1.1875rem;
+      font-weight: 700;
+      margin-bottom: 0.625rem;
+    }
+
+    .feature-card p {
+      font-size: 0.9375rem;
+      color: var(--text-secondary);
+      line-height: 1.65;
+    }
+
+    /* ── Comparison table ── */
+    .comparison {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 3rem;
+      font-size: 0.9375rem;
+    }
+
+    .comparison-table th,
+    .comparison-table td {
+      text-align: left;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .comparison-table thead th {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+
+    .comparison-table thead th:first-child { color: var(--text-secondary); }
+
+    .comparison-table thead th.ferrosa-col {
+      color: var(--accent);
+    }
+
+    .comparison-table tbody td:first-child {
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .comparison-table tbody td {
+      color: var(--text-secondary);
+    }
+
+    .comparison-table tbody td.ferrosa-col {
+      color: var(--accent-green);
+      font-weight: 600;
+    }
+
+    .comparison-table tbody tr:hover {
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    .check { color: var(--accent-green); }
+    .cross { color: var(--text-muted); }
+
+    /* ── CTA section ── */
+    .cta-section {
+      text-align: center;
+      padding: 6rem 2rem;
+    }
+
+    .cta-section h2 {
+      font-size: clamp(2rem, 4vw, 3rem);
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin-bottom: 1rem;
+    }
+
+    .cta-section p {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      margin-bottom: 2.5rem;
+      max-width: 520px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    /* ── Beta Banner ── */
+    .beta-banner {
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border);
+      text-align: center;
+      padding: 0.5rem 1rem;
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+      position: fixed;
+      top: 64px;
+      width: 100%;
+      z-index: 99;
+    }
+
+    .beta-tag {
+      display: inline-block;
+      background: var(--accent);
+      color: #fff;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+      vertical-align: middle;
+    }
+
+    /* ── Responsive ── */
+    @media (max-width: 768px) {
+      .features-grid { grid-template-columns: 1fr; }
+      nav { padding: 0 1rem; }
+      nav .nav-inner {
+        height: 64px;
+        min-height: 64px;
+        gap: 0.75rem;
+        padding: 0;
+        position: relative;
+      }
+      body { overflow-x: hidden; }
+      nav .logo { margin-right: auto; }
+      nav .nav-cta {
+        display: inline-flex;
+        flex-shrink: 0;
+        padding: 0.5rem 0.75rem;
+      }
+      nav .nav-toggle { display: inline-flex; }
+      nav .nav-links {
+        position: fixed;
+        top: 64px;
+        left: 0;
+        right: 0;
+        display: none;
+        flex-direction: column;
+        gap: 0;
+        padding: 0.5rem 1rem 1rem;
+        background: rgba(5, 7, 12, 0.98);
+        border-bottom: 1px solid var(--border);
+        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+      }
+      nav.nav-open .nav-links { display: flex; }
+      nav .nav-links li { list-style: none; }
+      nav .nav-links a {
+        display: block;
+        padding: 0.75rem 0;
+        white-space: nowrap;
+      }
+      section {
+        width: 100%;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        overflow-wrap: anywhere;
+      }
+      .hero { padding-top: 11rem; }
+      .hero h1 { font-size: clamp(2rem, 11vw, 3rem); }
+      .hero p { font-size: 1rem; }
+      .hero-actions { flex-direction: column; align-items: stretch; }
+      .btn-primary,
+      .btn-secondary { width: 100%; text-align: center; }
+      .beta-banner { top: 148px; font-size: 0.75rem; }
+      .comparison-table { font-size: 0.8125rem; }
+      .comparison-table th,
+      .comparison-table td { padding: 0.75rem 0.75rem; }
+    }
+  </style>
+
+<style>
+  .suite-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap:1.5rem; margin-top:2.5rem; }
+  .suite-card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:2rem; text-decoration:none; transition:border-color .2s, transform .2s, background .2s; }
+  .suite-card:hover { border-color:var(--accent); transform:translateY(-2px); background:var(--bg-card-hover); }
+  .kicker { color:var(--accent); font-size:.75rem; letter-spacing:.12em; font-weight:800; text-transform:uppercase; margin-bottom:.75rem; }
+  .cool { color:var(--accent-cool); }
+  .pill-row { display:flex; flex-wrap:wrap; gap:.5rem; margin:1.25rem 0; }
+  .pill { border:1px solid var(--border); background:var(--bg-secondary); color:var(--text-secondary); border-radius:999px; padding:.35rem .75rem; font-size:.8125rem; }
+  .doc-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:1rem; margin-top:1.5rem; }
+  .doc-card { background:var(--bg-card); border:1px solid var(--border); border-radius:14px; padding:1.4rem; transition:border-color .2s; }
+  .doc-card:hover { border-color:var(--border-hover); }
+  .doc-card h3 { margin-bottom:.5rem; }
+  .doc-card p, .suite-card p { color:var(--text-secondary); }
+  .doc-card .tag { display:inline-block; font-family:var(--font-mono); font-size:.72rem; color:var(--accent-cool); margin-bottom:.5rem; letter-spacing:.04em; }
+  .code-block { background:var(--code-bg); border:1px solid var(--border); border-radius:14px; padding:1.25rem; overflow:auto; margin:1rem 0; }
+  .code-block code, pre { font-family:var(--font-mono); font-size:.875rem; color:#cfe0f5; }
+  .note { border-left:3px solid var(--accent-cool); background:rgba(126,231,255,.08); padding:1rem 1.25rem; border-radius:0 12px 12px 0; color:var(--text-secondary); margin:1.5rem 0; }
+  .two-col { display:grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap:2rem; align-items:start; }
+
+  .reference-table-wrap { margin-top:1.5rem; border:1px solid var(--border); border-radius:16px; overflow:hidden; background:rgba(255,255,255,.02); }
+  .reference-table { width:100%; border-collapse:collapse; font-size:.875rem; }
+  .reference-table caption { text-align:left; padding:1rem 1.1rem; color:var(--text-secondary); border-bottom:1px solid var(--border); }
+  .reference-table th { text-align:left; padding:.75rem 1rem; color:var(--text-muted); font-size:.72rem; letter-spacing:.08em; text-transform:uppercase; background:rgba(255,255,255,.025); border-bottom:1px solid var(--border); }
+  .reference-table td { padding:.8rem 1rem; color:var(--text-secondary); border-bottom:1px solid rgba(255,255,255,.055); vertical-align:top; }
+  .reference-table tr:last-child td { border-bottom:0; }
+  .reference-table a { color:var(--text-primary); text-decoration:none; border-bottom:1px solid rgba(126,231,255,.35); }
+  .reference-table a:hover { color:var(--accent-cool); border-bottom-color:var(--accent-cool); }
+  .reference-table .ref-id { color:var(--accent-cool); font-family:var(--font-mono); white-space:nowrap; }
+  .reference-table .ref-theme { color:var(--text-muted); white-space:nowrap; }
+  @media (max-width: 760px) { .reference-table th:nth-child(3), .reference-table td:nth-child(3) { display:none; } }
+  @media (max-width: 800px) { .two-col { grid-template-columns:1fr; } }
+</style>
+
+<style>
+  /* Layered architecture diagram — built only from existing palette tokens. */
+  .arch-diagram { display:flex; flex-direction:column; gap:.75rem; margin:1rem 0; }
+  .arch-layer { border:1px solid var(--border); border-radius:14px; padding:1.1rem 1.25rem; background:var(--bg-card); }
+  .arch-layer .arch-role { font-family:var(--font-mono); font-size:.72rem; letter-spacing:.08em; text-transform:uppercase; color:var(--text-muted); margin-bottom:.4rem; }
+  .arch-layer .arch-name { font-weight:700; color:var(--text-primary); }
+  .arch-layer .arch-detail { color:var(--text-secondary); font-size:.9rem; margin-top:.35rem; }
+  .arch-layer.agent { border-color:var(--accent-steel); }
+  .arch-layer.mcp { border-color:var(--accent); }
+  .arch-layer.semantics { border-color:var(--accent-cool); }
+  .arch-layer.db { border-color:var(--accent-green); }
+  .arch-arrow { text-align:center; color:var(--accent-cool); font-family:var(--font-mono); font-size:1rem; line-height:1; }
+  .arch-chips { display:flex; flex-wrap:wrap; gap:.4rem; margin-top:.55rem; }
+  .arch-chip { border:1px solid var(--border); background:var(--bg-secondary); color:var(--text-secondary); border-radius:999px; padding:.25rem .6rem; font-size:.74rem; font-family:var(--font-mono); }
+  .signal-list { list-style:none; margin-top:1.25rem; display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:.6rem; }
+  .signal-list li { border:1px solid var(--border); border-radius:10px; padding:.7rem .9rem; background:var(--bg-card); color:var(--text-secondary); font-size:.9rem; }
+  .signal-list li b { color:var(--text-primary); font-weight:650; }
+  .step-row { display:grid; grid-template-columns: auto 1fr; gap:1rem; align-items:start; margin-top:1.1rem; }
+  .step-num { width:2rem; height:2rem; flex:none; border-radius:8px; background:rgba(52,140,255,.14); color:var(--accent); font-weight:800; font-family:var(--font-mono); display:flex; align-items:center; justify-content:center; }
+  .step-row p { color:var(--text-secondary); }
+  .step-row h4 { font-size:1.0625rem; font-weight:700; margin-bottom:.25rem; }
+</style>
+
+</head>
+<body>
+<!-- ═══════════════════ Navigation ═══════════════════ -->
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="logo" style="display:flex;align-items:center;gap:0.5rem;">
+      <img src="assets/brand/fm-logo.svg" alt="Fm" width="28" height="28" style="border-radius:7px;">
+      ferrosa <span>memory</span>
+    </a>
+    <ul class="nav-links" id="site-nav-links">
+      <li><a href="./">Overview</a></li>
+      <li><a href="how-it-works.html">How it works</a></li>
+      <li><a href="tools.html">Tools</a></li>
+      <li><a href="compare.html">Compare</a></li>
+      <li><a href="getting-started.html">Setup</a></li>
+      <li><a href="../database/">Database</a></li>
+      <li><a href="https://github.com/ferrosadb" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+    </ul>
+    <a href="how-it-works.html" class="nav-cta">How it works</a>
+    <button class="nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="site-nav-links"><span></span></button>
+  </div>
+</nav>
+
+<div class="beta-banner">
+  <span class="beta-tag">Developer Preview</span> Ferrosa Memory 0.15 — structured, linked, auditable memory for agentic systems.
+</div>
+
+<!-- ═══════════════════ Hero ═══════════════════ -->
+<section class="hero">
+  <img class="hero-logo" src="assets/brand/fm-logo.svg" alt="Ferrosa Memory logo">
+  <div class="hero-badge"><span class="dot"></span> Architecture · 0.15 · Developer Preview</div>
+  <h1>How Ferrosa Memory <span class="gradient">works.</span></h1>
+  <p>A thin memory layer over a real database — typed graph, bi-temporal facts, hybrid retrieval, background consolidation, and auditable forgetting — all reachable through MCP tools.</p>
+  <div class="hero-actions">
+    <a href="#architecture" class="btn-primary">Start with the architecture</a>
+    <a href="tools.html" class="btn-secondary">Browse the tools</a>
+  </div>
+</section>
+
+<!-- ═══════════════════ Architecture ═══════════════════ -->
+<section id="architecture">
+  <div class="section-label cool">The architecture</div>
+  <h2 class="section-title">Four layers, one clear contract.</h2>
+  <p class="section-subtitle">An agent never talks to storage directly. It calls MCP tools; Ferrosa Memory owns the <em>semantics</em> of memory; and Ferrosa DB provides durable, indexed substrate underneath. Each layer has a single job, so the layer above can stay simple.</p>
+  <div class="two-col" style="margin-top:2.5rem;">
+    <div>
+      <p style="color:var(--text-secondary);">At the top, an agent, IDE, or runtime issues a small, stable set of MCP calls — ingest, retrieve, link, explain, forget. It does not know how a fact is stored, indexed, or ranked; it only knows the tool contract.</p>
+      <p style="color:var(--text-secondary); margin-top:1rem;">The memory service translates those calls into <em>memory semantics</em>: entities and typed edges, bi-temporal facts, trajectory folds, context segments, intentions, and the forget journal. This is where dedup, supersession, ranking, and consolidation policy live.</p>
+      <p style="color:var(--text-secondary); margin-top:1rem;">Underneath, Ferrosa DB does the heavy lifting: CQL storage for the wide-column tables, HNSW vector indexes for semantic recall, a property graph for traversal, and S3-backed durability with hot/warm/cold tiering so memory survives restarts and scales past a single process.</p>
+    </div>
+    <div>
+      <div class="arch-diagram">
+        <div class="arch-layer agent">
+          <div class="arch-role">Caller</div>
+          <div class="arch-name">Agent · IDE · Runtime</div>
+          <div class="arch-detail">Issues a stable MCP tool contract; carries no storage knowledge.</div>
+        </div>
+        <div class="arch-arrow">▼ &nbsp;MCP tools</div>
+        <div class="arch-layer mcp">
+          <div class="arch-role">Interface</div>
+          <div class="arch-name">MCP tool surface</div>
+          <div class="arch-detail">ingest · retrieve · link · explain · forget</div>
+        </div>
+        <div class="arch-arrow">▼</div>
+        <div class="arch-layer semantics">
+          <div class="arch-role">Memory semantics</div>
+          <div class="arch-name">Ferrosa Memory service</div>
+          <div class="arch-chips">
+            <span class="arch-chip">entities + graph</span>
+            <span class="arch-chip">bi-temporal facts</span>
+            <span class="arch-chip">folds + segments</span>
+            <span class="arch-chip">hybrid retrieval</span>
+            <span class="arch-chip">consolidation</span>
+            <span class="arch-chip">forget journal</span>
+          </div>
+        </div>
+        <div class="arch-arrow">▼</div>
+        <div class="arch-layer db">
+          <div class="arch-role">Substrate</div>
+          <div class="arch-name">Ferrosa Database</div>
+          <div class="arch-chips">
+            <span class="arch-chip">CQL storage</span>
+            <span class="arch-chip">HNSW vectors</span>
+            <span class="arch-chip">property graph</span>
+            <span class="arch-chip">S3 tiering</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="code-block" style="margin-top:2rem;"><pre><code>Agent / IDE / runtime
+        │  MCP tools  (ingest · retrieve · link · explain · forget)
+        ▼
+Ferrosa Memory service        ← owns memory *semantics*
+  ├─ entities + typed graph
+  ├─ bi-temporal facts (supersession)
+  ├─ trajectory folds + context segments
+  ├─ hybrid retrieval (Reciprocal Rank Fusion)
+  ├─ dream-cycle consolidation
+  └─ auditable forget journal
+        │
+        ▼
+Ferrosa Database              ← durable, indexed substrate
+  CQL storage · HNSW vectors · property graph · S3 hot/warm/cold tiering</code></pre></div>
+</section>
+
+<!-- ═══════════════════ Primitives ═══════════════════ -->
+<section id="primitives" class="problem">
+  <section>
+    <div class="section-label cool">The memory primitives</div>
+    <h2 class="section-title">Memory as structured data, not opaque text.</h2>
+    <p class="section-subtitle">A vector store gives you one shape: a blob with an embedding. Ferrosa Memory gives you the shapes agents actually reason over — and stores each one natively so it can be queried, linked, and explained.</p>
+    <div class="doc-grid">
+      <div class="doc-card">
+        <span class="tag">entities · graph</span>
+        <h3>Entities &amp; typed graph</h3>
+        <p>Named entities are deduplicated with phonetic matching (Double Metaphone) and connected by typed edges — <code>depends_on</code>, <code>contains</code>, <code>calls</code>, <code>uses</code>, <code>references</code>, <code>related_to</code> — alongside legacy bidirectional links like <code>CO_OCCURS_WITH</code> and <code>SUPERSEDES</code>. An agent can follow relationships, not just match strings.</p>
+      </div>
+      <div class="doc-card">
+        <span class="tag">bi-temporal</span>
+        <h3>Bi-temporal facts</h3>
+        <p>Facts are timestamped and superseded rather than overwritten. Retrieval returns the most-recent-valid value by default, while the full supersession chain stays inspectable — so you can audit what was known, and when, and time-travel back through it.</p>
+      </div>
+      <div class="doc-card">
+        <span class="tag">memoization</span>
+        <h3>Memoization</h3>
+        <p>A content-hash-keyed cache of completed sub-call results. When a deterministic sub-task recurs, the prior result is returned from cache instead of paying for a redundant LLM call — memory that saves work, not just stores it.</p>
+      </div>
+      <div class="doc-card">
+        <span class="tag">plan trees</span>
+        <h3>Plan trees</h3>
+        <p>Hierarchical, depth-nested plan and task nodes capture how a complex job decomposes. When a sub-task returns, parent context is re-injected, so a deep agent keeps its place instead of losing the thread.</p>
+      </div>
+      <div class="doc-card">
+        <span class="tag">trajectory folds</span>
+        <h3>Trajectory folds</h3>
+        <p>Open a fold for a sub-task, append turns as work proceeds, then seal it with a summary and an embedding (a <code>FOLDED_INTO</code> edge). Long trajectories compress into recallable units without throwing away the detail underneath.</p>
+      </div>
+      <div class="doc-card">
+        <span class="tag">document chunks</span>
+        <h3>Document chunks</h3>
+        <p>Documents are stored as a hierarchy — document → section → chunk — with semantic previous/next links. When a search hits one chunk, <code>get_chunk_context</code> expands around it to recover the surrounding evidence a single hit would miss.</p>
+      </div>
+      <div class="doc-card">
+        <span class="tag">context segments</span>
+        <h3>Context segments</h3>
+        <p>Raw conversation turns are persisted as deterministic semantic segments, dual-indexed for both lexical (BM25) and vector recall, with temporal previous/next links for bounded expansion windows. The transcript becomes searchable structure.</p>
+      </div>
+    </div>
+  </section>
+</section>
+
+<!-- ═══════════════════ Hybrid retrieval ═══════════════════ -->
+<section id="retrieval">
+  <div class="section-label cool">Hybrid retrieval</div>
+  <h2 class="section-title">One ranked answer, fused from many kinds of evidence.</h2>
+  <p class="section-subtitle">No single signal is enough — vectors miss exact strings, keywords miss paraphrase, and neither knows what matters in <em>this</em> workspace. Ferrosa Memory runs many retrievers and combines them with Reciprocal Rank Fusion, so a result that several independent signals agree on rises to the top.</p>
+
+  <h3 style="margin-top:2.5rem; font-size:1.25rem; font-weight:700;">The signals fused by RRF</h3>
+  <ul class="signal-list">
+    <li><b>Phonetic entity match</b> — fuzzy name recall via Double Metaphone.</li>
+    <li><b>Entity ANN</b> — approximate-nearest-neighbour over entity embeddings (HNSW).</li>
+    <li><b>Fold-summary ANN</b> — semantic recall over sealed trajectory summaries.</li>
+    <li><b>Context-segment BM25</b> — lexical match over raw conversation segments.</li>
+    <li><b>Context-segment ANN</b> — semantic match over the same segments.</li>
+    <li><b>Document-chunk BM25</b> — lexical match over document chunks.</li>
+    <li><b>Document-chunk ANN</b> — semantic match over document chunks.</li>
+    <li><b>Document phonetic</b> — phonetic match against document content.</li>
+    <li><b>Warmth / recency</b> — session-aware decay favouring recently relevant memory.</li>
+    <li><b>PageRank centrality</b> — graph-structural authority of an entity.</li>
+    <li><b>Feedback reputation</b> — accumulated user-feedback signal on past results.</li>
+  </ul>
+
+  <div class="two-col" style="margin-top:2.5rem;">
+    <div class="feature-card">
+      <div class="feature-icon cyan">⚖️</div>
+      <h3>Fusion, then judgment</h3>
+      <p>Optional <strong>query decomposition</strong> expands a request into lexical and LLM-generated variants before retrieval. Reciprocal Rank Fusion merges every signal's ranking into one list. <strong>Workspace-aware reranking</strong> then boosts or demotes results by the current working directory, so local context wins. An optional <strong>LLM judge / reranker</strong> can take a final pass — but it is <em>off by default</em>.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon steel">🔁</div>
+      <h3>A retrieval loop that learns</h3>
+      <p>Relevance feedback on a result set is recorded and folded back into the <em>feedback reputation</em> signal, so future rankings reflect what actually helped. Recall is treated as a system that improves with use — not a fixed similarity threshold frozen at index time.</p>
+    </div>
+  </div>
+  <div class="note">Retrieval is capability-tuned, not magic. The point of fusing eleven signals is robustness: a result wins because phonetic, lexical, semantic, structural, and behavioural evidence agree — not because one embedding happened to land close.</div>
+</section>
+
+<!-- ═══════════════════ Consolidation ═══════════════════ -->
+<section id="consolidation" class="comparison">
+  <section>
+    <div class="section-label cool">Dream-cycle consolidation</div>
+    <h2 class="section-title">Memory that gets better while the agent is idle.</h2>
+    <p class="section-subtitle">Human memory consolidates during rest. Ferrosa Memory does the same: a background "dream cycle" runs during idle periods — and after enough new ingests — turning a pile of fresh facts into linked, ranked, durable knowledge. You can also force a pass with <code>run_consolidation</code> at wrap-up.</p>
+    <div class="doc-grid">
+      <div class="doc-card"><span class="tag">triage</span><h3>Triage</h3><p>Newly ingested memories are sorted and prepared for deeper processing, separating signal worth linking from noise that can rest.</p></div>
+      <div class="doc-card"><span class="tag">connect</span><h3>Connection discovery</h3><p>Within-fold and pairwise analysis surfaces relationships between memories that arrived separately, proposing new edges across the graph.</p></div>
+      <div class="doc-card"><span class="tag">insight</span><h3>Insight generation</h3><p>Clusters of co-occurring entities are summarized into higher-level insights, so recurring patterns become first-class, retrievable memory.</p></div>
+      <div class="doc-card"><span class="tag">rank</span><h3>PageRank recompute</h3><p>Graph centrality is recomputed as the structure grows, keeping the authority signal that feeds retrieval current with the latest links.</p></div>
+      <div class="doc-card"><span class="tag">decay</span><h3>Ebbinghaus warmth decay</h3><p>An Ebbinghaus-style forgetting curve cools memory that hasn't been touched, so stale context fades in ranking instead of crowding fresh recall.</p></div>
+      <div class="doc-card"><span class="tag">materialize</span><h3>Materialization</h3><p>High-confidence derived predicates are materialized for fast reuse, so repeatedly inferred facts don't have to be recomputed on every query.</p></div>
+    </div>
+  </section>
+</section>
+
+<!-- ═══════════════════ Auditable forgetting ═══════════════════ -->
+<section id="forgetting">
+  <div class="section-label cool">Auditable forgetting</div>
+  <h2 class="section-title">The 0.15 headline: memory you can safely remove.</h2>
+  <p class="section-subtitle">Deleting a memory in a connected graph is dangerous — it can orphan edges, break temporal chains, and invalidate derived facts. So <code>forget</code> is two-phase: look before you leap, then leap with a receipt.</p>
+
+  <div class="step-row">
+    <div class="step-num">1</div>
+    <div>
+      <h4>Propose — read-only</h4>
+      <p>A hybrid search finds forget candidates and computes their <strong>blast radius</strong>: direct edges, temporal supersession chains, derived facts that reference the entity, and inbound references. Nothing is mutated. The phase returns a <strong>signed, TTL'd token</strong> describing exactly what would change.</p>
+    </div>
+  </div>
+  <div class="step-row">
+    <div class="step-num">2</div>
+    <div>
+      <h4>Confirm — write</h4>
+      <p>Confirmation replays the token under a <strong>TOCTOU guard</strong>: a <code>content_hash</code> check rejects the operation if the underlying memory changed since the proposal, so you never delete something other than what you reviewed. The change is recorded in an <strong>append-only ForgetJournal</strong> before any state is touched.</p>
+    </div>
+  </div>
+
+  <div class="two-col" style="margin-top:2.5rem;">
+    <div class="feature-card">
+      <div class="feature-icon lock">↩️</div>
+      <h3>Reversible retract vs. hard delete</h3>
+      <p>The default mode is a <strong>reversible retraction</strong> — a soft-delete to <code>state=unavailable</code> that hides the memory from recall but keeps it restorable via <code>restore_forgotten</code>. When you genuinely need it gone, a <strong>hard delete</strong> performs a graph <code>DETACH DELETE</code>. Both are journaled.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon observe">🛟</div>
+      <h3>Crash recovery</h3>
+      <p>Because every forget is journaled before it executes, a crash mid-operation can't leave memory half-deleted. A startup <strong>recovery sweep</strong> reprocesses incomplete forgets to a clean state — the append-only journal is the source of truth.</p>
+    </div>
+  </div>
+  <div class="note">Memory you can remove — and prove you removed correctly — is memory you can trust. The blast-radius preview, signed token, TOCTOU guard, and journal exist so that forgetting is a deliberate, auditable operation rather than a destructive guess.</div>
+</section>
+
+<!-- ═══════════════════ Hooks & lifecycle ═══════════════════ -->
+<section id="lifecycle" class="problem">
+  <section>
+    <div class="section-label cool">Hooks &amp; session lifecycle</div>
+    <h2 class="section-title">Memory that shows up at the right moment — and stays quiet otherwise.</h2>
+    <p class="section-subtitle">The best memory layer is one an agent doesn't have to think about. Ferrosa Memory wires into the session lifecycle through hooks, so recall and capture happen automatically, scoped to the workspace, and biased toward silence over noise.</p>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon steel">🌅</div>
+        <h3>SessionStart recall</h3>
+        <p>When a session begins, a hook automatically runs <code>check_intentions</code> and a hybrid search for the current context — so the agent opens with what it already knows, before it reads a single file.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon cyan">✍️</div>
+        <h3>Turn capture</h3>
+        <p>A turn-capture hook persists conversation turns into context segments and queues consolidation, so today's work becomes tomorrow's recallable memory without an explicit save step.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon graph">🧭</div>
+        <h3>Workspace isolation</h3>
+        <p>0.15 derives stable, per-workspace hook sessions instead of leaning on process-global state — and fallback recall stays semantic and procedural, never a raw episodic transcript leaking across sessions.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon lock">🤫</div>
+        <h3>Prefer silence over noise</h3>
+        <p>Recall-relevance guards, lexical-overlap checks, and workspace filtering mean a hook would rather surface nothing than inject low-confidence context. Quiet recall keeps the agent's window clean.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon observe">⏳</div>
+        <h3>Intentions — prospective memory</h3>
+        <p><code>set_intention</code> defers an action to fire later on a Topic, FilePattern, Duration, or Context trigger; <code>check_intentions</code> fires the matching ones at session start. Memory remembers not just the past, but what to do next.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon index">📌</div>
+        <h3>Durable session tasks</h3>
+        <p>A focus stack, working set, and recovery hints survive restarts and support multi-agent handoff — so an interrupted agent can pick up exactly where the last one left off.</p>
+      </div>
+    </div>
+  </section>
+</section>
+
+<!-- ═══════════════════ CTA ═══════════════════ -->
+<section id="get-started" class="cta-section">
+  <h2>See it as tools, and against the alternatives.</h2>
+  <p>The architecture is the why. The tool catalog is the how — and the comparison shows what structured memory buys you over a vector store.</p>
+  <div class="hero-actions">
+    <a href="tools.html" class="btn-primary">Browse the tools</a>
+    <a href="compare.html" class="btn-secondary">Compare alternatives</a>
+  </div>
+</section>
+
+<footer>
+  <div style="max-width: 1200px; margin: 0 auto; padding: 3rem 2rem; border-top: 1px solid var(--border); display:flex; justify-content:space-between; gap:2rem; flex-wrap:wrap; color:var(--text-muted);">
+    <div>Ferrosa Memory <span style="color:var(--accent);">0.15</span> · Developer preview</div>
+    <div style="display:flex; gap:1rem; flex-wrap:wrap;">
+      <a href="./" style="color:var(--text-secondary); text-decoration:none;">Overview</a>
+      <a href="how-it-works.html" style="color:var(--text-secondary); text-decoration:none;">How it works</a>
+      <a href="tools.html" style="color:var(--text-secondary); text-decoration:none;">Tools</a>
+      <a href="compare.html" style="color:var(--text-secondary); text-decoration:none;">Compare</a>
+      <a href="getting-started.html" style="color:var(--text-secondary); text-decoration:none;">Setup</a>
+      <a href="../database/" style="color:var(--text-secondary); text-decoration:none;">Database</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll('nav').forEach((nav) => {
+    const toggle = nav.querySelector('.nav-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+      const open = nav.classList.toggle('nav-open');
+      toggle.setAttribute('aria-expanded', String(open));
+      toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Open navigation');
+    });
+    nav.querySelectorAll('.nav-links a').forEach((link) => {
+      link.addEventListener('click', () => {
+        nav.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.setAttribute('aria-label', 'Open navigation');
+      });
+    });
+  });
+</script>
+</body>
+</html>

--- a/docs/ferrosa-memory/index.html
+++ b/docs/ferrosa-memory/index.html
@@ -4,26 +4,27 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ferrosa Memory — Long-Context Linked Memory for Agents</title>
-  <meta name="description" content="Ferrosa Memory is a developer-preview memory system for agents with temporal facts, graph links, Datalog-style derived facts, query workbench, and visualization UI.">
-  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <title>Ferrosa Memory — Structured, Linked Memory for Agents</title>
+  <meta name="description" content="Ferrosa Memory is an MCP-native memory server for LLM agents: typed entity graph, bi-temporal facts, hybrid retrieval, Datalog-derived facts, dream-cycle consolidation, and auditable forgetting — backed by Ferrosa DB.">
+  <link rel="icon" type="image/svg+xml" href="assets/brand/fm-logo.svg">
   <style>
     :root {
-      --bg-primary: #0a0a0f;
-      --bg-secondary: #111118;
-      --bg-card: #16161f;
-      --bg-card-hover: #1c1c28;
-      --text-primary: #e8e8ed;
-      --text-secondary: #9494a3;
-      --text-muted: #6b6b7a;
-      --accent: #e2725b;
-      --accent-glow: rgba(226, 114, 91, 0.15);
-      --accent-secondary: #f4a261;
-      --accent-cool: #7c9cf5;
+      --bg-primary: #05070c;
+      --bg-secondary: #09111f;
+      --bg-card: #0e1828;
+      --bg-card-hover: #142337;
+      --text-primary: #e8eef7;
+      --text-secondary: #9fb0c6;
+      --text-muted: #647794;
+      --accent: #348cff;
+      --accent-glow: rgba(52, 140, 255, 0.18);
+      --accent-secondary: #7ee7ff;
+      --accent-cool: #7ee7ff;
+      --accent-steel: #516d92;
       --accent-green: #6bc9a0;
-      --border: #1e1e2a;
-      --border-hover: #2e2e3e;
-      --code-bg: #0d0d14;
+      --border: #17273d;
+      --border-hover: #25395a;
+      --code-bg: #060b14;
       --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
     }
@@ -46,7 +47,7 @@
       top: 0;
       width: 100%;
       z-index: 100;
-      background: rgba(10, 10, 15, 0.85);
+      background: rgba(5, 7, 12, 0.85);
       backdrop-filter: blur(20px);
       border-bottom: 1px solid var(--border);
       padding: 0 2rem;
@@ -160,6 +161,16 @@
       pointer-events: none;
     }
 
+    .hero-logo {
+      width: 88px;
+      height: 88px;
+      border-radius: 22px;
+      margin: 0 auto 1.75rem;
+      display: block;
+      box-shadow: 0 10px 40px rgba(52, 140, 255, 0.25);
+      position: relative;
+    }
+
     .hero-badge {
       display: inline-flex;
       align-items: center;
@@ -205,7 +216,7 @@
     .hero p {
       font-size: 1.25rem;
       color: var(--text-secondary);
-      max-width: 640px;
+      max-width: 680px;
       margin: 0 auto 2.5rem;
       line-height: 1.7;
     }
@@ -250,41 +261,6 @@
       background: var(--bg-card-hover);
     }
 
-    /* ── Stats bar ── */
-    .stats-bar {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: 1px;
-      background: var(--border);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      overflow: hidden;
-      margin-top: 4rem;
-    }
-
-    .stat {
-      background: var(--bg-secondary);
-      padding: 1.75rem 1.5rem;
-      text-align: center;
-    }
-
-    .stat-value {
-      font-size: 2rem;
-      font-weight: 800;
-      letter-spacing: -0.02em;
-      color: var(--text-primary);
-    }
-
-    .stat-value .unit { color: var(--accent); }
-
-    .stat-label {
-      font-size: 0.8125rem;
-      color: var(--text-muted);
-      margin-top: 0.25rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-
     /* ── Section headers ── */
     .section-label {
       font-size: 0.75rem;
@@ -306,7 +282,7 @@
     .section-subtitle {
       font-size: 1.125rem;
       color: var(--text-secondary);
-      max-width: 640px;
+      max-width: 680px;
       line-height: 1.7;
     }
 
@@ -326,40 +302,6 @@
     }
 
     .problem section { padding: 5rem 2rem; }
-
-    .pain-points {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 1.5rem;
-      margin-top: 3rem;
-    }
-
-    .pain-card {
-      background: var(--bg-primary);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 1.75rem;
-      transition: border-color 0.2s;
-    }
-
-    .pain-card:hover { border-color: var(--border-hover); }
-
-    .pain-icon {
-      font-size: 1.5rem;
-      margin-bottom: 1rem;
-    }
-
-    .pain-card h3 {
-      font-size: 1.0625rem;
-      font-weight: 700;
-      margin-bottom: 0.5rem;
-    }
-
-    .pain-card p {
-      font-size: 0.9375rem;
-      color: var(--text-secondary);
-      line-height: 1.6;
-    }
 
     /* ── Feature grid ── */
     .features-grid {
@@ -382,14 +324,6 @@
       transform: translateY(-2px);
     }
 
-    .feature-card.highlight {
-      grid-column: 1 / -1;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 3rem;
-      align-items: center;
-    }
-
     .feature-icon {
       width: 44px;
       height: 44px;
@@ -401,8 +335,8 @@
       margin-bottom: 1.25rem;
     }
 
-    .feature-icon.rust { background: rgba(226, 114, 91, 0.12); }
-    .feature-icon.s3 { background: rgba(244, 162, 97, 0.12); }
+    .feature-icon.steel { background: rgba(52, 140, 255, 0.14); }
+    .feature-icon.cyan { background: rgba(126, 231, 255, 0.14); }
     .feature-icon.cql { background: rgba(124, 156, 245, 0.12); }
     .feature-icon.graph { background: rgba(107, 201, 160, 0.12); }
     .feature-icon.lock { background: rgba(200, 130, 240, 0.12); }
@@ -420,71 +354,6 @@
       color: var(--text-secondary);
       line-height: 1.65;
     }
-
-    .feature-card .metric {
-      display: inline-block;
-      background: var(--bg-primary);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      padding: 0.25rem 0.625rem;
-      font-size: 0.8125rem;
-      font-family: var(--font-mono);
-      color: var(--accent);
-      margin-top: 0.75rem;
-    }
-
-    /* ── Code demo ── */
-    .code-demo {
-      background: var(--code-bg);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      overflow: hidden;
-    }
-
-    .code-tabs {
-      display: flex;
-      border-bottom: 1px solid var(--border);
-    }
-
-    .code-tab {
-      padding: 0.75rem 1.25rem;
-      font-size: 0.8125rem;
-      font-family: var(--font-mono);
-      color: var(--text-muted);
-      cursor: pointer;
-      border-bottom: 2px solid transparent;
-      transition: color 0.2s, border-color 0.2s;
-      background: none;
-      border-top: none;
-      border-left: none;
-      border-right: none;
-    }
-
-    .code-tab.active {
-      color: var(--accent);
-      border-bottom-color: var(--accent);
-    }
-
-    .code-tab:hover { color: var(--text-secondary); }
-
-    .code-block {
-      padding: 1.5rem;
-      font-family: var(--font-mono);
-      font-size: 0.875rem;
-      line-height: 1.8;
-      overflow-x: auto;
-      display: none;
-    }
-
-    .code-block.active { display: block; }
-
-    .code-block .kw { color: #c792ea; }
-    .code-block .fn { color: #82aaff; }
-    .code-block .str { color: #c3e88d; }
-    .code-block .cm { color: #546e7a; }
-    .code-block .num { color: #f78c6c; }
-    .code-block .type { color: #ffcb6b; }
-    .code-block .op { color: #89ddff; }
 
     /* ── Comparison table ── */
     .comparison {
@@ -542,110 +411,6 @@
     .check { color: var(--accent-green); }
     .cross { color: var(--text-muted); }
 
-    /* ── Architecture ── */
-    .arch-diagram {
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 3rem;
-      margin-top: 3rem;
-      text-align: center;
-    }
-
-    .arch-layers {
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-      max-width: 700px;
-      margin: 0 auto;
-    }
-
-    .arch-layer {
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-      background: var(--bg-primary);
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 1rem 1.5rem;
-      transition: border-color 0.2s;
-    }
-
-    .arch-layer:hover { border-color: var(--accent); }
-
-    .arch-layer-label {
-      font-size: 0.75rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--text-muted);
-      min-width: 100px;
-    }
-
-    .arch-layer-items {
-      display: flex;
-      gap: 0.5rem;
-      flex-wrap: wrap;
-    }
-
-    .arch-item {
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      padding: 0.375rem 0.75rem;
-      font-family: var(--font-mono);
-      font-size: 0.75rem;
-      color: var(--text-secondary);
-    }
-
-    .arch-arrow {
-      color: var(--text-muted);
-      font-size: 1.25rem;
-      text-align: center;
-    }
-
-    /* ── Use cases ── */
-    .use-cases {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 1.5rem;
-      margin-top: 3rem;
-    }
-
-    .use-case {
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 2rem;
-      transition: border-color 0.2s;
-    }
-
-    .use-case:hover { border-color: var(--border-hover); }
-
-    .use-case-label {
-      font-size: 0.75rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      margin-bottom: 0.75rem;
-    }
-
-    .use-case-label.migrate { color: var(--accent); }
-    .use-case-label.cloud { color: var(--accent-secondary); }
-    .use-case-label.graph-uc { color: var(--accent-green); }
-
-    .use-case h3 {
-      font-size: 1.125rem;
-      font-weight: 700;
-      margin-bottom: 0.625rem;
-    }
-
-    .use-case p {
-      font-size: 0.9375rem;
-      color: var(--text-secondary);
-      line-height: 1.65;
-    }
-
     /* ── CTA section ── */
     .cta-section {
       text-align: center;
@@ -663,51 +428,10 @@
       font-size: 1.125rem;
       color: var(--text-secondary);
       margin-bottom: 2.5rem;
-      max-width: 500px;
+      max-width: 520px;
       margin-left: auto;
       margin-right: auto;
     }
-
-    .cta-actions {
-      display: flex;
-      gap: 1rem;
-      justify-content: center;
-      flex-wrap: wrap;
-    }
-
-    /* ── Footer ── */
-    footer {
-      border-top: 1px solid var(--border);
-      padding: 3rem 2rem;
-    }
-
-    footer .footer-inner {
-      max-width: 1200px;
-      margin: 0 auto;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-
-    footer .footer-left {
-      font-size: 0.875rem;
-      color: var(--text-muted);
-    }
-
-    footer .footer-links {
-      display: flex;
-      gap: 1.5rem;
-      list-style: none;
-    }
-
-    footer .footer-links a {
-      color: var(--text-muted);
-      text-decoration: none;
-      font-size: 0.875rem;
-      transition: color 0.2s;
-    }
-
-    footer .footer-links a:hover { color: var(--text-secondary); }
 
     /* ── Beta Banner ── */
     .beta-banner {
@@ -738,11 +462,6 @@
 
     /* ── Responsive ── */
     @media (max-width: 768px) {
-      .stats-bar { grid-template-columns: repeat(2, 1fr); }
-      .feature-card.highlight {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-      }
       .features-grid { grid-template-columns: 1fr; }
       nav { padding: 0 1rem; }
       nav .nav-inner {
@@ -769,7 +488,7 @@
         flex-direction: column;
         gap: 0;
         padding: 0.5rem 1rem 1rem;
-        background: rgba(10, 10, 15, 0.98);
+        background: rgba(5, 7, 12, 0.98);
         border-bottom: 1px solid var(--border);
         box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
       }
@@ -796,7 +515,6 @@
       .comparison-table { font-size: 0.8125rem; }
       .comparison-table th,
       .comparison-table td { padding: 0.75rem 0.75rem; }
-      footer .footer-inner { flex-direction: column; gap: 1rem; }
     }
   </style>
 
@@ -804,31 +522,28 @@
   .suite-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap:1.5rem; margin-top:2.5rem; }
   .suite-card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:2rem; text-decoration:none; transition:border-color .2s, transform .2s, background .2s; }
   .suite-card:hover { border-color:var(--accent); transform:translateY(-2px); background:var(--bg-card-hover); }
-  .suite-card.memory:hover { border-color:var(--accent-cool); }
   .kicker { color:var(--accent); font-size:.75rem; letter-spacing:.12em; font-weight:800; text-transform:uppercase; margin-bottom:.75rem; }
-  .memory .kicker, .cool { color:var(--accent-cool); }
+  .cool { color:var(--accent-cool); }
   .pill-row { display:flex; flex-wrap:wrap; gap:.5rem; margin:1.25rem 0; }
   .pill { border:1px solid var(--border); background:var(--bg-secondary); color:var(--text-secondary); border-radius:999px; padding:.35rem .75rem; font-size:.8125rem; }
   .doc-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:1rem; margin-top:1.5rem; }
-  .doc-card { background:var(--bg-card); border:1px solid var(--border); border-radius:14px; padding:1.4rem; }
+  .doc-card { background:var(--bg-card); border:1px solid var(--border); border-radius:14px; padding:1.4rem; transition:border-color .2s; }
+  .doc-card:hover { border-color:var(--border-hover); }
   .doc-card h3 { margin-bottom:.5rem; }
   .doc-card p, .suite-card p { color:var(--text-secondary); }
+  .doc-card .tag { display:inline-block; font-family:var(--font-mono); font-size:.72rem; color:var(--accent-cool); margin-bottom:.5rem; letter-spacing:.04em; }
   .code-block { background:var(--code-bg); border:1px solid var(--border); border-radius:14px; padding:1.25rem; overflow:auto; margin:1rem 0; }
-  .code-block code, pre { font-family:var(--font-mono); font-size:.875rem; color:#d6d6e5; }
-  .note { border-left:3px solid var(--accent-cool); background:rgba(124,156,245,.08); padding:1rem 1.25rem; border-radius:0 12px 12px 0; color:var(--text-secondary); margin:1.5rem 0; }
+  .code-block code, pre { font-family:var(--font-mono); font-size:.875rem; color:#cfe0f5; }
+  .note { border-left:3px solid var(--accent-cool); background:rgba(126,231,255,.08); padding:1rem 1.25rem; border-radius:0 12px 12px 0; color:var(--text-secondary); margin:1.5rem 0; }
   .two-col { display:grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap:2rem; align-items:start; }
 
-  .screenshot-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap:1rem; margin-top:1.5rem; }
-  .screenshot-card { background:var(--bg-card); border:1px solid var(--border); border-radius:16px; overflow:hidden; }
-  .screenshot-card img { display:block; width:100%; height:auto; border-bottom:1px solid var(--border); }
-  .screenshot-card div { padding:1rem 1.2rem; color:var(--text-secondary); }
   .reference-table-wrap { margin-top:1.5rem; border:1px solid var(--border); border-radius:16px; overflow:hidden; background:rgba(255,255,255,.02); }
   .reference-table { width:100%; border-collapse:collapse; font-size:.875rem; }
   .reference-table caption { text-align:left; padding:1rem 1.1rem; color:var(--text-secondary); border-bottom:1px solid var(--border); }
   .reference-table th { text-align:left; padding:.75rem 1rem; color:var(--text-muted); font-size:.72rem; letter-spacing:.08em; text-transform:uppercase; background:rgba(255,255,255,.025); border-bottom:1px solid var(--border); }
   .reference-table td { padding:.8rem 1rem; color:var(--text-secondary); border-bottom:1px solid rgba(255,255,255,.055); vertical-align:top; }
   .reference-table tr:last-child td { border-bottom:0; }
-  .reference-table a { color:var(--text-primary); text-decoration:none; border-bottom:1px solid rgba(124,156,245,.35); }
+  .reference-table a { color:var(--text-primary); text-decoration:none; border-bottom:1px solid rgba(126,231,255,.35); }
   .reference-table a:hover { color:var(--accent-cool); border-bottom-color:var(--accent-cool); }
   .reference-table .ref-id { color:var(--accent-cool); font-family:var(--font-mono); white-space:nowrap; }
   .reference-table .ref-theme { color:var(--text-muted); white-space:nowrap; }
@@ -842,155 +557,142 @@
 <nav>
   <div class="nav-inner">
     <a href="/" class="logo" style="display:flex;align-items:center;gap:0.5rem;">
-      <img src="/favicon.svg" alt="Fe" width="28" height="28">
-      ferro<span>sa</span>
+      <img src="assets/brand/fm-logo.svg" alt="Fm" width="28" height="28" style="border-radius:7px;">
+      ferrosa <span>memory</span>
     </a>
     <ul class="nav-links" id="site-nav-links">
-      <li><a href="/database/">Database</a></li>
-      <li><a href="/ferrosa-memory/">Memory</a></li>
-      <li><a href="/ferrosa-memory/getting-started.html">Setup</a></li>
-      <li><a href="#examples">Examples</a></li>
+      <li><a href="./">Overview</a></li>
+      <li><a href="how-it-works.html">How it works</a></li>
+      <li><a href="tools.html">Tools</a></li>
+      <li><a href="compare.html">Compare</a></li>
+      <li><a href="getting-started.html">Setup</a></li>
+      <li><a href="../database/">Database</a></li>
       <li><a href="https://github.com/ferrosadb" target="_blank" rel="noopener noreferrer">GitHub</a></li>
     </ul>
-    <a href="#get-started" class="nav-cta">Get Started</a>
+    <a href="how-it-works.html" class="nav-cta">How it works</a>
     <button class="nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="site-nav-links"><span></span></button>
   </div>
 </nav>
 
 <div class="beta-banner">
-  <span class="beta-tag">Developer Preview</span> Ferrosa Memory is a 0.15.0 preview for agentic long-context memory.
+  <span class="beta-tag">Developer Preview</span> Ferrosa Memory 0.15 — structured, linked, auditable memory for agentic systems.
 </div>
 <section class="hero">
-  <div class="hero-badge"><span class="dot"></span> Ferrosa Memory · Developer Preview</div>
-  <h1>Linked memory for <span class="gradient">long-running agents.</span></h1>
-  <p>Ferrosa Memory gives agents a developer-preview memory layer: context segments, documents, entities, temporal facts, graph edges, hybrid retrieval, feedback-aware reranking, Datalog-style derived facts, and operator UIs for query, judge configuration, and visualization.</p>
+  <img class="hero-logo" src="assets/brand/fm-logo.svg" alt="Ferrosa Memory logo">
+  <div class="hero-badge"><span class="dot"></span> Ferrosa Memory · 0.15 · Developer Preview</div>
+  <h1>Memory your agents can <span class="gradient">query, link, and trust.</span></h1>
+  <p>Ferrosa Memory is an MCP-native memory server for LLM agents. Instead of dumping text into a vector store, it keeps a typed entity graph, bi-temporal facts, raw context segments, and Datalog-derived knowledge — retrieved with hybrid search, consolidated automatically, and forgettable with a full audit trail.</p>
   <div class="hero-actions">
-    <a href="getting-started.html" class="btn-primary">Quickstart</a>
-    <a href="#workbench" class="btn-secondary">Explore the UI</a>
+    <a href="how-it-works.html" class="btn-primary">See how it works</a>
+    <a href="compare.html" class="btn-secondary">Compare alternatives</a>
   </div>
 </section>
+
 <section id="overview">
   <div class="section-label cool">Why it exists</div>
-  <h2>Agents need memory that is structured, explainable, and queryable.</h2>
+  <h2 class="section-title">Most "agent memory" is a vector store with a summary on top.</h2>
+  <p class="section-subtitle">That loses the things agents actually need: when a fact changed, how facts relate, why a memory exists, and how to safely remove it. Ferrosa Memory treats memory as structured, queryable data — not opaque text.</p>
   <div class="doc-grid">
-    <div class="doc-card"><h3>Temporal facts</h3><p>Record what changed over time instead of overwriting history. Current facts stay easy to retrieve, while superseded facts remain inspectable for audit and debugging.</p></div>
-    <div class="doc-card"><h3>Graph links</h3><p>Entities, folds, facts, skills, and tags are connected with typed edges so an agent can follow relationships rather than only search text.</p></div>
-    <div class="doc-card"><h3>Retrieval + context windows</h3><p>Hybrid retrieval uses lexical, vector, phonetic, graph, workspace, and recency signals, then can expand around raw context or document chunks to recover neighboring evidence.</p></div>
-    <div class="doc-card"><h3>Datalog-style materialization</h3><p>Rules can derive and explain higher-level facts from graph state, making memory behavior easier to inspect than opaque summaries alone.</p></div>
+    <div class="doc-card"><h3>Bi-temporal facts</h3><p>Record what changed over time instead of overwriting history. The current fact stays easy to retrieve, while superseded facts remain inspectable for audit, debugging, and time-travel queries.</p></div>
+    <div class="doc-card"><h3>Typed entity graph</h3><p>Entities, folds, facts, skills, and tags are connected with typed edges (<code>depends_on</code>, <code>contains</code>, <code>calls</code>, <code>references</code>…) so an agent can follow relationships, not just match text.</p></div>
+    <div class="doc-card"><h3>Hybrid retrieval</h3><p>Recall fuses lexical, vector, phonetic, graph, workspace, and recency signals with Reciprocal Rank Fusion, then expands around raw context or document chunks to recover neighboring evidence.</p></div>
+    <div class="doc-card"><h3>Explainable derivation</h3><p>Datalog-style rules derive and <em>explain</em> higher-level facts from graph state, so memory behavior can be inspected and audited instead of trusted blindly.</p></div>
+    <div class="doc-card"><h3>Auditable forgetting</h3><p>The 0.15 <code>forget</code> flow shows the blast radius before anything changes, then retracts reversibly (or hard-deletes) with an append-only journal. Memory you can remove is memory you can trust.</p></div>
+    <div class="doc-card"><h3>Durable, tiered storage</h3><p>Built on Ferrosa DB: CQL storage, HNSW vector indexes, a property graph, and S3-backed durability with hot/warm/cold tiering. Memory survives restarts and scales past one process.</p></div>
   </div>
 </section>
-<section id="release-notes">
-  <div class="section-label cool">0.13 preview highlights</div>
-  <h2>Long-recall work is now wired into the memory service.</h2>
-  <div class="doc-grid">
-    <div class="doc-card"><h3>Document retrieval plane</h3><p>Documents, sections, chunks, and adjacency links can be stored as typed memory so answers that span neighboring chunks can be traversed instead of relying on a single ranked hit.</p></div>
-    <div class="doc-card"><h3>Candidate fanout + fusion</h3><p>Hybrid search can gather candidates from exact/document IDs, BM25, semantic vectors, phonetic matches, workspace boosts, graph neighbors, and recent session context before fusion.</p></div>
-    <div class="doc-card"><h3>Task-aware decomposition</h3><p>BRIGHT-Pro-style queries can generate task-native subqueries and merge candidate pools before final ranking, improving the support-doc-closed eval slice.</p></div>
-    <div class="doc-card"><h3>Feedback learning loop</h3><p>Agents, users, and optional judge models can send compact item feedback. Abstentions are tracked separately, and future ranking can account for workspace-specific relevance.</p></div>
-  </div>
-  <div class="note">Best known 0.13 BRIGHT-Pro support-doc-closed MCP slice settings: retrieval_k=25, candidate_limit=50, fusion_profile=all, query_decomposition=llm, query_embed_variants=true, chunk_expansion=none, rerank=false. On the 200-document biology slice this measured alpha_nDCG 0.816, NDCG 0.799, aspect_recall 0.940, and recall 0.796.</div>
-</section>
-<section id="architecture">
-  <div class="section-label">Architecture</div>
-  <h2>A thin memory adapter over database, graph, and inference surfaces.</h2>
-  <div class="two-col">
-    <div>
-      <p style="color:var(--text-secondary);">Ferrosa Memory exposes an MCP-compatible memory service and an operator workbench. The memory layer owns memory semantics—entities, folds, facts, retrieval outcomes, intentions, skills, Datalog rules, explanations—while Ferrosa Database provides CQL storage, graph traversal, and query surfaces.</p>
-      <p style="color:var(--text-secondary);">The public contract is intentionally small: agents call tools to ingest, retrieve, link, and explain memory. Operators use the workbench and visualization UI to inspect what happened.</p>
-    </div>
-    <div class="code-block"><pre><code>Agent / IDE / runtime
-        │ MCP
+
+<section id="how" class="problem">
+  <section>
+    <div class="section-label cool">How it works</div>
+    <h2 class="section-title">A thin memory layer over database, graph, and inference.</h2>
+    <div class="two-col">
+      <div>
+        <p style="color:var(--text-secondary);">Agents talk to Ferrosa Memory through a small set of MCP tools — ingest, retrieve, link, explain, and forget. The memory layer owns memory <em>semantics</em>: entities, folds, temporal facts, retrieval outcomes, intentions, skills, Datalog rules, and explanations.</p>
+        <p style="color:var(--text-secondary); margin-top:1rem;">Underneath, Ferrosa Database provides CQL storage, vector indexes, graph traversal, and durable S3-backed tiering. A background "dream cycle" consolidates new memories — discovering connections, scoring importance, and decaying stale recall — while you sleep.</p>
+        <p style="margin-top:1.5rem;"><a href="how-it-works.html" class="btn-secondary">Read the full architecture →</a></p>
+      </div>
+      <div class="code-block"><pre><code>Agent / IDE / runtime
+        │ MCP tools
         ▼
 Ferrosa Memory service
-  ├─ memory tools + routing
-  ├─ temporal facts + folds
+  ├─ entities + typed graph
+  ├─ bi-temporal facts
+  ├─ context segments + folds
+  ├─ hybrid retrieval (RRF)
+  ├─ dream-cycle consolidation
   ├─ Datalog-derived facts
-  ├─ Workbench query UIs
-  └─ Viz graph surface
+  └─ auditable forget journal
         │
         ▼
-Ferrosa Database storage + graph</code></pre></div>
-  </div>
+Ferrosa Database
+  CQL · HNSW vectors · graph · S3 tiering</code></pre></div>
+    </div>
+  </section>
 </section>
-<section id="workbench">
-  <div class="section-label cool">Workbench and visualization</div>
-  <h2>Query memory directly, then inspect what was linked.</h2>
-  <div class="doc-grid">
-    <div class="doc-card"><h3>Workbench</h3><p>The browser workbench includes Home, Viz, CQL Explorer, SPARQL Explorer, Datalog Explorer, Judge Config, Aliases, Rules, Approvals, and Explanations.</p></div>
-    <div class="doc-card"><h3>Query APIs</h3><p>Use <code>/workbench/api/cql/query</code>, <code>/workbench/api/sparql/query</code>, and <code>/workbench/api/datalog/query</code> while evaluating storage, graph, and derived-memory behavior.</p></div>
-    <div class="doc-card"><h3>Visualization</h3><p>The viz surface is served separately from the main memory API. In local developer preview, it is available at <code>http://localhost:18766/viz</code>.</p></div>
+
+<section id="tools">
+  <div class="section-label cool">Tool catalog</div>
+  <h2 class="section-title">Two tiers: a focused default set, and the full toolbox.</h2>
+  <p class="section-subtitle">Agents see a focused <strong>Tier&nbsp;1</strong> set of everyday tools by default. The full <strong>Tier&nbsp;2</strong> surface — batch operations, folds, bi-temporal facts, memo &amp; plan tracking, skills, consolidation, and the Datalog governance plane — unlocks with <code>include_all</code> when an operator needs it.</p>
+  <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon steel">🧰</div>
+      <h3>Tier 1 — Everyday memory (21 tools)</h3>
+      <p>Ingest and recall: <code>smart_ingest</code>, <code>hybrid_search</code>, entity lookup, typed edges, chunk &amp; turn context, intention checks, the full session-task surface, feedback, stats, <code>configure</code>, and <code>forget</code>. Everything an agent reaches for in a normal session.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon cyan">⚙️</div>
+      <h3>Tier 2 — Advanced &amp; operator (58 tools)</h3>
+      <p>Batch ingest/edit, trajectory folds, bi-temporal facts, memo &amp; plans, the intention lifecycle, stored skills, dream-cycle consolidation &amp; graph inference, the Datalog expert system (rules, claims, approvals, explanations), and config/introspection.</p>
+    </div>
   </div>
-  <div class="screenshot-grid">
-    <a class="screenshot-card" href="/assets/screenshots/ferrosa-memory-viz.png">
-      <img src="/assets/screenshots/ferrosa-memory-viz.png" alt="Ferrosa Memory visualization graph screenshot">
-      <div><strong>Memory visualization.</strong> Inspect linked entities and edges in the local preview graph UI.</div>
-    </a>
-    <a class="screenshot-card" href="/assets/screenshots/ferrosa-operations-console.png">
-      <img src="/assets/screenshots/ferrosa-operations-console.png" alt="Ferrosa operations console screenshot">
-      <div><strong>Operations console.</strong> Check node status, metrics, and operational views from a running Ferrosa system.</div>
-    </a>
-  </div>
-  <div class="note">In shared deployments, keep the visualization surface operator-only. The preview docs assume loopback/local use unless you explicitly configure TLS, auth, and tenant mappings.</div>
+  <p style="margin-top:2rem;"><a href="tools.html" class="btn-secondary">Browse the full tool catalog by level →</a></p>
 </section>
-<section id="quickstart">
-  <div class="section-label">Quickstart</div>
-  <h2>Local developer preview configuration.</h2>
-  <p style="color:var(--text-secondary); max-width:780px;">For the shortest path, run the hosted memory setup script. It downloads the onboarding prompt, optionally clones or updates the public repositories, offers to pull <code>nomic-embed-text-v2-moe</code>, installs Hermes/Claude/Codex hooks when requested, and hands the user to an LLM harness. Minimal native mode can use local filesystem storage with no S3/MinIO; the full Compose mode adds a three-node cluster and MinIO for operator testing.</p>
-  <div class="code-block"><pre><code>curl -fsSL https://ferrosadb.com/setup-memory.sh | bash
 
-# Optional semantic/vector search layer:
-ollama pull nomic-embed-text-v2-moe
-
-# ferrosa-memory.toml — local preview shape
-[server]
-transport = "http"
-http_port = 18765
-
-[ferrosa]
-contact_points = ["127.0.0.1:19042"]
-keyspace = "agent_memory"
-
-[viz]
-enabled = true
-bind = "127.0.0.1:18766"
-
-[retrieval]
-default_limit = 10
-
-[embeddings]
-provider = "ollama"
-model = "nomic-embed-text-v2-moe"
-dimensions = 768
-
-[security]
-# For local preview only. Use TLS + auth mapping for shared deployment.
-require_tls = false</code></pre></div>
-  <div class="code-block"><pre><code># Local URLs
-MCP endpoint:      http://localhost:18765/mcp
-Workbench:         http://localhost:18765/
-Visualization:     http://localhost:18766/viz
-Viz snapshot API:  http://localhost:18766/viz/snapshot</code></pre></div>
+<section id="whats-new" class="comparison">
+  <section>
+    <div class="section-label cool">What's new in 0.15</div>
+    <h2 class="section-title">Recall you can trust, and memory you can remove.</h2>
+    <div class="doc-grid">
+      <div class="doc-card"><span class="tag">forget</span><h3>Auditable forgetting</h3><p>Propose candidates, see the blast radius (edges, temporal chains, derived facts), then confirm a reversible retraction or a hard delete — all recorded in an append-only forget journal with crash recovery.</p></div>
+      <div class="doc-card"><span class="tag">recall</span><h3>Recall-relevance hardening</h3><p>Source-aware relevance guards, lexical-overlap checks, authority/PageRank adjustments, and workspace filtering so hooks prefer silence over noisy context. Native full-text indexing speeds lexical recall.</p></div>
+      <div class="doc-card"><span class="tag">session</span><h3>Durable session tasks</h3><p>First-class task state — focus stack, working set, and recovery hints — survives restarts and supports multi-agent handoff, so an interrupted agent can resume where it left off.</p></div>
+      <div class="doc-card"><span class="tag">hooks</span><h3>Workspace-isolated hooks</h3><p>Session-start recall derives stable, workspace-specific sessions instead of leaking process-global state, and fallback recall stays semantic/procedural — never raw episodic transcript.</p></div>
+    </div>
+    <div class="note">0.15 is a developer-preview release. Run it locally or self-hosted; keep the workbench and visualization surfaces operator-only unless you configure TLS, auth, and tenant isolation.</div>
+  </section>
 </section>
-<section id="examples">
-  <div class="section-label cool">Examples</div>
-  <h2>What agents can do with Ferrosa Memory.</h2>
-  <div class="doc-grid">
-    <div class="doc-card"><h3>Remember evolving project state</h3><p>Record an entity once, then write temporal facts as status changes. Ask for the current fact or inspect the supersession chain.</p></div>
-    <div class="doc-card"><h3>Link context into a graph</h3><p>Ingest raw conversation segments, extract entities, add typed edges, then retrieve adjacent memories by graph traversal.</p></div>
-    <div class="doc-card"><h3>Explain derived facts</h3><p>Use Datalog rules and explanation endpoints to show why a derived memory exists instead of treating memory as uninspectable text.</p></div>
-    <div class="doc-card"><h3>Operate the system</h3><p>Use liveness/readiness probes, metrics, query explorers, and the visualization UI to check whether memory is being recorded and linked as expected.</p></div>
-  </div>
+
+<section id="compare">
+  <div class="section-label cool">How it compares</div>
+  <h2 class="section-title">Built for structure, not just similarity.</h2>
+  <p class="section-subtitle">Vector stores and most memory layers answer "what looks similar?" Ferrosa Memory also answers "what changed, what's connected, why does this exist, and can I safely remove it?"</p>
+  <table class="comparison-table">
+    <thead>
+      <tr>
+        <th>Capability</th>
+        <th class="ferrosa-col">Ferrosa Memory</th>
+        <th>Vector store + RAG</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>Typed knowledge graph</td><td class="ferrosa-col">Yes</td><td>No — similarity only</td></tr>
+      <tr><td>Bi-temporal fact history</td><td class="ferrosa-col">Yes</td><td>Overwrite / append</td></tr>
+      <tr><td>Hybrid retrieval (lexical+vector+graph+recency)</td><td class="ferrosa-col">Yes — RRF over ~11 signals</td><td>Vector (± keyword)</td></tr>
+      <tr><td>Explainable derived facts</td><td class="ferrosa-col">Yes — Datalog</td><td>No</td></tr>
+      <tr><td>Auditable forgetting</td><td class="ferrosa-col">Yes — blast radius + journal</td><td>Manual delete</td></tr>
+      <tr><td>Automatic consolidation</td><td class="ferrosa-col">Yes — dream cycle</td><td>No</td></tr>
+      <tr><td>MCP-native tools</td><td class="ferrosa-col">Yes</td><td>Framework-dependent</td></tr>
+    </tbody>
+  </table>
+  <p style="margin-top:2rem;"><a href="compare.html" class="btn-secondary">See the full comparison vs. Mem0, Zep, and Letta →</a></p>
 </section>
+
 <section id="research">
   <div class="section-label">Research foundation</div>
-  <h2>Inspired by memory systems, graph retrieval, compression, and logic.</h2>
-  <p style="color:var(--text-secondary); max-width:820px;">Ferrosa Memory is product engineering, not a paper implementation, but the design is informed by recent and classic work on agent memory, virtual context, retrieval, Datalog-style inference, and memory evaluation.</p>
-  <div class="doc-grid">
-    <div class="doc-card"><h3>Agent memory systems</h3><p>The local research corpus includes papers on very-long-term conversational memory, episodic memory, cross-domain user memory, and multi-session agent tasks. These motivate temporal facts, context windows, and explicit update history.</p></div>
-    <div class="doc-card"><h3>Graph retrieval</h3><p>Graph-recall and GraphRAG work motivate making links inspectable instead of relying only on vector similarity. Ferrosa Memory borrows these ideas; it is not a direct implementation of any one paper.</p></div>
-    <div class="doc-card"><h3>Compression and evaluation</h3><p>LLMLingua-family prompt compression, long-memory benchmarks, and memory-system surveys shape how retrieval, summarization, and memory quality should be evaluated during preview.</p></div>
-    <div class="doc-card"><h3>Logic and safety</h3><p>Datalog-style derived facts and neuro-symbolic rule-evaluation work inform explainable memory operations. Preview deployments should keep memory tooling local or explicitly protected with TLS, auth, tenant isolation, and operator review.</p></div>
-  </div>
+  <h2 class="section-title">Engineering informed by the memory literature.</h2>
+  <p class="section-subtitle">Ferrosa Memory is product engineering, not a paper implementation — but the design draws on recent and classic work on agent memory, virtual context, graph retrieval, prompt compression, Datalog-style inference, and memory evaluation.</p>
   <div class="reference-table-wrap">
     <table class="reference-table">
       <caption>Selected references from the local research corpus. Links point to canonical arXiv records.</caption>
@@ -1001,37 +703,35 @@ Viz snapshot API:  http://localhost:18766/viz/snapshot</code></pre></div>
         <tr><td><a href="https://arxiv.org/abs/2402.17753">LoCoMo: Evaluating Very Long-Term Conversational Memory of LLM Agents</a></td><td class="ref-id">2402.17753</td><td class="ref-theme">long-term conversational memory</td></tr>
         <tr><td><a href="https://arxiv.org/abs/2410.10813">LongMemEval: Benchmarking Chat Assistants on Long-Term Interactive Memory</a></td><td class="ref-id">2410.10813</td><td class="ref-theme">memory evaluation</td></tr>
         <tr><td><a href="https://arxiv.org/abs/2509.18868">Memory in Large Language Models: Mechanisms, Evaluation and Evolution</a></td><td class="ref-id">2509.18868</td><td class="ref-theme">memory taxonomy</td></tr>
-        <tr><td><a href="https://arxiv.org/abs/2603.25973">MemoryCD: Benchmarking Long-Context User Memory for Lifelong Cross-Domain Personalization</a></td><td class="ref-id">2603.25973</td><td class="ref-theme">cross-domain user memory</td></tr>
         <tr><td><a href="https://arxiv.org/abs/2502.06975">Episodic Memory is the Missing Piece for Long-Term LLM Agents</a></td><td class="ref-id">2502.06975</td><td class="ref-theme">episodic memory</td></tr>
-        <tr><td><a href="https://arxiv.org/abs/2602.16313">Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks</a></td><td class="ref-id">2602.16313</td><td class="ref-theme">multi-session agents</td></tr>
         <tr><td><a href="https://arxiv.org/abs/2402.11821">Microstructures and Accuracy of Graph Recall by Large Language Models</a></td><td class="ref-id">2402.11821</td><td class="ref-theme">graph recall</td></tr>
         <tr><td><a href="https://arxiv.org/abs/2404.16130">From Local to Global: A Graph RAG Approach to Query-Focused Summarization</a></td><td class="ref-id">2404.16130</td><td class="ref-theme">GraphRAG</td></tr>
-        <tr><td><a href="https://arxiv.org/abs/2310.05736">LLMLingua: Compressing Prompts for Accelerated Inference of Large Language Models</a></td><td class="ref-id">2310.05736</td><td class="ref-theme">prompt compression</td></tr>
         <tr><td><a href="https://arxiv.org/abs/2310.06839">LongLLMLingua: Accelerating and Enhancing LLMs in Long Context Scenarios via Prompt Compression</a></td><td class="ref-id">2310.06839</td><td class="ref-theme">long-context compression</td></tr>
         <tr><td><a href="https://arxiv.org/abs/2402.04617">InfLLM: Training-Free Long-Context Extrapolation for LLMs with an Efficient Context Memory</a></td><td class="ref-id">2402.04617</td><td class="ref-theme">context memory</td></tr>
-        <tr><td><a href="https://arxiv.org/abs/2604.28087">Towards Neuro-symbolic Causal Rule Synthesis, Verification, and Evaluation Grounded in Legal and Safety Principles</a></td><td class="ref-id">2604.28087</td><td class="ref-theme">rules + verification</td></tr>
-        <tr><td><a href="https://arxiv.org/abs/2605.04018">Rethinking Reasoning-Intensive Retrieval: Evaluating and Advancing Retrievers in Agentic Search Systems</a></td><td class="ref-id">2605.04018</td><td class="ref-theme">agentic retrieval</td></tr>
       </tbody>
     </table>
   </div>
 </section>
+
 <section id="get-started" class="cta-section">
-  <h2>Preview Ferrosa Memory with your agents.</h2>
-  <p>Start local, inspect memory in the workbench, and use the viz surface to check how context is becoming linked memory.</p>
+  <h2>Give your agents memory worth keeping.</h2>
+  <p>Start local, inspect memory in the workbench, and watch raw context become linked, durable, queryable memory.</p>
   <div class="hero-actions">
-    <a href="getting-started.html" class="btn-primary">Configure local preview</a>
-    <a href="../database/" class="btn-secondary">Use Ferrosa Database</a>
+    <a href="how-it-works.html" class="btn-primary">How it works</a>
+    <a href="getting-started.html" class="btn-secondary">Set up locally</a>
   </div>
 </section>
+
 <footer>
   <div style="max-width: 1200px; margin: 0 auto; padding: 3rem 2rem; border-top: 1px solid var(--border); display:flex; justify-content:space-between; gap:2rem; flex-wrap:wrap; color:var(--text-muted);">
-    <div>Ferrosa Suite <span style="color:var(--accent);">0.15.0</span> · Developer preview</div>
+    <div>Ferrosa Memory <span style="color:var(--accent);">0.15</span> · Developer preview</div>
     <div style="display:flex; gap:1rem; flex-wrap:wrap;">
+      <a href="./" style="color:var(--text-secondary); text-decoration:none;">Overview</a>
+      <a href="how-it-works.html" style="color:var(--text-secondary); text-decoration:none;">How it works</a>
+      <a href="tools.html" style="color:var(--text-secondary); text-decoration:none;">Tools</a>
+      <a href="compare.html" style="color:var(--text-secondary); text-decoration:none;">Compare</a>
+      <a href="getting-started.html" style="color:var(--text-secondary); text-decoration:none;">Setup</a>
       <a href="../database/" style="color:var(--text-secondary); text-decoration:none;">Database</a>
-      <a href="./" style="color:var(--text-secondary); text-decoration:none;">Memory</a>
-      <a href="../database/getting-started.html" style="color:var(--text-secondary); text-decoration:none;">DB Docs</a>
-      <a href="getting-started.html" style="color:var(--text-secondary); text-decoration:none;">Memory Setup</a>
-      <a href="#examples" style="color:var(--text-secondary); text-decoration:none;">Memory Examples</a>
     </div>
   </div>
 </footer>

--- a/docs/ferrosa-memory/tools.html
+++ b/docs/ferrosa-memory/tools.html
@@ -1,0 +1,993 @@
+<!DOCTYPE html>
+<!-- ferrosadb.com marketing site -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ferrosa Memory — Tool Catalog by Level</title>
+  <meta name="description" content="Ferrosa Memory's tools across two tiers: Tier 1 is the focused 21-tool everyday memory set agents get by default; Tier 2 unlocks 58 advanced and operator tools with include_all. 79 MCP memory tools in all.">
+  <link rel="icon" type="image/svg+xml" href="assets/brand/fm-logo.svg">
+  <style>
+    :root {
+      --bg-primary: #05070c;
+      --bg-secondary: #09111f;
+      --bg-card: #0e1828;
+      --bg-card-hover: #142337;
+      --text-primary: #e8eef7;
+      --text-secondary: #9fb0c6;
+      --text-muted: #647794;
+      --accent: #348cff;
+      --accent-glow: rgba(52, 140, 255, 0.18);
+      --accent-secondary: #7ee7ff;
+      --accent-cool: #7ee7ff;
+      --accent-steel: #516d92;
+      --accent-green: #6bc9a0;
+      --border: #17273d;
+      --border-hover: #25395a;
+      --code-bg: #060b14;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* ── Navigation ── */
+    nav {
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 100;
+      background: rgba(5, 7, 12, 0.85);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border);
+      padding: 0 2rem;
+    }
+
+    nav .nav-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 64px;
+    }
+
+    nav .logo {
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--text-primary);
+      text-decoration: none;
+    }
+
+    nav .logo span { color: var(--accent); }
+
+    nav .nav-links {
+      display: flex;
+      gap: 2rem;
+      list-style: none;
+    }
+
+    nav .nav-links a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    nav .nav-links a:hover { color: var(--text-primary); }
+
+    nav .nav-cta {
+      background: var(--accent);
+      color: #fff;
+      padding: 0.5rem 1.25rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 600;
+      transition: opacity 0.2s;
+    }
+
+    nav .nav-cta:hover { opacity: 0.9; }
+
+    nav .nav-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      width: 2.5rem;
+      height: 2.5rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-card);
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+
+    nav .nav-toggle span,
+    nav .nav-toggle span::before,
+    nav .nav-toggle span::after {
+      display: block;
+      width: 1.1rem;
+      height: 2px;
+      border-radius: 2px;
+      background: currentColor;
+      content: '';
+      transition: transform 0.2s, opacity 0.2s;
+    }
+
+    nav .nav-toggle span { position: relative; }
+    nav .nav-toggle span::before { position: absolute; transform: translateY(-6px); }
+    nav .nav-toggle span::after { position: absolute; transform: translateY(6px); }
+
+    nav.nav-open .nav-toggle span { background: transparent; }
+    nav.nav-open .nav-toggle span::before { background: var(--text-primary); transform: rotate(45deg); }
+    nav.nav-open .nav-toggle span::after { background: var(--text-primary); transform: rotate(-45deg); }
+
+    /* ── Sections ── */
+    section {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 6rem 2rem;
+    }
+
+    /* ── Hero ── */
+    .hero {
+      padding-top: 11rem;
+      padding-bottom: 6rem;
+      text-align: center;
+      position: relative;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -60%);
+      width: 600px;
+      height: 600px;
+      background: radial-gradient(circle, var(--accent-glow) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    .hero-logo {
+      width: 88px;
+      height: 88px;
+      border-radius: 22px;
+      margin: 0 auto 1.75rem;
+      display: block;
+      box-shadow: 0 10px 40px rgba(52, 140, 255, 0.25);
+      position: relative;
+    }
+
+    .hero-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 100px;
+      padding: 0.375rem 1rem;
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+      margin-bottom: 2rem;
+    }
+
+    .hero-badge .dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-green);
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+
+    .hero h1 {
+      font-size: clamp(2.5rem, 6vw, 4.5rem);
+      font-weight: 800;
+      line-height: 1.08;
+      letter-spacing: -0.03em;
+      margin-bottom: 1.5rem;
+      position: relative;
+    }
+
+    .hero h1 .gradient {
+      background: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero p {
+      font-size: 1.25rem;
+      color: var(--text-secondary);
+      max-width: 680px;
+      margin: 0 auto 2.5rem;
+      line-height: 1.7;
+    }
+
+    .hero-actions {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+      padding: 0.75rem 2rem;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 1rem;
+      transition: transform 0.15s, box-shadow 0.15s;
+    }
+
+    .btn-primary:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 30px var(--accent-glow);
+    }
+
+    .btn-secondary {
+      background: var(--bg-card);
+      color: var(--text-primary);
+      padding: 0.75rem 2rem;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 1rem;
+      border: 1px solid var(--border);
+      transition: border-color 0.2s, background 0.2s;
+    }
+
+    .btn-secondary:hover {
+      border-color: var(--border-hover);
+      background: var(--bg-card-hover);
+    }
+
+    /* ── Section headers ── */
+    .section-label {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+
+    .section-title {
+      font-size: clamp(1.75rem, 4vw, 2.75rem);
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin-bottom: 1rem;
+      line-height: 1.15;
+    }
+
+    .section-subtitle {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      max-width: 680px;
+      line-height: 1.7;
+    }
+
+    .section-subtitle.centered {
+      margin: 0 auto;
+      text-align: center;
+    }
+
+    .section-title.centered { text-align: center; }
+    .section-label.centered { text-align: center; }
+
+    /* ── Problem section ── */
+    .problem {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .problem section { padding: 5rem 2rem; }
+
+    /* ── Feature grid ── */
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+
+    .feature-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 2.25rem;
+      transition: border-color 0.2s, transform 0.15s;
+    }
+
+    .feature-card:hover {
+      border-color: var(--border-hover);
+      transform: translateY(-2px);
+    }
+
+    .feature-icon {
+      width: 44px;
+      height: 44px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.25rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .feature-icon.steel { background: rgba(52, 140, 255, 0.14); }
+    .feature-icon.cyan { background: rgba(126, 231, 255, 0.14); }
+    .feature-icon.cql { background: rgba(124, 156, 245, 0.12); }
+    .feature-icon.graph { background: rgba(107, 201, 160, 0.12); }
+    .feature-icon.lock { background: rgba(200, 130, 240, 0.12); }
+    .feature-icon.index { background: rgba(100, 200, 220, 0.12); }
+    .feature-icon.observe { background: rgba(240, 200, 100, 0.12); }
+
+    .feature-card h3 {
+      font-size: 1.1875rem;
+      font-weight: 700;
+      margin-bottom: 0.625rem;
+    }
+
+    .feature-card p {
+      font-size: 0.9375rem;
+      color: var(--text-secondary);
+      line-height: 1.65;
+    }
+
+    /* ── Comparison table ── */
+    .comparison {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 3rem;
+      font-size: 0.9375rem;
+    }
+
+    .comparison-table th,
+    .comparison-table td {
+      text-align: left;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .comparison-table thead th {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+
+    .comparison-table thead th:first-child { color: var(--text-secondary); }
+
+    .comparison-table thead th.ferrosa-col {
+      color: var(--accent);
+    }
+
+    .comparison-table tbody td:first-child {
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .comparison-table tbody td {
+      color: var(--text-secondary);
+    }
+
+    .comparison-table tbody td.ferrosa-col {
+      color: var(--accent-green);
+      font-weight: 600;
+    }
+
+    .comparison-table tbody tr:hover {
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    .check { color: var(--accent-green); }
+    .cross { color: var(--text-muted); }
+
+    /* ── CTA section ── */
+    .cta-section {
+      text-align: center;
+      padding: 6rem 2rem;
+    }
+
+    .cta-section h2 {
+      font-size: clamp(2rem, 4vw, 3rem);
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin-bottom: 1rem;
+    }
+
+    .cta-section p {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      margin-bottom: 2.5rem;
+      max-width: 520px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    /* ── Beta Banner ── */
+    .beta-banner {
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border);
+      text-align: center;
+      padding: 0.5rem 1rem;
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+      position: fixed;
+      top: 64px;
+      width: 100%;
+      z-index: 99;
+    }
+
+    .beta-tag {
+      display: inline-block;
+      background: var(--accent);
+      color: #fff;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+      vertical-align: middle;
+    }
+
+    /* ── Responsive ── */
+    @media (max-width: 768px) {
+      .features-grid { grid-template-columns: 1fr; }
+      nav { padding: 0 1rem; }
+      nav .nav-inner {
+        height: 64px;
+        min-height: 64px;
+        gap: 0.75rem;
+        padding: 0;
+        position: relative;
+      }
+      body { overflow-x: hidden; }
+      nav .logo { margin-right: auto; }
+      nav .nav-cta {
+        display: inline-flex;
+        flex-shrink: 0;
+        padding: 0.5rem 0.75rem;
+      }
+      nav .nav-toggle { display: inline-flex; }
+      nav .nav-links {
+        position: fixed;
+        top: 64px;
+        left: 0;
+        right: 0;
+        display: none;
+        flex-direction: column;
+        gap: 0;
+        padding: 0.5rem 1rem 1rem;
+        background: rgba(5, 7, 12, 0.98);
+        border-bottom: 1px solid var(--border);
+        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+      }
+      nav.nav-open .nav-links { display: flex; }
+      nav .nav-links li { list-style: none; }
+      nav .nav-links a {
+        display: block;
+        padding: 0.75rem 0;
+        white-space: nowrap;
+      }
+      section {
+        width: 100%;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        overflow-wrap: anywhere;
+      }
+      .hero { padding-top: 11rem; }
+      .hero h1 { font-size: clamp(2rem, 11vw, 3rem); }
+      .hero p { font-size: 1rem; }
+      .hero-actions { flex-direction: column; align-items: stretch; }
+      .btn-primary,
+      .btn-secondary { width: 100%; text-align: center; }
+      .beta-banner { top: 148px; font-size: 0.75rem; }
+      .comparison-table { font-size: 0.8125rem; }
+      .comparison-table th,
+      .comparison-table td { padding: 0.75rem 0.75rem; }
+    }
+  </style>
+
+<style>
+  .suite-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap:1.5rem; margin-top:2.5rem; }
+  .suite-card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:2rem; text-decoration:none; transition:border-color .2s, transform .2s, background .2s; }
+  .suite-card:hover { border-color:var(--accent); transform:translateY(-2px); background:var(--bg-card-hover); }
+  .kicker { color:var(--accent); font-size:.75rem; letter-spacing:.12em; font-weight:800; text-transform:uppercase; margin-bottom:.75rem; }
+  .cool { color:var(--accent-cool); }
+  .pill-row { display:flex; flex-wrap:wrap; gap:.5rem; margin:1.25rem 0; }
+  .pill { border:1px solid var(--border); background:var(--bg-secondary); color:var(--text-secondary); border-radius:999px; padding:.35rem .75rem; font-size:.8125rem; }
+  .doc-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:1rem; margin-top:1.5rem; }
+  .doc-card { background:var(--bg-card); border:1px solid var(--border); border-radius:14px; padding:1.4rem; transition:border-color .2s; }
+  .doc-card:hover { border-color:var(--border-hover); }
+  .doc-card h3 { margin-bottom:.5rem; }
+  .doc-card p, .suite-card p { color:var(--text-secondary); }
+  .doc-card .tag { display:inline-block; font-family:var(--font-mono); font-size:.72rem; color:var(--accent-cool); margin-bottom:.5rem; letter-spacing:.04em; }
+  .code-block { background:var(--code-bg); border:1px solid var(--border); border-radius:14px; padding:1.25rem; overflow:auto; margin:1rem 0; }
+  .code-block code, pre { font-family:var(--font-mono); font-size:.875rem; color:#cfe0f5; }
+  .note { border-left:3px solid var(--accent-cool); background:rgba(126,231,255,.08); padding:1rem 1.25rem; border-radius:0 12px 12px 0; color:var(--text-secondary); margin:1.5rem 0; }
+  .two-col { display:grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap:2rem; align-items:start; }
+
+  .reference-table-wrap { margin-top:1.5rem; border:1px solid var(--border); border-radius:16px; overflow:hidden; background:rgba(255,255,255,.02); }
+  .reference-table { width:100%; border-collapse:collapse; font-size:.875rem; }
+  .reference-table caption { text-align:left; padding:1rem 1.1rem; color:var(--text-secondary); border-bottom:1px solid var(--border); }
+  .reference-table th { text-align:left; padding:.75rem 1rem; color:var(--text-muted); font-size:.72rem; letter-spacing:.08em; text-transform:uppercase; background:rgba(255,255,255,.025); border-bottom:1px solid var(--border); }
+  .reference-table td { padding:.8rem 1rem; color:var(--text-secondary); border-bottom:1px solid rgba(255,255,255,.055); vertical-align:top; }
+  .reference-table tr:last-child td { border-bottom:0; }
+  .reference-table a { color:var(--text-primary); text-decoration:none; border-bottom:1px solid rgba(126,231,255,.35); }
+  .reference-table a:hover { color:var(--accent-cool); border-bottom-color:var(--accent-cool); }
+  .reference-table .ref-id { color:var(--accent-cool); font-family:var(--font-mono); white-space:nowrap; }
+  .reference-table .ref-theme { color:var(--text-muted); white-space:nowrap; }
+  @media (max-width: 760px) { .reference-table th:nth-child(3), .reference-table td:nth-child(3) { display:none; } }
+  @media (max-width: 800px) { .two-col { grid-template-columns:1fr; } }
+</style>
+
+<style>
+  /* ── Tool catalog tables (uses existing tokens only) ── */
+  .tier-head { display:flex; flex-wrap:wrap; align-items:center; gap:.75rem; margin-bottom:.5rem; }
+  .tier-head .pill { font-family:var(--font-mono); }
+  .tier-count { color:var(--accent-cool); font-weight:700; }
+
+  .tool-group { margin-top:2rem; }
+  .group-heading { display:flex; align-items:baseline; gap:.6rem; margin-bottom:.6rem; padding-bottom:.5rem; border-bottom:1px solid var(--border); }
+  .group-heading h3 { font-size:1.0625rem; font-weight:700; letter-spacing:-0.01em; color:var(--text-primary); }
+  .group-heading .group-count { font-family:var(--font-mono); font-size:.78rem; color:var(--text-muted); }
+
+  .tool-table-wrap { border:1px solid var(--border); border-radius:14px; overflow:hidden; background:rgba(255,255,255,.02); }
+  .tool-table { width:100%; border-collapse:collapse; font-size:.9rem; }
+  .tool-table th { text-align:left; padding:.6rem 1rem; color:var(--text-muted); font-size:.7rem; letter-spacing:.08em; text-transform:uppercase; background:rgba(255,255,255,.025); border-bottom:1px solid var(--border); }
+  .tool-table td { padding:.7rem 1rem; color:var(--text-secondary); border-bottom:1px solid rgba(255,255,255,.05); vertical-align:top; }
+  .tool-table tr:last-child td { border-bottom:0; }
+  .tool-table tbody tr:hover { background:rgba(255,255,255,.02); }
+  .tool-table td.tool-name { white-space:nowrap; width:1%; }
+  .tool-table code { font-family:var(--font-mono); font-size:.84rem; color:var(--accent-cool); background:rgba(126,231,255,.08); padding:.12rem .42rem; border-radius:6px; }
+  @media (max-width: 600px) { .tool-table td.tool-name { white-space:normal; } .tool-table th, .tool-table td { padding:.55rem .7rem; } }
+</style>
+
+</head>
+<body>
+<!-- ═══════════════════ Navigation ═══════════════════ -->
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="logo" style="display:flex;align-items:center;gap:0.5rem;">
+      <img src="assets/brand/fm-logo.svg" alt="Fm" width="28" height="28" style="border-radius:7px;">
+      ferrosa <span>memory</span>
+    </a>
+    <ul class="nav-links" id="site-nav-links">
+      <li><a href="./">Overview</a></li>
+      <li><a href="how-it-works.html">How it works</a></li>
+      <li><a href="tools.html">Tools</a></li>
+      <li><a href="compare.html">Compare</a></li>
+      <li><a href="getting-started.html">Setup</a></li>
+      <li><a href="../database/">Database</a></li>
+      <li><a href="https://github.com/ferrosadb" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+    </ul>
+    <a href="how-it-works.html" class="nav-cta">How it works</a>
+    <button class="nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="site-nav-links"><span></span></button>
+  </div>
+</nav>
+
+<div class="beta-banner">
+  <span class="beta-tag">Developer Preview</span> Ferrosa Memory 0.15 — structured, linked, auditable memory for agentic systems.
+</div>
+<section class="hero">
+  <img class="hero-logo" src="assets/brand/fm-logo.svg" alt="Ferrosa Memory logo">
+  <div class="hero-badge"><span class="dot"></span> Ferrosa Memory · 0.15 · Tool catalog</div>
+  <h1>Two tiers. <span class="gradient">79 memory tools.</span></h1>
+  <p>Ferrosa Memory exposes its capabilities as MCP tools, organized by the <code>include_all</code> flag on <code>tools/list</code>. Tier&nbsp;1 is the focused default agent set — the everyday memory loop. Tier&nbsp;2 unlocks the advanced and operator toolbox when you ask for it.</p>
+  <div class="hero-actions">
+    <a href="#tier-1" class="btn-primary">See Tier 1</a>
+    <a href="#tier-2" class="btn-secondary">See Tier 2</a>
+  </div>
+</section>
+
+<!-- ═══════════════════ Why tiers ═══════════════════ -->
+<section id="why-tiers" class="problem">
+  <section>
+    <div class="section-label cool">Why two tiers</div>
+    <h2 class="section-title">A default surface that fits in an agent's head.</h2>
+    <div class="two-col">
+      <div>
+        <p style="color:var(--text-secondary);">Drowning an agent in nearly 80 tool definitions is its own kind of noise: every extra tool dilutes the model's attention, inflates the prompt, and makes the wrong call more likely. So Ferrosa Memory ships a focused default surface — the everyday memory loop of ingest, recall, link, track tasks, and forget — and keeps the rest opt-in.</p>
+        <p style="color:var(--text-secondary); margin-top:1rem;">This mirrors the same recall-hygiene philosophy that runs through 0.15: <strong>prefer signal over noise</strong>. Just as recall guards and workspace filtering keep retrieval quiet unless there's real signal, tiering keeps the tool list quiet unless an operator reaches for advanced or administrative work.</p>
+        <p style="color:var(--text-secondary); margin-top:1rem;">Tier&nbsp;2 is always one flag away. Batch operations, memo and plan tracking, the full intention lifecycle, trajectory folds, bi-temporal facts, stored skills, dream-cycle consolidation, and the Datalog governance plane are there when you need them — and out of the way when you don't.</p>
+      </div>
+      <div>
+        <div class="doc-card"><span class="tag">Tier 1</span><h3>The everyday memory loop</h3><p>21 tools an agent reaches for in a normal session: ingest and recall, typed edges, context expansion, triggered intentions, durable session tasks, feedback, stats, runtime config, and <code>forget</code>.</p></div>
+        <div class="doc-card" style="margin-top:1rem;"><span class="tag">Tier 2</span><h3>Advanced &amp; operator</h3><p>58 tools for batch work, memo &amp; plans, the intention lifecycle, folds, temporal facts, skills, consolidation and graph inference, the expert-system governance plane, and introspection — surfaced only with <code>include_all</code>.</p></div>
+      </div>
+    </div>
+  </section>
+</section>
+
+<!-- ═══════════════════ Tier 1 ═══════════════════ -->
+<section id="tier-1">
+  <div class="section-label cool">Tier 1 · default</div>
+  <div class="tier-head">
+    <h2 class="section-title" style="margin-bottom:0;">Everyday memory</h2>
+    <span class="pill"><span class="tier-count">21</span>&nbsp;tools</span>
+  </div>
+  <p class="section-subtitle">Returned by default on <code>tools/list</code>. This is the focused agent set — the loop a model runs every session.</p>
+
+  <div class="tool-group">
+    <div class="group-heading"><h3>Core memory</h3></div>
+    <div class="tool-table-wrap">
+      <table class="tool-table">
+        <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+        <tbody>
+          <tr><td class="tool-name"><code>smart_ingest</code></td><td>Ingest discovered facts with dedup + confidence scoring</td></tr>
+          <tr><td class="tool-name"><code>hybrid_search</code></td><td>Multi-strategy semantic+lexical+phonetic+graph search (RRF)</td></tr>
+          <tr><td class="tool-name"><code>retrieve_entities</code></td><td>Find entities by phonetic fuzzy match or semantic ANN</td></tr>
+          <tr><td class="tool-name"><code>list_entities</code></td><td>List entities with structured equality filters</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="tool-group">
+    <div class="group-heading"><h3>Graph</h3></div>
+    <div class="tool-table-wrap">
+      <table class="tool-table">
+        <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+        <tbody>
+          <tr><td class="tool-name"><code>create_edge</code></td><td>Build a typed graph edge</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="tool-group">
+    <div class="group-heading"><h3>Context</h3></div>
+    <div class="tool-table-wrap">
+      <table class="tool-table">
+        <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+        <tbody>
+          <tr><td class="tool-name"><code>get_chunk_context</code></td><td>Expand a document chunk via semantic prev/next links</td></tr>
+          <tr><td class="tool-name"><code>get_turn_chain</code></td><td>Walk forward through temporal next_turn edges</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="tool-group">
+    <div class="group-heading"><h3>Intentions</h3></div>
+    <div class="tool-table-wrap">
+      <table class="tool-table">
+        <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+        <tbody>
+          <tr><td class="tool-name"><code>check_intentions</code></td><td>Return triggered deferred actions (topic/file/duration/context)</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="tool-group">
+    <div class="group-heading"><h3>Session tasks</h3></div>
+    <div class="tool-table-wrap">
+      <table class="tool-table">
+        <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+        <tbody>
+          <tr><td class="tool-name"><code>session_task_put</code></td><td>Create/update a durable session task</td></tr>
+          <tr><td class="tool-name"><code>session_task_get</code></td><td>Retrieve a session task by UUID or alias</td></tr>
+          <tr><td class="tool-name"><code>session_task_current</code></td><td>Foreground task, working set, focus stack, recovery hints</td></tr>
+          <tr><td class="tool-name"><code>session_task_list</code></td><td>List durable session tasks (optionally by status)</td></tr>
+          <tr><td class="tool-name"><code>session_task_complete</code></td><td>Mark a task complete; return resume candidate</td></tr>
+          <tr><td class="tool-name"><code>session_task_cancel</code></td><td>Mark a task cancelled; update focus-stack recovery</td></tr>
+          <tr><td class="tool-name"><code>session_task_focus</code></td><td>Move a task to foreground; push previous onto the focus stack</td></tr>
+          <tr><td class="tool-name"><code>session_task_observe</code></td><td>Deterministic observation hook (task-shift/completion/lost-agent), no LLM judge</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="tool-group">
+    <div class="group-heading"><h3>Feedback &amp; ops</h3></div>
+    <div class="tool-table-wrap">
+      <table class="tool-table">
+        <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+        <tbody>
+          <tr><td class="tool-name"><code>record_feedback</code></td><td>Record relevance feedback on the last search result set</td></tr>
+          <tr><td class="tool-name"><code>get_stats</code></td><td>Health stats: entity/fold/session counts, consolidation status</td></tr>
+          <tr><td class="tool-name"><code>configure</code></td><td>Read/write runtime defaults (session, retrieval limit, workspace, cwd)</td></tr>
+          <tr><td class="tool-name"><code>all_tools</code></td><td>Return the full tool catalog</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="tool-group">
+    <div class="group-heading"><h3>Forgetting</h3></div>
+    <div class="tool-table-wrap">
+      <table class="tool-table">
+        <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+        <tbody>
+          <tr><td class="tool-name"><code>forget</code></td><td>Propose forget candidates with blast radius; confirm retract/hard-delete</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════ Tier 2 ═══════════════════ -->
+<section id="tier-2" class="comparison">
+  <section>
+    <div class="section-label cool">Tier 2 · include_all</div>
+    <div class="tier-head">
+      <h2 class="section-title" style="margin-bottom:0;">Advanced &amp; operator</h2>
+      <span class="pill"><span class="tier-count">58</span>&nbsp;tools</span>
+    </div>
+    <p class="section-subtitle">The full toolbox: batch operations, memo &amp; plans, the intention lifecycle, trajectory folds, bi-temporal facts, stored skills, the dream-cycle knowledge plane, the Datalog governance and expert-system surface, and introspection. Opt in with <code>include_all</code>.</p>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Core memory</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>upsert_entity</code></td><td>Create or update a single entity directly</td></tr>
+            <tr><td class="tool-name"><code>batch_ingest</code></td><td>Ingest many facts in one call with dedup + scoring</td></tr>
+            <tr><td class="tool-name"><code>ingest_entities</code></td><td>Insert a set of explicit entities</td></tr>
+            <tr><td class="tool-name"><code>count_entities_by_type</code></td><td>Count entities grouped by type</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Batch ops</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>batch_update_entities</code></td><td>Update many entities in one operation</td></tr>
+            <tr><td class="tool-name"><code>batch_delete_entities</code></td><td>Delete many entities in one operation</td></tr>
+            <tr><td class="tool-name"><code>delete_session</code></td><td>Remove a session and its associated state</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Memo &amp; plans</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>check_memo_cache</code></td><td>Look up a sub-call result by content hash</td></tr>
+            <tr><td class="tool-name"><code>store_memo_result</code></td><td>Cache a completed sub-call result</td></tr>
+            <tr><td class="tool-name"><code>write_plan_node</code></td><td>Record a hierarchical sub-task node</td></tr>
+            <tr><td class="tool-name"><code>get_plan_context</code></td><td>Retrieve the session's plan tree</td></tr>
+            <tr><td class="tool-name"><code>update_plan_node</code></td><td>Mark a plan node complete/failed</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Context &amp; folds</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>ingest_context_segments</code></td><td>Persist raw conversation turns as semantic segments</td></tr>
+            <tr><td class="tool-name"><code>search_context_segments</code></td><td>Search context segments (BM25 + vector)</td></tr>
+            <tr><td class="tool-name"><code>get_context_window</code></td><td>Expand a bounded window around a context segment</td></tr>
+            <tr><td class="tool-name"><code>start_fold</code></td><td>Open a trajectory fold for a sub-task</td></tr>
+            <tr><td class="tool-name"><code>append_to_fold</code></td><td>Append turns to an open fold</td></tr>
+            <tr><td class="tool-name"><code>complete_fold</code></td><td>Seal a fold with a summary + embedding</td></tr>
+            <tr><td class="tool-name"><code>retrieve_fold_context</code></td><td>Retrieve the context of a sealed fold</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Graph / edges</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>batch_create_edges</code></td><td>Create many typed edges in one operation</td></tr>
+            <tr><td class="tool-name"><code>batch_update_edges</code></td><td>Update many edges in one operation</td></tr>
+            <tr><td class="tool-name"><code>batch_delete_edges</code></td><td>Delete many edges in one operation</td></tr>
+            <tr><td class="tool-name"><code>explore_connections</code></td><td>Traverse the graph outward from an entity</td></tr>
+            <tr><td class="tool-name"><code>find_memory_chain</code></td><td>Find a connecting path between memories</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Temporal</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>write_temporal_fact</code></td><td>Record a timestamped fact with supersession</td></tr>
+            <tr><td class="tool-name"><code>get_temporal_chain</code></td><td>Walk the supersession chain for a fact</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Intentions lifecycle</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>set_intention</code></td><td>Set a deferred trigger</td></tr>
+            <tr><td class="tool-name"><code>list_intentions</code></td><td>List pending intentions, optionally across repos</td></tr>
+            <tr><td class="tool-name"><code>complete_intention</code></td><td>Mark a triggered intention done</td></tr>
+            <tr><td class="tool-name"><code>snooze_intention</code></td><td>Reset a triggered intention to pending</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Skills</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>ingest_skill</code></td><td>Store a reusable skill</td></tr>
+            <tr><td class="tool-name"><code>invoke_skill</code></td><td>Invoke a stored skill</td></tr>
+            <tr><td class="tool-name"><code>verify_skill</code></td><td>Verify a skill before use</td></tr>
+            <tr><td class="tool-name"><code>retrieve_skills_for_context</code></td><td>Retrieve skills relevant to the current context</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Knowledge plane / consolidation</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>run_consolidation</code></td><td>Force a background dream-cycle consolidation pass</td></tr>
+            <tr><td class="tool-name"><code>enrich_entities</code></td><td>Enrich entities with derived attributes</td></tr>
+            <tr><td class="tool-name"><code>importance_score</code></td><td>Score the importance of memories</td></tr>
+            <tr><td class="tool-name"><code>spread_activation</code></td><td>Activate related memories by graph spreading</td></tr>
+            <tr><td class="tool-name"><code>find_duplicates</code></td><td>Find duplicate entities for merge</td></tr>
+            <tr><td class="tool-name"><code>recursive_explore</code></td><td>Recursively explore connected memories</td></tr>
+            <tr><td class="tool-name"><code>query_derived</code></td><td>Query Datalog-derived facts</td></tr>
+            <tr><td class="tool-name"><code>list_derived_cache</code></td><td>List cached derived facts</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Governance / expert system</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>manage_rules</code></td><td>Manage Datalog derivation rules</td></tr>
+            <tr><td class="tool-name"><code>manage_claims</code></td><td>Manage claims in the expert system</td></tr>
+            <tr><td class="tool-name"><code>manage_approvals</code></td><td>Manage approvals for derived knowledge</td></tr>
+            <tr><td class="tool-name"><code>manage_aliases</code></td><td>Manage entity and predicate aliases</td></tr>
+            <tr><td class="tool-name"><code>manage_authority</code></td><td>Mark sources curated/authoritative or demote clutter for ranking</td></tr>
+            <tr><td class="tool-name"><code>explain_derived</code></td><td>Return a proof trace for a derived fact</td></tr>
+            <tr><td class="tool-name"><code>get_effective_rule_set</code></td><td>Get the currently effective rule set</td></tr>
+            <tr><td class="tool-name"><code>promote_predicate</code></td><td>Promote a predicate into the effective rule set</td></tr>
+            <tr><td class="tool-name"><code>promote_memory</code></td><td>Promote a memory's standing</td></tr>
+            <tr><td class="tool-name"><code>demote_memory</code></td><td>Demote a memory's standing</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Config &amp; introspection</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>describe</code></td><td>Describe the server's capabilities</td></tr>
+            <tr><td class="tool-name"><code>migration_status</code></td><td>Report schema/data migration status</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tool-group">
+      <div class="group-heading"><h3>Other</h3></div>
+      <div class="tool-table-wrap">
+        <table class="tool-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="tool-name"><code>ensure_parent_tag</code></td><td>Ensure a parent tag exists for grouping</td></tr>
+            <tr><td class="tool-name"><code>record_outcome</code></td><td>Record an outcome (including retrieval misses) to train ranking</td></tr>
+            <tr><td class="tool-name"><code>restore_forgotten</code></td><td>Restore a reversibly retracted memory</td></tr>
+            <tr><td class="tool-name"><code>predict_needed</code> <span style="color:var(--text-muted);font-size:.82rem;">(stub)</span></td><td>Predict memories likely needed next</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</section>
+
+<!-- ═══════════════════ Unlock note ═══════════════════ -->
+<section id="unlock">
+  <div class="section-label cool">Unlocking Tier 2</div>
+  <h2 class="section-title">One flag, when you need it.</h2>
+  <p class="section-subtitle">Tier 1 is the default. To surface the full toolbox, pass <code>include_all: true</code> on <code>tools/list</code> — your client then sees all 58 advanced and operator tools alongside the everyday set.</p>
+  <div class="note">Set <code>include_all: true</code> on the MCP <code>tools/list</code> request to reveal Tier 2. Leave it off (the default) for the focused everyday surface. The <code>all_tools</code> tool also enumerates the complete catalog from inside a session.</div>
+</section>
+
+<!-- ═══════════════════ CTA ═══════════════════ -->
+<section id="get-started" class="cta-section">
+  <h2>Memory tools that match the moment.</h2>
+  <p>Start with the focused default loop, then unlock the full toolbox when an operator needs it.</p>
+  <div class="hero-actions">
+    <a href="how-it-works.html" class="btn-primary">How it works</a>
+    <a href="getting-started.html" class="btn-secondary">Set up locally</a>
+  </div>
+</section>
+
+<footer>
+  <div style="max-width: 1200px; margin: 0 auto; padding: 3rem 2rem; border-top: 1px solid var(--border); display:flex; justify-content:space-between; gap:2rem; flex-wrap:wrap; color:var(--text-muted);">
+    <div>Ferrosa Memory <span style="color:var(--accent);">0.15</span> · Developer preview</div>
+    <div style="display:flex; gap:1rem; flex-wrap:wrap;">
+      <a href="./" style="color:var(--text-secondary); text-decoration:none;">Overview</a>
+      <a href="how-it-works.html" style="color:var(--text-secondary); text-decoration:none;">How it works</a>
+      <a href="tools.html" style="color:var(--text-secondary); text-decoration:none;">Tools</a>
+      <a href="compare.html" style="color:var(--text-secondary); text-decoration:none;">Compare</a>
+      <a href="getting-started.html" style="color:var(--text-secondary); text-decoration:none;">Setup</a>
+      <a href="../database/" style="color:var(--text-secondary); text-decoration:none;">Database</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll('nav').forEach((nav) => {
+    const toggle = nav.querySelector('.nav-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+      const open = nav.classList.toggle('nav-open');
+      toggle.setAttribute('aria-expanded', String(open));
+      toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Open navigation');
+    });
+    nav.querySelectorAll('.nav-links a').forEach((link) => {
+      link.addEventListener('click', () => {
+        nav.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.setAttribute('aria-label', 'Open navigation');
+      });
+    });
+  });
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -875,9 +875,9 @@
     <a class="suite-card memory" href="/ferrosa-memory/">
       <div class="kicker">Ferrosa Memory</div>
       <h3>Agent memory: durable, linked, queryable context.</h3>
-      <p>A developer-preview memory system for agents: temporal facts, entity graphs, folds, document/chunk retrieval, task-aware query decomposition, feedback-aware reranking, Datalog-style materialization, workbench query UIs, and visualization for inspecting what the agent is recording and linking.</p>
+      <p>An MCP-native memory server for agents: a typed entity graph, bi-temporal facts, hybrid retrieval, trajectory folds, document/chunk retrieval, dream-cycle consolidation, Datalog-derived facts, and auditable forgetting — nearly 80 tools across two tiers, on durable Ferrosa DB storage.</p>
       <p style="margin-top:1rem;"><span class="pill">MCP on 18765</span> <span class="pill">Viz on 18766</span></p>
-      <div class="pill-row"><span class="pill">MCP</span><span class="pill">Long context</span><span class="pill">Graph memory</span><span class="pill">Hybrid retrieval</span><span class="pill">Feedback</span><span class="pill">Viz</span></div>
+      <div class="pill-row"><span class="pill">MCP</span><span class="pill">Typed graph</span><span class="pill">Bi-temporal</span><span class="pill">Hybrid retrieval</span><span class="pill">Forgetting</span><span class="pill">Datalog</span></div>
     </a>
   </div>
 </section>
@@ -892,8 +892,8 @@
     <div class="doc-card">
       <h3>Research-inspired, product-shaped</h3>
       <p>Preview docs cite the papers and specs behind the design, including memory architectures, GraphRAG-style retrieval, Datalog materialization, MemoryArena-style evaluation, prompt/context compression, and privacy/security work for persistent agent memory.</p>
-      <a href="/ferrosa-memory/#research" style="color:var(--accent-cool); text-decoration:none; font-weight:700;">Read the research notes →</a><br>
-      <a href="/ferrosa-memory/getting-started.html" style="color:var(--accent-cool); text-decoration:none; font-weight:700;">Run the local memory stack →</a>
+      <a href="/ferrosa-memory/how-it-works.html" style="color:var(--accent-cool); text-decoration:none; font-weight:700;">See how it works →</a><br>
+      <a href="/ferrosa-memory/compare.html" style="color:var(--accent-cool); text-decoration:none; font-weight:700;">Compare vs. other memory servers →</a>
     </div>
   </div>
   <div class="screenshot-grid">


### PR DESCRIPTION
## Summary

Marketing-docs refresh for **Ferrosa Memory** on the public site (`docs/` → www.ferrosadb.com), aligned to the **v0.16.0** release. Re-skins the Ferrosa Memory subsection to the **blued-steel brand** from `ferrosa-memory/docs/brand/` (`#348cff` / `#7ee7ff` / `#516d92`, deep-field `#05070c`, `Fm/100` mark) while the parent Ferrosa site keeps its copper palette.

Scope is a **marketing refresh** — how it works, the tool catalog by level, and why-vs-other-memory-servers. It deliberately does not re-do install/getting-started (only re-skins it).

## Pages

| Page | Change |
|---|---|
| `ferrosa-memory/index.html` | Refreshed overview: positioning, how-it-works teaser, tool-tier summary, capabilities, comparison teaser. New Fm logo + favicon + sub-nav. |
| `ferrosa-memory/how-it-works.html` | **New** — architecture, memory primitives, hybrid RRF retrieval, dream-cycle consolidation, auditable forgetting, hooks. |
| `ferrosa-memory/tools.html` | **New** — full tool catalog by tier: Tier 1 = 21 everyday tools, Tier 2 = 58 advanced/operator tools (79 total), grouped. |
| `ferrosa-memory/compare.html` | **New** — capability matrix vs **Mem0 / Zep–Graphiti / Letta / vector+RAG**, per-competitor cards, cited sources, honest positioning. |
| `ferrosa-memory/getting-started.html` | Re-skinned to blued-steel; removed stale 0.13 benchmark figures. |
| `index.html` (landing) | Refreshed Memory card copy; linked the new pages. Copper parent palette unchanged. |

## Accuracy guardrails

- **Capability framing, no hard numbers.** No benchmark / latency / nDCG figures on any marketing page.
- **Competitor claims sourced.** Every claim on `compare.html` is grounded in the competitor's current public docs, with a Sources section. Includes the 2025–26 nuances (Mem0 graph-store + OpenMemory deprecations; Zep Community Edition deprecation; Letta is an MCP *client*, not server). Honest positioning credits competitors where they're more mature.
- **Tool tiers verified against source** (`ferrosa-memory` `dispatch.rs` `is_tier1`): Tier 1 = 21, Tier 2 = 58, total = 79.
- **Version**: pages track fmem **v0.16.0**; feature-attribution prose is de-versioned to stay accurate across releases. Suite/database version markers (`LATEST`, landing page) are intentionally unchanged — they track the database release line.

## Consistency

- All new pages share the anchor's `<head>` / `<nav>` / `<footer>` / script byte-identical.
- HTML/CSS/SVG only — no internal/spec content in `docs/`.