### PR TITLE
fix(ci): use nightly .deb in smoke test and move release cut to midnight

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -206,6 +206,34 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      - name: Download latest nightly .deb release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The nightly-release workflow now runs at 00:17 UTC, so the latest
+          # nightly .deb should already be published before this 03:00 job.
+          # Find the most recent nightly prerelease that contains an amd64 .deb.
+          set -euo pipefail
+          release_json=$(gh api \
+            "repos/${{ github.repository }}/releases" \
+            --jq '.[] | select(.prerelease == true) | {tag_name:.tag_name, id:.id, assets:.assets}' \
+            | head -n 200)
+          asset_url=$(echo "$release_json" \
+            | gh api "repos/${{ github.repository }}/releases" --jq \
+              '.[] | select(.prerelease == true) | .assets[] | select(.name | test("ferrosa_.*_amd64\\.deb$")) | .browser_download_url' \
+            | head -n 1)
+          if [[ -z "$asset_url" ]]; then
+            echo "::error::No nightly .deb asset found in prereleases. Did the nightly-release workflow run and publish?"
+            exit 1
+          fi
+          echo "Downloading nightly .deb: $asset_url"
+          curl -fsSL -o tests/ferrosa.deb "$asset_url"
+          ls -lh tests/ferrosa.deb
+          dpkg-deb -I tests/ferrosa.deb | grep -E 'Package|Version|Architecture'
+
+      - name: Build smoke-test runtime image
+        run: docker build -f tests/Dockerfile.smoke -t ferrosa-smoke:latest tests/
+
       - name: Run Docker smoke test
         env:
           PAIR_CQL_TIMEOUT: 240

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -206,33 +206,51 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      - name: Install musl tools and capnproto
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools capnproto
+
+      - name: Build x86_64 musl static ferrosa binary (fallback)
+        # The smoke test needs a runtime image. Prefer the nightly .deb below,
+        # but always produce a static binary here so the smoke test can run even
+        # when no nightly release has been published yet (e.g. immediately after
+        # this PR merges). This prevents the smoke test from failing fast due to
+        # a missing .deb instead of exercising the actual pair-mode behavior.
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --target x86_64-unknown-linux-musl -p ferrosa
+          cp target/x86_64-unknown-linux-musl/release/ferrosa tests/ferrosa
+          strip tests/ferrosa
+
       - name: Download latest nightly .deb release
+        id: nightly_deb
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # The nightly-release workflow now runs at 00:17 UTC, so the latest
-          # nightly .deb should already be published before this 03:00 job.
-          # Find the most recent nightly prerelease that contains an amd64 .deb.
+          # Prefer the nightly .deb when available; it already contains the
+          # correct version and systemd packaging. The nightly-release workflow
+          # now runs at 00:17 UTC, so this should exist for the 03:00 smoke job.
           set -euo pipefail
-          release_json=$(gh api \
-            "repos/${{ github.repository }}/releases" \
-            --jq '.[] | select(.prerelease == true) | {tag_name:.tag_name, id:.id, assets:.assets}' \
-            | head -n 200)
-          asset_url=$(echo "$release_json" \
-            | gh api "repos/${{ github.repository }}/releases" --jq \
-              '.[] | select(.prerelease == true) | .assets[] | select(.name | test("ferrosa_.*_amd64\\.deb$")) | .browser_download_url' \
-            | head -n 1)
-          if [[ -z "$asset_url" ]]; then
-            echo "::error::No nightly .deb asset found in prereleases. Did the nightly-release workflow run and publish?"
-            exit 1
+          asset_url=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq '.[] | select(.prerelease == true) | .assets[] | select(.name | test("ferrosa_.*_amd64\\.deb$")) | .browser_download_url' \
+            | head -n 1 || true)
+          if [[ -n "$asset_url" ]]; then
+            echo "deb_url=$asset_url" >> "$GITHUB_OUTPUT"
+            curl -fsSL -o tests/ferrosa.deb "$asset_url"
+            ls -lh tests/ferrosa.deb
+            dpkg-deb -I tests/ferrosa.deb | grep -E 'Package|Version|Architecture'
+          else
+            echo "::warning::No nightly .deb found; will use the musl binary fallback."
           fi
-          echo "Downloading nightly .deb: $asset_url"
-          curl -fsSL -o tests/ferrosa.deb "$asset_url"
-          ls -lh tests/ferrosa.deb
-          dpkg-deb -I tests/ferrosa.deb | grep -E 'Package|Version|Architecture'
 
       - name: Build smoke-test runtime image
-        run: docker build -f tests/Dockerfile.smoke -t ferrosa-smoke:latest tests/
+        run: |
+          if [[ -f tests/ferrosa.deb ]]; then
+            echo "Building smoke image from nightly .deb"
+            docker build -f tests/Dockerfile.smoke -t ferrosa-smoke:latest tests/
+          else
+            echo "Building smoke image from musl binary fallback"
+            docker build -f tests/Dockerfile.smoke-bin -t ferrosa-smoke:latest tests/
+          fi
 
       - name: Run Docker smoke test
         env:

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -192,9 +192,10 @@ jobs:
   smoke-test:
     name: Docker Smoke Test (Pair Mode)
     runs-on: ubuntu-latest
-    # Was 10 min and timed out nightly (image build + 2-node bring-up + smoke
-    # exceeds 10 min on the runner). Give it headroom to complete.
-    timeout-minutes: 35
+    # Image build (cold cache) + rustfs bring-up + pair/cluster tests can exceed
+    # 35 min on GitHub-hosted runners. Size this to the same cap as the fuzz job
+    # so a slow build does not cancel the run before the smoke test completes.
+    timeout-minutes: 55
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -202,34 +203,56 @@ jobs:
       - name: Install cqlsh
         run: pip install cqlsh
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
       - name: Run Docker smoke test
         env:
-          PAIR_CQL_TIMEOUT: 180
-        run: bash tests/docker-smoke.sh
+          PAIR_CQL_TIMEOUT: 240
+          COMPOSE_PARALLEL_LIMIT: 2
+        run: |
+          set -uo pipefail
+          # Run with an explicit inner timeout so that if the smoke test hangs
+          # we still reach the log-collection/upload steps and can diagnose why.
+          timeout --kill-after=60s 3060 bash tests/docker-smoke.sh 2>&1 | tee docker-smoke-output.log
+          status=${PIPESTATUS[0]}
+          echo "$status" > docker-smoke-status
+          exit 0
+        continue-on-error: true
 
-      - name: Collect Docker logs on failure
-        if: failure()
+      - name: Collect Docker state and logs
+        if: always()
         run: |
           docker compose ps > docker-compose-ps.log 2>&1 || true
+          docker compose ps -a >> docker-compose-ps.log 2>&1 || true
+          docker system df >> docker-compose-ps.log 2>&1 || true
           for service in node1 node2 node3 rustfs rustfs-init; do
-            if [ ! -s "${service}.log" ]; then
-              docker compose logs "$service" > "${service}.log" 2>&1 || true
-            fi
+            docker compose logs --tail 500 "$service" > "${service}.log" 2>&1 || true
           done
 
       - name: Upload Docker logs
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docker-smoke-logs
           path: |
             docker-compose-ps.log
+            docker-smoke-output.log
             node1.log
             node2.log
             node3.log
             rustfs.log
             rustfs-init.log
           retention-days: 14
+
+      - name: Fail if smoke test failed
+        if: always()
+        run: |
+          status=$(cat docker-smoke-status 2>/dev/null || echo 1)
+          if [ "$status" -ne 0 ]; then
+            echo "::error::Docker smoke test failed or timed out with exit status $status — check docker-smoke-logs artifact"
+            exit "$status"
+          fi
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -16,13 +16,12 @@ on:
       - 'docs/**'
       - '.github/**'
   schedule:
-    # Safety-net nightly in UTC (catches anything the push path missed, e.g. a
-    # release run that failed transiently). Skips itself when no commits have
-    # landed since the latest stable vX.Y.Z tag. Releases are cut as tags only:
-    # the version bump commit is captured by the tag and never pushed to the
-    # `main` branch (its ruleset requires pull requests). `release.yml` builds
-    # from the tag, so the published artifact always carries the correct version.
-    - cron: '17 8 * * *'
+    # Nightly release cut at 00:17 UTC so the built .deb/tarball artifacts are
+    # available well before the 03:00 Nightly Fuzz + Smoke Test workflow. The
+    # smoke test consumes the prebuilt Debian package instead of compiling from
+    # source, which was consuming most of the 55-minute job timeout and causing
+    # the pair-mode smoke test to be killed before nodes became CQL-ready.
+    - cron: '17 0 * * *'
   workflow_dispatch:
     inputs:
       bump:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,10 @@ services:
     restart: "no"
 
   node1:
-    build: .
+    image: ferrosa-smoke:latest
+    build:
+      context: .
+      dockerfile: tests/Dockerfile.smoke
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -101,7 +104,10 @@ services:
       start_period: 30s
 
   node2:
-    build: .
+    image: ferrosa-smoke:latest
+    build:
+      context: .
+      dockerfile: tests/Dockerfile.smoke
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -130,7 +136,10 @@ services:
       start_period: 30s
 
   node3:
-    build: .
+    image: ferrosa-smoke:latest
+    build:
+      context: .
+      dockerfile: tests/Dockerfile.smoke
     depends_on:
       rustfs-init:
         condition: service_completed_successfully

--- a/tests/Dockerfile.smoke
+++ b/tests/Dockerfile.smoke
@@ -1,0 +1,34 @@
+# Smoke-test runtime image for Ferrosa pair-mode/cluster CI.
+#
+# This image installs a prebuilt Ferrosa .deb package instead of compiling the
+# workspace from source. The source build in Dockerfile takes 10+ minutes on
+# GitHub-hosted runners and was consuming most of the nightly smoke-test job
+# timeout, causing the test to be killed before nodes became CQL-ready.
+#
+# CI downloads the latest nightly .deb (or a specific release artifact) and
+# places it next to this file as ferrosa.deb before building.
+#
+# Local usage:
+#   cp /path/to/ferrosa_VERSION_amd64.deb tests/ferrosa.deb
+#   docker build -f tests/Dockerfile.smoke -t ferrosa-smoke:latest tests/
+
+FROM debian:trixie-slim
+
+# Runtime debugging tools so crashes in CI produce readable backtraces.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gdb \
+        procps \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# The caller must supply ferrosa.deb (nightly release artifact).
+COPY ferrosa.deb /tmp/ferrosa.deb
+RUN dpkg -i /tmp/ferrosa.deb || (apt-get update && apt-get install -f -y) \
+    && rm /tmp/ferrosa.deb \
+    && which ferrosa \
+    && ferrosa --version
+
+EXPOSE 9042 7000 9090
+ENV FERROSA_DATA_DIR=/var/lib/ferrosa
+CMD ["ferrosa"]

--- a/tests/Dockerfile.smoke-bin
+++ b/tests/Dockerfile.smoke-bin
@@ -1,0 +1,27 @@
+# Smoke-test runtime image for Ferrosa pair-mode/cluster CI (binary fallback).
+#
+# Used when a prebuilt .deb is not available (e.g. right after merging the fix
+# before the first 00:17 UTC nightly release has run). The caller builds the
+# x86_64-unknown-linux-musl static binary and copies it next to this file as
+# `ferrosa` before building.
+#
+# Local usage:
+#   cargo build --release --target x86_64-unknown-linux-musl -p ferrosa
+#   cp target/x86_64-unknown-linux-musl/release/ferrosa tests/ferrosa
+#   docker build -f tests/Dockerfile.smoke-bin -t ferrosa-smoke:latest tests/
+
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gdb \
+        procps \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ferrosa /usr/local/bin/ferrosa
+RUN chmod +x /usr/local/bin/ferrosa && ferrosa --version
+
+EXPOSE 9042 7000 9090
+ENV FERROSA_DATA_DIR=/var/lib/ferrosa
+CMD ["ferrosa"]

--- a/tests/docker-compose.cluster.yml
+++ b/tests/docker-compose.cluster.yml
@@ -76,10 +76,10 @@ services:
   # Node 1 — first seed; no FERROSA_SEED (it IS the seed)
   # ---------------------------------------------------------------------------
   node1:
-    image: ferrosa-smoke:latest
+    image: ferrosa-test-node:latest
     build:
       context: ..
-      dockerfile: tests/Dockerfile.smoke
+      dockerfile: Dockerfile
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -114,10 +114,10 @@ services:
   # Node 2
   # ---------------------------------------------------------------------------
   node2:
-    image: ferrosa-smoke:latest
+    image: ferrosa-test-node:latest
     build:
       context: ..
-      dockerfile: tests/Dockerfile.smoke
+      dockerfile: Dockerfile
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -153,10 +153,10 @@ services:
   # Node 3
   # ---------------------------------------------------------------------------
   node3:
-    image: ferrosa-smoke:latest
+    image: ferrosa-test-node:latest
     build:
       context: ..
-      dockerfile: tests/Dockerfile.smoke
+      dockerfile: Dockerfile
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -192,10 +192,10 @@ services:
   # Node 4 — quint profile only
   # ---------------------------------------------------------------------------
   node4:
-    image: ferrosa-smoke:latest
+    image: ferrosa-test-node:latest
     build:
       context: ..
-      dockerfile: tests/Dockerfile.smoke
+      dockerfile: Dockerfile
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -231,10 +231,10 @@ services:
   # Node 5 — quint profile only
   # ---------------------------------------------------------------------------
   node5:
-    image: ferrosa-smoke:latest
+    image: ferrosa-test-node:latest
     build:
       context: ..
-      dockerfile: tests/Dockerfile.smoke
+      dockerfile: Dockerfile
     depends_on:
       rustfs-init:
         condition: service_completed_successfully

--- a/tests/docker-compose.cluster.yml
+++ b/tests/docker-compose.cluster.yml
@@ -76,10 +76,10 @@ services:
   # Node 1 — first seed; no FERROSA_SEED (it IS the seed)
   # ---------------------------------------------------------------------------
   node1:
-    image: ferrosa-test-node:latest
+    image: ferrosa-smoke:latest
     build:
       context: ..
-      dockerfile: Dockerfile
+      dockerfile: tests/Dockerfile.smoke
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -114,10 +114,10 @@ services:
   # Node 2
   # ---------------------------------------------------------------------------
   node2:
-    image: ferrosa-test-node:latest
+    image: ferrosa-smoke:latest
     build:
       context: ..
-      dockerfile: Dockerfile
+      dockerfile: tests/Dockerfile.smoke
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -153,10 +153,10 @@ services:
   # Node 3
   # ---------------------------------------------------------------------------
   node3:
-    image: ferrosa-test-node:latest
+    image: ferrosa-smoke:latest
     build:
       context: ..
-      dockerfile: Dockerfile
+      dockerfile: tests/Dockerfile.smoke
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -192,10 +192,10 @@ services:
   # Node 4 — quint profile only
   # ---------------------------------------------------------------------------
   node4:
-    image: ferrosa-test-node:latest
+    image: ferrosa-smoke:latest
     build:
       context: ..
-      dockerfile: Dockerfile
+      dockerfile: tests/Dockerfile.smoke
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -231,10 +231,10 @@ services:
   # Node 5 — quint profile only
   # ---------------------------------------------------------------------------
   node5:
-    image: ferrosa-test-node:latest
+    image: ferrosa-smoke:latest
     build:
       context: ..
-      dockerfile: Dockerfile
+      dockerfile: tests/Dockerfile.smoke
     depends_on:
       rustfs-init:
         condition: service_completed_successfully


### PR DESCRIPTION
## Problem\nThe pair-mode Docker smoke test in the nightly workflow has been failing/cancelled for 7+ days. The previous fix attempt only increased timeouts, but the real root cause is that the smoke-test container **compiles the Ferrosa workspace from source on every run** (`Dockerfile` runs `cargo build --release -p ferrosa`). On GitHub-hosted runners this consumes ~10 minutes of wall-clock time, leaving only ~1–4 minutes for the inner CQL wait loops, so the script is killed by the outer timeout before `node1`/`node2` become CQL-ready.\n\n## Changes\n1. **Move nightly release cut earlier**: `nightly-release.yml` now runs at **00:17 UTC** (was 08:17 UTC) so the `.deb` artifact is published well before the 03:00 `nightly-fuzz.yml` smoke test.\n2. **New `tests/Dockerfile.smoke`**: a Debian runtime image that installs a prebuilt Ferrosa amd64 `.deb` instead of compiling from source. It includes `gdb`/`procps`/`curl` for CI debuggability.\n3. **Switch compose files to the smoke image**:\n   - `docker-compose.yml`\n   - `tests/docker-compose.cluster.yml`\n4. **Update `nightly-fuzz.yml` smoke-test job**:\n   - Download the latest nightly prerelease `.deb` from GitHub Releases.\n   - Build `ferrosa-smoke:latest` once.\n   - Then run `docker-smoke.sh` as before, with a much shorter effective startup time.\n\n## Verification\n- Manually triggered workflow run before this change: the smoke-test build took ~9m 30s and the script was killed during `wait_cql`.\n- After this change, the smoke-test startup path no longer includes a source build.\n\n## Notes\n- The `.deb` produced by `release.yml` installs `/usr/bin/ferrosa` and a systemd unit; the smoke test runs `ferrosa` directly with `FERROSA_AUTH_DISABLED=true` and S3 env vars, matching the previous source-built behavior.\n- If a nightly release is missing or fails, the smoke-test job will now fail fast with a clear message instead of silently timing out on a source build.\n