### PR TITLE
feat(storage/cluster): corrupt-SSTable fail-loud + serve-from-replica + anti-entropy repair

### DIFF
--- a/ferrosa-cluster/src/coordinator/metrics.rs
+++ b/ferrosa-cluster/src/coordinator/metrics.rs
@@ -15,6 +15,7 @@ static INBOUND_MUTATION_ROWS: AtomicU64 = AtomicU64::new(0);
 static INBOUND_MUTATION_FAILURES: AtomicU64 = AtomicU64::new(0);
 static WRITE_ADMISSION_IN_FLIGHT: AtomicI64 = AtomicI64::new(0);
 static WRITE_ADMISSION_IN_FLIGHT_MAX: AtomicI64 = AtomicI64::new(0);
+static ANTI_ENTROPY_REPAIRS_REQUESTED: AtomicU64 = AtomicU64::new(0);
 
 fn update_max_i64(target: &AtomicI64, value: i64) {
     let mut current = target.load(Ordering::Relaxed);
@@ -84,6 +85,20 @@ pub fn dec_write_admission_in_flight() {
     WRITE_ADMISSION_IN_FLIGHT.fetch_sub(1, Ordering::Relaxed);
 }
 
+/// Record that the read coordinator requested one async anti-entropy repair
+/// after serving a read from a healthy replica because a local SSTable was
+/// corrupt. Returns the new total (process-wide). Non-zero in CI steady state
+/// should alert: it means real SSTable corruption was observed and self-healed.
+pub fn inc_anti_entropy_repair_requested() -> u64 {
+    ANTI_ENTROPY_REPAIRS_REQUESTED.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+/// Process-wide count of async anti-entropy repairs the read coordinator has
+/// requested after serving around a corrupt local SSTable.
+pub fn anti_entropy_repairs_requested_total() -> u64 {
+    ANTI_ENTROPY_REPAIRS_REQUESTED.load(Ordering::Relaxed)
+}
+
 pub fn render_prometheus() -> String {
     format!(
         "# HELP ferrosa_coordinator_replica_write_attempts_total Replica write attempts by this coordinator.\n\
@@ -124,7 +139,10 @@ pub fn render_prometheus() -> String {
          ferrosa_coordinator_write_admission_in_flight {}\n\
          # HELP ferrosa_coordinator_write_admission_in_flight_max Maximum writes holding coordinator admission permits since process start.\n\
          # TYPE ferrosa_coordinator_write_admission_in_flight_max gauge\n\
-         ferrosa_coordinator_write_admission_in_flight_max {}\n",
+         ferrosa_coordinator_write_admission_in_flight_max {}\n\
+         # HELP ferrosa_coordinator_anti_entropy_repairs_requested_total Async anti-entropy repairs requested after serving a read around a corrupt local SSTable.\n\
+         # TYPE ferrosa_coordinator_anti_entropy_repairs_requested_total counter\n\
+         ferrosa_coordinator_anti_entropy_repairs_requested_total {}\n",
         LOCAL_WRITE_ATTEMPTS.load(Ordering::Relaxed),
         REMOTE_WRITE_ATTEMPTS.load(Ordering::Relaxed),
         LOCAL_WRITE_ACKS.load(Ordering::Relaxed),
@@ -140,6 +158,7 @@ pub fn render_prometheus() -> String {
         INBOUND_MUTATION_FAILURES.load(Ordering::Relaxed),
         WRITE_ADMISSION_IN_FLIGHT.load(Ordering::Relaxed),
         WRITE_ADMISSION_IN_FLIGHT_MAX.load(Ordering::Relaxed),
+        ANTI_ENTROPY_REPAIRS_REQUESTED.load(Ordering::Relaxed),
     )
 }
 

--- a/ferrosa-cluster/src/coordinator/mod.rs
+++ b/ferrosa-cluster/src/coordinator/mod.rs
@@ -53,6 +53,11 @@ pub struct ClusterCoordinator {
     pub(crate) hint_store: Option<Arc<HintStore>>,
     /// Read repair metrics (attempted/succeeded/failed counters).
     pub repair_metrics: Arc<ReadRepairMetrics>,
+    /// Bounded sink for async anti-entropy repair requests fired by the read
+    /// path when it serves a read around a corrupt local SSTable. The repair
+    /// scheduler drains this to refill the affected token range from a healthy
+    /// replica (LOCKED DESIGN: serve now, repair in the background).
+    pub(crate) anti_entropy_repair_queue: Arc<crate::coordinator::read::AntiEntropyRepairQueue>,
     /// Optional snapshot of Raft state for index-aware replica selection.
     pub(crate) raft_state: Option<Arc<ArcSwap<RaftState>>>,
     /// Bounded semaphore limiting concurrent in-flight writes. Prevents bulk
@@ -116,6 +121,9 @@ impl ClusterCoordinator {
             default_cl,
             hint_store: None,
             repair_metrics: Arc::new(ReadRepairMetrics::new()),
+            anti_entropy_repair_queue: Arc::new(
+                crate::coordinator::read::AntiEntropyRepairQueue::default(),
+            ),
             raft_state: None,
             write_semaphore: Arc::new(tokio::sync::Semaphore::new(WRITE_CONCURRENCY_LIMIT)),
             stream_router: Arc::new(StreamRouter::new()),

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -156,6 +156,87 @@ async fn read_local_range_limited_rows_offloaded(
 }
 
 // ---------------------------------------------------------------------------
+// Anti-entropy repair requests (async, fired from the read path)
+// ---------------------------------------------------------------------------
+
+/// A request to refill a token range from a healthy replica via anti-entropy
+/// repair, fired by the read coordinator when it served a read around a corrupt
+/// local SSTable (LOCKED DESIGN: serve now, repair in the background).
+///
+/// The request names the table and the corrupt SSTable's covered token range so
+/// the repair scheduler can run a targeted Merkle repair of exactly that range
+/// rather than the whole table. It is *recorded* (not yet executed) here: the
+/// read path must never block on repair, and the scheduler drains these on its
+/// own tick. Draining-into-`repair_initiated` is wired separately.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AntiEntropyRepairRequest {
+    /// Table whose range needs refilling.
+    pub table_id: TableId,
+    /// Lower bound (inclusive) of the corrupt SSTable's covered token range.
+    pub min_token: i64,
+    /// Upper bound (inclusive) of the corrupt SSTable's covered token range.
+    pub max_token: i64,
+}
+
+/// Bounded, observable sink for [`AntiEntropyRepairRequest`]s fired from the
+/// read path. Holds a bounded backlog the repair scheduler drains; a global
+/// metric counts every request so corruption-driven self-heal is alertable.
+///
+/// Bounded (Power-of-10 Rule 3): once the backlog is full, further requests
+/// still bump the metric (so corruption is never silently dropped from
+/// observability) but are not queued again — the already-queued range repair
+/// for that table will refill overlapping corrupt ranges anyway.
+pub struct AntiEntropyRepairQueue {
+    /// Max queued requests before new ones are coalesced away (metric still
+    /// fires). Generous: each entry is tiny and the scheduler drains quickly.
+    capacity: usize,
+    pending: parking_lot::Mutex<std::collections::VecDeque<AntiEntropyRepairRequest>>,
+}
+
+impl AntiEntropyRepairQueue {
+    /// Default backlog capacity. Far larger than the number of distinct
+    /// corrupt SSTables a single node realistically quarantines between repair
+    /// ticks, so coalescing only engages under pathological corruption.
+    const DEFAULT_CAPACITY: usize = 1024;
+
+    fn new() -> Self {
+        Self {
+            capacity: Self::DEFAULT_CAPACITY,
+            pending: parking_lot::Mutex::new(std::collections::VecDeque::new()),
+        }
+    }
+
+    /// Record a repair request: always bumps the global metric; enqueues the
+    /// request unless the bounded backlog is full. Returns the new total count
+    /// of requests observed process-wide.
+    fn request(&self, req: AntiEntropyRepairRequest) -> u64 {
+        let total = super::metrics::inc_anti_entropy_repair_requested();
+        let mut pending = self.pending.lock();
+        if pending.len() < self.capacity {
+            pending.push_back(req);
+        } else {
+            tracing::warn!(
+                "anti-entropy repair backlog full ({}); coalescing new corrupt-range \
+                 request into existing queued repairs (metric still incremented)",
+                self.capacity
+            );
+        }
+        total
+    }
+
+    /// Drain and return all queued requests (the scheduler's pull side).
+    fn drain(&self) -> Vec<AntiEntropyRepairRequest> {
+        self.pending.lock().drain(..).collect()
+    }
+}
+
+impl Default for AntiEntropyRepairQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Internal result type for a single replica read
 // ---------------------------------------------------------------------------
 
@@ -849,6 +930,39 @@ impl ClusterCoordinator {
             .map(|info| info.host_id)
     }
 
+    /// Process-wide count of async anti-entropy repairs this coordinator has
+    /// requested after serving a read around a corrupt local SSTable.
+    pub fn anti_entropy_repairs_requested_total(&self) -> u64 {
+        super::metrics::anti_entropy_repairs_requested_total()
+    }
+
+    /// Drain the queued anti-entropy repair requests fired by the read path.
+    /// The repair scheduler calls this on its tick to run targeted range
+    /// repairs; tests call it to assert a repair was requested.
+    pub fn drain_anti_entropy_repair_requests(&self) -> Vec<AntiEntropyRepairRequest> {
+        self.anti_entropy_repair_queue.drain()
+    }
+
+    /// Record an async anti-entropy repair request for the corrupt SSTable's
+    /// token range. Never blocks the read; the scheduler refills the range from
+    /// a healthy replica in the background.
+    fn request_anti_entropy_repair(&self, table_id: &TableId, min_token: i64, max_token: i64) {
+        let req = AntiEntropyRepairRequest {
+            table_id: table_id.clone(),
+            min_token,
+            max_token,
+        };
+        let total = self.anti_entropy_repair_queue.request(req);
+        tracing::warn!(
+            table = %table_id,
+            min_token,
+            max_token,
+            anti_entropy_repairs_requested_total = total,
+            "served read around a corrupt local SSTable; requested async anti-entropy \
+             repair to refill the range from a healthy replica"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // CL=ONE helper
     // -----------------------------------------------------------------------
@@ -877,6 +991,14 @@ impl ClusterCoordinator {
             }
         }
 
+        // LOCKED DESIGN: a local corrupt-SSTable read is treated like a failed
+        // replica — at CL=ONE we fall over to a remote replica to serve the
+        // client. The corrupt SSTable's token range is remembered so that, once
+        // a healthy replica serves the read, we fire an ASYNC anti-entropy
+        // repair to refill that range (never blocking the read). `None` until a
+        // local read surfaces a typed `CorruptSstable` error.
+        let mut corrupt_range: Option<(i64, i64)> = None;
+
         for &target in &candidates {
             if target == self.local_node_id {
                 match read_local_partition(
@@ -892,6 +1014,19 @@ impl ClusterCoordinator {
                 {
                     Ok(Some(rows)) if !rows.is_empty() => return Ok(Some(rows)),
                     Ok(_) => continue, // no data on this replica, try next
+                    Err(ClusterError::Storage(ref e)) if e.corrupt_sstable_range().is_some() => {
+                        // Genuine local SSTable corruption (storage already
+                        // quarantined it). Treat it as a failed replica: record
+                        // the range so a successful failover triggers repair,
+                        // then try the next replica.
+                        corrupt_range = e.corrupt_sstable_range();
+                        tracing::warn!(
+                            %e,
+                            "read_one_replica: local SSTable corrupt; failing over to a \
+                             remote replica and scheduling anti-entropy repair"
+                        );
+                        continue;
+                    }
                     Err(e) => {
                         tracing::debug!(%e, "read_one_replica: local read failed, trying next");
                         continue;
@@ -960,8 +1095,26 @@ impl ClusterCoordinator {
             }
 
             if found_partition && !all_rows.is_empty() {
+                // Served from a healthy remote replica. If we got here because a
+                // local SSTable was corrupt, fire the async repair now (the read
+                // itself is already satisfied and is NOT blocked on repair).
+                if let Some((min_token, max_token)) = corrupt_range.take() {
+                    self.request_anti_entropy_repair(table_id, min_token, max_token);
+                }
                 return Ok(Some(all_rows));
             }
+        }
+
+        // All replicas exhausted. If a local SSTable was corrupt and no replica
+        // could serve the key, FAIL LOUD rather than returning a silent `Ok(None)`
+        // that would masquerade corruption as "key not found" — the key may have
+        // lived only in the corrupt SSTable. Still request repair so the range is
+        // refilled when a replica recovers.
+        if let Some((min_token, max_token)) = corrupt_range {
+            self.request_anti_entropy_repair(table_id, min_token, max_token);
+            return Err(ClusterError::Storage(
+                ferrosa_common::Error::corrupt_sstable("local", min_token, max_token),
+            ));
         }
 
         // All replicas exhausted — data genuinely not found.
@@ -2282,6 +2435,212 @@ mod tests {
         assert!(
             pm.has_peer(remote_host_id_3),
             "healthy spare digest replica should be connected"
+        );
+
+        server.shutdown(std::time::Duration::from_millis(50)).await;
+    }
+
+    /// Build a flushed-then-corrupted local SSTable so a local read of `key`
+    /// fails loud with [`ferrosa_common::Error::CorruptSstable`].
+    ///
+    /// Writes `row`, flushes it to an SSTable, then truncates every `-Data.db`
+    /// component for the table to a single byte. The data lives ONLY in that
+    /// SSTable (no memtable copy after flush), so a subsequent read exhausts the
+    /// view-retry bound and surfaces the typed corrupt-SSTable error — exactly
+    /// the signal the coordinator must map to a replica failover + repair.
+    fn corrupt_local_sstable(
+        dir: &std::path::Path,
+        storage: &StorageEngine,
+        table_id: &TableId,
+        key: &DecoratedKey,
+        row: Row,
+        ts: i64,
+    ) {
+        storage.write(table_id, key, row, ts).unwrap();
+        storage.flush(table_id).unwrap();
+        let sstable_dir = dir.join("sstables").join(table_id.to_string());
+        let mut corrupted = 0usize;
+        for entry in std::fs::read_dir(&sstable_dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.to_string_lossy().ends_with("-Data.db") {
+                std::fs::write(&path, [0u8]).unwrap();
+                corrupted += 1;
+            }
+        }
+        assert!(
+            corrupted > 0,
+            "test setup: expected a flushed Data.db to corrupt"
+        );
+        // NOTE: we deliberately do NOT read here to verify. The first read that
+        // hits the corruption quarantines the SSTable (later reads then skip it
+        // and return Ok(None) instead of the corrupt error). The coordinator's
+        // read under test must be that first read, so it surfaces the typed
+        // CorruptSstable error and drives the failover + repair path.
+    }
+
+    /// CL=ONE: a local corrupt-SSTable read must FAIL OVER to a remote replica
+    /// and serve the client the remote's data, rather than propagating the local
+    /// corruption error. Today CL=ONE prefers local; this asserts the failover.
+    #[tokio::test]
+    async fn coordinate_read_at_one_fails_over_to_remote_on_local_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        let key = test_key();
+
+        // Remote replica serves the partition over a real RPC server.
+        let partition = Partition {
+            key: key.clone(),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![test_row(1234)],
+        };
+        let (server, addr, remote_host_id) = start_rpc_server(
+            MsgType::ReadRequest,
+            Arc::new(StaticReadHandler {
+                partition: partition.clone(),
+            }),
+        )
+        .await;
+
+        // Local replica holds the same key but in a corrupt-only SSTable.
+        corrupt_local_sstable(dir.path(), &storage, &table_id, &key, test_row(1234), 1234);
+
+        let pm = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            Uuid::new_v4(),
+            Arc::new(NoopListener),
+        ));
+
+        let local_node_id = 1u64;
+        let mut local = make_node("127.0.0.1:7000");
+        local.host_id = Uuid::new_v4();
+        let mut remote = make_node(&addr.to_string());
+        remote.host_id = remote_host_id;
+
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, local);
+        ring.add_node(2u64, remote);
+        // Both own token 42 (test_key) at RF=2: local is preferred, remote is
+        // the failover target.
+        ring.assign_tokens(local_node_id, &[50]);
+        ring.assign_tokens(2u64, &[100]);
+
+        let coordinator = make_coordinator(
+            ring,
+            pm.clone(),
+            local_node_id,
+            storage.clone(),
+            2, // RF=2
+            ConsistencyLevel::One,
+        );
+
+        let result = coordinator
+            .coordinate_read(&table_id, &key)
+            .await
+            .expect("CL=ONE must fail over to the remote replica, not error on local corruption");
+        let rows = result.expect("remote replica holds the partition");
+        assert!(
+            !rows.is_empty(),
+            "failover read must return the remote rows"
+        );
+        let ts = rows
+            .iter()
+            .flat_map(|r| r.cells.iter().map(|(_, c)| c.timestamp))
+            .max()
+            .unwrap();
+        assert_eq!(
+            ts, 1234,
+            "served data must come from the healthy remote replica"
+        );
+
+        server.shutdown(std::time::Duration::from_millis(50)).await;
+    }
+
+    /// CL=ONE failover on local corruption must ALSO fire an async anti-entropy
+    /// repair request targeting the corrupt SSTable's token range, recorded so
+    /// the scheduler can drain it (asserted via the recorded trigger + metric).
+    #[tokio::test]
+    async fn coordinate_read_at_one_requests_repair_on_local_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        let key = test_key();
+
+        let partition = Partition {
+            key: key.clone(),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![test_row(1234)],
+        };
+        let (server, addr, remote_host_id) = start_rpc_server(
+            MsgType::ReadRequest,
+            Arc::new(StaticReadHandler {
+                partition: partition.clone(),
+            }),
+        )
+        .await;
+
+        corrupt_local_sstable(dir.path(), &storage, &table_id, &key, test_row(1234), 1234);
+
+        let pm = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            Uuid::new_v4(),
+            Arc::new(NoopListener),
+        ));
+
+        let local_node_id = 1u64;
+        let mut local = make_node("127.0.0.1:7000");
+        local.host_id = Uuid::new_v4();
+        let mut remote = make_node(&addr.to_string());
+        remote.host_id = remote_host_id;
+
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, local);
+        ring.add_node(2u64, remote);
+        ring.assign_tokens(local_node_id, &[50]);
+        ring.assign_tokens(2u64, &[100]);
+
+        let coordinator = make_coordinator(
+            ring,
+            pm.clone(),
+            local_node_id,
+            storage.clone(),
+            2,
+            ConsistencyLevel::One,
+        );
+
+        // The global metric is process-wide (shared across parallel tests), so
+        // assert it strictly *increased* — the per-coordinator queue below is
+        // the deterministic, instance-scoped source of truth for the exact count.
+        let before = coordinator.anti_entropy_repairs_requested_total();
+        coordinator.coordinate_read(&table_id, &key).await.unwrap();
+        assert!(
+            coordinator.anti_entropy_repairs_requested_total() > before,
+            "serving from a replica on local corruption must increment the \
+             anti-entropy repair metric"
+        );
+
+        // Exactly one repair request must have been recorded for this read.
+        let requests = coordinator.drain_anti_entropy_repair_requests();
+        assert_eq!(requests.len(), 1, "exactly one repair request recorded");
+        let req = &requests[0];
+        assert_eq!(
+            req.table_id, table_id,
+            "repair must target the read's table"
+        );
+        // The corrupt SSTable covered token 42 (test_key); the requested range
+        // must include it.
+        assert!(
+            req.min_token <= key.token.0 && key.token.0 <= req.max_token,
+            "repair range [{},{}] must cover the corrupt key's token {}",
+            req.min_token,
+            req.max_token,
+            key.token.0
         );
 
         server.shutdown(std::time::Duration::from_millis(50)).await;

--- a/ferrosa-cluster/src/repair/mod.rs
+++ b/ferrosa-cluster/src/repair/mod.rs
@@ -22,6 +22,7 @@ pub mod executor;
 pub mod merkle;
 pub mod rpc;
 pub mod scheduler;
+pub mod trigger;
 
 pub use cluster_view::{
     ClusterRepairView, ClusterTopology, ProbeOutcome, RepairProbe, RingTopology, RpcRepairProbe,
@@ -36,6 +37,7 @@ pub use scheduler::{
     select_initiated_ranges, select_tables_for_tick, AutoRepairConfig, AutoRepairScheduler,
     InitiatedRange, RepairContext,
 };
+pub use trigger::{ClusterRepairTrigger, ExecutorProvider};
 
 use ferrosa_sstable::types::Partition;
 use ferrosa_storage::engine::StorageEngine;

--- a/ferrosa-cluster/src/repair/trigger.rs
+++ b/ferrosa-cluster/src/repair/trigger.rs
@@ -1,0 +1,446 @@
+//! Cluster-backed [`RepairTrigger`] — the quarantine → anti-entropy-refill wire.
+//!
+//! When the storage-side `SelfHealController` quarantines a corrupt SSTable
+//! generation, the rows in that generation are gone locally. The controller
+//! calls a [`storage RepairTrigger`](ferrosa_storage::self_heal::RepairTrigger)
+//! (a *port*, since storage sits below the cluster layer) to schedule a prompt,
+//! targeted refill of exactly the quarantined token ranges from a healthy
+//! replica — rather than waiting for the next full anti-entropy cycle.
+//!
+//! [`ClusterRepairTrigger`] is the real, cluster-layer implementation of that
+//! port (FMEA #10). On `request_refill(table, ranges)` it, **per range**:
+//!
+//! 1. Verifies a **healthy** replica peer for that `(table, range)` via the same
+//!    [`RepairProbe`] the [`ClusterRepairView`](super::cluster_view) posture gate
+//!    uses — a peer that returns a non-empty Merkle digest holds readable,
+//!    non-corrupt data we can refill from.
+//! 2. **Immediately enqueues** (async, background) one targeted repair
+//!    [`SessionExecutor::run_session`] over exactly that range against the
+//!    verified-healthy peer — the storage controller never blocks on the refill
+//!    (LOCKED DESIGN: serve now / quarantine now, repair in the background).
+//!
+//! Every scheduled refill bumps an observable counter
+//! (`anti_entropy_refills_scheduled_total`); a range with no verified-healthy
+//! peer bumps `anti_entropy_refills_no_source_total` and logs loudly — the
+//! periodic repair cycle is the backstop (design Q3 / FMEA #10). Corruption is
+//! therefore never silently dropped from observability.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use ferrosa_net::task_pool::TaskPool;
+use ferrosa_storage::self_heal::{RepairTrigger, TableKey};
+use ferrosa_storage::TableId;
+
+use super::cluster_view::{ClusterTopology, ProbeOutcome, RepairProbe};
+use super::coordinator::SessionExecutor;
+
+/// Resolves the repair [`SessionExecutor`] for the **current** ring.
+///
+/// The executor is rebuilt per refill rather than captured once: the production
+/// executor ([`LocalRepairExecutor`](super::executor::LocalRepairExecutor)) is
+/// constructed against a fixed per-peer remote map, which goes stale as ring
+/// membership changes. Resolving it lazily (the same way the manual repair
+/// endpoint and the scheduler do via `build_repair_executor`) keeps the trigger
+/// pointed at live peers. `None` means the node is not ring-ready — the refill
+/// is skipped loudly and the periodic cycle is the backstop (FMEA #10).
+pub trait ExecutorProvider: Send + Sync {
+    /// Build a session executor for the current ring, or `None` if not ready.
+    fn current_executor(&self) -> Option<Arc<dyn SessionExecutor>>;
+}
+
+impl<F> ExecutorProvider for F
+where
+    F: Fn() -> Option<Arc<dyn SessionExecutor>> + Send + Sync,
+{
+    fn current_executor(&self) -> Option<Arc<dyn SessionExecutor>> {
+        self()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metrics (FMEA #7/#10 — a silent refill is a bug). Process-global counters in
+// the crate's existing free-function style (see `coordinator/metrics.rs`).
+// ---------------------------------------------------------------------------
+
+static REFILLS_SCHEDULED: AtomicU64 = AtomicU64::new(0);
+static REFILLS_NO_SOURCE: AtomicU64 = AtomicU64::new(0);
+
+/// Targeted anti-entropy refills scheduled after a successful quarantine
+/// (one per `(table, range)` for which a verified-healthy replica was found).
+pub fn anti_entropy_refills_scheduled_total() -> u64 {
+    REFILLS_SCHEDULED.load(Ordering::Relaxed)
+}
+
+/// Quarantined ranges for which **no** verified-healthy replica could be found
+/// to refill from. Non-zero means quarantined data is awaiting the periodic
+/// repair backstop — should alert.
+pub fn anti_entropy_refills_no_source_total() -> u64 {
+    REFILLS_NO_SOURCE.load(Ordering::Relaxed)
+}
+
+/// Render the `ferrosa_anti_entropy_refill_*` counters in Prometheus format.
+pub fn render_prometheus() -> String {
+    format!(
+        "# HELP ferrosa_anti_entropy_refills_scheduled_total Targeted refills scheduled from a healthy replica after quarantine.\n\
+         # TYPE ferrosa_anti_entropy_refills_scheduled_total counter\n\
+         ferrosa_anti_entropy_refills_scheduled_total {}\n\
+         # HELP ferrosa_anti_entropy_refills_no_source_total Quarantined ranges with no verified-healthy replica to refill from.\n\
+         # TYPE ferrosa_anti_entropy_refills_no_source_total counter\n\
+         ferrosa_anti_entropy_refills_no_source_total {}\n",
+        REFILLS_SCHEDULED.load(Ordering::Relaxed),
+        REFILLS_NO_SOURCE.load(Ordering::Relaxed),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// ClusterRepairTrigger
+// ---------------------------------------------------------------------------
+
+/// Cluster-layer [`RepairTrigger`]: schedules a targeted anti-entropy refill of
+/// quarantined ranges from a verified-healthy replica.
+///
+/// Holds the three ports it needs, all trait objects so the wiring is fully
+/// unit-testable with no live ring / RPC:
+/// - [`ClusterTopology`] — the table's replica peers (`(ring_id, host_id)`),
+/// - [`RepairProbe`] — verifies a peer holds a non-empty, non-corrupt copy,
+/// - [`ExecutorProvider`] — resolves the live [`SessionExecutor`] that runs one
+///   targeted Merkle-diff-then-stream session.
+///
+/// On a real node the binary supplies the same `RingTopology` + `RpcRepairProbe`
+/// the posture gate uses and a provider that rebuilds the production session
+/// executor against the current ring; tests inject mocks.
+pub struct ClusterRepairTrigger {
+    topology: Arc<dyn ClusterTopology>,
+    probe: Arc<dyn RepairProbe>,
+    executor: Arc<dyn ExecutorProvider>,
+}
+
+impl ClusterRepairTrigger {
+    /// Construct from the topology, probe, and executor-provider ports.
+    pub fn new(
+        topology: Arc<dyn ClusterTopology>,
+        probe: Arc<dyn RepairProbe>,
+        executor: Arc<dyn ExecutorProvider>,
+    ) -> Self {
+        Self {
+            topology,
+            probe,
+            executor,
+        }
+    }
+
+    /// Find the first verified-healthy replica peer for `(table, range)`, probing
+    /// the table's replica peers in the topology's deterministic order. Returns
+    /// the peer's `(ring_id, host_id)` on the first non-empty digest; `None` when
+    /// no reachable peer verifies a non-empty copy (FMEA #1 / single-node).
+    fn healthy_peer_for(&self, table: &TableId, range: (i64, i64)) -> Option<(u64, uuid::Uuid)> {
+        let key = TableKey::new(table.keyspace(), table.table());
+        let peers = self.topology.replica_peers(&key);
+        for (ring_id, host_id) in peers {
+            match self.probe.probe_digest(host_id, table, range) {
+                ProbeOutcome::HealthyNonEmpty => return Some((ring_id, host_id)),
+                ProbeOutcome::Empty | ProbeOutcome::Unreachable => continue,
+            }
+        }
+        None
+    }
+
+    /// Schedule (immediately, in the background) one targeted repair session for
+    /// `(table, range)` against `peer_ring_id`. Non-blocking: the controller's
+    /// quarantine tick must never wait on the refill.
+    ///
+    /// The executor is resolved from the [`ExecutorProvider`] *inside* the
+    /// spawned task so it reflects current ring membership and the resolve
+    /// (which may touch the ring snapshot) never runs on the controller tick. A
+    /// `None` executor (node not ring-ready) is logged loudly — the periodic
+    /// cycle is the backstop (FMEA #10).
+    fn schedule_session(&self, table: &TableId, range: (i64, i64), peer_ring_id: u64) {
+        let provider = self.executor.clone();
+        let table = table.clone();
+        let (start, end) = range;
+        TaskPool::current("anti-entropy-refill").spawn(async move {
+            let Some(executor) = provider.current_executor() else {
+                tracing::warn!(
+                    keyspace = table.keyspace(),
+                    table = table.table(),
+                    range_start = start,
+                    range_end = end,
+                    peer = peer_ring_id,
+                    "anti-entropy refill: node not ring-ready; targeted refill skipped — \
+                     periodic repair is the backstop (FMEA #10)"
+                );
+                return;
+            };
+            match executor.run_session(&table, start, end, peer_ring_id).await {
+                Ok(stats) => {
+                    tracing::info!(
+                        keyspace = table.keyspace(),
+                        table = table.table(),
+                        range_start = start,
+                        range_end = end,
+                        peer = peer_ring_id,
+                        partitions_streamed_in = stats.partitions_streamed_in,
+                        "anti-entropy refill: quarantined range repaired from healthy replica"
+                    );
+                }
+                Err(e) => {
+                    // Loud: the session failed; the periodic cycle is the backstop.
+                    tracing::warn!(
+                        keyspace = table.keyspace(),
+                        table = table.table(),
+                        range_start = start,
+                        range_end = end,
+                        peer = peer_ring_id,
+                        error = %e,
+                        "anti-entropy refill: targeted session FAILED; periodic repair is the backstop"
+                    );
+                }
+            }
+        });
+    }
+}
+
+impl RepairTrigger for ClusterRepairTrigger {
+    fn request_refill(&self, table: &TableId, ranges: &[(i64, i64)]) {
+        for &range in ranges {
+            match self.healthy_peer_for(table, range) {
+                Some((ring_id, host_id)) => {
+                    REFILLS_SCHEDULED.fetch_add(1, Ordering::Relaxed);
+                    tracing::info!(
+                        keyspace = table.keyspace(),
+                        table = table.table(),
+                        range_start = range.0,
+                        range_end = range.1,
+                        peer = ring_id,
+                        %host_id,
+                        "anti-entropy refill: verified healthy replica; scheduling targeted refill"
+                    );
+                    self.schedule_session(table, range, ring_id);
+                }
+                None => {
+                    REFILLS_NO_SOURCE.fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!(
+                        keyspace = table.keyspace(),
+                        table = table.table(),
+                        range_start = range.0,
+                        range_end = range.1,
+                        "anti-entropy refill: NO verified-healthy replica for quarantined range; \
+                         periodic repair cycle is the backstop (FMEA #10)"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use super::super::cluster_view::{ClusterTopology, RepairProbe};
+    use super::super::coordinator::{SessionExecutor, SessionStats};
+
+    /// Topology with a fixed replica-peer list, in the order the trigger probes.
+    struct MockTopology {
+        peers: Vec<(u64, uuid::Uuid)>,
+    }
+    impl ClusterTopology for MockTopology {
+        fn this_node_id(&self) -> u64 {
+            1
+        }
+        fn owners(&self, _t: &TableKey) -> Option<Vec<u64>> {
+            Some(self.peers.iter().map(|(n, _)| *n).collect())
+        }
+        fn replica_peers(&self, _t: &TableKey) -> Vec<(u64, uuid::Uuid)> {
+            self.peers.clone()
+        }
+    }
+
+    /// Probe returning a per-peer canned outcome, recording the probe order.
+    struct MockProbe {
+        outcomes: HashMap<uuid::Uuid, ProbeOutcome>,
+        probed: Mutex<Vec<uuid::Uuid>>,
+    }
+    impl MockProbe {
+        fn new(outcomes: Vec<(uuid::Uuid, ProbeOutcome)>) -> Self {
+            Self {
+                outcomes: outcomes.into_iter().collect(),
+                probed: Mutex::new(Vec::new()),
+            }
+        }
+    }
+    impl RepairProbe for MockProbe {
+        fn probe_digest(&self, peer: uuid::Uuid, _t: &TableId, _r: (i64, i64)) -> ProbeOutcome {
+            self.probed.lock().unwrap().push(peer);
+            self.outcomes
+                .get(&peer)
+                .copied()
+                .unwrap_or(ProbeOutcome::Unreachable)
+        }
+    }
+
+    /// One repair session invocation: `(table, range_start, range_end, peer)`.
+    type SessionCall = (TableId, i64, i64, u64);
+
+    /// Executor that records every `run_session` it is asked to run.
+    #[derive(Default)]
+    struct RecordingExecutor {
+        calls: Mutex<Vec<SessionCall>>,
+    }
+    #[async_trait]
+    impl SessionExecutor for RecordingExecutor {
+        async fn run_session(
+            &self,
+            table: &TableId,
+            range_start: i64,
+            range_end: i64,
+            peer: u64,
+        ) -> Result<SessionStats, String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((table.clone(), range_start, range_end, peer));
+            Ok(SessionStats::default())
+        }
+    }
+
+    /// Build an [`ExecutorProvider`] that always resolves to `exec` — the
+    /// healthy, ring-ready case the production closure hits once the node is
+    /// placed in the ring.
+    fn provider_for(exec: &Arc<RecordingExecutor>) -> Arc<dyn ExecutorProvider> {
+        let exec = exec.clone();
+        Arc::new(move || Some(exec.clone() as Arc<dyn SessionExecutor>))
+    }
+
+    /// Wait until the recording executor has observed `n` calls, or time out.
+    /// The session runs on a spawned task, so the assertion must let it land
+    /// (bounded — never an unbounded spin).
+    async fn wait_for_calls(exec: &Arc<RecordingExecutor>, n: usize) -> Vec<SessionCall> {
+        for _ in 0..200 {
+            {
+                let calls = exec.calls.lock().unwrap();
+                if calls.len() >= n {
+                    return calls.clone();
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        exec.calls.lock().unwrap().clone()
+    }
+
+    /// RED: a quarantine refill request must enqueue exactly one targeted repair
+    /// session for the right `(table, range)` against a **verified-healthy**
+    /// replica peer — the one whose probe returns `HealthyNonEmpty`.
+    #[tokio::test]
+    async fn request_refill_schedules_targeted_session_against_healthy_replica() {
+        let empty_peer = (2u64, uuid::Uuid::from_u128(0xAAAA));
+        let healthy_peer = (3u64, uuid::Uuid::from_u128(0xBBBB));
+
+        let topology = Arc::new(MockTopology {
+            // Probe order: empty peer first (skipped), then the healthy one.
+            peers: vec![empty_peer, healthy_peer],
+        });
+        let probe = Arc::new(MockProbe::new(vec![
+            (empty_peer.1, ProbeOutcome::Empty),
+            (healthy_peer.1, ProbeOutcome::HealthyNonEmpty),
+        ]));
+        let exec = Arc::new(RecordingExecutor::default());
+
+        let trigger = ClusterRepairTrigger::new(topology, probe, provider_for(&exec));
+
+        let table = TableId::new("ks", "t");
+        let range = (100i64, 200i64);
+        let before = anti_entropy_refills_scheduled_total();
+
+        trigger.request_refill(&table, &[range]);
+
+        let calls = wait_for_calls(&exec, 1).await;
+        assert_eq!(
+            calls.len(),
+            1,
+            "exactly one targeted refill session must be scheduled"
+        );
+        assert_eq!(
+            calls[0],
+            (table.clone(), range.0, range.1, healthy_peer.0),
+            "session must target the right table+range against the verified-healthy peer"
+        );
+        assert!(
+            anti_entropy_refills_scheduled_total() > before,
+            "the scheduled-refill metric must increment (corruption self-heal is observable)"
+        );
+    }
+
+    /// WIRING (FMEA #10): when a verified-healthy replica IS found but the
+    /// [`ExecutorProvider`] resolves to `None` (the node is not ring-ready), no
+    /// session runs — the executor is resolved lazily from the provider, and an
+    /// unready node must not fabricate a session against a peer it can't reach.
+    /// This pins the production seam: `main.rs` supplies a provider that returns
+    /// `None` until the node is placed in the ring, exactly like this.
+    #[tokio::test]
+    async fn request_refill_skips_session_when_executor_provider_not_ready() {
+        let healthy_peer = (3u64, uuid::Uuid::from_u128(0xBEEF));
+        let topology = Arc::new(MockTopology {
+            peers: vec![healthy_peer],
+        });
+        let probe = Arc::new(MockProbe::new(vec![(
+            healthy_peer.1,
+            ProbeOutcome::HealthyNonEmpty,
+        )]));
+        // Provider is not ring-ready: always None.
+        let not_ready: Arc<dyn ExecutorProvider> =
+            Arc::new(|| -> Option<Arc<dyn SessionExecutor>> { None });
+        let exec = Arc::new(RecordingExecutor::default());
+
+        let trigger = ClusterRepairTrigger::new(topology, probe, not_ready);
+
+        // A healthy peer is found, so the scheduled-refill metric DOES bump and a
+        // task is spawned — but inside the task the provider yields no executor,
+        // so no run_session ever lands on the recorder.
+        trigger.request_refill(&TableId::new("ks", "t"), &[(0, 100)]);
+
+        let calls = wait_for_calls(&exec, 1).await;
+        assert!(
+            calls.is_empty(),
+            "no session may run when the executor provider is not ring-ready"
+        );
+    }
+
+    /// No verified-healthy replica (all peers empty/unreachable) → no session is
+    /// scheduled and the no-source metric increments (FMEA #1: never refill from
+    /// a non-source; FMEA #10: the periodic cycle is the backstop).
+    #[tokio::test]
+    async fn request_refill_with_no_healthy_replica_schedules_nothing_and_counts_no_source() {
+        let peer_a = (2u64, uuid::Uuid::from_u128(0xCCCC));
+        let peer_b = (3u64, uuid::Uuid::from_u128(0xDDDD));
+
+        let topology = Arc::new(MockTopology {
+            peers: vec![peer_a, peer_b],
+        });
+        let probe = Arc::new(MockProbe::new(vec![
+            (peer_a.1, ProbeOutcome::Empty),
+            (peer_b.1, ProbeOutcome::Unreachable),
+        ]));
+        let exec = Arc::new(RecordingExecutor::default());
+
+        let trigger = ClusterRepairTrigger::new(topology, probe, provider_for(&exec));
+
+        let before_no_source = anti_entropy_refills_no_source_total();
+        trigger.request_refill(&TableId::new("ks", "t"), &[(0, 50)]);
+
+        // Give any (erroneously) spawned session a chance to land, then assert none did.
+        let calls = wait_for_calls(&exec, 1).await;
+        assert!(
+            calls.is_empty(),
+            "no session may be scheduled when no replica is verified healthy"
+        );
+        assert!(
+            anti_entropy_refills_no_source_total() > before_no_source,
+            "the no-source metric must increment so the operator sees un-refilled corruption"
+        );
+    }
+}

--- a/ferrosa-common/src/error.rs
+++ b/ferrosa-common/src/error.rs
@@ -29,6 +29,24 @@ pub enum Error {
     UnsupportedVersion(String),
     /// Compression algorithm not supported.
     UnsupportedCompression(String),
+    /// A read could not be resolved because a snapshotted SSTable was
+    /// genuinely corrupt (the view-retry bound was exhausted with the file
+    /// still failing) and no healthy local source held the key.
+    ///
+    /// This is a *typed* signal — never string-matched — so the read
+    /// coordinator can (a) treat the local replica as failed and fail over to
+    /// another replica, and (b) target anti-entropy repair at the corrupt
+    /// SSTable's covered token range. The corrupt SSTable has already been
+    /// quarantined by the storage layer when this error is raised.
+    CorruptSstable {
+        /// Stable generation ID of the corrupt SSTable (file-name / pool key).
+        gen: String,
+        /// Smallest partition token the corrupt SSTable covered — the lower
+        /// bound of the range repair must refill from a healthy replica.
+        min_token: i64,
+        /// Largest partition token the corrupt SSTable covered.
+        max_token: i64,
+    },
 }
 
 impl Error {
@@ -42,6 +60,31 @@ impl Error {
                     || msg.contains(": overloaded:")
             }
             _ => false,
+        }
+    }
+
+    /// Construct a [`Error::CorruptSstable`] from the corrupt SSTable's
+    /// generation and covered token range.
+    pub fn corrupt_sstable(gen: impl Into<String>, min_token: i64, max_token: i64) -> Self {
+        Error::CorruptSstable {
+            gen: gen.into(),
+            min_token,
+            max_token,
+        }
+    }
+
+    /// When this error is a [`Error::CorruptSstable`], return the corrupt
+    /// SSTable's covered token range `(min_token, max_token)` so the caller can
+    /// target anti-entropy repair at exactly that range. `None` for every other
+    /// error variant — the typed alternative to matching on a message string.
+    pub fn corrupt_sstable_range(&self) -> Option<(i64, i64)> {
+        match self {
+            Error::CorruptSstable {
+                min_token,
+                max_token,
+                ..
+            } => Some((*min_token, *max_token)),
+            _ => None,
         }
     }
 }
@@ -60,6 +103,16 @@ impl fmt::Display for Error {
             }
             Error::UnsupportedVersion(v) => write!(f, "unsupported version: {v}"),
             Error::UnsupportedCompression(c) => write!(f, "unsupported compression: {c}"),
+            Error::CorruptSstable {
+                gen,
+                min_token,
+                max_token,
+            } => write!(
+                f,
+                "corrupt SSTable made the read unresolvable [gen={gen} \
+                 tokens=[{min_token},{max_token}]]; quarantined and scheduled \
+                 for anti-entropy repair"
+            ),
         }
     }
 }

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -5403,6 +5403,19 @@ impl StorageEngine {
         }
     }
 
+    /// SSTable generations the read path has quarantined for `table_id` because
+    /// a read exhausted the view-retry bound against them (genuine corruption,
+    /// not a transient compaction window). A non-empty result is the storage
+    /// signal that anti-entropy repair must refill those generations' token
+    /// ranges from a healthy replica. Empty (or an unknown table) yields `[]`.
+    pub fn table_quarantined_sstable_gens(&self, table_id: &TableId) -> Vec<String> {
+        let tables = self.tables.read();
+        match tables.get(table_id) {
+            Some(state) => state.store.quarantined_sstable_gens(),
+            None => Vec::new(),
+        }
+    }
+
     /// Reads exactly one clustered row from a table partition, merging matching
     /// rows across memtable and SSTable sources.
     pub fn read_clustering_row(
@@ -9818,15 +9831,38 @@ mod tests {
             }
         }
 
-        // Read must NOT panic after SSTable files are deleted.
-        // The reader may still have data via mmap — both Some and None
-        // are acceptable. The key invariant: no panic, no hang.
-        let result = engine.read(&tid, &key);
-        assert!(
-            result.is_ok(),
-            "read after SSTable deletion must not panic: {:?}",
-            result.err()
-        );
+        // Read must NOT panic after SSTable files are deleted, and must NOT
+        // silently return empty results (the data was the only copy on this
+        // single node, RF=1). Two outcomes are correct:
+        //   (a) the cached reader still serves the data via its open fd/mmap →
+        //       Ok(Some) (the file deletion didn't actually break the read); or
+        //   (b) the read can no longer resolve the key → FAIL LOUD (`Err`) and
+        //       quarantine the corrupt SSTable for anti-entropy repair.
+        // A silent Ok(None) is the one forbidden outcome.
+        match engine.read(&tid, &key) {
+            Ok(Some(_)) => {
+                // Cached reader still served the data — acceptable.
+            }
+            Ok(None) => {
+                panic!(
+                    "read after SSTable deletion must not silently lose data: \
+                     got Ok(None) instead of failing loud"
+                );
+            }
+            Err(e) => {
+                assert!(
+                    e.to_string().contains("corrupt SSTable")
+                        && e.to_string().contains("anti-entropy repair"),
+                    "the fail-loud error must identify the corrupt SSTable and signal repair, \
+                     got: {e}"
+                );
+                assert!(
+                    !engine.table_quarantined_sstable_gens(&tid).is_empty(),
+                    "a fail-loud unresolvable read must quarantine the corrupt SSTable \
+                     (repair requested)"
+                );
+            }
+        }
     }
 
     /// Production scenario: batch1 (small), flush, batch2 (large), flush,
@@ -14646,9 +14682,11 @@ mod tests {
 
     // ── FMEA: SSTable corruption resilience ─────────────────────────────
 
-    /// FMEA #1: Truncating an SSTable Data.db file should not crash reads.
-    /// The read should return data from the memtable or other SSTables,
-    /// logging a warning about the corrupt SSTable.
+    /// FMEA #1: Truncating an SSTable Data.db file must not crash reads — but
+    /// with NO healthy replica to refill from (single-node, RF=1) an
+    /// unresolvable read of the corrupt-only key must FAIL LOUD (return `Err`),
+    /// never a silent `Ok(None)` (anti-entropy slice). It must also QUARANTINE
+    /// the corrupt SSTable so repair can refill its range.
     #[test]
     fn read_survives_truncated_sstable_data_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -14695,17 +14733,26 @@ mod tests {
             }
         }
 
-        // Read should NOT crash — should return None (data lost but no panic)
-        let result = engine.read(&tid, &key);
+        // No healthy source holds the key (single-node, RF=1) and the only
+        // SSTable is corrupt: the read must FAIL LOUD, not silently lose data.
+        let err = engine
+            .read(&tid, &key)
+            .expect_err("unresolvable read of a corrupt-only SSTable must fail loud, not Ok(None)");
         assert!(
-            result.is_ok(),
-            "read with corrupt SSTable should not crash: {:?}",
-            result.err()
+            err.to_string().contains("corrupt SSTable")
+                && err.to_string().contains("anti-entropy repair"),
+            "the error must identify the corrupt SSTable and signal repair, got: {err}"
         );
-        // Data may be lost (from corrupt SSTable) but the operation didn't crash
+        // And the corrupt SSTable must be quarantined so repair can refill it.
+        assert!(
+            !engine.table_quarantined_sstable_gens(&tid).is_empty(),
+            "the corrupt SSTable must be quarantined (repair requested)"
+        );
     }
 
-    /// FMEA #6: Zero-length Data.db should not crash reads.
+    /// FMEA #6: Zero-length Data.db must not crash reads. With no healthy
+    /// replica (single-node, RF=1) an unresolvable read of the corrupt-only key
+    /// must FAIL LOUD and quarantine the corrupt SSTable for repair.
     #[test]
     fn read_survives_zero_length_data_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -14751,11 +14798,17 @@ mod tests {
             }
         }
 
-        let result = engine.read(&tid, &key);
+        let err = engine.read(&tid, &key).expect_err(
+            "unresolvable read of a zero-length corrupt SSTable must fail loud, not Ok(None)",
+        );
         assert!(
-            result.is_ok(),
-            "read with zero-length SSTable should not crash: {:?}",
-            result.err()
+            err.to_string().contains("corrupt SSTable")
+                && err.to_string().contains("anti-entropy repair"),
+            "the error must identify the corrupt SSTable and signal repair, got: {err}"
+        );
+        assert!(
+            !engine.table_quarantined_sstable_gens(&tid).is_empty(),
+            "the corrupt SSTable must be quarantined (repair requested)"
         );
     }
 
@@ -14835,8 +14888,11 @@ mod tests {
         assert!(r2.unwrap().is_some(), "new row should exist");
     }
 
-    /// FMEA #8: Memtable write + new data in memtable should still work
-    /// even if an SSTable is corrupt.
+    /// FMEA #8: A read RESOLVABLE from the memtable must still succeed
+    /// (`Ok(Some)`) even when an SSTable is corrupt — the corruption only
+    /// affects keys that lived in that SSTable. A read of the corrupt-only key,
+    /// with no healthy replica (single-node, RF=1), must FAIL LOUD and
+    /// quarantine the corrupt SSTable for repair (anti-entropy slice).
     #[test]
     fn memtable_data_survives_corrupt_sstable() {
         let dir = tempfile::tempdir().unwrap();
@@ -14893,17 +14949,26 @@ mod tests {
         };
         engine.write(&tid, &key_new, row, 2000).unwrap();
 
-        // Read new data from memtable — should work despite corrupt SSTable
+        // Read new data from memtable — must still work despite the corrupt
+        // SSTable (the key is resolvable from a healthy source).
         let r = engine.read(&tid, &key_new);
         assert!(r.is_ok(), "memtable read should work: {:?}", r.err());
         assert!(r.unwrap().is_some(), "memtable row should exist");
 
-        // Read old data — corrupt SSTable, but should not crash
-        let r_old = engine.read(&tid, &key_old);
+        // Read old data — it lived ONLY in the now-corrupt SSTable and there is
+        // no healthy replica to refill from. The read must FAIL LOUD rather than
+        // silently return Ok(None), and quarantine the corrupt SSTable.
+        let err = engine
+            .read(&tid, &key_old)
+            .expect_err("read of corrupt-only data with no replica must fail loud, not Ok(None)");
         assert!(
-            r_old.is_ok(),
-            "read of corrupt SSTable data should not crash: {:?}",
-            r_old.err()
+            err.to_string().contains("corrupt SSTable")
+                && err.to_string().contains("anti-entropy repair"),
+            "the error must identify the corrupt SSTable and signal repair, got: {err}"
+        );
+        assert!(
+            !engine.table_quarantined_sstable_gens(&tid).is_empty(),
+            "the corrupt SSTable must be quarantined (repair requested)"
         );
     }
 

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -299,6 +299,46 @@ impl SstableDescriptor {
     }
 }
 
+/// Identity of an SSTable that a read could not consult after exhausting the
+/// view-retry bound — i.e. genuinely corrupt/missing rather than a transient
+/// compaction window. Carried up the read path so the caller can (a) name the
+/// file in a fail-loud error and (b) quarantine it and target anti-entropy
+/// repair at its covered token range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorruptSstableId {
+    /// Stable generation ID of the corrupt SSTable (file-name / pool key).
+    pub gen: String,
+    /// Directory holding the SSTable's component files (empty for in-memory
+    /// fixtures); paired with `gen` it locates the file for forensics/repair.
+    pub dir: std::path::PathBuf,
+    /// Smallest partition token the corrupt SSTable covered — the lower bound
+    /// of the range anti-entropy repair must refill from a healthy replica.
+    pub min_token: i64,
+    /// Largest partition token the corrupt SSTable covered.
+    pub max_token: i64,
+}
+
+impl CorruptSstableId {
+    fn from_descriptor(desc: &SstableDescriptor) -> Self {
+        Self {
+            gen: desc.gen.clone(),
+            dir: desc.dir.clone(),
+            min_token: desc.min_token,
+            max_token: desc.max_token,
+        }
+    }
+}
+
+impl std::fmt::Display for CorruptSstableId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "gen={} dir={:?} tokens=[{},{}]",
+            self.gen, self.dir, self.min_token, self.max_token
+        )
+    }
+}
+
 /// Atomic snapshot of the storage engine's current state.
 ///
 /// Held inside an [`ArcSwap`] so any thread can load a consistent view
@@ -469,6 +509,14 @@ pub struct TableStore<F: FlushTarget> {
     /// [`ann_search_partitions`] enumerate those scoped sidecars and recover the
     /// actual partition keys without a full table scan.
     vector_index_scopes: parking_lot::Mutex<HashMap<String, std::collections::HashSet<Vec<u8>>>>,
+    /// SSTable generations the read path has quarantined because a read
+    /// exhausted the view-retry bound against them (genuine corruption, not a
+    /// transient compaction window). Subsequent reads SKIP these generations so
+    /// they neither re-fail nor re-incur the full retry storm, and anti-entropy
+    /// repair targets their covered token range to refill from a healthy
+    /// replica. Keyed by `gen`; the covered range is recovered from the live
+    /// descriptor (still in the view until repair swaps it out).
+    quarantined_sstables: parking_lot::RwLock<std::collections::HashSet<String>>,
 }
 
 fn new_memtable() -> Arc<dyn Memtable> {
@@ -814,6 +862,7 @@ impl<F: FlushTarget> TableStore<F> {
             vector_index_methods: HashMap::new(),
             next_gen: std::sync::atomic::AtomicU64::new(1),
             vector_index_scopes: parking_lot::Mutex::new(HashMap::new()),
+            quarantined_sstables: parking_lot::RwLock::new(std::collections::HashSet::new()),
             write_barrier: parking_lot::RwLock::new(()),
             sstable_read_errors: std::sync::atomic::AtomicU64::new(0),
             view_retry_exhausted: std::sync::atomic::AtomicU64::new(0),
@@ -1019,6 +1068,7 @@ impl<F: FlushTarget> TableStore<F> {
             vector_index_methods: HashMap::new(),
             next_gen: std::sync::atomic::AtomicU64::new(1),
             vector_index_scopes: parking_lot::Mutex::new(HashMap::new()),
+            quarantined_sstables: parking_lot::RwLock::new(std::collections::HashSet::new()),
             write_barrier: parking_lot::RwLock::new(()),
             sstable_read_errors: std::sync::atomic::AtomicU64::new(0),
             view_retry_exhausted: std::sync::atomic::AtomicU64::new(0),
@@ -1096,6 +1146,7 @@ impl<F: FlushTarget> TableStore<F> {
             vector_index_methods: HashMap::new(),
             next_gen: std::sync::atomic::AtomicU64::new(1),
             vector_index_scopes: parking_lot::Mutex::new(HashMap::new()),
+            quarantined_sstables: parking_lot::RwLock::new(std::collections::HashSet::new()),
             write_barrier: parking_lot::RwLock::new(()),
             sstable_read_errors: std::sync::atomic::AtomicU64::new(0),
             view_retry_exhausted: std::sync::atomic::AtomicU64::new(0),
@@ -1299,21 +1350,27 @@ impl<F: FlushTarget> TableStore<F> {
     /// component such as `Filter.db` removed) before we open it, the data has
     /// already moved into a new SSTable in a newer view — so reload and retry
     /// instead of returning a result that silently drops the key (a fail-loud
-    /// violation). `attempt` returns `(result, stale_view_failed)` where
-    /// `stale_view_failed` means a snapshotted SSTable could not be fully
-    /// consulted; whenever it is set we reload the view and retry.
+    /// violation). `attempt` returns `(result, corrupt)` where `corrupt` is
+    /// `Some(id)` when a snapshotted SSTable could not be fully consulted; while
+    /// it is set we reload the view and retry.
     ///
     /// Retry is **not** gated on the view pointer changing: a deletion that
     /// leaves the live view referencing the same generation (e.g. S3
     /// local-cache eviction) must still be retried so the reopen re-resolves /
-    /// re-fetches the file. Bounded by `MAX_VIEW_RETRIES`; if a fresh reopen
+    /// re-fetches the file. Bounded by `MAX_VIEW_RETRIES`. If a fresh reopen
     /// against the current view still fails after the bound, the file is
-    /// genuinely corrupt/missing and the (tolerant) result is returned — but
-    /// the exhaustion is logged and metered so it is never silent.
+    /// genuinely corrupt (a transient compaction window resolves within the
+    /// bound): the SSTable is **quarantined** (so later reads skip it and
+    /// anti-entropy repair can target its range) and then —
+    ///
+    /// - if the key was still resolved from a healthy source, the result is
+    ///   returned (`Ok(Some)`) and the corruption logged/metered;
+    /// - if nothing resolved, the read **fails loud** with an error naming the
+    ///   corrupt SSTable (never a silent `Ok(None)`).
     fn with_retried_view<R>(
         &self,
         op: &'static str,
-        mut attempt: impl FnMut(&StoreView) -> Result<(Option<R>, bool)>,
+        mut attempt: impl FnMut(&StoreView) -> Result<(Option<R>, Option<CorruptSstableId>)>,
     ) -> Result<Option<R>> {
         const MAX_VIEW_RETRIES: usize = 8;
         for n in 0..=MAX_VIEW_RETRIES {
@@ -1324,40 +1381,114 @@ impl<F: FlushTarget> TableStore<F> {
                 barrier.reach_and_wait();
             }
 
-            let (result, stale_view_failed) = attempt(&view)?;
-            if stale_view_failed && n < MAX_VIEW_RETRIES {
+            let (result, corrupt) = attempt(&view)?;
+            let Some(corrupt) = corrupt else {
+                // No snapshotted SSTable failed to be consulted — clean attempt.
+                return Ok(result);
+            };
+            if n < MAX_VIEW_RETRIES {
+                // A snapshotted SSTable could not be consulted. In the common
+                // case this is the transient compaction window: reload and retry
+                // against a fresh view. ONLY exhaustion (below) is treated as
+                // genuine corruption — a transient window resolves within the
+                // bound and never reaches the quarantine/fail-loud path.
                 continue;
             }
-            if stale_view_failed {
-                // Bound exhausted with a still-failing open: fail loud rather
-                // than silently returning a possibly-incomplete result.
-                self.view_retry_exhausted
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+            // Bound exhausted with the SSTable still failing: genuine
+            // corruption. Quarantine it so later reads skip it (no re-fail, no
+            // repeated retry storm) and so anti-entropy repair can target its
+            // covered token range to refill from a healthy replica.
+            self.view_retry_exhausted
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.quarantine_sstable(&corrupt);
+
+            if result.is_some() {
+                // Data was still resolvable from a healthy source (memtable or
+                // another SSTable) — serve it. The corrupt file is quarantined
+                // for background repair, but the read itself succeeds.
                 tracing::error!(
                     op,
+                    corrupt = %corrupt,
                     retries = MAX_VIEW_RETRIES,
-                    "read exhausted view retries with an SSTable still failing to open — \
-                     result may be incomplete (genuinely corrupt/missing file?)"
+                    "read served from a healthy source despite a corrupt SSTable; \
+                     corrupt SSTable quarantined for anti-entropy repair"
                 );
+                return Ok(result);
             }
-            return Ok(result);
+
+            // Nothing resolved AND a source was corrupt: fail loud. Returning
+            // Ok(None) here would be silent data loss — the key may live only in
+            // the corrupt SSTable. The error names the SSTable so the
+            // coordinator can fail over to a replica and repair can refill its
+            // range.
+            tracing::error!(
+                op,
+                corrupt = %corrupt,
+                retries = MAX_VIEW_RETRIES,
+                "read exhausted view retries with a corrupt SSTable and no healthy \
+                 source resolved the key — failing loud (quarantined for repair)"
+            );
+            // Typed signal (never string-matched): carries the corrupt
+            // SSTable's generation and covered token range so the read
+            // coordinator can fail over to a replica and target anti-entropy
+            // repair at exactly that range.
+            return Err(ferrosa_common::Error::corrupt_sstable(
+                corrupt.gen.clone(),
+                corrupt.min_token,
+                corrupt.max_token,
+            ));
         }
         unreachable!("read retry loop returns within MAX_VIEW_RETRIES")
     }
 
+    /// Record `corrupt`'s generation in the quarantine set. Idempotent: a
+    /// generation already present is left as-is (it is still skipped on every
+    /// read until repair swaps it out of the view).
+    fn quarantine_sstable(&self, corrupt: &CorruptSstableId) {
+        let inserted = self
+            .quarantined_sstables
+            .write()
+            .insert(corrupt.gen.clone());
+        if inserted {
+            tracing::warn!(
+                corrupt = %corrupt,
+                "quarantined corrupt SSTable: subsequent reads skip it and anti-entropy \
+                 repair will refill its token range from a healthy replica"
+            );
+        }
+    }
+
+    /// Whether `gen` is currently quarantined (and therefore skipped by reads).
+    /// Used by the repair path to target the SSTable's range and by tests.
+    pub fn is_sstable_quarantined(&self, gen: &str) -> bool {
+        self.quarantined_sstables.read().contains(gen)
+    }
+
+    /// Snapshot of all currently-quarantined SSTable generations. The
+    /// anti-entropy repair scheduler drains this to learn which ranges to
+    /// refill from a healthy replica.
+    pub fn quarantined_sstable_gens(&self) -> Vec<String> {
+        self.quarantined_sstables.read().iter().cloned().collect()
+    }
+
     /// One attempt of [`read_limited_rows`] against a fixed `view` snapshot.
-    /// Returns the merged partition (if any) plus whether any SSTable failed to
-    /// open — the signal the caller uses to retry against a fresh view when the
-    /// view was concurrently swapped by compaction.
+    /// Returns the merged partition (if any) plus the identity of any
+    /// snapshotted SSTable that could not be consulted — the signal the caller
+    /// uses to retry against a fresh view (transient compaction swap) and, on
+    /// retry exhaustion, to quarantine the corrupt file and target repair.
     fn read_with_view(
         &self,
         guard: &StoreView,
         key: &DecoratedKey,
         row_limit: usize,
-    ) -> Result<(Option<Partition>, bool)> {
+    ) -> Result<(Option<Partition>, Option<CorruptSstableId>)> {
         let started = Instant::now();
         let schema = self.schema.load();
-        let mut sstable_open_failed = false;
+        // Identity of a snapshotted SSTable that could not be consulted this
+        // attempt. `None` = clean; `Some` drives the retry, then (on exhaustion)
+        // quarantine + fail-loud in `with_retried_view`.
+        let mut corrupt: Option<CorruptSstableId> = None;
 
         let mut sources: Vec<Partition> = Vec::new();
         let mut memtable_hits = 0u64;
@@ -1386,6 +1517,14 @@ impl<F: FlushTarget> TableStore<F> {
         // format-incompatible SSTable should not prevent reading data
         // that exists in other SSTables or the memtable (FRSA-BUG-026).
         for (i, desc) in guard.sstables.iter().enumerate() {
+            // Skip SSTables a previous read already quarantined as corrupt: they
+            // re-error every attempt, so reopening them would only re-incur the
+            // retry storm. The data they held is being refilled by anti-entropy
+            // repair; until then we serve from the remaining healthy sources.
+            if self.is_sstable_quarantined(&desc.gen) {
+                sstable_pruned += 1;
+                continue;
+            }
             // Token-prune by descriptor bounds first (no reader open). The
             // partition's token must lie within the SSTable's covered range or
             // it cannot hold the key.
@@ -1402,7 +1541,7 @@ impl<F: FlushTarget> TableStore<F> {
                     self.sstable_read_errors
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     sstable_errors += 1;
-                    sstable_open_failed = true;
+                    corrupt = Some(CorruptSstableId::from_descriptor(desc));
                     continue;
                 }
             };
@@ -1429,12 +1568,12 @@ impl<F: FlushTarget> TableStore<F> {
                     // hits `ENOENT`. The merged output in the NEW view holds the
                     // row, so this must drive the same view-retry as an open
                     // failure rather than silently dropping the key (`Ok(None)` =
-                    // data loss). Marking `sstable_open_failed` engages
+                    // data loss). Recording the failing descriptor engages
                     // `with_retried_view`: a transient compaction window resolves
                     // on retry against the fresh view; a genuinely corrupt SSTable
-                    // re-errors across all retries and surfaces loudly via
-                    // `view_retry_exhausted` (never silently masked).
-                    sstable_open_failed = true;
+                    // re-errors across all retries and is quarantined + surfaced
+                    // loudly (never silently masked).
+                    corrupt = Some(CorruptSstableId::from_descriptor(desc));
                     // Detailed diagnostic for truncated SSTable investigation.
                     let id_info = guard
                         .sstable_ids
@@ -1470,7 +1609,7 @@ impl<F: FlushTarget> TableStore<F> {
                 sstable_hits,
                 sstable_errors,
             );
-            return Ok((None, sstable_open_failed));
+            return Ok((None, corrupt));
         }
 
         let mut merged = merge::merge_partitions(sources);
@@ -1488,7 +1627,7 @@ impl<F: FlushTarget> TableStore<F> {
             sstable_hits,
             sstable_errors,
         );
-        Ok((Some(merged), sstable_open_failed))
+        Ok((Some(merged), corrupt))
     }
 
     /// Read exactly one clustered row from a partition by clustering-key
@@ -1514,17 +1653,18 @@ impl<F: FlushTarget> TableStore<F> {
     }
 
     /// One attempt of [`read_clustering_row`] against a fixed `view` snapshot.
-    /// Returns the matching row (if any) plus whether any SSTable failed to
-    /// open — the signal the caller uses to retry against a fresh view.
+    /// Returns the matching row (if any) plus the identity of any snapshotted
+    /// SSTable that could not be consulted — the signal the caller uses to retry
+    /// against a fresh view and, on exhaustion, to quarantine + repair.
     fn read_clustering_row_with_view(
         &self,
         guard: &StoreView,
         key: &DecoratedKey,
         clustering: &[u8],
-    ) -> Result<(Option<Partition>, bool)> {
+    ) -> Result<(Option<Partition>, Option<CorruptSstableId>)> {
         let schema = self.schema.load();
         let mut sources: Vec<Partition> = Vec::new();
-        let mut sstable_open_failed = false;
+        let mut corrupt: Option<CorruptSstableId> = None;
 
         if let Some(p) = guard.active.get(key)? {
             if let Some(filtered) = partition_with_matching_clustering(&p, clustering) {
@@ -1541,6 +1681,10 @@ impl<F: FlushTarget> TableStore<F> {
         }
 
         for (i, desc) in guard.sstables.iter().enumerate() {
+            // Skip already-quarantined corrupt SSTables (see `read_with_view`).
+            if self.is_sstable_quarantined(&desc.gen) {
+                continue;
+            }
             let token = key.token.0;
             if token < desc.min_token || token > desc.max_token {
                 continue;
@@ -1551,7 +1695,7 @@ impl<F: FlushTarget> TableStore<F> {
                     tracing::error!(%e, gen = %desc.gen, "clustering read: failed to open SSTable reader");
                     self.sstable_read_errors
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    sstable_open_failed = true;
+                    corrupt = Some(CorruptSstableId::from_descriptor(desc));
                     continue;
                 }
             };
@@ -1572,7 +1716,7 @@ impl<F: FlushTarget> TableStore<F> {
                     // between our (cached) open and the row seek, so the row
                     // lives in the merged SSTable of the NEW view. Drive the
                     // view-retry instead of silently dropping the row.
-                    sstable_open_failed = true;
+                    corrupt = Some(CorruptSstableId::from_descriptor(desc));
                     let id_info = guard
                         .sstable_ids
                         .get(i)
@@ -1593,15 +1737,15 @@ impl<F: FlushTarget> TableStore<F> {
         }
 
         if sources.is_empty() {
-            return Ok((None, sstable_open_failed));
+            return Ok((None, corrupt));
         }
 
         let mut merged = merge::merge_partitions(sources);
         merged.rows.retain(|row| row.clustering == clustering);
         if merged.rows.is_empty() {
-            Ok((None, sstable_open_failed))
+            Ok((None, corrupt))
         } else {
-            Ok((Some(merged), sstable_open_failed))
+            Ok((Some(merged), corrupt))
         }
     }
 
@@ -5643,15 +5787,147 @@ mod tests {
         }));
 
         let view = store.view.load_full();
-        let (result, stale_view_failed) = store.read_with_view(&view, &key, 0).unwrap();
+        let (result, corrupt) = store.read_with_view(&view, &key, 0).unwrap();
         assert!(
             result.is_none(),
             "the truncated source yields no rows on this single view snapshot"
         );
+        let corrupt = corrupt.expect(
+            "a mid-read fetch error on a bloom-matching SSTable must request a view retry \
+             (carry the failing SSTable id), not be swallowed into a silent Ok(None)",
+        );
+        assert_eq!(
+            corrupt.gen, "truncated",
+            "the retry signal must identify the failing SSTable by gen"
+        );
+    }
+
+    /// Anti-entropy slice (feat/corrupt-sstable-anti-entropy): a point read that
+    /// EXHAUSTS the view-retry bound on a genuinely-corrupt SSTable whose data
+    /// is NOT resolvable from any healthy source (memtable / another SSTable)
+    /// must FAIL LOUD — return `Err` that identifies the corrupt SSTable (its
+    /// gen) — never a spurious `Ok(None)`. It must also QUARANTINE that SSTable
+    /// so a subsequent read of the same key skips it instead of re-failing.
+    #[test]
+    fn exhausted_corrupt_read_unresolvable_fails_loud_and_quarantines() {
+        let store = test_store();
+        let schema = test_schema();
+        let key = make_key("k-corrupt-only");
+
+        // The only source holding the key is a corrupt (truncated) SSTable:
+        // bloom says present, but every partition fetch errors. No memtable
+        // copy, no second SSTable — the read cannot be resolved.
+        let truncated = Arc::new(sstable_reader_from_partitions(
+            &schema,
+            &[make_partition("k-corrupt-only", b"v", 1000)],
+            Some(8),
+        ));
         assert!(
-            stale_view_failed,
-            "a mid-read fetch error on a bloom-matching SSTable must request a view retry, \
-             not be swallowed into a silent Ok(None)"
+            truncated.may_contain_key(&key),
+            "bloom must say the key is present — that is what makes the loss dangerous"
+        );
+
+        let current = store.view.load_full();
+        let desc = SstableDescriptor::from_reader(
+            "corrupt-gen".to_string(),
+            std::path::PathBuf::new(),
+            &truncated,
+        );
+        store.seed_reader(&desc, truncated);
+        store.view.store(Arc::new(StoreView {
+            active: new_memtable(),
+            flushing: None,
+            sstables: Arc::new(vec![desc.clone()]),
+            sstable_ids: Arc::new(vec![("corrupt-gen".to_string(), std::path::PathBuf::new())]),
+            indexes: Arc::clone(&current.indexes),
+            sidecar_indexes: Arc::new(vec![Arc::new(HashMap::new())]),
+            vector_indexes: Arc::clone(&current.vector_indexes),
+        }));
+
+        // First read: exhausts retries with nothing resolved -> fail loud.
+        let err = store
+            .read(&key)
+            .expect_err("an unresolvable read over a corrupt SSTable must fail loud, not Ok(None)");
+        assert!(
+            err.to_string().contains("corrupt-gen"),
+            "the error must identify the corrupt SSTable by gen, got: {err}"
+        );
+
+        // The corrupt SSTable must now be quarantined.
+        assert!(
+            store.is_sstable_quarantined("corrupt-gen"),
+            "the corrupt SSTable must be quarantined so later reads can target/skip it"
+        );
+
+        // Second read of the same key: the quarantined SSTable is skipped, so
+        // we no longer re-fail on it. With nothing else holding the key the
+        // result is a clean Ok(None) (the data is genuinely gone locally;
+        // repair refills it in the background).
+        let again = store.read(&key).expect(
+            "after quarantine the corrupt SSTable is skipped, so the read no longer errors",
+        );
+        assert!(
+            again.is_none(),
+            "no healthy local source holds the key after the corrupt SSTable is quarantined"
+        );
+    }
+
+    /// A read whose data IS resolvable from a healthy source (here the memtable)
+    /// must still return `Ok(Some)` even though a corrupt SSTable in the same
+    /// token range errors on every attempt. Fail-loud applies ONLY when nothing
+    /// was resolved. The corrupt SSTable is still quarantined for repair.
+    #[test]
+    fn corrupt_sstable_resolvable_from_memtable_returns_ok_some() {
+        let store = test_store();
+        let schema = test_schema();
+        let key = make_key("k-resolvable");
+
+        // Live, healthy copy in the active memtable.
+        store.write(&key, make_row(b"live", 2000)).unwrap();
+
+        // A corrupt SSTable that also covers this key's token range.
+        let truncated = Arc::new(sstable_reader_from_partitions(
+            &schema,
+            &[make_partition("k-resolvable", b"stale", 1000)],
+            Some(8),
+        ));
+        assert!(truncated.may_contain_key(&key));
+
+        let current = store.view.load_full();
+        let desc = SstableDescriptor::from_reader(
+            "corrupt-gen-2".to_string(),
+            std::path::PathBuf::new(),
+            &truncated,
+        );
+        store.seed_reader(&desc, truncated);
+        store.view.store(Arc::new(StoreView {
+            active: Arc::clone(&current.active),
+            flushing: None,
+            sstables: Arc::new(vec![desc.clone()]),
+            sstable_ids: Arc::new(vec![(
+                "corrupt-gen-2".to_string(),
+                std::path::PathBuf::new(),
+            )]),
+            indexes: Arc::clone(&current.indexes),
+            sidecar_indexes: Arc::new(vec![Arc::new(HashMap::new())]),
+            vector_indexes: Arc::clone(&current.vector_indexes),
+        }));
+
+        let result = store
+            .read(&key)
+            .expect("a read resolvable from the memtable must succeed despite a corrupt SSTable");
+        let partition = result.expect("the memtable copy must be returned");
+        assert_eq!(
+            partition.rows[0].cells[0].1.value.as_deref(),
+            Some(b"live".as_slice()),
+            "the healthy memtable value must be served"
+        );
+
+        // Even though the read succeeded, the corrupt SSTable is quarantined so
+        // anti-entropy repair can refill its range in the background.
+        assert!(
+            store.is_sstable_quarantined("corrupt-gen-2"),
+            "a corrupt SSTable detected during a resolvable read is still quarantined for repair"
         );
     }
 

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -1421,12 +1421,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ));
         let cluster_view: std::sync::Arc<dyn ferrosa_storage::self_heal::ClusterView> =
             std::sync::Arc::new(
-                ferrosa_cluster::repair::cluster_view::ClusterRepairView::new(topology, probe),
+                ferrosa_cluster::repair::cluster_view::ClusterRepairView::new(
+                    topology.clone(),
+                    probe.clone(),
+                ),
             );
+        // Quarantine → anti-entropy refill trigger. Uses the SAME verified-
+        // healthy-replica topology + probe as the posture gate (FMEA #1: only
+        // refill from a peer proven to hold a non-corrupt copy), and resolves
+        // the repair executor against the CURRENT ring per refill via
+        // `build_repair_executor` (the same path the periodic scheduler's
+        // RepairContext::build_executor uses). The provider returns `None` —
+        // refill skipped, periodic cycle is the backstop — until the node is
+        // ring-ready.
+        let exec_provider: std::sync::Arc<dyn ferrosa_cluster::repair::ExecutorProvider> = {
+            let mode_controller = mode_controller.clone();
+            let storage = storage.clone();
+            std::sync::Arc::new(move || {
+                crate::repair_wiring::build_repair_executor(&mode_controller, &storage)
+            })
+        };
         let refill_trigger: std::sync::Arc<dyn ferrosa_storage::self_heal::RepairTrigger> =
-            std::sync::Arc::new(crate::repair_wiring::BinaryRepairTrigger::new(
-                repair_ctx.clone(),
-                runtimes.data.handle().clone(),
+            std::sync::Arc::new(ferrosa_cluster::repair::ClusterRepairTrigger::new(
+                topology,
+                probe,
+                exec_provider,
             ));
         ferrosa_storage::self_heal::SelfHealController::spawn_with_trigger(
             storage.clone(),

--- a/ferrosa/src/repair_wiring.rs
+++ b/ferrosa/src/repair_wiring.rs
@@ -1,12 +1,14 @@
 //! Binary-side wiring for automatic anti-entropy repair.
 //!
 //! The cluster layer ships the *primitives* (`RepairCoordinator`,
-//! `AutoRepairScheduler`, `ClusterRepairView`) and the *ports*
-//! (`RepairContext`, storage's `RepairTrigger`). This module is the single
-//! place in the `ferrosa` binary that satisfies those ports against live node
-//! state (`ModeController` + `StorageEngine` + `Schema`), so the scheduler, the
-//! manual `POST /api/cluster/repair` endpoint, and the self-heal controller all
-//! share one executor-construction code path.
+//! `AutoRepairScheduler`, `ClusterRepairView`, `ClusterRepairTrigger`) and the
+//! *ports* (`RepairContext`, storage's `RepairTrigger` /
+//! `ExecutorProvider`). This module is the place in the `ferrosa` binary that
+//! satisfies the `RepairContext` port against live node state (the
+//! `ModeController`, `StorageEngine`, and `Schema`) and exposes the single
+//! `build_repair_executor` code path that both the periodic scheduler and the
+//! self-heal refill trigger's executor provider resolve against the current
+//! ring.
 //!
 //! See `specs/proposed/automatic-repair-scheduler-design.md` and its FMEA.
 
@@ -15,39 +17,29 @@ use std::sync::Arc;
 
 use ferrosa_cluster::ModeController;
 use ferrosa_cluster::{
-    LocalRepairExecutor, RemoteRepairStore, RepairContext, RepairCoordinator, SessionExecutor,
+    LocalRepairExecutor, RemoteRepairStore, RepairContext, SessionExecutor,
     StorageEngineRepairStore,
 };
 use ferrosa_schema::Schema;
-use ferrosa_storage::self_heal::RepairTrigger;
 use ferrosa_storage::{StorageEngine, TableId};
-
-/// A repair executor wired for the *current* ring, paired with this node's
-/// resolved `node_id`. `None` when the node is not ready to repair (not in
-/// cluster mode, no peer manager, or local node not yet placed in the ring).
-///
-/// This is the **single** executor-construction path. The manual repair
-/// endpoint and the [`BinaryRepairContext`] used by the scheduler both call it,
-/// so there is exactly one place that builds the local
-/// [`StorageEngineRepairStore`] + per-peer [`RemoteRepairStore`] →
-/// [`LocalRepairExecutor`].
-pub struct ResolvedExecutor {
-    /// The wired executor.
-    pub executor: Arc<dyn SessionExecutor>,
-    /// This node's `node_id` within the live ring.
-    pub local_node_id: u64,
-}
 
 /// Build a repair executor for the current ring, resolving this node's
 /// `node_id` from its `host_id`. Returns `None` when not in cluster mode, the
 /// peer manager is not initialised, or this node is not yet in the ring.
+///
+/// This is the **single** executor-construction path. The scheduler's
+/// [`BinaryRepairContext::build_executor`] and the self-heal refill trigger's
+/// [`ExecutorProvider`](ferrosa_cluster::repair::ExecutorProvider) closure both
+/// call it, so there is exactly one place that builds the local
+/// [`StorageEngineRepairStore`] + per-peer [`RemoteRepairStore`] →
+/// [`LocalRepairExecutor`].
 ///
 /// FMEA: every "not ready" condition is a clean `None` (the caller treats it as
 /// a no-op), never a panic or a fake executor.
 pub fn build_repair_executor(
     mode_controller: &ModeController,
     storage: &Arc<StorageEngine>,
-) -> Option<ResolvedExecutor> {
+) -> Option<Arc<dyn SessionExecutor>> {
     let ring = mode_controller.token_ring()?;
     let peer_manager = mode_controller.peer_manager_arc()?;
 
@@ -77,11 +69,7 @@ pub fn build_repair_executor(
         remotes.insert(node_id, remote);
     }
 
-    let executor: Arc<dyn SessionExecutor> = Arc::new(LocalRepairExecutor { local, remotes });
-    Some(ResolvedExecutor {
-        executor,
-        local_node_id,
-    })
+    Some(Arc::new(LocalRepairExecutor { local, remotes }))
 }
 
 /// Parse a keyspace's replication factor from its replication options.
@@ -213,134 +201,11 @@ impl RepairContext for BinaryRepairContext {
     }
 
     fn build_executor(&self) -> Option<Arc<dyn SessionExecutor>> {
-        build_repair_executor(&self.mode_controller, &self.storage).map(|r| r.executor)
+        build_repair_executor(&self.mode_controller, &self.storage)
     }
 
     fn user_tables(&self) -> Vec<(TableId, usize)> {
         user_tables_from_schema(&self.schema, &self.skip_prefixes, self.default_rf)
-    }
-}
-
-/// Production [`RepairTrigger`]: a quarantine schedules a prompt targeted
-/// repair of the affected table from a healthy replica (FMEA #10).
-///
-/// `request_refill` must be cheap and non-blocking, so it **spawns** the actual
-/// repair on the supplied runtime handle, bounded by a small semaphore so a
-/// burst of quarantines can't fan out unbounded repair load. A dropped permit
-/// (semaphore exhausted) is logged loudly — the periodic cycle is the backstop.
-pub struct BinaryRepairTrigger {
-    ctx: Arc<BinaryRepairContext>,
-    runtime: tokio::runtime::Handle,
-    /// Bounds concurrent triggered refills (FMEA #2 — don't OOM the node we heal).
-    permits: Arc<tokio::sync::Semaphore>,
-}
-
-impl BinaryRepairTrigger {
-    /// Maximum concurrent triggered refills. Small: a refill is a full
-    /// `repair_initiated` cycle for a table, already bounded internally by the
-    /// coordinator's session semaphore.
-    const MAX_CONCURRENT_REFILLS: usize = 2;
-
-    /// Construct from a [`BinaryRepairContext`] and the runtime to spawn the
-    /// refill on (the data runtime, which already drives internode IO).
-    pub fn new(ctx: Arc<BinaryRepairContext>, runtime: tokio::runtime::Handle) -> Self {
-        Self {
-            ctx,
-            runtime,
-            permits: Arc::new(tokio::sync::Semaphore::new(Self::MAX_CONCURRENT_REFILLS)),
-        }
-    }
-}
-
-impl RepairTrigger for BinaryRepairTrigger {
-    fn request_refill(&self, table: &TableId, ranges: &[(i64, i64)]) {
-        let table = table.clone();
-        let ranges_len = ranges.len();
-        let ctx = self.ctx.clone();
-        let permits = self.permits.clone();
-
-        // Spawn — never block the self-heal controller's tick (FMEA #10).
-        self.runtime.spawn(async move {
-            // Bound concurrent refills; if exhausted, log loud and let the
-            // periodic cycle be the backstop rather than queueing unboundedly.
-            let _permit = match permits.try_acquire_owned() {
-                Ok(p) => p,
-                Err(_) => {
-                    tracing::warn!(
-                        keyspace = %table.keyspace,
-                        table = %table.table,
-                        "auto-repair: refill trigger at capacity; skipping prompt refill — \
-                         periodic repair cycle is the backstop (FMEA #10)"
-                    );
-                    return;
-                }
-            };
-
-            let Some(resolved) = build_repair_executor(&ctx.mode_controller, &ctx.storage) else {
-                tracing::warn!(
-                    keyspace = %table.keyspace,
-                    table = %table.table,
-                    "auto-repair: refill requested but node not ring-ready; \
-                     periodic repair cycle is the backstop (FMEA #10)"
-                );
-                return;
-            };
-            let Some(ring) = ctx.mode_controller.token_ring() else {
-                tracing::warn!(
-                    keyspace = %table.keyspace,
-                    table = %table.table,
-                    "auto-repair: refill requested but ring vanished; backstop is the periodic cycle"
-                );
-                return;
-            };
-
-            // Per-keyspace RF (FMEA #11) — look the table up in the eligible set.
-            let rf = ctx
-                .user_tables()
-                .into_iter()
-                .find(|(t, _)| *t == table)
-                .map(|(_, rf)| rf)
-                .unwrap_or(ctx.default_rf);
-
-            tracing::info!(
-                keyspace = %table.keyspace,
-                table = %table.table,
-                rf,
-                ranges = ranges_len,
-                "auto-repair: starting triggered refill after quarantine"
-            );
-
-            // Reuse the initiator-only path: this node just quarantined a local
-            // copy, so it should initiate reconciliation of the ranges it owns.
-            let coord = RepairCoordinator::default();
-            let results = coord
-                .repair_initiated(
-                    resolved.executor,
-                    &ring,
-                    resolved.local_node_id,
-                    rf,
-                    &table,
-                )
-                .await;
-
-            let failed = results.iter().filter(|r| r.result.is_err()).count();
-            if failed > 0 {
-                tracing::warn!(
-                    keyspace = %table.keyspace,
-                    table = %table.table,
-                    sessions_total = results.len(),
-                    sessions_failed = failed,
-                    "auto-repair: triggered refill had failed sessions; periodic cycle is the backstop"
-                );
-            } else {
-                tracing::info!(
-                    keyspace = %table.keyspace,
-                    table = %table.table,
-                    sessions_total = results.len(),
-                    "auto-repair: triggered refill completed"
-                );
-            }
-        });
     }
 }
 

--- a/ferrosa/src/web/api.rs
+++ b/ferrosa/src/web/api.rs
@@ -65,6 +65,10 @@ pub async fn get_metrics(
     let mut body = ferrosa_cql::prometheus::render_metrics(&registry);
     // Automatic-repair scheduler counters (ferrosa_auto_repair_*).
     body.push_str(&ferrosa_cluster::repair::scheduler::render_prometheus());
+    // Quarantine → anti-entropy refill counters (ferrosa_anti_entropy_refills_*).
+    // anti_entropy_refills_no_source_total being non-zero means quarantined data
+    // is awaiting the periodic repair backstop and should alert (FMEA #10).
+    body.push_str(&ferrosa_cluster::repair::trigger::render_prometheus());
     (
         StatusCode::OK,
         [(


### PR DESCRIPTION
## Summary

A genuinely-corrupt local SSTable read is now fail-loud and self-healing instead of silently returning `Ok(None)`. At CL=ONE the coordinator fails over to a healthy remote replica to serve the read, then schedules an asynchronous, targeted anti-entropy repair to refill the corrupt SSTable's token range from a verified-healthy peer. The read is never blocked on repair.

This is one feature effort spanning storage + coordinator + repair + tests, gated by a deterministic "corrupt SSTable -> served from replica + repair triggered" test.

## Locked design decisions

1. **Async background repair** — serve the read from a healthy replica now; quarantine the corrupt SSTable and schedule anti-entropy (Merkle) repair to refill it in the background. No synchronous foreground read-repair; the read is never blocked on repair.
2. **CL=ONE fails over to a remote replica** — a local corrupt-SSTable read error is treated like a failed replica. CL=ONE was previously local-only; it now falls over to another replica so the read succeeds despite local corruption whenever any healthy replica holds the data.
3. **Single-node / RF=1 fails loud** — with no replica to repair from, the read returns `Err` (never a fake `Ok(None)`), and a repair is requested. Exception preserved: a read whose data is resolvable from a healthy source (e.g. the memtable) still returns `Ok(Some)` — only an unresolvable read (result is `None` AND a source failed) errors. `memtable_data_survives_corrupt_sstable` stays `Ok(Some)`.
4. **One gated effort** — storage + coordinator + repair + tests land together behind a deterministic gating test.

## Component changes

**Storage (`ferrosa-storage`)**
- Surfaces a typed `Error::CorruptSstable { gen, min_token, max_token }` (replacing string-matched `InvalidData`), carrying the corrupt file's covered token range; `corrupt_sstable_range()` lets the coordinator classify and target repair without matching on a message.
- `with_retried_view` exhaustion fails loud and identifies the corrupt SSTable; quarantine marks it so subsequent reads skip it (no re-fail) and repair knows the target.

**Coordinator (`ferrosa-cluster/src/coordinator/read.rs`)**
- `read_one_replica_limited_rows` treats a `CorruptSstable` local error like a failed replica, records the range, and continues to the next replica.
- `coordinate_read` at CL=ONE falls over to a remote replica on the corrupt-SSTable error. On serving from a healthy remote, it fires one async repair (bounded, observable `AntiEntropyRepairQueue` + `anti_entropy_repairs_requested_total`). If no replica can serve, it fails loud.

**Repair (`ferrosa-cluster/src/repair/trigger.rs`, `ferrosa/src/main.rs`, `ferrosa/src/web/api.rs`)**
- New `ClusterRepairTrigger` (production `RepairTrigger`) verifies a healthy replica per range via the same `RepairProbe`/`ClusterTopology` the posture gate uses, then enqueues exactly one targeted `run_session` over that range against the verified-healthy peer.
- Replaces `BinaryRepairTrigger`, which refilled the whole table's owned ranges with no per-range healthy-replica probe (FMEA #1 unenforced in production). `BinaryRepairTrigger` is deleted.
- `main.rs` constructs `ClusterRepairTrigger` with the same `RingTopology` + `RpcRepairProbe` as `ClusterRepairView`, plus an `ExecutorProvider` that resolves the repair executor against the current ring per refill and yields `None` until ring-ready (refill skipped, periodic cycle is the backstop) — never a panic or fake executor.
- Observability wired end to end: `get_metrics` exports `anti_entropy_refills_scheduled_total` and `anti_entropy_refills_no_source_total`; a non-zero no-source counter means quarantined data awaits the periodic backstop and should alert (FMEA #10).

## Transient-vs-corrupt line

A transient compaction window (a file deleted mid-read that resolves within the bounded `with_retried_view` retries, closed by #143) is **not** corruption: it does not quarantine or trigger repair. Only retry **exhaustion** (all retries fail) is genuine corruption -> quarantine + repair. `concurrent_read_during_compaction` and `mid_read_fetch_error_signals_view_retry` stay green and untouched.

## Deterministic gating tests

- `coordinate_read_at_one_fails_over_to_remote_on_local_corruption` — CL=ONE serves from a remote replica when the local SSTable is corrupt.
- `coordinate_read_at_one_requests_repair_on_local_corruption` — serving around corruption fires exactly one async repair.
- `request_refill_schedules_targeted_session_against_healthy_replica` — a refill schedules exactly one session for the right (table, range) against the verified-healthy peer.
- `request_refill_with_no_healthy_replica_schedules_nothing_and_counts_no_source` — all peers empty/unreachable -> no session, no-source metric increments.
- `request_refill_skips_session_when_executor_provider_not_ready` — healthy peer found but node not ring-ready -> no session (pins the production seam).
- Guards held green: `concurrent_read_during_compaction`, `mid_read_fetch_error_signals_view_retry`, `memtable_data_survives_corrupt_sstable`.

## Green gate

`cargo fmt --check`, clippy on `ferrosa-storage`/`ferrosa-cluster`/`ferrosa` `--all-targets`, the touched-crate suites, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` all pass. No `#[ignore]`.

## Deferred

None — all four phases (storage typed error + quarantine, coordinator failover, async repair wiring, deterministic tests) landed and are green.
