### PR TITLE
fix(storage): close residual read-vs-compaction Ok(None) window (nightly fuzz)

### DIFF
--- a/ferrosa-sstable/src/io.rs
+++ b/ferrosa-sstable/src/io.rs
@@ -430,6 +430,19 @@ fn global_fd_cache() -> std::sync::Arc<FdCache> {
     }))
 }
 
+/// Drop the cached descriptor for `path` from the process-global `Data.db` fd
+/// cache, if present. Test-only.
+///
+/// An open fd survives `unlink` on Unix, so a still-cached descriptor would let
+/// a positional read succeed even after the file is deleted. The residual
+/// read-vs-compaction race test must model a read whose `Data.db` was deleted
+/// *and* whose fd has been evicted, so the next `read_at` re-opens by path and
+/// observes `ENOENT` — exactly the mid-read error the fix recovers from.
+#[doc(hidden)]
+pub fn evict_global_fd_for_test(path: impl AsRef<Path>) {
+    global_fd_cache().invalidate(path.as_ref());
+}
+
 fn should_mmap_component(path: &std::path::Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -6908,6 +6908,43 @@ impl StorageEngine {
         self.reader_pool.remove(&(table_id.to_string(), gen));
     }
 
+    /// Grab the currently-cached reader `Arc` for `(table_id, gen)` without
+    /// reopening or perturbing recency. Returns `None` if not resident.
+    ///
+    /// Used by the residual read-vs-compaction race test to capture an input
+    /// SSTable's pooled reader *before* a compaction swap evicts it, so the
+    /// same `Arc` can be re-seeded afterwards — modelling the window where
+    /// `open_reader` is a cache HIT (open succeeds, in-memory bloom matches) but
+    /// the data seek hits an already-deleted `Data.db` (`ENOENT` mid-read).
+    #[cfg(test)]
+    pub(crate) fn pooled_reader_arc_for_test(
+        &self,
+        table_id: &TableId,
+        gen: u64,
+    ) -> Option<
+        std::sync::Arc<ferrosa_sstable::reader::SSTableReader<ferrosa_sstable::io::FileReadAt>>,
+    > {
+        self.reader_pool.peek_arc(&(table_id.to_string(), gen))
+    }
+
+    /// Re-insert an already-open reader `Arc` for `(table_id, gen)` into the
+    /// pool, replacing any existing entry. Pairs with
+    /// [`Self::pooled_reader_arc_for_test`] to restore a cache HIT for an input
+    /// generation that a compaction swap evicted, so the next read takes the
+    /// cache-hit path against a now-deleted `Data.db`.
+    #[cfg(test)]
+    pub(crate) fn reseed_pooled_reader_for_test(
+        &self,
+        table_id: &TableId,
+        gen: u64,
+        reader: std::sync::Arc<
+            ferrosa_sstable::reader::SSTableReader<ferrosa_sstable::io::FileReadAt>,
+        >,
+    ) {
+        self.reader_pool
+            .insert_arc((table_id.to_string(), gen), reader);
+    }
+
     /// Returns the count of SSTable read errors for a table.
     pub fn sstable_read_errors(&self, table_id: &TableId) -> u64 {
         self.tables
@@ -12477,6 +12514,139 @@ mod tests {
         assert!(
             got.is_some(),
             "t2 must remain readable across a concurrent compaction that deleted its SSTable"
+        );
+    }
+
+    /// Residual window — the *cache-hit-then-mid-read-ENOENT* path that the
+    /// open-failure tests above do NOT exercise.
+    ///
+    /// `read_during_compaction_retries_against_new_view` deletes gen2 and lets
+    /// the resumed read REOPEN it, so `open_reader` returns `Err` (cache miss on
+    /// a deleted file) and the existing open-failure retry fires. The residual
+    /// race is subtler: the gen2 reader is still POOLED (a flush seeded it), so
+    /// `open_reader` is a cache HIT — open succeeds and the in-memory bloom says
+    /// the key is present — but `evict_local_input_sstable_files` already deleted
+    /// gen2's `Data.db`, so the *data seek* inside `get_partition_limited_rows`
+    /// re-opens the path and hits `ENOENT` MID-READ. Before the fix that `Err`
+    /// arm of `read_with_view` left `sstable_open_failed = false`, so no view
+    /// retry fired and the committed key vanished as a spurious `Ok(None)` —
+    /// silent data loss of a row that lives in the freshly-merged SSTable.
+    ///
+    /// This test reproduces that exact ordering deterministically with the
+    /// `ReadViewBarrier` hook: the read snapshots the pre-swap view (gen2), pauses
+    /// at the barrier while the compaction swap completes (merged output holds
+    /// t2; gen2 `Data.db` deleted), and we then (a) re-seed gen2's still-open
+    /// reader into the pool so the resumed `open_reader` is a cache HIT, and
+    /// (b) evict gen2's `Data.db` fd so the seek must re-open the deleted path.
+    /// On release the read takes open=ok → bloom=present → seek=ENOENT, which the
+    /// fix turns into a view retry that finds t2 in the merged SSTable.
+    ///
+    /// Non-vacuous: WITHOUT the fix the mid-read `Err` is swallowed and the read
+    /// returns `Ok(None)`, failing the `is_some()` assertion.
+    #[tokio::test]
+    async fn read_cache_hit_mid_read_delete_retries_against_new_view() {
+        use crate::store::read_race_test_hook::{ReadViewBarrier, ARMED};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = StorageEngineConfig::test_config(dir.path());
+        config.compaction.min_threshold = 2;
+        let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        // t1 -> gen1, t2 -> gen2. t2 lives ONLY in gen2 (no survivor SSTable).
+        // Each flush SEEDS the gen's reader into the pool, so a later read of t2
+        // is a cache hit that consults gen2's in-memory bloom.
+        engine
+            .write(&tid, &make_key("t1"), make_row(b"v1", 1000), 1000)
+            .unwrap();
+        engine.flush(&tid).unwrap();
+        engine
+            .write(&tid, &make_key("t2"), make_row(b"v2", 2000), 2000)
+            .unwrap();
+        engine.flush(&tid).unwrap();
+        assert_eq!(engine.sstable_count(&tid), 2);
+
+        // Identify gen2 (newest) and grab its still-pooled reader `Arc`. Holding
+        // this `Arc` keeps the reader (and its in-memory bloom) alive across the
+        // swap's pool eviction, so we can re-seed it as a cache hit afterwards.
+        let table_dir = dir.path().join("sstables").join(tid.to_string());
+        let gen2 = *StorageEngine::list_generations_in_dir(&table_dir)
+            .iter()
+            .max()
+            .expect("gen2 must exist");
+        let gen2_reader = engine
+            .pooled_reader_arc_for_test(&tid, gen2)
+            .expect("gen2 reader must be pooled after flush (cache-hit precondition)");
+        let gen2_data_db =
+            StorageEngine::generation_component_path_for_test(&table_dir, gen2, "Data.db")
+                .expect("gen2 Data.db path must resolve");
+
+        // Submit a compaction merging gen1+gen2; control when the swap applies.
+        {
+            let tables = engine.tables.read();
+            let state = tables.get(&tid).unwrap();
+            let metadata = engine.collect_sstable_metadata(&tid, state);
+            drop(tables);
+            let task = crate::compaction::metadata::CompactionTask {
+                inputs: metadata,
+                output_dir: dir.path().join("compaction"),
+                schema: test_schema(),
+                table_id: tid.clone(),
+            };
+            engine.compaction_executor.submit(task).unwrap();
+        }
+
+        // Reader thread: arm it so its read pauses right after snapshotting the
+        // still-unswapped view (referencing gen2).
+        let barrier = ReadViewBarrier::new();
+        let b_reader = Arc::clone(&barrier);
+        let eng = Arc::clone(&engine);
+        let rtid = tid.clone();
+        let reader = std::thread::spawn(move || {
+            ARMED.with(|c| *c.borrow_mut() = Some(b_reader));
+            eng.read(&rtid, &make_key("t2"))
+                .expect("read must not error")
+        });
+
+        // With the read holding the old view, drive the swap to completion:
+        // poll_compactions publishes the merged output and deletes gen2's files.
+        barrier.wait_reached();
+        let mut swapped = false;
+        for _ in 0..1500 {
+            engine.poll_compactions().await;
+            if engine.sstable_count(&tid) == 1 {
+                swapped = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            swapped,
+            "compaction swap should merge the two inputs into one (background merge never completed)"
+        );
+        assert!(
+            !gen2_data_db.exists(),
+            "the swap must have deleted gen2's Data.db (that is the mid-read ENOENT trigger)"
+        );
+
+        // Re-establish the cache-HIT precondition the swap just tore down: put
+        // gen2's still-open reader back in the pool so the resumed `open_reader`
+        // succeeds and its in-memory bloom reports t2 present...
+        engine.reseed_pooled_reader_for_test(&tid, gen2, Arc::clone(&gen2_reader));
+        // ...and evict gen2's Data.db descriptor so the data seek re-opens the
+        // (now-deleted) path and observes ENOENT instead of reading through a
+        // lingering unlinked fd.
+        ferrosa_sstable::io::evict_global_fd_for_test(&gen2_data_db);
+
+        barrier.release();
+        let got = reader.join().unwrap();
+        assert!(
+            got.is_some(),
+            "t2 must remain readable when a pooled (cache-hit) gen2 reader's Data.db was \
+             deleted mid-read by a concurrent compaction — the mid-read ENOENT must drive a \
+             view retry to the merged SSTable, never a spurious Ok(None) (silent data loss)"
         );
     }
 

--- a/ferrosa-storage/src/reader_pool.rs
+++ b/ferrosa-storage/src/reader_pool.rs
@@ -212,6 +212,20 @@ impl<K: Eq + Hash + Clone, V> ReaderPool<K, V> {
             .expect("reader pool mutex poisoned")
             .contains_key(key)
     }
+
+    /// Return the cached `Arc<V>` for `key` without opening on a miss and
+    /// without perturbing recency. Test-only: the read-vs-compaction race tests
+    /// grab a still-cached input reader before a swap evicts it, so they can
+    /// re-seed it afterwards to model a *cache-hit-then-deleted-file* mid-read
+    /// (the residual window), distinct from a cache-miss reopen failure.
+    #[cfg(test)]
+    pub fn peek_arc(&self, key: &K) -> Option<Arc<V>> {
+        self.inner
+            .lock()
+            .expect("reader pool mutex poisoned")
+            .get(key)
+            .map(|entry| Arc::clone(&entry.value))
+    }
 }
 
 #[cfg(test)]

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -1420,6 +1420,21 @@ impl<F: FlushTarget> TableStore<F> {
                 }
                 Ok(None) => {}
                 Err(e) => {
+                    // A mid-read error after a SUCCESSFUL open is the residual
+                    // read-vs-compaction window: the descriptor came from a view
+                    // snapshot that a concurrent compaction has since swapped out,
+                    // and `evict_local_input_sstable_files` deleted this input's
+                    // `Data.db` *between* our open (cached reader) and our seek —
+                    // so the index/bloom said "present" but the partition fetch
+                    // hits `ENOENT`. The merged output in the NEW view holds the
+                    // row, so this must drive the same view-retry as an open
+                    // failure rather than silently dropping the key (`Ok(None)` =
+                    // data loss). Marking `sstable_open_failed` engages
+                    // `with_retried_view`: a transient compaction window resolves
+                    // on retry against the fresh view; a genuinely corrupt SSTable
+                    // re-errors across all retries and surfaces loudly via
+                    // `view_retry_exhausted` (never silently masked).
+                    sstable_open_failed = true;
                     // Detailed diagnostic for truncated SSTable investigation.
                     let id_info = guard
                         .sstable_ids
@@ -1433,7 +1448,9 @@ impl<F: FlushTarget> TableStore<F> {
                         data_file_len = data_len,
                         sstable_count = guard.sstables.len(),
                         key = ?key.key.as_bytes(),
-                        "SSTable read error: skipping corrupt partition — data may be incomplete"
+                        "SSTable read error after successful open: retrying against a fresh \
+                         view (likely compaction deleted this input mid-read); data may be \
+                         incomplete only if the error persists across all retries"
                     );
                     self.sstable_read_errors
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1549,6 +1566,13 @@ impl<F: FlushTarget> TableStore<F> {
                 }
                 Ok(None) => {}
                 Err(e) => {
+                    // Mid-read error after a successful open: same residual
+                    // read-vs-compaction window as the partition-read path —
+                    // a concurrent compaction deleted this input's `Data.db`
+                    // between our (cached) open and the row seek, so the row
+                    // lives in the merged SSTable of the NEW view. Drive the
+                    // view-retry instead of silently dropping the row.
+                    sstable_open_failed = true;
                     let id_info = guard
                         .sstable_ids
                         .get(i)
@@ -1559,7 +1583,8 @@ impl<F: FlushTarget> TableStore<F> {
                         %id_info,
                         key = ?key.key.as_bytes(),
                         clustering = ?clustering,
-                        "SSTable exact clustering read error: skipping corrupt source — data may be incomplete"
+                        "SSTable exact clustering read error after successful open: retrying \
+                         against a fresh view (likely compaction deleted this input mid-read)"
                     );
                     self.sstable_read_errors
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -5568,6 +5593,65 @@ mod tests {
                 || err.to_string().contains("unexpected EOF")
                 || err.to_string().contains("UnexpectedEof"),
             "error should identify the SSTable read failure, got: {err}"
+        );
+    }
+
+    /// Regression for the residual read-vs-compaction data-loss window
+    /// (fix/read-compaction-residual-window): when a point read opens an SSTable
+    /// successfully and its bloom says the key IS present, but the partition
+    /// fetch returns `Err` (the input's `Data.db` was deleted by a concurrent
+    /// compaction *after* the cached reader opened and *before* the seek), the
+    /// read must signal `stale_view_failed = true` so `with_retried_view` retries
+    /// against the freshly-merged view — NOT swallow the error and return a
+    /// spurious `Ok(None)` (silent data loss). Before the fix the mid-read `Err`
+    /// arm of `read_with_view` left `sstable_open_failed = false`, so no retry
+    /// fired and the committed key vanished.
+    #[test]
+    fn mid_read_fetch_error_signals_view_retry() {
+        let store = test_store();
+        let schema = test_schema();
+        let key = make_key("k-residual");
+
+        // An SSTable that holds `key` (bloom + index present) but whose Data.db
+        // is truncated, so the partition fetch errors during the data seek —
+        // modelling a file deleted out from under a still-cached reader.
+        let truncated = Arc::new(sstable_reader_from_partitions(
+            &schema,
+            &[make_partition("k-residual", b"v", 1000)],
+            Some(8),
+        ));
+        assert!(
+            truncated.may_contain_key(&key),
+            "bloom must say the key is present — that is what makes the silent-loss window dangerous"
+        );
+
+        let current = store.view.load_full();
+        let desc = SstableDescriptor::from_reader(
+            "truncated".to_string(),
+            std::path::PathBuf::new(),
+            &truncated,
+        );
+        store.seed_reader(&desc, truncated);
+        store.view.store(Arc::new(StoreView {
+            active: new_memtable(),
+            flushing: None,
+            sstables: Arc::new(vec![desc.clone()]),
+            sstable_ids: Arc::new(vec![("truncated".to_string(), std::path::PathBuf::new())]),
+            indexes: Arc::clone(&current.indexes),
+            sidecar_indexes: Arc::new(vec![Arc::new(HashMap::new())]),
+            vector_indexes: Arc::clone(&current.vector_indexes),
+        }));
+
+        let view = store.view.load_full();
+        let (result, stale_view_failed) = store.read_with_view(&view, &key, 0).unwrap();
+        assert!(
+            result.is_none(),
+            "the truncated source yields no rows on this single view snapshot"
+        );
+        assert!(
+            stale_view_failed,
+            "a mid-read fetch error on a bloom-matching SSTable must request a view retry, \
+             not be swallowed into a silent Ok(None)"
         );
     }
 


### PR DESCRIPTION
## Residual read-vs-compaction `Ok(None)` window (nightly fuzz)

Nightly fuzz (`nightly-fuzz.yml` → "Property Test Fuzzing (bounded)") panicked in
`ferrosa-storage/src/engine.rs::tests::concurrent_read_during_compaction` at
`engine.rs:12383` — `r2`/`k2` returned `Ok(None)` for a committed key, i.e. silent
**data loss** of a row that lives in the freshly-merged SSTable of the new view. This
persisted on `main` even with prior fixes #129 (windows 2+3, `Ok(None)` hot path) and
#130 (window-1 degenerate/deleted `Filter.db`) plus `745ce74b` + the
`read_during_compaction_retries_against_new_view` deterministic test. A residual window
remained.

### The residual window (root cause)

The `StoreView` swap is atomic (`store.view.store(Arc::new(new_view))`), so the residual
window is **not** a partial view. It is a **cache-hit-then-mid-read-ENOENT** ordering:

1. A point read snapshots the store view (still referencing the input generation, gen2,
   which solely holds `t2`).
2. It opens gen2 from the reader pool — a flush already seeded it, so `open_reader` is a
   **cache HIT**: open succeeds and gen2's in-memory bloom/index report the key **present**.
3. A concurrent compaction's `swap_compacted_sstables` publishes the merged output and
   `evict_local_input_sstable_files` deletes gen2's `Data.db` **between** the cached open
   and the data seek.
4. The partition fetch inside `get_partition_limited_rows` re-opens the path and hits
   `Err(ENOENT)` **mid-read**.

The prior open-failure tests don't cover this — they reopen the deleted gen2 and fail at
`open()`. Here open succeeds (cached) and only the *seek* fails. The `Err` arm of
`read_with_view` / `read_clustering_row_with_view` swallowed that error as a
"skip corrupt partition" **without** setting `sstable_open_failed`, so `with_retried_view`
never retried and the read returned a spurious `Ok(None)` — the committed key vanished.

### Evidence

- Nightly fuzz panic: `engine.rs:12383:17` (`r2.is_some()` — "k2 must always be readable")
  / `engine.rs:12392:23`, on `main` (`0731ead9`) carrying all prior fixes.
- Non-vacuity proven locally: reverting only the two fix lines makes
  `store::tests::mid_read_fetch_error_signals_view_retry` fail with exactly
  *"a mid-read fetch error on a bloom-matching SSTable must request a view retry, not be
  swallowed into a silent Ok(None)"*.

### The fix

Treat a mid-read fetch error **after a successful open** the same as an open failure: set
`sstable_open_failed = true` in both the partition-read (`read_with_view`) and
clustering-row (`read_clustering_row_with_view`) `Err` arms. This engages the existing
bounded `with_retried_view` retry, which re-reads against the current view where the
merged output holds the row. Fail-loud preserved: a transient compaction window resolves
on the next retry; a genuinely corrupt/missing SSTable re-errors across all
`MAX_VIEW_RETRIES` and surfaces loudly via `view_retry_exhausted` — never silently masked.
The `assert!(r2.is_some(), ...)` invariant is unchanged.

### Deterministic regression tests

- `store::tests::mid_read_fetch_error_signals_view_retry` — unit-level: a bloom-matching,
  `Data.db`-truncated reader whose partition fetch errors; asserts `stale_view_failed` is
  raised (fails without the fix).
- `engine::tests::read_cache_hit_mid_read_delete_retries_against_new_view` — engine-level
  `ReadViewBarrier` model: a read snapshots the pre-swap view, pauses at the barrier while
  the compaction swap completes (merged output holds `t2`; gen2 `Data.db` deleted), then
  re-seeds gen2's still-open reader (cache HIT) and evicts gen2's `Data.db` fd (so the seek
  re-opens the deleted path and hits ENOENT). On release the read takes
  open=ok → bloom=present → seek=ENOENT and must drive a view retry to the merged SSTable.
  Fails as `Ok(None)` without the fix.

Supporting test-only accessors: `ReaderPool::peek_arc`,
`StorageEngine::{pooled_reader_arc,reseed_pooled_reader}_for_test`,
`ferrosa_sstable::io::evict_global_fd_for_test`.

### Green gate

`cargo fmt --check`; `cargo clippy -p ferrosa-storage --all-targets`;
`cargo test -p ferrosa-storage` (incl. `concurrent_read_during_compaction` and both new
tests); `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p ferrosa-storage` — all green.
