### PR TITLE
feat(postgres): UPDATE + DELETE — completes single-row CRUD

### DIFF
--- a/ferrosa-cql/src/bridge.rs
+++ b/ferrosa-cql/src/bridge.rs
@@ -8,10 +8,7 @@
 //! in `build_delete_row`.
 
 use std::net::IpAddr;
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use ferrosa_common::CellValue;
-use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
 use num_bigint::BigInt;
 
 use crate::ast::{CqlTypeName, Term};
@@ -742,59 +739,6 @@ fn resolve_builtin_type(name: &str) -> Option<CqlType> {
 }
 
 // ---------------------------------------------------------------------------
-// Function 5: build_delete_row
-// ---------------------------------------------------------------------------
-
-/// Build a storage [`Row`] representing a deletion.
-///
-/// - `delete_columns`: column indices to delete. If empty, this is a row-level
-///   deletion (range tombstone).
-/// - `clustering_values`: CQL values for clustering columns.
-/// - `timestamp`: deletion timestamp (microseconds).
-pub fn build_delete_row(
-    delete_columns: &[u16],
-    clustering_values: &[CqlValue],
-    timestamp: i64,
-) -> Row {
-    let clustering = encode_clustering(clustering_values);
-
-    // System clock: the one allowed unwrap
-    let now_secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as u32;
-
-    if delete_columns.is_empty() {
-        // Row-level deletion
-        Row {
-            clustering,
-            cells: vec![],
-            deletion: DeletionTime::new(timestamp, now_secs),
-            primary_key_liveness: LivenessInfo::NONE,
-        }
-    } else {
-        // Column-level deletion: tombstone each specified column.
-        // Must be sorted by column index — same requirement as build_row.
-        let mut cells: Vec<(u16, CellValue)> = delete_columns
-            .iter()
-            .map(|&idx| {
-                // CellValue.local_deletion_time is i32, DeletionTime.local_deletion_time is u32
-                let ldt = i32::try_from(now_secs).unwrap_or(i32::MAX);
-                (idx, CellValue::tombstone(timestamp, ldt))
-            })
-            .collect();
-        cells.sort_by_key(|(idx, _)| *idx);
-
-        Row {
-            clustering,
-            cells,
-            deletion: DeletionTime::LIVE,
-            primary_key_liveness: LivenessInfo::NONE,
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Function 6: partition_to_rows  (moved to ferrosa-row-bridge — D10 decoupling)
 // ---------------------------------------------------------------------------
 //
@@ -808,9 +752,9 @@ pub fn build_delete_row(
 // (used internally below) maps RowBridgeError back to CqlError via the
 // `crate::types::decode_value` wrapper.
 pub use ferrosa_row_bridge::{
-    build_decorated_key, build_row, decode_clustering, decode_pk, encode_clustering,
-    partition_to_rows, partition_to_rows_with_clustering, partition_to_rows_with_storage_mapping,
-    write_partition_raw_rows_with_storage_mapping,
+    build_decorated_key, build_delete_row, build_row, decode_clustering, decode_pk,
+    encode_clustering, partition_to_rows, partition_to_rows_with_clustering,
+    partition_to_rows_with_storage_mapping, write_partition_raw_rows_with_storage_mapping,
 };
 
 // ---------------------------------------------------------------------------
@@ -1195,8 +1139,9 @@ mod tests {
     use super::*;
     // Encoders moved to ferrosa-row-bridge (re-exported above); the tests below
     // still reference these directly.
-    use ferrosa_common::{DecoratedKey, PartitionKey};
+    use ferrosa_common::{CellValue, DecoratedKey, PartitionKey};
     use ferrosa_row_bridge::encode_value;
+    use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
 
     #[test]
     fn term_int_to_cql_int() {

--- a/ferrosa-postgres/src/query.rs
+++ b/ferrosa-postgres/src/query.rs
@@ -35,8 +35,8 @@ use std::sync::Arc;
 use ferrosa_common::{CqlType, CqlValue};
 use ferrosa_schema::{ColumnKind, Schema};
 use ferrosa_sql::{
-    execute, parse_statement, Column, ColumnType, ExecError, InsertStmt, MapCatalog, QueryResult,
-    Row, ScalarItem, ScalarValue, Statement, UpdateStmt, Value as SqlValue,
+    execute, parse_statement, Column, ColumnType, DeleteStmt, ExecError, InsertStmt, MapCatalog,
+    QueryResult, Row, ScalarItem, ScalarValue, Statement, UpdateStmt, Value as SqlValue,
 };
 use ferrosa_storage::{Mutation, StorageEngine};
 
@@ -722,9 +722,10 @@ pub async fn execute_query(
             "0A000",
             "SET/RESET session statements are not yet implemented",
         )],
-        // DML: single-row INSERT / UPDATE write through the engine.
+        // DML: single-row INSERT / UPDATE / DELETE write through the engine.
         Statement::Insert(ins) => execute_insert(engine, schema, &ins, default_schema),
         Statement::Update(upd) => execute_update(engine, schema, &upd, default_schema),
+        Statement::Delete(del) => execute_delete(engine, schema, &del, default_schema),
     }
 }
 
@@ -1050,6 +1051,93 @@ fn execute_update(
     match engine.write_atomic_batch(vec![mutation]) {
         Ok(()) => vec![BackendMessage::CommandComplete {
             tag: "UPDATE 1".to_string(),
+        }],
+        Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
+    }
+}
+
+/// Execute a single-row `DELETE`: a row-level tombstone. The equality `WHERE`
+/// supplies the full primary key identifying the row. Returns `CommandComplete
+/// "DELETE 1"` — the engine writes a tombstone unconditionally, so the count is
+/// reported as 1 when the write lands (Cassandra has no match count).
+fn execute_delete(
+    engine: &StorageEngine,
+    schema: &Schema,
+    del: &DeleteStmt,
+    default_schema: &str,
+) -> Vec<BackendMessage> {
+    use std::collections::HashMap;
+
+    let ks = del.table.schema.as_deref().unwrap_or(default_schema);
+    let table = del.table.table.as_str();
+    let snap = schema.snapshot();
+    let meta = match snap.tables.get(&(ks.to_string(), table.to_string())) {
+        Some(m) => m,
+        None => {
+            return vec![error_response(
+                "42P01",
+                &format!("relation \"{ks}.{table}\" does not exist"),
+            )]
+        }
+    };
+
+    let mut key_values: HashMap<String, CqlValue> = HashMap::new();
+    for (col_name, sv) in &del.where_eq {
+        let (col_meta, value) = match resolve_dml_value(meta, schema, ks, table, col_name, sv) {
+            Ok(r) => r,
+            Err(msg) => return vec![msg],
+        };
+        if !matches!(
+            col_meta.kind,
+            ColumnKind::PartitionKey | ColumnKind::Clustering
+        ) {
+            return vec![error_response(
+                "0A000",
+                &format!("DELETE WHERE supports only key columns; \"{col_name}\" is not a key"),
+            )];
+        }
+        key_values.insert(col_name.clone(), value);
+    }
+
+    let mut pk_values = Vec::with_capacity(meta.partition_key.len());
+    for name in &meta.partition_key {
+        match key_values.get(name) {
+            Some(v) => pk_values.push(v.clone()),
+            None => {
+                return vec![error_response(
+                    "23502",
+                    &format!("partition key column \"{name}\" must be specified in WHERE"),
+                )]
+            }
+        }
+    }
+    let mut ck_values = Vec::new();
+    for (name, _order) in &meta.clustering_key {
+        match key_values.get(name) {
+            Some(v) => ck_values.push(v.clone()),
+            None => {
+                return vec![error_response(
+                    "23502",
+                    &format!("clustering column \"{name}\" must be specified in WHERE"),
+                )]
+            }
+        }
+    }
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_micros() as i64)
+        .unwrap_or(0);
+    let key = match ferrosa_row_bridge::build_decorated_key(&pk_values, &[]) {
+        Ok(k) => k,
+        Err(e) => return vec![error_response("22000", &e.to_string())],
+    };
+    // Empty delete-columns => row-level tombstone.
+    let row = ferrosa_row_bridge::build_delete_row(&[], &ck_values, timestamp);
+    let mutation = Mutation::new(ks.to_string(), table.to_string(), key, vec![row], timestamp);
+    match engine.write_atomic_batch(vec![mutation]) {
+        Ok(()) => vec![BackendMessage::CommandComplete {
+            tag: "DELETE 1".to_string(),
         }],
         Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
     }

--- a/ferrosa-postgres/src/query.rs
+++ b/ferrosa-postgres/src/query.rs
@@ -36,7 +36,7 @@ use ferrosa_common::{CqlType, CqlValue};
 use ferrosa_schema::{ColumnKind, Schema};
 use ferrosa_sql::{
     execute, parse_statement, Column, ColumnType, ExecError, InsertStmt, MapCatalog, QueryResult,
-    Row, ScalarItem, ScalarValue, Statement, Value as SqlValue,
+    Row, ScalarItem, ScalarValue, Statement, UpdateStmt, Value as SqlValue,
 };
 use ferrosa_storage::{Mutation, StorageEngine};
 
@@ -722,8 +722,9 @@ pub async fn execute_query(
             "0A000",
             "SET/RESET session statements are not yet implemented",
         )],
-        // DML: single-row INSERT writes through the engine.
+        // DML: single-row INSERT / UPDATE write through the engine.
         Statement::Insert(ins) => execute_insert(engine, schema, &ins, default_schema),
+        Statement::Update(upd) => execute_update(engine, schema, &upd, default_schema),
     }
 }
 
@@ -898,6 +899,157 @@ fn execute_insert(
     match engine.write_atomic_batch(vec![mutation]) {
         Ok(()) => vec![BackendMessage::CommandComplete {
             tag: "INSERT 0 1".to_string(),
+        }],
+        Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
+    }
+}
+
+/// Resolve a `(column, value)` pair from a DML statement to its `CqlValue`,
+/// looking up the column's CQL type from `meta`. Returns the column metadata
+/// alongside so the caller can classify it (key vs regular). `$N`/function
+/// values fail loud (extended-protocol / unsupported).
+fn resolve_dml_value<'a>(
+    meta: &'a ferrosa_schema::TableMetadata,
+    schema: &Schema,
+    ks: &str,
+    table: &str,
+    col_name: &str,
+    sv: &ScalarValue,
+) -> Result<(&'a ferrosa_schema::ColumnMetadata, CqlValue), BackendMessage> {
+    let col_meta = meta.columns.get(col_name).ok_or_else(|| {
+        error_response(
+            "42703",
+            &format!("column \"{col_name}\" of relation \"{table}\" does not exist"),
+        )
+    })?;
+    let cql_type =
+        ferrosa_row_bridge::parse_cql_type_in_keyspace(&col_meta.column_type, ks, schema)
+            .map_err(|e| error_response("42704", &e.to_string()))?;
+    let value = match sv {
+        ScalarValue::Literal(v) => value_to_cql(v, &cql_type)?,
+        ScalarValue::Param(_) => {
+            return Err(error_response(
+                "0A000",
+                "$N parameters require the extended-query protocol (not yet supported)",
+            ))
+        }
+        ScalarValue::Func(_) => {
+            return Err(error_response(
+                "0A000",
+                "function calls in DML values are not supported",
+            ))
+        }
+    };
+    Ok((col_meta, value))
+}
+
+/// Execute a single-row `UPDATE`: a Cassandra-style upsert. The equality `WHERE`
+/// supplies the full primary key (which identifies the row); `SET` supplies the
+/// regular/static cells. Returns `CommandComplete "UPDATE 1"` — the engine write
+/// is a blind upsert, so the affected-row count is reported as 1 when the write
+/// lands (Cassandra has no match count; this is the documented semantic).
+fn execute_update(
+    engine: &StorageEngine,
+    schema: &Schema,
+    upd: &UpdateStmt,
+    default_schema: &str,
+) -> Vec<BackendMessage> {
+    use std::collections::HashMap;
+
+    let ks = upd.table.schema.as_deref().unwrap_or(default_schema);
+    let table = upd.table.table.as_str();
+    let snap = schema.snapshot();
+    let meta = match snap.tables.get(&(ks.to_string(), table.to_string())) {
+        Some(m) => m,
+        None => {
+            return vec![error_response(
+                "42P01",
+                &format!("relation \"{ks}.{table}\" does not exist"),
+            )]
+        }
+    };
+
+    // SET assignments -> regular/static cells (by storage index).
+    let mut regular_cells: Vec<(u16, CqlValue)> = Vec::new();
+    for (col_name, sv) in &upd.assignments {
+        let (col_meta, value) = match resolve_dml_value(meta, schema, ks, table, col_name, sv) {
+            Ok(r) => r,
+            Err(msg) => return vec![msg],
+        };
+        if !matches!(col_meta.kind, ColumnKind::Regular | ColumnKind::Static) {
+            return vec![error_response(
+                "0A000",
+                &format!("cannot UPDATE key column \"{col_name}\" in SET"),
+            )];
+        }
+        match meta.storage_column_index(col_name) {
+            Some(idx) => regular_cells.push((idx, value)),
+            None => {
+                return vec![error_response(
+                    "42703",
+                    &format!("column \"{col_name}\" not found in storage schema"),
+                )]
+            }
+        }
+    }
+
+    // WHERE equality -> key values (must be key columns).
+    let mut key_values: HashMap<String, CqlValue> = HashMap::new();
+    for (col_name, sv) in &upd.where_eq {
+        let (col_meta, value) = match resolve_dml_value(meta, schema, ks, table, col_name, sv) {
+            Ok(r) => r,
+            Err(msg) => return vec![msg],
+        };
+        if !matches!(
+            col_meta.kind,
+            ColumnKind::PartitionKey | ColumnKind::Clustering
+        ) {
+            return vec![error_response(
+                "0A000",
+                &format!("UPDATE WHERE supports only key columns; \"{col_name}\" is not a key"),
+            )];
+        }
+        key_values.insert(col_name.clone(), value);
+    }
+
+    let mut pk_values = Vec::with_capacity(meta.partition_key.len());
+    for name in &meta.partition_key {
+        match key_values.get(name) {
+            Some(v) => pk_values.push(v.clone()),
+            None => {
+                return vec![error_response(
+                    "23502",
+                    &format!("partition key column \"{name}\" must be specified in WHERE"),
+                )]
+            }
+        }
+    }
+    let mut ck_values = Vec::new();
+    for (name, _order) in &meta.clustering_key {
+        match key_values.get(name) {
+            Some(v) => ck_values.push(v.clone()),
+            None => {
+                return vec![error_response(
+                    "23502",
+                    &format!("clustering column \"{name}\" must be specified in WHERE"),
+                )]
+            }
+        }
+    }
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_micros() as i64)
+        .unwrap_or(0);
+    let key = match ferrosa_row_bridge::build_decorated_key(&pk_values, &[]) {
+        Ok(k) => k,
+        Err(e) => return vec![error_response("22000", &e.to_string())],
+    };
+    let row = ferrosa_row_bridge::build_row(&regular_cells, &ck_values, timestamp, None);
+    let mutation = Mutation::new(ks.to_string(), table.to_string(), key, vec![row], timestamp);
+    match engine.write_atomic_batch(vec![mutation]) {
+        Ok(()) => vec![BackendMessage::CommandComplete {
+            tag: "UPDATE 1".to_string(),
         }],
         Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
     }

--- a/ferrosa-row-bridge/src/lib.rs
+++ b/ferrosa-row-bridge/src/lib.rs
@@ -62,9 +62,9 @@ impl std::error::Error for RowBridgeError {}
 
 pub use codec::{decode_value, encode_value, parse_cql_type, parse_cql_type_in_keyspace};
 pub use row::{
-    build_decorated_key, build_row, decode_clustering, decode_pk, encode_clustering,
-    partition_to_rows, partition_to_rows_with_clustering, partition_to_rows_with_storage_mapping,
-    write_partition_raw_rows_with_storage_mapping,
+    build_decorated_key, build_delete_row, build_row, decode_clustering, decode_pk,
+    encode_clustering, partition_to_rows, partition_to_rows_with_clustering,
+    partition_to_rows_with_storage_mapping, write_partition_raw_rows_with_storage_mapping,
 };
 
 // Liveness helpers are re-exported for `ferrosa-cql`'s remaining metadata

--- a/ferrosa-row-bridge/src/row.rs
+++ b/ferrosa-row-bridge/src/row.rs
@@ -443,3 +443,47 @@ pub fn build_row(
         primary_key_liveness,
     }
 }
+
+/// Build a storage [`Row`] representing a deletion. Empty `delete_columns` is a
+/// row-level deletion (a partition/row tombstone); a non-empty list tombstones
+/// each named column. `clustering_values` locate the row; `timestamp` is micros.
+pub fn build_delete_row(
+    delete_columns: &[u16],
+    clustering_values: &[CqlValue],
+    timestamp: i64,
+) -> Row {
+    let clustering = encode_clustering(clustering_values);
+
+    // System clock: the one allowed unwrap.
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32;
+
+    if delete_columns.is_empty() {
+        Row {
+            clustering,
+            cells: vec![],
+            deletion: DeletionTime::new(timestamp, now_secs),
+            primary_key_liveness: LivenessInfo::NONE,
+        }
+    } else {
+        // Column-level deletion: tombstone each specified column. Cells MUST be
+        // sorted by column index — same requirement as build_row.
+        let mut cells: Vec<(u16, CellValue)> = delete_columns
+            .iter()
+            .map(|&idx| {
+                let ldt = i32::try_from(now_secs).unwrap_or(i32::MAX);
+                (idx, CellValue::tombstone(timestamp, ldt))
+            })
+            .collect();
+        cells.sort_by_key(|(idx, _)| *idx);
+
+        Row {
+            clustering,
+            cells,
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::NONE,
+        }
+    }
+}

--- a/ferrosa-sql/src/ast.rs
+++ b/ferrosa-sql/src/ast.rs
@@ -33,6 +33,8 @@ pub enum Statement {
     Reset { name: String },
     /// `INSERT INTO t (cols) VALUES (...)`. Boxed for size parity with `Select`.
     Insert(Box<InsertStmt>),
+    /// `UPDATE t SET ... WHERE ...`. Boxed for size parity with `Select`.
+    Update(Box<UpdateStmt>),
 }
 
 /// `INSERT INTO [schema.]table (col, ...) VALUES (val, ...)`. Single-row, with
@@ -42,6 +44,16 @@ pub struct InsertStmt {
     pub table: TableRef,
     pub columns: Vec<String>,
     pub values: Vec<ScalarValue>,
+}
+
+/// `UPDATE [schema.]table SET col = val, ... WHERE col = val [AND ...]`. The
+/// `WHERE` is restricted to equality on key columns (Cassandra-style upsert: the
+/// full primary key identifies the row); `assignments` are the SET cells.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateStmt {
+    pub table: TableRef,
+    pub assignments: Vec<(String, ScalarValue)>,
+    pub where_eq: Vec<(String, ScalarValue)>,
 }
 
 /// One projected scalar in a no-`FROM` SELECT, with an optional `AS` alias.

--- a/ferrosa-sql/src/ast.rs
+++ b/ferrosa-sql/src/ast.rs
@@ -35,6 +35,8 @@ pub enum Statement {
     Insert(Box<InsertStmt>),
     /// `UPDATE t SET ... WHERE ...`. Boxed for size parity with `Select`.
     Update(Box<UpdateStmt>),
+    /// `DELETE FROM t WHERE ...`. Boxed for size parity with `Select`.
+    Delete(Box<DeleteStmt>),
 }
 
 /// `INSERT INTO [schema.]table (col, ...) VALUES (val, ...)`. Single-row, with
@@ -53,6 +55,14 @@ pub struct InsertStmt {
 pub struct UpdateStmt {
     pub table: TableRef,
     pub assignments: Vec<(String, ScalarValue)>,
+    pub where_eq: Vec<(String, ScalarValue)>,
+}
+
+/// `DELETE FROM [schema.]table WHERE col = val [AND ...]`. Row-level delete; the
+/// equality `WHERE` supplies the full primary key identifying the row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeleteStmt {
+    pub table: TableRef,
     pub where_eq: Vec<(String, ScalarValue)>,
 }
 

--- a/ferrosa-sql/src/lib.rs
+++ b/ferrosa-sql/src/lib.rs
@@ -18,7 +18,7 @@ pub mod types;
 pub use ast::SelectStmt;
 pub use ast::{
     AggArg, Expr, InsertStmt, Operand, OrderItem, Projection, ScalarItem, ScalarValue, SelectItem,
-    Statement, Term,
+    Statement, Term, UpdateStmt,
 };
 pub use catalog::{Catalog, MapCatalog, SharedTable};
 pub use exec::{

--- a/ferrosa-sql/src/lib.rs
+++ b/ferrosa-sql/src/lib.rs
@@ -17,8 +17,8 @@ pub mod types;
 
 pub use ast::SelectStmt;
 pub use ast::{
-    AggArg, Expr, InsertStmt, Operand, OrderItem, Projection, ScalarItem, ScalarValue, SelectItem,
-    Statement, Term, UpdateStmt,
+    AggArg, DeleteStmt, Expr, InsertStmt, Operand, OrderItem, Projection, ScalarItem, ScalarValue,
+    SelectItem, Statement, Term, UpdateStmt,
 };
 pub use catalog::{Catalog, MapCatalog, SharedTable};
 pub use exec::{

--- a/ferrosa-sql/src/parser.rs
+++ b/ferrosa-sql/src/parser.rs
@@ -3,8 +3,8 @@
 use std::fmt;
 
 use crate::ast::{
-    AggArg, ColumnRef, Expr, InsertStmt, Join, Operand, OrderItem, Projection, ScalarItem,
-    ScalarValue, SelectItem, SelectStmt, Statement, TableRef, Term, UpdateStmt,
+    AggArg, ColumnRef, DeleteStmt, Expr, InsertStmt, Join, Operand, OrderItem, Projection,
+    ScalarItem, ScalarValue, SelectItem, SelectStmt, Statement, TableRef, Term, UpdateStmt,
 };
 use crate::exec::{AggFunc, CmpOp, SortDir};
 use crate::types::Value;
@@ -150,6 +150,7 @@ pub fn parse_statement(sql: &str) -> Result<Statement, ParseError> {
             "RESET" => p.parse_reset(),
             "INSERT" => p.parse_insert(),
             "UPDATE" => p.parse_update(),
+            "DELETE" => p.parse_delete(),
             other => Err(ParseError::Unexpected {
                 expected: "a statement",
                 found: other.to_string(),
@@ -639,6 +640,24 @@ impl Parser {
             assignments,
             where_eq,
         })))
+    }
+
+    /// `DELETE FROM [schema.]table WHERE col = val [AND ...]`. Assumes `self.pos`
+    /// is at the `DELETE` ident. `WHERE` is equality-only on key columns.
+    fn parse_delete(&mut self) -> Result<Statement, ParseError> {
+        self.next(); // DELETE
+        self.expect(&Tok::From, "FROM")?;
+        let table = self.parse_qualified_table()?;
+
+        self.expect(&Tok::Where, "WHERE")?;
+        let mut where_eq = vec![self.parse_assignment()?];
+        while matches!(self.peek(), Some(Tok::And)) {
+            self.next();
+            where_eq.push(self.parse_assignment()?);
+        }
+        self.expect_end()?;
+
+        Ok(Statement::Delete(Box::new(DeleteStmt { table, where_eq })))
     }
 
     /// Parse `[schema.]table` with NO trailing alias — for DML targets, where a
@@ -1687,6 +1706,25 @@ mod tests {
                 assert_eq!(u.where_eq, vec![("id".to_string(), ScalarValue::Param(2))]);
             }
             other => panic!("expected Update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_statement_delete() {
+        let stmt = parse_statement("DELETE FROM demo.t WHERE id = 1 AND ck = 2").unwrap();
+        match stmt {
+            Statement::Delete(d) => {
+                assert_eq!(d.table.schema.as_deref(), Some("demo"));
+                assert_eq!(d.table.table, "t");
+                assert_eq!(
+                    d.where_eq,
+                    vec![
+                        ("id".to_string(), ScalarValue::Literal(Value::Int(1))),
+                        ("ck".to_string(), ScalarValue::Literal(Value::Int(2))),
+                    ]
+                );
+            }
+            other => panic!("expected Delete, got {other:?}"),
         }
     }
 

--- a/ferrosa-sql/src/parser.rs
+++ b/ferrosa-sql/src/parser.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use crate::ast::{
     AggArg, ColumnRef, Expr, InsertStmt, Join, Operand, OrderItem, Projection, ScalarItem,
-    ScalarValue, SelectItem, SelectStmt, Statement, TableRef, Term,
+    ScalarValue, SelectItem, SelectStmt, Statement, TableRef, Term, UpdateStmt,
 };
 use crate::exec::{AggFunc, CmpOp, SortDir};
 use crate::types::Value;
@@ -149,6 +149,7 @@ pub fn parse_statement(sql: &str) -> Result<Statement, ParseError> {
             "SET" => p.parse_set(),
             "RESET" => p.parse_reset(),
             "INSERT" => p.parse_insert(),
+            "UPDATE" => p.parse_update(),
             other => Err(ParseError::Unexpected {
                 expected: "a statement",
                 found: other.to_string(),
@@ -609,6 +610,60 @@ impl Parser {
             columns,
             values,
         })))
+    }
+
+    /// `UPDATE [schema.]table SET col = val, ... WHERE col = val [AND ...]`.
+    /// Assumes `self.pos` is at the `UPDATE` ident. `WHERE` is equality-only
+    /// (the key columns identify the row, Cassandra-style upsert).
+    fn parse_update(&mut self) -> Result<Statement, ParseError> {
+        self.next(); // UPDATE
+        let table = self.parse_qualified_table()?;
+
+        self.expect_ident_kw("SET")?;
+        let mut assignments = vec![self.parse_assignment()?];
+        while matches!(self.peek(), Some(Tok::Comma)) {
+            self.next();
+            assignments.push(self.parse_assignment()?);
+        }
+
+        self.expect(&Tok::Where, "WHERE")?;
+        let mut where_eq = vec![self.parse_assignment()?];
+        while matches!(self.peek(), Some(Tok::And)) {
+            self.next();
+            where_eq.push(self.parse_assignment()?);
+        }
+        self.expect_end()?;
+
+        Ok(Statement::Update(Box::new(UpdateStmt {
+            table,
+            assignments,
+            where_eq,
+        })))
+    }
+
+    /// Parse `[schema.]table` with NO trailing alias — for DML targets, where a
+    /// following ident (`SET`, `WHERE`) is a keyword, not an alias.
+    fn parse_qualified_table(&mut self) -> Result<TableRef, ParseError> {
+        let first = self.ident()?;
+        let (schema, table) = if matches!(self.peek(), Some(Tok::Dot)) {
+            self.next();
+            (Some(first), self.ident()?)
+        } else {
+            (None, first)
+        };
+        Ok(TableRef {
+            schema,
+            table,
+            alias: None,
+        })
+    }
+
+    /// A `col = value` pair (used by `UPDATE`'s SET list and equality WHERE).
+    fn parse_assignment(&mut self) -> Result<(String, ScalarValue), ParseError> {
+        let col = self.ident()?;
+        self.expect(&Tok::Eq, "=")?;
+        let value = self.parse_scalar_value()?;
+        Ok((col, value))
     }
 
     /// A single SELECT-list entry: an aggregate `FUNC(...)` if an identifier
@@ -1588,6 +1643,51 @@ mod tests {
     #[test]
     fn parse_statement_insert_rejects_arity_mismatch() {
         assert!(parse_statement("INSERT INTO t (a, b) VALUES (1)").is_err());
+    }
+
+    #[test]
+    fn parse_statement_update() {
+        let stmt =
+            parse_statement("UPDATE demo.t SET v = 'x', n = 3 WHERE id = 1 AND ck = 2").unwrap();
+        match stmt {
+            Statement::Update(u) => {
+                assert_eq!(u.table.schema.as_deref(), Some("demo"));
+                assert_eq!(u.table.table, "t");
+                assert_eq!(
+                    u.assignments,
+                    vec![
+                        (
+                            "v".to_string(),
+                            ScalarValue::Literal(Value::Text("x".into()))
+                        ),
+                        ("n".to_string(), ScalarValue::Literal(Value::Int(3))),
+                    ]
+                );
+                assert_eq!(
+                    u.where_eq,
+                    vec![
+                        ("id".to_string(), ScalarValue::Literal(Value::Int(1))),
+                        ("ck".to_string(), ScalarValue::Literal(Value::Int(2))),
+                    ]
+                );
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_statement_update_with_params() {
+        let stmt = parse_statement("UPDATE t SET v = $1 WHERE id = $2").unwrap();
+        match stmt {
+            Statement::Update(u) => {
+                assert_eq!(
+                    u.assignments,
+                    vec![("v".to_string(), ScalarValue::Param(1))]
+                );
+                assert_eq!(u.where_eq, vec![("id".to_string(), ScalarValue::Param(2))]);
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Postgres DML: UPDATE + DELETE (completes single-row CRUD)

Stacked on #154 (`feat/ferrosa-sql-statement-foundation`, which adds INSERT). Together they give single-row **CRUD over the Postgres wire**, all on the one shared row encoder. **Retarget this PR to `main` once #154 merges.**

### ferrosa-sql
- `UPDATE [schema.]table SET col=val,... WHERE col=val [AND ...]` → `Statement::Update`
- `DELETE FROM [schema.]table WHERE col=val [AND ...]` → `Statement::Delete`
- equality-only WHERE on key columns; `parse_qualified_table` avoids reading `SET`/`WHERE` as a table alias. 3 parser tests.

### Shared encoder (no duplication)
Promoted `build_delete_row` into `ferrosa-row-bridge` alongside the key/row builders moved in #154; ferrosa-cql re-exports it. One canonical encoder family for both front-ends.

### ferrosa-postgres
- `execute_update` — WHERE equality supplies the full primary key, SET supplies regular/static cells → `CommandComplete "UPDATE 1"` (Cassandra-style upsert).
- `execute_delete` — WHERE supplies the key → row-level tombstone → `"DELETE 1"`.
- Shared `resolve_dml_value` (type resolution + literal→`CqlValue`); key-column-in-SET / non-key-in-WHERE / missing-key all fail loud (0A000/23502); `$N`/functions deferred to the extended protocol.

### Verification
**Live, cross-front-end**: INSERT×2 → UPDATE → DELETE over the PG wire, final state `(1,'alice',42.0)` (id=2 deleted, id=1 updated), confirmed **identically via PG and CQL SELECT**. UPDATE of a missing key upserts (Cassandra semantics). ferrosa-cql **943** lib tests pass (regression after the `build_delete_row` move); ferrosa-sql 125 · ferrosa-postgres 111. fmt / clippy `-D warnings` / `cargo doc -D warnings` clean.

### Still open (tracked, `t_4d3369fa`)
RETURNING, `$N` params over the extended protocol, ON CONFLICT, `= ANY($N)`; self-contained CI round-trip test (`t_16b8c8d1`); Accord write atomicity in transactions (`t_0f96cb47`).
