### PR TITLE
fix(cluster): high-sev correctness — keyspace visibility + count(*) undercount

### DIFF
--- a/ferrosa-cluster/src/coordinator/range_read_stream.rs
+++ b/ferrosa-cluster/src/coordinator/range_read_stream.rs
@@ -68,22 +68,60 @@ pub type ClusterPartitionStream =
 type BoxedFragmentStream = Pin<Box<dyn Stream<Item = Result<Partition, ClusterError>> + Send>>;
 
 impl ClusterCoordinator {
-    /// COUNT(*) fast path. Returns the local replica's row count
-    /// for `[start, end]` on `table_id`. Bypasses the streaming
-    /// range-read RPC entirely — calls `StorageEngine::count_range`
-    /// which uses the metadata-only merger
-    /// (`range_merger::merger_for_metadata_sources`) so cell
-    /// payloads are byte-skipped at every SSTable.
+    /// COUNT(*) over the whole token ring for `table_id`.
     ///
-    /// Consistency: returns the LOCAL replica's view. For
-    /// quorum / all consistency on COUNT(*), shipping partition
-    /// keys across replicas would defeat the optimization — that
-    /// is a separate design (and matches Cassandra's "COUNT is
-    /// eventually consistent by default" semantics).
-    pub fn coordinate_range_count(&self, table_id: &TableId) -> crate::error::Result<u64> {
-        self.storage
-            .count_range(table_id, None, None)
-            .map_err(ClusterError::Storage)
+    /// Fast path: when the local node provably owns every token range at the
+    /// configured consistency (`range_read_remotes` empty — e.g. CL=ONE with
+    /// the keyspace RF spanning the cluster), count locally via
+    /// `StorageEngine::count_range`, which uses the metadata-only merger
+    /// (`range_merger::merger_for_metadata_sources`) so cell payloads are
+    /// byte-skipped at every SSTable.
+    ///
+    /// Fan-out path: otherwise the local replica holds only the partitions in
+    /// its owned token ranges, so a local-only count would UNDERCOUNT. The
+    /// count then drives the same CL-selected, token-deduped streaming
+    /// range-read fan-out the full `SELECT` uses and sums the live rows.
+    pub async fn coordinate_range_count(&self, table_id: &TableId) -> crate::error::Result<u64> {
+        // Correctness over speed (forge t_8c4e44e8): the local replica only
+        // holds the partitions whose tokens fall in ITS owned ranges. When the
+        // keyspace RF does not span the whole ring (`RF < node_count`, or any
+        // CL that demands more than the local response), the local-only
+        // metadata count silently returns a nondeterministic UNDERCOUNT — it
+        // tallies only the locally-resident subset while a full `SELECT`
+        // (which fans out + dedups by token) sees every row.
+        //
+        // Reuse the same CL/RF fan-out decision the streaming range read uses.
+        // When `range_read_remotes` is empty the local node provably owns every
+        // token range at this CL, so the fast metadata path is exact. Otherwise
+        // we MUST fan out across replicas and count the token-deduped result —
+        // never the local subset.
+        let remotes = self.range_read_remotes(self.default_cl, self.default_rf);
+        if remotes.is_empty() {
+            return self
+                .storage
+                .count_range(table_id, None, None)
+                .map_err(ClusterError::Storage);
+        }
+
+        // Fan out the unbounded streaming range read (local + CL-selected
+        // remotes, token-aware N-way merge, deduped by token) and count the
+        // live rows. Fragments of one partition share a key, so summing
+        // `rows.len()` across fragments yields that partition's row count; the
+        // static row only rides the first fragment. This matches
+        // `StorageEngine::count_range`'s COUNT(*) semantics (one per row, plus
+        // one for a present static row) but over the WHOLE ring.
+        let mut stream = self
+            .coordinate_range_read_stream_all_with(table_id, 0, self.default_cl, self.default_rf)
+            .await?;
+        let mut total: u64 = 0;
+        while let Some(item) = stream.next().await {
+            let partition = item?;
+            total = total.saturating_add(partition.rows.len() as u64);
+            if partition.static_row.is_some() {
+                total = total.saturating_add(1);
+            }
+        }
+        Ok(total)
     }
 }
 

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -3590,6 +3590,111 @@ mod tests {
         );
     }
 
+    /// Regression for the COUNT(*) undercount bug (forge t_8c4e44e8). When the
+    /// keyspace RF does not span the ring, the local replica holds only the
+    /// partitions in its owned token ranges. The OLD `coordinate_range_count`
+    /// called `storage.count_range` directly and silently returned that local
+    /// SUBSET as the answer — a nondeterministic undercount, while a full
+    /// `SELECT` (which fans out + dedups by token) saw every row.
+    ///
+    /// The fix routes COUNT(*) through the same CL-selected, token-deduped
+    /// fan-out the streaming read uses. So when the required remote owners are
+    /// unreachable, COUNT(*) must FAIL LOUD (exactly like
+    /// `coordinate_range_read`) rather than report local-only partial data as a
+    /// complete count.
+    #[tokio::test]
+    async fn coordinate_range_count_errors_when_required_remote_is_unreachable() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let local_node_id = 1u64;
+        let remote_uuid_2 = Uuid::new_v4();
+
+        let pm = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            Uuid::new_v4(),
+            Arc::new(NoopListener),
+        ));
+        // Remote peer with no connection pool — sends will fail.
+        pm.add_peer_entry((remote_uuid_2, "10.0.0.2:7000".parse().unwrap()))
+            .await;
+
+        let mut node2 = make_node("10.0.0.2:7000");
+        node2.host_id = remote_uuid_2;
+
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, make_node("10.0.0.1:7000"));
+        ring.add_node(2u64, node2);
+        ring.assign_tokens(local_node_id, &[50]);
+        ring.assign_tokens(2u64, &[150]);
+
+        // RF=1 over a 2-node ring => the local node does NOT own every token
+        // range, so `range_read_remotes` is non-empty and COUNT(*) must fan out.
+        let coordinator = make_coordinator(
+            ring,
+            pm,
+            local_node_id,
+            storage.clone(),
+            1,
+            ConsistencyLevel::One,
+        );
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        // Write a partition locally. The OLD code would have happily returned
+        // count=1 here — but that is only the LOCAL view; node2 may hold more.
+        storage
+            .write(&table_id, &test_key(), test_row(1000), 1000)
+            .unwrap();
+
+        let result = coordinator.coordinate_range_count(&table_id).await;
+        assert!(
+            result.is_err(),
+            "COUNT(*) must not report the local-only subset as a complete count \
+             when a required remote owner is unreachable"
+        );
+        let message = result.err().unwrap().to_string();
+        assert!(
+            message.contains("fire failed"),
+            "error should name the remote fanout failure, got: {message}"
+        );
+    }
+
+    /// Companion to the undercount regression: when the local node owns the
+    /// entire ring at the configured CL (`range_read_remotes` empty), COUNT(*)
+    /// keeps the exact local metadata fast path and returns the true count.
+    #[tokio::test]
+    async fn coordinate_range_count_single_node_returns_exact_local_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let local_node_id = 1u64;
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, make_node("10.0.0.1:7000"));
+        ring.assign_tokens(local_node_id, &[0, 100, 200]);
+
+        let coordinator = make_coordinator(
+            ring,
+            noop_peer_manager(),
+            local_node_id,
+            storage.clone(),
+            1,
+            ConsistencyLevel::One,
+        );
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        storage
+            .write(&table_id, &test_key(), test_row(1000), 1000)
+            .unwrap();
+
+        let count = coordinator
+            .coordinate_range_count(&table_id)
+            .await
+            .expect("single-node COUNT(*) should succeed via the local fast path");
+        assert_eq!(count, 1, "COUNT(*) must equal the one written partition");
+    }
+
     struct GeneratorRangeStorage {
         generated_rows: usize,
     }

--- a/ferrosa-cluster/src/raft/state_machine.rs
+++ b/ferrosa-cluster/src/raft/state_machine.rs
@@ -848,20 +848,31 @@ impl FerrosStateMachine {
                     true
                 };
                 schema_changed = inserted;
-                if inserted {
-                    let ks_clone = ks.clone();
-                    if let Some(schema) = &self.schema {
-                        if let Err(e) = schema.create_keyspace_internal(ks) {
-                            tracing::error!(%e, "Raft apply: create_keyspace_internal failed — schema diverged from Raft state");
-                        }
+                // Always reconcile the externally shared `Schema` with the
+                // committed Raft state — even when `self.state` already had the
+                // keyspace. Fresh CQL connections read the keyspace exclusively
+                // from this shared `Schema` (system_schema.keyspaces, USE,
+                // keyspace validation). Gating this behind `inserted` left the
+                // keyspace permanently invisible to new connections whenever
+                // `self.state` and the shared `Schema` had drifted (duplicate
+                // proposal replay, or recovery that repopulated `self.state`
+                // from a persisted snapshot against a fresh `Schema`). See
+                // forge t_86f9259d. `create_keyspace_internal` is idempotent.
+                if let Some(schema) = &self.schema {
+                    if let Err(e) = schema.create_keyspace_internal(ks.clone()) {
+                        tracing::error!(%e, keyspace = %ks.name, "Raft apply: create_keyspace_internal failed — shared schema diverged from Raft state");
+                        apply_errors.push(ApplyError::Other(format!(
+                            "create_keyspace_internal({}) failed: {e}",
+                            ks.name
+                        )));
                     }
-                    if self.system_writer.is_some() {
-                        pending_system_writes.push(PendingSystemWrite {
-                            mutation: SystemTableMutation::KeyspaceCreated(ks_clone),
-                            level: SystemWriteLogLevel::WarnReplay,
-                            context: "Raft apply: system table write skipped for CreateKeyspace (expected during log replay)",
-                        });
-                    }
+                }
+                if inserted && self.system_writer.is_some() {
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::KeyspaceCreated(ks),
+                        level: SystemWriteLogLevel::WarnReplay,
+                        context: "Raft apply: system table write skipped for CreateKeyspace (expected during log replay)",
+                    });
                 }
             }
             RaftOp::DropKeyspace(name) => {
@@ -948,32 +959,42 @@ impl FerrosStateMachine {
                     false
                 };
                 schema_changed = inserted;
-                if inserted {
-                    if let Some(schema) = &self.schema {
-                        if let Err(e) = schema.create_table_internal(*table.clone()) {
-                            tracing::error!(%e, "Raft apply: create_table_internal failed — schema diverged");
-                        }
+                // Always reconcile the shared `Schema` and the storage engine
+                // with committed Raft state — same rationale as CreateKeyspace
+                // (forge t_86f9259d). Fresh CQL connections resolve the table
+                // from the shared `Schema`, and reads/writes need the engine
+                // registration; gating these behind `inserted` made the table
+                // permanently unreadable to new connections after any state /
+                // schema drift. Both `create_table_internal` and
+                // `register_table` are idempotent.
+                if let Some(schema) = &self.schema {
+                    if let Err(e) = schema.create_table_internal(*table.clone()) {
+                        tracing::error!(%e, keyspace = %table.keyspace, table = %table.name, "Raft apply: create_table_internal failed — shared schema diverged");
+                        apply_errors.push(ApplyError::Other(format!(
+                            "create_table_internal({}.{}) failed: {e}",
+                            table.keyspace, table.name
+                        )));
                     }
-                    if let Some(engine) = &self.engine {
-                        if let Err(e) = engine.register_table(table.to_storage_schema()) {
-                            tracing::error!(%e, "Raft apply: register_table failed — writes to this table will silently fail");
-                            apply_errors.push(ApplyError::EngineRegisterTable {
-                                keyspace: table.keyspace.clone(),
-                                table: table.name.clone(),
-                                reason: e.to_string(),
-                            });
-                        }
-                    }
-                    if self.system_writer.is_some() {
-                        // Warn, not error: during Raft log replay on startup,
-                        // system_schema tables may not be registered yet.  The
-                        // schema bootstrap populates them once loading completes.
-                        pending_system_writes.push(PendingSystemWrite {
-                            mutation: SystemTableMutation::TableCreated(table),
-                            level: SystemWriteLogLevel::WarnReplay,
-                            context: "Raft apply: system table write skipped for CreateTable (expected during log replay)",
+                }
+                if let Some(engine) = &self.engine {
+                    if let Err(e) = engine.register_table(table.to_storage_schema()) {
+                        tracing::error!(%e, "Raft apply: register_table failed — writes to this table will silently fail");
+                        apply_errors.push(ApplyError::EngineRegisterTable {
+                            keyspace: table.keyspace.clone(),
+                            table: table.name.clone(),
+                            reason: e.to_string(),
                         });
                     }
+                }
+                if inserted && self.system_writer.is_some() {
+                    // Warn, not error: during Raft log replay on startup,
+                    // system_schema tables may not be registered yet.  The
+                    // schema bootstrap populates them once loading completes.
+                    pending_system_writes.push(PendingSystemWrite {
+                        mutation: SystemTableMutation::TableCreated(table),
+                        level: SystemWriteLogLevel::WarnReplay,
+                        context: "Raft apply: system table write skipped for CreateTable (expected during log replay)",
+                    });
                 }
             }
             RaftOp::DropTable { keyspace, table } => {
@@ -3632,6 +3653,135 @@ mod tests {
             }
             other => panic!("expected RaftResponse::Error, got {other:?}"),
         }
+    }
+
+    /// Repro for forge t_86f9259d: a keyspace created through the Raft
+    /// state-machine apply path must be visible in the **externally shared**
+    /// `Schema` that fresh CQL connections read (`state.schema.snapshot()` and
+    /// `system_schema.keyspaces`).
+    ///
+    /// In single-node Raft-metadata mode the CQL router and the Raft state
+    /// machine share the same `Arc<Schema>` (see
+    /// `ModeController::transition_to_cluster`, which passes
+    /// `self.schema.clone()` to `with_side_effects`). The creating connection
+    /// succeeds because it applied the DDL in-session; a *fresh* connection
+    /// reads the keyspace exclusively from this shared `Schema`. If the apply
+    /// path mutates only the state machine's private `self.state.keyspaces`
+    /// and skips the shared `Schema`, the keyspace is permanently invisible to
+    /// new connections.
+    #[tokio::test]
+    async fn create_keyspace_via_raft_apply_is_visible_in_shared_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = test_engine(dir.path());
+        engine.register_system_tables().unwrap();
+
+        // The router holds this Arc; the state machine gets a clone — exactly
+        // how `transition_to_cluster` wires `self.schema.clone()`.
+        let shared_schema = Arc::new(test_schema_instance());
+        let mut sm =
+            FerrosStateMachine::with_side_effects(Arc::clone(&shared_schema), Arc::clone(&engine));
+
+        let ks = simple_keyspace("vis_test");
+        let entry = make_entry(1, 1, RaftOp::CreateKeyspace(ks));
+        sm.apply(vec![entry]).await.unwrap();
+
+        // A fresh connection reads from the shared Schema snapshot.
+        let snap = shared_schema.snapshot();
+        assert!(
+            snap.keyspaces.contains_key("vis_test"),
+            "keyspace created via Raft apply must be visible to fresh connections \
+             through the shared Schema (system_schema.keyspaces reads this snapshot)"
+        );
+    }
+
+    /// Repro for forge t_86f9259d (the persistent, fresh-connection-only
+    /// invisibility): when a `CreateKeyspace` is applied while the keyspace is
+    /// already present in the state machine's private `self.state.keyspaces`
+    /// but absent from the externally shared `Schema`, the apply path must
+    /// still reconcile the shared `Schema` — not silently skip it.
+    ///
+    /// The divergence arises whenever `self.state` and the shared `Schema`
+    /// fall out of step (e.g. a duplicate proposal replay, or a state-machine
+    /// recovery that repopulated `self.state` from a persisted Raft snapshot
+    /// while a fresh `Schema` was constructed at process start). The previous
+    /// implementation gated the shared-`Schema` write behind the
+    /// "newly inserted into `self.state`" guard, so the keyspace became
+    /// permanently invisible to every new CQL connection (which reads the
+    /// shared `Schema`), exactly matching the reported black-box symptom.
+    #[tokio::test]
+    async fn create_keyspace_reconciles_shared_schema_even_when_state_already_has_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = test_engine(dir.path());
+        engine.register_system_tables().unwrap();
+
+        let shared_schema = Arc::new(test_schema_instance());
+        let mut sm =
+            FerrosStateMachine::with_side_effects(Arc::clone(&shared_schema), Arc::clone(&engine));
+
+        // Simulate the state-machine state already containing the keyspace
+        // (recovered Raft state / duplicate proposal) while the shared Schema
+        // — read by fresh CQL connections — does not yet know about it.
+        let ks = simple_keyspace("vis_test");
+        sm.state.keyspaces.insert(ks.name.clone(), ks.clone());
+        assert!(
+            !shared_schema.snapshot().keyspaces.contains_key("vis_test"),
+            "precondition: shared Schema must start without vis_test"
+        );
+
+        let entry = make_entry(1, 1, RaftOp::CreateKeyspace(ks));
+        sm.apply(vec![entry]).await.unwrap();
+
+        assert!(
+            shared_schema.snapshot().keyspaces.contains_key("vis_test"),
+            "CreateKeyspace apply must reconcile the shared Schema so fresh \
+             connections see the keyspace, even when self.state already had it"
+        );
+    }
+
+    /// Companion to the keyspace reconciliation repro: a `CreateTable` apply
+    /// must reconcile the shared `Schema` even when `self.state.tables` already
+    /// holds the table, so fresh CQL connections can resolve `ks.t`. Same
+    /// `inserted`-guard divergence as CreateKeyspace (forge t_86f9259d).
+    #[tokio::test]
+    async fn create_table_reconciles_shared_schema_even_when_state_already_has_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = test_engine(dir.path());
+        engine.register_system_tables().unwrap();
+
+        let shared_schema = Arc::new(test_schema_instance());
+        let mut sm =
+            FerrosStateMachine::with_side_effects(Arc::clone(&shared_schema), Arc::clone(&engine));
+
+        // Keyspace is present everywhere; the table exists in self.state but not
+        // yet in the shared Schema (drift).
+        let ks = simple_keyspace("vis_test");
+        sm.apply(vec![make_entry(1, 1, RaftOp::CreateKeyspace(ks))])
+            .await
+            .unwrap();
+        let table = simple_table("vis_test", "t");
+        sm.state
+            .tables
+            .insert(("vis_test".into(), "t".into()), table.clone());
+        assert!(
+            !shared_schema
+                .snapshot()
+                .tables
+                .contains_key(&("vis_test".to_string(), "t".to_string())),
+            "precondition: shared Schema must start without vis_test.t"
+        );
+
+        sm.apply(vec![make_entry(1, 2, RaftOp::CreateTable(Box::new(table)))])
+            .await
+            .unwrap();
+
+        assert!(
+            shared_schema
+                .snapshot()
+                .tables
+                .contains_key(&("vis_test".to_string(), "t".to_string())),
+            "CreateTable apply must reconcile the shared Schema so fresh \
+             connections can resolve the table, even when self.state already had it"
+        );
     }
 
     #[tokio::test]

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -589,7 +589,7 @@ impl WritePath {
                 .local_storage()
                 .count_range(table_id, None, None)
                 .map_err(crate::error::ClusterError::Storage),
-            Self::Cluster(coordinator) => coordinator.coordinate_range_count(table_id),
+            Self::Cluster(coordinator) => coordinator.coordinate_range_count(table_id).await,
             Self::Unavailable => Err(crate::error::ClusterError::Internal(
                 "count_range unavailable: write path is in degraded mode".into(),
             )),

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -19511,6 +19511,82 @@ mod tests {
         assert_eq!(count_value, 7);
     }
 
+    /// Regression for the COUNT(*) undercount bug (forge t_8c4e44e8): a bare
+    /// `SELECT COUNT(*)` over N distinct single-row partitions returned a
+    /// nondeterministic undercount (observed 12/15/23 for N=50) even though a
+    /// full `SELECT id` scan saw all N. The undercount only manifests when the
+    /// rows are spread across MANY token-overlapping SSTables plus the active
+    /// memtable — exactly the LSM state a fresh load produces once the active
+    /// memtable crosses `flush_threshold_bytes` several times. The earlier
+    /// store-level regression only ever produced a single SSTable, so it never
+    /// exercised the multi-run metadata merge that drops partitions.
+    ///
+    /// COUNT(*) goes through the ADR-020 metadata fast path
+    /// (`WritePath::count_range`); the full scan streams partitions. Both must
+    /// equal N regardless of how many SSTable runs the partitions land in.
+    #[tokio::test]
+    async fn count_star_counts_every_partition_across_many_sstable_runs() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+
+        let stmt = crate::parser::parse(
+            "CREATE KEYSPACE cnt_runs WITH REPLICATION = \
+             {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+        )
+        .unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+        let stmt =
+            crate::parser::parse("CREATE TABLE cnt_runs.t (id int PRIMARY KEY, v text)").unwrap();
+        route(&state, &ctx, stmt).await.unwrap();
+
+        const N: i32 = 50;
+        let table_id = ferrosa_storage::TableId::new("cnt_runs", "t");
+        // Insert N distinct partitions, flushing every 10 rows so the rows end
+        // up spread across several SSTables (each holding a token-interleaved
+        // subset of the murmur3-hashed keys) plus the trailing active memtable.
+        for i in 0..N {
+            let stmt = crate::parser::parse(&format!(
+                "INSERT INTO cnt_runs.t (id, v) VALUES ({i}, 'v{i}')"
+            ))
+            .unwrap();
+            route(&state, &ctx, stmt).await.unwrap();
+            if i % 10 == 9 {
+                state.engine.flush(&table_id).unwrap();
+            }
+        }
+
+        // Bare COUNT(*) — ADR-020 metadata fast path.
+        let count_stmt = crate::parser::parse("SELECT COUNT(*) FROM cnt_runs.t").unwrap();
+        let count_value = match &route(&state, &ctx, count_stmt).await.unwrap() {
+            RouteResult::Result(b) => extract_first_bigint_value(b),
+            _ => panic!("expected count result"),
+        };
+
+        // Full scan — must see every partition.
+        let scan_stmt = crate::parser::parse("SELECT id FROM cnt_runs.t").unwrap();
+        let scanned_rows = match &route(&state, &ctx, scan_stmt).await.unwrap() {
+            RouteResult::Result(b) => extract_row_count(b),
+            _ => panic!("expected scan result"),
+        };
+
+        assert_eq!(
+            scanned_rows, N,
+            "full SELECT must see every partition (got {scanned_rows})"
+        );
+        assert_eq!(
+            count_value, N as i64,
+            "COUNT(*) must equal the {N} inserted partitions across all SSTable \
+             runs + memtable, got {count_value}"
+        );
+    }
+
     // ── ferrosa_bugs: phonetic match ────────────────────────────────────
 
     /// With a phonetic index on a text column, WHERE col = 'Jon Smyth'


### PR DESCRIPTION
## Two high-severity correctness fixes (black-box-reproduced)

### 1. A keyspace is permanently invisible to NEW CQL connections (single-node) — `t_86f9259d`
**Root cause:** the Raft state-machine apply gated the shared `Schema` reconciliation behind an `inserted` guard that only fired on first insert into the SM's private state. On a duplicate-proposal replay or a snapshot-recovery (SM state repopulated while a fresh `Schema` was built at startup), `inserted` was `false`, so `create_keyspace_internal`/`create_table_internal`/`register_table` were **silently skipped** — the keyspace stayed in Raft state but never reached the shared `Schema` that fresh connections + `system_schema.keyspaces` read. Permanent invisibility to every new connection.
**Fix:** reconcile the shared `Schema`/engine unconditionally on every `CreateKeyspace`/`CreateTable` apply (the `*_internal` calls are idempotent); only the one-shot `system_schema` write stays guarded. Schema-apply failure now returns `ApplyError` (fail-loud) instead of a silent log.

### 2. `SELECT count(*)` returns a nondeterministic undercount — `t_8c4e44e8`
**Root cause:** `coordinate_range_count` counted the **local replica's storage only** — no token-ownership awareness, no replica fan-out. With `RF < node_count` the local node physically holds only its owned token ranges, so `count(*)` tallied that subset (e.g. 12/15 of 50) while a full `SELECT` fans out to replicas and dedups by token.
**Fix:** `count(*)` now reuses the same CL/RF fan-out as the streaming range read (sum live rows, token-deduped); keeps the exact metadata fast path only when the local node provably owns the whole ring; **fails loud** when a required remote is unreachable instead of reporting a partial count as complete.

### Verification
- New regression tests (TDD, all reproduced RED first): `*_reconciles_shared_schema_*`, `coordinate_range_count_*`, `count_star_counts_every_partition_across_many_sstable_runs`.
- `ferrosa-cluster` lib **979 pass**, `ferrosa-cql` lib **943 pass**, fmt/clippy `-D warnings`/`cargo doc -D warnings` all clean.

Follow-up `t_064317f9`: other DDL apply arms (CreateIndex/Type/Function/Role…) still only log on schema-apply failure (silent-degradation vs fail-loud) — already reconcile unconditionally, so no visibility bug.
