### PR TITLE
feat(install): install-memory.sh parity with install.sh (channels, idempotency, upgrade restart)

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -41,3 +41,22 @@ jobs:
           gh release edit "$TAG" --repo "$REPO" \
             --draft=false --prerelease=false --latest
           echo "Promoted ${TAG} to stable (latest, not prerelease)."
+
+      - name: Notify Homebrew tap to resync formulae
+        env:
+          # Fine-grained PAT (or classic repo-scoped token) with contents:write
+          # on ferrosadb/homebrew-tap. GITHUB_TOKEN cannot dispatch cross-repo.
+          # Absent token => skip (the tap's hourly cron still picks it up).
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "${TAP_TOKEN:-}" ]; then
+            echo "HOMEBREW_TAP_TOKEN not set; skipping tap notify (hourly cron will sync)."
+            exit 0
+          fi
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${TAP_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ferrosadb/homebrew-tap/dispatches \
+            -d '{"event_type":"release-promoted"}'
+          echo "Dispatched release-promoted to ferrosadb/homebrew-tap."

--- a/docs/install-memory.sh
+++ b/docs/install-memory.sh
@@ -101,12 +101,11 @@ fi
 
 # ---------- idempotency: compare against what's installed ----------
 read_installed_version() {
-  if [ -f "$VERSION_STAMP" ]; then
-    cat "$VERSION_STAMP"
-  elif [ -x "${BIN_DIR}/ferrosa-memory-mcp" ]; then
-    # Best-effort fallback for installs predating the version stamp.
-    "${BIN_DIR}/ferrosa-memory-mcp" --version 2>/dev/null | awk 'NR==1{print "v"$NF}'
-  fi
+  # Stamp-only: ferrosa-memory-mcp is a stdio MCP server with no --version flag
+  # (running it just starts the server), so there is no safe way to probe an
+  # installed version from the binary. Installs predating the stamp are treated
+  # as fresh and simply reinstalled.
+  [ -f "$VERSION_STAMP" ] && cat "$VERSION_STAMP"
 }
 INSTALLED_VERSION="$(read_installed_version || true)"
 IS_UPGRADE="no"; [ -n "$INSTALLED_VERSION" ] && IS_UPGRADE="yes"

--- a/docs/install-memory.sh
+++ b/docs/install-memory.sh
@@ -3,9 +3,20 @@
 # offers system-service registration. Assumes Ferrosa is already running at
 # localhost:9042 (install via https://ferrosadb.com/install.sh first).
 #
+# It is idempotent: re-running upgrades an existing install in place. When the
+# resolved version already matches what's installed it does nothing (use
+# --force to reinstall).
+#
+# Channels:
+#   stable  (default) — the latest release a maintainer has promoted (GitHub
+#                       "latest"). Resolves via /releases/latest.
+#   nightly           — the newest published release, including the prereleases
+#                       cut automatically each night. Resolves via /releases.
+#
 # Usage:
 #   curl -fsSL https://ferrosadb.com/install-memory.sh | bash
-#   curl -fsSL https://ferrosadb.com/install-memory.sh | bash -s -- --version v0.12.0 --no-service
+#   curl -fsSL https://ferrosadb.com/install-memory.sh | bash -s -- --channel nightly
+#   curl -fsSL https://ferrosadb.com/install-memory.sh | bash -s -- --version v0.16.0 --no-service
 set -euo pipefail
 
 REPO="ferrosadb/ferrosa-memory"
@@ -15,36 +26,52 @@ BIN_DIR="${INSTALL_ROOT}/bin"
 CONFIG_DIR="${INSTALL_ROOT}/config"
 DATA_DIR="${INSTALL_ROOT}/data"
 LOG_DIR="${INSTALL_ROOT}/logs"
+# Separate stamp from ferrosa's own .version so the two installers don't clobber
+# each other's idempotency state.
+VERSION_STAMP="${INSTALL_ROOT}/.memory-version"
 
 VERSION=""
+CHANNEL="stable"   # stable|nightly
+FORCE="no"
 WANT_SERVICE=""    # ask|yes|no
 
+# ---------- arg parsing ----------
 while [ $# -gt 0 ]; do
   case "$1" in
     --version)      VERSION="$2"; shift 2 ;;
+    --channel)      CHANNEL="$2"; shift 2 ;;
+    --force)        FORCE="yes"; shift ;;
     --no-service)   WANT_SERVICE="no"; shift ;;
     --service)      WANT_SERVICE="yes"; shift ;;
     -h|--help)
       cat <<EOF
 ferrosa-memory installer
-  --version <tag>           install a specific tag (default: latest)
-  --service / --no-service  enable or skip system-service install
+  --version <tag>            install a specific tag (overrides --channel)
+  --channel stable|nightly   release channel (default: stable)
+  --force                    reinstall even if already up to date
+  --service / --no-service   enable or skip system-service install
 EOF
       exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
 
+case "$CHANNEL" in
+  stable|nightly) ;;
+  *) echo "error: --channel must be 'stable' or 'nightly'" >&2; exit 2 ;;
+esac
+
 say() { printf ':: %s\n' "$*" >&2; }
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
 
+# ---------- platform detect ----------
 detect_target() {
   local os arch
   os=$(uname -s); arch=$(uname -m)
   case "$os/$arch" in
     Darwin/arm64)              echo "aarch64-apple-darwin" ;;
     Darwin/x86_64)
-      die "Intel macOS is not supported in v0.x. Please build from source: https://github.com/ferrosadb/ferrosa-memory#building" ;;
+      die "Intel macOS is not supported. Please build from source: https://github.com/ferrosadb/ferrosa-memory#building" ;;
     Linux/x86_64)              echo "x86_64-unknown-linux-musl" ;;
     Linux/aarch64|Linux/arm64) echo "aarch64-unknown-linux-musl" ;;
     *) die "unsupported platform: $os/$arch" ;;
@@ -52,16 +79,52 @@ detect_target() {
 }
 TARGET=$(detect_target)
 
+# ---------- resolve the tag to install ----------
+# stable  -> /releases/latest (only non-prerelease, maintainer-promoted)
+# nightly -> /releases (newest published, includes nightly prereleases)
+resolve_channel_tag() {
+  case "$CHANNEL" in
+    stable)
+      curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1 ;;
+    nightly)
+      curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1 ;;
+  esac
+}
+
 if [ -z "$VERSION" ]; then
-  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-              | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
+  VERSION=$(resolve_channel_tag) || true
+  [ -n "$VERSION" ] || die "no ${CHANNEL} release found at ${RELEASE_HOST}"
+  say "resolved ${CHANNEL} channel to ${VERSION}"
 fi
-[ -n "$VERSION" ] || die "no release found at https://github.com/${REPO}/releases"
+
+# ---------- idempotency: compare against what's installed ----------
+read_installed_version() {
+  if [ -f "$VERSION_STAMP" ]; then
+    cat "$VERSION_STAMP"
+  elif [ -x "${BIN_DIR}/ferrosa-memory-mcp" ]; then
+    # Best-effort fallback for installs predating the version stamp.
+    "${BIN_DIR}/ferrosa-memory-mcp" --version 2>/dev/null | awk 'NR==1{print "v"$NF}'
+  fi
+}
+INSTALLED_VERSION="$(read_installed_version || true)"
+IS_UPGRADE="no"; [ -n "$INSTALLED_VERSION" ] && IS_UPGRADE="yes"
+
+if [ "$INSTALLED_VERSION" = "$VERSION" ] && [ "$FORCE" = "no" ]; then
+  say "ferrosa-memory ${VERSION} is already installed (up to date); use --force to reinstall"
+  exit 0
+fi
+
+if [ "$IS_UPGRADE" = "yes" ]; then
+  say "upgrading ferrosa-memory ${INSTALLED_VERSION} -> ${VERSION}"
+fi
 
 TARBALL="ferrosa-memory-${VERSION}-${TARGET}.tar.gz"
 URL="${RELEASE_HOST}/download/${VERSION}/${TARBALL}"
 SUMS_URL="${RELEASE_HOST}/download/${VERSION}/SHA256SUMS"
 
+# ---------- download + verify ----------
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 say "downloading $TARBALL"
@@ -72,12 +135,16 @@ say "verifying SHA256"
 ( cd "$TMP" && grep "$TARBALL" SHA256SUMS | shasum -a 256 -c - ) \
   || die "checksum verification FAILED"
 
+# ---------- install layout ----------
 say "installing to $INSTALL_ROOT"
 mkdir -p "$BIN_DIR" "$CONFIG_DIR" "$DATA_DIR" "$LOG_DIR"
 tar -xzf "$TMP/$TARBALL" -C "$TMP"
 
 cp "$TMP/ferrosa-memory-mcp" "$BIN_DIR/"
 chmod +x "$BIN_DIR/ferrosa-memory-mcp"
+
+# Record the installed version so the next run is idempotent.
+printf '%s\n' "$VERSION" > "$VERSION_STAMP"
 
 if [ ! -f "$CONFIG_DIR/ferrosa-memory.toml" ]; then
   cp "$TMP/config/ferrosa-memory.example.toml" "$CONFIG_DIR/ferrosa-memory.toml"
@@ -86,6 +153,7 @@ else
   say "kept existing $CONFIG_DIR/ferrosa-memory.toml"
 fi
 
+# ---------- service registration ----------
 prompt_yes() {
   local q="$1" a
   read -r -p "$q [y/N] " a < /dev/tty
@@ -124,16 +192,42 @@ do_service() {
   esac
 }
 
+# On upgrade, restart an already-registered service so the new binary is the
+# one actually running (the path is unchanged, so the old process keeps the
+# old inode until restarted).
+restart_service_if_present() {
+  case "$(uname -s)" in
+    Darwin)
+      local plist="$HOME/Library/LaunchAgents/com.ferrosa-memory.mcp.plist"
+      [ -f "$plist" ] || return 0
+      launchctl kickstart -k "gui/$(id -u)/com.ferrosa-memory.mcp" 2>/dev/null \
+        && say "restarted launchd service to apply the upgrade" || true ;;
+    Linux)
+      local unit="$HOME/.config/systemd/user/ferrosa-memory.service"
+      [ -f "$unit" ] || return 0
+      systemctl --user restart ferrosa-memory.service 2>/dev/null \
+        && say "restarted systemd --user service to apply the upgrade" || true ;;
+  esac
+}
+
+# Explicit flags always win. Otherwise: prompt on a fresh install, and on an
+# upgrade quietly restart an existing service without re-prompting.
 case "$WANT_SERVICE" in
   yes) do_service ;;
   no)  : ;;
-  "")  prompt_yes "Register ferrosa-memory as a user service (autostart on login)?" \
-         && do_service ;;
+  "")
+    if [ "$IS_UPGRADE" = "yes" ]; then
+      restart_service_if_present
+    else
+      prompt_yes "Register ferrosa-memory as a user service (autostart on login)?" \
+        && do_service
+    fi ;;
 esac
 
+# ---------- finish ----------
 cat <<EOF >&2
 
-ferrosa-memory $VERSION installed.
+ferrosa-memory $VERSION installed (${CHANNEL} channel).
 
   binary: $BIN_DIR/ferrosa-memory-mcp
   config: $CONFIG_DIR/ferrosa-memory.toml
@@ -153,6 +247,9 @@ To register with Claude Code, add to your MCP config:
       }
     }
   }
+
+Upgrade later by re-running this installer (idempotent):
+  curl -fsSL https://ferrosadb.com/install-memory.sh | bash -s -- --channel ${CHANNEL}
 
 Docs: https://github.com/ferrosadb/ferrosa-memory
 EOF

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -104,9 +104,11 @@ fi
 read_installed_version() {
   if [ -f "$VERSION_STAMP" ]; then
     cat "$VERSION_STAMP"
-  elif [ -x "${BIN_DIR}/ferrosa" ]; then
-    # Best-effort fallback for installs predating the version stamp.
-    "${BIN_DIR}/ferrosa" --version 2>/dev/null | awk 'NR==1{print "v"$NF}'
+  elif [ -x "${BIN_DIR}/ferrosa-ctl" ]; then
+    # Best-effort fallback for installs predating the version stamp. The main
+    # `ferrosa` binary boots the server on any args (no --version); ferrosa-ctl
+    # has a clean --version that prints "ferrosa-ctl X.Y.Z".
+    "${BIN_DIR}/ferrosa-ctl" --version 2>/dev/null | awk 'NR==1{print "v"$NF}'
   fi
 }
 INSTALLED_VERSION="$(read_installed_version || true)"


### PR DESCRIPTION
`docs/install-memory.sh` is the canonical installer served at ferrosadb.com/install-memory.sh (GitHub Pages). It lagged `install.sh` on updatability. This brings it to parity:

- `--channel stable|nightly` (matches install.sh; was stable-only)
- `.memory-version` stamp + "already up to date / use --force" short-circuit (was: always reinstalled)
- restart an already-registered launchd/systemd service on upgrade
- `--force`

Verified: `bash -n`, shellcheck clean, and live channel resolution (stable→v0.16.0, nightly→v0.21.0).

Note: a separate Homebrew tap (ferrosadb/homebrew-tap) now provides `brew install ferrosadb/tap/ferrosa[-memory]`.