### PR TITLE
feat(flight): Arrow Flight query endpoint + push-CDC SUBSCRIBE re-integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -125,6 +126,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -252,6 +259,241 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a3ec4fe573f9d1f59d99c085197ef669b00b088ba1d7bb75224732d9357a74"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dcf19f07792d8c7f91086c67b574a79301e367029b17fcf63fb854332246a10"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7845c32b41f7053e37a075b3c2f29c6f5ea1b3ca6e5df7a2d325ee6e1b4a63cf"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5c681a99606f3316f2a99d9c8b6fa3aad0b1d34d8f6d7a1b471893940219d8"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365f8527d4f87b133eeb862f9b8093c009d41a210b8f101f91aa2392f61daac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30dac4d23ac769300349197b845e0fd18c7f9f15d260d4659ae6b5a9ca06f586"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd962fc3bf7f60705b25bcaa8eb3318b2545aa1d528656525ebdd6a17a6cd6fb"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-flight"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e3a40b6ef36f4c17d1fae5af3438c3d6c660401f9ac8a4d921c27d368b8dee"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-schema",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "paste",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3527365b24372f9c948f16e53738eb098720eea2093ae73c7af04ac5e30a39b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdec0024749fc0d95e025c0b0266d78613727b3b3a5d4cf8ea47eb6d38afdd1"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.14.0",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af2db0e62a508d34ddf4f76bfd6109b6ecc845257c9cba6f939653668f89ac"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-row"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da30e9d10e9c52f09ea0cf15086d6d785c11ae8dcc3ea5f16d402221b6ac7735"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b0f9c0c3582dd55db0f136d3b44bfa0189df07adcf7dc7f2f2e74db0f52eb8"
+
+[[package]]
+name = "arrow-select"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fc337f01635218493c23da81a364daf38c694b05fc20569c3193c11c561984"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d596a9fc25dae556672d5069b090331aca8acb93cae426d8b7dcdf1c558fa0ce"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +544,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +574,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -349,11 +622,38 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -364,7 +664,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -381,6 +681,26 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -788,16 +1108,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets",
 ]
 
 [[package]]
@@ -925,6 +1246,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1231,6 +1572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.7.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1624,27 @@ dependencies = [
  "crypto-bigint",
  "libm",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1748,12 +2116,14 @@ name = "ferrosa"
 version = "0.13.0"
 dependencies = [
  "arc-swap",
- "axum",
+ "axum 0.8.9",
  "base64 0.22.1",
  "dashmap",
+ "ferrosa-cdc",
  "ferrosa-cluster",
  "ferrosa-common",
  "ferrosa-cql",
+ "ferrosa-flight",
  "ferrosa-graph",
  "ferrosa-net",
  "ferrosa-postgres",
@@ -1786,6 +2156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferrosa-cdc"
+version = "0.13.0"
+dependencies = [
+ "ferrosa-common",
+ "ferrosa-sstable",
+ "tokio",
+]
+
+[[package]]
 name = "ferrosa-cluster"
 version = "0.13.0"
 dependencies = [
@@ -1795,6 +2174,7 @@ dependencies = [
  "bytes",
  "crc32fast",
  "dashmap",
+ "ferrosa-cdc",
  "ferrosa-common",
  "ferrosa-index",
  "ferrosa-net",
@@ -1907,12 +2287,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferrosa-flight"
+version = "0.13.0"
+dependencies = [
+ "arrow",
+ "arrow-flight",
+ "ferrosa-cluster",
+ "ferrosa-common",
+ "ferrosa-cql",
+ "ferrosa-schema",
+ "futures",
+ "hex",
+ "hmac 0.12.1",
+ "num-bigint",
+ "sha2 0.10.9",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "ferrosa-graph"
 version = "0.13.0"
 dependencies = [
  "arc-swap",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "axum-server",
  "base64 0.22.1",
  "bincode",
@@ -1961,7 +2363,7 @@ dependencies = [
 name = "ferrosa-index-builder"
 version = "0.13.0"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "bytes",
  "clap",
  "ferrosa-common",
@@ -2151,7 +2553,7 @@ dependencies = [
 name = "ferrosa-sparql"
 version = "0.13.0"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "base64 0.22.1",
  "ferrosa-cluster",
  "ferrosa-common",
@@ -2283,6 +2685,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -2580,6 +2992,18 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3215,6 +3639,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,6 +3802,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -3485,6 +3972,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,6 +4009,15 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3547,12 +4057,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4389,6 +4911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4761,6 +5292,18 @@ dependencies = [
  "log",
  "rustc-hash",
  "smallvec",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6181,6 +6724,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6425,9 +6977,12 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
+ "async-stream",
  "async-trait",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -6437,6 +6992,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,6 +2306,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-skiplist",
  "dashmap",
+ "ferrosa-cdc",
  "ferrosa-common",
  "ferrosa-index",
  "ferrosa-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
  "bytes",
  "chrono",
  "dashmap",
+ "ferrosa-cdc",
  "ferrosa-cluster",
  "ferrosa-common",
  "ferrosa-index",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "ferrosa-ctl",
     "ferrosa-cluster",
     "ferrosa-cql",
+    "ferrosa-flight",
     "ferrosa-graph",
     "ferrosa-index",
     "ferrosa-net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "ferrosa",
     "ferrosa-common",
+    "ferrosa-cdc",
     "ferrosa-ctl",
     "ferrosa-cluster",
     "ferrosa-cql",

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -1,0 +1,96 @@
+# ferrosa-driver (Python)
+
+A **drop-in replacement for the DataStax `cassandra-driver`** that adds
+ferrosa's `SUBSCRIBE` — real-time, push-based change streaming over the CQL
+wire (port 9042).
+
+Standard statements (`SELECT`/`INSERT`/`CREATE`/…) go through the real
+`cassandra-driver` unchanged. `SUBSCRIBE` cannot — it is a *continuous server
+push*, not one-response-per-query, which the stock driver's request/response
+model can't consume — so it runs over a dedicated raw connection that streams
+each change as it commits.
+
+## Install
+
+```bash
+pip install ./drivers          # or: cd drivers && pip install -e .
+```
+
+Requires `cassandra-driver>=3.0` (pulled in automatically).
+
+## Drop-in usage
+
+Swap the import; everything else is identical:
+
+```python
+# before:  from cassandra.cluster import Cluster
+#          from cassandra.auth import PlainTextAuthProvider
+from ferrosa_driver import Cluster, PlainTextAuthProvider
+
+cluster = Cluster(["127.0.0.1"], port=9042,
+                  auth_provider=PlainTextAuthProvider("cassandra", "cassandra"))
+session = cluster.connect()
+session.execute("INSERT INTO demo.t (id, v) VALUES (1, 'a')")   # standard path
+```
+
+## SUBSCRIBE (the addition)
+
+Two equivalent entry points — a standalone function, or `session.subscribe(...)`
+which reuses the session's contact point + credentials:
+
+```python
+from ferrosa_driver import subscribe
+
+with subscribe("127.0.0.1", "SUBSCRIBE demo.t ON COMMITTED",
+               username="cassandra", password="cassandra") as stream:
+    for change in stream:        # blocks until the next change is *pushed*
+        print(change)            # namedtuple keyed by the result columns
+
+# or, reusing an existing session:
+with session.subscribe("SUBSCRIBE demo.t ON LOCAL") as stream:
+    for change in stream:
+        print(change)
+```
+
+- `ON LOCAL` → the **WrittenOnNode** stream: every local commit (commit-log append).
+- `ON COMMITTED` → the **CommittedToCluster** stream: changes committed across the cluster.
+
+Each item is a `namedtuple` keyed by the result columns — the same shape the
+`cassandra-driver` yields for a `SELECT` row.
+
+## Real-time, not polling
+
+Delivery is **event-driven push**: the iterator blocks on the socket and is
+woken the instant the server pushes a change frame — there is no polling
+interval. Latency is the commit cost plus the wire hop, with no poll-interval
+floor.
+
+## Two-process demo
+
+Against a running ferrosa server (CQL on 9042):
+
+```bash
+# terminal 1 — subscribe (prints each change live)
+python examples/subscribe_process.py --stream COMMITTED
+
+# terminal 2 — write (standard driver INSERTs)
+python examples/write_process.py --rows 5
+```
+
+Each `INSERT` in terminal 2 appears in terminal 1 in real time.
+
+## Offline tests
+
+The wire codec has server-free tests (synthetic frames):
+
+```bash
+python tests/test_protocol.py
+```
+
+## Protocol note
+
+`SUBSCRIBE` is delivered as a sequence of CQL `RESULT`/`Rows` frames pushed on
+the query's stream id over time. This package speaks CQL native protocol v4
+directly for that path (STARTUP → optional PLAIN auth → `QUERY(SUBSCRIBE)` →
+loop-read `RESULT` frames), decoding the common scalar/temporal types. All other
+functionality is delegated to `cassandra-driver`.

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -41,13 +41,13 @@ which reuses the session's contact point + credentials:
 ```python
 from ferrosa_driver import subscribe
 
-with subscribe("127.0.0.1", "SUBSCRIBE demo.t ON COMMITTED",
+with subscribe("127.0.0.1", "SUBSCRIBE SELECT * FROM demo.t ON COMMITTED",
                username="cassandra", password="cassandra") as stream:
     for change in stream:        # blocks until the next change is *pushed*
         print(change)            # namedtuple keyed by the result columns
 
 # or, reusing an existing session:
-with session.subscribe("SUBSCRIBE demo.t ON LOCAL") as stream:
+with session.subscribe("SUBSCRIBE SELECT * FROM demo.t ON LOCAL") as stream:
     for change in stream:
         print(change)
 ```
@@ -57,6 +57,14 @@ with session.subscribe("SUBSCRIBE demo.t ON LOCAL") as stream:
 
 Each item is a `namedtuple` keyed by the result columns — the same shape the
 `cassandra-driver` yields for a `SELECT` row.
+
+## Verified live
+
+Against a running ferrosa server (CQL on 127.0.0.1:19142): a standard-driver
+`INSERT` and `subscribe(...)` over the same wire — each change arrived as a
+decoded `Row` namedtuple with **0.3–1.2 ms** write→deliver latency (sub-poll by
+orders of magnitude). Standard ops use the real `cassandra-driver`; only the
+SUBSCRIBE stream uses the dedicated raw connection.
 
 ## Real-time, not polling
 

--- a/drivers/examples/subscribe_process.py
+++ b/drivers/examples/subscribe_process.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Subscriber process: stream live changes from a ferrosa table over CQL (9042).
+
+Run this in one terminal, then run write_process.py in another against the same
+ferrosa server — each INSERT shows up here in real time (event-driven push, not
+polling).
+
+    python subscribe_process.py --stream COMMITTED   # cluster-committed changes
+    python subscribe_process.py --stream LOCAL        # local commits (WrittenOnNode)
+"""
+import argparse
+import sys
+
+from ferrosa_driver import subscribe
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=9042)
+    ap.add_argument("--keyspace", default="demo")
+    ap.add_argument("--table", default="t")
+    ap.add_argument("--stream", choices=["LOCAL", "COMMITTED"], default="COMMITTED")
+    ap.add_argument("--user", default="cassandra")
+    ap.add_argument("--password", default="cassandra")
+    ap.add_argument("--count", type=int, default=0, help="stop after N changes (0 = forever)")
+    args = ap.parse_args()
+
+    query = f"SUBSCRIBE {args.keyspace}.{args.table} ON {args.stream}"
+    print(f"[subscriber] {query}  ({args.host}:{args.port})", flush=True)
+    n = 0
+    with subscribe(
+        args.host, query, port=args.port, username=args.user, password=args.password
+    ) as stream:
+        for change in stream:
+            n += 1
+            print(f"[subscriber] change #{n}: {change}", flush=True)
+            if args.count and n >= args.count:
+                break
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/drivers/examples/subscribe_process.py
+++ b/drivers/examples/subscribe_process.py
@@ -26,7 +26,7 @@ def main() -> int:
     ap.add_argument("--count", type=int, default=0, help="stop after N changes (0 = forever)")
     args = ap.parse_args()
 
-    query = f"SUBSCRIBE {args.keyspace}.{args.table} ON {args.stream}"
+    query = f"SUBSCRIBE SELECT * FROM {args.keyspace}.{args.table} ON {args.stream}"
     print(f"[subscriber] {query}  ({args.host}:{args.port})", flush=True)
     n = 0
     with subscribe(

--- a/drivers/examples/write_process.py
+++ b/drivers/examples/write_process.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Writer process: standard cassandra-driver writes that the subscriber sees live.
+
+Uses the re-exported standard driver API (no SUBSCRIBE here) — proving the
+package is a drop-in for ordinary work. Run after starting subscribe_process.py.
+
+    python write_process.py --rows 5
+"""
+import argparse
+import sys
+import time
+
+from ferrosa_driver import Cluster, PlainTextAuthProvider
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=9042)
+    ap.add_argument("--keyspace", default="demo")
+    ap.add_argument("--table", default="t")
+    ap.add_argument("--user", default="cassandra")
+    ap.add_argument("--password", default="cassandra")
+    ap.add_argument("--rows", type=int, default=5)
+    ap.add_argument("--interval", type=float, default=1.0, help="seconds between inserts")
+    args = ap.parse_args()
+
+    cluster = Cluster(
+        [args.host],
+        port=args.port,
+        auth_provider=PlainTextAuthProvider(args.user, args.password),
+    )
+    session = cluster.connect()
+    session.execute(
+        f"CREATE KEYSPACE IF NOT EXISTS {args.keyspace} "
+        "WITH replication = {'class':'SimpleStrategy','replication_factor':1}"
+    )
+    session.execute(
+        f"CREATE TABLE IF NOT EXISTS {args.keyspace}.{args.table} (id int PRIMARY KEY, v text)"
+    )
+    for i in range(1, args.rows + 1):
+        session.execute(
+            f"INSERT INTO {args.keyspace}.{args.table} (id, v) VALUES (%s, %s)",
+            (i, f"value-{i}"),
+        )
+        print(f"[writer] inserted id={i}", flush=True)
+        time.sleep(args.interval)
+    cluster.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/drivers/ferrosa_driver/__init__.py
+++ b/drivers/ferrosa_driver/__init__.py
@@ -19,7 +19,7 @@ over a dedicated connection via :func:`subscribe` (or the added
                       auth_provider=PlainTextAuthProvider("cassandra", "cassandra"))
     session = cluster.connect()
     session.execute("INSERT INTO ks.t (id, v) VALUES (1, 'a')")   # standard path
-    with session.subscribe("SUBSCRIBE ks.t ON COMMITTED") as stream:
+    with session.subscribe("SUBSCRIBE SELECT * FROM ks.t ON COMMITTED") as stream:
         for change in stream:                                      # pushed in real time
             print(change)
 """

--- a/drivers/ferrosa_driver/__init__.py
+++ b/drivers/ferrosa_driver/__init__.py
@@ -1,0 +1,75 @@
+"""ferrosa_driver — a drop-in replacement for the DataStax ``cassandra-driver``
+that adds ferrosa's ``SUBSCRIBE`` (real-time change streaming).
+
+The full standard driver API is re-exported unchanged, so existing code keeps
+working by swapping the import:
+
+    # before
+    from cassandra.cluster import Cluster
+    from cassandra.auth import PlainTextAuthProvider
+    # after — identical behaviour, plus SUBSCRIBE
+    from ferrosa_driver import Cluster, PlainTextAuthProvider
+
+Standard statements (SELECT/INSERT/...) go through the real driver. ``SUBSCRIBE``
+cannot — it is a continuous server push, not one-response-per-query — so it runs
+over a dedicated connection via :func:`subscribe` (or the added
+``session.subscribe(...)``), yielding each change in real time:
+
+    cluster = Cluster(["127.0.0.1"], port=9042,
+                      auth_provider=PlainTextAuthProvider("cassandra", "cassandra"))
+    session = cluster.connect()
+    session.execute("INSERT INTO ks.t (id, v) VALUES (1, 'a')")   # standard path
+    with session.subscribe("SUBSCRIBE ks.t ON COMMITTED") as stream:
+        for change in stream:                                      # pushed in real time
+            print(change)
+"""
+
+from __future__ import annotations
+
+# Re-export the standard driver API so this is a drop-in import swap.
+from cassandra.cluster import (  # noqa: F401
+    Cluster,
+    ExecutionProfile,
+    ResultSet,
+    Session,
+)
+from cassandra.auth import PlainTextAuthProvider  # noqa: F401
+from cassandra.query import (  # noqa: F401
+    BatchStatement,
+    PreparedStatement,
+    SimpleStatement,
+)
+
+from .subscribe import SubscribeStream, subscribe
+
+__all__ = [
+    "Cluster",
+    "Session",
+    "ExecutionProfile",
+    "ResultSet",
+    "PlainTextAuthProvider",
+    "SimpleStatement",
+    "PreparedStatement",
+    "BatchStatement",
+    "subscribe",
+    "SubscribeStream",
+]
+
+
+def _session_subscribe(self, query, *, timeout=None):
+    """``session.subscribe(query)`` — open a SUBSCRIBE reusing this session's
+    cluster contact point, port, and (PlainText) credentials."""
+    cluster = self.cluster
+    contact_points = list(getattr(cluster, "contact_points", []) or [])
+    host = str(contact_points[0]) if contact_points else "127.0.0.1"
+    port = getattr(cluster, "port", 9042) or 9042
+    auth = getattr(cluster, "auth_provider", None)
+    username = getattr(auth, "username", None) if auth is not None else None
+    password = getattr(auth, "password", None) if auth is not None else None
+    return subscribe(
+        host, query, port=port, username=username, password=password, timeout=timeout
+    )
+
+
+# Add `.subscribe(...)` to the standard driver Session (drop-in ergonomics).
+Session.subscribe = _session_subscribe

--- a/drivers/ferrosa_driver/_protocol.py
+++ b/drivers/ferrosa_driver/_protocol.py
@@ -1,0 +1,273 @@
+"""Minimal CQL native-protocol v4 codec — just enough for ferrosa SUBSCRIBE.
+
+The standard cassandra-driver models every request as exactly one response on a
+stream id, then frees the stream. ferrosa's ``SUBSCRIBE`` instead pushes a
+*continuous* sequence of RESULT/Rows frames on the query's stream id as change
+events occur. The high-level driver cannot consume that, so this module speaks
+the wire protocol directly on a dedicated socket: STARTUP (+ optional PLAIN
+auth) -> QUERY(subscribe) -> read RESULT/Rows frames forever.
+
+Only the subset needed for SUBSCRIBE is implemented; everything else (prepared
+statements, batches, paging, the full type system) stays in the real driver,
+which this package re-exports unchanged.
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import uuid
+from datetime import datetime, timezone
+from ipaddress import ip_address
+
+# --- frame opcodes (CQL v4) ------------------------------------------------
+OP_STARTUP = 0x01
+OP_READY = 0x02
+OP_AUTHENTICATE = 0x03
+OP_AUTH_RESPONSE = 0x0F
+OP_AUTH_SUCCESS = 0x10
+OP_QUERY = 0x07
+OP_RESULT = 0x08
+OP_ERROR = 0x00
+
+VERSION_REQUEST = 0x04
+VERSION_RESPONSE = 0x84
+
+# RESULT kinds
+RESULT_VOID = 0x0001
+RESULT_ROWS = 0x0002
+
+# consistency levels
+CL_ONE = 0x0001
+
+# column type ids (option id -> name); enough for SUBSCRIBE result rows.
+_TYPE_CUSTOM = 0x0000
+_TYPE_ASCII = 0x0001
+_TYPE_BIGINT = 0x0002
+_TYPE_BLOB = 0x0003
+_TYPE_BOOLEAN = 0x0004
+_TYPE_COUNTER = 0x0005
+_TYPE_DOUBLE = 0x0007
+_TYPE_FLOAT = 0x0008
+_TYPE_INT = 0x0009
+_TYPE_TIMESTAMP = 0x000B
+_TYPE_UUID = 0x000C
+_TYPE_VARCHAR = 0x000D
+_TYPE_TIMEUUID = 0x000F
+_TYPE_INET = 0x0010
+_TYPE_SMALLINT = 0x0013
+_TYPE_TINYINT = 0x0014
+_COLLECTION_TYPES = {0x0020, 0x0021, 0x0022}  # list, map, set (nested option follows)
+
+
+class ProtocolError(Exception):
+    """A wire-level protocol failure (bad frame, server ERROR, auth failure)."""
+
+
+# --- low-level reads/writes ------------------------------------------------
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ProtocolError("connection closed by server")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _write_frame(sock: socket.socket, stream: int, opcode: int, body: bytes) -> None:
+    header = struct.pack(">BBhBI", VERSION_REQUEST, 0, stream, opcode, len(body))
+    sock.sendall(header + body)
+
+
+def _read_frame(sock: socket.socket) -> tuple[int, int, bytes]:
+    """Return (stream_id, opcode, body) of the next frame."""
+    header = _recv_exact(sock, 9)
+    _version, _flags, stream, opcode, length = struct.unpack(">BBhBI", header)
+    body = _recv_exact(sock, length) if length else b""
+    return stream, opcode, body
+
+
+def _string(s: str) -> bytes:
+    raw = s.encode("utf-8")
+    return struct.pack(">H", len(raw)) + raw
+
+
+def _long_string(s: str) -> bytes:
+    raw = s.encode("utf-8")
+    return struct.pack(">I", len(raw)) + raw
+
+
+def _string_map(m: dict[str, str]) -> bytes:
+    out = struct.pack(">H", len(m))
+    for k, v in m.items():
+        out += _string(k) + _string(v)
+    return out
+
+
+# --- a cursor over a frame body -------------------------------------------
+class _Reader:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.pos = 0
+
+    def u8(self) -> int:
+        v = self.data[self.pos]
+        self.pos += 1
+        return v
+
+    def i16(self) -> int:
+        (v,) = struct.unpack_from(">h", self.data, self.pos)
+        self.pos += 2
+        return v
+
+    def u16(self) -> int:
+        (v,) = struct.unpack_from(">H", self.data, self.pos)
+        self.pos += 2
+        return v
+
+    def i32(self) -> int:
+        (v,) = struct.unpack_from(">i", self.data, self.pos)
+        self.pos += 4
+        return v
+
+    def string(self) -> str:
+        n = self.u16()
+        s = self.data[self.pos : self.pos + n].decode("utf-8")
+        self.pos += n
+        return s
+
+    def bytes_(self) -> bytes | None:
+        n = self.i32()
+        if n < 0:
+            return None  # NULL
+        v = self.data[self.pos : self.pos + n]
+        self.pos += n
+        return v
+
+    def option(self) -> int:
+        """Read a [option] type id, skipping nested option(s) for collections."""
+        type_id = self.u16()
+        if type_id in _COLLECTION_TYPES:
+            self.option()  # element type
+            if type_id == 0x0021:  # map: a second nested option
+                self.option()
+        elif type_id == _TYPE_CUSTOM:
+            self.string()  # custom class name
+        return type_id
+
+
+# --- value decoding --------------------------------------------------------
+def _decode_value(type_id: int, raw: bytes | None):
+    if raw is None:
+        return None
+    if type_id in (_TYPE_VARCHAR, _TYPE_ASCII):
+        return raw.decode("utf-8", "replace")
+    if type_id == _TYPE_INT:
+        return struct.unpack(">i", raw)[0]
+    if type_id in (_TYPE_BIGINT, _TYPE_COUNTER):
+        return struct.unpack(">q", raw)[0]
+    if type_id == _TYPE_SMALLINT:
+        return struct.unpack(">h", raw)[0]
+    if type_id == _TYPE_TINYINT:
+        return struct.unpack(">b", raw)[0]
+    if type_id == _TYPE_BOOLEAN:
+        return raw != b"\x00"
+    if type_id == _TYPE_FLOAT:
+        return struct.unpack(">f", raw)[0]
+    if type_id == _TYPE_DOUBLE:
+        return struct.unpack(">d", raw)[0]
+    if type_id in (_TYPE_UUID, _TYPE_TIMEUUID):
+        return uuid.UUID(bytes=raw)
+    if type_id == _TYPE_TIMESTAMP:
+        millis = struct.unpack(">q", raw)[0]
+        return datetime.fromtimestamp(millis / 1000.0, tz=timezone.utc)
+    if type_id == _TYPE_INET:
+        return ip_address(raw)
+    # blob / unknown -> raw bytes (lossless)
+    return raw
+
+
+def _decode_rows(body: bytes) -> tuple[list[str], list[tuple]]:
+    """Decode a RESULT/Rows body into (column_names, [row_tuples])."""
+    r = _Reader(body)
+    kind = r.i32()
+    if kind != RESULT_ROWS:
+        # VOID or other — no rows to deliver.
+        return [], []
+    flags = r.i32()
+    col_count = r.i32()
+    has_more_pages = bool(flags & 0x0002)
+    if has_more_pages:
+        r.bytes_()  # paging state (ignored for a live subscription)
+    no_metadata = bool(flags & 0x0004)
+    global_spec = bool(flags & 0x0001)
+    names: list[str] = []
+    type_ids: list[int] = []
+    if not no_metadata:
+        if global_spec:
+            r.string()  # global keyspace
+            r.string()  # global table
+        for _ in range(col_count):
+            if not global_spec:
+                r.string()  # per-col keyspace
+                r.string()  # per-col table
+            names.append(r.string())
+            type_ids.append(r.option())
+    row_count = r.i32()
+    rows: list[tuple] = []
+    for _ in range(row_count):
+        rows.append(tuple(_decode_value(type_ids[c], r.bytes_()) for c in range(col_count)))
+    return names, rows
+
+
+# --- handshake + query -----------------------------------------------------
+def open_connection(
+    host: str,
+    port: int,
+    username: str | None = None,
+    password: str | None = None,
+    timeout: float | None = None,
+) -> socket.socket:
+    """Open a socket and complete STARTUP (+ optional PLAIN auth)."""
+    sock = socket.create_connection((host, port), timeout=timeout)
+    sock.settimeout(timeout)
+    _write_frame(sock, 0, OP_STARTUP, _string_map({"CQL_VERSION": "3.0.0"}))
+    _stream, opcode, body = _read_frame(sock)
+    if opcode == OP_READY:
+        return sock
+    if opcode == OP_AUTHENTICATE:
+        token = b"\x00" + (username or "").encode() + b"\x00" + (password or "").encode()
+        _write_frame(sock, 0, OP_AUTH_RESPONSE, struct.pack(">I", len(token)) + token)
+        _stream, opcode, body = _read_frame(sock)
+        if opcode == OP_AUTH_SUCCESS:
+            return sock
+        raise ProtocolError(f"authentication failed (opcode 0x{opcode:02x})")
+    if opcode == OP_ERROR:
+        raise ProtocolError(f"server ERROR during STARTUP: {_error_message(body)}")
+    raise ProtocolError(f"unexpected STARTUP response opcode 0x{opcode:02x}")
+
+
+def send_query(sock: socket.socket, cql: str, stream: int = 1) -> None:
+    body = _long_string(cql) + struct.pack(">HB", CL_ONE, 0x00)
+    _write_frame(sock, stream, OP_QUERY, body)
+
+
+def _error_message(body: bytes) -> str:
+    r = _Reader(body)
+    code = r.i32()
+    try:
+        msg = r.string()
+    except Exception:
+        msg = ""
+    return f"[code 0x{code:08x}] {msg}"
+
+
+def read_result_rows(sock: socket.socket) -> tuple[list[str], list[tuple]]:
+    """Block for the next frame; return decoded (names, rows). Raises on ERROR."""
+    _stream, opcode, body = _read_frame(sock)
+    if opcode == OP_RESULT:
+        return _decode_rows(body)
+    if opcode == OP_ERROR:
+        raise ProtocolError(f"server ERROR: {_error_message(body)}")
+    raise ProtocolError(f"unexpected frame opcode 0x{opcode:02x} while subscribed")

--- a/drivers/ferrosa_driver/subscribe.py
+++ b/drivers/ferrosa_driver/subscribe.py
@@ -89,7 +89,7 @@ def subscribe(
 ) -> SubscribeStream:
     """Open a live SUBSCRIBE against ``contact_point:port`` and stream changes.
 
-    >>> with subscribe("127.0.0.1", "SUBSCRIBE ks.t ON COMMITTED",
+    >>> with subscribe("127.0.0.1", "SUBSCRIBE SELECT * FROM ks.t ON COMMITTED",
     ...                 username="cassandra", password="cassandra") as stream:
     ...     for change in stream:
     ...         print(change)

--- a/drivers/ferrosa_driver/subscribe.py
+++ b/drivers/ferrosa_driver/subscribe.py
@@ -1,0 +1,105 @@
+"""SUBSCRIBE support layered on top of the standard cassandra-driver API.
+
+Standard queries go through the real driver (re-exported from the package
+root); ``subscribe`` opens its own raw connection because the continuous push
+does not fit the driver's one-response-per-stream model.
+"""
+
+from __future__ import annotations
+
+import keyword
+import re
+from collections import namedtuple
+from typing import Iterator, List, Optional
+
+from . import _protocol
+
+_IDENT_RE = re.compile(r"\W|^(?=\d)")
+
+
+def _sanitize(names: List[str]) -> List[str]:
+    """Make column names valid, unique Python identifiers for a namedtuple."""
+    out: List[str] = []
+    seen: dict[str, int] = {}
+    for i, name in enumerate(names):
+        ident = _IDENT_RE.sub("_", name) or f"col{i}"
+        if keyword.iskeyword(ident):
+            ident += "_"
+        if ident in seen:
+            seen[ident] += 1
+            ident = f"{ident}_{seen[ident]}"
+        else:
+            seen[ident] = 0
+        out.append(ident)
+    return out
+
+
+class SubscribeStream:
+    """An open SUBSCRIBE. Iterate to receive change events in real time.
+
+    Each item is a ``namedtuple`` keyed by the result column names — the same
+    shape the cassandra-driver yields for a SELECT row. The iterator blocks
+    until the next change is pushed (event-driven; there is no polling). Use as
+    a context manager, or call :meth:`close`, to tear down the connection.
+    """
+
+    def __init__(self, sock, query: str):
+        self._sock = sock
+        self.query = query
+        self._row_cls = None
+        self._buffered: list = []
+
+    def __iter__(self) -> Iterator:
+        return self
+
+    def __next__(self):
+        while True:
+            if self._buffered:
+                return self._buffered.pop(0)
+            names, rows = _protocol.read_result_rows(self._sock)
+            if self._row_cls is None and names:
+                self._row_cls = namedtuple("Row", _sanitize(names))
+            if self._row_cls is not None:
+                self._buffered = [self._row_cls(*r) for r in rows]
+            else:
+                self._buffered = list(rows)
+            # An empty frame (0 rows) is a keep-alive — loop and keep waiting.
+
+    def close(self) -> None:
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+    def __enter__(self) -> "SubscribeStream":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.close()
+
+
+def subscribe(
+    contact_point: str,
+    query: str,
+    *,
+    port: int = 9042,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    timeout: Optional[float] = None,
+) -> SubscribeStream:
+    """Open a live SUBSCRIBE against ``contact_point:port`` and stream changes.
+
+    >>> with subscribe("127.0.0.1", "SUBSCRIBE ks.t ON COMMITTED",
+    ...                 username="cassandra", password="cassandra") as stream:
+    ...     for change in stream:
+    ...         print(change)
+
+    ``query`` must be a ``SUBSCRIBE`` statement; ``ON LOCAL`` streams local
+    commits (WrittenOnNode), ``ON COMMITTED`` streams cluster-committed changes
+    (CommittedToCluster). Returns a :class:`SubscribeStream`.
+    """
+    if not query.lstrip().upper().startswith("SUBSCRIBE"):
+        raise ValueError("subscribe() requires a SUBSCRIBE statement")
+    sock = _protocol.open_connection(contact_point, port, username, password, timeout)
+    _protocol.send_query(sock, query)
+    return SubscribeStream(sock, query)

--- a/drivers/pyproject.toml
+++ b/drivers/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "ferrosa-driver"
+version = "0.1.0"
+description = "Drop-in replacement for the DataStax cassandra-driver that adds ferrosa SUBSCRIBE (real-time change streaming)."
+requires-python = ">=3.8"
+dependencies = ["cassandra-driver>=3.0"]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ferrosa_driver*"]

--- a/drivers/tests/test_protocol.py
+++ b/drivers/tests/test_protocol.py
@@ -1,0 +1,83 @@
+"""Offline tests for the SUBSCRIBE wire codec — no server required.
+
+Builds synthetic RESULT/Rows frames and feeds them through a fake socket to
+verify decoding + SubscribeStream iteration.
+"""
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ferrosa_driver import _protocol  # noqa: E402
+from ferrosa_driver.subscribe import SubscribeStream  # noqa: E402
+
+
+def _rows_body(rows):
+    """Encode a RESULT/Rows body for a fixed (id int, name text) schema."""
+    b = struct.pack(">i", _protocol.RESULT_ROWS)
+    b += struct.pack(">i", 0x0001)  # flags: global_tables_spec
+    b += struct.pack(">i", 2)  # column count
+    b += _protocol._string("demo") + _protocol._string("t")  # global ks/table
+    b += _protocol._string("id") + struct.pack(">H", _protocol._TYPE_INT)
+    b += _protocol._string("name") + struct.pack(">H", _protocol._TYPE_VARCHAR)
+    b += struct.pack(">i", len(rows))
+    for (id_, name) in rows:
+        idv = struct.pack(">i", id_)
+        b += struct.pack(">i", len(idv)) + idv
+        nv = name.encode("utf-8")
+        b += struct.pack(">i", len(nv)) + nv
+    return b
+
+
+def _result_frame(body):
+    return struct.pack(">BBhBI", 0x84, 0, 1, _protocol.OP_RESULT, len(body)) + body
+
+
+class FakeSocket:
+    """Serves a fixed byte stream over recv(); raises EOF-like when drained."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+        self._pos = 0
+
+    def recv(self, n: int) -> bytes:
+        if self._pos >= len(self._data):
+            return b""  # closed
+        chunk = self._data[self._pos : self._pos + n]
+        self._pos += len(chunk)
+        return chunk
+
+    def close(self):
+        pass
+
+
+def test_decode_rows_typed_values():
+    names, rows = _protocol._decode_rows(_rows_body([(1, "alice"), (2, "bob")]))
+    assert names == ["id", "name"]
+    assert rows == [(1, "alice"), (2, "bob")]
+
+
+def test_subscribe_stream_yields_namedtuples():
+    # Two pushed frames, one row each — the continuous-push shape.
+    stream_bytes = _result_frame(_rows_body([(10, "x")])) + _result_frame(_rows_body([(20, "y")]))
+    stream = SubscribeStream(FakeSocket(stream_bytes), "SUBSCRIBE demo.t ON COMMITTED")
+    first = next(stream)
+    assert (first.id, first.name) == (10, "x")
+    second = next(stream)
+    assert (second.id, second.name) == (20, "y")
+
+
+def test_empty_frame_is_skipped_then_next_delivered():
+    # An empty (0-row) keep-alive frame followed by a real one.
+    stream_bytes = _result_frame(_rows_body([])) + _result_frame(_rows_body([(7, "z")]))
+    stream = SubscribeStream(FakeSocket(stream_bytes), "SUBSCRIBE demo.t ON LOCAL")
+    row = next(stream)
+    assert (row.id, row.name) == (7, "z")
+
+
+if __name__ == "__main__":
+    test_decode_rows_typed_values()
+    test_subscribe_stream_yields_namedtuples()
+    test_empty_frame_is_skipped_then_next_delivered()
+    print("ferrosa_driver protocol codec: all offline tests passed")

--- a/drivers/tests/test_protocol.py
+++ b/drivers/tests/test_protocol.py
@@ -61,7 +61,7 @@ def test_decode_rows_typed_values():
 def test_subscribe_stream_yields_namedtuples():
     # Two pushed frames, one row each — the continuous-push shape.
     stream_bytes = _result_frame(_rows_body([(10, "x")])) + _result_frame(_rows_body([(20, "y")]))
-    stream = SubscribeStream(FakeSocket(stream_bytes), "SUBSCRIBE demo.t ON COMMITTED")
+    stream = SubscribeStream(FakeSocket(stream_bytes), "SUBSCRIBE SELECT * FROM demo.t ON COMMITTED")
     first = next(stream)
     assert (first.id, first.name) == (10, "x")
     second = next(stream)
@@ -71,7 +71,7 @@ def test_subscribe_stream_yields_namedtuples():
 def test_empty_frame_is_skipped_then_next_delivered():
     # An empty (0-row) keep-alive frame followed by a real one.
     stream_bytes = _result_frame(_rows_body([])) + _result_frame(_rows_body([(7, "z")]))
-    stream = SubscribeStream(FakeSocket(stream_bytes), "SUBSCRIBE demo.t ON LOCAL")
+    stream = SubscribeStream(FakeSocket(stream_bytes), "SUBSCRIBE SELECT * FROM demo.t ON LOCAL")
     row = next(stream)
     assert (row.id, row.name) == (7, "z")
 

--- a/ferrosa-cdc/Cargo.toml
+++ b/ferrosa-cdc/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ferrosa-cdc"
+description = "Change-data-capture event types and bus for Ferrosa SUBSCRIBE streams"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+# Foundation-only dependencies (see specs/proposed/arrow-flight-endpoint/dsm-analysis.md):
+# ferrosa-cdc must NOT depend on ferrosa-storage (which depends on ferrosa-cdc),
+# so CdcEvent reuses ferrosa_sstable::Row rather than ferrosa_storage::Mutation.
+ferrosa-common = { path = "../ferrosa-common" }
+ferrosa-sstable = { path = "../ferrosa-sstable" }
+tokio = { version = "1", features = ["sync"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/ferrosa-cdc/src/lib.rs
+++ b/ferrosa-cdc/src/lib.rs
@@ -1,0 +1,285 @@
+//! Change-data-capture (CDC) event types and bus for Ferrosa SUBSCRIBE.
+//!
+//! SUBSCRIBE was scoped to expose two optional, event-driven change streams,
+//! not a polled SELECT snapshot (see
+//! `specs/proposed/arrow-flight-endpoint/subscribe-cdc-architecture.md`):
+//!
+//! - [`CdcStream::WrittenOnNode`] — every mutation durably written to this
+//!   node's commit log, ordered by the mutation timestamp.
+//! - [`CdcStream::CommittedToCluster`] — mutations the cluster has agreed/acked
+//!   (Accord commit, or a regular-CL quorum ack on the coordinator).
+//!
+//! This crate is a foundation-layer crate: it depends only on `ferrosa-common`
+//! and `ferrosa-sstable` so that producers (`ferrosa-storage`, `ferrosa-cluster`)
+//! and consumers (`ferrosa-cql`, `ferrosa-flight`) can all depend on it without
+//! introducing a dependency cycle. In particular [`CdcEvent`] reuses
+//! [`ferrosa_sstable::types::Row`] and never embeds `ferrosa_storage::Mutation`.
+//!
+//! The bus is bounded per subscriber. A subscriber that falls behind receives an
+//! explicit [`CdcRecvError::Lagged`] gap signal carrying the number of dropped
+//! events — it is never silently skipped (FMEA F16/F18). A slow subscriber can
+//! therefore never block a producer (the write path).
+
+use std::sync::Arc;
+
+use ferrosa_common::accord::Timestamp as AccordTimestamp;
+use ferrosa_common::DecoratedKey;
+use ferrosa_sstable::types::Row;
+use tokio::sync::broadcast;
+
+/// Which change stream an event belongs to. A subscriber selects one stream;
+/// to follow both, open two subscriptions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CdcStream {
+    /// Local durable writes (commit-log append), ordered by mutation timestamp.
+    WrittenOnNode,
+    /// Cluster-agreed writes (Accord commit / regular-CL quorum ack).
+    CommittedToCluster,
+}
+
+/// A single change event delivered on a CDC stream.
+///
+/// Carries the same payload a commit-log `Mutation` does, but expressed only in
+/// foundation-layer types so this crate stays below `ferrosa-storage` in the
+/// dependency graph. `mutation_id` is the dedup key for at-least-once delivery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CdcEvent {
+    /// Stream this event belongs to.
+    pub stream: CdcStream,
+    /// Target keyspace.
+    pub keyspace: String,
+    /// Target table.
+    pub table: String,
+    /// Decorated partition key.
+    pub key: DecoratedKey,
+    /// Mutated rows (reused verbatim from the commit-log mutation).
+    pub rows: Vec<Row>,
+    /// Mutation/write timestamp in microseconds. Ordering key for
+    /// `WrittenOnNode` and for regular-CL `CommittedToCluster` events.
+    pub timestamp: i64,
+    /// Agreed Accord timestamp, present only for Accord-committed transactions
+    /// on the `CommittedToCluster` stream. `None` for regular-CL and local writes.
+    pub accord_ts: Option<AccordTimestamp>,
+    /// Unique mutation id (commit-log `mutation_id`); the dedup key.
+    pub mutation_id: [u8; 16],
+}
+
+/// Error returned by [`CdcSubscription::recv`] / [`CdcSubscription::try_recv`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CdcRecvError {
+    /// The subscriber fell behind and `skipped` events were dropped from its
+    /// bounded queue. This is the **gap signal**: the consumer must resync from
+    /// a checkpoint rather than assume continuity. Never silent.
+    Lagged { skipped: u64 },
+    /// No event is currently available (non-blocking `try_recv` only).
+    Empty,
+    /// The bus was dropped; the stream is closed and will yield no more events.
+    Closed,
+}
+
+/// A bounded, multi-subscriber CDC event bus with one channel per stream.
+///
+/// Producers call [`CdcBus::publish`]; consumers call [`CdcBus::subscribe`].
+/// The per-stream capacity bounds memory; overflow surfaces as
+/// [`CdcRecvError::Lagged`] on the lagging subscriber only.
+#[derive(Debug)]
+pub struct CdcBus {
+    written_on_node: broadcast::Sender<CdcEvent>,
+    committed: broadcast::Sender<CdcEvent>,
+}
+
+impl CdcBus {
+    /// Create a bus whose per-stream subscriber queue holds at most `capacity`
+    /// events before a slow subscriber starts receiving gap signals.
+    ///
+    /// # Panics
+    /// Panics if `capacity == 0` (a zero-capacity stream could never deliver).
+    pub fn new(capacity: usize) -> Arc<Self> {
+        assert!(capacity > 0, "CDC bus capacity must be non-zero");
+        let (written_on_node, _) = broadcast::channel(capacity);
+        let (committed, _) = broadcast::channel(capacity);
+        Arc::new(Self {
+            written_on_node,
+            committed,
+        })
+    }
+
+    fn sender(&self, stream: CdcStream) -> &broadcast::Sender<CdcEvent> {
+        match stream {
+            CdcStream::WrittenOnNode => &self.written_on_node,
+            CdcStream::CommittedToCluster => &self.committed,
+        }
+    }
+
+    /// Publish an event to its stream. Returns the number of live subscribers
+    /// the event was delivered to (`0` when nobody is subscribed — a normal,
+    /// non-error case: a producer never blocks or fails on absent consumers).
+    pub fn publish(&self, event: CdcEvent) -> usize {
+        let sender = self.sender(event.stream);
+        // `send` errors only when there are zero receivers; that is expected
+        // when no consumer is attached, so we treat it as "delivered to none".
+        sender.send(event).unwrap_or(0)
+    }
+
+    /// Whether `stream` currently has at least one live subscriber.
+    ///
+    /// Producers on a hot path (e.g. the commit-log append) use this to avoid
+    /// building/cloning a [`CdcEvent`] when nobody is listening.
+    pub fn has_subscribers(&self, stream: CdcStream) -> bool {
+        self.sender(stream).receiver_count() > 0
+    }
+
+    /// Subscribe to a single stream. Each subscription has its own bounded
+    /// queue; a slow one only affects itself.
+    pub fn subscribe(&self, stream: CdcStream) -> CdcSubscription {
+        CdcSubscription {
+            stream,
+            rx: self.sender(stream).subscribe(),
+        }
+    }
+}
+
+/// A consumer's handle to one CDC stream.
+#[derive(Debug)]
+pub struct CdcSubscription {
+    stream: CdcStream,
+    rx: broadcast::Receiver<CdcEvent>,
+}
+
+impl CdcSubscription {
+    /// The stream this subscription follows.
+    pub fn stream(&self) -> CdcStream {
+        self.stream
+    }
+
+    /// Await the next event. Returns [`CdcRecvError::Lagged`] (gap signal) if the
+    /// queue overflowed, or [`CdcRecvError::Closed`] once the bus is gone.
+    pub async fn recv(&mut self) -> Result<CdcEvent, CdcRecvError> {
+        match self.rx.recv().await {
+            Ok(event) => Ok(event),
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                Err(CdcRecvError::Lagged { skipped })
+            }
+            Err(broadcast::error::RecvError::Closed) => Err(CdcRecvError::Closed),
+        }
+    }
+
+    /// Non-blocking variant of [`recv`](Self::recv).
+    pub fn try_recv(&mut self) -> Result<CdcEvent, CdcRecvError> {
+        match self.rx.try_recv() {
+            Ok(event) => Ok(event),
+            Err(broadcast::error::TryRecvError::Lagged(skipped)) => {
+                Err(CdcRecvError::Lagged { skipped })
+            }
+            Err(broadcast::error::TryRecvError::Empty) => Err(CdcRecvError::Empty),
+            Err(broadcast::error::TryRecvError::Closed) => Err(CdcRecvError::Closed),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrosa_common::PartitionKey;
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+
+    fn event(stream: CdcStream, id: u8) -> CdcEvent {
+        CdcEvent {
+            stream,
+            keyspace: "ks".to_string(),
+            table: "t".to_string(),
+            key: DecoratedKey::new(PartitionKey::from(b"pk".as_slice())),
+            rows: vec![Row {
+                clustering: vec![],
+                cells: vec![],
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::default(),
+            }],
+            timestamp: id as i64,
+            accord_ts: None,
+            mutation_id: [id; 16],
+        }
+    }
+
+    #[test]
+    fn streams_are_isolated() {
+        let bus = CdcBus::new(8);
+        let mut local = bus.subscribe(CdcStream::WrittenOnNode);
+        let mut committed = bus.subscribe(CdcStream::CommittedToCluster);
+
+        assert_eq!(bus.publish(event(CdcStream::WrittenOnNode, 1)), 1);
+
+        let got = local.try_recv().expect("local subscriber sees the event");
+        assert_eq!(got.mutation_id, [1; 16]);
+        // The committed subscriber must not see a written-on-node event.
+        assert_eq!(committed.try_recv(), Err(CdcRecvError::Empty));
+    }
+
+    #[test]
+    fn fans_out_to_all_subscribers() {
+        let bus = CdcBus::new(8);
+        let mut a = bus.subscribe(CdcStream::CommittedToCluster);
+        let mut b = bus.subscribe(CdcStream::CommittedToCluster);
+
+        assert_eq!(bus.publish(event(CdcStream::CommittedToCluster, 7)), 2);
+
+        assert_eq!(a.try_recv().unwrap().mutation_id, [7; 16]);
+        assert_eq!(b.try_recv().unwrap().mutation_id, [7; 16]);
+    }
+
+    #[test]
+    fn overflow_emits_gap_signal_not_silent_drop() {
+        // Capacity 4, publish 6 without draining: the 2 oldest are dropped and
+        // the subscriber is told via Lagged — never silently skipped (F16/F18).
+        let bus = CdcBus::new(4);
+        let mut sub = bus.subscribe(CdcStream::WrittenOnNode);
+        for i in 0..6u8 {
+            bus.publish(event(CdcStream::WrittenOnNode, i));
+        }
+        assert_eq!(sub.try_recv(), Err(CdcRecvError::Lagged { skipped: 2 }));
+        // After observing the gap, delivery resumes from the oldest retained event.
+        assert_eq!(sub.try_recv().unwrap().mutation_id, [2; 16]);
+    }
+
+    #[test]
+    fn publish_without_subscribers_is_not_an_error() {
+        let bus = CdcBus::new(4);
+        assert_eq!(bus.publish(event(CdcStream::WrittenOnNode, 9)), 0);
+    }
+
+    #[test]
+    fn has_subscribers_tracks_live_subscriptions_per_stream() {
+        let bus = CdcBus::new(4);
+        assert!(!bus.has_subscribers(CdcStream::WrittenOnNode));
+        let sub = bus.subscribe(CdcStream::WrittenOnNode);
+        assert!(bus.has_subscribers(CdcStream::WrittenOnNode));
+        // Other stream is unaffected.
+        assert!(!bus.has_subscribers(CdcStream::CommittedToCluster));
+        drop(sub);
+        assert!(!bus.has_subscribers(CdcStream::WrittenOnNode));
+    }
+
+    #[tokio::test]
+    async fn async_recv_delivers_event() {
+        let bus = CdcBus::new(4);
+        let mut sub = bus.subscribe(CdcStream::CommittedToCluster);
+        bus.publish(event(CdcStream::CommittedToCluster, 3));
+        let got = sub.recv().await.expect("event delivered");
+        assert_eq!(got.stream, CdcStream::CommittedToCluster);
+        assert_eq!(got.mutation_id, [3; 16]);
+    }
+
+    #[test]
+    fn closed_bus_reports_closed() {
+        let bus = CdcBus::new(4);
+        let mut sub = bus.subscribe(CdcStream::WrittenOnNode);
+        drop(bus);
+        assert_eq!(sub.try_recv(), Err(CdcRecvError::Closed));
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be non-zero")]
+    fn zero_capacity_panics() {
+        let _ = CdcBus::new(0);
+    }
+}

--- a/ferrosa-cluster/Cargo.toml
+++ b/ferrosa-cluster/Cargo.toml
@@ -10,6 +10,7 @@ bincode = "1"
 bytes = "1"
 crc32fast = "1"
 dashmap = "6"
+ferrosa-cdc = { path = "../ferrosa-cdc" }
 ferrosa-common = { path = "../ferrosa-common" }
 ferrosa-index = { path = "../ferrosa-index" }
 ferrosa-net = { path = "../ferrosa-net" }

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -548,6 +548,55 @@ impl DepWaitApplier {
 }
 
 // ===========================================================================
+// CdcPublishingApplier — publish CommittedToCluster CDC on durable apply
+// ===========================================================================
+
+/// Decorates a [`StorageApplier`] to publish a `CommittedToCluster` CDC event
+/// after a successful durable apply, so live CQL `SUBSCRIBE ... ON COMMITTED`
+/// (and the Arrow Flight endpoint) receive Accord-committed writes. No-op when
+/// no committed-stream subscriber is attached. The inner applier's fail-loud
+/// contract is preserved — the event is published only after `inner.apply`
+/// returns `Ok`.
+pub struct CdcPublishingApplier {
+    inner: Arc<dyn StorageApplier>,
+    cdc: Arc<ferrosa_cdc::CdcBus>,
+}
+
+impl CdcPublishingApplier {
+    pub fn new(inner: Arc<dyn StorageApplier>, cdc: Arc<ferrosa_cdc::CdcBus>) -> Self {
+        Self { inner, cdc }
+    }
+}
+
+impl StorageApplier for CdcPublishingApplier {
+    fn apply(&self, txn_id: TxnId, mutation: ApplyMutation) -> Result<(), ApplyError> {
+        // Build the CDC event before `mutation` is consumed, and only if a
+        // committed-stream subscriber is actually listening.
+        let event = if self.cdc.has_subscribers(ferrosa_cdc::CdcStream::CommittedToCluster) {
+            Mutation::deserialize_from(&mutation.data)
+                .ok()
+                .map(|m| ferrosa_cdc::CdcEvent {
+                    stream: ferrosa_cdc::CdcStream::CommittedToCluster,
+                    keyspace: m.keyspace.clone(),
+                    table: m.table.clone(),
+                    key: m.key.clone(),
+                    rows: m.rows.clone(),
+                    timestamp: m.timestamp,
+                    accord_ts: Some(mutation.t),
+                    mutation_id: m.mutation_id,
+                })
+        } else {
+            None
+        };
+        self.inner.apply(txn_id, mutation)?;
+        if let Some(ev) = event {
+            self.cdc.publish(ev);
+        }
+        Ok(())
+    }
+}
+
+// ===========================================================================
 // Tests
 // ===========================================================================
 

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -1150,4 +1150,188 @@ mod engine_applier_tests {
             "a cell written at a later agreed t must not be visible to a read at an earlier t"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // End-to-end streaming SUBSCRIBE latency with two simultaneous connections:
+    // one on the local-commit stream (WrittenOnNode, fired at commit-log append)
+    // and one on the full-Accord stream (CommittedToCluster, fired by the
+    // CdcPublishingApplier after a durable Accord apply). Measures write->deliver
+    // latency for each path and prints the distribution.
+    //
+    // NOTE: single-node, in-process push bus — both streams deliver in
+    // microseconds. The local-vs-committed *gap* (cluster consensus / quorum
+    // round-trip) only manifests in a multi-node deployment; here both paths are
+    // dominated by the same local commit-log append.
+    fn report(label: &str, samples: &mut [u64]) {
+        samples.sort_unstable();
+        let n = samples.len();
+        let avg = samples.iter().sum::<u64>() / n as u64;
+        let p50 = samples[n / 2];
+        let p99 = samples[(n * 99 / 100).min(n - 1)];
+        eprintln!(
+            "SUBSCRIBE latency [{label}] over {n} writes: avg={:.1}µs p50={:.1}µs p99={:.1}µs",
+            avg as f64 / 1000.0,
+            p50 as f64 / 1000.0,
+            p99 as f64 / 1000.0,
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_latency_two_connections_local_and_full_accord() {
+        let (engine, _dir) = make_engine();
+        let bus = ferrosa_cdc::CdcBus::new(8192);
+        engine.set_cdc_bus(bus.clone());
+
+        // Two simultaneous subscriber connections.
+        let mut local = bus.subscribe(ferrosa_cdc::CdcStream::WrittenOnNode);
+        let mut committed = bus.subscribe(ferrosa_cdc::CdcStream::CommittedToCluster);
+
+        let applier =
+            CdcPublishingApplier::new(Arc::new(EngineStorageApplier::new(engine.clone())), bus);
+
+        const WARMUP: usize = 20;
+        const N: usize = 300;
+
+        // --- Local-commit path: plain engine writes fire WrittenOnNode only. ---
+        let mut local_ns = Vec::with_capacity(N);
+        for i in 0..(WARMUP + N) {
+            let key = make_key(&format!("local{i}"));
+            let m = Mutation::new(
+                KS.to_string(),
+                TABLE.to_string(),
+                key,
+                vec![make_row(format!("v{i}").as_bytes(), 1_000 + i as i64)],
+                1_000 + i as i64,
+            );
+            let t0 = std::time::Instant::now();
+            engine.write_atomic_batch(vec![m]).expect("local write");
+            let ev = local.recv().await.expect("WrittenOnNode delivered");
+            let dt = t0.elapsed();
+            assert_eq!(ev.stream, ferrosa_cdc::CdcStream::WrittenOnNode);
+            if i >= WARMUP {
+                local_ns.push(dt.as_nanos() as u64);
+            }
+        }
+
+        // --- Full-Accord path: applier.apply does a durable apply, then the
+        //     decorator publishes CommittedToCluster (and the inner write fires
+        //     WrittenOnNode, which we drain). ---
+        let mut committed_ns = Vec::with_capacity(N);
+        for i in 0..(WARMUP + N) {
+            let key = make_key(&format!("accord{i}"));
+            let t = accord_ts(10_000 + i as u64);
+            let m = encoded_mutation(key, format!("v{i}").as_bytes(), 10_000 + i as i64, t, vec![]);
+            let t0 = std::time::Instant::now();
+            applier.apply(txn(1, 10_000 + i as u64), m).expect("accord apply");
+            let ev = committed.recv().await.expect("CommittedToCluster delivered");
+            let dt = t0.elapsed();
+            assert_eq!(ev.stream, ferrosa_cdc::CdcStream::CommittedToCluster);
+            assert_eq!(ev.accord_ts, Some(t), "committed event carries the accord ts");
+            // Drain the WrittenOnNode the inner write produced, so the local
+            // subscriber does not lag.
+            local.recv().await.expect("inner WrittenOnNode");
+            if i >= WARMUP {
+                committed_ns.push(dt.as_nanos() as u64);
+            }
+        }
+
+        report("local commit (WrittenOnNode)", &mut local_ns);
+        report("full accord (CommittedToCluster)", &mut committed_ns);
+        assert_eq!(local_ns.len(), N);
+        assert_eq!(committed_ns.len(), N);
+    }
+
+    // -----------------------------------------------------------------------
+    // MULTI-NODE model: two nodes, each with its own StorageEngine + push CDC
+    // bus. Node A takes local writes (WrittenOnNode); node B is a replica that
+    // applies cluster-committed writes via the real Accord apply path
+    // (CdcPublishingApplier -> CommittedToCluster). Subscribers on each node
+    // measure write->deliver latency, PROVING delivery is event-driven push:
+    //   * delivery is dominated by the commit cost, with NO poll-interval floor;
+    //   * after a long idle gap a single committed write is delivered
+    //     immediately — a poll-based CDC would be bounded by its interval.
+    //
+    // (A fully network-formed cluster latency number additionally needs the
+    // live-infra cluster harness; this models the replica apply + CDC fan-out,
+    // which is where CommittedToCluster actually fires on a cluster commit.)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn multinode_subscribe_is_realtime_push_not_poll() {
+        // --- Two independent nodes. ---
+        let (engine_a, _da) = make_engine();
+        let bus_a = ferrosa_cdc::CdcBus::new(8192);
+        engine_a.set_cdc_bus(bus_a.clone());
+        let (engine_b, _db) = make_engine();
+        let bus_b = ferrosa_cdc::CdcBus::new(8192);
+        engine_b.set_cdc_bus(bus_b.clone());
+
+        // Two subscriber connections, one per node.
+        let mut sub_a_local = bus_a.subscribe(ferrosa_cdc::CdcStream::WrittenOnNode);
+        let mut sub_b_committed = bus_b.subscribe(ferrosa_cdc::CdcStream::CommittedToCluster);
+
+        // Node B applies cluster-committed writes (replica apply path).
+        let applier_b = CdcPublishingApplier::new(
+            Arc::new(EngineStorageApplier::new(engine_b.clone())),
+            bus_b,
+        );
+
+        const N: usize = 200;
+        let mut a_local_ns = Vec::with_capacity(N);
+        let mut b_committed_ns = Vec::with_capacity(N);
+        for i in 0..N {
+            // Local commit on node A -> WrittenOnNode delivered to A's subscriber.
+            let m_a = Mutation::new(
+                KS.to_string(),
+                TABLE.to_string(),
+                make_key(&format!("a{i}")),
+                vec![make_row(format!("v{i}").as_bytes(), 1_000 + i as i64)],
+                1_000 + i as i64,
+            );
+            let t0 = std::time::Instant::now();
+            engine_a.write_atomic_batch(vec![m_a]).expect("node A write");
+            sub_a_local.recv().await.expect("A WrittenOnNode delivered");
+            a_local_ns.push(t0.elapsed().as_nanos() as u64);
+
+            // Cluster-committed apply on node B -> CommittedToCluster to B's sub.
+            let t = accord_ts(100_000 + i as u64);
+            let m_b = encoded_mutation(
+                make_key(&format!("b{i}")),
+                format!("v{i}").as_bytes(),
+                100_000 + i as i64,
+                t,
+                vec![],
+            );
+            let t1 = std::time::Instant::now();
+            applier_b.apply(txn(2, 100_000 + i as u64), m_b).expect("node B apply");
+            sub_b_committed.recv().await.expect("B CommittedToCluster delivered");
+            b_committed_ns.push(t1.elapsed().as_nanos() as u64);
+        }
+        report("node A local-commit (WrittenOnNode)", &mut a_local_ns);
+        report("node B cluster-committed (CommittedToCluster)", &mut b_committed_ns);
+
+        // --- Push-vs-poll discriminator: idle, then ONE committed write. A
+        //     poll-based CDC would deliver no sooner than its next tick; a push
+        //     bus delivers as soon as the apply commits. ---
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        let t = accord_ts(900_000);
+        let m = encoded_mutation(make_key("idle"), b"x", 900_000, t, vec![]);
+        let t0 = std::time::Instant::now();
+        applier_b.apply(txn(2, 900_000), m).expect("post-idle apply");
+        let ev = sub_b_committed
+            .recv()
+            .await
+            .expect("post-idle CommittedToCluster delivered");
+        let idle_deliver = t0.elapsed();
+        eprintln!("after 250ms idle, CommittedToCluster delivered in {idle_deliver:?}");
+        assert_eq!(ev.accord_ts, Some(t));
+        // Load-robust bound: the measured number (printed above) is the real
+        // proof — it is dominated by the commit fsync (~ms), NOT a poll interval.
+        // A poll-based CDC (e.g. a segment-reader on a multi-second checkpoint
+        // interval) could not deliver this fast regardless of CPU contention.
+        assert!(
+            idle_deliver < std::time::Duration::from_secs(1),
+            "real-time push CDC must deliver promptly after the commit \
+             (got {idle_deliver:?}); a poll-based stream would be bounded by its \
+             poll interval regardless of the idle gap"
+        );
+    }
 }

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -572,7 +572,10 @@ impl StorageApplier for CdcPublishingApplier {
     fn apply(&self, txn_id: TxnId, mutation: ApplyMutation) -> Result<(), ApplyError> {
         // Build the CDC event before `mutation` is consumed, and only if a
         // committed-stream subscriber is actually listening.
-        let event = if self.cdc.has_subscribers(ferrosa_cdc::CdcStream::CommittedToCluster) {
+        let event = if self
+            .cdc
+            .has_subscribers(ferrosa_cdc::CdcStream::CommittedToCluster)
+        {
             Mutation::deserialize_from(&mutation.data)
                 .ok()
                 .map(|m| ferrosa_cdc::CdcEvent {
@@ -1220,13 +1223,28 @@ mod engine_applier_tests {
         for i in 0..(WARMUP + N) {
             let key = make_key(&format!("accord{i}"));
             let t = accord_ts(10_000 + i as u64);
-            let m = encoded_mutation(key, format!("v{i}").as_bytes(), 10_000 + i as i64, t, vec![]);
+            let m = encoded_mutation(
+                key,
+                format!("v{i}").as_bytes(),
+                10_000 + i as i64,
+                t,
+                vec![],
+            );
             let t0 = std::time::Instant::now();
-            applier.apply(txn(1, 10_000 + i as u64), m).expect("accord apply");
-            let ev = committed.recv().await.expect("CommittedToCluster delivered");
+            applier
+                .apply(txn(1, 10_000 + i as u64), m)
+                .expect("accord apply");
+            let ev = committed
+                .recv()
+                .await
+                .expect("CommittedToCluster delivered");
             let dt = t0.elapsed();
             assert_eq!(ev.stream, ferrosa_cdc::CdcStream::CommittedToCluster);
-            assert_eq!(ev.accord_ts, Some(t), "committed event carries the accord ts");
+            assert_eq!(
+                ev.accord_ts,
+                Some(t),
+                "committed event carries the accord ts"
+            );
             // Drain the WrittenOnNode the inner write produced, so the local
             // subscriber does not lag.
             local.recv().await.expect("inner WrittenOnNode");
@@ -1269,10 +1287,8 @@ mod engine_applier_tests {
         let mut sub_b_committed = bus_b.subscribe(ferrosa_cdc::CdcStream::CommittedToCluster);
 
         // Node B applies cluster-committed writes (replica apply path).
-        let applier_b = CdcPublishingApplier::new(
-            Arc::new(EngineStorageApplier::new(engine_b.clone())),
-            bus_b,
-        );
+        let applier_b =
+            CdcPublishingApplier::new(Arc::new(EngineStorageApplier::new(engine_b.clone())), bus_b);
 
         const N: usize = 200;
         let mut a_local_ns = Vec::with_capacity(N);
@@ -1287,7 +1303,9 @@ mod engine_applier_tests {
                 1_000 + i as i64,
             );
             let t0 = std::time::Instant::now();
-            engine_a.write_atomic_batch(vec![m_a]).expect("node A write");
+            engine_a
+                .write_atomic_batch(vec![m_a])
+                .expect("node A write");
             sub_a_local.recv().await.expect("A WrittenOnNode delivered");
             a_local_ns.push(t0.elapsed().as_nanos() as u64);
 
@@ -1301,12 +1319,20 @@ mod engine_applier_tests {
                 vec![],
             );
             let t1 = std::time::Instant::now();
-            applier_b.apply(txn(2, 100_000 + i as u64), m_b).expect("node B apply");
-            sub_b_committed.recv().await.expect("B CommittedToCluster delivered");
+            applier_b
+                .apply(txn(2, 100_000 + i as u64), m_b)
+                .expect("node B apply");
+            sub_b_committed
+                .recv()
+                .await
+                .expect("B CommittedToCluster delivered");
             b_committed_ns.push(t1.elapsed().as_nanos() as u64);
         }
         report("node A local-commit (WrittenOnNode)", &mut a_local_ns);
-        report("node B cluster-committed (CommittedToCluster)", &mut b_committed_ns);
+        report(
+            "node B cluster-committed (CommittedToCluster)",
+            &mut b_committed_ns,
+        );
 
         // --- Push-vs-poll discriminator: idle, then ONE committed write. A
         //     poll-based CDC would deliver no sooner than its next tick; a push
@@ -1315,7 +1341,9 @@ mod engine_applier_tests {
         let t = accord_ts(900_000);
         let m = encoded_mutation(make_key("idle"), b"x", 900_000, t, vec![]);
         let t0 = std::time::Instant::now();
-        applier_b.apply(txn(2, 900_000), m).expect("post-idle apply");
+        applier_b
+            .apply(txn(2, 900_000), m)
+            .expect("post-idle apply");
         let ev = sub_b_committed
             .recv()
             .await

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -790,9 +790,19 @@ pub fn build_accord_state_machine(
     sync_writer: Arc<dyn SyncWriter>,
     storage: Arc<ferrosa_storage::engine::StorageEngine>,
 ) -> AccordStateMachine {
-    let applier = Arc::new(crate::accord::apply::EngineStorageApplier::new(
+    let engine_applier = Arc::new(crate::accord::apply::EngineStorageApplier::new(
         storage.clone(),
     ));
+    // When a CDC bus is attached, publish CommittedToCluster on apply so live
+    // CQL SUBSCRIBE ... ON COMMITTED (and Arrow Flight) see Accord-committed
+    // writes; otherwise use the engine applier directly.
+    let applier: Arc<dyn crate::accord::apply::StorageApplier> = match storage.cdc_bus() {
+        Some(bus) => Arc::new(crate::accord::apply::CdcPublishingApplier::new(
+            engine_applier,
+            bus,
+        )),
+        None => engine_applier,
+    };
     let reader = Arc::new(crate::accord::apply::EngineStorageReader::new(storage));
     AccordStateMachine::with_applier_and_reader(node_id, sync_writer, applier, reader)
 }

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -1216,6 +1216,10 @@ impl ModeController {
         {
             let storage = self.storage.clone();
             let accord_state = accord_state_for_maintenance;
+            // Honor shutdown: without this the maintenance loop ignores the
+            // cancel token and shutdown() blocks the full 10s drain deadline
+            // before abort_all() force-kills it (×3 nodes = ~30s in tests).
+            let maint_cancel = self.cancel.clone();
             self.spawn_tracked(async move {
                 let urgent_flush_interval_millis =
                     std::env::var("FERROSA_URGENT_FLUSH_INTERVAL_MILLIS")
@@ -1228,7 +1232,11 @@ impl ModeController {
                 ));
                 let mut ticks = 0u64;
                 loop {
-                    interval.tick().await;
+                    // Stop promptly on shutdown instead of being force-aborted.
+                    tokio::select! {
+                        _ = maint_cancel.cancelled() => break,
+                        _ = interval.tick() => {}
+                    }
                     ticks = ticks.wrapping_add(1);
 
                     if storage.take_flush_request() {

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -93,6 +93,39 @@ fn cluster_error_to_common(err: ClusterError) -> ferrosa_common::Error {
     }
 }
 
+/// Build a `CommittedToCluster` CDC event for a regular-CL write, if the
+/// engine's shared CDC bus has a committed-stream subscriber.
+///
+/// Coordinator-side: a regular-CL write reaches "committed to cluster" when the
+/// coordinator achieves its consistency level (the caller publishes only after
+/// the write returns `Ok`). Ordered by the write `timestamp` — there is no
+/// Accord timestamp for non-Accord writes (decision O-8). Returns the bus +
+/// event so the row is cloned only when a subscriber is actually listening; the
+/// caller publishes after success. `None` (no allocation) otherwise.
+fn committed_cdc_event(
+    storage: &StorageEngine,
+    table_id: &TableId,
+    key: &DecoratedKey,
+    rows: &[Row],
+    timestamp: i64,
+) -> Option<(Arc<ferrosa_cdc::CdcBus>, ferrosa_cdc::CdcEvent)> {
+    let bus = storage.cdc_bus()?;
+    if !bus.has_subscribers(ferrosa_cdc::CdcStream::CommittedToCluster) {
+        return None;
+    }
+    let event = ferrosa_cdc::CdcEvent {
+        stream: ferrosa_cdc::CdcStream::CommittedToCluster,
+        keyspace: table_id.keyspace.clone(),
+        table: table_id.table.clone(),
+        key: key.clone(),
+        rows: rows.to_vec(),
+        timestamp,
+        accord_ts: None,
+        mutation_id: uuid::Uuid::new_v4().into_bytes(),
+    };
+    Some((bus, event))
+}
+
 /// The active write path. Swapped atomically via `ArcSwap` when the
 /// deployment mode changes (standalone → pair → cluster).
 ///
@@ -153,13 +186,44 @@ impl WritePath {
                         .coordinate_write(&m)
                         .await
                         .map_err(|e| ferrosa_common::Error::InvalidData(format!("pair: {e}")))?;
+                    if let Some((bus, ev)) = committed_cdc_event(
+                        coordinator.local_storage(),
+                        &TableId::new(&m.keyspace, &m.table),
+                        &m.key,
+                        &m.rows,
+                        m.timestamp,
+                    ) {
+                        bus.publish(ev);
+                    }
                 }
                 Ok(())
             }
-            Self::Cluster(coordinator) => coordinator
-                .coordinate_logged_batch(mutations)
-                .await
-                .map_err(cluster_error_to_common),
+            Self::Cluster(coordinator) => {
+                // Capture committed-CDC events before `mutations` is moved into
+                // the batch (clones only when a committed subscriber exists).
+                let pending: Vec<_> = mutations
+                    .iter()
+                    .filter_map(|m| {
+                        committed_cdc_event(
+                            &coordinator.storage,
+                            &TableId::new(&m.keyspace, &m.table),
+                            &m.key,
+                            &m.rows,
+                            m.timestamp,
+                        )
+                    })
+                    .collect();
+                let res = coordinator
+                    .coordinate_logged_batch(mutations)
+                    .await
+                    .map_err(cluster_error_to_common);
+                if res.is_ok() {
+                    for (bus, ev) in pending {
+                        bus.publish(ev);
+                    }
+                }
+                res
+            }
         }
     }
 
@@ -744,21 +808,57 @@ impl WritePath {
                     vec![row],
                     timestamp,
                 );
-                coordinator
+                let res = coordinator
                     .coordinate_write(&mutation)
                     .await
-                    .map_err(cluster_error_to_common)
+                    .map_err(cluster_error_to_common);
+                if res.is_ok() {
+                    if let Some((bus, ev)) = committed_cdc_event(
+                        coordinator.local_storage(),
+                        table_id,
+                        &mutation.key,
+                        &mutation.rows,
+                        mutation.timestamp,
+                    ) {
+                        bus.publish(ev);
+                    }
+                }
+                res
             }
-            Self::Cluster(coordinator) => match strategy {
-                ReplicationStrategy::Simple { replication_factor } => coordinator
-                    .coordinate_write_with(table_id, key, row, timestamp, cl, *replication_factor)
-                    .await
-                    .map_err(cluster_error_to_common),
-                ReplicationStrategy::NetworkTopology { .. } => coordinator
-                    .coordinate_write_nts(table_id, key, row, timestamp, cl, strategy)
-                    .await
-                    .map_err(cluster_error_to_common),
-            },
+            Self::Cluster(coordinator) => {
+                // Capture the committed-CDC payload before `row` is moved into
+                // the coordinate call; clones only if a subscriber is listening.
+                let pending = committed_cdc_event(
+                    &coordinator.storage,
+                    table_id,
+                    key,
+                    std::slice::from_ref(&row),
+                    timestamp,
+                );
+                let res = match strategy {
+                    ReplicationStrategy::Simple { replication_factor } => coordinator
+                        .coordinate_write_with(
+                            table_id,
+                            key,
+                            row,
+                            timestamp,
+                            cl,
+                            *replication_factor,
+                        )
+                        .await
+                        .map_err(cluster_error_to_common),
+                    ReplicationStrategy::NetworkTopology { .. } => coordinator
+                        .coordinate_write_nts(table_id, key, row, timestamp, cl, strategy)
+                        .await
+                        .map_err(cluster_error_to_common),
+                };
+                if res.is_ok() {
+                    if let Some((bus, ev)) = pending {
+                        bus.publish(ev);
+                    }
+                }
+                res
+            }
         }
     }
 }
@@ -860,6 +960,43 @@ mod tests {
         // Verify data was written
         let result = storage.read(&table_id, &key).unwrap();
         assert!(result.is_some(), "DirectWritePath should write to storage");
+    }
+
+    #[test]
+    fn committed_cdc_event_only_when_subscribed() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        let bus = ferrosa_cdc::CdcBus::new(16);
+        storage.set_cdc_bus(bus.clone());
+
+        let table_id = TableId::new("ks", "t");
+        let key = DecoratedKey {
+            token: Token(1),
+            key: PartitionKey::new(vec![1]),
+        };
+        let row = Row {
+            clustering: vec![],
+            cells: vec![(0, CellValue::live(b"v".to_vec(), 1000))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(1000),
+        };
+
+        // No committed-stream subscriber → no event built (no allocation).
+        assert!(
+            committed_cdc_event(&storage, &table_id, &key, std::slice::from_ref(&row), 1000)
+                .is_none()
+        );
+
+        // With a subscriber → event built with the right fields, accord_ts None.
+        let _sub = bus.subscribe(ferrosa_cdc::CdcStream::CommittedToCluster);
+        let (_bus, ev) =
+            committed_cdc_event(&storage, &table_id, &key, std::slice::from_ref(&row), 1000)
+                .expect("committed CDC event built when subscribed");
+        assert_eq!(ev.stream, ferrosa_cdc::CdcStream::CommittedToCluster);
+        assert_eq!(ev.keyspace, "ks");
+        assert_eq!(ev.table, "t");
+        assert_eq!(ev.rows, vec![row]);
+        assert!(ev.accord_ts.is_none());
     }
 
     #[tokio::test]

--- a/ferrosa-cql/Cargo.toml
+++ b/ferrosa-cql/Cargo.toml
@@ -11,6 +11,7 @@ arc-swap = "1.7"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 dashmap = "6"
+ferrosa-cdc = { path = "../ferrosa-cdc" }
 ferrosa-cluster = { path = "../ferrosa-cluster" }
 ferrosa-common = { path = "../ferrosa-common" }
 ferrosa-net = { path = "../ferrosa-net" }

--- a/ferrosa-cql/Cargo.toml
+++ b/ferrosa-cql/Cargo.toml
@@ -48,6 +48,8 @@ uuid = { version = "1", features = ["v4"] }
 asc-udf = ["ferrosa-udf/asc-udf"]
 # Opt-in tests needing external infrastructure (e.g. the asc toolchain bundle).
 live-infra-tests = []
+# Exposes test_util::standalone_for_test for downstream crates' integration tests.
+test-util = []
 
 [dev-dependencies]
 proptest = "1"

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -6,6 +6,40 @@
 use std::time::Duration;
 use uuid::Uuid;
 
+/// Which change stream(s) a `SUBSCRIBE` follows.
+///
+/// `Snapshot` is the legacy poll-and-diff behavior (re-execute the SELECT every
+/// `interval`). `Cdc` selects the event-driven change-data-capture streams via
+/// an explicit `ON LOCAL | COMMITTED` clause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SubscribeStreams {
+    /// No `ON` clause — legacy snapshot polling (re-runs the SELECT).
+    #[default]
+    Snapshot,
+    /// Event-driven CDC: `written-on-node` (local) and/or `committed-to-cluster`.
+    Cdc {
+        /// `ON LOCAL` — local commit-log (written-on-node) change stream.
+        local: bool,
+        /// `ON COMMITTED` — cluster-committed change stream.
+        committed: bool,
+    },
+}
+
+/// Parameters of a `SUBSCRIBE` statement, grouped so they can be threaded as a
+/// unit through the AST → router → connection layers without re-listing each
+/// field at every site (and so new CDC options are a one-field change).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubscribeSpec {
+    /// The inner statement being subscribed to (must be a SELECT).
+    pub inner: Box<Statement>,
+    /// `EVERY <duration>` poll interval (snapshot mode).
+    pub interval: Option<Duration>,
+    /// `DELTA` — deliver only changed rows (snapshot mode).
+    pub delta: bool,
+    /// Which change stream(s) to follow (`ON LOCAL | COMMITTED`).
+    pub streams: SubscribeStreams,
+}
+
 /// Top-level parsed statement.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
@@ -108,11 +142,7 @@ pub enum Statement {
         arg_types: Option<Vec<CqlTypeName>>,
         if_exists: bool,
     },
-    Subscribe {
-        inner: Box<Statement>,
-        interval: Option<Duration>,
-        delta: bool,
-    },
+    Subscribe(SubscribeSpec),
     Unsubscribe {
         stream_id: Option<u16>,
     },
@@ -711,12 +741,13 @@ mod tests {
             geo_nearest: None,
             geo_predicates: vec![],
         });
-        let stmt = Statement::Subscribe {
+        let stmt = Statement::Subscribe(SubscribeSpec {
             inner: Box::new(inner),
             interval: None,
             delta: false,
-        };
-        assert!(matches!(stmt, Statement::Subscribe { .. }));
+            streams: SubscribeStreams::Snapshot,
+        });
+        assert!(matches!(stmt, Statement::Subscribe(_)));
     }
 
     #[test]

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -629,32 +629,37 @@ pub(crate) async fn handle_connection<S>(
                         inner,
                         interval,
                         delta,
+                        streams,
                     } => {
-                        let interval = match interval {
-                            Some(d) => d,
-                            None => {
-                                // Change-driven mode not yet implemented
-                                let err = CqlError::Invalid(
-                                    "SUBSCRIBE without EVERY not yet supported; \
-                                     use SUBSCRIBE ... EVERY <interval>"
-                                        .into(),
-                                );
-                                let body = err.encode_body().freeze();
-                                let frame = CqlFrame {
-                                    header: FrameHeader {
-                                        version: VERSION_RESPONSE,
-                                        flags: 0,
-                                        stream_id,
-                                        opcode: Opcode::Error,
-                                        length: 0,
-                                    },
-                                    body,
-                                };
-                                if framed.send(frame).await.is_err() {
-                                    break;
+                        // Snapshot mode requires EVERY <interval>; event-driven CDC
+                        // mode (ON LOCAL|COMMITTED) needs no interval.
+                        let snapshot_interval = match streams {
+                            crate::ast::SubscribeStreams::Cdc { .. } => None,
+                            crate::ast::SubscribeStreams::Snapshot => match interval {
+                                Some(d) => Some(d),
+                                None => {
+                                    let err = CqlError::Invalid(
+                                        "SUBSCRIBE without EVERY not yet supported; \
+                                         use SUBSCRIBE ... EVERY <interval>"
+                                            .into(),
+                                    );
+                                    let body = err.encode_body().freeze();
+                                    let frame = CqlFrame {
+                                        header: FrameHeader {
+                                            version: VERSION_RESPONSE,
+                                            flags: 0,
+                                            stream_id,
+                                            opcode: Opcode::Error,
+                                            length: 0,
+                                        },
+                                        body,
+                                    };
+                                    if framed.send(frame).await.is_err() {
+                                        break;
+                                    }
+                                    continue;
                                 }
-                                continue;
-                            }
+                            },
                         };
 
                         // Create a cancellation token and register the subscription.
@@ -705,23 +710,39 @@ pub(crate) async fn handle_connection<S>(
                             must_change_password: false,
                         });
 
-                        crate::subscribe::spawn_subscription_poll(
-                            stream_id,
-                            interval,
-                            state.clone(),
-                            auth,
-                            current_keyspace.clone(),
-                            *inner,
-                            sub_tx.clone(),
-                            cancel,
-                            delta,
-                            task_pool.clone(),
-                        );
+                        match streams {
+                            crate::ast::SubscribeStreams::Cdc { local, committed } => {
+                                crate::subscribe::spawn_cdc_subscription(
+                                    stream_id,
+                                    state.clone(),
+                                    auth,
+                                    current_keyspace.clone(),
+                                    *inner,
+                                    sub_tx.clone(),
+                                    cancel,
+                                    local,
+                                    committed,
+                                    task_pool.clone(),
+                                );
+                            }
+                            crate::ast::SubscribeStreams::Snapshot => {
+                                crate::subscribe::spawn_subscription_poll(
+                                    stream_id,
+                                    snapshot_interval
+                                        .expect("snapshot mode resolves an interval above"),
+                                    state.clone(),
+                                    auth,
+                                    current_keyspace.clone(),
+                                    *inner,
+                                    sub_tx.clone(),
+                                    cancel,
+                                    delta,
+                                    task_pool.clone(),
+                                );
+                            }
+                        }
 
-                        debug!(
-                            "subscription started for {peer} stream={stream_id} interval={:?}",
-                            interval
-                        );
+                        debug!("subscription started for {peer} stream={stream_id}");
                     }
                     HandleResult::CancelSubscription { stream_id: sub_id } => {
                         subscription_state.cancel(sub_id);
@@ -829,26 +850,33 @@ where
             inner,
             interval,
             delta,
+            streams,
         } => {
-            let interval = match interval {
-                Some(d) => d,
-                None => {
-                    let err = CqlError::Invalid(
-                        "SUBSCRIBE without EVERY not yet supported; use SUBSCRIBE ... EVERY <interval>"
-                            .into(),
-                    );
-                    let frame = CqlFrame {
-                        header: FrameHeader {
-                            version: VERSION_RESPONSE,
-                            flags: 0,
-                            stream_id,
-                            opcode: Opcode::Error,
-                            length: 0,
-                        },
-                        body: err.encode_body().freeze(),
-                    };
-                    return framed.send(frame).await.is_ok();
-                }
+            use crate::ast::SubscribeStreams;
+            // Snapshot mode (no ON clause) requires EVERY <interval>; event-driven
+            // CDC mode (ON LOCAL|COMMITTED) needs no interval.
+            let snapshot_interval = match streams {
+                SubscribeStreams::Cdc { .. } => None,
+                SubscribeStreams::Snapshot => match interval {
+                    Some(d) => Some(d),
+                    None => {
+                        let err = CqlError::Invalid(
+                            "SUBSCRIBE without EVERY not yet supported; use SUBSCRIBE ... EVERY <interval>"
+                                .into(),
+                        );
+                        let frame = CqlFrame {
+                            header: FrameHeader {
+                                version: VERSION_RESPONSE,
+                                flags: 0,
+                                stream_id,
+                                opcode: Opcode::Error,
+                                length: 0,
+                            },
+                            body: err.encode_body().freeze(),
+                        };
+                        return framed.send(frame).await.is_ok();
+                    }
+                },
             };
             let cancel = tokio_util::sync::CancellationToken::new();
             let handle = crate::subscribe::SubscriptionHandle {
@@ -888,18 +916,36 @@ where
                 is_superuser: true,
                 must_change_password: false,
             });
-            crate::subscribe::spawn_subscription_poll(
-                stream_id,
-                interval,
-                state.clone(),
-                auth,
-                current_keyspace.clone(),
-                *inner,
-                sub_tx.clone(),
-                cancel,
-                delta,
-                TaskPool::current("cql-subscription"),
-            );
+            match streams {
+                SubscribeStreams::Cdc { local, committed } => {
+                    crate::subscribe::spawn_cdc_subscription(
+                        stream_id,
+                        state.clone(),
+                        auth,
+                        current_keyspace.clone(),
+                        *inner,
+                        sub_tx.clone(),
+                        cancel,
+                        local,
+                        committed,
+                        TaskPool::current("cql-cdc-subscription"),
+                    );
+                }
+                SubscribeStreams::Snapshot => {
+                    crate::subscribe::spawn_subscription_poll(
+                        stream_id,
+                        snapshot_interval.expect("snapshot mode resolves an interval above"),
+                        state.clone(),
+                        auth,
+                        current_keyspace.clone(),
+                        *inner,
+                        sub_tx.clone(),
+                        cancel,
+                        delta,
+                        TaskPool::current("cql-subscription"),
+                    );
+                }
+            }
             true
         }
         HandleResult::CancelSubscription { stream_id: sub_id } => {
@@ -977,11 +1023,13 @@ pub(crate) enum HandleResult {
     /// Close immediately without sending anything (reserved for future use).
     #[allow(dead_code)]
     CloseNow,
-    /// Subscription accepted — send void ACK, then spawn polling task.
+    /// Subscription accepted — send void ACK, then spawn the delivery task
+    /// (snapshot poll, or an event-driven CDC subscriber per `streams`).
     StartSubscription {
         inner: Box<crate::ast::Statement>,
         interval: Option<Duration>,
         delta: bool,
+        streams: crate::ast::SubscribeStreams,
     },
     /// Unsubscribe — cancel one or all subscriptions.
     CancelSubscription { stream_id: Option<u16> },
@@ -1405,10 +1453,12 @@ async fn handle_query(
             inner,
             interval,
             delta,
+            streams,
         }) => HandleResult::StartSubscription {
             inner,
             interval,
             delta,
+            streams,
         },
         Ok(RouteResult::Unsubscribe { stream_id }) => {
             HandleResult::CancelSubscription { stream_id }

--- a/ferrosa-cql/src/lib.rs
+++ b/ferrosa-cql/src/lib.rs
@@ -37,6 +37,8 @@ pub mod router;
 pub mod server;
 pub mod session;
 pub mod subscribe;
+#[cfg(any(test, feature = "test-util"))]
+pub mod test_util;
 pub mod topology;
 pub mod transaction_keys;
 pub mod transaction_limits;

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -2177,6 +2177,40 @@ impl<'input> Parser<'input> {
         }
         let inner = self.parse_select().map(Statement::Select)?;
 
+        // Optional `ON LOCAL | COMMITTED | LOCAL, COMMITTED` — selects the
+        // event-driven change-data-capture stream(s). Absent => snapshot mode.
+        let streams = if self.lexer.eat(&TokenKind::Keyword(Keyword::On))? {
+            let mut local = false;
+            let mut committed = false;
+            loop {
+                // Scope the peek borrow so we can advance the lexer afterwards.
+                let which = {
+                    let tok = self.lexer.peek()?;
+                    match &tok.kind {
+                        TokenKind::Ident(s) if s.eq_ignore_ascii_case("local") => 0u8,
+                        TokenKind::Ident(s) if s.eq_ignore_ascii_case("committed") => 1u8,
+                        _ => {
+                            return Err(CqlError::SyntaxError(
+                                "SUBSCRIBE ... ON expects LOCAL and/or COMMITTED".to_string(),
+                            ))
+                        }
+                    }
+                };
+                self.lexer.next_token()?;
+                if which == 0 {
+                    local = true;
+                } else {
+                    committed = true;
+                }
+                if !self.lexer.eat(&TokenKind::Comma)? {
+                    break;
+                }
+            }
+            SubscribeStreams::Cdc { local, committed }
+        } else {
+            SubscribeStreams::Snapshot
+        };
+
         // Optional EVERY <duration>
         let interval = if self.lexer.eat(&TokenKind::Keyword(Keyword::Every))? {
             let dur = self.parse_duration()?;
@@ -2194,11 +2228,12 @@ impl<'input> Parser<'input> {
         // Optional DELTA
         let delta = self.lexer.eat(&TokenKind::Keyword(Keyword::Delta))?;
 
-        Ok(Statement::Subscribe {
+        Ok(Statement::Subscribe(SubscribeSpec {
             inner: Box::new(inner),
             interval,
             delta,
-        })
+            streams,
+        }))
     }
 
     fn parse_unsubscribe(&mut self) -> Result<Statement, CqlError> {
@@ -4941,14 +4976,12 @@ mod tests {
     fn parse_subscribe_select() {
         let stmt = parse("SUBSCRIBE SELECT * FROM users WHERE active = true").unwrap();
         match stmt {
-            Statement::Subscribe {
-                inner,
-                interval,
-                delta,
-            } => {
-                assert!(interval.is_none());
-                assert!(!delta);
-                assert!(matches!(*inner, Statement::Select { .. }));
+            Statement::Subscribe(spec) => {
+                assert!(spec.interval.is_none());
+                assert!(!spec.delta);
+                assert!(matches!(*spec.inner, Statement::Select { .. }));
+                // No ON clause => legacy snapshot mode.
+                assert_eq!(spec.streams, SubscribeStreams::Snapshot);
             }
             _ => panic!("expected Subscribe"),
         }
@@ -4958,8 +4991,8 @@ mod tests {
     fn parse_subscribe_with_every() {
         let stmt = parse("SUBSCRIBE SELECT * FROM t EVERY 5s").unwrap();
         match stmt {
-            Statement::Subscribe { interval, .. } => {
-                assert_eq!(interval, Some(Duration::from_secs(5)));
+            Statement::Subscribe(spec) => {
+                assert_eq!(spec.interval, Some(Duration::from_secs(5)));
             }
             _ => panic!("expected Subscribe"),
         }
@@ -4969,20 +5002,69 @@ mod tests {
     fn parse_subscribe_with_delta() {
         let stmt = parse("SUBSCRIBE SELECT * FROM t DELTA").unwrap();
         match stmt {
-            Statement::Subscribe { delta, .. } => assert!(delta),
+            Statement::Subscribe(spec) => assert!(spec.delta),
             _ => panic!("expected Subscribe"),
         }
+    }
+
+    #[test]
+    fn parse_subscribe_on_committed() {
+        let stmt = parse("SUBSCRIBE SELECT * FROM t ON COMMITTED").unwrap();
+        match stmt {
+            Statement::Subscribe(spec) => assert_eq!(
+                spec.streams,
+                SubscribeStreams::Cdc {
+                    local: false,
+                    committed: true
+                }
+            ),
+            _ => panic!("expected Subscribe"),
+        }
+    }
+
+    #[test]
+    fn parse_subscribe_on_local() {
+        let stmt = parse("SUBSCRIBE SELECT * FROM t ON LOCAL").unwrap();
+        match stmt {
+            Statement::Subscribe(spec) => assert_eq!(
+                spec.streams,
+                SubscribeStreams::Cdc {
+                    local: true,
+                    committed: false
+                }
+            ),
+            _ => panic!("expected Subscribe"),
+        }
+    }
+
+    #[test]
+    fn parse_subscribe_on_local_and_committed() {
+        // Case-insensitive, comma-separated, order-independent.
+        let stmt = parse("SUBSCRIBE SELECT * FROM t on local, Committed").unwrap();
+        match stmt {
+            Statement::Subscribe(spec) => assert_eq!(
+                spec.streams,
+                SubscribeStreams::Cdc {
+                    local: true,
+                    committed: true
+                }
+            ),
+            _ => panic!("expected Subscribe"),
+        }
+    }
+
+    #[test]
+    fn parse_subscribe_on_rejects_unknown_stream() {
+        assert!(parse("SUBSCRIBE SELECT * FROM t ON BOGUS").is_err());
     }
 
     #[test]
     fn parse_subscribe_every_and_delta() {
         let stmt = parse("SUBSCRIBE SELECT * FROM t EVERY 1s DELTA").unwrap();
         match stmt {
-            Statement::Subscribe {
-                interval, delta, ..
-            } => {
-                assert_eq!(interval, Some(Duration::from_secs(1)));
-                assert!(delta);
+            Statement::Subscribe(spec) => {
+                assert_eq!(spec.interval, Some(Duration::from_secs(1)));
+                assert!(spec.delta);
             }
             _ => panic!("expected Subscribe"),
         }

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1540,11 +1540,13 @@ pub async fn route(
         Statement::DropIndex(di) => route_drop_index(state, ctx, di)
             .await
             .map(RouteResult::Result),
-        Statement::Subscribe {
-            inner,
-            interval,
-            delta,
-        } => {
+        Statement::Subscribe(spec) => {
+            let crate::ast::SubscribeSpec {
+                inner,
+                interval,
+                delta,
+                streams: _streams,
+            } = spec;
             // Validate: inner must be a Select
             match inner.as_ref() {
                 Statement::Select(s) => {

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -965,11 +965,13 @@ pub enum RouteResult {
     Result(BytesMut),
     /// USE keyspace: returns the new keyspace name and a SetKeyspace frame body.
     SetKeyspace(String, BytesMut),
-    /// Subscription accepted — connection should spawn a polling task.
+    /// Subscription accepted — connection should spawn the delivery task
+    /// (snapshot poll, or an event-driven CDC subscriber per `streams`).
     Subscribe {
         inner: Box<Statement>,
         interval: Option<std::time::Duration>,
         delta: bool,
+        streams: crate::ast::SubscribeStreams,
     },
     /// Unsubscribe — cancel one or all subscriptions.
     Unsubscribe { stream_id: Option<u16> },
@@ -1567,25 +1569,16 @@ pub async fn route(
                     ))
                 }
             }
-            match streams {
-                // Legacy snapshot mode (no ON clause): re-execute the SELECT on
-                // an interval. Unchanged behavior.
-                crate::ast::SubscribeStreams::Snapshot => Ok(RouteResult::Subscribe {
-                    inner,
-                    interval,
-                    delta,
-                }),
-                // Event-driven CDC (ON LOCAL|COMMITTED): the producer side is
-                // wired (commit-log + Accord apply publish to the engine's CDC
-                // bus), but the streaming consumer that reads the bus, filters,
-                // and encodes change events to RESULT frames is not yet built.
-                // Fail loud rather than silently behaving like a poll.
-                crate::ast::SubscribeStreams::Cdc { .. } => Err(CqlError::Invalid(
-                    "SUBSCRIBE ... ON LOCAL|COMMITTED (event-driven change-data-capture) \
-                     is not yet supported"
-                        .into(),
-                )),
-            }
+            // Snapshot mode re-executes the SELECT on an interval; CDC mode
+            // (ON LOCAL|COMMITTED) streams change events from the engine's CDC
+            // bus. The connection layer spawns the right delivery task per
+            // `streams`.
+            Ok(RouteResult::Subscribe {
+                inner,
+                interval,
+                delta,
+                streams,
+            })
         }
         Statement::Unsubscribe { stream_id } => Ok(RouteResult::Unsubscribe { stream_id }),
         Statement::CreateType {
@@ -4698,12 +4691,6 @@ pub async fn route_select_raw(
 /// Streaming by construction: it handles **one event's rows** (a single write),
 /// never a materialized result set. Returns `Ok(None)` if the table is unknown
 /// (e.g. dropped between subscribe and delivery) so the caller can skip it.
-// Justification for allow(dead_code): the non-test caller is the CDC SUBSCRIBE
-// consumer (spawn_cdc_subscription), landing in the next slice (t_d30ecb1f).
-// This function is already exercised + correctness-checked by the test
-// `cdc_event_frame_matches_select_for_same_row` (byte-equivalence vs the SELECT
-// read path). The allow is removed when the consumer wires it in.
-#[allow(dead_code)]
 pub(crate) fn cdc_event_to_result_frame(
     schema: &Schema,
     ks: &str,

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -4687,6 +4687,87 @@ pub async fn route_select_raw(
     route_select_user_table(state, ctx, ks, s).await
 }
 
+/// Encode a single CDC change event's rows (one mutation, for `ks.{select.table}`)
+/// into a CQL RESULT frame matching `select`'s projection.
+///
+/// Reuses the exact row-mapping pipeline as the SELECT read path
+/// (`build_column_info` + `storage_to_table_indices` +
+/// `partition_to_rows_with_storage_mapping` + `select_columns` + `encode_rows`)
+/// so a change event encodes identically to how the same rows would read back.
+///
+/// Streaming by construction: it handles **one event's rows** (a single write),
+/// never a materialized result set. Returns `Ok(None)` if the table is unknown
+/// (e.g. dropped between subscribe and delivery) so the caller can skip it.
+// Justification for allow(dead_code): the non-test caller is the CDC SUBSCRIBE
+// consumer (spawn_cdc_subscription), landing in the next slice (t_d30ecb1f).
+// This function is already exercised + correctness-checked by the test
+// `cdc_event_frame_matches_select_for_same_row` (byte-equivalence vs the SELECT
+// read path). The allow is removed when the consumer wires it in.
+#[allow(dead_code)]
+pub(crate) fn cdc_event_to_result_frame(
+    schema: &Schema,
+    ks: &str,
+    select: &SelectStatement,
+    key: ferrosa_common::DecoratedKey,
+    rows: Vec<ferrosa_sstable::types::Row>,
+) -> Result<Option<BytesMut>, CqlError> {
+    let snap = schema.snapshot();
+    let table_meta = match snap.tables.get(&(ks.to_string(), select.table.clone())) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let (col_names, col_types) = build_column_info(table_meta, &select.columns, ks, schema)?;
+    let all_col_names: Vec<String> = table_meta.columns.keys().cloned().collect();
+    let all_col_types: Vec<CqlType> = table_meta
+        .columns
+        .values()
+        .map(|c| resolve_col_type(&c.column_type, ks, schema))
+        .collect::<Result<Vec<_>, _>>()?;
+    let pk_indices: Vec<usize> = table_meta
+        .partition_key
+        .iter()
+        .map(|name| {
+            table_meta.columns.get_index_of(name).ok_or_else(|| {
+                CqlError::Invalid(format!("partition key column '{}' not found", name))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let ck_indices: Vec<usize> = table_meta
+        .clustering_key
+        .iter()
+        .map(|(name, _)| {
+            table_meta.columns.get_index_of(name).ok_or_else(|| {
+                CqlError::Invalid(format!("clustering key column '{}' not found", name))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let storage_to_table = storage_to_table_indices(table_meta);
+
+    let partition = ferrosa_sstable::types::Partition {
+        key,
+        deletion: ferrosa_sstable::types::DeletionTime::LIVE,
+        static_row: None,
+        rows,
+    };
+    let all_rows = bridge::partition_to_rows_with_storage_mapping(
+        &partition,
+        &all_col_names,
+        &all_col_types,
+        &pk_indices,
+        &ck_indices,
+        &storage_to_table,
+    );
+    let selected = select_columns(&all_rows, &all_col_names, &col_names);
+    Ok(Some(result::encode_rows(
+        &col_names,
+        &col_types,
+        ks,
+        &select.table,
+        &selected,
+    )))
+}
+
 // ── Virtual table helpers ────────────────────────────────────────────────
 
 /// Convert a `DataType` (from ferrosa-common) to the CQL protocol `CqlType`.
@@ -11580,6 +11661,65 @@ mod tests {
             RouteResult::Result(b) => assert_eq!(&b[0..4], &0x0002i32.to_be_bytes()),
             _ => panic!("expected Result"),
         }
+    }
+
+    /// The CDC change-event encoder must produce the *same* RESULT frame as the
+    /// proven SELECT read path for the same stored row — encoding-equivalence,
+    /// which guards against the CDC path mis-mapping columns/types/values.
+    #[tokio::test]
+    async fn cdc_event_frame_matches_select_for_same_row() {
+        use futures::StreamExt;
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+
+        for ddl in [
+            "CREATE KEYSPACE ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE ks.users (id int PRIMARY KEY, name text)",
+            "INSERT INTO ks.users (id, name) VALUES (1, 'alice')",
+        ] {
+            let stmt = crate::parser::parse(ddl).unwrap();
+            route(&state, &ctx, stmt).await.unwrap();
+        }
+
+        // Expected: how the SELECT read path encodes this row.
+        let select = match crate::parser::parse("SELECT * FROM ks.users").unwrap() {
+            Statement::Select(s) => s,
+            _ => panic!("expected SELECT"),
+        };
+        let raw = route_select_raw(&state, &ctx, &select).await.unwrap();
+        assert_eq!(raw.rows.len(), 1, "exactly one row was inserted");
+        let expected = crate::result::encode_rows(
+            &raw.column_names,
+            &raw.column_types,
+            "ks",
+            "users",
+            &raw.rows,
+        );
+
+        // Actual: encode the stored partition's rows as a CDC change event.
+        let table_id = TableId::new("ks", "users");
+        let mut stream = state.engine.range_iter(&table_id, None, None);
+        let partition = stream
+            .next()
+            .await
+            .expect("one partition present")
+            .expect("partition read ok");
+        let frame =
+            cdc_event_to_result_frame(&state.schema, "ks", &select, partition.key, partition.rows)
+                .unwrap()
+                .expect("table exists");
+
+        assert_eq!(
+            frame, expected,
+            "CDC event frame must byte-match the SELECT-path frame for the same row"
+        );
     }
 
     /// Transient replication ('<full>/<transient>') must be rejected at the

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1545,7 +1545,7 @@ pub async fn route(
                 inner,
                 interval,
                 delta,
-                streams: _streams,
+                streams,
             } = spec;
             // Validate: inner must be a Select
             match inner.as_ref() {
@@ -1567,11 +1567,25 @@ pub async fn route(
                     ))
                 }
             }
-            Ok(RouteResult::Subscribe {
-                inner,
-                interval,
-                delta,
-            })
+            match streams {
+                // Legacy snapshot mode (no ON clause): re-execute the SELECT on
+                // an interval. Unchanged behavior.
+                crate::ast::SubscribeStreams::Snapshot => Ok(RouteResult::Subscribe {
+                    inner,
+                    interval,
+                    delta,
+                }),
+                // Event-driven CDC (ON LOCAL|COMMITTED): the producer side is
+                // wired (commit-log + Accord apply publish to the engine's CDC
+                // bus), but the streaming consumer that reads the bus, filters,
+                // and encodes change events to RESULT frames is not yet built.
+                // Fail loud rather than silently behaving like a poll.
+                crate::ast::SubscribeStreams::Cdc { .. } => Err(CqlError::Invalid(
+                    "SUBSCRIBE ... ON LOCAL|COMMITTED (event-driven change-data-capture) \
+                     is not yet supported"
+                        .into(),
+                )),
+            }
         }
         Statement::Unsubscribe { stream_id } => Ok(RouteResult::Unsubscribe { stream_id }),
         Statement::CreateType {

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -9042,6 +9042,111 @@ fn evaluate_where_rhs_term(
     bridge::term_to_cql_value(term, expected_type)
 }
 
+/// Compute the Murmur3 partition token for a candidate `row` on the Direct
+/// (standalone) read path.
+///
+/// Gathers the partition-key column values in declared PK order and decorates
+/// them with the same composite encoding the engine uses for placement. Returns
+/// `Ok(None)` when any partition-key column is absent or NULL in the row — such
+/// a row cannot satisfy a `token()` bound, so the caller rejects it.
+fn row_partition_token(
+    row: &[Option<CqlValue>],
+    all_col_names: &[String],
+    all_col_types: &[CqlType],
+    table_meta: &TableMetadata,
+) -> Result<Option<ferrosa_common::Token>, CqlError> {
+    let mut pk_values: Vec<CqlValue> = Vec::with_capacity(table_meta.partition_key.len());
+    let mut pk_types: Vec<CqlType> = Vec::with_capacity(table_meta.partition_key.len());
+    for pk_col in &table_meta.partition_key {
+        let Some(idx) = all_col_names.iter().position(|n| n == pk_col) else {
+            return Ok(None);
+        };
+        let Some(value) = row.get(idx).and_then(Option::as_ref) else {
+            return Ok(None);
+        };
+        pk_values.push(value.clone());
+        pk_types.push(all_col_types[idx].clone());
+    }
+    if pk_values.is_empty() {
+        return Ok(None);
+    }
+    let dk = bridge::build_decorated_key(&pk_values, &pk_types)?;
+    Ok(Some(dk.token))
+}
+
+/// Resolve the bound token on the RHS of a `token(pk) op <bound>` predicate.
+///
+/// Two RHS shapes are accepted, matching the parser and Cassandra:
+/// - `token(<literal>)` — a `FunctionCall` whose argument is encoded and hashed
+///   exactly like a partition key, yielding its ring position.
+/// - a bare integer literal — the raw token value itself (`Token(n)`).
+fn token_bound_value(term: &Term) -> Result<ferrosa_common::Token, CqlError> {
+    match term {
+        Term::FunctionCall { name, args, .. } if name.eq_ignore_ascii_case("token") => {
+            if args.len() != 1 {
+                return Err(CqlError::Invalid(
+                    "token() bound must take exactly one argument".into(),
+                ));
+            }
+            let value = bridge::term_to_cql_value(&args[0], &CqlType::Varchar).or_else(|_| {
+                // Numeric/other literals: infer the encoding from the literal
+                // itself rather than forcing a text coercion.
+                bridge::term_to_cql_value(&args[0], &literal_inferred_type(&args[0]))
+            })?;
+            let dk = bridge::build_decorated_key(&[value], &[CqlType::Varchar])?;
+            Ok(dk.token)
+        }
+        Term::IntegerLiteral(n) => Ok(ferrosa_common::Token(*n)),
+        other => Err(CqlError::Invalid(format!(
+            "token() bound must be token(<value>) or an integer literal, got {other:?}"
+        ))),
+    }
+}
+
+/// Best-effort CQL type for a literal term, used when a `token(<literal>)`
+/// argument is not text and must be encoded with its natural representation.
+fn literal_inferred_type(term: &Term) -> CqlType {
+    match term {
+        Term::IntegerLiteral(_) => CqlType::Bigint,
+        Term::FloatLiteral(_) => CqlType::Double,
+        Term::BoolLiteral(_) => CqlType::Boolean,
+        Term::UuidLiteral(_) => CqlType::Uuid,
+        Term::BlobLiteral(_) => CqlType::Blob,
+        _ => CqlType::Varchar,
+    }
+}
+
+/// Apply a single `token(pk) op <bound>` predicate to a candidate row on the
+/// Direct read path. Returns whether the row's partition token satisfies the
+/// bound. The coordinator path routes by token range and never reaches here.
+fn token_clause_matches(
+    wc: &WhereClause,
+    row: &[Option<CqlValue>],
+    all_col_names: &[String],
+    all_col_types: &[CqlType],
+    table_meta: &TableMetadata,
+) -> Result<bool, CqlError> {
+    let Some(row_token) = row_partition_token(row, all_col_names, all_col_types, table_meta)?
+    else {
+        return Ok(false);
+    };
+    let bound = token_bound_value(&wc.value)?;
+    let matches = match &wc.op {
+        ComparisonOp::Gt => row_token > bound,
+        ComparisonOp::Lt => row_token < bound,
+        ComparisonOp::Ge => row_token >= bound,
+        ComparisonOp::Le => row_token <= bound,
+        ComparisonOp::Eq => row_token == bound,
+        ComparisonOp::Ne => row_token != bound,
+        other => {
+            return Err(CqlError::Invalid(format!(
+                "unsupported operator {other:?} on a token() WHERE predicate"
+            )));
+        }
+    };
+    Ok(matches)
+}
+
 /// Evaluate WHERE predicates against a row for ALLOW FILTERING post-filter.
 fn evaluate_where_predicates(
     row: &[Option<CqlValue>],
@@ -9053,10 +9158,16 @@ fn evaluate_where_predicates(
     state: &SharedState,
 ) -> Result<bool, CqlError> {
     for wc in where_clauses {
-        // Skip token() predicates — token range filtering is handled by
-        // the scan bounds, not by post-filter row evaluation.
+        // token() predicates: on the Direct/standalone read path there is no
+        // coordinator routing by token range, so the bound must be applied here
+        // by computing the candidate row's partition token. (The cluster
+        // coordinator path routes to replicas by token and never reaches this
+        // function, so it is unaffected.)
         if wc.token_fn {
-            continue;
+            if token_clause_matches(wc, row, all_col_names, all_col_types, table_meta)? {
+                continue;
+            }
+            return Ok(false);
         }
         // Skip fts_match() predicates — full-text search is handled by
         // the FTI lookup path, not by post-filter row evaluation.
@@ -19091,6 +19202,150 @@ mod tests {
             "evaluate_where_predicates with fts_match + matching PK clause \
              should return true"
         );
+    }
+
+    // ── token() WHERE bounds on the standalone Direct read path ─────────
+
+    /// Regression test: on the Direct/standalone read path,
+    /// `evaluate_where_predicates` must apply `token(pk)` lower/upper bounds
+    /// by computing each candidate row's partition token and comparing it
+    /// against the bound tokens. Before the fix it skipped `token_fn` clauses
+    /// entirely, so `SELECT ... WHERE token(pk) > A AND token(pk) <= B`
+    /// returned ALL rows instead of only those in the half-open range `(A, B]`.
+    #[tokio::test]
+    async fn evaluate_where_predicates_applies_token_bounds_on_direct_path() {
+        use crate::ast::{ComparisonOp, Term, WhereClause};
+        use ferrosa_common::cql_type::CqlValue;
+
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+
+        let stmt = crate::parser::parse(
+            "CREATE KEYSPACE tok_ks WITH REPLICATION = \
+             {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+        )
+        .unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        let stmt =
+            crate::parser::parse("CREATE TABLE tok_ks.parts (id text PRIMARY KEY, v int)").unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        let snap = state.schema.snapshot();
+        let table_meta = snap
+            .tables
+            .get(&("tok_ks".to_string(), "parts".to_string()))
+            .unwrap();
+
+        let all_col_names: Vec<String> = table_meta.columns.keys().cloned().collect();
+        let all_col_types: Vec<CqlType> = all_col_names
+            .iter()
+            .map(|name| {
+                resolve_col_type(
+                    &table_meta.columns[name].column_type,
+                    "tok_ks",
+                    &state.schema,
+                )
+                .unwrap()
+            })
+            .collect();
+        let id_idx = all_col_names.iter().position(|n| n == "id").unwrap();
+
+        // Candidate partition keys. Compute each one's Murmur3 token with the
+        // SAME helper the fix uses, so the expected set is derived, not magic.
+        let keys = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"];
+        let mut tokens: Vec<(String, i64)> = keys
+            .iter()
+            .map(|k| {
+                let dk = bridge::build_decorated_key(
+                    &[CqlValue::Text((*k).to_string())],
+                    &[CqlType::Varchar],
+                )
+                .unwrap();
+                ((*k).to_string(), dk.token.0)
+            })
+            .collect();
+        tokens.sort_by_key(|(_, t)| *t);
+
+        // Choose bounds so a strict subset lies in (A, B]: drop the lowest
+        // token (excluded by `>`) and keep the rest up to the 2nd-highest.
+        let lower_key = tokens[0].0.clone();
+        let upper_key = tokens[tokens.len() - 2].0.clone();
+        let lower_token = tokens[0].1;
+        let upper_token = tokens[tokens.len() - 2].1;
+
+        let lower_clause = WhereClause {
+            column: "id".to_string(),
+            op: ComparisonOp::Gt,
+            value: Term::FunctionCall {
+                keyspace: None,
+                name: "token".to_string(),
+                args: vec![Term::StringLiteral(lower_key)],
+            },
+            token_fn: true,
+        };
+        let upper_clause = WhereClause {
+            column: "id".to_string(),
+            op: ComparisonOp::Le,
+            value: Term::FunctionCall {
+                keyspace: None,
+                name: "token".to_string(),
+                args: vec![Term::StringLiteral(upper_key)],
+            },
+            token_fn: true,
+        };
+
+        let mut kept = 0usize;
+        for (key, tok) in &tokens {
+            let row: Vec<Option<CqlValue>> = all_col_names
+                .iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    if i == id_idx {
+                        Some(CqlValue::Text(key.clone()))
+                    } else {
+                        Some(CqlValue::Int(0))
+                    }
+                })
+                .collect();
+
+            let in_range = *tok > lower_token && *tok <= upper_token;
+            let result = evaluate_where_predicates(
+                &row,
+                &[lower_clause.clone(), upper_clause.clone()],
+                &all_col_names,
+                &all_col_types,
+                table_meta,
+                "tok_ks",
+                &state,
+            )
+            .unwrap();
+            assert_eq!(
+                result, in_range,
+                "row key={key} token={tok} expected in_range={in_range} \
+                 for bounds ({lower_token}, {upper_token}]; token() WHERE \
+                 bounds must be applied on the Direct path"
+            );
+            if in_range {
+                kept += 1;
+            }
+        }
+
+        // Sanity: the bounds must actually exclude at least the lowest row,
+        // otherwise the test would pass even if token bounds were ignored.
+        assert!(
+            kept < tokens.len(),
+            "test bounds must exclude at least one row; got kept={kept} of {}",
+            tokens.len()
+        );
+        assert!(kept > 0, "test bounds must keep at least one row");
     }
 
     // ── ferrosa_bugs: COUNT(*) column name ──────────────────────────────

--- a/ferrosa-cql/src/subscribe.rs
+++ b/ferrosa-cql/src/subscribe.rs
@@ -314,6 +314,125 @@ pub fn spawn_subscription_poll(
     });
 }
 
+/// Spawn an event-driven CDC subscription (`SUBSCRIBE ... ON LOCAL|COMMITTED`).
+///
+/// Reads change events from the engine's shared CDC bus for the selected
+/// stream(s), filters them to the SELECT's target table, encodes each event to
+/// a CQL RESULT frame via [`crate::router::cdc_event_to_result_frame`], and
+/// pushes it to the connection. **Streaming**: one event at a time, bounded by
+/// the bus; never materializes the change stream. A lagging consumer receives a
+/// loud gap log (the bounded bus drops oldest); the connection-closed or
+/// cancelled cases stop the task.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_cdc_subscription(
+    stream_id: i16,
+    state: Arc<SharedState>,
+    auth: AuthContext,
+    keyspace: Option<String>,
+    inner: Statement,
+    push_tx: mpsc::Sender<SubscriptionPush>,
+    cancel: CancellationToken,
+    local: bool,
+    committed: bool,
+    task_pool: TaskPool,
+) {
+    task_pool.spawn(async move {
+        // Permission was already enforced at SUBSCRIBE time (router check).
+        let _ = &auth;
+
+        let select = match inner {
+            Statement::Select(s) => s,
+            _ => {
+                tracing::error!(stream_id, "CDC subscription inner is not a SELECT");
+                return;
+            }
+        };
+        let ks = match select.keyspace.clone().or(keyspace) {
+            Some(k) => k,
+            None => {
+                tracing::error!(stream_id, "CDC subscription has no keyspace");
+                return;
+            }
+        };
+        let table = select.table.clone();
+
+        // The shared CDC bus is attached to the engine in production startup.
+        let bus = match state.engine.cdc_bus() {
+            Some(b) => b,
+            None => {
+                tracing::error!(
+                    stream_id, %ks, %table,
+                    "CDC SUBSCRIBE requested but no CDC bus is attached to the engine"
+                );
+                return;
+            }
+        };
+
+        let mut local_sub = local.then(|| bus.subscribe(ferrosa_cdc::CdcStream::WrittenOnNode));
+        let mut committed_sub =
+            committed.then(|| bus.subscribe(ferrosa_cdc::CdcStream::CommittedToCluster));
+
+        loop {
+            // Await the next event from whichever stream(s) are active, or stop
+            // on cancel. One event at a time — backpressure is the bounded bus.
+            let event = match (local_sub.as_mut(), committed_sub.as_mut()) {
+                (Some(l), Some(c)) => tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    e = l.recv() => e,
+                    e = c.recv() => e,
+                },
+                (Some(s), None) | (None, Some(s)) => tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    e = s.recv() => e,
+                },
+                (None, None) => break,
+            };
+
+            match event {
+                Ok(ev) => {
+                    // Only deliver changes for this subscription's table.
+                    if ev.keyspace != ks || ev.table != table {
+                        continue;
+                    }
+                    match crate::router::cdc_event_to_result_frame(
+                        &state.schema,
+                        &ks,
+                        &select,
+                        ev.key,
+                        ev.rows,
+                    ) {
+                        Ok(Some(body)) => {
+                            let push = SubscriptionPush {
+                                stream_id,
+                                body: body.freeze(),
+                            };
+                            if push_tx.send(push).await.is_err() {
+                                break; // connection writer gone
+                            }
+                        }
+                        Ok(None) => { /* table dropped between subscribe and event */ }
+                        Err(e) => {
+                            tracing::error!(stream_id, %ks, %table, error = %e, "CDC encode failed");
+                        }
+                    }
+                }
+                Err(ferrosa_cdc::CdcRecvError::Lagged { skipped }) => {
+                    // Fail-loud gap: the consumer fell behind and the bounded bus
+                    // dropped events. Log; a future refinement emits an explicit
+                    // gap marker so clients can resync.
+                    tracing::warn!(
+                        stream_id, %ks, %table, skipped,
+                        "CDC subscription lagged — change events were dropped"
+                    );
+                }
+                Err(ferrosa_cdc::CdcRecvError::Closed) => break,
+                Err(ferrosa_cdc::CdcRecvError::Empty) => {}
+            }
+        }
+        tracing::debug!(stream_id, "CDC subscription ended");
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -483,6 +602,86 @@ mod tests {
             kind, 0x0002,
             "expected Rows RESULT kind (0x0002), got 0x{kind:04X}"
         );
+    }
+
+    /// End-to-end CDC: a write must publish a WrittenOnNode change event that
+    /// the CDC subscription encodes and delivers as a RESULT frame — proving
+    /// the producer (commit-log tap) -> bus -> consumer path is live.
+    #[tokio::test]
+    async fn cdc_subscription_delivers_frame_on_write() {
+        use crate::router::{route, RequestContext};
+        use ferrosa_cluster::consistency::ConsistencyLevel;
+
+        let (state, _dir) = test_shared_state();
+        // Attach the shared CDC bus (production does this in main.rs).
+        let bus = ferrosa_cdc::CdcBus::new(64);
+        state.engine.set_cdc_bus(bus.clone());
+
+        let auth = superuser_auth();
+        let ctx = RequestContext {
+            auth: &auth,
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        for ddl in [
+            "CREATE KEYSPACE ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE ks.t (id int PRIMARY KEY, v text)",
+        ] {
+            route(&state, &ctx, crate::parser::parse(ddl).unwrap())
+                .await
+                .unwrap();
+        }
+
+        // Spawn the CDC subscription (written-on-node) BEFORE the write.
+        let (tx, mut rx) = mpsc::channel::<SubscriptionPush>(8);
+        let cancel = CancellationToken::new();
+        let inner = crate::parser::parse("SELECT * FROM ks.t").unwrap();
+        spawn_cdc_subscription(
+            9,
+            state.clone(),
+            superuser_auth(),
+            None,
+            inner,
+            tx,
+            cancel,
+            true,  // local (written-on-node)
+            false, // committed
+            TaskPool::current("test-cdc"),
+        );
+
+        // Wait until the subscriber has registered on the bus so the write
+        // actually publishes (the has_subscribers guard).
+        for _ in 0..2000 {
+            if bus.has_subscribers(ferrosa_cdc::CdcStream::WrittenOnNode) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert!(
+            bus.has_subscribers(ferrosa_cdc::CdcStream::WrittenOnNode),
+            "CDC subscriber must register on the bus"
+        );
+
+        // Write a row — the commit-log append publishes a WrittenOnNode event.
+        route(
+            &state,
+            &ctx,
+            crate::parser::parse("INSERT INTO ks.t (id, v) VALUES (1, 'x')").unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // The subscription must deliver a Rows RESULT frame for the change.
+        let push = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("timed out waiting for CDC frame")
+            .expect("channel closed without a frame");
+        assert_eq!(push.stream_id, 9);
+        let kind = i32::from_be_bytes([push.body[0], push.body[1], push.body[2], push.body[3]]);
+        assert_eq!(kind, 0x0002, "expected Rows RESULT kind, got 0x{kind:04X}");
     }
 
     /// After cancellation the polling task must stop sending frames and the

--- a/ferrosa-cql/src/subscribe.rs
+++ b/ferrosa-cql/src/subscribe.rs
@@ -318,7 +318,7 @@ pub fn spawn_subscription_poll(
 ///
 /// Reads change events from the engine's shared CDC bus for the selected
 /// stream(s), filters them to the SELECT's target table, encodes each event to
-/// a CQL RESULT frame via [`crate::router::cdc_event_to_result_frame`], and
+/// a CQL RESULT frame via `crate::router::cdc_event_to_result_frame`, and
 /// pushes it to the connection. **Streaming**: one event at a time, bounded by
 /// the bus; never materializes the change stream. A lagging consumer receives a
 /// loud gap log (the bounded bus drops oldest); the connection-closed or

--- a/ferrosa-cql/src/test_util.rs
+++ b/ferrosa-cql/src/test_util.rs
@@ -1,0 +1,117 @@
+//! Test-only helpers for constructing a standalone [`SharedState`].
+//!
+//! Gated behind the `test-util` feature so external crates (e.g.
+//! `ferrosa-flight`) can build a real, single-node execution context in their
+//! integration tests without duplicating the ~80-line fixture. Not compiled
+//! into normal builds.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+use ferrosa_schema::{
+    AuthMethod, DeploymentMode, LogAuditSink, NodeConfig, PasswordHasher, PasswordPolicy,
+    RateLimitConfig, Schema, SchemaConfig,
+};
+use ferrosa_storage::engine::{StorageEngine, StorageEngineConfig};
+use ferrosa_storage::{CommitLogConfig, CompactionConfig};
+
+use crate::observability::CqlMetrics;
+use crate::prepared::PreparedCache;
+use crate::router::SharedState;
+use crate::topology::ClientTopologyPolicy;
+use crate::virtual_tables::active_queries::QueryTracker;
+use crate::virtual_tables::connections::ConnectionTracker;
+use crate::virtual_tables::{FullScanTracker, IndexUsageTracker};
+
+/// Build a standalone (single-node, `Direct` write/DDL path) `SharedState`
+/// rooted at `data_dir`. Auth is disabled; DML/DDL execute against a real local
+/// `StorageEngine`. The caller owns `data_dir` (e.g. a `tempfile::TempDir`).
+pub fn standalone_for_test(data_dir: &Path) -> Arc<SharedState> {
+    let commit_log = CommitLogConfig {
+        log_dir: data_dir.join("commitlog"),
+        checkpoint_dir: data_dir.join("commitlog"),
+        archive: None,
+        ..CommitLogConfig::default()
+    };
+    let engine_config = StorageEngineConfig {
+        commit_log,
+        compaction: CompactionConfig::from_env(data_dir.join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: data_dir.to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
+    let schema = Arc::new(
+        Schema::new(SchemaConfig {
+            hasher: PasswordHasher::Bcrypt { cost: 4 },
+            password_policy: PasswordPolicy::permissive(),
+            auth_method: AuthMethod::Password,
+            rate_limit: RateLimitConfig::default(),
+            audit_sink: Box::new(LogAuditSink),
+            secrets: Box::new(ferrosa_schema::EnvSecretsProvider),
+            mode: DeploymentMode::Development,
+        })
+        .unwrap(),
+    );
+    let node_config = Arc::new(NodeConfig {
+        cluster_name: "test".into(),
+        data_center: "dc1".into(),
+        rack: "rack1".into(),
+        rpc_port: 9042,
+        host_id: uuid::Uuid::new_v4(),
+        listen_address: "127.0.0.1".parse().unwrap(),
+        listen_port: 7000,
+        broadcast_address: "127.0.0.1".parse().unwrap(),
+        broadcast_port: 7000,
+        rpc_address: "127.0.0.1".parse().unwrap(),
+        internal_rpc_address: "127.0.0.1".parse().unwrap(),
+        internal_rpc_port: 9042,
+        tokens: vec![],
+    });
+    let udf_executor =
+        Arc::new(ferrosa_udf::UdfExecutor::new(ferrosa_udf::SandboxConfig::default()).unwrap());
+    let mode_controller =
+        ferrosa_cluster::ModeController::standalone_for_test(schema.clone(), engine.clone());
+    Arc::new(SharedState {
+        core: Arc::new(ferrosa_session::SessionCore {
+            engine: engine.clone(),
+            schema: schema.clone(),
+            node_config,
+            cluster_state: Arc::new(ArcSwap::from_pointee(
+                ferrosa_cluster::ClusterStateHolder::Standalone,
+            )),
+            write_path: Arc::new(ArcSwap::from_pointee(ferrosa_cluster::WritePath::direct(
+                engine.clone(),
+            ))),
+            ddl_path: Arc::new(ArcSwap::from_pointee(ferrosa_cluster::DdlPath::Direct {
+                schema,
+                engine,
+            })),
+            udf_executor,
+            mode_controller,
+            auth_warn: false,
+            peer_manager: None,
+            accord_clock: None,
+        }),
+        prepared_cache: Arc::new(PreparedCache::new(10 * 1024 * 1024)),
+        connection_tracker: Arc::new(ConnectionTracker::new()),
+        query_tracker: Arc::new(QueryTracker::new()),
+        full_scan_tracker: Arc::new(FullScanTracker::new()),
+        index_usage_tracker: Arc::new(IndexUsageTracker::new()),
+        event_sender: tokio::sync::broadcast::channel(64).0,
+        cql_metrics: Arc::new(CqlMetrics::new()),
+        topology_policy: ClientTopologyPolicy::default(),
+    })
+}

--- a/ferrosa-flight/Cargo.toml
+++ b/ferrosa-flight/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ferrosa-flight"
+description = "Apache Arrow Flight (gRPC) query endpoint for Ferrosa"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+arrow = { version = "53", features = ["ipc"] }
+arrow-flight = "53"
+tonic = "0.12"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+futures = "0.3"
+tokio = { version = "1", features = ["rt", "macros"] }
+tracing = "0.1"
+ferrosa-common = { path = "../ferrosa-common" }
+ferrosa-cql = { path = "../ferrosa-cql" }
+ferrosa-cluster = { path = "../ferrosa-cluster" }
+ferrosa-schema = { path = "../ferrosa-schema" }
+
+[dev-dependencies]
+num-bigint = "0.4"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tempfile = "3"
+ferrosa-cql = { path = "../ferrosa-cql", features = ["test-util"] }

--- a/ferrosa-flight/Cargo.toml
+++ b/ferrosa-flight/Cargo.toml
@@ -23,6 +23,7 @@ ferrosa-schema = { path = "../ferrosa-schema" }
 
 [dev-dependencies]
 num-bigint = "0.4"
+uuid = { version = "1", features = ["v4"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tempfile = "3"

--- a/ferrosa-flight/src/convert.rs
+++ b/ferrosa-flight/src/convert.rs
@@ -1,0 +1,978 @@
+//! Convert ferrosa CQL query results into Apache Arrow record batches.
+//!
+//! The Flight `DoGet` path runs a CQL `SELECT` via `ferrosa_cql`'s structured
+//! result (`route_select_raw` → typed `column_types` + `Vec<Vec<Option<CqlValue>>>`)
+//! and converts it here, **column by column**, into an Arrow [`RecordBatch`].
+//!
+//! Fail-loud: an unsupported CQL type or a value that does not match its
+//! column's declared type returns an error rather than silently producing wrong
+//! data. Every CQL type is covered — scalars, temporal, inet, varint, decimal
+//! (as exact text), `list`/`set`, `map`, `tuple`, `udt`, and `vector`. The
+//! reverse path ([`record_batch_to_rows`], for `DoPut`) covers the common
+//! scalar Arrow types and fails loud (`UnsupportedArrow`) on the rest.
+
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BinaryArray, BooleanArray, Date32Array, Float32Array, Float64Array, Int16Array,
+    Int32Array, Int64Array, Int8Array, IntervalMonthDayNanoArray, StringArray,
+    Time64NanosecondArray, TimestampMillisecondArray,
+};
+use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, Schema, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use ferrosa_common::{CqlType, CqlValue};
+
+/// Decoded Arrow batch: column names + row-major CQL values (the `DoPut` shape).
+pub type DecodedRows = (Vec<String>, Vec<Vec<Option<CqlValue>>>);
+
+/// Error converting a CQL result set to an Arrow record batch.
+#[derive(Debug)]
+pub enum ConvertError {
+    /// The CQL type has no Arrow mapping yet (rich/rare types).
+    Unsupported(CqlType),
+    /// A cell's value did not match its column's declared CQL type.
+    TypeMismatch {
+        column: usize,
+        expected: &'static str,
+    },
+    /// Arrow rejected the assembled batch (e.g. column length mismatch).
+    Arrow(arrow::error::ArrowError),
+    /// An Arrow `DataType` has no CQL mapping (reverse / `DoPut` path).
+    UnsupportedArrow(DataType),
+}
+
+impl std::fmt::Display for ConvertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConvertError::Unsupported(t) => {
+                write!(f, "Arrow conversion of CQL type {t:?} is not yet supported")
+            }
+            ConvertError::TypeMismatch { column, expected } => {
+                write!(
+                    f,
+                    "column {column}: value did not match expected {expected}"
+                )
+            }
+            ConvertError::Arrow(e) => write!(f, "arrow batch assembly failed: {e}"),
+            ConvertError::UnsupportedArrow(dt) => {
+                write!(f, "Arrow type {dt:?} has no CQL mapping (DoPut)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConvertError {}
+
+/// Map a CQL type to its Arrow `DataType`, or `None` if unsupported.
+pub fn cql_type_to_arrow(t: &CqlType) -> Option<DataType> {
+    use CqlType::*;
+    Some(match t {
+        Int => DataType::Int32,
+        Bigint | Counter => DataType::Int64,
+        Smallint => DataType::Int16,
+        Tinyint => DataType::Int8,
+        Float => DataType::Float32,
+        Double => DataType::Float64,
+        Boolean => DataType::Boolean,
+        Ascii | Varchar => DataType::Utf8,
+        Blob => DataType::Binary,
+        Timestamp => DataType::Timestamp(TimeUnit::Millisecond, None),
+        // Uuid/Timeuuid as canonical text in v1 (FixedSizeBinary(16) is a refinement).
+        Uuid | Timeuuid => DataType::Utf8,
+        // Text representations for types whose exact value is best preserved as a
+        // string (IP literal; arbitrary-precision integer).
+        Inet | Varint => DataType::Utf8,
+        Date => DataType::Date32,
+        Time => DataType::Time64(TimeUnit::Nanosecond),
+        Duration => DataType::Interval(IntervalUnit::MonthDayNano),
+        List(inner) | Set(inner) => {
+            let item = cql_type_to_arrow(inner)?;
+            DataType::List(Arc::new(Field::new("item", item, true)))
+        }
+        // Cassandra `vector<float, N>` -> fixed-width list of f32.
+        Vector(_, dim) => DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            *dim as i32,
+        ),
+        Map(k, v) => DataType::Map(
+            map_entries_field(cql_type_to_arrow(k)?, cql_type_to_arrow(v)?),
+            false,
+        ),
+        Tuple(elems) => {
+            let mut fields = Vec::with_capacity(elems.len());
+            for (i, t) in elems.iter().enumerate() {
+                fields.push(Field::new(i.to_string(), cql_type_to_arrow(t)?, true));
+            }
+            DataType::Struct(Fields::from(fields))
+        }
+        Udt {
+            fields: udt_fields, ..
+        } => {
+            let mut fields = Vec::with_capacity(udt_fields.len());
+            for (name, t) in udt_fields {
+                fields.push(Field::new(name, cql_type_to_arrow(t)?, true));
+            }
+            DataType::Struct(Fields::from(fields))
+        }
+        // Decimal carries a per-VALUE scale, which Arrow's column-level
+        // Decimal128(precision, scale) cannot represent; emit the exact decimal
+        // as text (lossless), matching how varint/inet are handled.
+        Decimal => DataType::Utf8,
+    })
+}
+
+/// Format a CQL decimal (`unscaled` x 10^-`scale`) as an exact decimal string.
+/// `unscaled` is the signed integer rendering of the unscaled value.
+fn format_decimal(scale: i32, unscaled: &str) -> String {
+    if scale <= 0 {
+        // value = unscaled x 10^(-scale): append |scale| trailing zeros.
+        return format!("{unscaled}{}", "0".repeat(scale.unsigned_abs() as usize));
+    }
+    let scale = scale as usize;
+    let (sign, digits) = unscaled
+        .strip_prefix('-')
+        .map_or(("", unscaled), |d| ("-", d));
+    if digits.len() > scale {
+        let point = digits.len() - scale;
+        format!("{sign}{}.{}", &digits[..point], &digits[point..])
+    } else {
+        format!("{sign}0.{}{}", "0".repeat(scale - digits.len()), digits)
+    }
+}
+
+/// The `entries` struct field of an Arrow `Map` (keys non-null, values
+/// nullable). Single source of truth so the column `DataType` from
+/// [`cql_type_to_arrow`] and the array built in `build_map` are identical.
+fn map_entries_field(key_dt: DataType, val_dt: DataType) -> Arc<Field> {
+    let entries = DataType::Struct(Fields::from(vec![
+        Field::new("keys", key_dt, false),
+        Field::new("values", val_dt, true),
+    ]));
+    Arc::new(Field::new("entries", entries, false))
+}
+
+/// Convert a structured CQL result (column metadata + rows) into an Arrow
+/// `RecordBatch`. All columns are nullable (CQL cells can be absent/NULL).
+pub fn rows_to_record_batch(
+    column_names: &[String],
+    column_types: &[CqlType],
+    rows: &[Vec<Option<CqlValue>>],
+) -> Result<RecordBatch, ConvertError> {
+    let mut fields = Vec::with_capacity(column_types.len());
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(column_types.len());
+
+    for (c, ct) in column_types.iter().enumerate() {
+        let dt = cql_type_to_arrow(ct).ok_or_else(|| ConvertError::Unsupported(ct.clone()))?;
+        arrays.push(build_array(ct, rows, c)?);
+        let name = column_names
+            .get(c)
+            .cloned()
+            .unwrap_or_else(|| format!("col{c}"));
+        fields.push(Field::new(name, dt, true));
+    }
+
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays).map_err(ConvertError::Arrow)
+}
+
+/// Decode an Arrow `RecordBatch` into column names + row-major CQL values — the
+/// inverse of [`rows_to_record_batch`], used by the Flight `DoPut` write path.
+///
+/// Covers the common scalar Arrow types; richer types fail loud
+/// (`UnsupportedArrow`). `Utf8` decodes to `Text` — the target table's declared
+/// column type disambiguates text/uuid/inet/varint when the row is written.
+pub fn record_batch_to_rows(batch: &RecordBatch) -> Result<DecodedRows, ConvertError> {
+    let schema = batch.schema();
+    let names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+
+    let mut cols: Vec<Vec<Option<CqlValue>>> = Vec::with_capacity(batch.num_columns());
+    for c in 0..batch.num_columns() {
+        cols.push(decode_column(batch.column(c), schema.field(c).data_type())?);
+    }
+
+    // Transpose column-major -> row-major.
+    let mut rows = Vec::with_capacity(batch.num_rows());
+    for i in 0..batch.num_rows() {
+        rows.push(cols.iter().map(|col| col[i].clone()).collect());
+    }
+    Ok((names, rows))
+}
+
+/// Decode one Arrow column into per-row `Option<CqlValue>` (NULL slot -> `None`).
+fn decode_column(arr: &ArrayRef, dt: &DataType) -> Result<Vec<Option<CqlValue>>, ConvertError> {
+    use arrow::array::Array;
+    macro_rules! scalar {
+        ($arrty:ty, $make:expr) => {{
+            let a = arr
+                .as_any()
+                .downcast_ref::<$arrty>()
+                .ok_or_else(|| ConvertError::UnsupportedArrow(dt.clone()))?;
+            (0..a.len())
+                .map(|i| {
+                    if a.is_null(i) {
+                        None
+                    } else {
+                        Some($make(a.value(i)))
+                    }
+                })
+                .collect()
+        }};
+    }
+    Ok(match dt {
+        DataType::Int32 => scalar!(Int32Array, CqlValue::Int),
+        DataType::Int64 => scalar!(Int64Array, CqlValue::Bigint),
+        DataType::Int16 => scalar!(Int16Array, CqlValue::Smallint),
+        DataType::Int8 => scalar!(Int8Array, CqlValue::Tinyint),
+        DataType::Boolean => scalar!(BooleanArray, CqlValue::Boolean),
+        DataType::Float32 => scalar!(Float32Array, |v: f32| CqlValue::Float(v.to_bits())),
+        DataType::Float64 => scalar!(Float64Array, |v: f64| CqlValue::Double(v.to_bits())),
+        DataType::Utf8 => scalar!(StringArray, |v: &str| CqlValue::Text(v.to_string())),
+        DataType::Binary => scalar!(BinaryArray, |v: &[u8]| CqlValue::Blob(v.to_vec())),
+        DataType::Timestamp(TimeUnit::Millisecond, _) => {
+            scalar!(TimestampMillisecondArray, CqlValue::Timestamp)
+        }
+        other => return Err(ConvertError::UnsupportedArrow(other.clone())),
+    })
+}
+
+/// Build one Arrow column array from the values at index `c` across `rows`.
+fn build_array(
+    ct: &CqlType,
+    rows: &[Vec<Option<CqlValue>>],
+    c: usize,
+) -> Result<ArrayRef, ConvertError> {
+    let values: Vec<Option<CqlValue>> = rows
+        .iter()
+        .map(|r| r.get(c).and_then(|cell| cell.as_ref()).cloned())
+        .collect();
+    build_values(ct, &values, c)
+}
+
+/// Build an Arrow array from a flat slice of typed values. Recurses for the
+/// element type of `list`/`set` columns. `column` is the originating column
+/// index, used only for `TypeMismatch` reporting.
+fn build_values(
+    ct: &CqlType,
+    values: &[Option<CqlValue>],
+    column: usize,
+) -> Result<ArrayRef, ConvertError> {
+    // Primitive columns: collect Option<T> (NULL/absent -> None), erroring on a
+    // value whose variant doesn't match the column's declared type.
+    macro_rules! prim {
+        ($arrty:ty, $variant:pat, $bind:ident => $val:expr, $exp:literal) => {{
+            let mut out = Vec::with_capacity(values.len());
+            for v in values {
+                match v.as_ref() {
+                    None | Some(CqlValue::Null) => out.push(None),
+                    Some($variant) => out.push(Some($val)),
+                    Some(_) => {
+                        return Err(ConvertError::TypeMismatch {
+                            column,
+                            expected: $exp,
+                        })
+                    }
+                }
+            }
+            Arc::new(<$arrty>::from(out)) as ArrayRef
+        }};
+    }
+
+    // String-valued columns: map the matching variant(s) to an owned String.
+    macro_rules! string_col {
+        ($exp:literal, $($variant:pat => $s:expr),+ $(,)?) => {{
+            let mut out: Vec<Option<String>> = Vec::with_capacity(values.len());
+            for v in values {
+                match v.as_ref() {
+                    None | Some(CqlValue::Null) => out.push(None),
+                    $(Some($variant) => out.push(Some($s)),)+
+                    Some(_) => return Err(ConvertError::TypeMismatch { column, expected: $exp }),
+                }
+            }
+            Arc::new(StringArray::from(out)) as ArrayRef
+        }};
+    }
+
+    Ok(match ct {
+        CqlType::Int => prim!(Int32Array, CqlValue::Int(v), v => *v, "int"),
+        CqlType::Bigint => prim!(Int64Array, CqlValue::Bigint(v), v => *v, "bigint"),
+        CqlType::Counter => prim!(Int64Array, CqlValue::Counter(v), v => *v, "counter"),
+        CqlType::Smallint => prim!(Int16Array, CqlValue::Smallint(v), v => *v, "smallint"),
+        CqlType::Tinyint => prim!(Int8Array, CqlValue::Tinyint(v), v => *v, "tinyint"),
+        CqlType::Float => prim!(Float32Array, CqlValue::Float(b), b => f32::from_bits(*b), "float"),
+        CqlType::Double => {
+            prim!(Float64Array, CqlValue::Double(b), b => f64::from_bits(*b), "double")
+        }
+        CqlType::Boolean => prim!(BooleanArray, CqlValue::Boolean(v), v => *v, "boolean"),
+        CqlType::Timestamp => {
+            prim!(TimestampMillisecondArray, CqlValue::Timestamp(v), v => *v, "timestamp")
+        }
+        CqlType::Ascii | CqlType::Varchar => string_col!(
+            "text",
+            CqlValue::Ascii(s) => s.clone(),
+            CqlValue::Text(s) => s.clone(),
+        ),
+        CqlType::Uuid | CqlType::Timeuuid => string_col!(
+            "uuid",
+            CqlValue::Uuid(u) => u.to_string(),
+            CqlValue::Timeuuid(u) => u.to_string(),
+        ),
+        CqlType::Inet => string_col!("inet", CqlValue::Inet(ip) => ip.to_string()),
+        CqlType::Varint => string_col!("varint", CqlValue::Varint(v) => v.to_string()),
+        CqlType::Blob => {
+            let owned: Vec<Option<Vec<u8>>> = {
+                let mut out = Vec::with_capacity(values.len());
+                for v in values {
+                    match v.as_ref() {
+                        None | Some(CqlValue::Null) => out.push(None),
+                        Some(CqlValue::Blob(b)) => out.push(Some(b.clone())),
+                        Some(_) => {
+                            return Err(ConvertError::TypeMismatch {
+                                column,
+                                expected: "blob",
+                            })
+                        }
+                    }
+                }
+                out
+            };
+            let refs: Vec<Option<&[u8]>> = owned.iter().map(|o| o.as_deref()).collect();
+            Arc::new(BinaryArray::from(refs)) as ArrayRef
+        }
+        CqlType::Date => {
+            // Cassandra `date` is days-since-epoch offset so that 2^31 == 1970-01-01;
+            // Arrow Date32 is signed days since 1970-01-01.
+            prim!(Date32Array, CqlValue::Date(d), d => (*d as i64 - (1i64 << 31)) as i32, "date")
+        }
+        CqlType::Time => prim!(Time64NanosecondArray, CqlValue::Time(t), t => *t, "time"),
+        CqlType::Duration => {
+            let mut out: Vec<Option<arrow::datatypes::IntervalMonthDayNano>> =
+                Vec::with_capacity(values.len());
+            for v in values {
+                match v.as_ref() {
+                    None | Some(CqlValue::Null) => out.push(None),
+                    Some(CqlValue::Duration {
+                        months,
+                        days,
+                        nanos,
+                    }) => out.push(Some(arrow::datatypes::IntervalMonthDayNano::new(
+                        *months, *days, *nanos,
+                    ))),
+                    Some(_) => {
+                        return Err(ConvertError::TypeMismatch {
+                            column,
+                            expected: "duration",
+                        })
+                    }
+                }
+            }
+            Arc::new(IntervalMonthDayNanoArray::from(out)) as ArrayRef
+        }
+        CqlType::List(inner) | CqlType::Set(inner) => build_list(inner, values, column)?,
+        CqlType::Vector(_, dim) => build_vector(*dim, values, column)?,
+        CqlType::Map(k, v) => build_map(k, v, values, column)?,
+        CqlType::Tuple(elems) => build_tuple(elems, values, column)?,
+        CqlType::Udt {
+            fields: udt_fields, ..
+        } => build_udt(udt_fields, values, column)?,
+        CqlType::Decimal => string_col!(
+            "decimal",
+            CqlValue::Decimal { scale, unscaled } => format_decimal(*scale, &unscaled.to_string()),
+        ),
+    })
+}
+
+/// Assemble an Arrow `StructArray` from ordered `(name, type)` fields, the
+/// per-field value columns (each `values.len()` long), and per-row validity.
+fn assemble_struct(
+    field_defs: &[(String, CqlType)],
+    per_field: Vec<Vec<Option<CqlValue>>>,
+    valid: Vec<bool>,
+    column: usize,
+) -> Result<ArrayRef, ConvertError> {
+    use arrow::array::StructArray;
+    use arrow::buffer::NullBuffer;
+
+    let mut fields = Vec::with_capacity(field_defs.len());
+    let mut children: Vec<ArrayRef> = Vec::with_capacity(field_defs.len());
+    for ((name, ft), col) in field_defs.iter().zip(per_field) {
+        let arr = build_values(ft, &col, column)?;
+        fields.push(Arc::new(Field::new(name, arr.data_type().clone(), true)));
+        children.push(arr);
+    }
+    Ok(Arc::new(StructArray::new(
+        Fields::from(fields),
+        children,
+        Some(NullBuffer::from(valid)),
+    )) as ArrayRef)
+}
+
+/// `tuple<...>` -> Arrow `StructArray` with positional field names "0","1",...
+/// Each element type recurses through `build_values`; a NULL tuple is a null row.
+fn build_tuple(
+    elem_types: &[CqlType],
+    values: &[Option<CqlValue>],
+    column: usize,
+) -> Result<ArrayRef, ConvertError> {
+    let arity = elem_types.len();
+    let mut per_field: Vec<Vec<Option<CqlValue>>> = (0..arity)
+        .map(|_| Vec::with_capacity(values.len()))
+        .collect();
+    let mut valid = Vec::with_capacity(values.len());
+
+    for v in values {
+        match v.as_ref() {
+            None | Some(CqlValue::Null) => {
+                for col in per_field.iter_mut() {
+                    col.push(None);
+                }
+                valid.push(false);
+            }
+            Some(CqlValue::Tuple(elems)) => {
+                for (i, col) in per_field.iter_mut().enumerate() {
+                    col.push(elems.get(i).cloned().flatten());
+                }
+                valid.push(true);
+            }
+            Some(_) => {
+                return Err(ConvertError::TypeMismatch {
+                    column,
+                    expected: "tuple",
+                })
+            }
+        }
+    }
+
+    let defs: Vec<(String, CqlType)> = elem_types
+        .iter()
+        .enumerate()
+        .map(|(i, t)| (i.to_string(), t.clone()))
+        .collect();
+    assemble_struct(&defs, per_field, valid, column)
+}
+
+/// `udt` -> Arrow `StructArray` with the UDT's named fields (positional, matching
+/// the type's field order). A NULL UDT is a null row.
+fn build_udt(
+    field_defs: &[(String, CqlType)],
+    values: &[Option<CqlValue>],
+    column: usize,
+) -> Result<ArrayRef, ConvertError> {
+    let n = field_defs.len();
+    let mut per_field: Vec<Vec<Option<CqlValue>>> =
+        (0..n).map(|_| Vec::with_capacity(values.len())).collect();
+    let mut valid = Vec::with_capacity(values.len());
+
+    for v in values {
+        match v.as_ref() {
+            None | Some(CqlValue::Null) => {
+                for col in per_field.iter_mut() {
+                    col.push(None);
+                }
+                valid.push(false);
+            }
+            Some(CqlValue::Udt(entries)) => {
+                for (i, col) in per_field.iter_mut().enumerate() {
+                    col.push(entries.get(i).and_then(|(_, val)| val.clone()));
+                }
+                valid.push(true);
+            }
+            Some(_) => {
+                return Err(ConvertError::TypeMismatch {
+                    column,
+                    expected: "udt",
+                })
+            }
+        }
+    }
+
+    assemble_struct(field_defs, per_field, valid, column)
+}
+
+/// Build an Arrow `MapArray` for a `map<k, v>` column: flatten every row's
+/// entries into parallel key/value child arrays with per-row offsets and
+/// validity (a NULL row is a null map, distinct from an empty map). Keys and
+/// values recurse through `build_values`.
+fn build_map(
+    kt: &CqlType,
+    vt: &CqlType,
+    values: &[Option<CqlValue>],
+    column: usize,
+) -> Result<ArrayRef, ConvertError> {
+    use arrow::array::{MapArray, StructArray};
+    use arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+
+    let mut offsets: Vec<i32> = Vec::with_capacity(values.len() + 1);
+    offsets.push(0);
+    let mut keys: Vec<Option<CqlValue>> = Vec::new();
+    let mut vals: Vec<Option<CqlValue>> = Vec::new();
+    let mut valid: Vec<bool> = Vec::with_capacity(values.len());
+
+    for v in values {
+        match v.as_ref() {
+            None | Some(CqlValue::Null) => valid.push(false),
+            Some(CqlValue::Map(entries)) => {
+                for (k, val) in entries {
+                    keys.push(Some(k.clone()));
+                    vals.push(Some(val.clone()));
+                }
+                valid.push(true);
+            }
+            Some(_) => {
+                return Err(ConvertError::TypeMismatch {
+                    column,
+                    expected: "map",
+                })
+            }
+        }
+        offsets.push(keys.len() as i32);
+    }
+
+    let key_arr = build_values(kt, &keys, column)?;
+    let val_arr = build_values(vt, &vals, column)?;
+    let entries_field = map_entries_field(key_arr.data_type().clone(), val_arr.data_type().clone());
+    let struct_fields = match entries_field.data_type() {
+        DataType::Struct(fields) => fields.clone(),
+        _ => unreachable!("map_entries_field always builds a struct"),
+    };
+    let entries = StructArray::new(struct_fields, vec![key_arr, val_arr], None);
+    let offsets = OffsetBuffer::new(ScalarBuffer::from(offsets));
+    let nulls = NullBuffer::from(valid);
+    Ok(Arc::new(MapArray::new(
+        entries_field,
+        offsets,
+        entries,
+        Some(nulls),
+        false,
+    )) as ArrayRef)
+}
+
+/// Build an Arrow `FixedSizeListArray` of `Float32` for a `vector<float, dim>`
+/// column. Values are stored as f32 bit patterns. A NULL row still occupies
+/// `dim` child slots (filled null) so the fixed stride holds; a non-NULL vector
+/// with the wrong length is a data error (fail loud).
+fn build_vector(
+    dim: usize,
+    values: &[Option<CqlValue>],
+    column: usize,
+) -> Result<ArrayRef, ConvertError> {
+    use arrow::array::FixedSizeListArray;
+    use arrow::buffer::NullBuffer;
+
+    let mut child: Vec<Option<f32>> = Vec::with_capacity(values.len() * dim);
+    let mut valid: Vec<bool> = Vec::with_capacity(values.len());
+
+    for v in values {
+        match v.as_ref() {
+            None | Some(CqlValue::Null) => {
+                child.extend(std::iter::repeat_n(None, dim));
+                valid.push(false);
+            }
+            Some(CqlValue::Vector(bits)) => {
+                if bits.len() != dim {
+                    return Err(ConvertError::TypeMismatch {
+                        column,
+                        expected: "vector<float, dim>",
+                    });
+                }
+                child.extend(bits.iter().map(|b| Some(f32::from_bits(*b))));
+                valid.push(true);
+            }
+            Some(_) => {
+                return Err(ConvertError::TypeMismatch {
+                    column,
+                    expected: "vector",
+                })
+            }
+        }
+    }
+
+    let child_arr = Arc::new(Float32Array::from(child)) as ArrayRef;
+    let field = Arc::new(Field::new("item", DataType::Float32, true));
+    let nulls = NullBuffer::from(valid);
+    Ok(Arc::new(FixedSizeListArray::new(
+        field,
+        dim as i32,
+        child_arr,
+        Some(nulls),
+    )) as ArrayRef)
+}
+
+/// Build an Arrow `ListArray` for a `list<inner>` / `set<inner>` column:
+/// flatten every row's elements into one child array, tracking per-row offsets
+/// and validity (a NULL row is a null list, distinct from an empty list).
+fn build_list(
+    inner: &CqlType,
+    values: &[Option<CqlValue>],
+    column: usize,
+) -> Result<ArrayRef, ConvertError> {
+    use arrow::array::ListArray;
+    use arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+
+    let mut offsets: Vec<i32> = Vec::with_capacity(values.len() + 1);
+    offsets.push(0);
+    let mut child: Vec<Option<CqlValue>> = Vec::new();
+    let mut valid: Vec<bool> = Vec::with_capacity(values.len());
+
+    for v in values {
+        match v.as_ref() {
+            None | Some(CqlValue::Null) => valid.push(false),
+            Some(CqlValue::List(items)) | Some(CqlValue::Set(items)) => {
+                child.extend(items.iter().cloned().map(Some));
+                valid.push(true);
+            }
+            Some(_) => {
+                return Err(ConvertError::TypeMismatch {
+                    column,
+                    expected: "list/set",
+                })
+            }
+        }
+        offsets.push(child.len() as i32);
+    }
+
+    let child_arr = build_values(inner, &child, column)?;
+    let field = Arc::new(Field::new("item", child_arr.data_type().clone(), true));
+    let offsets = OffsetBuffer::new(ScalarBuffer::from(offsets));
+    let nulls = NullBuffer::from(valid);
+    Ok(Arc::new(ListArray::new(field, offsets, child_arr, Some(nulls))) as ArrayRef)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, BooleanArray, Date32Array, Int32Array, StringArray};
+
+    #[test]
+    fn converts_scalar_columns_with_nulls() {
+        let names = vec!["id".to_string(), "name".to_string(), "active".to_string()];
+        let types = vec![CqlType::Int, CqlType::Varchar, CqlType::Boolean];
+        let rows = vec![
+            vec![
+                Some(CqlValue::Int(1)),
+                Some(CqlValue::Text("alice".into())),
+                Some(CqlValue::Boolean(true)),
+            ],
+            // a row with a NULL name (absent cell handled the same way)
+            vec![
+                Some(CqlValue::Int(2)),
+                Some(CqlValue::Null),
+                Some(CqlValue::Boolean(false)),
+            ],
+        ];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        assert_eq!(batch.num_columns(), 3);
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.schema().field(0).name(), "id");
+
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(ids.value(0), 1);
+        assert_eq!(ids.value(1), 2);
+
+        let nbatch = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(nbatch.value(0), "alice");
+        assert!(nbatch.is_null(1), "NULL name -> Arrow null slot");
+
+        let active = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(active.value(0));
+        assert!(!active.value(1));
+    }
+
+    #[test]
+    fn converts_decimal_to_text() {
+        let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let types = vec![CqlType::Decimal, CqlType::Decimal, CqlType::Decimal];
+        let rows = vec![vec![
+            // 12345 x 10^-2 = 123.45
+            Some(CqlValue::Decimal {
+                scale: 2,
+                unscaled: num_bigint::BigInt::from(12345),
+            }),
+            // 5 x 10^-3 = 0.005 (zero-padded)
+            Some(CqlValue::Decimal {
+                scale: 3,
+                unscaled: num_bigint::BigInt::from(5),
+            }),
+            // -7 x 10^2 = -700 (negative, non-positive scale)
+            Some(CqlValue::Decimal {
+                scale: -2,
+                unscaled: num_bigint::BigInt::from(-7),
+            }),
+        ]];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        let col = |i: usize| {
+            batch
+                .column(i)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(0)
+                .to_string()
+        };
+        assert_eq!(col(0), "123.45");
+        assert_eq!(col(1), "0.005");
+        assert_eq!(col(2), "-700");
+    }
+
+    #[test]
+    fn reverse_unsupported_arrow_fails_loud() {
+        // record_batch_to_rows covers common scalars; a Date32 column (produced
+        // by the forward path) has no reverse mapping -> UnsupportedArrow.
+        let batch = rows_to_record_batch(
+            &["d".to_string()],
+            &[CqlType::Date],
+            &[vec![Some(CqlValue::Date(2_147_483_648))]],
+        )
+        .unwrap();
+        let err = record_batch_to_rows(&batch).unwrap_err();
+        assert!(matches!(err, ConvertError::UnsupportedArrow(_)));
+    }
+
+    #[test]
+    fn converts_list_column_with_null_and_empty() {
+        use arrow::array::ListArray;
+        let names = vec!["tags".to_string()];
+        let types = vec![CqlType::List(Box::new(CqlType::Int))];
+        let rows = vec![
+            vec![Some(CqlValue::List(vec![
+                CqlValue::Int(1),
+                CqlValue::Int(2),
+            ]))],
+            vec![Some(CqlValue::Null)],         // null list
+            vec![Some(CqlValue::List(vec![]))], // empty list (distinct from null)
+            vec![Some(CqlValue::List(vec![CqlValue::Int(3)]))],
+        ];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        assert_eq!(batch.num_rows(), 4);
+        let list = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        assert!(!list.is_null(0));
+        assert_eq!(list.value(0).len(), 2);
+        assert!(list.is_null(1), "NULL list -> null slot");
+        assert!(!list.is_null(2));
+        assert_eq!(list.value(2).len(), 0, "empty list -> 0-length, not null");
+        // Children are flattened across non-null lists: [1, 2, 3].
+        let child = list.values().as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(child.len(), 3);
+        assert_eq!(child.value(0), 1);
+        assert_eq!(child.value(2), 3);
+    }
+
+    #[test]
+    fn converts_temporal_inet_varint_duration() {
+        use std::net::IpAddr;
+        let names = vec![
+            "d".to_string(),
+            "t".to_string(),
+            "ip".to_string(),
+            "vi".to_string(),
+            "dur".to_string(),
+        ];
+        let types = vec![
+            CqlType::Date,
+            CqlType::Time,
+            CqlType::Inet,
+            CqlType::Varint,
+            CqlType::Duration,
+        ];
+        let rows = vec![vec![
+            Some(CqlValue::Date(2_147_483_648)), // 2^31 == 1970-01-01 -> Date32 0
+            Some(CqlValue::Time(3_600_000_000_000)), // 01:00:00 in nanoseconds
+            Some(CqlValue::Inet("127.0.0.1".parse::<IpAddr>().unwrap())),
+            Some(CqlValue::Varint(num_bigint::BigInt::from(
+                123_456_789_012_345_678i64,
+            ))),
+            Some(CqlValue::Duration {
+                months: 1,
+                days: 2,
+                nanos: 3,
+            }),
+        ]];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        assert_eq!(batch.num_columns(), 5);
+
+        let d = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Date32Array>()
+            .unwrap();
+        assert_eq!(d.value(0), 0, "2^31 maps to the Arrow epoch (0 days)");
+
+        let ip = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ip.value(0), "127.0.0.1");
+
+        let vi = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(vi.value(0), "123456789012345678");
+    }
+
+    #[test]
+    fn converts_vector_to_fixed_size_list() {
+        use arrow::array::{FixedSizeListArray, Float32Array};
+        let names = vec!["embedding".to_string()];
+        let types = vec![CqlType::Vector(Box::new(CqlType::Float), 3)];
+        let rows = vec![
+            vec![Some(CqlValue::Vector(vec![
+                1.0f32.to_bits(),
+                2.0f32.to_bits(),
+                3.0f32.to_bits(),
+            ]))],
+            vec![Some(CqlValue::Null)],
+        ];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        let fsl = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .unwrap();
+        assert_eq!(fsl.value_length(), 3, "fixed dimension 3");
+        assert!(!fsl.is_null(0));
+        assert!(fsl.is_null(1), "NULL vector -> null row");
+        let v0 = fsl.value(0);
+        let f = v0.as_any().downcast_ref::<Float32Array>().unwrap();
+        assert_eq!(f.value(0), 1.0);
+        assert_eq!(f.value(2), 3.0);
+    }
+
+    #[test]
+    fn converts_map_to_map_array() {
+        use arrow::array::MapArray;
+        let names = vec!["attrs".to_string()];
+        let types = vec![CqlType::Map(
+            Box::new(CqlType::Varchar),
+            Box::new(CqlType::Int),
+        )];
+        let rows = vec![
+            vec![Some(CqlValue::Map(vec![
+                (CqlValue::Text("a".into()), CqlValue::Int(1)),
+                (CqlValue::Text("b".into()), CqlValue::Int(2)),
+            ]))],
+            vec![Some(CqlValue::Null)],
+        ];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        let m = batch.column(0).as_any().downcast_ref::<MapArray>().unwrap();
+        assert!(!m.is_null(0));
+        assert!(m.is_null(1), "NULL map -> null row");
+        assert_eq!(m.value_length(0), 2);
+        let keys = m.keys().as_any().downcast_ref::<StringArray>().unwrap();
+        let vals = m.values().as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(keys.value(0), "a");
+        assert_eq!(vals.value(1), 2);
+    }
+
+    #[test]
+    fn converts_tuple_to_struct() {
+        use arrow::array::StructArray;
+        let names = vec!["t".to_string()];
+        let types = vec![CqlType::Tuple(vec![CqlType::Int, CqlType::Varchar])];
+        let rows = vec![
+            vec![Some(CqlValue::Tuple(vec![
+                Some(CqlValue::Int(7)),
+                Some(CqlValue::Text("x".into())),
+            ]))],
+            vec![Some(CqlValue::Null)],
+        ];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        let s = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert_eq!(s.num_columns(), 2);
+        assert!(!s.is_null(0));
+        assert!(s.is_null(1), "NULL tuple -> null row");
+        let f0 = s.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(f0.value(0), 7);
+    }
+
+    #[test]
+    fn converts_udt_to_struct_with_named_fields() {
+        use arrow::array::StructArray;
+        let names = vec!["addr".to_string()];
+        let types = vec![CqlType::Udt {
+            keyspace: "ks".into(),
+            name: "address".into(),
+            fields: vec![
+                ("city".into(), CqlType::Varchar),
+                ("zip".into(), CqlType::Int),
+            ],
+        }];
+        let rows = vec![vec![Some(CqlValue::Udt(vec![
+            ("city".into(), Some(CqlValue::Text("NYC".into()))),
+            ("zip".into(), Some(CqlValue::Int(10001))),
+        ]))]];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        let s = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert_eq!(s.num_columns(), 2);
+        match s.data_type() {
+            DataType::Struct(f) => {
+                assert_eq!(f[0].name(), "city");
+                assert_eq!(f[1].name(), "zip");
+            }
+            other => panic!("expected struct, got {other:?}"),
+        }
+        let zip = s.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(zip.value(0), 10001);
+    }
+
+    #[test]
+    fn record_batch_round_trips_scalars() {
+        let names = vec!["id".to_string(), "name".to_string(), "active".to_string()];
+        let types = vec![CqlType::Int, CqlType::Varchar, CqlType::Boolean];
+        let rows = vec![
+            vec![
+                Some(CqlValue::Int(1)),
+                Some(CqlValue::Text("alice".into())),
+                Some(CqlValue::Boolean(true)),
+            ],
+            vec![Some(CqlValue::Int(2)), None, Some(CqlValue::Boolean(false))],
+        ];
+
+        let batch = rows_to_record_batch(&names, &types, &rows).unwrap();
+        let (decoded_names, decoded_rows) = record_batch_to_rows(&batch).unwrap();
+        assert_eq!(decoded_names, names);
+        assert_eq!(decoded_rows, rows, "scalars round-trip CQL -> Arrow -> CQL");
+    }
+
+    #[test]
+    fn type_mismatch_fails_loud() {
+        // Column declared Int but a row carries Text — must error, not coerce.
+        let names = vec!["id".to_string()];
+        let types = vec![CqlType::Int];
+        let rows = vec![vec![Some(CqlValue::Text("oops".into()))]];
+        let err = rows_to_record_batch(&names, &types, &rows).unwrap_err();
+        assert!(matches!(err, ConvertError::TypeMismatch { column: 0, .. }));
+    }
+}

--- a/ferrosa-flight/src/lib.rs
+++ b/ferrosa-flight/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod convert;
+pub mod plan;
+pub mod server;
+pub mod service;
+pub mod token;

--- a/ferrosa-flight/src/plan.rs
+++ b/ferrosa-flight/src/plan.rs
@@ -2,15 +2,25 @@
 //!
 //! The CQL `SELECT` path supports `token(pk)` predicates, so a per-token-range
 //! Flight read is just the base `SELECT` plus a `token(...)` bound. This module
-//! generates those bounded statements. `GetFlightInfo` will emit one
+//! generates those bounded statements. `GetFlightInfo` emits one
 //! `FlightEndpoint` per ring token range — each ticket a bounded `SELECT`,
-//! located on the replica that owns the range — letting a client read ranges in
-//! parallel.
+//! located on the replica(s) that own the range — letting a client read ranges
+//! in parallel.
 //!
-//! Cluster-dependent prerequisites (tracked follow-ups, NOT in this module):
-//! ring token-range enumeration from `cluster_state`, and advertising each
-//! node's Flight gRPC address (the topology currently tracks only the
-//! internode/CQL addresses), needed for `FlightEndpoint` locations.
+//! [`distributed_endpoints`] is the pure planner: given the live [`TokenRing`],
+//! the keyspace [`ReplicationStrategy`], the table's partition-key columns, and
+//! a resolver mapping a ring node-id to that node's advertised Flight address,
+//! it returns one [`EndpointPlan`] per range. The wiring in
+//! [`crate::service`]`::get_flight_info` supplies the resolver (local node from
+//! `FERROSA_FLIGHT_BROADCAST`; remote nodes from the ring's internode host +
+//! the configured Flight port) and turns each plan into a `FlightEndpoint`.
+//!
+//! Standalone / empty ring (no cluster topology) yields a single plan carrying
+//! the unbounded base `SELECT` and no location, which preserves the prior
+//! single-self-endpoint behavior.
+
+use ferrosa_cluster::ring::strategy::ReplicationStrategy;
+use ferrosa_cluster::ring::TokenRing;
 
 /// Append a half-open `(start, end]` token-range bound to a base `SELECT`.
 ///
@@ -33,8 +43,248 @@ pub fn token_bounded_select(
     }
 }
 
+/// One distributed Flight endpoint: a token-range-scoped `SELECT` ticket plus
+/// the advertised Flight addresses of the replicas that own the range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EndpointPlan {
+    /// CQL the client should redeem via `DoGet` (bounded to this range, unless
+    /// it is the single whole-ring fallback, which carries the base `SELECT`).
+    pub ticket_cql: String,
+    /// Advertised Flight addresses (e.g. `grpc://host:port`) of the replicas
+    /// that own this range. May be empty when a replica's address cannot be
+    /// resolved (the client then falls back to the connection it asked on).
+    pub locations: Vec<String>,
+}
+
+/// Enumerate every half-open `(start, end]` token range over the ring, paired
+/// with the replica node-ids that own it under `strategy`.
+///
+/// Mirrors the partitioning used by repair's range enumeration: each adjacent
+/// pair of distinct ring tokens is a range, owned by the replica set of the
+/// range's *start* token. The wrap-around segment from `i64::MIN` to the
+/// smallest token is emitted explicitly so callers never special-case it.
+///
+/// Returns an empty vec for an empty ring — the caller treats that as the
+/// standalone single-endpoint case.
+pub fn ring_token_ranges(ring: &TokenRing, strategy: &ReplicationStrategy) -> Vec<RangeOwners> {
+    let mut tokens: Vec<i64> = ring
+        .node_ids()
+        .iter()
+        .flat_map(|&n| ring.tokens_for_node(n))
+        .collect();
+    tokens.sort_unstable();
+    tokens.dedup();
+    if tokens.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ranges = Vec::with_capacity(tokens.len() + 1);
+    let first = tokens[0];
+    // Leading wrap segment (MIN, first] when the ring does not start at MIN.
+    if first != i64::MIN {
+        ranges.push(RangeOwners {
+            start: i64::MIN,
+            end: first,
+            replicas: ring.replicas_for_strategy(i64::MIN, strategy),
+        });
+    }
+    for (i, &start) in tokens.iter().enumerate() {
+        let end = tokens.get(i + 1).copied().unwrap_or(i64::MAX);
+        ranges.push(RangeOwners {
+            start,
+            end,
+            replicas: ring.replicas_for_strategy(start, strategy),
+        });
+    }
+    ranges
+}
+
+/// A token range and the replica node-ids that own it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeOwners {
+    pub start: i64,
+    pub end: i64,
+    pub replicas: Vec<u64>,
+}
+
+/// Build one [`EndpointPlan`] per ring token range for `base_select`.
+///
+/// `resolve_flight_addr` maps a replica's ring node-id to its advertised Flight
+/// address; it returns `None` when the address is unknown (e.g. a node with no
+/// Flight broadcast configured), in which case that replica is simply omitted
+/// from the range's locations — the endpoint is still emitted so the data is
+/// not dropped, and the client falls back to the connection it queried on.
+///
+/// When the ring is empty (standalone / no cluster topology), a single plan is
+/// returned carrying the unbounded `base_select` and no location — preserving
+/// the prior single-self-endpoint behavior.
+pub fn distributed_endpoints<F>(
+    base_select: &str,
+    pk_columns: &[String],
+    ring: &TokenRing,
+    strategy: &ReplicationStrategy,
+    mut resolve_flight_addr: F,
+) -> Vec<EndpointPlan>
+where
+    F: FnMut(u64) -> Option<String>,
+{
+    let ranges = ring_token_ranges(ring, strategy);
+    if ranges.is_empty() {
+        return vec![EndpointPlan {
+            ticket_cql: base_select.to_string(),
+            locations: Vec::new(),
+        }];
+    }
+    ranges
+        .into_iter()
+        .map(|r| EndpointPlan {
+            ticket_cql: token_bounded_select(base_select, pk_columns, r.start, r.end),
+            locations: r
+                .replicas
+                .iter()
+                .filter_map(|&nid| resolve_flight_addr(nid))
+                .collect(),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use ferrosa_cluster::raft::{NodeInfo, NodeState};
+    use uuid::Uuid;
+
+    fn ring_node(addr: &str) -> NodeInfo {
+        NodeInfo {
+            host_id: Uuid::new_v4(),
+            addr: addr.to_string(),
+            data_center: "dc1".to_string(),
+            rack: "rack1".to_string(),
+            state: NodeState::Normal,
+            cql_broadcast: None,
+        }
+    }
+
+    fn simple(rf: usize) -> ReplicationStrategy {
+        ReplicationStrategy::Simple {
+            replication_factor: rf,
+        }
+    }
+
+    #[test]
+    fn empty_ring_yields_single_unbounded_endpoint() {
+        let ring = TokenRing::new();
+        let plans = distributed_endpoints(
+            "SELECT * FROM ks.t",
+            &["id".to_string()],
+            &ring,
+            &simple(1),
+            |_| Some("grpc://node:50051".to_string()),
+        );
+        assert_eq!(plans.len(), 1, "standalone/empty ring → one endpoint");
+        assert_eq!(plans[0].ticket_cql, "SELECT * FROM ks.t");
+        assert!(
+            plans[0].locations.is_empty(),
+            "self endpoint carries no explicit location"
+        );
+    }
+
+    #[test]
+    fn multi_node_ring_yields_endpoint_per_range_with_distinct_tickets() {
+        let mut ring = TokenRing::new();
+        ring.add_node(1, ring_node("10.0.0.1:7000"));
+        ring.add_node(2, ring_node("10.0.0.2:7000"));
+        ring.add_node(3, ring_node("10.0.0.3:7000"));
+        ring.assign_tokens(1, &[0]);
+        ring.assign_tokens(2, &[100]);
+        ring.assign_tokens(3, &[200]);
+
+        let plans = distributed_endpoints(
+            "SELECT id FROM ks.t",
+            &["id".to_string()],
+            &ring,
+            &simple(1),
+            |nid| Some(format!("grpc://10.0.0.{nid}:50051")),
+        );
+
+        // Ranges: (MIN,0], (0,100], (100,200], (200,MAX] → 4 ranges.
+        assert_eq!(plans.len(), 4, "one endpoint per ring range: {plans:?}");
+
+        // Every ticket is a distinct token-bounded SELECT.
+        let tickets: std::collections::HashSet<&str> =
+            plans.iter().map(|p| p.ticket_cql.as_str()).collect();
+        assert_eq!(tickets.len(), plans.len(), "distinct range tickets");
+        for p in &plans {
+            assert!(
+                p.ticket_cql.contains("token(id) >") && p.ticket_cql.contains("token(id) <="),
+                "ticket carries token bounds: {}",
+                p.ticket_cql
+            );
+            assert_eq!(p.locations.len(), 1, "RF=1 → exactly one replica location");
+            assert!(
+                p.locations[0].starts_with("grpc://10.0.0."),
+                "location is the owning replica's Flight addr: {:?}",
+                p.locations
+            );
+        }
+    }
+
+    #[test]
+    fn rf_greater_than_one_advertises_multiple_replica_locations() {
+        let mut ring = TokenRing::new();
+        ring.add_node(1, ring_node("10.0.0.1:7000"));
+        ring.add_node(2, ring_node("10.0.0.2:7000"));
+        ring.add_node(3, ring_node("10.0.0.3:7000"));
+        ring.assign_tokens(1, &[0]);
+        ring.assign_tokens(2, &[100]);
+        ring.assign_tokens(3, &[200]);
+
+        let plans = distributed_endpoints(
+            "SELECT id FROM ks.t",
+            &["id".to_string()],
+            &ring,
+            &simple(2),
+            |nid| Some(format!("grpc://10.0.0.{nid}:50051")),
+        );
+        assert!(
+            plans.iter().all(|p| p.locations.len() == 2),
+            "RF=2 → two replica locations per range: {plans:?}"
+        );
+    }
+
+    #[test]
+    fn unresolvable_replica_address_is_omitted_not_faked() {
+        let mut ring = TokenRing::new();
+        ring.add_node(1, ring_node("10.0.0.1:7000"));
+        ring.add_node(2, ring_node("10.0.0.2:7000"));
+        ring.assign_tokens(1, &[0]);
+        ring.assign_tokens(2, &[100]);
+
+        // Node 2 has no resolvable Flight address.
+        let plans = distributed_endpoints(
+            "SELECT id FROM ks.t",
+            &["id".to_string()],
+            &ring,
+            &simple(1),
+            |nid| (nid == 1).then(|| "grpc://10.0.0.1:50051".to_string()),
+        );
+        // Ranges owned by node 2 have zero locations (no fabricated address),
+        // but the endpoint is still present so the data is reachable.
+        assert!(
+            plans.iter().any(|p| p.locations.is_empty()),
+            "node-2 range emits an endpoint with no faked location: {plans:?}"
+        );
+        assert!(
+            plans
+                .iter()
+                .any(|p| p.locations == vec!["grpc://10.0.0.1:50051"]),
+            "node-1 ranges still carry the real location: {plans:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod token_bound_tests {
     use super::*;
 
     #[test]

--- a/ferrosa-flight/src/plan.rs
+++ b/ferrosa-flight/src/plan.rs
@@ -1,0 +1,73 @@
+//! Distributed-read planning (W-002).
+//!
+//! The CQL `SELECT` path supports `token(pk)` predicates, so a per-token-range
+//! Flight read is just the base `SELECT` plus a `token(...)` bound. This module
+//! generates those bounded statements. `GetFlightInfo` will emit one
+//! `FlightEndpoint` per ring token range — each ticket a bounded `SELECT`,
+//! located on the replica that owns the range — letting a client read ranges in
+//! parallel.
+//!
+//! Cluster-dependent prerequisites (tracked follow-ups, NOT in this module):
+//! ring token-range enumeration from `cluster_state`, and advertising each
+//! node's Flight gRPC address (the topology currently tracks only the
+//! internode/CQL addresses), needed for `FlightEndpoint` locations.
+
+/// Append a half-open `(start, end]` token-range bound to a base `SELECT`.
+///
+/// `pk_columns` are the partition-key columns for the `token(...)` call (in key
+/// order). The half-open convention matches Cassandra's ring ranges; the full
+/// ring is one `(MIN, MAX]` range, so wrap-around is avoided by treating MIN as
+/// an exclusive sentinel.
+pub fn token_bounded_select(
+    base_select: &str,
+    pk_columns: &[String],
+    start: i64,
+    end: i64,
+) -> String {
+    let pks = pk_columns.join(", ");
+    let bound = format!("token({pks}) > {start} AND token({pks}) <= {end}");
+    if base_select.to_ascii_lowercase().contains(" where ") {
+        format!("{base_select} AND {bound}")
+    } else {
+        format!("{base_select} WHERE {bound}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn appends_where_when_absent() {
+        let s = token_bounded_select("SELECT id FROM ks.t", &["id".to_string()], -10, 20);
+        assert_eq!(
+            s,
+            "SELECT id FROM ks.t WHERE token(id) > -10 AND token(id) <= 20"
+        );
+    }
+
+    #[test]
+    fn appends_and_when_where_present() {
+        let s = token_bounded_select(
+            "SELECT id FROM ks.t WHERE id = 5",
+            &["id".to_string()],
+            0,
+            9,
+        );
+        assert_eq!(
+            s,
+            "SELECT id FROM ks.t WHERE id = 5 AND token(id) > 0 AND token(id) <= 9"
+        );
+    }
+
+    #[test]
+    fn composite_partition_key() {
+        let s = token_bounded_select(
+            "SELECT * FROM ks.t",
+            &["a".to_string(), "b".to_string()],
+            1,
+            2,
+        );
+        assert!(s.contains("token(a, b) > 1 AND token(a, b) <= 2"), "{s}");
+    }
+}

--- a/ferrosa-flight/src/server.rs
+++ b/ferrosa-flight/src/server.rs
@@ -1,0 +1,47 @@
+//! Flight gRPC server bootstrap.
+//!
+//! `flight_service` wraps [`FerrosaFlight`] in the generated
+//! `FlightServiceServer` so callers can mount it on a `tonic` server (with
+//! their own TLS / shutdown / incoming wiring); `serve` is the simple
+//! bind-and-run path used by the binary.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use arrow_flight::flight_service_server::FlightServiceServer;
+
+use ferrosa_cql::router::SharedState;
+
+use crate::service::FerrosaFlight;
+
+/// Wrap the Flight service in its gRPC server adapter, ready to add to a
+/// `tonic::transport::Server` (or serve over a custom incoming stream in tests).
+pub fn flight_service(
+    state: Arc<SharedState>,
+    signing_key: Vec<u8>,
+) -> FlightServiceServer<FerrosaFlight> {
+    FlightServiceServer::new(FerrosaFlight::new(state, signing_key))
+}
+
+/// Serve a pre-configured Flight service (e.g. with key rotation / custom TTL).
+pub async fn serve_service(
+    addr: SocketAddr,
+    service: FerrosaFlight,
+) -> Result<(), tonic::transport::Error> {
+    tonic::transport::Server::builder()
+        .add_service(FlightServiceServer::new(service))
+        .serve(addr)
+        .await
+}
+
+/// Serve the Flight endpoint on `addr` until the future is dropped/cancelled.
+///
+/// Auth is enforced per-RPC (see [`crate::service`]); the endpoint is only
+/// anonymous-safe because every read RPC requires a verified bearer token.
+pub async fn serve(
+    addr: SocketAddr,
+    state: Arc<SharedState>,
+    signing_key: Vec<u8>,
+) -> Result<(), tonic::transport::Error> {
+    serve_service(addr, FerrosaFlight::new(state, signing_key)).await
+}

--- a/ferrosa-flight/src/service.rs
+++ b/ferrosa-flight/src/service.rs
@@ -813,7 +813,7 @@ impl FlightService for FerrosaFlight {
         Ok(Response::new(Box::pin(acks) as Self::DoExchangeStream))
     }
 
-    /// Handle a supported action (see [`SUPPORTED_ACTIONS`]). `server.info`
+    /// Handle a supported action (see `SUPPORTED_ACTIONS`). `server.info`
     /// reports the service name + crate version; `token.validate` echoes the
     /// verified bearer identity. Both require auth; any other type is rejected
     /// with `InvalidArgument`.

--- a/ferrosa-flight/src/service.rs
+++ b/ferrosa-flight/src/service.rs
@@ -1,0 +1,521 @@
+//! Arrow Flight gRPC service — read path (`DoGet` / `GetFlightInfo` / `GetSchema`).
+//!
+//! A client places a CQL `SELECT` string in the Flight command/ticket; it is
+//! executed by `ferrosa-cql` (`route_select_raw`) and the result is converted
+//! to Arrow and streamed back. `DoPut` writes Arrow rows into the
+//! `ferrosa-table` (`keyspace.table` metadata header) as CQL INSERTs.
+//! `DoExchange` and `ListFlights` remain `Unimplemented`.
+//!
+//! Auth (decision D4): `Handshake` validates CQL credentials via
+//! `Schema::authenticate` and returns a signed bearer token; every other RPC
+//! requires `authorization: Bearer <token>`, and the request's `AuthContext` is
+//! derived from the verified token claims — there is no anonymous access.
+//!
+//! `DoGet` streams the result one page at a time (FMEA F5), so peak memory is
+//! bounded to a single page rather than the whole result set.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use arrow::record_batch::RecordBatch;
+use arrow_flight::encode::FlightDataEncoderBuilder;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::{
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
+    HandshakeRequest, HandshakeResponse, PollInfo, SchemaResult, Ticket,
+};
+use futures::{Stream, TryStreamExt};
+use tonic::{Request, Response, Status, Streaming};
+
+use ferrosa_common::CqlValue;
+use ferrosa_cql::ast::Statement;
+use ferrosa_cql::router::{RequestContext, SharedState};
+
+type BoxStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send>>;
+
+/// Lifetime of a bearer token issued by `Handshake`, in seconds.
+const TOKEN_TTL_SECS: u64 = 3600;
+
+/// Rows per page for `DoGet` streaming. Bounds peak memory to one page rather
+/// than materializing the whole result set.
+const DEFAULT_PAGE_SIZE: usize = 1024;
+
+/// Ferrosa's Arrow Flight service. Executes CQL queries and streams Arrow.
+pub struct FerrosaFlight {
+    state: Arc<SharedState>,
+    /// HMAC keys for bearer tokens. `[0]` is the current key (used to sign new
+    /// tokens); all keys are accepted on verify, giving a rotation overlap
+    /// window during which tokens signed by a just-retired key still validate.
+    signing_keys: Vec<Vec<u8>>,
+    /// Lifetime of issued tokens, seconds.
+    token_ttl_secs: u64,
+    /// Rows per `DoGet` page (peak-memory bound).
+    page_size: usize,
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+impl FerrosaFlight {
+    /// Build the service over the shared CQL execution state and the current
+    /// token-signing key.
+    pub fn new(state: Arc<SharedState>, signing_key: Vec<u8>) -> Self {
+        Self {
+            state,
+            signing_keys: vec![signing_key],
+            token_ttl_secs: TOKEN_TTL_SECS,
+            page_size: DEFAULT_PAGE_SIZE,
+        }
+    }
+
+    /// Add previous signing keys still accepted on verify (rotation overlap).
+    /// New tokens are always signed with the current key (`new`'s key).
+    pub fn with_previous_keys(mut self, previous: impl IntoIterator<Item = Vec<u8>>) -> Self {
+        self.signing_keys.extend(previous);
+        self
+    }
+
+    /// Override the issued-token TTL (seconds). Clamped to >= 1.
+    pub fn with_token_ttl(mut self, secs: u64) -> Self {
+        self.token_ttl_secs = secs.max(1);
+        self
+    }
+
+    /// Override the `DoGet` page size (rows per streamed batch). Clamped to >= 1.
+    pub fn with_page_size(mut self, page_size: usize) -> Self {
+        self.page_size = page_size.max(1);
+        self
+    }
+
+    /// Verify the `authorization: Bearer <token>` header and derive the
+    /// request's `AuthContext`. Missing/invalid/expired -> `Unauthenticated`.
+    // `Status` is tonic's standard (large) error type, used uniformly by every
+    // RPC; boxing it here would just force unboxing at the `?` call sites.
+    #[allow(clippy::result_large_err)]
+    fn authenticate(
+        &self,
+        metadata: &tonic::metadata::MetadataMap,
+    ) -> Result<ferrosa_schema::AuthContext, Status> {
+        let header = metadata
+            .get("authorization")
+            .ok_or_else(|| Status::unauthenticated("missing bearer token"))?;
+        let token = header
+            .to_str()
+            .map_err(|_| Status::unauthenticated("invalid authorization header"))?
+            .strip_prefix("Bearer ")
+            .ok_or_else(|| Status::unauthenticated("expected 'Bearer <token>'"))?;
+        let claims = crate::token::verify_with_keys(&self.signing_keys, token, now_secs())
+            .map_err(|e| Status::unauthenticated(format!("authentication failed: {e}")))?;
+        Ok(ferrosa_schema::AuthContext {
+            role: claims.role,
+            is_superuser: claims.is_superuser,
+            must_change_password: false,
+        })
+    }
+
+    /// Parse a Flight command, requiring a `SELECT`.
+    #[allow(clippy::result_large_err)] // tonic Status is the uniform RPC error type
+    fn parse_select(cql: &str) -> Result<ferrosa_cql::ast::SelectStatement, Status> {
+        match ferrosa_cql::parser::parse(cql)
+            .map_err(|e| Status::invalid_argument(format!("CQL parse error: {e}")))?
+        {
+            Statement::Select(s) => Ok(s),
+            _ => Err(Status::invalid_argument(
+                "Flight command must be a SELECT statement",
+            )),
+        }
+    }
+
+    /// Execute a CQL SELECT under `auth` and convert one (small) page to a single
+    /// Arrow batch — used by `GetFlightInfo`/`GetSchema`, which only need the
+    /// schema, so this fetches just one page rather than the whole result.
+    async fn query_to_batch(
+        &self,
+        cql: &str,
+        auth: &ferrosa_schema::AuthContext,
+    ) -> Result<RecordBatch, Status> {
+        let select = Self::parse_select(cql)?;
+        let ks: Option<String> = None;
+        let ctx = RequestContext {
+            auth,
+            current_keyspace: &ks,
+            consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: ferrosa_cql::paging::PagingParams {
+                page_size: Some(1),
+                paging_state: None,
+            },
+            client_address: String::new(),
+        };
+
+        let raw = ferrosa_cql::router::route_select_raw(&self.state, &ctx, &select)
+            .await
+            .map_err(|e| Status::internal(format!("query execution failed: {e}")))?;
+
+        crate::convert::rows_to_record_batch(&raw.column_names, &raw.column_types, &raw.rows)
+            .map_err(|e| Status::internal(format!("Arrow conversion failed: {e}")))
+    }
+}
+
+/// Paging cursor state for the streaming `DoGet`.
+enum Page {
+    /// Fetch the next page using this continuation (None on the first page).
+    Fetch(Option<Vec<u8>>),
+    /// All pages delivered.
+    Done,
+}
+
+/// A CQL identifier: leading letter/underscore, then alphanumerics/underscores.
+/// Used to reject injection via column/table names (which are interpolated into
+/// generated INSERTs, unlike values which are escaped literals).
+fn valid_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// `keyspace.table`, both valid identifiers.
+fn valid_table(t: &str) -> bool {
+    matches!(t.split_once('.'), Some((ks, tbl)) if valid_ident(ks) && valid_ident(tbl))
+}
+
+/// Render a CQL value as a literal for a generated INSERT. Strings are escaped
+/// (`'` -> `''`) and blobs hex-encoded, so interpolation is injection-safe.
+/// `None` for NULL/non-finite-float/unsupported -> the column is omitted.
+fn cql_literal(v: &CqlValue) -> Option<String> {
+    Some(match v {
+        CqlValue::Int(n) => n.to_string(),
+        CqlValue::Bigint(n) | CqlValue::Counter(n) | CqlValue::Timestamp(n) => n.to_string(),
+        CqlValue::Smallint(n) => n.to_string(),
+        CqlValue::Tinyint(n) => n.to_string(),
+        CqlValue::Boolean(b) => b.to_string(),
+        CqlValue::Float(bits) => {
+            let f = f32::from_bits(*bits);
+            if !f.is_finite() {
+                return None;
+            }
+            format!("{f}")
+        }
+        CqlValue::Double(bits) => {
+            let f = f64::from_bits(*bits);
+            if !f.is_finite() {
+                return None;
+            }
+            format!("{f}")
+        }
+        CqlValue::Text(s) | CqlValue::Ascii(s) => format!("'{}'", s.replace('\'', "''")),
+        CqlValue::Blob(b) => format!("0x{}", hex::encode(b)),
+        _ => return None,
+    })
+}
+
+/// Build an `INSERT INTO <table> (...) VALUES (...)` for one row, including only
+/// the present, representable columns. `Ok(None)` if the row has nothing to
+/// write. Errors on an invalid column identifier (injection guard).
+#[allow(clippy::result_large_err)] // tonic Status is the uniform RPC error type
+fn build_insert(
+    table: &str,
+    names: &[String],
+    row: &[Option<CqlValue>],
+) -> Result<Option<String>, Status> {
+    let mut cols = Vec::new();
+    let mut vals = Vec::new();
+    for (name, cell) in names.iter().zip(row) {
+        let Some(value) = cell else { continue };
+        let Some(lit) = cql_literal(value) else {
+            continue;
+        };
+        if !valid_ident(name) {
+            return Err(Status::invalid_argument(format!(
+                "invalid column identifier {name:?}"
+            )));
+        }
+        cols.push(name.as_str());
+        vals.push(lit);
+    }
+    if cols.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(format!(
+        "INSERT INTO {table} ({}) VALUES ({})",
+        cols.join(", "),
+        vals.join(", ")
+    )))
+}
+
+#[tonic::async_trait]
+impl FlightService for FerrosaFlight {
+    type HandshakeStream = BoxStream<HandshakeResponse>;
+    type ListFlightsStream = BoxStream<FlightInfo>;
+    type DoGetStream = BoxStream<FlightData>;
+    type DoPutStream = BoxStream<arrow_flight::PutResult>;
+    type DoExchangeStream = BoxStream<FlightData>;
+    type DoActionStream = BoxStream<arrow_flight::Result>;
+    type ListActionsStream = BoxStream<ActionType>;
+
+    /// Stream the result of the CQL query carried in the ticket, one page at a
+    /// time, so peak memory is bounded to a single page rather than the whole
+    /// result. The first page is always emitted (even with zero rows) so the
+    /// client still receives the schema.
+    async fn do_get(
+        &self,
+        request: Request<Ticket>,
+    ) -> Result<Response<Self::DoGetStream>, Status> {
+        let auth = self.authenticate(request.metadata())?;
+        let cql = String::from_utf8(request.into_inner().ticket.to_vec())
+            .map_err(|_| Status::invalid_argument("ticket is not valid UTF-8 CQL"))?;
+        // Validate it is a SELECT up front so a bad command fails the call (not
+        // mid-stream).
+        let select = Self::parse_select(&cql)?;
+
+        let state = Arc::clone(&self.state);
+        let page_size = self.page_size as i32;
+
+        let batches = futures::stream::unfold(Page::Fetch(None), move |page| {
+            let state = Arc::clone(&state);
+            let select = select.clone();
+            let auth = auth.clone();
+            async move {
+                let cursor = match page {
+                    Page::Done => return None,
+                    Page::Fetch(cursor) => cursor,
+                };
+                let ks: Option<String> = None;
+                let ctx = RequestContext {
+                    auth: &auth,
+                    current_keyspace: &ks,
+                    consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+                    serial_consistency: None,
+                    paging: ferrosa_cql::paging::PagingParams {
+                        page_size: Some(page_size),
+                        paging_state: cursor,
+                    },
+                    client_address: String::new(),
+                };
+                match ferrosa_cql::router::route_select_raw(&state, &ctx, &select).await {
+                    Ok(page_res) => {
+                        let next = match page_res.paging_state {
+                            Some(c) => Page::Fetch(Some(c)),
+                            None => Page::Done,
+                        };
+                        let batch = crate::convert::rows_to_record_batch(
+                            &page_res.column_names,
+                            &page_res.column_types,
+                            &page_res.rows,
+                        )
+                        .map_err(|e| FlightError::ExternalError(e.to_string().into()));
+                        Some((batch, next))
+                    }
+                    Err(e) => Some((
+                        Err(FlightError::ExternalError(
+                            format!("query execution failed: {e}").into(),
+                        )),
+                        Page::Done,
+                    )),
+                }
+            }
+        });
+
+        // Schema is inferred from the first emitted batch (always present).
+        let flight_data = FlightDataEncoderBuilder::new()
+            .build(batches)
+            .map_err(|e| Status::internal(format!("Flight encode error: {e}")));
+
+        Ok(Response::new(Box::pin(flight_data) as Self::DoGetStream))
+    }
+
+    /// Return the schema (and a single self-endpoint) for a CQL command.
+    async fn get_flight_info(
+        &self,
+        request: Request<FlightDescriptor>,
+    ) -> Result<Response<FlightInfo>, Status> {
+        let auth = self.authenticate(request.metadata())?;
+        let descriptor = request.into_inner();
+        let cql = String::from_utf8(descriptor.cmd.to_vec())
+            .map_err(|_| Status::invalid_argument("descriptor.cmd is not valid UTF-8 CQL"))?;
+        let batch = self.query_to_batch(&cql, &auth).await?;
+        let schema = batch.schema();
+
+        // Single endpoint: the client redeems the same CQL ticket on this
+        // connection (distributed per-token-range endpoints are W-002).
+        let endpoint = FlightEndpoint::new().with_ticket(Ticket {
+            ticket: descriptor.cmd.clone(),
+        });
+        let info = FlightInfo::new()
+            .try_with_schema(&schema)
+            .map_err(|e| Status::internal(format!("schema encode error: {e}")))?
+            .with_descriptor(descriptor)
+            .with_endpoint(endpoint);
+        Ok(Response::new(info))
+    }
+
+    /// Return just the Arrow schema for a CQL command.
+    async fn get_schema(
+        &self,
+        request: Request<FlightDescriptor>,
+    ) -> Result<Response<SchemaResult>, Status> {
+        let auth = self.authenticate(request.metadata())?;
+        let cql = String::from_utf8(request.into_inner().cmd.to_vec())
+            .map_err(|_| Status::invalid_argument("descriptor.cmd is not valid UTF-8 CQL"))?;
+        let batch = self.query_to_batch(&cql, &auth).await?;
+        let options = arrow::ipc::writer::IpcWriteOptions::default();
+        let result = SchemaResult::try_from(arrow_flight::SchemaAsIpc::new(
+            batch.schema().as_ref(),
+            &options,
+        ))
+        .map_err(|e| Status::internal(format!("schema encode error: {e}")))?;
+        Ok(Response::new(result))
+    }
+
+    /// Validate `username\0password` credentials and return a signed bearer
+    /// token in the response payload for use on subsequent RPCs.
+    async fn handshake(
+        &self,
+        request: Request<Streaming<HandshakeRequest>>,
+    ) -> Result<Response<Self::HandshakeStream>, Status> {
+        let mut stream = request.into_inner();
+        let msg = stream
+            .message()
+            .await?
+            .ok_or_else(|| Status::unauthenticated("empty handshake stream"))?;
+
+        let payload = msg.payload;
+        let sep = payload
+            .iter()
+            .position(|&b| b == 0)
+            .ok_or_else(|| Status::unauthenticated("payload must be username\\0password"))?;
+        let username = std::str::from_utf8(&payload[..sep])
+            .map_err(|_| Status::unauthenticated("username is not valid UTF-8"))?;
+        let password = std::str::from_utf8(&payload[sep + 1..])
+            .map_err(|_| Status::unauthenticated("password is not valid UTF-8"))?;
+
+        let auth = self
+            .state
+            .schema
+            .authenticate(username, password)
+            .map_err(|_| Status::unauthenticated("invalid credentials"))?;
+
+        let claims = crate::token::Claims {
+            role: auth.role,
+            is_superuser: auth.is_superuser,
+            expires_at: now_secs() + self.token_ttl_secs,
+        };
+        let token = crate::token::issue(&self.signing_keys[0], &claims);
+        let response = HandshakeResponse {
+            protocol_version: 0,
+            payload: token.into_bytes().into(),
+        };
+        Ok(Response::new(
+            Box::pin(futures::stream::once(async move { Ok(response) })) as Self::HandshakeStream,
+        ))
+    }
+
+    async fn list_flights(
+        &self,
+        _request: Request<Criteria>,
+    ) -> Result<Response<Self::ListFlightsStream>, Status> {
+        Err(Status::unimplemented("ListFlights not implemented"))
+    }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("PollFlightInfo not implemented"))
+    }
+
+    /// Write Arrow rows into `keyspace.table` (from the `ferrosa-table`
+    /// metadata header). Each row becomes a CQL INSERT routed through the normal
+    /// write path (key/token derivation, consistency, replication). Returns the
+    /// number of rows written in the `PutResult` app metadata.
+    async fn do_put(
+        &self,
+        request: Request<Streaming<FlightData>>,
+    ) -> Result<Response<Self::DoPutStream>, Status> {
+        let auth = self.authenticate(request.metadata())?;
+        let table = request
+            .metadata()
+            .get("ferrosa-table")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| {
+                Status::invalid_argument("missing 'ferrosa-table' metadata (keyspace.table)")
+            })?
+            .to_string();
+        if !valid_table(&table) {
+            return Err(Status::invalid_argument(
+                "'ferrosa-table' must be keyspace.table identifiers",
+            ));
+        }
+
+        let stream = request
+            .into_inner()
+            .map_err(|s| FlightError::ExternalError(Box::new(s)));
+        let mut batches =
+            arrow_flight::decode::FlightRecordBatchStream::new_from_flight_data(stream);
+
+        let mut written: i64 = 0;
+        while let Some(batch) = batches
+            .try_next()
+            .await
+            .map_err(|e| Status::invalid_argument(format!("Flight decode error: {e}")))?
+        {
+            let (names, rows) = crate::convert::record_batch_to_rows(&batch)
+                .map_err(|e| Status::invalid_argument(format!("Arrow conversion failed: {e}")))?;
+            for row in &rows {
+                let Some(sql) = build_insert(&table, &names, row)? else {
+                    continue;
+                };
+                let stmt = ferrosa_cql::parser::parse(&sql)
+                    .map_err(|e| Status::internal(format!("generated CQL parse error: {e}")))?;
+                let ks: Option<String> = None;
+                let ctx = RequestContext {
+                    auth: &auth,
+                    current_keyspace: &ks,
+                    consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+                    serial_consistency: None,
+                    paging: ferrosa_cql::paging::PagingParams::default(),
+                    client_address: String::new(),
+                };
+                ferrosa_cql::router::route(&self.state, &ctx, stmt)
+                    .await
+                    .map_err(|e| Status::internal(format!("write failed: {e}")))?;
+                written += 1;
+            }
+        }
+
+        let result = arrow_flight::PutResult {
+            app_metadata: written.to_string().into_bytes().into(),
+        };
+        Ok(Response::new(
+            Box::pin(futures::stream::once(async move { Ok(result) })) as Self::DoPutStream,
+        ))
+    }
+
+    async fn do_exchange(
+        &self,
+        _request: Request<Streaming<FlightData>>,
+    ) -> Result<Response<Self::DoExchangeStream>, Status> {
+        Err(Status::unimplemented(
+            "DoExchange not implemented (channel slice pending)",
+        ))
+    }
+
+    async fn do_action(
+        &self,
+        _request: Request<Action>,
+    ) -> Result<Response<Self::DoActionStream>, Status> {
+        Err(Status::unimplemented("DoAction not implemented"))
+    }
+
+    async fn list_actions(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<Self::ListActionsStream>, Status> {
+        Err(Status::unimplemented("ListActions not implemented"))
+    }
+}

--- a/ferrosa-flight/src/service.rs
+++ b/ferrosa-flight/src/service.rs
@@ -44,6 +44,39 @@ const TOKEN_TTL_SECS: u64 = 3600;
 /// than materializing the whole result set.
 const DEFAULT_PAGE_SIZE: usize = 1024;
 
+/// Default Flight gRPC port advertised in distributed `FlightEndpoint`
+/// locations. Used for remote replicas (whose ring metadata records only the
+/// internode address) when `FERROSA_FLIGHT_PORT` is unset.
+const DEFAULT_FLIGHT_PORT: u16 = 50051;
+
+/// Env var: this node's externally-reachable Flight address advertised to
+/// clients (e.g. `grpc://flight.example.com:50051`). Used as the location for
+/// ranges this node owns.
+const ENV_FLIGHT_BROADCAST: &str = "FERROSA_FLIGHT_BROADCAST";
+
+/// Env var: the Flight gRPC port to combine with a remote replica's internode
+/// host when building its advertised location.
+const ENV_FLIGHT_PORT: &str = "FERROSA_FLIGHT_PORT";
+
+/// Resolve the Flight gRPC port for remote replica locations from the
+/// environment, falling back to [`DEFAULT_FLIGHT_PORT`].
+fn flight_port_from_env() -> u16 {
+    std::env::var(ENV_FLIGHT_PORT)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_FLIGHT_PORT)
+}
+
+/// This node's advertised Flight address from [`ENV_FLIGHT_BROADCAST`], if set.
+/// Fail-loud contract: when unset we return `None` and the caller advertises no
+/// location for self-owned ranges (the client falls back to the connection it
+/// queried on) rather than fabricating an address that may be unreachable.
+fn flight_broadcast_from_env() -> Option<String> {
+    std::env::var(ENV_FLIGHT_BROADCAST)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
 /// Ferrosa's Arrow Flight service. Executes CQL queries and streams Arrow.
 pub struct FerrosaFlight {
     state: Arc<SharedState>,
@@ -55,6 +88,14 @@ pub struct FerrosaFlight {
     token_ttl_secs: u64,
     /// Rows per `DoGet` page (peak-memory bound).
     page_size: usize,
+    /// This node's externally-reachable Flight address, advertised as the
+    /// location for ranges this node owns. `None` when `FERROSA_FLIGHT_BROADCAST`
+    /// is unset — self-owned ranges then advertise no location (the client
+    /// falls back to the connection it queried on) rather than a faked address.
+    flight_advertise: Option<String>,
+    /// Flight gRPC port combined with a remote replica's internode host to
+    /// build its advertised location (the ring records only internode addrs).
+    flight_port: u16,
 }
 
 fn now_secs() -> u64 {
@@ -73,7 +114,22 @@ impl FerrosaFlight {
             signing_keys: vec![signing_key],
             token_ttl_secs: TOKEN_TTL_SECS,
             page_size: DEFAULT_PAGE_SIZE,
+            flight_advertise: flight_broadcast_from_env(),
+            flight_port: flight_port_from_env(),
         }
+    }
+
+    /// Override this node's advertised Flight address (the location used for
+    /// ranges this node owns). Overrides `FERROSA_FLIGHT_BROADCAST`.
+    pub fn with_flight_advertise(mut self, addr: impl Into<String>) -> Self {
+        self.flight_advertise = Some(addr.into());
+        self
+    }
+
+    /// Override the Flight gRPC port used to build remote replica locations.
+    pub fn with_flight_port(mut self, port: u16) -> Self {
+        self.flight_port = port;
+        self
     }
 
     /// Add previous signing keys still accepted on verify (rotation overlap).
@@ -222,6 +278,101 @@ impl FerrosaFlight {
             .into_iter()
             .map(|(ks, tbl)| format!("SELECT * FROM {ks}.{tbl}"))
             .collect()
+    }
+
+    /// Resolve the keyspace for a `SELECT`: the explicit `ks.table` prefix wins,
+    /// else there is none (this front-end has no per-session keyspace), which we
+    /// surface to the caller as "cannot scope to a single table".
+    fn select_keyspace(select: &ferrosa_cql::ast::SelectStatement) -> Option<&str> {
+        select.keyspace.as_deref()
+    }
+
+    /// The partition-key columns of `ks.table`, in key order, from the live
+    /// schema snapshot. `None` if the table is unknown (then we cannot build
+    /// `token(...)` bounds and fall back to a single endpoint).
+    fn partition_key_columns(&self, ks: &str, table: &str) -> Option<Vec<String>> {
+        let snap = self.state.schema.snapshot();
+        snap.tables
+            .get(&(ks.to_string(), table.to_string()))
+            .map(|t| t.partition_key.clone())
+    }
+
+    /// The keyspace's replication strategy from the live schema snapshot,
+    /// defaulting to `Simple{rf:1}` when unknown (matches the router's default).
+    fn keyspace_strategy(&self, ks: &str) -> ferrosa_cluster::ring::strategy::ReplicationStrategy {
+        use ferrosa_cluster::ring::strategy::ReplicationStrategy;
+        let snap = self.state.schema.snapshot();
+        snap.keyspaces
+            .get(ks)
+            .and_then(|km| ReplicationStrategy::try_from(&km.replication).ok())
+            .unwrap_or(ReplicationStrategy::Simple {
+                replication_factor: 1,
+            })
+    }
+
+    /// Map a ring node-id to its advertised Flight URI.
+    ///
+    /// The local node (matched by `host_id` → ring node-id) advertises
+    /// `self.flight_advertise`; remote nodes combine their ring internode host
+    /// with `self.flight_port`. Returns `None` when the address is unknown so
+    /// the planner omits it rather than fabricating an unreachable location.
+    fn resolve_flight_addr(
+        &self,
+        ring: &ferrosa_cluster::ring::TokenRing,
+        local_node_id: u64,
+        node_id: u64,
+    ) -> Option<String> {
+        if node_id == local_node_id {
+            return self.flight_advertise.clone();
+        }
+        let info = ring.get_node(node_id)?;
+        let host = info
+            .addr
+            .rsplit_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(&info.addr);
+        Some(format!("grpc://{host}:{}", self.flight_port))
+    }
+
+    /// Build the distributed `FlightEndpoint` list for `select`.
+    ///
+    /// Returns one endpoint per ring token range when a cluster ring is present
+    /// and the table is known; otherwise `None`, signalling the caller to keep
+    /// the single self-endpoint (standalone / unknown-table behavior).
+    fn distributed_endpoints(
+        &self,
+        select: &ferrosa_cql::ast::SelectStatement,
+        base_cql: &str,
+    ) -> Option<Vec<FlightEndpoint>> {
+        let ring = self.state.core.mode_controller.token_ring()?;
+        let ks = Self::select_keyspace(select)?;
+        let pk = self.partition_key_columns(ks, &select.table)?;
+        let strategy = self.keyspace_strategy(ks);
+        let local_node_id =
+            ferrosa_cluster::raft::uuid_to_node_id(self.state.core.mode_controller.host_id());
+
+        let plans = crate::plan::distributed_endpoints(base_cql, &pk, &ring, &strategy, |nid| {
+            self.resolve_flight_addr(&ring, local_node_id, nid)
+        });
+        // A single whole-ring plan is indistinguishable from the standalone
+        // case — let the caller emit its self-endpoint instead.
+        if plans.len() <= 1 {
+            return None;
+        }
+        Some(
+            plans
+                .into_iter()
+                .map(|p| {
+                    let mut ep = FlightEndpoint::new().with_ticket(Ticket {
+                        ticket: p.ticket_cql.into_bytes().into(),
+                    });
+                    for loc in p.locations {
+                        ep = ep.with_location(loc);
+                    }
+                    ep
+                })
+                .collect(),
+        )
     }
 }
 
@@ -436,15 +587,42 @@ impl FlightService for FerrosaFlight {
         Ok(Response::new(Box::pin(flight_data) as Self::DoGetStream))
     }
 
-    /// Return the schema (and a single self-endpoint) for a CQL command.
+    /// Return the schema and the Flight endpoints for a CQL command.
+    ///
+    /// On a cluster topology with a known table, emits one `FlightEndpoint` per
+    /// token range — each ticket a token-bounded `SELECT`, located on the
+    /// replica(s) that own the range — so a client can read ranges in parallel
+    /// (W-002). On a standalone topology (or an unknown table) it emits a single
+    /// endpoint redeeming the original command on this connection.
     async fn get_flight_info(
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
         let auth = self.authenticate(request.metadata())?;
-        // Single endpoint: the client redeems the same CQL ticket on this
-        // connection (distributed per-token-range endpoints are W-002).
-        let info = self.flight_info_for(request.into_inner(), &auth).await?;
+        let descriptor = request.into_inner();
+        let cql = String::from_utf8(descriptor.cmd.to_vec())
+            .map_err(|_| Status::invalid_argument("descriptor.cmd is not valid UTF-8 CQL"))?;
+        let select = Self::parse_select(&cql)?;
+        let batch = self.query_to_batch(&cql, &auth).await?;
+        let schema = batch.schema();
+
+        let endpoints = self
+            .distributed_endpoints(&select, &cql)
+            .unwrap_or_else(|| {
+                // Standalone / unknown table: redeem the same CQL ticket on this
+                // connection (single self-endpoint, no explicit location).
+                vec![FlightEndpoint::new().with_ticket(Ticket {
+                    ticket: descriptor.cmd.clone(),
+                })]
+            });
+
+        let mut info = FlightInfo::new()
+            .try_with_schema(&schema)
+            .map_err(|e| Status::internal(format!("schema encode error: {e}")))?
+            .with_descriptor(descriptor);
+        for endpoint in endpoints {
+            info = info.with_endpoint(endpoint);
+        }
         Ok(Response::new(info))
     }
 

--- a/ferrosa-flight/src/service.rs
+++ b/ferrosa-flight/src/service.rs
@@ -6,8 +6,8 @@
 //! `ferrosa-table` (`keyspace.table` metadata header) as CQL INSERTs.
 //! `DoExchange` is a bidirectional streaming upsert: it consumes the same
 //! inbound Arrow batches as `DoPut` and emits one `FlightData` acknowledgement
-//! per batch (rows-applied count in `app_metadata`). `ListFlights` remains
-//! `Unimplemented`.
+//! per batch (rows-applied count in `app_metadata`). `ListFlights`,
+//! `PollFlightInfo`, `DoAction`, and `ListActions` are implemented.
 //!
 //! Auth (decision D4): `Handshake` validates CQL credentials via
 //! `Schema::authenticate` and returns a signed bearer token; every other RPC
@@ -181,6 +181,47 @@ impl FerrosaFlight {
 
         crate::convert::rows_to_record_batch(&raw.column_names, &raw.column_types, &raw.rows)
             .map_err(|e| Status::internal(format!("Arrow conversion failed: {e}")))
+    }
+
+    /// Build the `FlightInfo` for a CQL command `descriptor`: its Arrow schema
+    /// plus a single self-endpoint whose ticket is the same command (the client
+    /// redeems it via `do_get`). Shared by `get_flight_info` and
+    /// `poll_flight_info`.
+    #[allow(clippy::result_large_err)] // tonic Status is the uniform RPC error type
+    async fn flight_info_for(
+        &self,
+        descriptor: FlightDescriptor,
+        auth: &ferrosa_schema::AuthContext,
+    ) -> Result<FlightInfo, Status> {
+        let cql = String::from_utf8(descriptor.cmd.to_vec())
+            .map_err(|_| Status::invalid_argument("descriptor.cmd is not valid UTF-8 CQL"))?;
+        let batch = self.query_to_batch(&cql, auth).await?;
+        let endpoint = FlightEndpoint::new().with_ticket(Ticket {
+            ticket: descriptor.cmd.clone(),
+        });
+        FlightInfo::new()
+            .try_with_schema(&batch.schema())
+            .map_err(|e| Status::internal(format!("schema encode error: {e}")))
+            .map(|info| info.with_descriptor(descriptor).with_endpoint(endpoint))
+    }
+
+    /// The `SELECT * FROM ks.t` commands for every queryable (non-system) table,
+    /// sorted for determinism, optionally filtered to tables whose `ks.table`
+    /// name starts with `prefix`.
+    fn queryable_table_commands(&self, prefix: &str) -> Vec<String> {
+        let snapshot = self.state.schema.snapshot();
+        let mut tables: Vec<(String, String)> = snapshot
+            .tables
+            .keys()
+            .filter(|(ks, _)| !ferrosa_schema::is_system_keyspace(ks))
+            .filter(|(ks, tbl)| format!("{ks}.{tbl}").starts_with(prefix))
+            .cloned()
+            .collect();
+        tables.sort();
+        tables
+            .into_iter()
+            .map(|(ks, tbl)| format!("SELECT * FROM {ks}.{tbl}"))
+            .collect()
     }
 }
 
@@ -401,22 +442,9 @@ impl FlightService for FerrosaFlight {
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
         let auth = self.authenticate(request.metadata())?;
-        let descriptor = request.into_inner();
-        let cql = String::from_utf8(descriptor.cmd.to_vec())
-            .map_err(|_| Status::invalid_argument("descriptor.cmd is not valid UTF-8 CQL"))?;
-        let batch = self.query_to_batch(&cql, &auth).await?;
-        let schema = batch.schema();
-
         // Single endpoint: the client redeems the same CQL ticket on this
         // connection (distributed per-token-range endpoints are W-002).
-        let endpoint = FlightEndpoint::new().with_ticket(Ticket {
-            ticket: descriptor.cmd.clone(),
-        });
-        let info = FlightInfo::new()
-            .try_with_schema(&schema)
-            .map_err(|e| Status::internal(format!("schema encode error: {e}")))?
-            .with_descriptor(descriptor)
-            .with_endpoint(endpoint);
+        let info = self.flight_info_for(request.into_inner(), &auth).await?;
         Ok(Response::new(info))
     }
 
@@ -481,18 +509,44 @@ impl FlightService for FerrosaFlight {
         ))
     }
 
+    /// Enumerate the queryable (non-system) tables as `FlightInfo` entries: one
+    /// per table, each carrying its Arrow schema and a `SELECT * FROM ks.t`
+    /// ticket that `do_get` accepts. An optional `Criteria.expression` (UTF-8)
+    /// filters to tables whose `ks.table` name starts with that prefix.
     async fn list_flights(
         &self,
-        _request: Request<Criteria>,
+        request: Request<Criteria>,
     ) -> Result<Response<Self::ListFlightsStream>, Status> {
-        Err(Status::unimplemented("ListFlights not implemented"))
+        let auth = self.authenticate(request.metadata())?;
+        let prefix = String::from_utf8(request.into_inner().expression.to_vec())
+            .map_err(|_| Status::invalid_argument("criteria expression is not valid UTF-8"))?;
+
+        let mut flights = Vec::new();
+        for cql in self.queryable_table_commands(&prefix) {
+            let descriptor = FlightDescriptor::new_cmd(cql.into_bytes());
+            flights.push(self.flight_info_for(descriptor, &auth).await?);
+        }
+        let stream = futures::stream::iter(flights.into_iter().map(Ok));
+        Ok(Response::new(Box::pin(stream) as Self::ListFlightsStream))
     }
 
+    /// Resolve a query descriptor to its `FlightInfo` (the same one
+    /// `get_flight_info` produces) and report it complete: the result is ready
+    /// immediately, so progress is `1.0` and there is no continuation
+    /// descriptor (long-running async polling is W-002).
     async fn poll_flight_info(
         &self,
-        _request: Request<FlightDescriptor>,
+        request: Request<FlightDescriptor>,
     ) -> Result<Response<PollInfo>, Status> {
-        Err(Status::unimplemented("PollFlightInfo not implemented"))
+        let auth = self.authenticate(request.metadata())?;
+        let info = self.flight_info_for(request.into_inner(), &auth).await?;
+        let poll = PollInfo {
+            info: Some(info),
+            flight_descriptor: None,
+            progress: Some(1.0),
+            expiration_time: None,
+        };
+        Ok(Response::new(poll))
     }
 
     /// Write Arrow rows into `keyspace.table` (from the `ferrosa-table`
@@ -581,17 +635,66 @@ impl FlightService for FerrosaFlight {
         Ok(Response::new(Box::pin(acks) as Self::DoExchangeStream))
     }
 
+    /// Handle a supported action (see [`SUPPORTED_ACTIONS`]). `server.info`
+    /// reports the service name + crate version; `token.validate` echoes the
+    /// verified bearer identity. Both require auth; any other type is rejected
+    /// with `InvalidArgument`.
     async fn do_action(
         &self,
-        _request: Request<Action>,
+        request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
-        Err(Status::unimplemented("DoAction not implemented"))
+        let auth = self.authenticate(request.metadata())?;
+        let action = request.into_inner();
+        let body: Vec<u8> = match action.r#type.as_str() {
+            "server.info" => format!(
+                "{{\"service\":\"ferrosa-flight\",\"version\":\"{}\"}}",
+                env!("CARGO_PKG_VERSION")
+            )
+            .into_bytes(),
+            "token.validate" => format!(
+                "{{\"role\":\"{}\",\"is_superuser\":{}}}",
+                auth.role, auth.is_superuser
+            )
+            .into_bytes(),
+            other => {
+                return Err(Status::invalid_argument(format!(
+                    "unknown action type {other:?}"
+                )))
+            }
+        };
+        let result = arrow_flight::Result { body: body.into() };
+        Ok(Response::new(
+            Box::pin(futures::stream::once(async move { Ok(result) })) as Self::DoActionStream,
+        ))
     }
 
+    /// Advertise the actions [`do_action`](Self::do_action) supports.
     async fn list_actions(
         &self,
-        _request: Request<Empty>,
+        request: Request<Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
-        Err(Status::unimplemented("ListActions not implemented"))
+        self.authenticate(request.metadata())?;
+        let actions: Vec<ActionType> = SUPPORTED_ACTIONS
+            .iter()
+            .map(|(r#type, description)| ActionType {
+                r#type: (*r#type).to_string(),
+                description: (*description).to_string(),
+            })
+            .collect();
+        let stream = futures::stream::iter(actions.into_iter().map(Ok));
+        Ok(Response::new(Box::pin(stream) as Self::ListActionsStream))
     }
 }
+
+/// Action types `do_action` handles, with their descriptions. `list_actions`
+/// advertises exactly this set, so the two stay in lock-step.
+const SUPPORTED_ACTIONS: &[(&str, &str)] = &[
+    (
+        "server.info",
+        "Return the Flight service name and crate version as JSON.",
+    ),
+    (
+        "token.validate",
+        "Validate the presented bearer token and return its verified role.",
+    ),
+];

--- a/ferrosa-flight/src/service.rs
+++ b/ferrosa-flight/src/service.rs
@@ -4,7 +4,10 @@
 //! executed by `ferrosa-cql` (`route_select_raw`) and the result is converted
 //! to Arrow and streamed back. `DoPut` writes Arrow rows into the
 //! `ferrosa-table` (`keyspace.table` metadata header) as CQL INSERTs.
-//! `DoExchange` and `ListFlights` remain `Unimplemented`.
+//! `DoExchange` is a bidirectional streaming upsert: it consumes the same
+//! inbound Arrow batches as `DoPut` and emits one `FlightData` acknowledgement
+//! per batch (rows-applied count in `app_metadata`). `ListFlights` remains
+//! `Unimplemented`.
 //!
 //! Auth (decision D4): `Handshake` validates CQL credentials via
 //! `Schema::authenticate` and returns a signed bearer token; every other RPC
@@ -118,6 +121,25 @@ impl FerrosaFlight {
         })
     }
 
+    /// Extract and validate the `ferrosa-table` (`keyspace.table`) write target
+    /// from request metadata. Shared by `do_put` and `do_exchange`.
+    #[allow(clippy::result_large_err)] // tonic Status is the uniform RPC error type
+    fn target_table(&self, metadata: &tonic::metadata::MetadataMap) -> Result<String, Status> {
+        let table = metadata
+            .get("ferrosa-table")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| {
+                Status::invalid_argument("missing 'ferrosa-table' metadata (keyspace.table)")
+            })?
+            .to_string();
+        if !valid_table(&table) {
+            return Err(Status::invalid_argument(
+                "'ferrosa-table' must be keyspace.table identifiers",
+            ));
+        }
+        Ok(table)
+    }
+
     /// Parse a Flight command, requiring a `SELECT`.
     #[allow(clippy::result_large_err)] // tonic Status is the uniform RPC error type
     fn parse_select(cql: &str) -> Result<ferrosa_cql::ast::SelectStatement, Status> {
@@ -212,6 +234,50 @@ fn cql_literal(v: &CqlValue) -> Option<String> {
         CqlValue::Blob(b) => format!("0x{}", hex::encode(b)),
         _ => return None,
     })
+}
+
+/// A `DoExchange` acknowledgement for one applied batch: an otherwise-empty
+/// `FlightData` carrying the decimal rows-applied count in `app_metadata`
+/// (same count convention as `do_put`'s `PutResult.app_metadata`).
+fn ack_flight_data(written: i64) -> FlightData {
+    FlightData::new().with_app_metadata(written.to_string().into_bytes())
+}
+
+/// Write every row of one decoded Arrow batch into `table` via the normal CQL
+/// write path (`do_put` / `do_exchange` share this). Returns the number of rows
+/// applied. Fail-loud: a conversion, parse, or write error propagates as
+/// `Status` — a batch is never silently dropped.
+#[allow(clippy::result_large_err)] // tonic Status is the uniform RPC error type
+async fn write_batch(
+    state: &SharedState,
+    auth: &ferrosa_schema::AuthContext,
+    table: &str,
+    batch: &RecordBatch,
+) -> Result<i64, Status> {
+    let (names, rows) = crate::convert::record_batch_to_rows(batch)
+        .map_err(|e| Status::invalid_argument(format!("Arrow conversion failed: {e}")))?;
+    let mut written: i64 = 0;
+    for row in &rows {
+        let Some(sql) = build_insert(table, &names, row)? else {
+            continue;
+        };
+        let stmt = ferrosa_cql::parser::parse(&sql)
+            .map_err(|e| Status::internal(format!("generated CQL parse error: {e}")))?;
+        let ks: Option<String> = None;
+        let ctx = RequestContext {
+            auth,
+            current_keyspace: &ks,
+            consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: ferrosa_cql::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        ferrosa_cql::router::route(state, &ctx, stmt)
+            .await
+            .map_err(|e| Status::internal(format!("write failed: {e}")))?;
+        written += 1;
+    }
+    Ok(written)
 }
 
 /// Build an `INSERT INTO <table> (...) VALUES (...)` for one row, including only
@@ -438,19 +504,7 @@ impl FlightService for FerrosaFlight {
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
         let auth = self.authenticate(request.metadata())?;
-        let table = request
-            .metadata()
-            .get("ferrosa-table")
-            .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| {
-                Status::invalid_argument("missing 'ferrosa-table' metadata (keyspace.table)")
-            })?
-            .to_string();
-        if !valid_table(&table) {
-            return Err(Status::invalid_argument(
-                "'ferrosa-table' must be keyspace.table identifiers",
-            ));
-        }
+        let table = self.target_table(request.metadata())?;
 
         let stream = request
             .into_inner()
@@ -464,28 +518,7 @@ impl FlightService for FerrosaFlight {
             .await
             .map_err(|e| Status::invalid_argument(format!("Flight decode error: {e}")))?
         {
-            let (names, rows) = crate::convert::record_batch_to_rows(&batch)
-                .map_err(|e| Status::invalid_argument(format!("Arrow conversion failed: {e}")))?;
-            for row in &rows {
-                let Some(sql) = build_insert(&table, &names, row)? else {
-                    continue;
-                };
-                let stmt = ferrosa_cql::parser::parse(&sql)
-                    .map_err(|e| Status::internal(format!("generated CQL parse error: {e}")))?;
-                let ks: Option<String> = None;
-                let ctx = RequestContext {
-                    auth: &auth,
-                    current_keyspace: &ks,
-                    consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
-                    serial_consistency: None,
-                    paging: ferrosa_cql::paging::PagingParams::default(),
-                    client_address: String::new(),
-                };
-                ferrosa_cql::router::route(&self.state, &ctx, stmt)
-                    .await
-                    .map_err(|e| Status::internal(format!("write failed: {e}")))?;
-                written += 1;
-            }
+            written += write_batch(&self.state, &auth, &table, &batch).await?;
         }
 
         let result = arrow_flight::PutResult {
@@ -496,13 +529,56 @@ impl FlightService for FerrosaFlight {
         ))
     }
 
+    /// Bidirectional streaming upsert with per-batch acknowledgement. The client
+    /// pushes a stream of `FlightData` (decoded to `RecordBatch`es); each batch's
+    /// rows are written into the `ferrosa-table` (`keyspace.table` header) via the
+    /// same write path as `do_put`, and for every processed batch the server emits
+    /// one outbound `FlightData` whose `app_metadata` is the decimal rows-applied
+    /// count for that batch. Fail-loud: a decode/conversion/write error ends the
+    /// stream with a `Status` rather than silently dropping a batch.
+    ///
+    /// Out of scope (post-v1): a live-subscribe channel over `DoExchange`.
     async fn do_exchange(
         &self,
-        _request: Request<Streaming<FlightData>>,
+        request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
-        Err(Status::unimplemented(
-            "DoExchange not implemented (channel slice pending)",
-        ))
+        let auth = self.authenticate(request.metadata())?;
+        let table = self.target_table(request.metadata())?;
+        let state = Arc::clone(&self.state);
+
+        let inbound = request
+            .into_inner()
+            .map_err(|s| FlightError::ExternalError(Box::new(s)));
+        let batches = arrow_flight::decode::FlightRecordBatchStream::new_from_flight_data(inbound);
+
+        // One ack per inbound batch. `unfold` keeps the upsert strictly ordered
+        // (apply batch N, ack N, then poll batch N+1) and stops on the first
+        // error, so a failure is never hidden behind a later "success" ack.
+        let acks = futures::stream::unfold(batches, move |mut batches| {
+            let auth = auth.clone();
+            let table = table.clone();
+            let state = Arc::clone(&state);
+            async move {
+                let batch = match batches.try_next().await {
+                    Ok(Some(b)) => b,
+                    Ok(None) => return None,
+                    Err(e) => {
+                        return Some((
+                            Err(Status::invalid_argument(format!(
+                                "Flight decode error: {e}"
+                            ))),
+                            batches,
+                        ))
+                    }
+                };
+                let ack = write_batch(&state, &auth, &table, &batch)
+                    .await
+                    .map(ack_flight_data);
+                Some((ack, batches))
+            }
+        });
+
+        Ok(Response::new(Box::pin(acks) as Self::DoExchangeStream))
     }
 
     async fn do_action(

--- a/ferrosa-flight/src/token.rs
+++ b/ferrosa-flight/src/token.rs
@@ -1,0 +1,229 @@
+//! Signed bearer tokens for the Flight endpoint (decision D4).
+//!
+//! A `Handshake` validates CQL credentials and issues a token carrying the
+//! authenticated role; subsequent RPCs present it as a bearer credential and
+//! the server derives the request's `AuthContext` from the verified claims —
+//! no anonymous access. Tokens are HMAC-SHA256 signed over a compact payload
+//! and carry an absolute expiry.
+//!
+//! Format: `hex(payload) "." hex(hmac_sha256(key, payload))`, where
+//! `payload = "{expires_at}:{is_superuser as 0|1}:{role}"`. Hex keeps the token
+//! header-safe without coupling to a specific base64 API version. Keys are
+//! process-held; [`verify_with_keys`] accepts a set of keys (current + recently
+//! retired), so rotation has an overlap window rather than invalidating every
+//! outstanding token at once.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Verified identity carried by a bearer token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Claims {
+    pub role: String,
+    pub is_superuser: bool,
+    /// Absolute expiry, seconds since the Unix epoch.
+    pub expires_at: u64,
+}
+
+/// Why a token was rejected. Never leaks which check failed to the wire beyond
+/// a generic "unauthenticated"; the variants exist for server-side logging.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TokenError {
+    /// Structurally invalid (no separator, bad hex, non-UTF8/garbled payload).
+    Malformed,
+    /// HMAC did not match — forged or tampered.
+    BadSignature,
+    /// Past its `expires_at`.
+    Expired,
+}
+
+impl std::fmt::Display for TokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TokenError::Malformed => write!(f, "malformed bearer token"),
+            TokenError::BadSignature => write!(f, "bearer token signature mismatch"),
+            TokenError::Expired => write!(f, "bearer token expired"),
+        }
+    }
+}
+
+impl std::error::Error for TokenError {}
+
+fn payload_bytes(claims: &Claims) -> Vec<u8> {
+    format!(
+        "{}:{}:{}",
+        claims.expires_at,
+        u8::from(claims.is_superuser),
+        claims.role
+    )
+    .into_bytes()
+}
+
+fn mac(key: &[u8], msg: &[u8]) -> HmacSha256 {
+    // HMAC accepts a key of any length, so this never errors.
+    let mut m = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    m.update(msg);
+    m
+}
+
+/// Issue a signed bearer token for `claims`.
+pub fn issue(key: &[u8], claims: &Claims) -> String {
+    let payload = payload_bytes(claims);
+    let sig = mac(key, &payload).finalize().into_bytes();
+    format!("{}.{}", hex::encode(&payload), hex::encode(sig))
+}
+
+/// Verify a bearer token against `key` at `now_secs`, returning its claims.
+///
+/// Signature is checked in constant time (`verify_slice`) before the payload is
+/// trusted; expiry is checked last so a forged token never reports "expired".
+pub fn verify(key: &[u8], token: &str, now_secs: u64) -> Result<Claims, TokenError> {
+    let (payload_hex, sig_hex) = token.split_once('.').ok_or(TokenError::Malformed)?;
+    let payload = hex::decode(payload_hex).map_err(|_| TokenError::Malformed)?;
+    let sig = hex::decode(sig_hex).map_err(|_| TokenError::Malformed)?;
+
+    mac(key, &payload)
+        .verify_slice(&sig)
+        .map_err(|_| TokenError::BadSignature)?;
+
+    let text = std::str::from_utf8(&payload).map_err(|_| TokenError::Malformed)?;
+    let mut parts = text.splitn(3, ':');
+    let expires_at: u64 = parts
+        .next()
+        .ok_or(TokenError::Malformed)?
+        .parse()
+        .map_err(|_| TokenError::Malformed)?;
+    let is_superuser = match parts.next() {
+        Some("1") => true,
+        Some("0") => false,
+        _ => return Err(TokenError::Malformed),
+    };
+    let role = parts.next().ok_or(TokenError::Malformed)?.to_string();
+
+    if now_secs >= expires_at {
+        return Err(TokenError::Expired);
+    }
+    Ok(Claims {
+        role,
+        is_superuser,
+        expires_at,
+    })
+}
+
+/// Verify against any of `keys` — supporting key rotation with an overlap
+/// window: tokens are signed with the current key but stay valid while a
+/// previous key is still in the set. Returns the claims from the first key that
+/// validates. Error precedence reflects intent: `Malformed` (structural, key-
+/// independent) short-circuits; a key whose signature matches but is expired
+/// yields `Expired`; otherwise `BadSignature` (matched no key).
+pub fn verify_with_keys(
+    keys: &[Vec<u8>],
+    token: &str,
+    now_secs: u64,
+) -> Result<Claims, TokenError> {
+    let mut expired = false;
+    for key in keys {
+        match verify(key, token, now_secs) {
+            Ok(claims) => return Ok(claims),
+            Err(TokenError::Malformed) => return Err(TokenError::Malformed),
+            Err(TokenError::Expired) => expired = true,
+            Err(TokenError::BadSignature) => {}
+        }
+    }
+    Err(if expired {
+        TokenError::Expired
+    } else {
+        TokenError::BadSignature
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn claims() -> Claims {
+        Claims {
+            role: "alice".to_string(),
+            is_superuser: false,
+            expires_at: 2_000,
+        }
+    }
+
+    #[test]
+    fn issue_then_verify_round_trips() {
+        let key = b"secret-signing-key";
+        let token = issue(key, &claims());
+        assert_eq!(verify(key, &token, 1_000).unwrap(), claims());
+    }
+
+    #[test]
+    fn role_with_colons_survives() {
+        // role is the splitn(3) remainder, so embedded ':' is preserved.
+        let c = Claims {
+            role: "ns:team:svc".to_string(),
+            is_superuser: true,
+            expires_at: 2_000,
+        };
+        let key = b"k";
+        assert_eq!(verify(key, &issue(key, &c), 1).unwrap(), c);
+    }
+
+    #[test]
+    fn tampered_signature_is_rejected() {
+        let key = b"secret-signing-key";
+        let mut token = issue(key, &claims());
+        // Flip the last hex nibble of the signature.
+        let last = token.pop().unwrap();
+        token.push(if last == 'a' { 'b' } else { 'a' });
+        assert_eq!(verify(key, &token, 1_000), Err(TokenError::BadSignature));
+    }
+
+    #[test]
+    fn wrong_key_is_rejected() {
+        let token = issue(b"key-one", &claims());
+        assert_eq!(
+            verify(b"key-two", &token, 1_000),
+            Err(TokenError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        let key = b"secret-signing-key";
+        let token = issue(key, &claims()); // expires_at = 2000
+        assert_eq!(verify(key, &token, 2_000), Err(TokenError::Expired));
+        assert_eq!(verify(key, &token, 2_001), Err(TokenError::Expired));
+    }
+
+    #[test]
+    fn verify_with_keys_supports_rotation() {
+        let old = b"old-key".to_vec();
+        let new = b"new-key".to_vec();
+        // Token issued under the OLD key still validates while old is in the set.
+        let token = issue(&old, &claims());
+        let keys = vec![new.clone(), old.clone()]; // current first, previous second
+        assert_eq!(verify_with_keys(&keys, &token, 1_000).unwrap(), claims());
+
+        // Once the old key is rotated out, the token no longer validates.
+        assert_eq!(
+            verify_with_keys(&[new], &token, 1_000),
+            Err(TokenError::BadSignature)
+        );
+
+        // A signature-valid-but-expired token reports Expired, not BadSignature,
+        // even when other (non-matching) keys are present.
+        assert_eq!(
+            verify_with_keys(&[b"other".to_vec(), old], &token, 2_000),
+            Err(TokenError::Expired)
+        );
+    }
+
+    #[test]
+    fn malformed_tokens_are_rejected() {
+        let key = b"k";
+        assert_eq!(verify(key, "no-separator", 1), Err(TokenError::Malformed));
+        assert_eq!(verify(key, "zz.zz", 1), Err(TokenError::Malformed));
+    }
+}

--- a/ferrosa-flight/tests/distributed_endpoints.rs
+++ b/ferrosa-flight/tests/distributed_endpoints.rs
@@ -1,0 +1,188 @@
+//! `GetFlightInfo` distributed-endpoint behavior (W-002).
+//!
+//! On a multi-range cluster topology, `get_flight_info` must return one
+//! `FlightEndpoint` per token range, each carrying a DISTINCT token-bounded
+//! `SELECT` ticket and the advertised Flight location(s) of the owning
+//! replica(s). On a standalone topology (no ring) it must return exactly one
+//! endpoint redeeming the original command — the prior behavior.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::FlightDescriptor;
+use tonic::Request;
+
+use ferrosa_cluster::raft::{NodeInfo, NodeState};
+use ferrosa_cluster::ring::TokenRing;
+use ferrosa_cql::router::{route, RequestContext, SharedState};
+use ferrosa_flight::service::FerrosaFlight;
+use ferrosa_flight::token::{self, Claims};
+
+const KEY: &[u8] = b"flight-test-signing-key";
+
+fn superuser_token() -> String {
+    token::issue(
+        KEY,
+        &Claims {
+            role: "cassandra".to_string(),
+            is_superuser: true,
+            expires_at: 4_102_444_800,
+        },
+    )
+}
+
+fn bearer<T>(msg: T, token: &str) -> Request<T> {
+    let mut req = Request::new(msg);
+    req.metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    req
+}
+
+fn superuser() -> ferrosa_schema::AuthContext {
+    ferrosa_schema::AuthContext {
+        role: "cassandra".to_string(),
+        is_superuser: true,
+        must_change_password: false,
+    }
+}
+
+async fn exec(state: &SharedState, cql: &str) {
+    let auth = superuser();
+    let ks: Option<String> = None;
+    let ctx = RequestContext {
+        auth: &auth,
+        current_keyspace: &ks,
+        consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+        serial_consistency: None,
+        paging: ferrosa_cql::paging::PagingParams::default(),
+        client_address: String::new(),
+    };
+    let stmt = ferrosa_cql::parser::parse(cql).unwrap_or_else(|e| panic!("parse {cql:?}: {e}"));
+    route(state, &ctx, stmt)
+        .await
+        .unwrap_or_else(|e| panic!("route {cql:?}: {e}"));
+}
+
+fn ring_node(addr: &str) -> NodeInfo {
+    NodeInfo {
+        host_id: uuid::Uuid::new_v4(),
+        addr: addr.to_string(),
+        data_center: "dc1".to_string(),
+        rack: "rack1".to_string(),
+        state: NodeState::Normal,
+        cql_broadcast: None,
+    }
+}
+
+async fn seeded_state() -> (Arc<SharedState>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let state = ferrosa_cql::test_util::standalone_for_test(dir.path());
+    exec(
+        &state,
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}",
+    )
+    .await;
+    exec(&state, "CREATE TABLE ks.t (id int PRIMARY KEY, name text)").await;
+    exec(&state, "INSERT INTO ks.t (id, name) VALUES (1, 'alice')").await;
+    (state, dir)
+}
+
+#[tokio::test]
+async fn standalone_returns_single_endpoint() {
+    let (state, _dir) = seeded_state().await;
+    let svc = FerrosaFlight::new(Arc::clone(&state), KEY.to_vec());
+
+    let info = svc
+        .get_flight_info(bearer(
+            FlightDescriptor::new_cmd("SELECT id, name FROM ks.t"),
+            &superuser_token(),
+        ))
+        .await
+        .expect("get_flight_info ok")
+        .into_inner();
+
+    assert_eq!(
+        info.endpoint.len(),
+        1,
+        "standalone topology → exactly one endpoint"
+    );
+    // The single endpoint redeems the original command.
+    let ticket = info.endpoint[0]
+        .ticket
+        .as_ref()
+        .expect("endpoint has a ticket");
+    assert_eq!(
+        ticket.ticket.as_ref(),
+        b"SELECT id, name FROM ks.t",
+        "self endpoint carries the original command"
+    );
+}
+
+#[tokio::test]
+async fn multi_range_topology_returns_endpoint_per_range() {
+    let (state, _dir) = seeded_state().await;
+
+    // Install a 3-node ring so the table spans multiple token ranges.
+    let mut ring = TokenRing::new();
+    ring.add_node(1, ring_node("10.0.0.1:7000"));
+    ring.add_node(2, ring_node("10.0.0.2:7000"));
+    ring.add_node(3, ring_node("10.0.0.3:7000"));
+    ring.assign_tokens(1, &[0]);
+    ring.assign_tokens(2, &[100]);
+    ring.assign_tokens(3, &[200]);
+    state.core.mode_controller.set_token_ring(Arc::new(ring));
+
+    let svc = FerrosaFlight::new(Arc::clone(&state), KEY.to_vec());
+
+    let info = svc
+        .get_flight_info(bearer(
+            FlightDescriptor::new_cmd("SELECT id, name FROM ks.t"),
+            &superuser_token(),
+        ))
+        .await
+        .expect("get_flight_info ok")
+        .into_inner();
+
+    assert!(
+        info.endpoint.len() > 1,
+        "multi-range topology → more than one endpoint, got {}",
+        info.endpoint.len()
+    );
+
+    // Every endpoint carries a DISTINCT, token-bounded ticket.
+    let mut tickets = HashSet::new();
+    for ep in &info.endpoint {
+        let t = ep.ticket.as_ref().expect("endpoint has ticket");
+        let cql = std::str::from_utf8(&t.ticket).expect("utf8 ticket");
+        assert!(
+            cql.contains("token(id) >") && cql.contains("token(id) <="),
+            "range ticket carries token bounds: {cql}"
+        );
+        assert!(
+            tickets.insert(cql.to_string()),
+            "tickets are distinct: {cql}"
+        );
+    }
+
+    // At least one endpoint advertises a replica Flight location.
+    let with_location = info
+        .endpoint
+        .iter()
+        .filter(|ep| !ep.location.is_empty())
+        .count();
+    assert!(
+        with_location > 0,
+        "endpoints advertise replica Flight locations"
+    );
+    // Locations look like Flight gRPC URIs on the ring's hosts.
+    for ep in &info.endpoint {
+        for loc in &ep.location {
+            assert!(
+                loc.uri.contains("10.0.0."),
+                "location points at a ring host: {}",
+                loc.uri
+            );
+        }
+    }
+}

--- a/ferrosa-flight/tests/exchange_path.rs
+++ b/ferrosa-flight/tests/exchange_path.rs
@@ -1,0 +1,211 @@
+//! Full-transport e2e for `DoExchange`: run the Flight service on a real tonic
+//! gRPC server, handshake for a bearer token, open a bidirectional
+//! `do_exchange` channel, push N Arrow `RecordBatch`es of rows into it, assert
+//! we receive N acknowledgements (each carrying the rows-applied count in
+//! `app_metadata`), then `do_get` the rows back and assert they were written.
+
+use std::sync::Arc;
+
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::encode::FlightDataEncoderBuilder;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::{FlightData, HandshakeRequest, Ticket};
+use futures::{stream, StreamExt, TryStreamExt};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::Request;
+
+use ferrosa_common::{CqlType, CqlValue};
+use ferrosa_cql::router::{route, RequestContext, SharedState};
+
+async fn exec(state: &SharedState, cql: &str) {
+    let auth = ferrosa_schema::AuthContext {
+        role: "cassandra".to_string(),
+        is_superuser: true,
+        must_change_password: false,
+    };
+    let ks: Option<String> = None;
+    let ctx = RequestContext {
+        auth: &auth,
+        current_keyspace: &ks,
+        consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+        serial_consistency: None,
+        paging: ferrosa_cql::paging::PagingParams::default(),
+        client_address: String::new(),
+    };
+    let stmt = ferrosa_cql::parser::parse(cql).unwrap_or_else(|e| panic!("parse {cql:?}: {e}"));
+    route(state, &ctx, stmt)
+        .await
+        .unwrap_or_else(|e| panic!("route {cql:?}: {e}"));
+}
+
+/// One (id, name) row as a single-row Arrow `RecordBatch`.
+fn one_row_batch(id: i32, name: &str) -> arrow::record_batch::RecordBatch {
+    ferrosa_flight::convert::rows_to_record_batch(
+        &["id".to_string(), "name".to_string()],
+        &[CqlType::Int, CqlType::Varchar],
+        &[vec![
+            Some(CqlValue::Int(id)),
+            Some(CqlValue::Text(name.to_string())),
+        ]],
+    )
+    .unwrap()
+}
+
+/// Encode `batches` into one FlightData stream (one schema message + one data
+/// message per batch) — the wire form a real client sends to `do_exchange`.
+async fn encode_batches(batches: Vec<arrow::record_batch::RecordBatch>) -> Vec<FlightData> {
+    FlightDataEncoderBuilder::new()
+        .build(stream::iter(batches.into_iter().map(Ok::<_, FlightError>)))
+        .try_collect()
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn do_exchange_upserts_each_batch_and_acks() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = ferrosa_cql::test_util::standalone_for_test(dir.path());
+    exec(
+        &state,
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}",
+    )
+    .await;
+    exec(&state, "CREATE TABLE ks.t (id int PRIMARY KEY, name text)").await;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let svc = ferrosa_flight::server::flight_service(Arc::clone(&state), b"server-key".to_vec());
+    let server = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+    });
+
+    let mut client = FlightServiceClient::connect(format!("http://{addr}"))
+        .await
+        .expect("connect");
+
+    // Handshake -> bearer token.
+    let handshake = stream::once(async {
+        HandshakeRequest {
+            protocol_version: 0,
+            payload: b"cassandra\0cassandra".to_vec().into(),
+        }
+    });
+    let token = String::from_utf8(
+        client
+            .handshake(handshake)
+            .await
+            .unwrap()
+            .into_inner()
+            .message()
+            .await
+            .unwrap()
+            .unwrap()
+            .payload
+            .to_vec(),
+    )
+    .unwrap();
+
+    // Three single-row batches -> one schema + three data messages on the wire.
+    let inbound = encode_batches(vec![
+        one_row_batch(100, "alpha"),
+        one_row_batch(200, "beta"),
+        one_row_batch(300, "gamma"),
+    ])
+    .await;
+    let n_batches = 3;
+
+    let mut req = Request::new(stream::iter(inbound));
+    req.metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    req.metadata_mut()
+        .insert("ferrosa-table", "ks.t".parse().unwrap());
+
+    let acks: Vec<FlightData> = client
+        .do_exchange(req)
+        .await
+        .expect("do_exchange ok")
+        .into_inner()
+        .map(|r| r.expect("ack stream item"))
+        .collect()
+        .await;
+
+    assert_eq!(acks.len(), n_batches, "one ack per processed inbound batch");
+    // Each ack carries the rows-applied count for its batch in app_metadata.
+    for ack in &acks {
+        let count = String::from_utf8(ack.app_metadata.to_vec()).expect("ack count utf8");
+        assert_eq!(count, "1", "each batch applied exactly one row");
+    }
+
+    // The rows must actually be readable back via do_get.
+    let mut get_req = Request::new(Ticket {
+        ticket: "SELECT id, name FROM ks.t".into(),
+    });
+    get_req
+        .metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    let data = client.do_get(get_req).await.unwrap().into_inner();
+    let batches: Vec<_> = FlightRecordBatchStream::new_from_flight_data(
+        data.map_err(|s| FlightError::ExternalError(Box::new(s))),
+    )
+    .try_collect()
+    .await
+    .unwrap();
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 3, "all three exchanged rows written and read back");
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn do_exchange_requires_a_valid_bearer() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = ferrosa_cql::test_util::standalone_for_test(dir.path());
+    exec(
+        &state,
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}",
+    )
+    .await;
+    exec(&state, "CREATE TABLE ks.t (id int PRIMARY KEY, name text)").await;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let svc = ferrosa_flight::server::flight_service(Arc::clone(&state), b"server-key".to_vec());
+    let server = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+    });
+
+    let mut client = FlightServiceClient::connect(format!("http://{addr}"))
+        .await
+        .expect("connect");
+
+    // No bearer token, with the table header present.
+    let mut req = Request::new(stream::iter(
+        encode_batches(vec![one_row_batch(1, "x")]).await,
+    ));
+    req.metadata_mut()
+        .insert("ferrosa-table", "ks.t".parse().unwrap());
+
+    // The unauthenticated status surfaces either on the call or on the first
+    // stream poll, depending on transport timing.
+    let outcome = client.do_exchange(req).await;
+    let code = match outcome {
+        Ok(resp) => resp
+            .into_inner()
+            .next()
+            .await
+            .expect("a stream item")
+            .expect_err("unauthenticated exchange must error")
+            .code(),
+        Err(status) => status.code(),
+    };
+    assert_eq!(code, tonic::Code::Unauthenticated);
+
+    server.abort();
+}

--- a/ferrosa-flight/tests/grpc_handshake.rs
+++ b/ferrosa-flight/tests/grpc_handshake.rs
@@ -1,0 +1,227 @@
+//! Full-transport e2e: run the Flight service on a real tonic gRPC server,
+//! connect a `FlightServiceClient`, perform a `Handshake` to obtain a bearer
+//! token, then `do_get` a SELECT with that token and decode the Arrow stream.
+//! Also asserts that an unauthenticated `do_get` is rejected over the wire.
+
+use std::sync::Arc;
+
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::encode::FlightDataEncoderBuilder;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::{FlightData, HandshakeRequest, Ticket};
+use futures::{stream, TryStreamExt};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::Request;
+
+use ferrosa_common::{CqlType, CqlValue};
+use ferrosa_cql::router::{route, RequestContext, SharedState};
+
+async fn exec(state: &SharedState, cql: &str) {
+    let auth = ferrosa_schema::AuthContext {
+        role: "cassandra".to_string(),
+        is_superuser: true,
+        must_change_password: false,
+    };
+    let ks: Option<String> = None;
+    let ctx = RequestContext {
+        auth: &auth,
+        current_keyspace: &ks,
+        consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+        serial_consistency: None,
+        paging: ferrosa_cql::paging::PagingParams::default(),
+        client_address: String::new(),
+    };
+    let stmt = ferrosa_cql::parser::parse(cql).unwrap_or_else(|e| panic!("parse {cql:?}: {e}"));
+    route(state, &ctx, stmt)
+        .await
+        .unwrap_or_else(|e| panic!("route {cql:?}: {e}"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_grpc_handshake_then_do_get() {
+    // Seed a single-node keyspace/table with two rows.
+    let dir = tempfile::tempdir().unwrap();
+    let state = ferrosa_cql::test_util::standalone_for_test(dir.path());
+    exec(
+        &state,
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}",
+    )
+    .await;
+    exec(&state, "CREATE TABLE ks.t (id int PRIMARY KEY, name text)").await;
+    exec(&state, "INSERT INTO ks.t (id, name) VALUES (1, 'alice')").await;
+    exec(&state, "INSERT INTO ks.t (id, name) VALUES (2, 'bob')").await;
+
+    // Start the Flight server on an ephemeral port.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let svc = ferrosa_flight::server::flight_service(Arc::clone(&state), b"server-key".to_vec());
+    let server = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+    });
+
+    let mut client = FlightServiceClient::connect(format!("http://{addr}"))
+        .await
+        .expect("connect to flight server");
+
+    // Handshake with the seeded default superuser -> bearer token.
+    let handshake = stream::once(async {
+        HandshakeRequest {
+            protocol_version: 0,
+            payload: b"cassandra\0cassandra".to_vec().into(),
+        }
+    });
+    let mut hs_resp = client
+        .handshake(handshake)
+        .await
+        .expect("handshake ok")
+        .into_inner();
+    let token_msg = hs_resp
+        .message()
+        .await
+        .expect("handshake stream")
+        .expect("a handshake response");
+    let token = String::from_utf8(token_msg.payload.to_vec()).unwrap();
+    assert!(!token.is_empty(), "handshake should issue a token");
+
+    // Authenticated do_get streams the rows back as Arrow.
+    let mut req = Request::new(Ticket {
+        ticket: "SELECT id, name FROM ks.t".into(),
+    });
+    req.metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    let data = client.do_get(req).await.expect("do_get ok").into_inner();
+    let batches: Vec<_> = FlightRecordBatchStream::new_from_flight_data(
+        data.map_err(|s| FlightError::ExternalError(Box::new(s))),
+    )
+    .try_collect()
+    .await
+    .expect("decode arrow stream");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 2, "both rows round-trip over gRPC");
+
+    // An unauthenticated do_get is rejected over the wire.
+    let unauth = client
+        .do_get(Request::new(Ticket {
+            ticket: "SELECT id FROM ks.t".into(),
+        }))
+        .await;
+    assert_eq!(
+        unauth.unwrap_err().code(),
+        tonic::Code::Unauthenticated,
+        "missing bearer must be rejected"
+    );
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn do_put_writes_rows_then_do_get_reads_them_back() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = ferrosa_cql::test_util::standalone_for_test(dir.path());
+    exec(
+        &state,
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}",
+    )
+    .await;
+    exec(&state, "CREATE TABLE ks.t (id int PRIMARY KEY, name text)").await;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let svc = ferrosa_flight::server::flight_service(Arc::clone(&state), b"server-key".to_vec());
+    let server = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+    });
+
+    let mut client = FlightServiceClient::connect(format!("http://{addr}"))
+        .await
+        .expect("connect");
+
+    // Handshake for a bearer token.
+    let handshake = stream::once(async {
+        HandshakeRequest {
+            protocol_version: 0,
+            payload: b"cassandra\0cassandra".to_vec().into(),
+        }
+    });
+    let token = String::from_utf8(
+        client
+            .handshake(handshake)
+            .await
+            .unwrap()
+            .into_inner()
+            .message()
+            .await
+            .unwrap()
+            .unwrap()
+            .payload
+            .to_vec(),
+    )
+    .unwrap();
+
+    // Build an Arrow batch (two rows) and encode it to FlightData.
+    let batch = ferrosa_flight::convert::rows_to_record_batch(
+        &["id".to_string(), "name".to_string()],
+        &[CqlType::Int, CqlType::Varchar],
+        &[
+            vec![Some(CqlValue::Int(10)), Some(CqlValue::Text("ten".into()))],
+            vec![
+                Some(CqlValue::Int(20)),
+                Some(CqlValue::Text("twenty".into())),
+            ],
+        ],
+    )
+    .unwrap();
+    let flight_data: Vec<FlightData> = FlightDataEncoderBuilder::new()
+        .build(stream::iter(vec![Ok::<_, FlightError>(batch)]))
+        .try_collect()
+        .await
+        .unwrap();
+
+    // DoPut the batch into ks.t.
+    let mut put_req = Request::new(stream::iter(flight_data));
+    put_req
+        .metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    put_req
+        .metadata_mut()
+        .insert("ferrosa-table", "ks.t".parse().unwrap());
+    let put_resp = client.do_put(put_req).await.expect("do_put ok");
+    let written = String::from_utf8(
+        put_resp
+            .into_inner()
+            .message()
+            .await
+            .unwrap()
+            .expect("a put result")
+            .app_metadata
+            .to_vec(),
+    )
+    .unwrap();
+    assert_eq!(written, "2", "two rows written");
+
+    // DoGet reads the written rows back.
+    let mut get_req = Request::new(Ticket {
+        ticket: "SELECT id, name FROM ks.t".into(),
+    });
+    get_req
+        .metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    let data = client.do_get(get_req).await.unwrap().into_inner();
+    let batches: Vec<_> = FlightRecordBatchStream::new_from_flight_data(
+        data.map_err(|s| FlightError::ExternalError(Box::new(s))),
+    )
+    .try_collect()
+    .await
+    .unwrap();
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 2, "both DoPut rows read back via DoGet");
+
+    server.abort();
+}

--- a/ferrosa-flight/tests/minor_rpcs.rs
+++ b/ferrosa-flight/tests/minor_rpcs.rs
@@ -1,0 +1,300 @@
+//! Tests for the four minor Flight RPCs: `list_flights`, `poll_flight_info`,
+//! `do_action`, and `list_actions`. Each mirrors the read-path harness: seed a
+//! keyspace/table through the CQL engine, then drive the RPC with a bearer
+//! token and assert on the real result (and that auth is enforced).
+
+use std::sync::Arc;
+
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::{Action, Criteria, Empty, FlightDescriptor};
+use futures::TryStreamExt;
+use tonic::Request;
+
+use ferrosa_cql::router::{route, RequestContext, SharedState};
+use ferrosa_flight::service::FerrosaFlight;
+use ferrosa_flight::token::{self, Claims};
+
+const KEY: &[u8] = b"flight-test-signing-key";
+
+fn superuser_token() -> String {
+    token::issue(
+        KEY,
+        &Claims {
+            role: "cassandra".to_string(),
+            is_superuser: true,
+            expires_at: 4_102_444_800, // year 2100
+        },
+    )
+}
+
+fn bearer<T>(msg: T, token: &str) -> Request<T> {
+    let mut req = Request::new(msg);
+    req.metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    req
+}
+
+fn superuser() -> ferrosa_schema::AuthContext {
+    ferrosa_schema::AuthContext {
+        role: "cassandra".to_string(),
+        is_superuser: true,
+        must_change_password: false,
+    }
+}
+
+fn ctx<'a>(auth: &'a ferrosa_schema::AuthContext, ks: &'a Option<String>) -> RequestContext<'a> {
+    RequestContext {
+        auth,
+        current_keyspace: ks,
+        consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+        serial_consistency: None,
+        paging: ferrosa_cql::paging::PagingParams::default(),
+        client_address: String::new(),
+    }
+}
+
+async fn exec(state: &SharedState, cql: &str) {
+    let auth = superuser();
+    let ks: Option<String> = None;
+    let stmt = ferrosa_cql::parser::parse(cql).unwrap_or_else(|e| panic!("parse {cql:?}: {e}"));
+    route(state, &ctx(&auth, &ks), stmt)
+        .await
+        .unwrap_or_else(|e| panic!("route {cql:?}: {e}"));
+}
+
+async fn seeded_service() -> (FerrosaFlight, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let state = ferrosa_cql::test_util::standalone_for_test(dir.path());
+    exec(
+        &state,
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}",
+    )
+    .await;
+    exec(&state, "CREATE TABLE ks.t (id int PRIMARY KEY, name text)").await;
+    exec(&state, "CREATE TABLE ks.other (id int PRIMARY KEY)").await;
+    (FerrosaFlight::new(Arc::clone(&state), KEY.to_vec()), dir)
+}
+
+// ---- list_flights ----------------------------------------------------------
+
+#[tokio::test]
+async fn list_flights_enumerates_user_tables() {
+    let (svc, _dir) = seeded_service().await;
+
+    let resp = svc
+        .list_flights(bearer(Criteria::default(), &superuser_token()))
+        .await
+        .expect("list_flights ok");
+    let flights: Vec<_> = resp.into_inner().try_collect().await.expect("collect");
+
+    // The two user tables must both appear; system keyspaces must not.
+    let tickets: Vec<String> = flights
+        .iter()
+        .map(|f| String::from_utf8(f.endpoint[0].ticket.as_ref().unwrap().ticket.to_vec()).unwrap())
+        .collect();
+    assert!(
+        tickets.iter().any(|t| t == "SELECT * FROM ks.t"),
+        "ks.t flight present; got {tickets:?}"
+    );
+    assert!(
+        tickets.iter().any(|t| t == "SELECT * FROM ks.other"),
+        "ks.other flight present; got {tickets:?}"
+    );
+    assert!(
+        tickets.iter().all(|t| t.contains("FROM ks.")),
+        "only user-keyspace tables; got {tickets:?}"
+    );
+    // Each flight carries a real Arrow schema (non-empty IPC schema bytes).
+    assert!(
+        flights.iter().all(|f| !f.schema.is_empty()),
+        "each FlightInfo carries an encoded schema"
+    );
+}
+
+#[tokio::test]
+async fn list_flights_respects_criteria_prefix() {
+    let (svc, _dir) = seeded_service().await;
+
+    let criteria = Criteria {
+        expression: b"ks.t".to_vec().into(),
+    };
+    let resp = svc
+        .list_flights(bearer(criteria, &superuser_token()))
+        .await
+        .expect("list_flights ok");
+    let flights: Vec<_> = resp.into_inner().try_collect().await.expect("collect");
+    let tickets: Vec<String> = flights
+        .iter()
+        .map(|f| String::from_utf8(f.endpoint[0].ticket.as_ref().unwrap().ticket.to_vec()).unwrap())
+        .collect();
+
+    // "ks.t" is a prefix of both "ks.t" and ... but "ks.other" does NOT start
+    // with "ks.t", so it must be excluded.
+    assert!(
+        tickets.iter().any(|t| t == "SELECT * FROM ks.t"),
+        "prefix match keeps ks.t; got {tickets:?}"
+    );
+    assert!(
+        tickets.iter().all(|t| t != "SELECT * FROM ks.other"),
+        "prefix match excludes ks.other; got {tickets:?}"
+    );
+}
+
+#[tokio::test]
+async fn list_flights_requires_bearer() {
+    let (svc, _dir) = seeded_service().await;
+    match svc.list_flights(Request::new(Criteria::default())).await {
+        Ok(_) => panic!("unauthenticated list_flights must be rejected"),
+        Err(e) => assert_eq!(e.code(), tonic::Code::Unauthenticated),
+    }
+}
+
+// ---- poll_flight_info ------------------------------------------------------
+
+#[tokio::test]
+async fn poll_flight_info_returns_completed_info() {
+    let (svc, _dir) = seeded_service().await;
+
+    let descriptor = FlightDescriptor::new_cmd(b"SELECT id, name FROM ks.t".to_vec());
+    let resp = svc
+        .poll_flight_info(bearer(descriptor, &superuser_token()))
+        .await
+        .expect("poll_flight_info ok");
+    let poll = resp.into_inner();
+
+    let info = poll.info.expect("PollInfo carries a FlightInfo");
+    assert!(!info.schema.is_empty(), "info carries an encoded schema");
+    assert_eq!(info.endpoint.len(), 1, "single self-endpoint");
+    // v1 has no long-running poll: the result is complete, so no continuation
+    // descriptor is returned and progress is 1.0.
+    assert!(
+        poll.flight_descriptor.is_none(),
+        "completed poll has no continuation descriptor"
+    );
+    assert_eq!(
+        poll.progress,
+        Some(1.0),
+        "completed poll reports progress 1.0"
+    );
+}
+
+#[tokio::test]
+async fn poll_flight_info_requires_bearer() {
+    let (svc, _dir) = seeded_service().await;
+    let descriptor = FlightDescriptor::new_cmd(b"SELECT id, name FROM ks.t".to_vec());
+    match svc.poll_flight_info(Request::new(descriptor)).await {
+        Ok(_) => panic!("unauthenticated poll_flight_info must be rejected"),
+        Err(e) => assert_eq!(e.code(), tonic::Code::Unauthenticated),
+    }
+}
+
+// ---- list_actions ----------------------------------------------------------
+
+#[tokio::test]
+async fn list_actions_advertises_known_actions() {
+    let (svc, _dir) = seeded_service().await;
+
+    let resp = svc
+        .list_actions(bearer(Empty {}, &superuser_token()))
+        .await
+        .expect("list_actions ok");
+    let actions: Vec<_> = resp.into_inner().try_collect().await.expect("collect");
+
+    let types: Vec<&str> = actions.iter().map(|a| a.r#type.as_str()).collect();
+    assert!(
+        types.contains(&"server.info"),
+        "server.info advertised; got {types:?}"
+    );
+    assert!(
+        types.contains(&"token.validate"),
+        "token.validate advertised; got {types:?}"
+    );
+    assert!(
+        actions.iter().all(|a| !a.description.is_empty()),
+        "every action carries a description"
+    );
+}
+
+#[tokio::test]
+async fn list_actions_requires_bearer() {
+    let (svc, _dir) = seeded_service().await;
+    match svc.list_actions(Request::new(Empty {})).await {
+        Ok(_) => panic!("unauthenticated list_actions must be rejected"),
+        Err(e) => assert_eq!(e.code(), tonic::Code::Unauthenticated),
+    }
+}
+
+// ---- do_action -------------------------------------------------------------
+
+#[tokio::test]
+async fn do_action_server_info_returns_version() {
+    let (svc, _dir) = seeded_service().await;
+
+    let action = Action {
+        r#type: "server.info".to_string(),
+        body: Vec::new().into(),
+    };
+    let resp = svc
+        .do_action(bearer(action, &superuser_token()))
+        .await
+        .expect("do_action ok");
+    let results: Vec<_> = resp.into_inner().try_collect().await.expect("collect");
+    assert_eq!(results.len(), 1, "one result body");
+    let body = String::from_utf8(results[0].body.to_vec()).unwrap();
+    assert!(
+        body.contains(env!("CARGO_PKG_VERSION")),
+        "server.info reports the crate version; got {body:?}"
+    );
+    assert!(
+        body.contains("ferrosa-flight"),
+        "server.info names the service; got {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn do_action_token_validate_reports_role() {
+    let (svc, _dir) = seeded_service().await;
+
+    let action = Action {
+        r#type: "token.validate".to_string(),
+        body: Vec::new().into(),
+    };
+    let resp = svc
+        .do_action(bearer(action, &superuser_token()))
+        .await
+        .expect("do_action ok");
+    let results: Vec<_> = resp.into_inner().try_collect().await.expect("collect");
+    assert_eq!(results.len(), 1, "one result body");
+    let body = String::from_utf8(results[0].body.to_vec()).unwrap();
+    assert!(
+        body.contains("cassandra"),
+        "token.validate echoes the verified role; got {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn do_action_rejects_unknown_type() {
+    let (svc, _dir) = seeded_service().await;
+
+    let action = Action {
+        r#type: "no.such.action".to_string(),
+        body: Vec::new().into(),
+    };
+    match svc.do_action(bearer(action, &superuser_token())).await {
+        Ok(_) => panic!("unknown action type must be rejected"),
+        Err(e) => assert_eq!(e.code(), tonic::Code::InvalidArgument),
+    }
+}
+
+#[tokio::test]
+async fn do_action_requires_bearer() {
+    let (svc, _dir) = seeded_service().await;
+    let action = Action {
+        r#type: "server.info".to_string(),
+        body: Vec::new().into(),
+    };
+    match svc.do_action(Request::new(action)).await {
+        Ok(_) => panic!("unauthenticated do_action must be rejected"),
+        Err(e) => assert_eq!(e.code(), tonic::Code::Unauthenticated),
+    }
+}

--- a/ferrosa-flight/tests/read_path.rs
+++ b/ferrosa-flight/tests/read_path.rs
@@ -1,0 +1,201 @@
+//! End-to-end test of the Flight read path: drive DDL/DML through the CQL
+//! engine, then redeem a `SELECT` via `do_get` (with bearer auth) and decode the
+//! streamed Arrow back into record batches.
+
+use std::sync::Arc;
+
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::Ticket;
+use futures::TryStreamExt;
+use tonic::Request;
+
+use ferrosa_cql::router::{route, RequestContext, SharedState};
+use ferrosa_flight::service::FerrosaFlight;
+use ferrosa_flight::token::{self, Claims};
+
+const KEY: &[u8] = b"flight-test-signing-key";
+
+fn superuser_token() -> String {
+    token::issue(
+        KEY,
+        &Claims {
+            role: "cassandra".to_string(),
+            is_superuser: true,
+            expires_at: 4_102_444_800, // year 2100 — comfortably in the future
+        },
+    )
+}
+
+fn bearer<T>(msg: T, token: &str) -> Request<T> {
+    let mut req = Request::new(msg);
+    req.metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    req
+}
+
+fn superuser() -> ferrosa_schema::AuthContext {
+    ferrosa_schema::AuthContext {
+        role: "cassandra".to_string(),
+        is_superuser: true,
+        must_change_password: false,
+    }
+}
+
+fn ctx<'a>(auth: &'a ferrosa_schema::AuthContext, ks: &'a Option<String>) -> RequestContext<'a> {
+    RequestContext {
+        auth,
+        current_keyspace: ks,
+        consistency: ferrosa_cluster::consistency::ConsistencyLevel::One,
+        serial_consistency: None,
+        paging: ferrosa_cql::paging::PagingParams::default(),
+        client_address: String::new(),
+    }
+}
+
+async fn exec(state: &SharedState, cql: &str) {
+    let auth = superuser();
+    let ks: Option<String> = None;
+    let stmt = ferrosa_cql::parser::parse(cql).unwrap_or_else(|e| panic!("parse {cql:?}: {e}"));
+    route(state, &ctx(&auth, &ks), stmt)
+        .await
+        .unwrap_or_else(|e| panic!("route {cql:?}: {e}"));
+}
+
+async fn seeded_service() -> (FerrosaFlight, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let state = ferrosa_cql::test_util::standalone_for_test(dir.path());
+    exec(
+        &state,
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}",
+    )
+    .await;
+    exec(&state, "CREATE TABLE ks.t (id int PRIMARY KEY, name text)").await;
+    exec(&state, "INSERT INTO ks.t (id, name) VALUES (1, 'alice')").await;
+    exec(&state, "INSERT INTO ks.t (id, name) VALUES (2, 'bob')").await;
+    (FerrosaFlight::new(Arc::clone(&state), KEY.to_vec()), dir)
+}
+
+#[tokio::test]
+async fn do_get_streams_select_result_as_arrow() {
+    let (svc, _dir) = seeded_service().await;
+
+    let resp = svc
+        .do_get(bearer(
+            Ticket {
+                ticket: "SELECT id, name FROM ks.t".into(),
+            },
+            &superuser_token(),
+        ))
+        .await
+        .expect("do_get ok");
+
+    let inner = resp
+        .into_inner()
+        .map_err(|s| FlightError::ExternalError(Box::new(s)));
+    let batches: Vec<_> = FlightRecordBatchStream::new_from_flight_data(inner)
+        .try_collect()
+        .await
+        .expect("decode flight stream");
+
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2, "two inserted rows should round-trip");
+    assert_eq!(batches[0].num_columns(), 2, "id + name columns");
+    assert_eq!(batches[0].schema().field(0).name(), "id");
+    assert_eq!(batches[0].schema().field(1).name(), "name");
+}
+
+#[tokio::test]
+async fn do_get_requires_a_valid_bearer() {
+    let (svc, _dir) = seeded_service().await;
+    let ticket = || Ticket {
+        ticket: "SELECT id, name FROM ks.t".into(),
+    };
+
+    // No token at all.
+    match svc.do_get(Request::new(ticket())).await {
+        Ok(_) => panic!("unauthenticated do_get must be rejected"),
+        Err(e) => assert_eq!(e.code(), tonic::Code::Unauthenticated),
+    }
+
+    // Token signed with the wrong key.
+    let forged = token::issue(
+        b"not-the-server-key",
+        &Claims {
+            role: "cassandra".to_string(),
+            is_superuser: true,
+            expires_at: 4_102_444_800,
+        },
+    );
+    match svc.do_get(bearer(ticket(), &forged)).await {
+        Ok(_) => panic!("forged token must be rejected"),
+        Err(e) => assert_eq!(e.code(), tonic::Code::Unauthenticated),
+    }
+}
+
+#[tokio::test]
+async fn do_get_streams_multiple_pages() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = ferrosa_cql::test_util::standalone_for_test(dir.path());
+    exec(
+        &state,
+        "CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy','replication_factor':1}",
+    )
+    .await;
+    exec(&state, "CREATE TABLE ks.t (id int PRIMARY KEY, name text)").await;
+    for i in 1..=3 {
+        exec(
+            &state,
+            &format!("INSERT INTO ks.t (id, name) VALUES ({i}, 'n{i}')"),
+        )
+        .await;
+    }
+
+    // page_size = 1 forces paging: the result must arrive as multiple batches,
+    // not one materialized batch.
+    let svc = FerrosaFlight::new(state, KEY.to_vec()).with_page_size(1);
+    let resp = svc
+        .do_get(bearer(
+            Ticket {
+                ticket: "SELECT id, name FROM ks.t".into(),
+            },
+            &superuser_token(),
+        ))
+        .await
+        .expect("do_get ok");
+
+    let inner = resp
+        .into_inner()
+        .map_err(|s| FlightError::ExternalError(Box::new(s)));
+    let batches: Vec<_> = FlightRecordBatchStream::new_from_flight_data(inner)
+        .try_collect()
+        .await
+        .expect("decode flight stream");
+
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 3, "all rows stream across pages");
+    assert!(
+        batches.len() >= 2,
+        "page_size=1 should stream multiple batches, got {}",
+        batches.len()
+    );
+}
+
+#[tokio::test]
+async fn do_get_rejects_non_select() {
+    let (svc, _dir) = seeded_service().await;
+    // Authenticated, but the command is not a SELECT.
+    match svc
+        .do_get(bearer(
+            Ticket {
+                ticket: "INSERT INTO ks.t (id, name) VALUES (3, 'x')".into(),
+            },
+            &superuser_token(),
+        ))
+        .await
+    {
+        Ok(_) => panic!("non-SELECT ticket must be rejected"),
+        Err(e) => assert_eq!(e.code(), tonic::Code::InvalidArgument),
+    }
+}

--- a/ferrosa-storage/Cargo.toml
+++ b/ferrosa-storage/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 ferrosa-common = { path = "../ferrosa-common" }
+ferrosa-cdc = { path = "../ferrosa-cdc" }
 ferrosa-index = { path = "../ferrosa-index" }
 ferrosa-schema = { path = "../ferrosa-schema" }
 ferrosa-sstable = { path = "../ferrosa-sstable" }

--- a/ferrosa-storage/src/commitlog/mod.rs
+++ b/ferrosa-storage/src/commitlog/mod.rs
@@ -42,7 +42,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use ferrosa_cdc::{CdcBus, CdcEvent, CdcStream};
 use ferrosa_common::key::DecoratedKey;
 use ferrosa_sstable::types::Row;
@@ -384,10 +384,12 @@ pub struct CommitLog {
     /// None when archiving is disabled.
     archive_tx: Option<tokio::sync::mpsc::Sender<u64>>,
 
-    /// Optional CDC bus. When attached and a `WrittenOnNode` subscriber is live,
-    /// each successful append publishes a change event. `None` (the default)
-    /// keeps the append hot path entirely free of CDC cost.
-    cdc: Option<Arc<CdcBus>>,
+    /// Optional CDC bus, attachable at runtime via [`set_cdc`](Self::set_cdc).
+    /// When attached and a `WrittenOnNode` subscriber is live, each successful
+    /// append publishes a change event. Empty (the default) keeps the append hot
+    /// path entirely free of CDC cost. `ArcSwapOption` so the bus can be injected
+    /// after the engine is built (lock-free load on the hot path).
+    cdc: ArcSwapOption<CdcBus>,
 }
 
 impl CommitLog {
@@ -424,16 +426,28 @@ impl CommitLog {
             next_segment_id: AtomicU64::new(first_segment_id + 1),
             archived: Mutex::new(HashSet::new()),
             archive_tx: None,
-            cdc: None,
+            cdc: ArcSwapOption::empty(),
         })
     }
 
     /// Attaches a CDC bus so successful appends publish `WrittenOnNode` change
     /// events (the local change-data-capture stream). Builder-style; returns
     /// `self` for chaining at construction.
-    pub fn with_cdc(mut self, bus: Arc<CdcBus>) -> Self {
-        self.cdc = Some(bus);
+    pub fn with_cdc(self, bus: Arc<CdcBus>) -> Self {
+        self.cdc.store(Some(bus));
         self
+    }
+
+    /// Attaches (or replaces) the CDC bus at runtime — used to inject the shared
+    /// bus after the engine is constructed. Lock-free; safe to call while
+    /// appends are in flight.
+    pub fn set_cdc(&self, bus: Arc<CdcBus>) {
+        self.cdc.store(Some(bus));
+    }
+
+    /// The attached CDC bus, if any.
+    pub fn cdc(&self) -> Option<Arc<CdcBus>> {
+        self.cdc.load_full()
     }
 
     /// Publishes a `WrittenOnNode` CDC event for a just-appended mutation.
@@ -450,7 +464,8 @@ impl CommitLog {
         timestamp: i64,
         mutation_id: [u8; 16],
     ) {
-        let Some(bus) = &self.cdc else { return };
+        let guard = self.cdc.load();
+        let Some(bus) = guard.as_ref() else { return };
         if !bus.has_subscribers(CdcStream::WrittenOnNode) {
             return;
         }
@@ -1326,6 +1341,28 @@ mod tests {
         let config = CommitLogConfig::test_config(dir.path());
         let cl = CommitLog::new(config).unwrap();
         cl.append(&simple_mutation()).unwrap();
+        cl.shutdown().unwrap();
+    }
+
+    #[test]
+    fn set_cdc_attaches_bus_at_runtime() {
+        // The bus can be injected AFTER construction (the production wiring path).
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig::test_config(dir.path());
+        let cl = CommitLog::new(config).unwrap();
+
+        let bus = CdcBus::new(16);
+        cl.set_cdc(Arc::clone(&bus)); // runtime attach
+        let mut sub = bus.subscribe(CdcStream::WrittenOnNode);
+
+        let m = simple_mutation();
+        cl.append(&m).unwrap();
+
+        let event = sub
+            .try_recv()
+            .expect("runtime-attached bus receives WrittenOnNode events");
+        assert_eq!(event.mutation_id, m.mutation_id);
+
         cl.shutdown().unwrap();
     }
 

--- a/ferrosa-storage/src/commitlog/mod.rs
+++ b/ferrosa-storage/src/commitlog/mod.rs
@@ -43,6 +43,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
+use ferrosa_cdc::{CdcBus, CdcEvent, CdcStream};
 use ferrosa_common::key::DecoratedKey;
 use ferrosa_sstable::types::Row;
 use parking_lot::Mutex;
@@ -382,6 +383,11 @@ pub struct CommitLog {
     /// Channel sender for notifying the archiver of closed segments.
     /// None when archiving is disabled.
     archive_tx: Option<tokio::sync::mpsc::Sender<u64>>,
+
+    /// Optional CDC bus. When attached and a `WrittenOnNode` subscriber is live,
+    /// each successful append publishes a change event. `None` (the default)
+    /// keeps the append hot path entirely free of CDC cost.
+    cdc: Option<Arc<CdcBus>>,
 }
 
 impl CommitLog {
@@ -418,7 +424,46 @@ impl CommitLog {
             next_segment_id: AtomicU64::new(first_segment_id + 1),
             archived: Mutex::new(HashSet::new()),
             archive_tx: None,
+            cdc: None,
         })
+    }
+
+    /// Attaches a CDC bus so successful appends publish `WrittenOnNode` change
+    /// events (the local change-data-capture stream). Builder-style; returns
+    /// `self` for chaining at construction.
+    pub fn with_cdc(mut self, bus: Arc<CdcBus>) -> Self {
+        self.cdc = Some(bus);
+        self
+    }
+
+    /// Publishes a `WrittenOnNode` CDC event for a just-appended mutation.
+    ///
+    /// No-op (and no allocation) when no bus is attached or no subscriber is
+    /// listening — the row clone happens only when an event will be delivered,
+    /// so this stays off the cost path for the common no-CDC case.
+    fn emit_written_on_node(
+        &self,
+        keyspace: &str,
+        table: &str,
+        key: &DecoratedKey,
+        rows: &[Row],
+        timestamp: i64,
+        mutation_id: [u8; 16],
+    ) {
+        let Some(bus) = &self.cdc else { return };
+        if !bus.has_subscribers(CdcStream::WrittenOnNode) {
+            return;
+        }
+        bus.publish(CdcEvent {
+            stream: CdcStream::WrittenOnNode,
+            keyspace: keyspace.to_string(),
+            table: table.to_string(),
+            key: key.clone(),
+            rows: rows.to_vec(),
+            timestamp,
+            accord_ts: None,
+            mutation_id,
+        });
     }
 
     /// Opens an existing commit log directory, replays uncommitted mutations,
@@ -660,6 +705,17 @@ impl CommitLog {
             sync_notify_start.elapsed(),
         );
 
+        // CDC: publish the local change-data-capture event after the write is
+        // durable in the segment buffer (WrittenOnNode stream).
+        self.emit_written_on_node(
+            &mutation.keyspace,
+            &mutation.table,
+            &mutation.key,
+            &mutation.rows,
+            mutation.timestamp,
+            mutation.mutation_id,
+        );
+
         Ok(position)
     }
 
@@ -711,9 +767,10 @@ impl CommitLog {
         );
 
         let write_start = Instant::now();
+        let mutation_id = Uuid::new_v4().into_bytes();
         let position = segment.write_single_row_entry(
             offset,
-            Uuid::new_v4().into_bytes(),
+            mutation_id,
             &table_id.keyspace,
             &table_id.table,
             key,
@@ -743,6 +800,16 @@ impl CommitLog {
             &COMMITLOG_APPEND_SYNC_NOTIFY_MICROS_TOTAL,
             &COMMITLOG_APPEND_SYNC_NOTIFY_MICROS_MAX,
             sync_notify_start.elapsed(),
+        );
+
+        // CDC: publish the local change-data-capture event (WrittenOnNode).
+        self.emit_written_on_node(
+            &table_id.keyspace,
+            &table_id.table,
+            key,
+            std::slice::from_ref(row),
+            timestamp,
+            mutation_id,
         );
 
         Ok(position)
@@ -1138,6 +1205,7 @@ fn parse_segment_id(filename: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ferrosa_cdc::{CdcBus, CdcRecvError, CdcStream};
     use ferrosa_common::{CellValue, DecoratedKey, PartitionKey};
     use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
 
@@ -1173,6 +1241,92 @@ mod tests {
             }],
             timestamp: 42_000,
         }
+    }
+
+    #[test]
+    fn append_publishes_written_on_node_cdc_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig::test_config(dir.path());
+        let bus = CdcBus::new(16);
+        let cl = CommitLog::new(config).unwrap().with_cdc(Arc::clone(&bus));
+        // Subscribe BEFORE the write so the event is captured.
+        let mut sub = bus.subscribe(CdcStream::WrittenOnNode);
+
+        let m = simple_mutation();
+        cl.append(&m).unwrap();
+
+        let event = sub.try_recv().expect("CDC event published on append");
+        assert_eq!(event.stream, CdcStream::WrittenOnNode);
+        assert_eq!(event.keyspace, m.keyspace);
+        assert_eq!(event.table, m.table);
+        assert_eq!(event.key, m.key);
+        assert_eq!(event.rows, m.rows);
+        assert_eq!(event.timestamp, m.timestamp);
+        assert_eq!(event.mutation_id, m.mutation_id);
+        assert!(event.accord_ts.is_none());
+
+        cl.shutdown().unwrap();
+    }
+
+    #[test]
+    fn append_single_row_publishes_written_on_node_cdc_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig::test_config(dir.path());
+        let bus = CdcBus::new(16);
+        let cl = CommitLog::new(config).unwrap().with_cdc(Arc::clone(&bus));
+        let mut sub = bus.subscribe(CdcStream::WrittenOnNode);
+
+        let table_id = TableId::new("ks2", "t2");
+        let key = DecoratedKey::new(PartitionKey::new(b"pk_single".to_vec()));
+        let row = Row {
+            clustering: vec![9],
+            cells: vec![(0, CellValue::live(b"v".to_vec(), 2000))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(2000),
+        };
+        cl.append_single_row(&table_id, &key, &row, 99_000).unwrap();
+
+        let event = sub
+            .try_recv()
+            .expect("CDC event published on single-row append");
+        assert_eq!(event.stream, CdcStream::WrittenOnNode);
+        assert_eq!(event.keyspace, "ks2");
+        assert_eq!(event.table, "t2");
+        assert_eq!(event.key, key);
+        assert_eq!(event.rows, vec![row]);
+        assert_eq!(event.timestamp, 99_000);
+        // mutation_id is generated by the single-row path; just confirm it is non-legacy.
+        assert_ne!(event.mutation_id, [0u8; 16]);
+
+        cl.shutdown().unwrap();
+    }
+
+    #[test]
+    fn append_without_cdc_subscriber_does_not_publish() {
+        // Bus attached, but nobody subscribed: append succeeds and produces no
+        // event (and the hot path skips the row clone).
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig::test_config(dir.path());
+        let bus = CdcBus::new(16);
+        let cl = CommitLog::new(config).unwrap().with_cdc(Arc::clone(&bus));
+
+        cl.append(&simple_mutation()).unwrap();
+
+        // Subscribe only now; the earlier write must not be replayed to us.
+        let mut late = bus.subscribe(CdcStream::WrittenOnNode);
+        assert_eq!(late.try_recv(), Err(CdcRecvError::Empty));
+
+        cl.shutdown().unwrap();
+    }
+
+    #[test]
+    fn append_without_cdc_bus_works() {
+        // No bus attached at all (the default): append is unaffected.
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig::test_config(dir.path());
+        let cl = CommitLog::new(config).unwrap();
+        cl.append(&simple_mutation()).unwrap();
+        cl.shutdown().unwrap();
     }
 
     #[test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -5371,6 +5371,19 @@ impl StorageEngine {
         }
     }
 
+    /// Attach (or replace) the CDC bus used by the commit log to publish
+    /// `WrittenOnNode` change-data-capture events. Inject the shared bus here
+    /// after the engine is constructed; lock-free and safe under concurrent
+    /// writes.
+    pub fn set_cdc_bus(&self, bus: std::sync::Arc<ferrosa_cdc::CdcBus>) {
+        self.commit_log.set_cdc(bus);
+    }
+
+    /// The CDC bus attached to this engine's commit log, if any.
+    pub fn cdc_bus(&self) -> Option<std::sync::Arc<ferrosa_cdc::CdcBus>> {
+        self.commit_log.cdc()
+    }
+
     /// Reads a partition from a table, merging memtable and SSTable sources.
     pub fn read(
         &self,

--- a/ferrosa/Cargo.toml
+++ b/ferrosa/Cargo.toml
@@ -12,9 +12,11 @@ path = "src/main.rs"
 arc-swap = "1.7"
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
+ferrosa-cdc = { path = "../ferrosa-cdc" }
 ferrosa-cluster = { path = "../ferrosa-cluster" }
 ferrosa-common = { path = "../ferrosa-common" }
 ferrosa-cql = { path = "../ferrosa-cql" }
+ferrosa-flight = { path = "../ferrosa-flight", optional = true }
 ferrosa-graph = { path = "../ferrosa-graph" }
 ferrosa-sparql = { path = "../ferrosa-sparql" }
 ferrosa-net = { path = "../ferrosa-net" }
@@ -44,6 +46,8 @@ tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_support
 
 [features]
 default = []
+# Arrow Flight (gRPC) query endpoint on port 8815 (see ferrosa-flight).
+flight = ["dep:ferrosa-flight"]
 otel = [
     "tracing-opentelemetry",
     "opentelemetry",

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -1354,11 +1354,72 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Clone write_path and ddl_path before shared_state is moved into the CQL server.
     let cluster_write_path = shared_state.write_path.clone();
     let cluster_ddl_path = shared_state.ddl_path.clone();
+    // Clone the shared execution state for the Flight endpoint before it is
+    // moved into the CQL server (feature-gated so it is not an unused clone).
+    #[cfg(feature = "flight")]
+    let flight_state = shared_state.clone();
     let cql_server = ferrosa_cql::server::CqlServer::new(cql_config, shared_state).with_task_pool(
         ferrosa_net::task_pool::TaskPool::runtime("cql", runtimes.cql.clone()),
     );
     let cql_addr = cql_server.start_background().await?;
     tracing::info!(%cql_addr, "CQL server listening");
+
+    // 9c. Arrow Flight (gRPC) query endpoint — port 8815, behind the `flight`
+    // feature. Auth is enforced per-RPC (signed bearer tokens); only
+    // anonymous-safe because every read RPC requires a verified token.
+    #[cfg(feature = "flight")]
+    {
+        let flight_bind =
+            std::env::var("FERROSA_FLIGHT_BIND").unwrap_or_else(|_| "0.0.0.0:8815".to_string());
+        match flight_bind.parse::<std::net::SocketAddr>() {
+            Ok(flight_addr) => {
+                let signing_key = match std::env::var("FERROSA_FLIGHT_SIGNING_KEY") {
+                    Ok(k) if !k.is_empty() => k.into_bytes(),
+                    _ => {
+                        tracing::warn!(
+                            "FERROSA_FLIGHT_SIGNING_KEY unset — using an ephemeral Flight token \
+                             key; bearer tokens will not survive a restart or work across nodes. \
+                             Set FERROSA_FLIGHT_SIGNING_KEY for stable auth."
+                        );
+                        uuid::Uuid::new_v4().into_bytes().to_vec()
+                    }
+                };
+                let previous_keys: Vec<Vec<u8>> =
+                    std::env::var("FERROSA_FLIGHT_SIGNING_KEY_PREVIOUS")
+                        .ok()
+                        .into_iter()
+                        .flat_map(|v| {
+                            v.split(',')
+                                .filter(|s| !s.is_empty())
+                                .map(|s| s.as_bytes().to_vec())
+                                .collect::<Vec<_>>()
+                        })
+                        .collect();
+                let token_ttl_secs: u64 = std::env::var("FERROSA_FLIGHT_TOKEN_TTL_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(3600);
+                let mut service =
+                    ferrosa_flight::service::FerrosaFlight::new(flight_state, signing_key)
+                        .with_token_ttl(token_ttl_secs);
+                if !previous_keys.is_empty() {
+                    service = service.with_previous_keys(previous_keys);
+                }
+                runtimes.background.spawn(async move {
+                    if let Err(e) = ferrosa_flight::server::serve_service(flight_addr, service).await
+                    {
+                        tracing::error!(error = %e, "Arrow Flight server exited");
+                    }
+                });
+                tracing::info!(%flight_addr, "Arrow Flight server listening");
+            }
+            Err(e) => tracing::error!(
+                bind = %flight_bind,
+                error = %e,
+                "invalid FERROSA_FLIGHT_BIND — Flight server not started"
+            ),
+        }
+    }
 
     // 9b. Web observability console — reuse the same registry as the CQL router.
     let web_state = web::WebAppState {

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -1406,7 +1406,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     service = service.with_previous_keys(previous_keys);
                 }
                 runtimes.background.spawn(async move {
-                    if let Err(e) = ferrosa_flight::server::serve_service(flight_addr, service).await
+                    if let Err(e) =
+                        ferrosa_flight::server::serve_service(flight_addr, service).await
                     {
                         tracing::error!(error = %e, "Arrow Flight server exited");
                     }

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -711,6 +711,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let storage = Arc::new(storage);
 
+    // Attach the push-based CDC bus to the engine's commit log so live CQL
+    // SUBSCRIBE (WrittenOnNode / CommittedToCluster) and the Arrow Flight
+    // endpoint receive change events. Bounded ring; lock-free, runtime-attached.
+    const CDC_BUS_CAPACITY: usize = 1024;
+    storage.set_cdc_bus(ferrosa_cdc::CdcBus::new(CDC_BUS_CAPACITY));
+
     // Register persisted system tables before any local schema restore or
     // cluster-mode Raft replay. Without this, the cluster state machine's
     // SystemTableWriter hits "table not registered: system_schema.*" during


### PR DESCRIPTION
## Arrow Flight query endpoint + push-CDC re-integration

Adds an Apache Arrow Flight (gRPC) query endpoint and re-integrates the
push-based CDC SUBSCRIBE path onto the rewritten `main`.

### Arrow Flight (`ferrosa-flight`, behind the `flight` feature)
- `handshake` — HMAC-SHA256 bearer tokens with **key rotation + configurable TTL**
- `do_get` streaming reads with **paging** (peak memory bounded to one page)
- `get_flight_info` — **distributed: one endpoint per token range** (token-bounded
  tickets + replica locations for parallel reads); single endpoint on standalone
- `get_schema`
- `do_put` — bulk ingest (Arrow→CQL, injection-safe)
- `do_exchange` — **bidirectional streaming upsert with per-batch acks**
- `list_flights`, `poll_flight_info`, `do_action`, `list_actions`
- Full CQL↔Arrow type coverage incl. decimal/list/map/set/tuple/UDT/vector
- Server wired into `main.rs` (`FERROSA_FLIGHT_BIND`, signing key + rotation, TTL,
  `FERROSA_FLIGHT_BROADCAST`/`FERROSA_FLIGHT_PORT` for distributed locations)

### CDC / SUBSCRIBE
- Push-based `CdcBus` (tokio broadcast): `WrittenOnNode` (commit-log tap) +
  `CommittedToCluster` (Accord apply via the `CdcPublishingApplier` decorator over
  `main`'s `EngineStorageApplier`) — keeps `main`'s correct Accord apply and
  restores the live SUBSCRIBE feed on top of it
- Verified real-time push end-to-end over the CQL wire (sub-ms delivery); 2-node /
  multi-node latency harness asserts no poll-interval floor

### `token()` correctness fix
- Standalone Direct `SELECT` now applies `token()` WHERE bounds (previously
  ignored → returned all rows); coordinator path unchanged. Prereq for correct
  per-range distributed reads.

### Python drop-in driver (`./drivers/ferrosa_driver`)
- API-compatible with the DataStax `cassandra-driver`; adds `SUBSCRIBE` over a
  dedicated raw connection (the stock driver can't consume the continuous push)

### Verification
- Full workspace gate green (`cargo test --all-features`, clippy `-D warnings`,
  fmt — excluding live-infra tests needing containers/Firecracker, as with jepsen/asc)
- `ferrosa-flight`: 46 tests; `ferrosa-cql` SUBSCRIBE: 31 tests; token fix test
- Driver: offline codec tests + live e2e over CQL :19142

### Still open (tracked follow-ups)
- Streaming joins / live-subscribe over `do_exchange` (`t_5fae178a`, W-004, post-v1)
- Advertise each node's real Flight address in ring/`NodeInfo` metadata (`t_59d30d3d`)
- SUBSCRIBE in the other language drivers (`t_196638d3`)
