### PR TITLE
feat(release): CalVer nightlies, SemVer stable (promote = recut)

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -79,42 +79,55 @@ jobs:
         env:
           VERSION: ${{ steps.next.outputs.next_version }}
         run: |
-          perl -0pi -e 's/(\[workspace\.package\]\s+version\s*=\s*)"[^"]+"/${1}"'"${VERSION}"'"/s' Cargo.toml
+          # Nightlies carry a `-nightly` SemVer pre-release on the computed next
+          # version (e.g. 0.22.0-nightly). The release TAG is CalVer (see below);
+          # the binary's --version reports this informative base. Promotion to
+          # stable recuts a clean SemVer (see promote-release.yml).
+          NIGHTLY_VERSION="${VERSION}-nightly"
+          perl -0pi -e 's/(\[workspace\.package\]\s+version\s*=\s*)"[^"]+"/${1}"'"${NIGHTLY_VERSION}"'"/s' Cargo.toml
           cargo update -w
           git diff -- Cargo.toml Cargo.lock
 
-      - name: Create release commit and tag
+      - name: Create release commit and CalVer tag
         if: steps.next.outputs.should_release == 'true'
         env:
           NEXT_VERSION: ${{ steps.next.outputs.next_version }}
-          NEXT_TAG: ${{ steps.next.outputs.next_tag }}
           BASE_TAG: ${{ steps.next.outputs.base_tag }}
           BUMP: ${{ steps.next.outputs.bump }}
           COMMIT_COUNT: ${{ steps.next.outputs.commit_count }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Nightly tags are CalVer (vYYYY.MM.DD.HHMM, UTC) so they are visually
+          # distinct from stable SemVer (vX.Y.Z) in the releases list. The
+          # version math (next-release-version.sh) ignores 4-segment CalVer tags,
+          # so nightlies never pollute the stable base.
+          NIGHTLY_TAG="v$(date -u +%Y.%m.%d.%H%M)"
+          if git rev-parse -q --verify "refs/tags/${NIGHTLY_TAG}" >/dev/null; then
+            echo "error: nightly tag ${NIGHTLY_TAG} already exists (two cuts in the same UTC minute); rerun shortly" >&2
+            exit 1
+          fi
+          echo "NIGHTLY_TAG=${NIGHTLY_TAG}" >> "$GITHUB_ENV"
           git add Cargo.toml Cargo.lock
           # The release commit carries the version bump and is captured by the
           # tag. We intentionally do NOT push it to the default branch: the
           # `main` ruleset requires pull requests, so a direct branch push is
           # rejected (GH013). The tag is the release artifact source; main's
           # Cargo.toml version is decorative between releases.
-          git commit -m "chore(release): ${NEXT_TAG}"
-          git tag -a "${NEXT_TAG}" \
-            -m "${NEXT_TAG} (${GITHUB_EVENT_NAME} release)" \
-            -m "${BUMP} bump from ${BASE_TAG} after ${COMMIT_COUNT} commits."
+          git commit -m "chore(nightly): ${NIGHTLY_TAG} (${NEXT_VERSION}-nightly)"
+          git tag -a "${NIGHTLY_TAG}" \
+            -m "${NIGHTLY_TAG} nightly (${GITHUB_EVENT_NAME})" \
+            -m "${BUMP} bump target ${NEXT_VERSION} from ${BASE_TAG} after ${COMMIT_COUNT} commits."
           # Push the tag only (the branch ruleset does not cover refs/tags/*).
-          git push origin "${NEXT_TAG}"
+          git push origin "${NIGHTLY_TAG}"
 
       - name: Dispatch release build
         if: steps.next.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          NEXT_TAG: ${{ steps.next.outputs.next_tag }}
         # Explicit dispatch is required: tags pushed with GITHUB_TOKEN do NOT
         # trigger release.yml's `on: push` (GitHub's recursion guard). Every
         # auto-cut release — whether from a merge, the nightly cron, or a manual
         # dispatch — is a prerelease (the "nightly" channel); a maintainer
         # promotes it to stable via promote-release.yml.
-        run: gh workflow run release.yml --ref "${NEXT_TAG}" -f prerelease=true
+        run: gh workflow run release.yml --ref "${NIGHTLY_TAG}" -f prerelease=true

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,62 +1,88 @@
 name: Promote Release to Stable
 
-# Blesses an existing (nightly/prerelease) release as the stable channel:
-# marks it --latest and clears the prerelease flag. This is the only path by
-# which a release leaves the "nightly" channel and becomes "stable".
-#
-# Releases are cut nightly as prereleases (see nightly-release.yml +
-# release.yml). When a build has been validated, promote its tag here.
+# Promotes a CalVer nightly (vYYYY.MM.DD.HHMM, a prerelease) to a stable SemVer
+# release (vX.Y.Z). Because nightly and stable are now SEPARATE tags, promotion
+# is a recut, not a flag flip: we check out the nightly's commit, compute the
+# next stable SemVer from Conventional Commit history, tag it, and rebuild so
+# the stable artifacts carry a clean SemVer (the nightly binaries report
+# `X.Y.Z-nightly`). release.yml publishes it as `--latest`, not prerelease.
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing release tag to promote to stable (e.g. v0.14.0)'
+        description: 'Nightly tag to promote (CalVer, e.g. v2026.06.16.0817)'
         required: true
         type: string
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: promote-release-${{ github.repository }}
   cancel-in-progress: false
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   promote:
-    name: Mark ${{ github.event.inputs.tag }} as stable
+    name: Promote ${{ github.event.inputs.tag }} -> stable SemVer
     runs-on: ubuntu-latest
     steps:
-      - name: Promote tag to stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04-25
+
+      - name: Validate nightly tag and compute stable SemVer
+        id: calc
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.event.inputs.tag }}
         run: |
-          # Fail loudly if the tag has no release to promote.
+          # The nightly must exist as a release.
           if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "error: no release found for tag ${TAG} in ${REPO}" >&2
             exit 1
           fi
-          gh release edit "$TAG" --repo "$REPO" \
-            --draft=false --prerelease=false --latest
-          echo "Promoted ${TAG} to stable (latest, not prerelease)."
-
-      - name: Notify Homebrew tap to resync formulae
-        env:
-          # Fine-grained PAT (or classic repo-scoped token) with contents:write
-          # on ferrosadb/homebrew-tap. GITHUB_TOKEN cannot dispatch cross-repo.
-          # Absent token => skip (the tap's hourly cron still picks it up).
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        run: |
-          if [ -z "${TAP_TOKEN:-}" ]; then
-            echo "HOMEBREW_TAP_TOKEN not set; skipping tap notify (hourly cron will sync)."
-            exit 0
+          if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "error: tag ${TAG} not found in this checkout" >&2
+            exit 1
           fi
-          curl -fsSL -X POST \
-            -H "Authorization: Bearer ${TAP_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/ferrosadb/homebrew-tap/dispatches \
-            -d '{"event_type":"release-promoted"}'
-          echo "Dispatched release-promoted to ferrosadb/homebrew-tap."
+          # Compute the next stable SemVer relative to the nightly's COMMIT, so
+          # the bump reflects exactly what this nightly contains. Detach there
+          # first; the script only counts commits up to HEAD.
+          git checkout -q "refs/tags/${TAG}"
+          # force=true: a promotion is intentional even if the script's
+          # commits-since-stable guard would otherwise skip.
+          bash .github/scripts/next-release-version.sh auto true
+
+      - name: Create stable commit and SemVer tag
+        env:
+          NEXT_VERSION: ${{ steps.calc.outputs.next_version }}
+          NEXT_TAG: ${{ steps.calc.outputs.next_tag }}
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # We are detached at the nightly commit. Set a clean SemVer version and
+          # capture it on the new tag (not pushed to main, same as nightly cuts).
+          perl -0pi -e 's/(\[workspace\.package\]\s+version\s*=\s*)"[^"]+"/${1}"'"${NEXT_VERSION}"'"/s' Cargo.toml
+          cargo update -w
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): ${NEXT_TAG} (promoted from nightly ${TAG})"
+          git tag -a "${NEXT_TAG}" \
+            -m "${NEXT_TAG} stable" \
+            -m "Promoted from nightly ${TAG}."
+          git push origin "${NEXT_TAG}"
+
+      - name: Dispatch stable release build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ steps.calc.outputs.next_tag }}
+        # prerelease=false => release.yml marks it --latest (the stable channel).
+        run: gh workflow run release.yml --ref "${NEXT_TAG}" -f prerelease=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,3 +363,24 @@ jobs:
             --title "Ferrosa v${VERSION}" \
             --notes "$NOTES" \
             "${REL_FLAGS[@]}"
+
+      - name: Notify Homebrew tap (stable releases only)
+        # Fire only for a stable publish (prerelease=false), and only AFTER the
+        # release exists above — so the tap's /releases/latest resync sees it.
+        if: ${{ github.event.inputs.prerelease == 'false' }}
+        env:
+          # Fine-grained PAT with contents:write on ferrosadb/homebrew-tap.
+          # GITHUB_TOKEN cannot dispatch cross-repo. Absent => skip (hourly cron).
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "${TAP_TOKEN:-}" ]; then
+            echo "HOMEBREW_TAP_TOKEN not set; skipping tap notify (hourly cron will sync)."
+            exit 0
+          fi
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${TAP_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ferrosadb/homebrew-tap/dispatches \
+            -d '{"event_type":"release-promoted"}'
+          echo "Dispatched release-promoted to ferrosadb/homebrew-tap."

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -15,11 +15,17 @@ consumes them.
   workflow (`nightly-release.yml`) and the same tag-only mechanics. Doc/spec-only
   merges are excluded (`paths-ignore`) so prose changes don't trigger a full
   multi-platform build.
-- **Two channels:**
-  - **nightly** — every automatically cut `vX.Y.Z` release. Marked as a GitHub
-    *prerelease*.
-  - **stable** — a nightly release a maintainer has *promoted*. Marked
-    *latest*, not prerelease.
+- **Two channels, two tag schemes:**
+  - **nightly** — every automatically cut release. Tagged **CalVer**
+    `vYYYY.MM.DD.HHMM` (UTC) and marked a GitHub *prerelease*. The binary
+    reports `<next-semver>-nightly` (e.g. `0.22.0-nightly`).
+  - **stable** — a nightly a maintainer has *promoted*. Tagged **SemVer**
+    `vX.Y.Z`, marked *latest*, not prerelease. Promotion **recuts** a clean
+    SemVer from the nightly's commit (it is no longer a flag flip — the two are
+    separate tags), so stable artifacts carry a plain `X.Y.Z`.
+  - The CalVer/SemVer split makes the channel obvious in the releases list.
+    `next-release-version.sh` only treats 3-segment `vX.Y.Z` tags as the stable
+    base, so CalVer nightlies never pollute the version math.
 - **Releases are tag-only.** The version-bump commit lives on the tag, never on
   `main`. `main`'s `Cargo.toml` version is therefore decorative between
   releases; the released artifact always carries the correct version.
@@ -44,16 +50,24 @@ and push only the tag.
 
 ```
 nightly-release.yml  (on: push→main [merge], cron 08:17 UTC, or manual)
-  └─ next-release-version.sh        # SemVer from Conventional Commits since last vX.Y.Z tag
-  └─ should_release? (commits since last tag) — else skip
-  └─ bump Cargo.toml + commit (local only)
-  └─ git tag vX.Y.Z  →  git push origin vX.Y.Z      # tag only, never main
+  └─ next-release-version.sh        # next SemVer from Conventional Commits since last vX.Y.Z tag
+  └─ should_release? (commits since last stable tag) — else skip
+  └─ bump Cargo.toml to <next>-nightly + commit (local only)
+  └─ git tag vYYYY.MM.DD.HHMM  →  git push origin <calver tag>   # CalVer, tag only, never main
   └─ gh workflow run release.yml -f prerelease=true # explicit: GITHUB_TOKEN tag
                                                     # pushes don't trigger on:push
-release.yml  (per built tag)
+
+promote-release.yml  (manual: input = nightly CalVer tag)
+  └─ git checkout <nightly tag>     # detach at the nightly's commit
+  └─ next-release-version.sh        # clean next SemVer relative to that commit
+  └─ set Cargo.toml to X.Y.Z + commit (local only)
+  └─ git tag vX.Y.Z  →  git push origin vX.Y.Z       # SemVer, tag only
+  └─ gh workflow run release.yml -f prerelease=false # rebuild as stable (--latest)
+
+release.yml  (per built tag — CalVer or SemVer)
   └─ build musl x86_64/aarch64 + macOS aarch64 tarballs, .deb, Homebrew bottle
   └─ SHA256SUMS
-  └─ gh release create … --prerelease   # nightly channel by default
+  └─ gh release create … (--prerelease for nightly, --latest for stable)
 ```
 
 Conventional Commit → bump mapping (see `.github/scripts/next-release-version.sh`):
@@ -69,13 +83,19 @@ bump. Keep commit subjects conventional so the auto-bump is correct.
 
 ## Promoting nightly → stable
 
-When a nightly build is validated, promote its tag:
+When a nightly build is validated, promote it by its **CalVer** tag:
 
-- **UI:** Actions → *Promote Release to Stable* → enter the tag (e.g. `v0.14.0`).
-- **CLI:** `gh release edit v0.14.0 --repo ferrosadb/ferrosa --prerelease=false --latest`
+- **UI:** Actions → *Promote Release to Stable* → enter the nightly tag
+  (e.g. `v2026.06.16.0817`).
 
-This marks it `latest` and clears the prerelease flag, so the **stable** channel
-now resolves to it.
+Promotion checks out that nightly's commit, computes the next stable SemVer from
+Conventional Commit history, tags `vX.Y.Z`, and dispatches `release.yml` with
+`prerelease=false` so it rebuilds and publishes as `--latest`. The **stable**
+channel (`/releases/latest`) then resolves to the new SemVer release.
+
+> Promotion is a **recut**, not a flag flip: nightly (CalVer) and stable (SemVer)
+> are separate tags/releases. The stable binaries are rebuilt so they report a
+> clean `X.Y.Z` instead of `X.Y.Z-nightly`.
 
 ## Installer (`docs/install.sh`, served at ferrosadb.com/install.sh)
 


### PR DESCRIPTION
## Why
Nightly and stable releases were both `vX.Y.Z`, distinguished only by the prerelease flag — indistinguishable in the releases list.

## What
- **Nightlies** are now tagged **CalVer** `vYYYY.MM.DD.HHMM` (UTC), prerelease; workspace version = `<next-semver>-nightly`.
- **Stable** stays **SemVer** `vX.Y.Z`. Promotion **recuts**: checks out the nightly's commit, computes the next SemVer, tags it, and rebuilds as `--latest` (no longer a flag flip, since the two are now separate tags). Stable binaries report a clean `X.Y.Z`.
- `next-release-version.sh` needs **no change** — it already matches only 3-segment `vX.Y.Z` as the stable base, so CalVer nightlies never pollute the math (verified).

## Unaffected
Installer `--channel` resolution (newest / `/releases/latest`) and the Homebrew tap (stable only) keep working — tarball names follow the tag in all cases.

## Verified
YAML valid; base-selection correctly ignores CalVer + `-nightly` tags; `-nightly` is valid SemVer prerelease. Docs updated in specs/release-process.md.

Mirror PR for ferrosa-memory to follow.