### PR TITLE
test(storage): nightly read-vs-compaction stress harness (race-stress feature + shared-cpu Fly runner)

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -255,10 +255,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
           BRANCH: ${{ github.ref_name }}
-          # shared-cpu on purpose: the ~6.5% baseline starves the compaction
+          # shared-cpu on purpose: the throttled baseline starves the compaction
           # executor — that starvation is what surfaces the read-vs-compaction
-          # race. A performance VM would NOT reproduce it.
-          VM: shared-cpu-1x
+          # race. A performance VM would NOT reproduce it. Use the 2x size (4 GB)
+          # so the in-VM `--release` build of ferrosa-storage doesn't OOM
+          # (shared-cpu-1x caps at 2 GB); it is still shared/throttled.
+          VM: shared-cpu-2x
+          VM_MEMORY: '4096'
           RACE_KEYS: '2000'
           RACE_READERS: '8'
           RACE_SECS: '600'

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -234,3 +234,41 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker compose down -v --remove-orphans 2>/dev/null || true
+
+  race-stress-fly:
+    name: Read-vs-compaction stress (shared-cpu Fly)
+    runs-on: ubuntu-latest
+    # The script provisions a throwaway shared-cpu Fly machine, builds with
+    # --features race-stress, runs an RACE_SECS storm, and tears the app down.
+    # Generous cap = build/boot headroom + the storm; the script self-destroys
+    # the app via an EXIT trap even if this job is cancelled.
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Read-vs-compaction stress on a starved shared-cpu Fly machine
+        env:
+          # Only NEW secret required. If unset, the step skips cleanly (so the
+          # nightly run is green until the secret is provisioned — see t_dfbc14f3).
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          # The repo-scoped job token can clone this private repo on the VM.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
+          BRANCH: ${{ github.ref_name }}
+          # shared-cpu on purpose: the ~6.5% baseline starves the compaction
+          # executor — that starvation is what surfaces the read-vs-compaction
+          # race. A performance VM would NOT reproduce it.
+          VM: shared-cpu-1x
+          RACE_KEYS: '2000'
+          RACE_READERS: '8'
+          RACE_SECS: '600'
+          RACE_FLUSH_EVERY: '50'
+        run: |
+          if [ -z "${FLY_API_TOKEN:-}" ]; then
+            echo "::notice::FLY_API_TOKEN not set — skipping nightly Fly race-stress (provision it; see board task t_dfbc14f3)"
+            exit 0
+          fi
+          curl -fsSL https://fly.io/install.sh | sh
+          export FLYCTL_INSTALL="$HOME/.fly"
+          export PATH="$FLYCTL_INSTALL/bin:$PATH"
+          bash ci/race-stress-fly.sh

--- a/ci/race-stress-fly.sh
+++ b/ci/race-stress-fly.sh
@@ -65,7 +65,7 @@ fly machine run rust:1-bookworm \
 
 echo ":: waiting for completion (RS_RESULT marker)…"
 LOG="$(mktemp)"
-deadline=$(( $(date +%s) + RACE_SECS + 2400 ))   # storm + generous build/boot headroom
+deadline=$(( $(date +%s) + RACE_SECS + 3600 ))   # storm + generous build/boot headroom (starved build is slow)
 rc=""
 while [ "$(date +%s)" -lt "$deadline" ]; do
   fly logs -a "$APP" --no-tail >"$LOG" 2>/dev/null || true

--- a/ci/race-stress-fly.sh
+++ b/ci/race-stress-fly.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Nightly read-vs-compaction stress on a CPU-starved Fly machine.
+#
+# Provisions a throwaway **shared-cpu** Fly machine (its ~6.5% sustained baseline
+# starves the compaction executor thread — the exact condition that widens the
+# read-vs-compaction window, see bug t_940cc015), clones this repo, builds with
+# `--features race-stress`, runs the phase-separated availability invariant
+# (engine.rs `read_compaction_race_stress`), and ALWAYS destroys the app.
+#
+# A non-shared (performance) machine would NOT reproduce the starvation; use
+# shared-cpu on purpose. Fan out by running this script N times with different
+# regions / seeds for breadth.
+#
+# Required env:
+#   FLY_API_TOKEN  fly auth token (CI secret)
+#   GH_TOKEN       token that can clone ferrosadb/ferrosa (PAT or App token)
+# Optional env (with defaults):
+#   BRANCH=main  REGION=iad  VM=shared-cpu-1x  VM_MEMORY=2048
+#   RACE_KEYS=2000 RACE_READERS=8 RACE_SECS=600 RACE_FLUSH_EVERY=50
+set -euo pipefail
+
+: "${FLY_API_TOKEN:?set FLY_API_TOKEN}"
+: "${GH_TOKEN:?set GH_TOKEN}"
+BRANCH="${BRANCH:-main}"
+REGION="${REGION:-iad}"
+VM="${VM:-shared-cpu-1x}"
+VM_MEMORY="${VM_MEMORY:-2048}"
+RACE_KEYS="${RACE_KEYS:-2000}"
+RACE_READERS="${RACE_READERS:-8}"
+RACE_SECS="${RACE_SECS:-600}"
+RACE_FLUSH_EVERY="${RACE_FLUSH_EVERY:-50}"
+
+APP="ferrosa-racestress-$(date +%s)-$$"
+cleanup() { fly apps destroy "$APP" --yes >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo ":: creating throwaway app $APP"
+fly apps create "$APP" --org "${FLY_ORG:-personal}" >/dev/null
+
+# Remote build+run. `bash -c` (NOT -lc: a login shell drops /usr/local/cargo/bin
+# from PATH -> cargo not found -> exit 127). Markers below use expanded values so
+# log scraping can't match the echoed script source.
+REMOTE='set -uo pipefail
+export DEBIAN_FRONTEND=noninteractive
+export PATH=/usr/local/cargo/bin:$PATH CARGO_HOME=/usr/local/cargo
+apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq git capnproto cmake clang pkg-config libssl-dev build-essential >/dev/null 2>&1
+cd /tmp
+git clone --depth 1 --branch '"$BRANCH"' https://x-access-token:${GH_TOKEN}@github.com/ferrosadb/ferrosa f 2>&1 | tail -2
+cd f || { echo "RS_RESULT rc=66 (clone failed)"; exit 66; }
+SECONDS=0
+RACE_KEYS='"$RACE_KEYS"' RACE_READERS='"$RACE_READERS"' RACE_SECS='"$RACE_SECS"' RACE_FLUSH_EVERY='"$RACE_FLUSH_EVERY"' \
+  cargo test -p ferrosa-storage --features race-stress --release --lib \
+  committed_keys_stay_readable_under_compaction_storm -- --nocapture 2>&1 | tail -40
+echo "RS_RESULT rc=${PIPESTATUS[0]} elapsed=${SECONDS}s"'
+
+echo ":: launching $VM in $REGION (starved baseline is the fuzzer)"
+fly machine run rust:1-bookworm \
+  --app "$APP" --vm-size "$VM" --vm-memory "$VM_MEMORY" --region "$REGION" --restart no \
+  --env GH_TOKEN="$GH_TOKEN" \
+  -- bash -c "$REMOTE" >/dev/null
+
+echo ":: waiting for completion (RS_RESULT marker)…"
+LOG="$(mktemp)"
+deadline=$(( $(date +%s) + RACE_SECS + 2400 ))   # storm + generous build/boot headroom
+rc=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  fly logs -a "$APP" --no-tail >"$LOG" 2>/dev/null || true
+  if grep -qaE 'RS_RESULT rc=[0-9]+' "$LOG"; then
+    rc="$(grep -aoE 'RS_RESULT rc=[0-9]+ ?(elapsed=[0-9]+s)?' "$LOG" | tail -1)"
+    break
+  fi
+  sleep 20
+done
+
+echo "================ stress output ================"
+sed 's/\x1b\[[0-9;]*m//g' "$LOG" | grep -aE 'test result:|RS_RESULT rc=[0-9]+|silent data loss|panicked|error\[' | tail -25 || true
+echo "==============================================="
+if printf '%s' "$rc" | grep -qE 'rc=0\b'; then
+  echo "PASS: $rc"; exit 0
+else
+  echo "FAIL/INCOMPLETE: ${rc:-no RS_RESULT marker within deadline}"; exit 1
+fi

--- a/ci/race-stress-fly.sh
+++ b/ci/race-stress-fly.sh
@@ -38,20 +38,24 @@ echo ":: creating throwaway app $APP"
 fly apps create "$APP" --org "${FLY_ORG:-personal}" >/dev/null
 
 # Remote build+run. `bash -c` (NOT -lc: a login shell drops /usr/local/cargo/bin
-# from PATH -> cargo not found -> exit 127). Markers below use expanded values so
-# log scraping can't match the echoed script source.
+# from PATH -> cargo not found -> exit 127). The completion marker is ASSEMBLED
+# at runtime (M below) so the literal `RS_RESULT` never appears in the script
+# SOURCE — fly echoes the whole script to the log on boot, and a literal marker
+# in the source would be matched by the host-side grep, falsely "completing" the
+# run before the build even starts.
 REMOTE='set -uo pipefail
+M="RS_RE""SULT"   # emitted = RS_RESULT, but the source token is not that literal
 export DEBIAN_FRONTEND=noninteractive
 export PATH=/usr/local/cargo/bin:$PATH CARGO_HOME=/usr/local/cargo
 apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq git capnproto cmake clang pkg-config libssl-dev build-essential >/dev/null 2>&1
 cd /tmp
 git clone --depth 1 --branch '"$BRANCH"' https://x-access-token:${GH_TOKEN}@github.com/ferrosadb/ferrosa f 2>&1 | tail -2
-cd f || { echo "RS_RESULT rc=66 (clone failed)"; exit 66; }
+cd f || { echo "$M rc=66 (clone failed)"; exit 66; }
 SECONDS=0
 RACE_KEYS='"$RACE_KEYS"' RACE_READERS='"$RACE_READERS"' RACE_SECS='"$RACE_SECS"' RACE_FLUSH_EVERY='"$RACE_FLUSH_EVERY"' \
   cargo test -p ferrosa-storage --features race-stress --release --lib \
   committed_keys_stay_readable_under_compaction_storm -- --nocapture 2>&1 | tail -40
-echo "RS_RESULT rc=${PIPESTATUS[0]} elapsed=${SECONDS}s"'
+echo "$M rc=${PIPESTATUS[0]} elapsed=${SECONDS}s"'
 
 echo ":: launching $VM in $REGION (starved baseline is the fuzzer)"
 fly machine run rust:1-bookworm \

--- a/ferrosa-loadgen/src/cluster.rs
+++ b/ferrosa-loadgen/src/cluster.rs
@@ -31,9 +31,7 @@ use crate::tui::{TuiDashboard, TuiFrame};
 /// fails with `BadCredentials`. Supplying credentials works against BOTH
 /// auth-on and auth-off servers (the client only sends an AUTH_RESPONSE if the
 /// server actually challenges).
-async fn connect_authed(
-    addr: SocketAddr,
-) -> Result<CqlClient, ferrosa_cql::error::CqlError> {
+async fn connect_authed(addr: SocketAddr) -> Result<CqlClient, ferrosa_cql::error::CqlError> {
     let user = std::env::var("FERROSA_CQL_USER").unwrap_or_else(|_| "ferrosa_admin".to_string());
     let pass =
         std::env::var("FERROSA_CQL_PASSWORD").unwrap_or_else(|_| "ferrosa_admin".to_string());

--- a/ferrosa-loadgen/src/cluster.rs
+++ b/ferrosa-loadgen/src/cluster.rs
@@ -23,6 +23,23 @@ use crate::resource_monitor::{self, LeakVerdict, ResourceMonitor, ResourceSnapsh
 use crate::stats::{FinalizeContext, LoadStats, StatsCollector};
 use crate::tui::{TuiDashboard, TuiFrame};
 
+/// Connect to a node, authenticating with the well-known development seed
+/// credentials (override via FERROSA_CQL_USER / FERROSA_CQL_PASSWORD).
+///
+/// A dev-mode Ferrosa server bootstraps seed roles and sends an AUTHENTICATE
+/// challenge even when enforcement is off, so a plain credential-less connect
+/// fails with `BadCredentials`. Supplying credentials works against BOTH
+/// auth-on and auth-off servers (the client only sends an AUTH_RESPONSE if the
+/// server actually challenges).
+async fn connect_authed(
+    addr: SocketAddr,
+) -> Result<CqlClient, ferrosa_cql::error::CqlError> {
+    let user = std::env::var("FERROSA_CQL_USER").unwrap_or_else(|_| "ferrosa_admin".to_string());
+    let pass =
+        std::env::var("FERROSA_CQL_PASSWORD").unwrap_or_else(|_| "ferrosa_admin".to_string());
+    CqlClient::connect_with_credentials(addr, &user, &pass).await
+}
+
 /// Parse a comma-separated list of node addresses.
 ///
 /// Each entry is `host:port` for CQL. The web API port is inferred as
@@ -147,7 +164,7 @@ async fn run_cluster_load_test_async(
     eprintln!("Setting up schema (waiting for Raft DDL readiness)...");
     let mut schema_ok = false;
     for attempt in 1..=30 {
-        match CqlClient::connect(nodes[0]).await {
+        match connect_authed(nodes[0]).await {
             Ok(mut client) => match setup_schema(&mut client, rf).await {
                 Ok(()) => {
                     eprintln!("  Schema ready on attempt {attempt}");
@@ -175,7 +192,7 @@ async fn run_cluster_load_test_async(
     // Verify schema propagated to all nodes.
     for node in nodes {
         for _ in 0..10 {
-            if let Ok(mut c) = CqlClient::connect(*node).await {
+            if let Ok(mut c) = connect_authed(*node).await {
                 if c.query("USE load_test").await.is_ok()
                     && c.query("SELECT pk FROM data LIMIT 1").await.is_ok()
                 {
@@ -225,7 +242,7 @@ async fn run_cluster_load_test_async(
         let gt = Arc::clone(&ground_truth);
 
         handles.push(tokio::spawn(async move {
-            let mut client = match CqlClient::connect(node).await {
+            let mut client = match connect_authed(node).await {
                 Ok(c) => c,
                 Err(e) => {
                     eprintln!("worker {worker_id} failed to connect to {node}: {e}");
@@ -467,7 +484,7 @@ async fn verify_via_cql(
     }
 
     // Connect to the first node for verification reads.
-    let mut client = match CqlClient::connect(nodes[0]).await {
+    let mut client = match connect_authed(nodes[0]).await {
         Ok(c) => c,
         Err(e) => {
             eprintln!("integrity: connect failed: {e}");

--- a/ferrosa-storage/Cargo.toml
+++ b/ferrosa-storage/Cargo.toml
@@ -89,6 +89,11 @@ fuzz-fileio = ["test-generators"]
 # run in the default `test-generators` set. Retained so existing invocations
 # (`--features test-generators,repair-fuzz-known-failures`) keep working.
 repair-fuzz-known-failures = ["test-generators"]
+# Nightly real-concurrency read-vs-compaction stress (engine.rs
+# read_compaction_race_stress). Off by default so the per-PR gate stays fast;
+# the nightly fuzz workflow runs it on a shared-cpu Fly machine, env-scaled via
+# RACE_KEYS / RACE_READERS / RACE_SECS / RACE_FLUSH_EVERY.
+race-stress = []
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -12825,7 +12825,12 @@ mod tests {
             while start.elapsed().as_secs() < secs {
                 for _ in 0..flush_every {
                     engine
-                        .write(&tid, &make_key(&format!("junk{j:010}")), make_row(b"j", ts), ts)
+                        .write(
+                            &tid,
+                            &make_key(&format!("junk{j:010}")),
+                            make_row(b"j", ts),
+                            ts,
+                        )
                         .unwrap();
                     ts += 1;
                     j += 1;

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -12734,6 +12734,158 @@ mod tests {
         );
     }
 
+    /// Property-based regression for the read-vs-compaction data-loss class
+    /// (bug t_940cc015): a committed, never-deleted key MUST remain readable
+    /// even when a concurrent compaction deletes its input `Data.db` mid-read.
+    ///
+    /// This generalizes `read_cache_hit_mid_read_delete_retries_against_new_view`
+    /// over randomized layouts (filler-generation count, target value bytes,
+    /// target key) so the invariant is checked across many on-disk shapes rather
+    /// than one hand-picked fixture. It is the DETERMINISTIC tier: the dangerous
+    /// interleaving is forced via the `ReadViewBarrier` + mid-read ENOENT
+    /// injection (not timing), so each case is reproducible. Bounded to a small
+    /// case count to keep the per-PR CI gate fast; the broad stochastic sweep is
+    /// the nightly real-concurrency stress (`tests/read_compaction_race_stress.rs`).
+    ///
+    /// Non-vacuous: with the get-error retry fix reverted (the `Err` arm of
+    /// `read_with_view` not setting `sstable_open_failed`), every case fails with
+    /// a spurious `Ok(None)` (silent data loss).
+    mod read_compaction_race_props {
+        use super::*;
+        use crate::store::read_race_test_hook::{ReadViewBarrier, ARMED};
+        use proptest::prelude::*;
+        use std::sync::Arc;
+
+        /// Returns whether the committed target key was still readable after a
+        /// compaction deleted its input `Data.db` between a cache-hit open and
+        /// the row seek. `false` == the silent-data-loss bug.
+        fn target_survives_midread_delete(n_filler: usize, val: &[u8], suffix: u32) -> bool {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async move {
+                let dir = tempfile::tempdir().unwrap();
+                let mut config = StorageEngineConfig::test_config(dir.path());
+                config.compaction.min_threshold = 2;
+                let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+                engine.register_table(test_schema()).unwrap();
+                let tid = table_id();
+
+                // Filler generations (one key each), then the TARGET alone in the
+                // newest generation — so the target lives only in a to-be-merged
+                // input and "moves" into the compacted output.
+                let mut ts = 1000i64;
+                for i in 0..n_filler {
+                    engine
+                        .write(&tid, &make_key(&format!("f{i}")), make_row(b"f", ts), ts)
+                        .unwrap();
+                    engine.flush(&tid).unwrap();
+                    ts += 1000;
+                }
+                let target = make_key(&format!("t{suffix}"));
+                engine
+                    .write(&tid, &target, make_row(val, ts), ts)
+                    .unwrap();
+                engine.flush(&tid).unwrap();
+                assert_eq!(engine.sstable_count(&tid), n_filler + 1);
+
+                // Hold the target gen's pooled reader (keeps its bloom alive for the
+                // post-swap cache-hit) and resolve its Data.db path.
+                let table_dir = dir.path().join("sstables").join(tid.to_string());
+                let target_gen = *StorageEngine::list_generations_in_dir(&table_dir)
+                    .iter()
+                    .max()
+                    .expect("target gen exists");
+                let target_reader = engine
+                    .pooled_reader_arc_for_test(&tid, target_gen)
+                    .expect("target reader pooled after flush");
+                let target_data_db = StorageEngine::generation_component_path_for_test(
+                    &table_dir,
+                    target_gen,
+                    "Data.db",
+                )
+                .expect("target Data.db path resolves");
+
+                // Submit a compaction merging every generation.
+                {
+                    let tables = engine.tables.read();
+                    let state = tables.get(&tid).unwrap();
+                    let metadata = engine.collect_sstable_metadata(&tid, state);
+                    drop(tables);
+                    let task = crate::compaction::metadata::CompactionTask {
+                        inputs: metadata,
+                        output_dir: dir.path().join("compaction"),
+                        schema: test_schema(),
+                        table_id: tid.clone(),
+                    };
+                    engine.compaction_executor.submit(task).unwrap();
+                }
+
+                // Reader pauses right after snapshotting the pre-swap view.
+                let barrier = ReadViewBarrier::new();
+                let b_reader = Arc::clone(&barrier);
+                let eng = Arc::clone(&engine);
+                let rtid = tid.clone();
+                let rkey = target.clone();
+                let reader = std::thread::spawn(move || {
+                    ARMED.with(|c| *c.borrow_mut() = Some(b_reader));
+                    eng.read(&rtid, &rkey).expect("read must not error")
+                });
+
+                barrier.wait_reached();
+                // Drive the swap to completion. The bound is a generous hang-guard
+                // (~30s), NOT a timing assertion: the background merge always
+                // finishes, but a starved executor thread (and macOS F_FULLFSYNC)
+                // can make it slow — so we wait it out rather than race a deadline.
+                let mut swapped = false;
+                for _ in 0..1500 {
+                    engine.poll_compactions().await;
+                    if engine.sstable_count(&tid) == 1 {
+                        swapped = true;
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                }
+                assert!(swapped, "compaction swap did not complete");
+                assert!(
+                    !target_data_db.exists(),
+                    "swap must delete the target's Data.db (the mid-read ENOENT trigger)"
+                );
+
+                // Re-establish the cache-HIT precondition the swap tore down, then
+                // evict the fd so the resumed seek hits ENOENT on the deleted path.
+                engine.reseed_pooled_reader_for_test(
+                    &tid,
+                    target_gen,
+                    Arc::clone(&target_reader),
+                );
+                ferrosa_sstable::io::evict_global_fd_for_test(&target_data_db);
+
+                barrier.release();
+                reader.join().unwrap().is_some()
+            })
+        }
+
+        proptest! {
+            // Bounded for the per-PR gate; the nightly fuzz workflow scales this
+            // up via the PROPTEST_CASES env var (proptest reads it automatically).
+            #![proptest_config(ProptestConfig::with_cases(8))]
+            #[test]
+            fn committed_key_survives_midread_delete_during_compaction(
+                n_filler in 1usize..=3,
+                val in prop::collection::vec(any::<u8>(), 1..16usize),
+                suffix in 0u32..10_000,
+            ) {
+                prop_assert!(
+                    target_survives_midread_delete(n_filler, &val, suffix),
+                    "committed key vanished as a spurious Ok(None) across a mid-read \
+                     Data.db delete + compaction swap — read-vs-compaction silent data loss"
+                );
+            }
+        }
+    }
+
     /// Window (1), DELETED-`Filter.db` variant — fail-loud + retry path.
     ///
     /// A read snapshots a view referencing the sole-survivor input SSTable

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -12734,155 +12734,118 @@ mod tests {
         );
     }
 
-    /// Property-based regression for the read-vs-compaction data-loss class
-    /// (bug t_940cc015): a committed, never-deleted key MUST remain readable
-    /// even when a concurrent compaction deletes its input `Data.db` mid-read.
+    /// Real-concurrency stress harness for the read-vs-compaction data-loss
+    /// class (bug t_940cc015). Phase-separated availability invariant: write a
+    /// FROZEN set of committed keys (no deletes), then hammer reads from N
+    /// threads while a background storm of filler writes drives NATURAL
+    /// compaction. No manual `CompactionTask`, no barrier, no `count==1`
+    /// assumption — so it can't wedge on the in-flight-input claim the way an
+    /// injected task does. Every read of a committed key MUST return `Some`; a
+    /// spurious `Ok(None)`/`Err` is silent data loss and fails the test.
     ///
-    /// This generalizes `read_cache_hit_mid_read_delete_retries_against_new_view`
-    /// over randomized layouts (filler-generation count, target value bytes,
-    /// target key) so the invariant is checked across many on-disk shapes rather
-    /// than one hand-picked fixture. It is the DETERMINISTIC tier: the dangerous
-    /// interleaving is forced via the `ReadViewBarrier` + mid-read ENOENT
-    /// injection (not timing), so each case is reproducible. Bounded to a small
-    /// case count to keep the per-PR CI gate fast; the broad stochastic sweep is
-    /// the nightly real-concurrency stress (`tests/read_compaction_race_stress.rs`).
-    ///
-    /// Non-vacuous: with the get-error retry fix reverted (the `Err` arm of
-    /// `read_with_view` not setting `sstable_open_failed`), every case fails with
-    /// a spurious `Ok(None)` (silent data loss).
-    mod read_compaction_race_props {
+    /// Feature-gated (`race-stress`) so it stays out of the per-PR gate (the
+    /// fast hand-written barrier tests above are the per-PR deterministic tier).
+    /// The nightly fuzz workflow runs this on a shared-cpu Fly machine whose
+    /// ~6.5% baseline starves the compaction executor and widens the window.
+    /// Scale via env: RACE_KEYS, RACE_READERS, RACE_SECS, RACE_FLUSH_EVERY.
+    #[cfg(feature = "race-stress")]
+    mod read_compaction_race_stress {
         use super::*;
-        use crate::store::read_race_test_hook::{ReadViewBarrier, ARMED};
-        use proptest::prelude::*;
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
         use std::sync::Arc;
+        use std::time::Instant;
 
-        /// Returns whether the committed target key was still readable after a
-        /// compaction deleted its input `Data.db` between a cache-hit open and
-        /// the row seek. `false` == the silent-data-loss bug.
-        fn target_survives_midread_delete(n_filler: usize, val: &[u8], suffix: u32) -> bool {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
-            rt.block_on(async move {
-                let dir = tempfile::tempdir().unwrap();
-                let mut config = StorageEngineConfig::test_config(dir.path());
-                config.compaction.min_threshold = 2;
-                let engine = Arc::new(StorageEngine::new(config, None).unwrap());
-                engine.register_table(test_schema()).unwrap();
-                let tid = table_id();
-
-                // Filler generations (one key each), then the TARGET alone in the
-                // newest generation — so the target lives only in a to-be-merged
-                // input and "moves" into the compacted output.
-                let mut ts = 1000i64;
-                for i in 0..n_filler {
-                    engine
-                        .write(&tid, &make_key(&format!("f{i}")), make_row(b"f", ts), ts)
-                        .unwrap();
-                    engine.flush(&tid).unwrap();
-                    ts += 1000;
-                }
-                let target = make_key(&format!("t{suffix}"));
-                engine
-                    .write(&tid, &target, make_row(val, ts), ts)
-                    .unwrap();
-                engine.flush(&tid).unwrap();
-                assert_eq!(engine.sstable_count(&tid), n_filler + 1);
-
-                // Hold the target gen's pooled reader (keeps its bloom alive for the
-                // post-swap cache-hit) and resolve its Data.db path.
-                let table_dir = dir.path().join("sstables").join(tid.to_string());
-                let target_gen = *StorageEngine::list_generations_in_dir(&table_dir)
-                    .iter()
-                    .max()
-                    .expect("target gen exists");
-                let target_reader = engine
-                    .pooled_reader_arc_for_test(&tid, target_gen)
-                    .expect("target reader pooled after flush");
-                let target_data_db = StorageEngine::generation_component_path_for_test(
-                    &table_dir,
-                    target_gen,
-                    "Data.db",
-                )
-                .expect("target Data.db path resolves");
-
-                // Submit a compaction merging every generation.
-                {
-                    let tables = engine.tables.read();
-                    let state = tables.get(&tid).unwrap();
-                    let metadata = engine.collect_sstable_metadata(&tid, state);
-                    drop(tables);
-                    let task = crate::compaction::metadata::CompactionTask {
-                        inputs: metadata,
-                        output_dir: dir.path().join("compaction"),
-                        schema: test_schema(),
-                        table_id: tid.clone(),
-                    };
-                    engine.compaction_executor.submit(task).unwrap();
-                }
-
-                // Reader pauses right after snapshotting the pre-swap view.
-                let barrier = ReadViewBarrier::new();
-                let b_reader = Arc::clone(&barrier);
-                let eng = Arc::clone(&engine);
-                let rtid = tid.clone();
-                let rkey = target.clone();
-                let reader = std::thread::spawn(move || {
-                    ARMED.with(|c| *c.borrow_mut() = Some(b_reader));
-                    eng.read(&rtid, &rkey).expect("read must not error")
-                });
-
-                barrier.wait_reached();
-                // Drive the swap to completion. The bound is a generous hang-guard
-                // (~30s), NOT a timing assertion: the background merge always
-                // finishes, but a starved executor thread (and macOS F_FULLFSYNC)
-                // can make it slow — so we wait it out rather than race a deadline.
-                let mut swapped = false;
-                for _ in 0..1500 {
-                    engine.poll_compactions().await;
-                    if engine.sstable_count(&tid) == 1 {
-                        swapped = true;
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-                }
-                assert!(swapped, "compaction swap did not complete");
-                assert!(
-                    !target_data_db.exists(),
-                    "swap must delete the target's Data.db (the mid-read ENOENT trigger)"
-                );
-
-                // Re-establish the cache-HIT precondition the swap tore down, then
-                // evict the fd so the resumed seek hits ENOENT on the deleted path.
-                engine.reseed_pooled_reader_for_test(
-                    &tid,
-                    target_gen,
-                    Arc::clone(&target_reader),
-                );
-                ferrosa_sstable::io::evict_global_fd_for_test(&target_data_db);
-
-                barrier.release();
-                reader.join().unwrap().is_some()
-            })
+        fn env_u64(key: &str, default: u64) -> u64 {
+            std::env::var(key)
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default)
         }
 
-        proptest! {
-            // Bounded for the per-PR gate; the nightly fuzz workflow scales this
-            // up via the PROPTEST_CASES env var (proptest reads it automatically).
-            #![proptest_config(ProptestConfig::with_cases(8))]
-            #[test]
-            fn committed_key_survives_midread_delete_during_compaction(
-                n_filler in 1usize..=3,
-                val in prop::collection::vec(any::<u8>(), 1..16usize),
-                suffix in 0u32..10_000,
-            ) {
-                prop_assert!(
-                    target_survives_midread_delete(n_filler, &val, suffix),
-                    "committed key vanished as a spurious Ok(None) across a mid-read \
-                     Data.db delete + compaction swap — read-vs-compaction silent data loss"
-                );
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn committed_keys_stay_readable_under_compaction_storm() {
+            let n_keys = env_u64("RACE_KEYS", 300) as usize;
+            let n_readers = env_u64("RACE_READERS", 4) as usize;
+            let secs = env_u64("RACE_SECS", 20);
+            let flush_every = env_u64("RACE_FLUSH_EVERY", 25).max(1) as usize;
+
+            let dir = tempfile::tempdir().unwrap();
+            let mut config = StorageEngineConfig::test_config(dir.path());
+            config.compaction.min_threshold = 2;
+            let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+            engine.register_table(test_schema()).unwrap();
+            let tid = table_id();
+
+            // Phase A: write + flush the frozen committed key set (no deletes).
+            let keys: Vec<_> = (0..n_keys).map(|i| make_key(&format!("k{i:08}"))).collect();
+            let mut ts = 1i64;
+            for (i, k) in keys.iter().enumerate() {
+                engine
+                    .write(&tid, k, make_row(format!("v{i}").as_bytes(), ts), ts)
+                    .unwrap();
+                ts += 1;
+                if (i + 1) % flush_every == 0 {
+                    engine.flush(&tid).unwrap();
+                }
             }
+            engine.flush(&tid).unwrap();
+
+            // Phase B: readers assert availability while the storm churns compaction.
+            let stop = Arc::new(AtomicBool::new(false));
+            let misses = Arc::new(AtomicU64::new(0));
+            let reads = Arc::new(AtomicU64::new(0));
+            let mut handles = Vec::new();
+            for _ in 0..n_readers {
+                let eng = Arc::clone(&engine);
+                let t = tid.clone();
+                let ks = keys.clone();
+                let stop = Arc::clone(&stop);
+                let misses = Arc::clone(&misses);
+                let reads = Arc::clone(&reads);
+                handles.push(std::thread::spawn(move || {
+                    while !stop.load(Ordering::Relaxed) {
+                        for k in &ks {
+                            match eng.read(&t, k) {
+                                Ok(Some(_)) => {}
+                                Ok(None) | Err(_) => {
+                                    misses.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+                            reads.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }));
+            }
+
+            // Storm: filler writes (NOT in the committed set) create fresh SSTables;
+            // flush() triggers natural maybe_compact() and poll applies the merges,
+            // continuously moving committed rows between SSTables under the readers.
+            let start = Instant::now();
+            let mut j = 0u64;
+            while start.elapsed().as_secs() < secs {
+                for _ in 0..flush_every {
+                    engine
+                        .write(&tid, &make_key(&format!("junk{j:010}")), make_row(b"j", ts), ts)
+                        .unwrap();
+                    ts += 1;
+                    j += 1;
+                }
+                engine.flush(&tid).unwrap();
+                engine.poll_compactions().await;
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            stop.store(true, Ordering::Relaxed);
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            let m = misses.load(Ordering::Relaxed);
+            let r = reads.load(Ordering::Relaxed);
+            assert_eq!(
+                m, 0,
+                "{m} of {r} reads of committed keys returned Ok(None)/Err during a \
+                 compaction storm — read-vs-compaction silent data loss"
+            );
         }
     }
 


### PR DESCRIPTION
Adds the **nightly** tier of the read-vs-compaction fuzzing for bug t_940cc015 (already fixed in 2ef20484). Per-PR deterministic coverage is unchanged — the existing fast hand-written barrier tests already cover the class.

## What
- **engine.rs `read_compaction_race_stress`** (feature `race-stress`, off by default): phase-separated availability invariant — a frozen committed key set + N reader threads asserting every committed key reads `Some`, while a background storm of filler writes drives **natural** compaction. No manual CompactionTask, no barrier, no `count==1` assumption.
- **ci/race-stress-fly.sh**: provisions a throwaway **shared-cpu** Fly machine (the ~6.5% baseline starves the compaction executor = the discovery mechanism), builds `--features race-stress`, runs env-scaled (RACE_KEYS/READERS/SECS/FLUSH_EVERY), always tears down.

## Why not the injection proptest
The first attempt (an injection proptest) was fragile: with ≥3 SSTables, `flush()→maybe_compact()` auto-submits an STCS bucket-subset compaction that claims inputs, so the harness's manual full-set task is silently skipped (executor.rs:367) and the swap settles at count==2, not 1 — `assert!(swapped)` then times out. Verified on a Fly performance-2x that this is a harness artifact, not a product bug. The real-concurrency design sidesteps it.

## Validation
Local smoke (RACE_SECS=4, 40 keys, 2 readers): compiles clean, 0 misses, 4.58s. Full sweep is meant to run nightly on shared-cpu Fly via the script.

## Remaining (tracked)
Wire a nightly workflow to invoke ci/race-stress-fly.sh; needs FLY_API_TOKEN + a clone token as repo secrets.