### PR TITLE
docs: per-crate README + specs for all 25 crates (+ architect review, process rule)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository. This complements
+[`CLAUDE.md`](CLAUDE.md) — read that for the full project overview, workspace
+layout, design decisions, and test policy. This file highlights the rules an
+agent most often gets wrong.
+
+## Per-crate docs are part of the definition of done
+
+Every crate in the workspace carries its own documentation:
+
+- **`<crate>/README.md`** — what's implemented, how the crate works, and its
+  dependencies (the crates it calls) and dependents (the crates that call it).
+- **`<crate>/specs/`** — `overview.md` (architecture), `fmea.md` (failure modes /
+  known issues), `roadmap.md` (Now / Next / Later), and `data-flow.md` for the
+  heavier crates.
+
+**Rule:** changing a crate's behavior, public API, dependency set, or
+known-issue/roadmap status is **not finished until that crate's `README.md` +
+`specs/` are updated to match.** A crate's docs must reflect its *current*
+implementation and dependency set. Treat stale crate docs the same as a failing
+test — do not open a PR with code changes whose crate docs are out of date.
+
+The crate-centric map (all crates + the runtime dependency graph) lives at
+[`specs/crates.md`](specs/crates.md). Cross-cutting topic specs live under
+[`specs/reference/`](specs/reference/).
+
+## Other rules agents must follow
+
+- **TDD** — every feature/fix follows red-green-refactor (`/tdd`). No code lands
+  without a test exercising it.
+- **Hygiene before pushing** — `cargo fmt --check`, `cargo clippy --all-targets`
+  (zero warnings), `cargo test`, and `cargo doc` with `-D warnings`, across the
+  full workspace, must pass locally. Do not push and hope. (CI also requires
+  these — the `main` merge queue gates on them.)
+- **Never commit to `main`** — feature branch + PR. Tag-only releases; the
+  version is owned by nightly automation (never hand-edit `[workspace.package]
+  version`).
+- **Conventional Commits** — the release bump level is computed from commit
+  subjects (`feat:`/`fix:`/`feat!:`).
+- **Fail loud, never fake** — prefer a clear error over a silent fallback that
+  returns wrong/empty results. (This is also what the FMEAs in each crate's
+  `specs/` exist to surface.)
+
+## Mermaid in docs
+
+GitHub's Mermaid renderer treats `<Type>` in diagram text as an HTML tag and
+breaks the diagram. In any Mermaid block, escape generic/placeholder angle
+brackets as `&lt;`/`&gt;` (e.g. `Vec&lt;Row&gt;`). `<br/>` and `<<choice>>` are
+valid and fine.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,17 @@ Always apply Rust idioms and best practices. Use the language's type system to p
 3. `cargo test -p <crate>` — affected crate tests pass
 4. `cargo build --all-targets` — full workspace compiles clean
 5. Feature branch — never commit to main directly
+6. **Update the modified crate's docs** — see the rule below.
+
+### Per-crate docs are part of "done"
+
+Every crate carries its own `README.md` (what's implemented, how it works, its
+dependencies/dependents) and a `specs/` directory (`overview.md`, `fmea.md`,
+`roadmap.md`). **Changing a crate's behavior, public API, dependency set, or
+known-issue/roadmap status is not done until that crate's `README.md` + `specs/`
+are updated to match.** A crate's docs must reflect its *current* implementation
+and dependency set — stale crate docs are treated like a failing check. The
+crate-centric index lives at [`specs/crates.md`](specs/crates.md).
 
 ### CI must pass before pushing
 

--- a/ferrosa-cdc/README.md
+++ b/ferrosa-cdc/README.md
@@ -1,0 +1,118 @@
+# ferrosa-cdc
+
+> The change-data-capture event types and bounded, multi-subscriber bus that
+> power Ferrosa's `SUBSCRIBE` change streams — shared by every producer (storage,
+> cluster) and consumer (CQL push, planned Arrow Flight) without a dependency cycle.
+
+## What this crate is
+
+A small, foundation-layer crate that owns the **`CdcEvent`** payload type and the
+**`CdcBus`** that carries those events from write-path producers to streaming
+consumers. `SUBSCRIBE` was deliberately scoped as two *optional, event-driven*
+change streams, not a polled `SELECT` snapshot, so the engine needs one shared
+push channel that sits *below* `ferrosa-storage` in the dependency graph. This
+crate is that channel.
+
+It depends on only `ferrosa-common` and `ferrosa-sstable`. That constraint is
+load-bearing: `ferrosa-storage` (a producer) depends on `ferrosa-cdc`, so
+`ferrosa-cdc` must **not** depend back on `ferrosa-storage`. Consequently
+`CdcEvent` reuses `ferrosa_sstable::types::Row` and never embeds
+`ferrosa_storage::Mutation`.
+
+## The two streams
+
+A subscriber selects exactly one stream; to follow both, open two subscriptions.
+
+- **`CdcStream::WrittenOnNode`** — every mutation durably written to *this* node's
+  commit log, ordered by mutation timestamp. Published by `ferrosa-storage`'s
+  commit-log append path.
+- **`CdcStream::CommittedToCluster`** — mutations the cluster has agreed/acked
+  (an Accord commit, or a regular-CL quorum ack on the coordinator). Published by
+  `ferrosa-cluster`.
+
+## What's implemented
+
+- **`CdcEvent`** — `stream`, `keyspace`, `table`, decorated `key`, mutated `rows`
+  (verbatim `Row`s), `timestamp` (microseconds, the ordering key), optional
+  `accord_ts` (present only for Accord-committed events), and `mutation_id`
+  (`[u8; 16]`, the dedup key for at-least-once delivery).
+- **`CdcBus`** — one `tokio::sync::broadcast` channel per stream behind a single
+  bus. `new(capacity)` (panics on `capacity == 0`), `publish` (returns the live
+  subscriber count; zero subscribers is a normal non-error case), `has_subscribers`
+  (hot-path guard so producers skip building an event when nobody listens), and
+  `subscribe`.
+- **`CdcSubscription`** — a consumer handle with its own bounded queue. `recv`
+  (async) / `try_recv` (non-blocking) return `Result<CdcEvent, CdcRecvError>`.
+- **`CdcRecvError`** — `Lagged { skipped }` (the **gap signal**: the queue
+  overflowed and `skipped` events were dropped — never silent), `Empty`
+  (`try_recv` only), `Closed` (bus dropped).
+
+## Bounded-queue / gap semantics
+
+The bus is bounded **per subscriber**. A slow subscriber can never block a
+producer (the write path): when its queue overflows, the oldest events are
+dropped from *its* queue only, and the next `recv`/`try_recv` returns
+`CdcRecvError::Lagged { skipped: N }`. This is an explicit gap signal — the
+consumer must resync from a checkpoint rather than assume continuity. Delivery
+then resumes from the oldest retained event. (FMEA F16/F18: a dropped event is
+never silently skipped.)
+
+## Wiring status (honest)
+
+- **Producers — wired.** `ferrosa-storage` publishes `WrittenOnNode` from
+  commit-log append (`commitlog/mod.rs`), guarded by `has_subscribers`.
+  `ferrosa-cluster` publishes `CommittedToCluster` for regular-CL writes
+  (`write_path.rs::committed_cdc_event`) and for Accord-committed transactions
+  (`accord/apply.rs::CdcPublishingApplier`, installed in
+  `accord/state_machine.rs`).
+- **Shared bus — wired.** `ferrosa/src/main.rs` constructs one
+  `CdcBus::new(1024)` and attaches it to the engine via `storage.set_cdc_bus(...)`,
+  so both producer paths and the CQL consumer share the same bus instance.
+- **CQL consumer — wired.** `ferrosa-cql::subscribe::spawn_cdc_subscription`
+  subscribes to the selected stream(s), converts each `CdcEvent` to a CQL RESULT
+  frame, and surfaces `Lagged` to the client.
+- **Arrow Flight consumer — NOT wired.** The `ferrosa-flight` crate exists but
+  does not yet subscribe to the bus. The lib docs name `ferrosa-flight` as an
+  intended consumer; that integration is still pending.
+
+## Public API
+
+| Area | Item |
+|------|------|
+| Event | `CdcEvent`, `CdcStream::{WrittenOnNode, CommittedToCluster}` |
+| Bus | `CdcBus::{new, publish, has_subscribers, subscribe}` |
+| Subscription | `CdcSubscription::{stream, recv, try_recv}` |
+| Errors | `CdcRecvError::{Lagged, Empty, Closed}` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — `DecoratedKey`, `accord::Timestamp` (the `accord_ts`
+  field type).
+- **`ferrosa-sstable`** — `types::Row` (the mutated-row payload, reused verbatim).
+
+External: `tokio` (the `sync` feature, for `broadcast`). **Never** depends on
+`ferrosa-storage` (would create a cycle).
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa`** — owns the shared `CdcBus` and injects it at startup.
+- **`ferrosa-cluster`** — publishes `CommittedToCluster` events.
+- **`ferrosa-cql`** — subscribes and pushes events to `SUBSCRIBE` clients.
+- **`ferrosa-storage`** — publishes `WrittenOnNode` events from the commit log.
+
+## Tests
+
+8 in-crate unit tests in `src/lib.rs`: stream isolation, fan-out to multiple
+subscribers, overflow → `Lagged` gap signal (not a silent drop), publish with no
+subscribers, per-stream `has_subscribers` tracking, async `recv`, closed-bus
+reporting, and the zero-capacity panic. End-to-end producer/consumer wiring is
+exercised in the consuming crates (`ferrosa-storage` commit-log tests,
+`ferrosa-cluster` write-path tests, `ferrosa-cql` subscribe tests).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — types, streams, bus, data flow, invariants
+- [FMEA / known issues](specs/fmea.md) — failure modes + gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-cdc/specs/fmea.md
+++ b/ferrosa-cdc/specs/fmea.md
@@ -1,0 +1,44 @@
+---
+crate: ferrosa-cdc
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-cdc — FMEA / Known Issues
+
+Failure modes are ranked by **RPN = Severity × Occurrence × Detection** (1–10
+each; higher = worse). This crate is tiny but sits on the live write-path-to-
+streaming-consumer boundary, so correctness-of-delivery severities are high.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| CDC-1 | Slow subscriber's bounded queue overflows | Events dropped from that subscriber's queue | 7 | 6 | 2 | 84 | **By design, surfaced.** Drop is per-subscriber only; next `recv`/`try_recv` returns `Lagged { skipped }` so the consumer resyncs from a checkpoint. Covered by `overflow_emits_gap_signal_not_silent_drop`. Residual risk: consumer that ignores `Lagged` silently loses data — owned by the consumer, not this crate. |
+| CDC-2 | Capacity chosen too small for real write rate | Frequent `Lagged`, consumers in constant resync, effective stream starvation | 6 | 5 | 4 | 120 | **Open tuning gap.** `main.rs` hard-codes `CdcBus::new(1024)`; there is no per-stream sizing, backpressure metric, or `Lagged`-rate counter. No way to observe how often the gap signal fires in production. |
+| CDC-3 | Arrow Flight consumer not wired | The `CommittedToCluster`/`WrittenOnNode` streams have no Flight reader despite lib docs naming `ferrosa-flight` as a consumer | 4 | 8 | 2 | 64 | **Known gap, not a defect.** `ferrosa-flight` exists but does not subscribe. CQL `SUBSCRIBE` is the only live consumer today. Track Flight integration in roadmap. |
+| CDC-4 | Producer publishes without honoring `has_subscribers`, or builds events when nobody listens | Wasted allocation/clone on the hot write path | 3 | 3 | 5 | 45 | Both producers guard with `has_subscribers` before constructing a `CdcEvent` (storage commit-log append; cluster `committed_cdc_event`/`CdcPublishingApplier`). A new producer that forgets the guard would regress this silently — convention, not enforced. |
+| CDC-5 | At-least-once delivery yields a duplicate `CdcEvent` | Consumer applies a change twice | 5 | 3 | 4 | 60 | Delivery is at-least-once; `mutation_id` (`[u8; 16]`) is the documented dedup key. Dedup is the **consumer's** responsibility; this crate provides the key but does not deduplicate. |
+| CDC-6 | Lib docs cite a missing spec (`specs/proposed/arrow-flight-endpoint/subscribe-cdc-architecture.md`) | Dangling doc reference; design rationale not discoverable | 2 | 7 | 1 | 14 | **Documentation gap.** The referenced file is absent in this checkout. `specs/overview.md` here now carries the design rationale; the lib-doc link should be repointed or the spec restored. |
+| CDC-7 | Zero capacity bus constructed | A stream that can never deliver | 8 | 1 | 1 | 8 | `CdcBus::new` asserts `capacity > 0` and panics otherwise (fail-loud at construction). Covered by `zero_capacity_panics`. |
+| CDC-8 | Ordering assumption violated (consumer assumes total order across streams) | Consumer reorders/correlates incorrectly | 5 | 3 | 5 | 75 | `timestamp` orders within a stream; `accord_ts` is present only for Accord-committed events. There is **no** cross-stream global order and no in-crate test asserting per-stream ordering under concurrency. Document the ordering contract; consumers must not assume cross-stream order. |
+
+## Top risks to act on
+
+1. **CDC-2 (RPN 120)** — capacity is an un-tuned, unobservable constant. Add a
+   `Lagged`-event / dropped-count metric and make per-stream capacity
+   configurable, so operators can see and fix starvation rather than guess.
+2. **CDC-8 (RPN 75)** — the ordering contract is implicit. Pin it down (per-stream
+   timestamp order; no cross-stream order) in docs and add a concurrency ordering
+   test, so consumers don't build on an unguaranteed assumption.
+3. **CDC-1 (RPN 84)** — the gap-signal mechanism is correct and tested, but its
+   *value* depends on every consumer handling `Lagged`. Keep the "must resync on
+   `Lagged`" contract loud in consumer docs.
+
+## Detection assets
+
+- In-crate: `overflow_emits_gap_signal_not_silent_drop`, `streams_are_isolated`,
+  `fans_out_to_all_subscribers`, `has_subscribers_tracks_live_subscriptions_per_stream`,
+  `publish_without_subscribers_is_not_an_error`, `async_recv_delivers_event`,
+  `closed_bus_reports_closed`, `zero_capacity_panics`.
+- End-to-end (consuming crates): `ferrosa-storage` commit-log append-publishes-CDC
+  tests, `ferrosa-cluster` `committed_cdc_event_only_when_subscribed`, and
+  `ferrosa-cql` `cdc_subscription_delivers_frame_on_write`.

--- a/ferrosa-cdc/specs/overview.md
+++ b/ferrosa-cdc/specs/overview.md
@@ -1,0 +1,122 @@
+---
+crate: ferrosa-cdc
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  Change-data-capture event types and a bounded, multi-subscriber bus for
+  Ferrosa SUBSCRIBE. Exposes two event-driven change streams (WrittenOnNode,
+  CommittedToCluster) over a per-subscriber bounded queue that surfaces overflow
+  as an explicit Lagged gap signal — never a silent drop. A foundation-layer
+  crate (ferrosa-common + ferrosa-sstable only) so storage and cluster producers
+  and CQL/Flight consumers can all depend on it without a dependency cycle.
+---
+
+# ferrosa-cdc — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-cdc` is the **shared push channel** for Ferrosa's `SUBSCRIBE` feature.
+`SUBSCRIBE` was scoped to expose two optional, event-driven change streams rather
+than a polled `SELECT` snapshot, so the engine needs a single bus that write-path
+producers publish to and streaming consumers read from.
+
+Its boundary is deliberately narrow: it knows the foundation value model
+(`DecoratedKey`, `accord::Timestamp` from `ferrosa-common`) and the storage row
+shape (`Row` from `ferrosa-sstable`), and nothing about commit-log internals,
+Accord/Raft, CQL framing, or transport. It owns *what a change event is* and *how
+events fan out to bounded subscribers* — not how they are produced or rendered.
+
+It exists below `ferrosa-storage` in the dependency graph **on purpose**:
+`ferrosa-storage` is a producer that depends on `ferrosa-cdc`, so `ferrosa-cdc`
+must not depend back on it. That is why `CdcEvent` reuses
+`ferrosa_sstable::types::Row` and never embeds `ferrosa_storage::Mutation`.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `lib` (`src/lib.rs`, ~285 LoC incl. tests) | `CdcStream`, `CdcEvent`, `CdcRecvError`, `CdcBus`, `CdcSubscription` — the entire public surface |
+
+This is a single-module crate; the type set is small and intentionally flat.
+
+## Core types
+
+- **`CdcStream`** — `WrittenOnNode` (local durable commit-log writes) or
+  `CommittedToCluster` (Accord commit / regular-CL quorum ack). `Copy`/`Eq`/`Hash`.
+- **`CdcEvent`** — `stream`, `keyspace`, `table`, `key: DecoratedKey`,
+  `rows: Vec&lt;Row&gt;`, `timestamp: i64` (microseconds; ordering key),
+  `accord_ts: Option&lt;Timestamp&gt;` (Some only on Accord-committed events),
+  `mutation_id: [u8; 16]` (dedup key for at-least-once delivery).
+- **`CdcBus`** — two `tokio::sync::broadcast` senders, one per stream, behind a
+  single `Arc`-wrapped bus.
+- **`CdcSubscription`** — one consumer's `broadcast::Receiver` plus the stream it
+  follows; owns its bounded queue.
+- **`CdcRecvError`** — `Lagged { skipped }`, `Empty`, `Closed`.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  subgraph Producers
+    ST[ferrosa-storage<br/>commit-log append]
+    CL[ferrosa-cluster<br/>write_path / CdcPublishingApplier]
+  end
+  BUS[CdcBus<br/>per-stream broadcast]
+  subgraph Consumers
+    CQL[ferrosa-cql<br/>spawn_cdc_subscription]
+    FL[ferrosa-flight<br/>planned, not wired]
+  end
+  ST -->|publish WrittenOnNode| BUS
+  CL -->|publish CommittedToCluster| BUS
+  BUS -->|subscribe + recv| CQL
+  BUS -.->|future| FL
+```
+
+**Publish path:** a producer first calls `has_subscribers(stream)` to avoid
+building/cloning a `CdcEvent` when nobody is listening; if there is at least one
+subscriber it constructs the event and calls `publish`. `publish` routes by
+`event.stream` to the matching broadcast sender. A send with zero receivers is
+*not* an error — it returns `0` delivered, because a producer must never block or
+fail on absent consumers (the write path stays hot).
+
+**Consume path:** a consumer `subscribe`s to one stream and drives `recv`
+(async) or `try_recv`. Each subscription has its own bounded queue sized by the
+bus `capacity`. When that queue overflows, the oldest events are dropped from
+*that subscriber's* queue only and the next receive returns
+`Lagged { skipped }`; delivery then resumes from the oldest retained event.
+
+## Key invariants
+
+1. **No silent drop.** Bounded-queue overflow is always surfaced as
+   `CdcRecvError::Lagged { skipped }`. A consumer that sees `Lagged` must resync
+   from a checkpoint; it is never given a quietly truncated stream (FMEA F16/F18).
+2. **Producers never block on slow consumers.** Per-subscriber bounded queues +
+   broadcast semantics mean a lagging subscriber affects only itself. `publish`
+   with zero receivers returns `0`, not an error.
+3. **No dependency on `ferrosa-storage`.** Enforced structurally — the reverse
+   edge already exists, so a dependency here would form a cycle. `CdcEvent` uses
+   `ferrosa_sstable::types::Row`, never `ferrosa_storage::Mutation`.
+4. **`mutation_id` is the at-least-once dedup key.** Delivery is at-least-once;
+   consumers deduplicate on `mutation_id`.
+5. **Streams are isolated.** A `WrittenOnNode` event is never delivered to a
+   `CommittedToCluster` subscriber, and vice versa.
+
+## Wiring status
+
+Producers and the shared bus are wired end to end: `ferrosa/src/main.rs`
+constructs `CdcBus::new(1024)` and attaches it via `storage.set_cdc_bus(...)`;
+`ferrosa-storage` publishes `WrittenOnNode`; `ferrosa-cluster` publishes
+`CommittedToCluster` (regular-CL in `write_path.rs`, Accord via
+`CdcPublishingApplier`); `ferrosa-cql` consumes via `spawn_cdc_subscription`. The
+`ferrosa-flight` (Arrow Flight) consumer named in the lib docs is **not yet
+wired** — that crate exists but does not subscribe to the bus.
+
+## Position in the dependency graph
+
+Foundation-layer / leaf-adjacent: depends only on `ferrosa-common` and
+`ferrosa-sstable`. Depended on by `ferrosa`, `ferrosa-cluster`, `ferrosa-cql`,
+and `ferrosa-storage`. See the root crate index for the full graph.
+
+> Note: the lib-doc reference to
+> `specs/proposed/arrow-flight-endpoint/subscribe-cdc-architecture.md` points at a
+> file not present in this checkout — see [fmea.md](fmea.md) (CDC-6).

--- a/ferrosa-cdc/specs/roadmap.md
+++ b/ferrosa-cdc/specs/roadmap.md
@@ -1,0 +1,56 @@
+---
+crate: ferrosa-cdc
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-cdc — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), the dependency/usage review, and
+the wiring audit of the consuming crates.
+
+## Now (highest value)
+
+- **Observability for the gap signal (FMEA CDC-2).** Add a dropped-event /
+  `Lagged` counter per stream so operators can see when subscribers fall behind.
+  Today overflow is correct and surfaced to the consumer, but invisible to
+  monitoring — there is no way to know the `1024` capacity is too small until a
+  client complains.
+- **Make per-stream capacity configurable.** Replace the hard-coded
+  `CdcBus::new(1024)` in `ferrosa/src/main.rs` with a config-driven value, and
+  allow `WrittenOnNode` and `CommittedToCluster` to be sized independently.
+
+## Next
+
+- **Pin and test the ordering contract (FMEA CDC-8).** Document that events are
+  ordered by `timestamp` *within* a stream and that there is no cross-stream
+  global order; add a concurrency test asserting per-stream ordering so consumers
+  don't build on an unguaranteed assumption.
+- **Wire the Arrow Flight consumer (FMEA CDC-3).** `ferrosa-flight` is named as a
+  consumer in the lib docs but does not subscribe to the bus. Add the Flight
+  subscription path (subscribe → encode `CdcEvent` to Arrow record batches →
+  stream), mirroring `ferrosa-cql::spawn_cdc_subscription`.
+- **Repair the dangling spec reference (FMEA CDC-6).** Restore or repoint
+  `specs/proposed/arrow-flight-endpoint/subscribe-cdc-architecture.md` referenced
+  from `src/lib.rs`; the design rationale now lives in
+  [specs/overview.md](overview.md).
+
+## Later
+
+- **Resync/checkpoint helper.** After a `Lagged`, consumers must resync from a
+  checkpoint. A shared helper (or a documented protocol) for turning a `Lagged`
+  into a bounded backfill would keep the gap-handling logic out of every consumer.
+- **Consumer-side dedup helper.** Delivery is at-least-once with `mutation_id` as
+  the dedup key; a small shared dedup window/utility would prevent each consumer
+  reimplementing it.
+- **Property-test fan-out + overflow** across many subscribers and stream mixes as
+  a regression net independent of the consuming crates.
+
+## Non-goals
+
+- Event production (commit-log append, Accord/Raft apply) — owned by
+  `ferrosa-storage` / `ferrosa-cluster`.
+- Protocol framing / transport (CQL RESULT frames, Arrow Flight gRPC) — owned by
+  the consumers (`ferrosa-cql`, `ferrosa-flight`).
+- Durable/replayable CDC log — this is an in-memory, at-least-once push bus, not a
+  persisted change log.

--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -1,0 +1,153 @@
+# ferrosa-cluster
+
+> The distribution layer: Raft metadata consensus (openraft), tunable-consistency
+> read/write coordination, the cluster-formation state machine, anti-entropy
+> repair, hinted handoff, and Accord strict-serializable transactions.
+
+## What this crate is
+
+`ferrosa-cluster` turns a set of single-node `ferrosa-storage` engines into a
+distributed database. It owns four largely independent subsystems that share a
+token ring and a Raft-replicated metadata state machine:
+
+1. **Raft metadata consensus** (`raft/`) — schema/DDL, membership, token
+   assignments, and cluster config are replicated through openraft 0.9 (a pinned
+   ferrosa fork with PreVote + CheckQuorum). The state machine is in-memory
+   `RaftState`; the log is sled-backed.
+2. **Read/write coordination** (`coordinator/`) — fans writes and reads out to
+   replicas with tunable CQL consistency-level (CL) enforcement, write
+   backpressure, read repair, batchlog, and range/streaming reads.
+3. **Cluster formation** (`controller/`, `mode.rs`, `ring/`, `pair/`) — the
+   `ModeController` state machine drives `Standalone → Pair → Forming → Cluster`,
+   the token ring computes replicas (SimpleStrategy / NetworkTopologyStrategy),
+   and pair mode gives two-node durability before a Raft quorum exists.
+4. **Anti-entropy & repair** (`repair/`, `hints/`) — Merkle-tree repair sessions,
+   an automatic repair scheduler, hinted handoff for transiently-down replicas,
+   and a quarantine → refill trigger from the storage self-heal path.
+
+It also implements **Accord** (`accord/`), an EPaxos-family protocol for
+strict-serializable multi-key / cross-shard transactions and LWT.
+
+> **Correctness-evidence honesty.** The Accord and Raft subsystems have extensive
+> *in-crate, deterministic* tests (state-machine, recovery, property, and
+> simulated-nemesis). There is **no external/public Jepsen run yet** — the
+> `ferrosa-jepsen` end-to-end harness is an approved-but-unbuilt standalone crate
+> ([specs/todo/jepsen-e2e-test-plan.md](../specs/todo/jepsen-e2e-test-plan.md)).
+> Treat consensus/transaction correctness as *tested*, not *proven in the wild*.
+> See [specs/fmea.md](specs/fmea.md).
+
+## What's implemented
+
+### Raft metadata consensus (`raft/`)
+- openraft 0.9 with features `serde`, `storage-v2`, `loosen-follower-log-revert`,
+  plus a pinned fork adding **PreVote** (`raft_enable_pre_vote`, default on) and
+  **CheckQuorum** (`raft_check_quorum_ratio`, default 0.75) per ADR-012.
+- `FerrosStateMachine` / `RaftState` — keyspaces, tables, roles/grants, indexes,
+  types, UDFs/UDAs, members, token map, per-node index status, cluster config.
+- `SledLogStore` — sled-backed log + meta trees, legacy-format migration, log
+  inspection/reset tooling.
+- `election_guard.rs` — `run_election_guard` watchdog (P0-17/P0-19): a burst
+  detector and a 30 s rolling-window detector that call `elect(false)` to suppress
+  divergence-driven election storms for 60 s; `ELECTION_STORM_TERM_JUMPS_TOTAL`.
+- `snapshot_pusher.rs` — leader-side sweep (P0-20) that triggers snapshot +
+  heartbeat to lagging followers; `INSTALLSNAPSHOT_PUSHES_TOTAL`.
+- `snapshot_transport.rs` — snapshots travel on `Lane::Bulk` (not `Lane::Raft`),
+  3 MiB chunks, 60 s per-chunk timeout.
+- `multi_dc_apply.rs` / `group_id.rs` — per-DC Raft groups (UUID-v5 group ids),
+  HLC reorder buffer + applied-txn ledger for cross-DC Accord apply (ADR-015).
+- `raft_forward.rs` — forward client writes / membership updates to the leader.
+
+### Coordination (`coordinator/`, `consistency.rs`, `write_path.rs`)
+- `ConsistencyLevel` — full CQL CL set incl. `Serial`/`LocalSerial`; `block_for` /
+  `block_for_dc` quorum math, wire + string codecs.
+- `coordinator/write.rs` — replica fan-out with `cl.block_for(rf)` ack threshold,
+  NTS / `LOCAL_QUORUM` / `EACH_QUORUM` per-DC variants, hinted handoff for failed
+  replicas, post-quorum hint drain, lazy mutation encoding.
+- `coordinator/read.rs` — two-phase digest reads, inline read repair on digest
+  mismatch (fail-loud `ReadTimeout` rather than serve stale), corrupt-SSTable
+  failover feeding the bounded `AntiEntropyRepairQueue` (cap 1024) — *serve now,
+  repair in background* (LOCKED DESIGN).
+- `coordinator/cl_routing.rs` — W8.4 learner-aware routing (voter-only quorums,
+  leader-only serial, cross-DC Accord routing).
+- `coordinator/batch.rs` — 3-phase logged batchlog (write → fan out → delete only
+  on full success) with replay task; `DEFAULT_BATCH_CONCURRENCY = 32`.
+- `coordinator/{range_read_stream,stream_*}.rs` — ADR-020 streaming range reads
+  (default; legacy capped path behind `FERROSA_BULK_STREAMING_RANGE_READ=0`).
+- **Write backpressure**: `WRITE_CONCURRENCY_LIMIT = 128` semaphore prevents bulk
+  CQL inserts from starving Raft heartbeats on the tokio runtime.
+
+### Formation (`controller/`, `mode.rs`, `ring/`, `pair/`, `rebalance.rs`)
+- `DeploymentMode` + `ModeController` — the `Standalone → Pair → Forming →
+  Cluster` state machine with degraded states; `ClusterStateHolder` dispatches
+  `SingleNode` / `Pair` / `Raft` cluster state.
+- `controller/bootstrap/` — 8-phase formation pipeline (DeliverInvites →
+  EstablishPools → CreateRaft → WaitLeader → ReplaySchema → BootstrapStream →
+  Promote → DrainQueue).
+- `ring/` — `TokenRing` (BTreeMap), SimpleStrategy + NetworkTopologyStrategy
+  replica selection with rack diversity, learner `owns_tokens` handling.
+- `controller/membership.rs` — `MembershipChanger` mutates the four membership
+  stores atomically (state machine, openraft voters, network node-map, peers);
+  add/remove voter, learner-only join, promote/demote, DC swap drain.
+- `controller/cluster_rejoin.rs` — P0-21 rejoin after formation timeout;
+  `CLUSTER_REJOIN_ATTEMPTS_TOTAL` / `_FAILURES_TOTAL`.
+- `pair/` — two-node primary/secondary coordination (role from TCP direction,
+  not UUID election), switchover, catch-up.
+- `rebalance.rs` — token-skew rebalancing with data streaming.
+
+### Repair & hints (`repair/`, `hints/`)
+- `repair/merkle.rs` — depth-15 Merkle trees (32 768 leaves), content-aware
+  partition hashing, divergent-leaf detection.
+- `repair/{coordinator,executor}.rs` — Merkle-then-stream sessions with bounded
+  fetch/apply chunks; deterministic single-initiator selection (no thundering
+  herd); timestamp ties surfaced, never auto-resolved (Aphyr-safe).
+- `repair/scheduler.rs` — `AutoRepairScheduler` / `AutoRepairConfig` (24 h default
+  interval, round-robin tables), Prometheus metrics.
+- `repair/trigger.rs` — quarantine → anti-entropy refill: a corrupt SSTable
+  quarantined in storage schedules a targeted refill from a verified-healthy peer.
+- `hints/` — per-peer on-disk hint segments (CRC32, crash-recoverable),
+  byte-budget backpressure (no silent loss → `needs_repair` + ERROR), FIFO
+  at-least-once delivery as `MutationForward`. **No time-based TTL** (budget cap).
+
+### Accord transactions (`accord/`)
+- `coordinator.rs` / `state_machine.rs` — PreAccept → {fast path | Accept} →
+  Commit → Apply, fast/slow quorum math, HLC timestamps + `TxnId`.
+- `recovery.rs` — Paxos-style recovery selecting by highest `accepted_ballot`.
+- `dep_wait.rs` — waits-for graph with deterministic cycle-breaking.
+- `cross_shard.rs` / `cross_dc_adapter.rs` — multi-shard atomicity, cross-DC glue.
+- `electorate.rs` / `epoch.rs` — JoinElectorate membership gates, epoch tracking.
+- `durability.rs`, `leaseholder.rs`, `linearizable_read.rs`, `two_phase_ddl.rs`.
+- In-crate Jepsen-style tests: `jepsen_bank.rs`, `jepsen_nemesis.rs`,
+  `recovery_scenarios.rs`, `proptests.rs` — all on the deterministic `TestCluster`.
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+`ferrosa-cdc`, `ferrosa-common`, `ferrosa-index`, `ferrosa-net`,
+`ferrosa-schema`, `ferrosa-sstable`, `ferrosa-storage`.
+
+**Called by** (crates that depend on this):
+`ferrosa`, `ferrosa-cql`, `ferrosa-ctl`, `ferrosa-flight`, `ferrosa-graph`,
+`ferrosa-session`, `ferrosa-sparql`.
+
+External: `openraft` (pinned fork), `sled`, `tokio`, `arc-swap`, `dashmap`,
+`parking_lot`, `bincode`, `crc32fast`, `uuid`, `serde`, `tracing`.
+
+## Tests
+
+~1050 test functions across the crate (in-module `#[cfg(test)]` + `tests/`).
+Notable integration suites: `failure_mode_matrix` (44), `raft_election_storm`
+(36), `leader_snapshot_push` (31), `accord_lwt_concurrent` (21),
+`accord_nemesis` (15), `correctness` (11), `cluster_formation` (10). All run on
+deterministic in-process harnesses unless gated behind `live-infra-tests`.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — subsystem map, invariants, position
+- [Data flow](specs/data-flow.md) — tunable-CL write + Accord transaction diagrams
+- [FMEA / known issues](specs/fmea.md) — ranked failure modes + real evidence gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later
+
+Related reference specs: `specs/reference/cluster-formation-architecture.md`,
+`specs/reference/anti-entropy-repair-architecture.md`,
+`specs/decisions/015-multi-dc-raft-per-dc-accord.md`,
+`specs/todo/jepsen-e2e-test-plan.md`.

--- a/ferrosa-cluster/specs/data-flow.md
+++ b/ferrosa-cluster/specs/data-flow.md
@@ -1,0 +1,114 @@
+---
+crate: ferrosa-cluster
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa-cluster — Data Flow
+
+Two end-to-end flows: a **tunable-consistency write** (the eventually-consistent
+data path) and an **Accord transaction** (the strict-serializable path). Both
+share the `TokenRing` for replica selection and run over `ferrosa-net` peers.
+
+> Note: identifiers below are written without raw angle brackets so the diagrams
+> render — e.g. `Option Partition` rather than the generic-parameter form.
+
+## 1. Tunable-CL write coordination
+
+A front-end (e.g. `ferrosa-cql`) hands a mutation to
+`ClusterCoordinator::coordinate_write*`. The coordinator gates on the write
+semaphore (backpressure protecting Raft), resolves replicas, fans out, and
+returns once `cl.block_for(rf)` acks arrive — hinting failed replicas.
+
+```mermaid
+flowchart TD
+    FE["Front-end (ferrosa-cql / graph / flight)"] -->|coordinate_write key,row,ts,cl,rf| CO["ClusterCoordinator"]
+    CO --> SEM{"acquire write_semaphore permit?<br/>cap WRITE_CONCURRENCY_LIMIT = 128"}
+    SEM -->|no permit| UNAVAIL["return Unavailable<br/>(fail-loud backpressure)"]
+    SEM -->|permit acquired| RING["TokenRing.replicas token,rf<br/>(SimpleStrategy / NTS)"]
+    RING --> THRESH{"replicas.len gte cl.block_for rf ?"}
+    THRESH -->|no| UNAVAIL2["return Unavailable"]
+    THRESH -->|yes| FAN["fan out: local write + remote MutationForward"]
+
+    FAN --> L["local StorageEngine.apply"]
+    FAN --> R1["replica 2 (remote peer)"]
+    FAN --> R2["replica 3 (remote peer)"]
+
+    L --> COLLECT["collect acks"]
+    R1 --> COLLECT
+    R2 --> COLLECT
+
+    COLLECT --> MET{"acks gte block_for rf ?"}
+    MET -->|no, timed out| WT["return WriteTimeout"]
+    MET -->|yes| HINT["store hints for failed replicas<br/>(HintStore, byte-budget capped)"]
+    HINT --> DRAIN["spawn post-quorum hint drain<br/>(detached, holds permit)"]
+    DRAIN --> OK["return Ok to front-end"]
+
+    HINT -.->|no hint store| WARN["log ERROR: divergent replicas<br/>need anti-entropy repair"]
+```
+
+Key points: the permit is held by the post-quorum drain task so stragglers are
+captured as hints without blocking the client. NTS / `LOCAL_QUORUM` /
+`EACH_QUORUM` variants compute per-DC ack thresholds via `block_for_dc`. The
+symmetric read path issues one full read plus `block_for - 1` digest reads, then
+on digest mismatch fail-loud re-fetches the newest copy and repairs stale
+replicas inline before returning.
+
+## 2. Accord transaction (strict-serializable)
+
+`AccordCoordinator` runs the EPaxos-family protocol across the shards a
+transaction touches. The common case commits in one round trip (fast path); a
+conflict forces the Accept phase (slow path). Apply waits on conflicting
+dependencies before writing to storage at the agreed HLC timestamp.
+
+```mermaid
+sequenceDiagram
+    participant FE as Front-end (LWT / multi-key txn)
+    participant CO as AccordCoordinator
+    participant HLC as HybridLogicalClock
+    participant R as Replicas (per shard)
+    participant DW as DepWaitGraph
+    participant ST as StorageApplier
+
+    FE->>CO: begin txn (keys, mutation)
+    CO->>HLC: now -> t0
+    CO->>CO: TxnId from t0, node
+
+    Note over CO,R: PreAccept phase
+    CO->>R: PreAccept t0, keys
+    R->>R: scan ConflictIndex -> deps, propose t gte t0
+    R-->>CO: PreAcceptOk t, deps
+
+    alt fast quorum agrees t == t0 and identical deps
+        Note over CO,R: Fast path (1 RTT) — FastPathCommit
+    else any t gt t0 or differing deps
+        Note over CO,R: Slow path — Accept phase (2 RTT)
+        CO->>R: Accept t_merged max, deps_merged union, fresh ballot
+        R-->>CO: AcceptOk (or NACK on higher ballot)
+    end
+
+    CO->>R: Commit final t, deps (fire-and-forget)
+
+    Note over CO,R: Apply phase
+    CO->>R: Apply t, deps, mutation bytes
+    R->>DW: wait until all deps reach Applied
+    DW-->>R: deps applied (cycle? abort highest t0)
+    R->>ST: apply mutation at timestamp t (idempotent)
+    ST-->>R: persisted
+    R-->>CO: applied
+    CO-->>FE: txn result
+
+    Note over CO,R: Coordinator failure -> RecoveryCoordinator<br/>re-proposes by highest accepted_ballot (Paxos rule)
+```
+
+Fast/slow quorum sizes: `slow = rf/2 + 1`; `fast = (3f+1)/2 + 1` where
+`f = rf - slow`. Cross-shard transactions dispatch PreAccept to every
+participating shard and abort atomically if any shard fails. Cross-DC apply routes
+`AccordApply` entries through per-DC Raft, buffered by HLC in a reorder buffer and
+deduplicated by an applied-txn ledger (ADR-015).
+
+> Correctness caveat: both flows are validated by deterministic in-crate tests
+> only. The fast/slow-path, recovery, and dep-wait logic have property + scenario
+> coverage, but there is **no external Jepsen run** confirming these flows hold
+> under real partitions, clock skew, and disk faults — see [fmea.md](fmea.md)
+> CL-1 and [../specs/todo/jepsen-e2e-test-plan.md](../specs/todo/jepsen-e2e-test-plan.md).

--- a/ferrosa-cluster/specs/fmea.md
+++ b/ferrosa-cluster/specs/fmea.md
@@ -1,0 +1,54 @@
+---
+crate: ferrosa-cluster
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-cluster — FMEA / Known Issues
+
+Failure modes are ranked by **RPN = Severity × Occurrence × Detection** (1–10
+each; higher = worse). This is the distribution layer, so safety failures are
+cluster-wide and severities run high. Several entries are *evidence* gaps
+(insufficient validation) rather than known-broken code — those are called out.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| CL-1 | **No external/public Jepsen validation of Accord + Raft.** All consensus/transaction tests are in-crate, deterministic harnesses (`TestCluster`, simulated nemesis). Real partitions, clock skew, fsync faults, and Byzantine timing are not exercised end-to-end. | A linearizability/strict-serializability violation that only manifests under real-world faults would ship undetected | 10 | 4 | 8 | 320 | **Open evidence gap.** `ferrosa-jepsen` harness designed + approved (`specs/todo/jepsen-e2e-test-plan.md`) but **not built**. Strong in-crate property/recovery tests reduce occurrence but cannot close detection. Treat correctness as *tested, not proven*. |
+| CL-2 | **Raft election storm on log divergence.** A follower whose log falls behind bumps its term unboundedly (no pre-vote in upstream openraft 0.9), burning CPU and inflating terms while the cluster is stable (observed T18,348 vs leader T8). | Hot node, term inflation, replication backoff; can block snapshot delivery | 8 | 5 | 4 | 160 | **Mitigated.** Pinned openraft fork adds PreVote + CheckQuorum (ADR-012, default on). Belt-and-suspenders `election_guard` watchdog (P0-17/P0-19) suppresses storms (`elect(false)` 60 s) and exposes `ELECTION_STORM_TERM_JUMPS_TOTAL`; `snapshot_pusher` (P0-20) pushes snapshots to lagging followers. Guard/pusher slated for removal (W4.11/W4.12) only after a clean Jepsen window — which depends on CL-1. |
+| CL-3 | **Write backpressure exhaustion starves the data path.** `WRITE_CONCURRENCY_LIMIT = 128` semaphore protects Raft from bulk-insert runtime saturation, but a saturated cluster returns `Unavailable` once all 128 permits are held. | Bulk writers see `Unavailable`/`WriteTimeout` under load; client must retry/throttle | 6 | 5 | 3 | 90 | **By design, fail-loud.** Limit prevents the worse failure (Raft heartbeat starvation → election storms). Constant is fixed, not tunable; batch path has a separate `DEFAULT_BATCH_CONCURRENCY = 32`. Tuning guidance + per-tenant limits are roadmap items. |
+| CL-4 | **Accord coordinator-failure recovery edge cases.** Recovery must re-propose by highest `accepted_ballot` (not `max_ballot_seen`); supersession ordering and cross-DC recovery are exercised only on the deterministic harness. | Wrong recovery decision → committed value lost or duplicated → serializability violation | 10 | 2 | 7 | 140 | Recovery rule + ballot invariant covered by `recovery_scenarios.rs` (13) and `proptests.rs`. Cross-DC adapter is thin glue with **no in-crate cross-DC failure test**. Depends on CL-1 for real validation. |
+| CL-5 | **Accord storage-apply seam untested under crashes.** Apply path dep-waits then writes via `StorageApplier`; in-crate tests use `NoopStorageApplier`, so real durability-under-crash on the engine-backed applier is unproven here. | A transaction reported applied may not be durable after a crash at the wrong moment | 9 | 2 | 7 | 126 | Dep-wait + idempotent re-apply implemented; production wires the engine applier. Crash-durability of the seam is a CL-1-adjacent evidence gap. |
+| CL-6 | **Read-repair / re-fetch failure on digest mismatch.** If the newest replica cannot be re-fetched, the read fails loud (`ReadTimeout`) rather than serving a possibly-stale copy. | Reads error transiently under replica flakiness instead of returning data | 5 | 4 | 3 | 60 | **By design, fail-loud** to protect linearizability. Inline repair writes the resolved value to stale replicas before returning. Acceptable trade vs. silent staleness. |
+| CL-7 | **Hinted-handoff eviction loses mutations.** Hints are byte-budget-capped per peer (`max_per_peer_mb`, default 1 GiB); a long-down peer overflows the budget and new hints are rejected. **No time-based TTL.** | Mutations destined for a long-down replica are dropped; replicas diverge until repair | 7 | 3 | 3 | 63 | **Fail-loud, designed.** Overflow rejected at append (no silent loss), `needs_repair` flag set + ERROR logged; anti-entropy repair is the documented backstop. TTL-based expiry not implemented. |
+| CL-8 | **Anti-entropy repair queue overflow under sustained corruption.** Read-path corrupt-SSTable detections feed a bounded queue (cap 1024); on overflow requests coalesce (global counter still increments, enqueue skipped). | Some refill requests dropped; affected ranges wait for the periodic scheduler | 6 | 3 | 4 | 72 | Bounded by design (serve-now/repair-later LOCKED DESIGN). Global metric always increments so overflow is observable; 24 h `AutoRepairScheduler` is the backstop. |
+| CL-9 | **Formation timeout falls back to Pair (silent durability reduction).** If a leader is not elected within `formation_timeout_secs`, the node reverts to `DegradedPair` and spawns `attempt_rejoin` instead of crashing. | Cluster may run with fewer replicas than configured RF; writes during the window have reduced durability | 7 | 3 | 4 | 84 | **Disclosed fallback.** Counters `LEADER_ELECTION_TIMEOUTS`, `FORMATION_REDUCED_DURABILITY_WRITES`, `RAFT_PUBLISH_NO_SUBSCRIBERS`, `RAFT_INITIALIZE_FAILURES` surface the condition; `cluster_rejoin` (P0-21) retries with capped backoff and counts `CLUSTER_REJOIN_FAILURES_TOTAL`. Operator must REPAIR after full membership. |
+| CL-10 | **Merkle XOR hash collision (false-negative divergence).** Depth-15 leaves XOR 64-bit content hashes; a collision can mask real divergence (~2⁻³² per diverging content, Cassandra-equivalent). | Two replicas with different data hash equal → repair skips them → permanent silent divergence | 8 | 1 | 8 | 64 | Accepted trade-off matching Cassandra. Hash widened 32→64 bit and made content-aware (was key-only). Residual risk inherent to Merkle anti-entropy. |
+| CL-11 | **Multi-DC Accord apply reorder-buffer stall.** Cross-DC `AccordApply` entries buffer by HLC; if writes outrun the `max_skew` watermark (default 200 ms), the buffer grows past `REORDER_BUFFER_ALARM_DEPTH = 100`. | Cross-DC apply latency rises; buffer pressure under clock skew | 5 | 3 | 4 | 60 | Alarm metric on buffer depth; applied-txn ledger dedupes; GC bounds memory. Cross-DC paths are newest and least battle-tested (ADR-015). |
+| CL-12 | **Bincode Raft-log wire fragility.** `RaftOp` variant reordering silently corrupts the persisted log. | A careless enum edit bricks log replay across a rolling upgrade | 9 | 1 | 5 | 45 | `raft_op_variant_tag_stability` test pins discriminants; recovery tooling `ferrosa-ctl raft log-inspect`/`log-truncate`; legacy format auto-migrated on load. |
+
+## Top risks to act on
+
+1. **CL-1 (RPN 320)** — the dominant risk is *evidence*, not a known bug: there is
+   no external Jepsen run. Until `ferrosa-jepsen` lands, every "strict
+   serializability holds" claim rests on deterministic in-crate tests. Build the
+   harness; it also gates removal of the CL-2 election-guard/snapshot-pusher
+   safety nets.
+2. **CL-2 (RPN 160)** — election storms are well-mitigated (PreVote + CheckQuorum +
+   guard + pusher), but the mitigations are *layered band-aids* awaiting Jepsen
+   confirmation before the band-aids come off. Keep the guard until CL-1 closes.
+3. **CL-4 / CL-5 (RPN 140 / 126)** — Accord recovery and the storage-apply seam are
+   the correctness-critical paths least covered by real-fault testing; prioritise
+   them in the Jepsen workload set and add cross-DC failure cases.
+
+## Detection assets
+
+- `ELECTION_STORM_TERM_JUMPS_TOTAL`, `INSTALLSNAPSHOT_PUSHES_TOTAL` (Raft health).
+- `LEADER_ELECTION_TIMEOUTS`, `FORMATION_REDUCED_DURABILITY_WRITES`,
+  `RAFT_PUBLISH_NO_SUBSCRIBERS`, `RAFT_INITIALIZE_FAILURES` (formation).
+- `CLUSTER_REJOIN_ATTEMPTS_TOTAL` / `_FAILURES_TOTAL` (rejoin).
+- `ferrosa_auto_repair_*`, `ferrosa_anti_entropy_refills_{scheduled,no_source}_total`,
+  timestamp-tie counters (repair); hint `needs_repair` ERROR logs.
+- In-crate suites: `failure_mode_matrix` (44), `raft_election_storm` (36),
+  `leader_snapshot_push` (31), `accord_lwt_concurrent` (21), `accord_nemesis` (15),
+  `recovery_scenarios` (13), `proptests`, `repair_fuzz` (7).
+- **Missing:** external Jepsen/Knossos/Elle history checking (CL-1).

--- a/ferrosa-cluster/specs/overview.md
+++ b/ferrosa-cluster/specs/overview.md
@@ -1,0 +1,122 @@
+---
+crate: ferrosa-cluster
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The distribution layer that turns single-node ferrosa-storage engines into a
+  cluster: Raft metadata consensus (openraft 0.9 fork with PreVote + CheckQuorum),
+  tunable-CL read/write coordination with write backpressure and read repair, the
+  Standalone→Pair→Forming→Cluster formation state machine, Merkle anti-entropy
+  repair + hinted handoff, and Accord strict-serializable transactions. Consensus
+  and transaction logic are heavily *tested in-crate* on deterministic harnesses;
+  external/public Jepsen validation is tracked (ferrosa-jepsen) but not yet built.
+---
+
+# ferrosa-cluster — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-cluster` is the **distribution boundary**. Below it sits
+`ferrosa-storage` (a single-node engine); above it sit the query front-ends
+(`ferrosa-cql`, `ferrosa-graph`, `ferrosa-sparql`, `ferrosa-flight`,
+`ferrosa-session`) and the control surface (`ferrosa`, `ferrosa-ctl`). It is the
+*only* place that knows how data and metadata are replicated, routed, and
+reconciled across nodes.
+
+It owns five concerns that share a token ring + a Raft-replicated metadata state
+machine but are otherwise loosely coupled:
+
+1. **Metadata consensus** — strongly-consistent DDL/membership/tokens via Raft.
+2. **Data-path coordination** — eventually-consistent, tunable-CL reads/writes.
+3. **Formation** — bringing nodes from standalone to a quorum-backed cluster.
+4. **Anti-entropy** — Merkle repair + hinted handoff to converge replicas.
+5. **Transactions** — Accord for strict-serializable multi-key / LWT operations.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `raft/` | openraft type config, `FerrosStateMachine`/`RaftState`, `SledLogStore`, network, handlers, `election_guard`, `snapshot_pusher`, `snapshot_transport`, `multi_dc_apply`, `group_id` |
+| `coordinator/` | `ClusterCoordinator`: `write`, `read`, `batch` (batchlog), `cl_routing`, `truncate`, streaming range reads (`range_read_stream`, `stream_*`) |
+| `consistency.rs` | `ConsistencyLevel` enum, `block_for`/`block_for_dc`, wire + string codecs |
+| `controller/` | `ModeController`, `ClusterStateHolder`, `bootstrap/` 8-phase pipeline, `membership` (`MembershipChanger`), `cluster_rejoin`, `invite`, `operator`, `peer_*` |
+| `mode.rs` | `DeploymentMode` enum + transition rules |
+| `ring/` | `TokenRing`, SimpleStrategy + NetworkTopologyStrategy replica selection |
+| `pair/` | two-node primary/secondary coordination, switchover, catch-up |
+| `rebalance.rs` | token-skew rebalancing with data streaming |
+| `repair/` | Merkle trees, repair coordinator/executor, scheduler, quarantine→refill trigger, RPC, cluster view |
+| `hints/` | per-peer hint segments, delivery/replay, CRC + crash recovery |
+| `accord/` | EPaxos-family transactions: coordinator, state machine, recovery, dep-wait, cross-shard/DC, electorate, durability, deterministic test cluster |
+| `state.rs` | `SingleNodeClusterState` / `PairClusterState` / `RaftClusterState` |
+| `write_path.rs`, `raft_forward.rs`, `ddl_path.rs`, `index_coordination.rs`, `streaming/`, `system_table_*` | write routing, leader forwarding, DDL routing, index build coordination, SSTable streaming, system-table persistence |
+
+## Data flow (summary)
+
+**Tunable-CL write.** A front-end calls `ClusterCoordinator::coordinate_write*`.
+The coordinator acquires a `write_semaphore` permit (cap 128, backpressure),
+resolves replicas from the `TokenRing`, computes the ack threshold
+`cl.block_for(rf)`, writes locally and fans out to remotes, and returns once the
+threshold is met. Failed replicas get hints; post-quorum stragglers are drained in
+a detached task. See [data-flow.md](data-flow.md).
+
+**Tunable-CL read.** `coordinate_read*` issues one full read + (block_for − 1)
+digest reads, then resolves. On digest mismatch it fail-loud re-fetches the newest
+copy and repairs stale replicas inline; on a corrupt local SSTable it fails over
+to a healthy replica and enqueues a background anti-entropy refill.
+
+**DDL / membership.** Mutations are wrapped as `RaftOp`, proposed via
+`raft.client_write` (forwarded to the leader if needed via `raft_forward`),
+committed, and applied deterministically into `RaftState` on every node.
+
+**Accord transaction.** `AccordCoordinator` runs PreAccept → (fast path or Accept)
+→ Commit → Apply across the participating shards, dep-waiting on conflicting
+transactions before applying to storage at the agreed HLC timestamp. See
+[data-flow.md](data-flow.md).
+
+## Key invariants
+
+1. **CL is an ack/digest threshold, never a fake success.** Writes return only
+   after `cl.block_for(rf)` acks; reads return only after `block_for` matching
+   digests. A read that cannot resolve a digest mismatch returns `ReadTimeout`,
+   not stale data.
+2. **Raft serves only metadata.** Schema, membership, tokens, and cluster config
+   flow through Raft; user data does not. This keeps the Raft log small and
+   apply-fast, and is why write backpressure (`WRITE_CONCURRENCY_LIMIT = 128`)
+   protects Raft heartbeats from data-path saturation.
+3. **Repair never silently picks a winner.** Equal-timestamp content divergence is
+   recorded as a timestamp tie and surfaced, not auto-resolved.
+4. **Corruption is loud.** Corrupt SSTables fail over + enqueue refill; hint
+   eviction sets `needs_repair` and logs ERROR; formation under-durability
+   increments a counter. No path masquerades corruption as "not found".
+5. **Single deterministic repair initiator per range.** Computed as a pure
+   function of the ring (lowest live `host_id`), so each range is repaired once.
+6. **Membership mutates four stores atomically.** `MembershipChanger` keeps the
+   Raft state machine, openraft voter set, network node-map, and peer table in
+   sync; a partial change is an error, not a silent skew.
+
+## Correctness evidence (be honest)
+
+- **What exists:** ~1050 in-crate tests, including Accord state-machine/recovery
+  scenarios, property tests (ballot invariant, recovery determinism, dep-wait
+  cycle detection, HLC monotonicity), simulated bank/nemesis workloads on the
+  deterministic `TestCluster`, Raft election-storm and snapshot-push suites, and a
+  failure-mode matrix.
+- **What does NOT exist yet:** a real external/public Jepsen run. `ferrosa-jepsen`
+  (multi-language CQL drivers, Firecracker/Fly chaos plane, Knossos/Elle checking)
+  is an **approved but unbuilt** standalone crate
+  ([../specs/todo/jepsen-e2e-test-plan.md](../specs/todo/jepsen-e2e-test-plan.md)).
+- **Implication:** consensus + transaction safety is *tested deterministically*,
+  not *empirically validated under real partitions, clock skew, and disk faults.*
+  This is the crate's headline FMEA gap — see [fmea.md](fmea.md).
+
+## Position in the dependency graph
+
+**Calls** `ferrosa-cdc`, `ferrosa-common`, `ferrosa-index`, `ferrosa-net`,
+`ferrosa-schema`, `ferrosa-sstable`, `ferrosa-storage`.
+
+**Called by** `ferrosa`, `ferrosa-cql`, `ferrosa-ctl`, `ferrosa-flight`,
+`ferrosa-graph`, `ferrosa-session`, `ferrosa-sparql`.
+
+It is a hub crate: a wide fan-in of front-ends depend on its coordinator/consensus
+API, so its public surface (CL semantics, `ModeController`, `MembershipChanger`,
+repair) changes ripple broadly. See the [root crate index](../../specs/crates.md).

--- a/ferrosa-cluster/specs/roadmap.md
+++ b/ferrosa-cluster/specs/roadmap.md
@@ -1,0 +1,62 @@
+---
+crate: ferrosa-cluster
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-cluster — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), in-code deprecation markers,
+reference/decision specs, and the dependency/usage review. Ordered by value.
+
+## Now (highest value)
+
+- **Build the external Jepsen harness (FMEA CL-1).** `ferrosa-jepsen` is designed
+  and approved (`specs/todo/jepsen-e2e-test-plan.md`) but not built. It is the only
+  thing that converts "Accord/Raft is *tested*" into "*validated under real
+  partitions, clock skew, and disk faults*". This is the single highest-leverage
+  item — it also gates Now-item #2.
+- **Add cross-DC + apply-seam failure cases to the transaction tests (CL-4, CL-5).**
+  The cross-DC adapter has no in-crate failure test, and the storage-apply seam is
+  tested only with `NoopStorageApplier`. Add deterministic crash-at-apply and
+  cross-DC partition scenarios now (cheap), pending the full Jepsen run.
+
+## Next
+
+- **Retire the election-storm safety nets once Jepsen is clean (CL-2).**
+  `election_guard.rs` (W4.11) and `snapshot_pusher.rs` (W4.12) are explicitly
+  marked for deletion after a clean Jepsen window against the PreVote+CheckQuorum
+  build. Do not remove before CL-1 closes; track the two-week clean-window gate.
+- **Make write backpressure observable and tunable (CL-3).** `WRITE_CONCURRENCY_LIMIT`
+  (128) is a hard constant. Add an admission/queue-depth metric and consider a
+  configurable / per-tenant limit so operators can trade Raft-protection headroom
+  against bulk-write throughput instead of hitting an opaque `Unavailable`.
+- **Finish the `ApplyError` migration (raft state machine).** `ApplyError` types
+  the engine-register path; remaining schema/system-writer failure sites still use
+  `Other(String)`. Type them so apply failures are classified, not stringly.
+- **Cross-DC Accord hardening (CL-11).** Reorder-buffer back-pressure policy beyond
+  the alarm depth, and clock-skew runbook tie-in for the watermark stall path.
+
+## Later
+
+- **Hint TTL / time-based expiry (CL-7).** Today hints are only byte-budget-capped;
+  a long-down peer overflows and triggers `needs_repair`. A time bound would let
+  operators reason about hint freshness independent of volume.
+- **Anti-entropy queue sizing + adaptive scheduling (CL-8).** Tune the 1024-deep
+  queue and let the scheduler prioritise ranges with recent corruption signals
+  rather than pure round-robin.
+- **Merkle false-negative reduction (CL-10).** Investigate a second hash or
+  configurable depth for high-divergence tables where the ~2⁻³² per-leaf
+  false-negative rate is unacceptable.
+- **Multi-DC SERIAL / LWT routing.** `cl_routing` currently returns
+  `NotImplementedCrossDc` for multi-DC serial consistency (deferred). Implement
+  cross-DC LWT when a consumer needs it.
+
+## Non-goals
+
+- **User-data durability/storage** — owned by `ferrosa-storage`; this crate routes
+  and reconciles, it does not persist SSTables.
+- **CQL / Bolt / SPARQL / Flight protocol framing and query planning** — owned by
+  the front-end crates that call this one.
+- **Putting user data through Raft** — Raft is metadata-only by design (keeps the
+  log small and protects heartbeats); the data path stays on the coordinator.

--- a/ferrosa-common/README.md
+++ b/ferrosa-common/README.md
@@ -1,0 +1,142 @@
+# ferrosa-common
+
+> The leaf crate: the shared low-level type vocabulary (`Token`,
+> `DecoratedKey`, `CellValue`, `CqlType`/`CqlValue`, `Error`) that every other
+> Ferrosa crate builds on.
+
+## What this crate is
+
+`ferrosa-common` is the **bottom of the dependency graph**. It depends on no
+other Ferrosa crate and is depended on by essentially every other crate in the
+workspace. It owns the small set of types that the storage engine, the CQL/PG
+front-ends, the cluster layer, and the index/UDF crates all have to agree on:
+the hash-ring `Token` and `DecoratedKey`, the storage `CellValue`, the CQL type
+model (`CqlType`/`CqlValue`), the workspace-wide `Error`/`Result`, the Accord
+HLC/timestamp/ballot types, and the Cassandra-compatible Murmur3 hash.
+
+Several of these types live here specifically to **break dependency cycles**:
+`CqlType`/`CqlValue` were moved out of `ferrosa-cql` so `ferrosa-udf` (and
+others below `ferrosa-cql`) can reference them without pulling in the large CQL
+crate; `TableSchema` lives here so storage and schema can share it without a
+cycle through `ferrosa-sstable`. Wire-format CQL encode/decode does **not** live
+here — it lives in `ferrosa-cql` / `ferrosa-row-bridge`.
+
+## What's implemented
+
+- **Hash ring** — `Token` (`i64` newtype over Murmur3 `h1`), `Token::from_key`,
+  `Token::MIN`/`MAX`; `murmur3::hash3_x64_128` (Cassandra-bit-compatible,
+  including the deliberate tail sign-extension bug).
+- **Keys** — `PartitionKey` (raw bytes) and `DecoratedKey` (key + cached token,
+  ordered by token then key bytes, with `filter_hash` for Bloom double-hashing).
+- **Storage cell** — `CellValue` with live / expiring / tombstone constructors
+  and `is_live`/`is_tombstone`/`is_expiring`; sentinels `NO_TIMESTAMP`,
+  `NO_TTL`, `NO_DELETION_TIME`.
+- **CQL type model** — `DataType` (scalar descriptor, `#[non_exhaustive]`),
+  `CqlType` (full type tree incl. List/Map/Set/Tuple/Udt/Vector, with protocol
+  `type_id()`), and `CqlValue` (runtime value with manual IEEE-754-total `Ord`).
+- **Errors** — `Error` (`#[non_exhaustive]`) + `Result`; notable typed variant
+  `Error::CorruptSstable { gen, min_token, max_token }` with `corrupt_sstable()`
+  / `corrupt_sstable_range()` for failover + targeted repair, and
+  `is_backpressure()` for overload classification.
+- **Accord primitives** — `Timestamp`, `TxnId`, `BallotNumber` /
+  `AcceptedBallot` / `PromisedBallot` (type-safe role separation),
+  `HybridLogicalClock` (lock-free, drift-rejecting `merge`), `BallotGenerator`,
+  `TxnPhase` / `TxnState`.
+- **Schema** — `TableSchema`, `ColumnDefinition`, `PinConfig` (NVMe pinning from
+  table extensions), plus fail-loud helpers `fixed_width_for_marshal_type`,
+  `validate_cell_bytes`, `validate_clustering_shape`, and the
+  `legacy_storage_column_order_warning` detector.
+- **Geometry** — `Geometry` (Point + single-ring Polygon), `marshal_wkb` /
+  `parse_wkb` (fail-loud on unknown byte-order, unsupported type, trailing
+  bytes, antimeridian crossing).
+- **Task spawning** — `TaskPool`: an explicit spawn target wrapping an optional
+  dedicated `tokio::runtime::Runtime`, with a documented `current()` fallback to
+  ambient `tokio::spawn`.
+- **Test generators** — behind the `test-generators` feature: proptest
+  strategies (`arb_cell_value`, `arb_cell`, `arb_partition_key`,
+  `arb_decorated_key`) shared across crates.
+
+## How it works
+
+One module per concern; all are pure data + small methods with no I/O except the
+HLC reading the system clock:
+
+- **`token`** / **`murmur3`** — the ring position and the hash that produces it.
+- **`key`** — `PartitionKey` and `DecoratedKey` (token cached at construction).
+- **`cell`** — `CellValue` state machine (live / expiring / tombstone).
+- **`data_type`** / **`cql_type`** — the type descriptors and runtime values.
+- **`error`** — workspace `Error`/`Result`, including the typed `CorruptSstable`
+  repair signal.
+- **`accord`** — Accord timestamps, ballots, HLC, and per-txn state.
+- **`schema`** — `TableSchema` and the marshal-type / clustering validators.
+- **`geometry`** — WKB marshal/parse for the supported geometry subset.
+- **`task_pool`** — runtime-aware spawn helper.
+
+The crate root (`lib.rs`) re-exports the headline types so downstream code
+writes `ferrosa_common::{DecoratedKey, CqlValue, Error}` rather than reaching
+into modules.
+
+## Public API (key entry points)
+
+| Area | Types / functions |
+|------|-------------------|
+| Ring | `Token`, `Token::from_key`, `murmur3::hash3_x64_128` |
+| Keys | `PartitionKey`, `DecoratedKey`, `DecoratedKey::filter_hash` |
+| Cells | `CellValue::{live,expiring,tombstone,is_live,is_tombstone,is_expiring}` |
+| Types | `DataType`, `CqlType::type_id`, `CqlValue` |
+| Errors | `Error`, `Result`, `Error::{corrupt_sstable,corrupt_sstable_range,is_backpressure}` |
+| Accord | `Timestamp`, `TxnId`, `BallotNumber`/`AcceptedBallot`/`PromisedBallot`, `HybridLogicalClock`, `BallotGenerator`, `TxnPhase`, `TxnState` |
+| Schema | `TableSchema`, `ColumnDefinition`, `PinConfig`, `fixed_width_for_marshal_type`, `validate_cell_bytes`, `validate_clustering_shape` |
+| Geometry | `Geometry`, `marshal_wkb`, `parse_wkb` |
+| Spawning | `TaskPool` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **NONE** — `ferrosa-common` is the **leaf crate**. It depends on no other
+  Ferrosa crate, by design: it sits at the bottom of the graph so the cycle-prone
+  shared types (`CqlType`/`CqlValue`, `TableSchema`) can be reused without
+  pulling in `ferrosa-cql`. External deps only: `num-bigint`, `serde`, `uuid`,
+  `tokio` (rt), and `proptest` (optional, `test-generators`).
+
+**Called by** (crates that depend on this — essentially every crate):
+
+- **`ferrosa`** — binary; uses the shared error/key/value model throughout.
+- **`ferrosa-cdc`** — change-data types built on `CellValue`/`CqlValue`.
+- **`ferrosa-cluster`** — ring placement via `Token`/`DecoratedKey`, Accord types.
+- **`ferrosa-cql`** — `CqlType`/`CqlValue` (re-exported), `Error` mapping.
+- **`ferrosa-ctl`** — CLI/TUI consumes the shared types for display.
+- **`ferrosa-flight`** — Arrow Flight endpoint maps `CqlValue`/`CqlType`.
+- **`ferrosa-graph`** — property-graph values over `CqlValue`.
+- **`ferrosa-index`** — indexes keyed by `DecoratedKey`/`CqlValue`.
+- **`ferrosa-index-builder`** — standalone builder shares key/value model.
+- **`ferrosa-loadgen`** — generates rows using the shared cell/value types.
+- **`ferrosa-net`** — internode framing of keys/tokens; `TaskPool` for runtimes.
+- **`ferrosa-postgres`** — PG front-end reuses `CqlValue`/`Error`.
+- **`ferrosa-row-bridge`** — encodes/decodes `CqlValue`/`CellValue`/`DecoratedKey`.
+- **`ferrosa-schema`** — extends `TableSchema`/`ColumnDefinition`.
+- **`ferrosa-session`** — session state over the shared error/value types.
+- **`ferrosa-sparql`** — SPARQL results mapped to `CqlValue`.
+- **`ferrosa-sstable`** — reads/writes `CellValue` and `DecoratedKey`; uses
+  `Error::CorruptSstable`.
+- **`ferrosa-storage`** — memtable/compaction keyed on `DecoratedKey`; raises
+  `CorruptSstable`; spawns via `TaskPool`.
+- **`ferrosa-udf`** — `CqlType`/`CqlValue` without a `ferrosa-cql` dependency.
+- **`ferrosa-worker`** — background tasks via `TaskPool`.
+
+## Tests
+
+In-crate unit tests are healthy and co-located with each module: **95 `#[test]`
+functions** across the crate (accord 28, schema 18, geometry 17, murmur3 7, key
+6, token 5, cql_type 5, cell 4, error 3, data_type 2). Murmur3 is covered by
+characterization vectors generated from Cassandra source for bit-exact
+compatibility. Gaps and the highest-risk areas (HLC clock `expect`, geometry
+subset) are tracked in [specs/fmea.md](specs/fmea.md) and
+[specs/roadmap.md](specs/roadmap.md).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, data flow
+- [FMEA / known issues](specs/fmea.md) — failure modes + gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-common/specs/fmea.md
+++ b/ferrosa-common/specs/fmea.md
@@ -1,0 +1,49 @@
+---
+crate: ferrosa-common
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-common — FMEA / Known Issues
+
+Failure modes are ranked by **RPN = Severity × Occurrence × Detection** (1–10
+each; higher = worse). This is the leaf crate, so its failure modes propagate to
+every crate above it — severities are correspondingly high.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| FC-1 | `HybridLogicalClock::wall_clock_ns()` panics via `.expect("system clock before Unix epoch")` | A clock anomaly (NTP step before epoch / VM clock glitch) panics the thread on **every** `now()`/`merge()` — i.e. on the Accord hot path. Violates "check all returns" (no `Result`) | 8 | 2 | 5 | 80 | **Open.** `now()`/`merge()` return owned values, not `Result`; the only failure path is a hard panic. Should saturate-to-0 or surface a typed clock error. See roadmap Now. |
+| FC-2 | Murmur3 drift from Cassandra (e.g. tail sign-extension "fixed") | Every key re-tokenizes → silent, total misplacement vs. existing SSTables and ring | 10 | 1 | 4 | 40 | Characterization vectors from Cassandra source (`murmur3::tests`, `tools/generate_murmur3_vectors.java`); the sign-extension asymmetry is documented as intentional. |
+| FC-3 | `CqlValue` cross-type `Ord` regresses (discriminant index or `total_cmp` changed) | Sorted structures keyed on `CqlValue` mis-order → wrong query results / index corruption | 9 | 2 | 6 | 108 | `total_cmp` for float/double/vector + fixed `discriminant_index`; covered by `cql_type::tests` ordering cases, but the **full** cross-type matrix is not exhaustively property-tested. |
+| FC-4 | `parse_wkb` rejects valid-but-unsupported geometry as an error (only Point + single-ring Polygon; antimeridian deferred to P2-d) | Callers needing MultiPolygon / holes / antimeridian get `InvalidData`, not a result | 4 | 4 | 2 | 32 | **Designed fail-loud** (clear error messages, not silent NULL). Tracked as a feature gap, not a bug. |
+| FC-5 | `TaskPool::current()` silently falls back to ambient `tokio::spawn` | Subsystem work lands on the default runtime instead of its tunable pool → contention (cf. the Raft-starvation class of bug) without a hard signal | 6 | 4 | 6 | 144 | **Documented but quiet.** Doc comment warns hot paths should prefer `runtime()`, but `current()` does not log/meter when it spawns on the ambient runtime — a degradation with no observable line. |
+| FC-6 | New `#[non_exhaustive]` `Error`/`DataType` variant breaks downstream matches | Compile break (or worse, a wildcard arm silently swallows a new error) | 5 | 2 | 3 | 30 | `#[non_exhaustive]` is deliberate; downstream wildcard arms must be audited when variants are added. |
+| FC-7 | `Error::is_backpressure()` classifies overload by **substring** match on `InvalidData` messages | A reworded backpressure message stops being treated as backpressure → request fails as a hard error instead of shedding load | 6 | 3 | 7 | 126 | **String-matching anti-pattern.** Checks `contains("local disk free space below write reserve")` / `starts_with("overloaded:")`. Contrast with the typed `CorruptSstable` path; backpressure should be a typed variant too. |
+| FC-8 | `test-generators` proptest strategies cover only `CellValue`/keys, not `CqlValue`/`CqlType` | Downstream property tests can't exercise the full value space from the shared generators | 3 | 5 | 4 | 60 | Generators exist for cells + keys; a `CqlValue` strategy would let every consumer property-test round-trips. Roadmap Next. |
+
+## Top risks to act on
+
+1. **FC-5 (RPN 144)** — `TaskPool::current()` is a *silent* degradation: it
+   spawns on the ambient runtime with no log/metric. Given Ferrosa's history of
+   runtime-contention bugs (Raft heartbeat starvation), an un-instrumented
+   fallback onto the wrong runtime is exactly the kind of "looks fine, runs hot"
+   failure the fail-loud rule warns against. Add a one-shot `warn!` + a counter.
+2. **FC-7 (RPN 126)** — backpressure is detected by substring-matching error
+   messages. Promote it to a typed `Error::Overloaded`/`Backpressure` variant so
+   classification can't silently break when a message is reworded.
+3. **FC-3 (RPN 108)** — `CqlValue` total order underpins index/sort correctness;
+   add a property test over the full cross-type matrix as a regression net.
+
+## Detection assets
+
+- `murmur3::tests` — Cassandra characterization vectors (bit-exact placement).
+- `accord::tests` (28 tests) — HLC monotonicity, drift rejection, ballot roles,
+  `TxnState` transitions.
+- `cql_type::tests` / `schema::tests` / `geometry::tests` — type IDs, ordering,
+  marshal-type validation, WKB round-trips and error paths.
+- `key::tests` / `token::tests` / `cell::tests` — ring order, tie-breaking,
+  cell-state predicates.
+
+**Detection gaps:** no in-crate test forces the HLC clock-error path (FC-1), no
+exhaustive `CqlValue` ordering property test (FC-3), and no observability on the
+`TaskPool::current()` fallback (FC-5).

--- a/ferrosa-common/specs/overview.md
+++ b/ferrosa-common/specs/overview.md
@@ -1,0 +1,106 @@
+---
+crate: ferrosa-common
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The leaf crate at the bottom of the Ferrosa dependency graph. It owns the
+  shared low-level type vocabulary — Token/DecoratedKey, CellValue, the full
+  CqlType/CqlValue model, the workspace Error/Result, Accord HLC/timestamp/ballot
+  types, Cassandra-compatible Murmur3, TableSchema, and a runtime-aware TaskPool.
+  Several types live here specifically to break dependency cycles (CqlType/CqlValue
+  out of ferrosa-cql; TableSchema out of ferrosa-sstable). It depends on no other
+  Ferrosa crate and is depended on by essentially every one of them.
+---
+
+# ferrosa-common — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-common` is the **single shared type vocabulary** for the workspace. Its
+boundary is deliberately minimal: pure data types plus small, total methods, with
+no I/O anywhere except `HybridLogicalClock` reading the system clock. It knows
+nothing about wire framing, query planning, storage layout, transport, or
+consensus orchestration — those live in the crates above it.
+
+It exists because many crates must agree **byte-for-byte and bit-for-bit** on a
+handful of primitives: the hash-ring `Token`/`DecoratedKey`, the storage
+`CellValue`, the CQL type model, and the workspace `Error`. Placing them at the
+bottom of the graph lets cycle-prone types be shared without an upward
+dependency — `CqlType`/`CqlValue` were moved out of `ferrosa-cql` so
+`ferrosa-udf` can use them without the large CQL crate, and `TableSchema` lives
+here so storage and schema share it without a cycle through `ferrosa-sstable`.
+
+## Module map
+
+| Module | LoC | Responsibility |
+|--------|-----|----------------|
+| `accord` (`src/accord.rs`) | 1177 | Accord `Timestamp`, `TxnId`, ballot newtypes, `HybridLogicalClock` (lock-free, drift-checked `merge`), `BallotGenerator`, `TxnPhase`/`TxnState` |
+| `schema` (`src/schema.rs`) | 637 | `TableSchema`, `ColumnDefinition`, `PinConfig`; fail-loud `fixed_width_for_marshal_type` / `validate_cell_bytes` / `validate_clustering_shape`; legacy column-order detector |
+| `geometry` (`src/geometry.rs`) | 436 | `Geometry` (Point + single-ring Polygon), WKB `marshal_wkb` / `parse_wkb` |
+| `cql_type` (`src/cql_type.rs`) | 334 | `CqlType` (full type tree + `type_id`), `CqlValue` (runtime value, IEEE-754-total `Ord`), bigint serde |
+| `murmur3` (`src/murmur3.rs`) | 283 | Cassandra-bit-compatible `hash3_x64_128` (preserves the tail sign-extension bug) |
+| `key` (`src/key.rs`) | 176 | `PartitionKey`, `DecoratedKey` (cached token, token-then-bytes order, `filter_hash`) |
+| `error` (`src/error.rs`) | 168 | `Error` / `Result`; typed `CorruptSstable` repair signal; `is_backpressure` |
+| `cell` (`src/cell.rs`) | 151 | `CellValue` live/expiring/tombstone + sentinels |
+| `data_type` (`src/data_type.rs`) | 89 | `DataType` scalar descriptor (`#[non_exhaustive]`) |
+| `token` (`src/token.rs`) | 79 | `Token` newtype + `from_key` |
+| `task_pool` (`src/task_pool.rs`) | 71 | `TaskPool` runtime-aware spawn helper |
+| `test_generators` (`src/test_generators.rs`) | 48 | proptest strategies (feature `test-generators`) |
+| `lib` (`src/lib.rs`) | 39 | module declarations + headline re-exports |
+
+## Data flow / role
+
+`ferrosa-common` is not a pipeline; it is the **shared alphabet** the pipelines
+speak. Two representative roles:
+
+**Placement.** A partition key's raw bytes →
+`Token::from_key` (`murmur3::hash3_x64_128` `h1`) → `DecoratedKey { token, key }`.
+The cluster layer uses the token to pick owning nodes; the storage/SSTable layer
+uses the same `DecoratedKey` ordering (token, then key bytes) for on-disk
+position; `filter_hash` feeds Bloom double-hashing. One hash, computed once,
+agreed on everywhere.
+
+**Typed failure.** When a read can't be resolved because an SSTable is corrupt,
+`ferrosa-storage` raises `Error::CorruptSstable { gen, min_token, max_token }`.
+The read coordinator calls `corrupt_sstable_range()` (never string-matches the
+message) to fail over to another replica and target anti-entropy repair at
+exactly the corrupt token range.
+
+```mermaid
+flowchart TD
+    PK["PartitionKey (bytes)"] --> M["murmur3::hash3_x64_128"]
+    M --> TOK["Token (h1)"]
+    TOK --> DK["DecoratedKey { token, key }"]
+    DK --> CL["ferrosa-cluster: node placement"]
+    DK --> SS["ferrosa-sstable: on-disk order + Bloom (h1,h2)"]
+    CT["CqlType / CqlValue"] --> CQL["ferrosa-cql / ferrosa-postgres / ferrosa-udf"]
+    ERR["Error::CorruptSstable {gen,min,max}"] --> RC["read coordinator: failover + targeted repair"]
+```
+
+## Key invariants
+
+1. **Leaf crate — no Ferrosa dependency.** `ferrosa-common` depends on no other
+   workspace crate. This is structural: it is what lets `CqlType`/`CqlValue` and
+   `TableSchema` be shared without cycles. Adding a Ferrosa dependency here would
+   re-introduce the cycle the move was meant to break.
+2. **Murmur3 is bit-identical to Cassandra.** `hash3_x64_128` must reproduce
+   `org.apache.cassandra.utils.MurmurHash.hash3_x64_128` exactly, **including**
+   the asymmetric tail handling (sign-extended tail bytes vs. zero-extended
+   body). Characterization vectors enforce this; changing it re-tokenizes every
+   key and silently corrupts placement.
+3. **`DecoratedKey` orders by token, then key bytes.** Matches Cassandra's
+   `DecoratedKey.compareTo`; both SSTable order and ring ownership depend on it.
+4. **`CqlValue` has a total order across all variants.** Float/Double/Vector use
+   `total_cmp` and a fixed cross-type discriminant index, so `Ord` is total even
+   for NaN — required wherever values are used as sorted keys.
+5. **`CorruptSstable` is a typed signal, never string-matched.** The repair range
+   is read via `corrupt_sstable_range()`.
+6. **`#[non_exhaustive]` on `Error` and `DataType`.** New variants can be added
+   without a semver break; downstream matches must keep a wildcard arm.
+
+## Position in the dependency graph
+
+The bottom. Depends on no Ferrosa crate (external only: `num-bigint`, `serde`,
+`uuid`, `tokio`, optional `proptest`). Depended on by essentially every other
+crate in the workspace — see the [README dependency list](../README.md#dependencies)
+and the [root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-common/specs/roadmap.md
+++ b/ferrosa-common/specs/roadmap.md
@@ -1,0 +1,60 @@
+---
+crate: ferrosa-common
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-common — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), in-code markers, and the
+dependency/usage review. The crate has **no `TODO`/`FIXME`/`unimplemented!`
+markers in source** — the items below come from real gaps found while reading
+the code, not from leftover tags.
+
+## Now (highest value)
+
+- **Make the HLC clock read fail-safe (FMEA FC-1).** `wall_clock_ns()` calls
+  `.expect("system clock before Unix epoch")` on the Accord hot path; a clock
+  step before the epoch panics the thread inside `now()`/`merge()`. Either
+  saturate the duration to `0` (with a one-shot warning) or thread a typed clock
+  error out of `now()`. No node should crash because NTP moved the wall clock.
+- **Instrument `TaskPool::current()` (FMEA FC-5).** The ambient-runtime fallback
+  is undocumented at runtime: emit a one-shot `warn!` and a counter the first
+  time a named pool spawns on `tokio::spawn` instead of its dedicated runtime, so
+  the "wrong runtime" degradation is observable (consistent with the fail-loud
+  rule and the Raft-starvation history).
+
+## Next
+
+- **Promote backpressure to a typed `Error` variant (FMEA FC-7).**
+  `is_backpressure()` substring-matches `InvalidData` messages
+  (`"...below write reserve"`, `"overloaded:"`). Add an explicit
+  `Error::Overloaded`/`Backpressure` variant so load shedding can't break when a
+  message string is reworded — mirroring the typed `CorruptSstable` design.
+- **Property-test `CqlValue` total order (FMEA FC-3).** Add a proptest that the
+  cross-type `Ord` (discriminant index + `total_cmp`) is a true total order
+  across the full variant space — index and sort correctness depend on it.
+- **Extend `test-generators` to `CqlValue`/`CqlType` (FMEA FC-8).** Today the
+  shared proptest strategies cover only `CellValue` and keys; a `CqlValue`
+  strategy would let every downstream crate property-test value round-trips from
+  one place.
+
+## Later
+
+- **Broaden geometry support (FMEA FC-4).** `parse_wkb`/`marshal_wkb` handle only
+  Point and single-ring Polygon, and reject antimeridian-crossing polygons
+  ("deferred to P2-d"). Add MultiPolygon / interior rings / antimeridian handling
+  when a consumer needs them — the current behavior is a documented fail-loud
+  limitation, not a bug.
+- **Audit `#[non_exhaustive]` downstream matches (FMEA FC-6).** When new
+  `Error`/`DataType` variants are added, sweep downstream wildcard arms so a new
+  error isn't silently swallowed by a catch-all.
+
+## Non-goals
+
+- Wire-format CQL encode/decode — lives in `ferrosa-cql` / `ferrosa-row-bridge`.
+- Any dependency on another Ferrosa crate — this crate is the leaf by design;
+  taking an upward dependency would re-introduce the cycle the type moves
+  (`CqlType`/`CqlValue`, `TableSchema`) were made to break.
+- Consensus orchestration, storage layout, transport — only the shared *types*
+  for them live here.

--- a/ferrosa-cql/README.md
+++ b/ferrosa-cql/README.md
@@ -1,0 +1,140 @@
+# ferrosa-cql
+
+> The CQL native-protocol (v4/v5) server — the client-facing front-end to the
+> Ferrosa database. The largest, most central crate in the workspace (~54k LoC).
+
+## What this crate is
+
+`ferrosa-cql` implements the Cassandra-compatible **CQL native binary protocol**
+end to end: TCP accept loop, per-connection framing, SASL auth, a hand-written
+lexer/parser, query routing into schema and storage, the result-set encoder,
+prepared statements, pagination, lightweight transactions (LWT) over Accord, and
+the streaming `SUBSCRIBE`/CDC extension. Clients are standard CQL drivers
+(scylla-rust-driver, cdrs-tokio, the DataStax Java driver, NoSQLBench).
+
+It is the integration hub of the storage stack: it depends on eleven sibling
+crates and is the place where a wire frame becomes a storage mutation or a read.
+The companion SQL front-end (`ferrosa-postgres`) shares this crate's *row codec*
+— that logic was extracted to `ferrosa-row-bridge` (decision **D10**) and is
+**re-exported** here at its original public paths so in-crate callers are
+unaffected (see [Bridge re-export](#bridge-re-export-d10)).
+
+## What's implemented
+
+- **TCP server** (`server.rs`) — accept loop, per-connection Tokio task, optional
+  rustls TLS, per-IP and global connection caps, per-connection in-flight
+  semaphore returning `Overloaded` on saturation, `auth_disabled` resolution.
+- **Frame codec** (`frame.rs`) — `tokio_util::codec` `Framed` decoder/encoder for
+  the 9-byte CQL header + body, opcode table, LZ4/Snappy body compression, and a
+  custom `STREAMING_FLAG` (bit 0x10) for SUBSCRIBE response frames.
+- **Connection state machine** (`connection.rs`, ~4k LoC) — STARTUP → (AUTH) →
+  READY handshake, per-opcode dispatch (QUERY / PREPARE / EXECUTE / BATCH /
+  REGISTER / OPTIONS), bind-marker counting, subscription push pump.
+- **Lexer + parser** (`lexer.rs`, `parser.rs` ~5.9k LoC, `ast.rs`) — hand-written
+  tokenizer and recursive-descent parser producing a `Statement` AST: full DML,
+  DDL (keyspace/table/index/type/role/function/aggregate), BATCH, LWT `IF`
+  clauses, `USING TIMESTAMP/TTL`, ANN/geo `SELECT` extensions.
+- **Router** (`router.rs`, ~22k LoC) — the central dispatch: `route()` classifies
+  a `Statement`, tracks it for observability, checks permissions (M8), and
+  delegates to `route_select`/`route_insert`/`route_update`/`route_delete`/
+  `route_batch` and the DDL/role handlers. Fast paths exist for prepared
+  SELECT/INSERT. ORDER BY classification picks an inline vs. spillable temp-sort
+  plan. Carries the security mitigations (M8 permissions, M12 batch cap).
+- **Bridge** (`bridge.rs`) — parser `Term` → wire `CqlValue` → storage
+  `CellValue`/`Row` conversions, server-side function eval (`now()`,
+  `toTimestamp()`), and the **re-export** of the row codec from
+  `ferrosa-row-bridge`.
+- **Result encoding** (`result.rs`, `types.rs`) — CQL RESULT-frame encoder, the
+  16-bit type system, and the re-exported `encode_value`/`decode_value` codec.
+- **Prepared statements** (`prepared.rs`) — `moka` W-TinyLFU cache keyed by the
+  MD5 of the query text, weight-bounded.
+- **Pagination** (`paging.rs`) — opaque `paging_state` cursor (pk + ck +
+  remaining-in-partition flag) for CQL v5 paging.
+- **LWT / transactions** (`accord_router.rs`, `transaction_keys.rs`,
+  `transaction_limits.rs`) — routing decision (Accord in cluster mode, local in
+  standalone), `IF [NOT] EXISTS` / `IF <cond>` CAS semantics with the `[applied]`
+  result column, partition-key extraction for Accord, and per-connection
+  transaction limits (concurrency / timeout / key count).
+- **SUBSCRIBE / CDC** (`subscribe.rs`, `event.rs`) — per-connection streaming
+  subscriptions that re-run an inner SELECT on an interval and push delta frames;
+  dual-timestamp (Accord ts + apply ts) events; CQL `EVENT` push via a broadcast
+  channel.
+- **Virtual tables** (`virtual_tables/`) — `system_observability.*` and runtime
+  introspection tables (active_queries, connections, billing, index_usage,
+  full_scan_reasons, materialization queues, alerts, query_fingerprints, …).
+- **Observability** (`observability.rs`, `prometheus.rs`) — per-opcode CQL
+  metrics and a Prometheus text renderer.
+- **Topology** (`topology.rs`) — public-vs-internal address policy for
+  `system.local` / `system.peers_v2`.
+- **Client** (`client.rs`) — a thin CQL client reusing `CqlCodec`, used by
+  `ferrosa-ctl`.
+
+## Bridge re-export (D10)
+
+The byte-for-byte CQL row codec and `Partition`→row decomposition do **not** live
+here — they were extracted into the dependency-light `ferrosa-row-bridge` crate so
+`ferrosa-postgres` can reuse the *identical* encoder/decoder without depending on
+this ~54k-LoC crate. `ferrosa-cql` re-exports them at their original paths:
+
+- `ferrosa_cql::types::{encode_value, decode_value}` ← `ferrosa_row_bridge`
+- `ferrosa_cql::bridge::{build_decorated_key, build_row, build_delete_row,
+  encode_clustering, decode_pk, decode_clustering, partition_to_rows*, …}`
+- `ferrosa_cql::bridge::{parse_cql_type, parse_cql_type_in_keyspace}`
+
+`error.rs` provides `From<RowBridgeError> for CqlError` so the hundreds of
+in-crate callers see no behavioural change. The rule: **there is exactly one row
+encoder, and it lives in `ferrosa-row-bridge`** — a divergent copy is the top
+SQL-front-end FMEA risk.
+
+## Public API (key entry points)
+
+| Area | Entry points |
+|------|--------------|
+| Server | `server::{CqlServer, ServerConfig, resolve_auth_disabled}` |
+| Framing | `frame::{CqlCodec, CqlFrame, FrameHeader, Opcode, Compression}` |
+| Routing | `router::{route, SharedState, RequestContext, RouteResult}` |
+| LWT/Accord | `accord_router::{route_decision, RoutingMode, RouteDecision}` |
+| Prepared | `prepared::{PreparedCache, PreparedPlan}` |
+| Paging | `paging::PagingState` |
+| Subscribe | `subscribe::{SubscriptionHandle, SubscriptionEvent, run_subscription_poll}` |
+| Types/codec | `types::{CqlType, CqlValue, encode_value, decode_value}` (codec re-exported) |
+| Client | `client::{CqlClient, ResultRow}` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- `ferrosa-cdc` — change-data-capture feed for SUBSCRIBE/CDC.
+- `ferrosa-cluster` — consistency levels, Accord/LWT routing, DDL path, peers.
+- `ferrosa-common` — `CqlType`, `CqlValue`, `Token`, `DecoratedKey`, `CellValue`.
+- `ferrosa-index` — `IndexType` and secondary-index query support.
+- `ferrosa-net` — internode `TaskPool`, framing helpers, graceful drain.
+- `ferrosa-row-bridge` — **the re-exported row codec** (D10).
+- `ferrosa-schema` — keyspaces/tables/roles, `AuthContext`, permissions, virtual tables.
+- `ferrosa-session` — `SessionCore`, the protocol-agnostic engine state.
+- `ferrosa-sstable` — `Partition`/`Row` shapes consumed on the read path.
+- `ferrosa-storage` — `StorageEngine`, temp-sort reservations, table IDs.
+- `ferrosa-udf` — user-defined function/aggregate execution.
+
+**Called by** (crates that depend on this):
+
+- `ferrosa` — the main binary wires up and runs the CQL server.
+- `ferrosa-ctl` — uses the thin `client` for cluster management.
+- `ferrosa-flight` — Arrow Flight endpoint reuses CQL parsing/routing.
+- `ferrosa-loadgen` — load testing against the CQL layer.
+
+## Tests
+
+~945 in-crate test functions (heaviest: `router.rs` 253, `parser.rs` 158,
+`bridge.rs` 121, `connection.rs` 43) plus integration tests under `tests/`
+(`handshake`, `auth_integration`, `auth_warn_mode`, `bolt_transaction_state`,
+`cassandra_cql_examples`). In-code TODO/FIXME density is very low (1 marker);
+the real gaps are tracked structurally — see the FMEA.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, position
+- [Data flow](specs/data-flow.md) — INSERT/SELECT through frame→parse→route→storage + the bridge re-export
+- [FMEA / known issues](specs/fmea.md) — failure modes + real gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later
+- Topic reference: [`specs/reference/cql.md`](../specs/reference/cql.md)

--- a/ferrosa-cql/specs/data-flow.md
+++ b/ferrosa-cql/specs/data-flow.md
@@ -1,0 +1,128 @@
+---
+crate: ferrosa-cql
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa-cql — Data Flow
+
+How a CQL frame becomes a storage mutation or a read, and how the row codec is
+shared with `ferrosa-postgres` via `ferrosa-row-bridge` (D10).
+
+All type names in the diagrams escape angle brackets (e.g. `Vec&lt;T&gt;`) so the
+Mermaid renderer does not treat them as HTML.
+
+## INSERT path (write)
+
+A client `INSERT` arrives as a QUERY (or EXECUTE) frame, is parsed, permission-
+checked, converted to a storage row via the re-exported `ferrosa-row-bridge`
+builders, and applied through the session/storage engine.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Drv as CQL driver
+    participant Codec as frame::CqlCodec
+    participant Conn as connection (per-conn task)
+    participant Par as lexer + parser
+    participant Rt as router::route
+    participant Br as bridge (+ row-bridge re-export)
+    participant Eng as SessionCore / StorageEngine
+
+    Drv->>Codec: QUERY/EXECUTE frame bytes
+    Codec->>Conn: CqlFrame (decoded header + body)
+    Conn->>Par: CQL text
+    Par-->>Conn: Statement::Insert (AST)
+    Conn->>Rt: route(state, ctx, stmt)
+    Rt->>Rt: check_permission (M8), batch cap (M12)
+    Rt->>Br: term_to_cql_value (range-checked, M5)
+    Br->>Br: build_decorated_key + build_row<br/>(re-exported from ferrosa-row-bridge)
+    Br-->>Rt: DecoratedKey + storage Row
+    Rt->>Eng: write mutation (tunable CL)
+    Eng-->>Rt: ack
+    Rt-->>Conn: RouteResult (void / [applied])
+    Conn->>Codec: RESULT frame body
+    Codec-->>Drv: encoded RESULT bytes
+```
+
+LWT variants (`IF NOT EXISTS` / `IF <cond>` with serial consistency) branch at
+`route()` into `accord_router::route_lwt_via_accord` when `peer_manager` and
+`accord_clock` are present; in standalone/pair mode that path fails loud with a
+`ServerError` (FMEA CQL-1).
+
+## SELECT path (read)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Drv as CQL driver
+    participant Codec as frame::CqlCodec
+    participant Conn as connection (per-conn task)
+    participant Par as lexer + parser
+    participant Rt as router::route_select
+    participant Pl as planner (scan + ORDER BY)
+    participant Eng as StorageEngine
+    participant Br as bridge (row-bridge re-export)
+    participant Res as result encoder
+
+    Drv->>Codec: QUERY/EXECUTE frame bytes
+    Codec->>Conn: CqlFrame
+    Conn->>Par: CQL text
+    Par-->>Conn: Statement::Select (AST)
+    Conn->>Rt: route(state, ctx, stmt)
+    Rt->>Rt: check_permission (M8)
+    Rt->>Pl: classify scan + ORDER BY plan
+    Pl-->>Rt: ScanPlan (inline or spillable temp-sort)
+    Rt->>Eng: read Partition(s)
+    Eng-->>Rt: Vec&lt;Partition&gt;
+    Rt->>Br: partition_to_rows_with_storage_mapping<br/>(tombstone/TTL skip, storage→table order)
+    Br-->>Rt: Vec&lt;Vec&lt;Option&lt;CqlValue&gt;&gt;&gt;
+    Rt->>Res: project + LIMIT + paging_state
+    Res-->>Conn: Rows RESULT frame body
+    Conn->>Codec: frame
+    Codec-->>Drv: encoded rows (+ paging_state if more)
+```
+
+When more rows remain, `result.rs` attaches an opaque `paging::PagingState`
+cursor (pk + ck + remaining flag). NOTE: that cursor is currently unsigned —
+FMEA CQL-2.
+
+## Bridge re-export relationship (D10)
+
+The CQL row codec and `Partition`→row decomposition physically live in
+`ferrosa-row-bridge`; `ferrosa-cql` re-exports them at their original public
+paths so in-crate callers are unchanged and `ferrosa-postgres` can reuse the
+*identical* encoder without depending on this ~54k-LoC crate.
+
+```mermaid
+flowchart TD
+    subgraph rb[ferrosa-row-bridge]
+        enc["encode_value / decode_value"]
+        rows["build_row / build_decorated_key<br/>partition_to_rows*"]
+        err["RowBridgeError"]
+    end
+
+    subgraph cql[ferrosa-cql]
+        types["types::encode_value / decode_value<br/>(re-export + RowBridgeError to CqlError)"]
+        bridge["bridge::build_row / build_decorated_key<br/>partition_to_rows* (re-export)"]
+        router["router::route_* callers"]
+    end
+
+    subgraph pg[ferrosa-postgres]
+        pgdml["DML + read path"]
+    end
+
+    enc --> types
+    rows --> bridge
+    err --> types
+    types --> router
+    bridge --> router
+    enc --> pgdml
+    rows --> pgdml
+
+    note["Invariant: exactly ONE row encoder.<br/>A forked copy is the top SQL-front-end FMEA risk."]
+    rb -.-> note
+```
+
+Key point: there is **one** encoder. `ferrosa-cql` never re-implements the codec;
+it only adapts `RowBridgeError` into `CqlError` at the boundary (`error.rs`).

--- a/ferrosa-cql/specs/fmea.md
+++ b/ferrosa-cql/specs/fmea.md
@@ -1,0 +1,44 @@
+---
+crate: ferrosa-cql
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-cql — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (each 1–10,
+higher = worse). This crate is the entire client path, so most severities are
+high. Entries below reflect gaps found in the code, not hypotheticals.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| CQL-1 | LWT routed to Accord in standalone/pair mode where `peer_manager`/`accord_clock` are absent | `INSERT ... IF NOT EXISTS` / `IF <cond>` return `ServerError` ("not yet implemented") instead of executing | 8 | 5 | 2 | 80 | **Designed fail-loud** (p0-03): `route()` returns a clear error rather than a silent non-linearizable local path. Full coordinator driver tracked on `fix/p0-03b-accord-network`. Real functional gap, but observable. |
+| CQL-2 | `paging_state` cursor is opaque but **unsigned** — `PagingState::encode/decode` is a plain length-prefixed pk+ck+flag with no HMAC | A client can forge/tamper a paging token to resume at an arbitrary key, bypassing the original query's partition scope (cross-partition read / IDOR-style) | 7 | 4 | 7 | 196 | **Open gap.** Decode validates lengths but not authenticity. Sign the cursor with a per-server key, or bind it to the prepared/query id. See roadmap. |
+| CQL-3 | Encoder divergence vs `ferrosa-postgres` if the re-exported row codec were ever forked into this crate | Rows written via one front-end read back wrong/invisible via the other (silent corruption) | 10 | 1 | 6 | 60 | **Structural**: codec is the single re-export from `ferrosa-row-bridge` (D10); no second encoder exists here. Reinforced by the PG differential oracle. |
+| CQL-4 | Permission check omitted on a new `route_*` handler | Unauthorized DML/DDL succeeds (privilege escalation) | 9 | 2 | 5 | 90 | M8 convention: every `route_*` calls `Schema::check_permission`. Risk is a *new* handler forgetting it — not enforced by the type system. Add a lint/test that every route is permission-gated. |
+| CQL-5 | `router.rs` is a 22.4k-LoC monolith (`route()` + ~60 `route_*` handlers in one file) | Hard to review; high chance a change to one handler regresses another; reviewers miss missing checks (feeds CQL-4) | 6 | 6 | 6 | 216 | **Open structural debt.** Split DML / DDL / role / type-function handlers into submodules. Test density (253 tests) partially compensates detection. |
+| CQL-6 | Subscription poll re-runs the inner SELECT on an interval with no global cap on rows/work per tick | A broad subscribed SELECT over a large table re-scans every interval, amplifying load (DoS-by-subscription) | 6 | 3 | 6 | 108 | Per-connection `max_subscriptions` bounds count; per-tick scan cost is not bounded. Add a per-subscription row/byte budget and backpressure. |
+| CQL-7 | `COMPACT` statement parses and routes but is not implemented | `COMPACT` returns "not supported / not implemented" error | 3 | 3 | 2 | 18 | **Designed**: explicit error message; manual SSTable compaction is intentionally not exposed. Low severity (UCS runs automatically). |
+| CQL-8 | Auth flag drift — historically `FERROSA_AUTH_ENABLED` (storage) and `FERROSA_AUTH_DISABLED` (CQL) could disagree, so the server sent `AUTHENTICATE` while storage accepted everything, breaking standard drivers | Drivers fail to connect, or connect with mismatched auth expectations | 7 | 2 | 4 | 56 | **Fixed**: `resolve_auth_disabled()` makes storage `auth_enabled` the single source of truth; the env override is deprecated and logs a warning. Covered by unit tests. |
+| CQL-9 | Server-side `now()` minting a non-16-byte TimeUUID | TimeUUID-clustered tables wedge at memtable flush (data-loss-class bug) | 9 | 1 | 4 | 36 | **Fixed + documented invariant**: `eval_now()` always returns 16 bytes; guards the prior flush-wedge bug. |
+| CQL-10 | In-flight semaphore (default 128) or per-IP cap rejecting legitimate bursts as `Overloaded` | Spurious `Overloaded` errors under legitimate load spikes | 4 | 3 | 3 | 36 | Tunable via `ServerConfig`; designed backpressure that fails loud rather than queueing unboundedly. |
+
+## Top risks to act on
+
+1. **CQL-5 (RPN 216)** — the 22.4k-LoC `router.rs` monolith. It is the dominant
+   *detection* risk: missing permission checks (CQL-4) and other regressions hide
+   in a file too large to review as a unit. Decompose into per-statement-family
+   submodules.
+2. **CQL-2 (RPN 196)** — the unsigned `paging_state` cursor. It is opaque to
+   clients by convention only; nothing prevents a crafted token from resuming at
+   an attacker-chosen key. Sign or scope-bind the cursor.
+3. **CQL-6 (RPN 108) / CQL-1 (RPN 80)** — unbounded per-tick subscription scans,
+   and the standalone LWT-on-Accord functional gap (already fail-loud).
+
+## Detection assets
+
+- ~945 in-crate tests (router 253, parser 158, bridge 121).
+- Integration tests: `tests/{handshake, auth_integration, auth_warn_mode,
+  bolt_transaction_state, cassandra_cql_examples}.rs`.
+- Postgres differential oracle (in `ferrosa-postgres`) guards the shared codec.
+- Per-opcode CQL metrics + Prometheus endpoint surface error/overload rates.

--- a/ferrosa-cql/specs/overview.md
+++ b/ferrosa-cql/specs/overview.md
@@ -1,0 +1,104 @@
+---
+crate: ferrosa-cql
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The CQL native-protocol (v4/v5) server and the largest, most central crate in
+  the workspace (~54k LoC). It owns the full client path — TCP accept, frame
+  codec, SASL auth, lexer/parser, query routing into schema and storage, result
+  encoding, prepared statements, pagination, LWT over Accord, and the streaming
+  SUBSCRIBE/CDC extension. It re-exports the byte-identical row codec from
+  ferrosa-row-bridge (D10) so the Postgres front-end shares exactly one encoder.
+---
+
+# ferrosa-cql — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-cql` is the **client-facing front-end** of Ferrosa. Its boundary spans
+from the raw TCP socket to the storage engine: it decodes CQL binary frames,
+authenticates, parses CQL text into an AST, routes statements through the schema
+and storage engines, and encodes result sets back onto the wire. It speaks the
+Cassandra native protocol (negotiating v4 for responses, accepting v5 requests)
+so unmodified CQL drivers connect to it.
+
+It is deliberately the **integration hub** rather than a leaf: it depends on
+eleven sibling crates and turns a wire frame into a storage mutation/read. The
+one piece it does *not* own is the row codec — that lives in `ferrosa-row-bridge`
+and is re-exported here (decision **D10**) so `ferrosa-postgres` reuses the exact
+same encode/decode without depending on this large crate.
+
+## Module map
+
+| Module | LoC | Responsibility |
+|--------|-----|----------------|
+| `router` | ~22.4k | Central `route()` dispatch: permission checks, DML/DDL handlers, prepared fast paths, ORDER BY planning, `SharedState` |
+| `parser` | ~5.9k | Recursive-descent CQL parser → `Statement` AST |
+| `connection` | ~4.0k | Per-connection state machine, handshake, per-opcode dispatch, subscription pump |
+| `bridge` | ~2.7k | `Term`↔`CqlValue`↔storage conversions, server-side fn eval, **row-codec re-export** |
+| `frame` | ~1.4k | CQL header/body codec, opcodes, LZ4/Snappy compression, streaming flag |
+| `lexer` | ~1.4k | Hand-written CQL tokenizer |
+| `accord_router` | ~1.2k | LWT-on-Accord routing decisions + CAS execute-phase logic |
+| `subscribe` | ~1.2k | Per-connection streaming subscriptions, dual-timestamp events |
+| `prometheus` | ~1.1k | Prometheus text rendering of virtual-table + runtime metrics |
+| `server` | ~1.1k | TCP accept loop, TLS, connection caps, `auth_disabled` resolution |
+| `client` | ~1.0k | Thin CQL client (used by ferrosa-ctl) |
+| `result` | ~0.9k | RESULT-frame encoder |
+| `ast` | ~0.9k | Statement/expression AST |
+| `types` | ~0.6k | 16-bit CQL type system, codec re-export |
+| `transaction_keys` / `transaction_limits` | ~1.0k | Accord partition-key extraction, per-connection txn limits |
+| `planner` | ~0.6k | Scan planning |
+| `error` / `paging` / `duration` / `session` / `topology` / `event` / `observability` / `prepared` | — | Error type + `From<RowBridgeError>`, paging cursor, duration type, session, topology policy, EVENT, metrics, prepared cache |
+| `virtual_tables/` | ~4.5k | `system_observability.*` runtime introspection tables |
+
+## Concurrency model
+
+Each TCP connection gets its own Tokio task owning a `Framed<TcpStream, CqlCodec>`.
+Hot paths are lock-free: schema reads via `ArcSwap::load()`, prepared-statement
+lookups via `moka` (W-TinyLFU), storage via `Arc<StorageEngine>`. `SharedState`
+holds the shared engine state (`Arc<SessionCore>` via `Deref`) plus the trackers,
+metrics, event broadcast channel, and prepared cache. A per-connection in-flight
+semaphore (default 128) returns `Overloaded` rather than unbounded queueing.
+
+## Data flow
+
+**Write (INSERT/UPDATE/DELETE).** Frame bytes → `CqlCodec::decode` → opcode
+dispatch in `connection` → `parser` → `Statement` → `router::route()`. The router
+checks permissions (M8), converts `Term`s to `CqlValue`s via `bridge`, builds the
+`DecoratedKey` + storage `Row` via the re-exported `ferrosa-row-bridge` builders,
+and applies through `SessionCore`'s write path / `StorageEngine`. LWT statements
+(serial consistency set, cluster mode) detour through `accord_router` →
+`route_lwt_via_accord`. A void/applied RESULT frame is encoded back.
+
+**Read (SELECT).** Same front half; `router::route_select` resolves the table,
+plans the scan (`planner`, ORDER BY classification), reads `Partition`s from
+storage, decomposes them to rows via the re-exported
+`partition_to_rows_with_storage_mapping` (tombstone/TTL skipping, storage→table
+column mapping), applies projection/LIMIT/paging, and `result.rs` encodes the
+Rows RESULT frame (with `paging_state` when more pages remain).
+
+See [data-flow.md](data-flow.md) for the sequence diagrams.
+
+## Key invariants
+
+1. **One row encoder.** Encode/decode is the re-export from `ferrosa-row-bridge`;
+   no second encoder exists in this crate (D10). A divergent copy would silently
+   corrupt cross-front-end reads.
+2. **Permission check on every route.** Each `route_*` function calls
+   `Schema::check_permission` (M8); warn-mode logs+counts denials but proceeds.
+3. **Batch size capped.** `MAX_BATCH_STATEMENTS` (default 500, M12) bounds BATCH.
+4. **Range-checked narrowing.** `bridge` range-checks all narrowing integer
+   conversions (M5); no `unwrap()` on user data (M4).
+5. **Fail loud on the Accord gap.** LWT routing in standalone/pair mode returns a
+   clear `ServerError` rather than silently falling back to a non-linearizable
+   local path (p0-03 policy).
+6. **16-byte TimeUUID from `now()`.** `eval_now()` guarantees a 16-byte encoding —
+   a short one wedges TimeUUID-clustered tables at flush.
+
+## Position in the dependency graph
+
+A hub, not a leaf. Depends on eleven sibling crates (`ferrosa-cdc`,
+`-cluster`, `-common`, `-index`, `-net`, `-row-bridge`, `-schema`, `-session`,
+`-sstable`, `-storage`, `-udf`); depended on by `ferrosa`, `ferrosa-ctl`,
+`ferrosa-flight`, `ferrosa-loadgen`. See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-cql/specs/roadmap.md
+++ b/ferrosa-cql/specs/roadmap.md
@@ -1,0 +1,55 @@
+---
+crate: ferrosa-cql
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-cql — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), in-code "not yet implemented"
+markers, and the dependency/usage review. In-code TODO density is very low; the
+real backlog is structural and security-shaped.
+
+## Now (highest value)
+
+- **Sign / scope-bind the `paging_state` cursor** (FMEA CQL-2). Today
+  `PagingState::encode/decode` is an unsigned length-prefixed pk+ck+flag. Add an
+  HMAC with a per-server key (or bind the cursor to the originating query/prepared
+  id) so a tampered token cannot resume at an attacker-chosen partition.
+- **Decompose `router.rs`** (FMEA CQL-5). At 22.4k LoC it is the dominant review
+  risk. Split into per-family submodules (`router/dml.rs`, `router/ddl.rs`,
+  `router/roles.rs`, `router/types_functions.rs`) keeping `route()` as the thin
+  dispatcher. This directly lowers the chance of a missing permission check
+  (CQL-4) slipping through.
+- **Enforce the M8 permission-check invariant by test** (FMEA CQL-4). Add a test
+  (or lint) asserting every `route_*` handler calls `check_permission`, so a new
+  handler cannot ship without authorization.
+
+## Next
+
+- **Complete LWT-on-Accord for non-cluster modes** (FMEA CQL-1). The CQL layer
+  fails loud when `peer_manager`/`accord_clock` are absent; finish the coordinator
+  driver (`fix/p0-03b-accord-network`, p0-03b gap) so standalone/pair-mode LWT
+  executes rather than erroring.
+- **Bound per-tick subscription work** (FMEA CQL-6). Add a per-subscription
+  row/byte budget and backpressure so a broad subscribed SELECT cannot re-scan a
+  large table every interval.
+- **Subscription/CDC delta correctness tests** against `ferrosa-cdc` — verify the
+  dual-timestamp (Accord ts / apply ts) ordering under concurrent writes.
+
+## Later
+
+- **`COMPACT` support** (FMEA CQL-7) — only if a real operator need emerges; UCS
+  compaction runs automatically, so this stays a deliberate non-feature for now.
+- **Collections / UDT / tuple / vector round-trip coverage** at the CQL boundary,
+  tracking the matching `ferrosa-row-bridge` type-matrix work so unsupported types
+  fail loud rather than decoding to NULL.
+- **Prepared-statement cache observability** — expose hit/miss/evict counters via
+  the Prometheus endpoint to tune the W-TinyLFU weight budget.
+
+## Non-goals
+
+- The row encode/decode codec — it lives in `ferrosa-row-bridge` (D10) and is only
+  re-exported here. Changes to encoding belong there, not in this crate.
+- Cassandra internode wire compatibility — Ferrosa uses its own internode protocol
+  (`ferrosa-net`); only the *client* CQL protocol is Cassandra-compatible.

--- a/ferrosa-ctl/README.md
+++ b/ferrosa-ctl/README.md
@@ -1,0 +1,116 @@
+# ferrosa-ctl
+
+> The operator CLI + ratatui TUI for a Ferrosa node: live observability over
+> CQL, cluster lifecycle over the web admin API, and offline SSTable / Raft-log
+> recovery straight against the data directory.
+
+## What this crate is
+
+`ferrosa-ctl` is the **single binary** (`[[bin]] name = "ferrosa-ctl"`) operators
+use to inspect and administer a Ferrosa node. It is a leaf in the dependency
+graph — nothing depends on it. It talks to a node through three distinct
+channels, and several subcommands operate with **no live node at all** (offline
+recovery against a stopped node's files):
+
+1. **CQL native protocol (`--host`, default `127.0.0.1:9042`)** — read-only
+   `SELECT`s against the `system_observability.*` and `system.peers` virtual
+   tables, plus `ALTER ROLE` for `auth set-password`.
+2. **Web admin HTTP API (`--web-port`, default `9090`)** — cluster membership,
+   ring, repair, snapshot/restore, learner lifecycle, leader transfer.
+3. **Offline filesystem / sled / S3** — SSTable corruption triage & salvage and
+   Raft-log inspect/truncate/reset, run against a **stopped** node's data dir.
+
+## What's implemented
+
+### Observability (CQL, read-only)
+
+| Subcommand | What it does |
+|------------|--------------|
+| `status` | Node up + active-connection count (`system_observability.connections`). |
+| `connections [--sort <col>]` | Active CQL connections; optional client-side sort. |
+| `queries [--long-running]` | Running queries (`active_queries`); `--long-running` sorts by `elapsed_ms` desc. |
+| `storage` | Storage engine stats (`storage_stats`). |
+| `topology` | Ring topology from `system.peers`. |
+| `peers` | Peer node list from `system.peers`. |
+| `monitor [--panel <name>]` | ratatui TUI dashboard (Connections / Queries / Storage), 2 s refresh. |
+
+### Auth (CQL)
+
+- `auth set-password [--user --admin-user --admin-password-env --ssl --force --no-confirm]`
+  — reads the new password with no echo, connects as the admin role (env →
+  seed-default → prompt fallback), issues `ALTER ROLE "<u>" WITH PASSWORD = '…'`.
+  Identifier/literal escaping is applied; the **server** hashes the cleartext.
+  `--ssl` is rejected (TLS not yet supported by `CqlClient`).
+
+### Cluster lifecycle (web admin HTTP API, port 9090)
+
+| Subcommand | Endpoint |
+|------------|----------|
+| `add-node <host_id>` | `POST /api/cluster/add-node` |
+| `decommission [host_id]` | `POST /api/cluster/decommission` |
+| `ring` | `GET /api/cluster/ring` |
+| `rebalance` | `POST /api/cluster/rebalance` |
+| `repair --keyspace --table [--rf 3]` | `POST /api/cluster/repair?…` |
+| `raft transfer-leader --to <host_id>` | `POST /api/cluster/raft/transfer-leader` |
+| `cluster add-learner <host_id> <addr> [--owns-tokens]` | `POST /api/cluster/add-learner` |
+| `cluster promote-to-voter <host_id>` | `POST /api/cluster/promote-to-voter` |
+| `cluster demote-to-learner <host_id>` | `POST /api/cluster/demote-to-learner` |
+| `snapshot create\|list\|delete` | `…/api/snapshots[…]` |
+| `restore <name> [--point-in-time --force]` | `POST /api/restore` |
+
+Several of these (`raft transfer-leader`, the three `cluster` learner-lifecycle
+commands, and `snapshot`/`restore`) call endpoints that are **not yet served by
+the node**; they surface the upstream `404`/`501` with a spec pointer rather
+than faking success.
+
+### Offline Raft recovery (sled, node must be stopped)
+
+- `raft reset --data-dir [--dry-run]` — atomically replaces the raft dir so the
+  node rejoins as a fresh learner (does **not** open sled, so no lock contention).
+- `raft log-inspect --data-dir [--json]` — decodes every persisted log entry,
+  reports readable/unreadable split + vote/committed/purge markers.
+- `raft log-truncate --data-dir --from <idx> [--dry-run] [--yes]` — destructive;
+  drops entries `>= --from`, clamps committed. `--from` is mandatory; mutation
+  requires `--yes`.
+- `cluster bootstrap-dc --dc --seeds` — Sprint-6 scaffolding: derives and prints
+  the per-DC `RaftGroupId`; the live wire-up is deferred (Sprint 7).
+
+### Offline SSTable triage & recovery (filesystem / live CQL / S3)
+
+All verdicts delegate to the engine's own `StorageEngine::smoke_test_generation`
+so ctl can never disagree with what the node decides at boot.
+
+- `sstable scan <dir> [--include-quarantine --json]` — classify every generation OK/CORRUPT.
+- `sstable inspect <dir> <gen> [--json]` — deep per-generation report + corruption-class hint.
+- `sstable quarantine <dir> [--apply --json]` — move CORRUPT live gens into `quarantine/` (dry-run default; node stopped to apply; files moved, never deleted).
+- `sstable salvage <dir> [--include-quarantine --json]` — measure recoverable-row yield (pure read).
+- `sstable reingest <dir> [--user --password-env --apply --include-quarantine --limit]` — salvage CORRUPT gens and re-insert through the **live** write path (`--host`), preserving original timestamps; dry-run default.
+- `sstable s3-clean <dir> [--apply]` — delete CORRUPT generations' objects from the object store so a cold restart can't re-download them; dry-run default.
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on): ferrosa-cluster, ferrosa-common,
+ferrosa-cql, ferrosa-schema, ferrosa-session, ferrosa-sstable, ferrosa-storage,
+ferrosa-udf.
+
+Runtime dependencies are `ferrosa-cluster`, `ferrosa-common`, `ferrosa-cql`,
+`ferrosa-sstable`, `ferrosa-storage`. `ferrosa-schema`, `ferrosa-session`, and
+`ferrosa-udf` are **dev-dependencies** used by the integration test harness.
+External: `clap`, `tokio`, `reqwest` (rustls), `ratatui`, `crossterm`,
+`tabled`, `object_store` (aws), `rpassword`, `sled`, `serde`/`serde_json`.
+
+**Called by**: NONE — it is a CLI binary, the leaf of the dependency graph.
+
+## Tests
+
+178 test functions across the crate: argument parsing (`src/main.rs`, 46),
+command formatting / URL+body construction / offline raft (`src/commands.rs`,
+70), TUI state machine & rendering helpers (`src/tui.rs`, 12), password flow
+(`src/auth.rs`, 17), SSTable triage (`src/commands/sstable.rs`, 22), and a CQL
+virtual-table integration suite (`tests/integration.rs`, 11).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — channels, module map, data flow
+- [FMEA / known issues](specs/fmea.md) — failure modes + real gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-ctl/specs/fmea.md
+++ b/ferrosa-ctl/specs/fmea.md
@@ -1,0 +1,46 @@
+---
+crate: ferrosa-ctl
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-ctl — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). `ferrosa-ctl` is an operator tool, so the worst outcomes are
+**destructive recovery commands run against the wrong target** and **commands
+that silently look successful when the node side does nothing**.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| CTL-1 | `raft log-truncate` run with the wrong `--from` (or on a node that didn't need it) | Permanent loss of committed metadata ops `>= from` on that node | 10 | 3 | 5 | 150 | `--from` is mandatory (clap-required); mutation needs `--yes`; `--dry-run` previews; `log-inspect` prints the exact `--from` to use. **Residual gap:** no cross-node consistency check — the operator must repeat correctly on every damaged node. |
+| CTL-2 | Unwired HTTP endpoint (`raft transfer-leader`, `cluster add-learner/promote/demote`, `snapshot`, `restore`) treated by the operator as a working operation | Operator believes a membership/PITR change happened when it didn't | 7 | 5 | 3 | 105 | Commands surface upstream `404`/`501` with a spec pointer (fail-loud). **Residual gap:** `snapshot`/`restore` POST to endpoints the node does not yet serve, so they only "work" once the node side lands; status is not obvious from `--help`. |
+| CTL-3 | `sstable s3-clean --apply` deletes object-store generations on a misread `<keyspace>.<table>` dir name | Durable S3 copies of (mis)identified gens deleted; cold restart can't recover them | 9 | 2 | 5 | 90 | Dry-run default; only CORRUPT gens (per the engine smoke test) are targeted; reuses engine `FERROSA_S3_*` config. **Residual gap:** deletion is irreversible and depends on the dir being named exactly `<keyspace>.<table>`. |
+| CTL-4 | `auth set-password` quoting/escaping bug lets a crafted role/password break out of the `ALTER ROLE` statement | CQL injection in an admin path | 9 | 1 | 4 | 36 | `escape_double_quotes`/`escape_single_quotes` applied; dedicated unit tests for `'` in password and `"` in role. Low occurrence; server also validates. |
+| CTL-5 | `--ssl` requested for `auth set-password` | Operator expects an encrypted admin connection; cleartext password would otherwise traverse the network | 8 | 2 | 2 | 32 | `CqlClient` has no TLS yet, so `--ssl` **errors out** rather than silently connecting in cleartext. **Open gap:** no TLS for any CQL command — admin password crosses the wire in cleartext on non-localhost. |
+| CTL-6 | `sstable reingest --apply` re-inserts salvaged rows but some rows are unrecoverable / silently dropped | Partial recovery presented without a clear "what was lost" tally | 6 | 4 | 5 | 120 | Resilient salvage recovers header + leading rows; per-row insert failures are counted (`failed`) not fatal; `--limit` enables a controlled first run; dry-run default. **Residual gap:** rows beyond the first decode failure in a partition are not recovered and the yield is an estimate. |
+| CTL-7 | Web-API command output is the raw server body; a partial/odd JSON shape is printed verbatim | Operator misreads ring/repair/restore result | 4 | 4 | 4 | 64 | `ring` does best-effort column extraction; `repair` pretty-prints JSON when parseable else dumps raw. Non-2xx always becomes an error. Cosmetic, not data-affecting. |
+| CTL-8 | `cluster bootstrap-dc` looks like it created a per-DC Raft group | Operator assumes a DC group exists | 5 | 3 | 3 | 45 | Output explicitly says "Sprint 6 scaffolding — the live HTTP wire-up lands in Sprint 7"; only derives + prints the `RaftGroupId`. |
+
+## Top risks to act on
+
+1. **CTL-1 (RPN 150)** — `raft log-truncate` is the most dangerous command:
+   irreversible committed-data loss, and correctness depends on the operator
+   applying the right `--from` on every damaged node. Mitigations are good but
+   there is no automated multi-node guard.
+2. **CTL-6 (RPN 120)** — `sstable reingest` yield is best-effort; the gap
+   between "rows salvaged" and "rows that actually existed" is not surfaced,
+   so a partial recovery can read as complete.
+3. **CTL-2 / CTL-5** — several lifecycle commands target endpoints the node
+   doesn't serve yet, and no CQL command uses TLS (admin password in cleartext
+   off-localhost). Both are fail-loud today but are real functional gaps.
+
+## Detection assets
+
+- `tests/integration.rs` — boots a real CQL server + `system_observability.*`
+  virtual tables and exercises the queries the observability commands issue.
+- `src/main.rs` parsing tests (46) pin every subcommand's flags, defaults, and
+  the `--from`-required / dry-run-default invariants.
+- `src/auth.rs` tests cover password validation and `ALTER ROLE` escaping.
+- `src/commands/sstable.rs` tests run against genuine BTI fixtures via
+  `ferrosa-storage`'s `test-support` feature.

--- a/ferrosa-ctl/specs/overview.md
+++ b/ferrosa-ctl/specs/overview.md
@@ -1,0 +1,107 @@
+---
+crate: ferrosa-ctl
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The operator CLI + ratatui TUI for a Ferrosa node. It reaches a node over
+  three channels — read-only CQL for observability, the web admin HTTP API for
+  cluster lifecycle, and direct filesystem/sled/S3 access for offline SSTable
+  and Raft-log recovery on a stopped node. It is a leaf binary: nothing depends
+  on it.
+---
+
+# ferrosa-ctl — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-ctl` is the single administrative/observability binary for a Ferrosa
+node. Its boundary is "anything an operator does from outside the node process":
+look at live state, drive cluster membership, and recover a damaged node's
+on-disk state. It deliberately spans **three transports**, because the
+operations it serves live behind three different node surfaces.
+
+It is the **leaf** of the workspace dependency graph — no crate depends on it.
+
+## The three channels
+
+| Channel | Used for | Surface |
+|---------|----------|---------|
+| CQL native protocol (`--host`, default `:9042`) | observability reads, `auth set-password` | `system_observability.*`, `system.peers`, `ALTER ROLE` |
+| Web admin HTTP API (`--web-port`, default `:9090`) | cluster membership, ring, repair, snapshot/restore, learner lifecycle, leader transfer | `POST/GET /api/cluster/*`, `/api/snapshots`, `/api/restore` |
+| Offline (filesystem / sled / object store) | SSTable triage & salvage, Raft-log inspect/truncate/reset | data dir, sled raft store, `FERROSA_S3_*` |
+
+```mermaid
+flowchart TD
+    OP["operator"] --> CTL["ferrosa-ctl (clap)"]
+    CTL -->|CQL :9042| OBS["system_observability.* / system.peers / ALTER ROLE"]
+    CTL -->|HTTP :9090| WEB["web admin API: cluster / snapshots / restore"]
+    CTL -->|filesystem| FS["SSTable dirs + quarantine/"]
+    CTL -->|sled| RAFT["raft log_store (stopped node)"]
+    CTL -->|object_store| S3["S3 / MinIO objects"]
+```
+
+## Module map
+
+| Module | LoC | Responsibility |
+|--------|-----|----------------|
+| `main` (`src/main.rs`) | ~1411 | clap `Cli` + `Commands`/sub-action enums, `#[tokio::main]` dispatch, exit codes |
+| `commands` (`src/commands.rs`) | ~2182 | CQL observability `run_*`, web-API cluster commands, offline raft reset/inspect/truncate, `cluster bootstrap-dc`, table/empty printers |
+| `commands::sstable` (`src/commands/sstable.rs`) | ~1717 | offline SSTable scan / inspect / quarantine / salvage / reingest / s3-clean |
+| `tui` (`src/tui.rs`) | ~517 | ratatui dashboard: `Panel`, `AppState`, `render*`, `event_loop` |
+| `auth` (`src/auth.rs`) | ~440 | `set-password` flow: validation, `ALTER ROLE` builder w/ escaping, admin-pw resolution, `CqlExecutor` trait |
+| `lib` (`src/lib.rs`) | 8 | re-exports `commands`/`auth`/`tui` for the integration tests |
+
+The binary is structured so I/O is separable from logic: the TUI splits
+`render`/state from terminal I/O; `auth` splits `validate_new_password` /
+`build_alter_role_statement` / `run_set_password` from connect+prompt; `sstable`
+splits `*_report` / `*_plan` from the `sstable_*` print wrappers. This is what
+lets 178 tests run without a node.
+
+## Data flow
+
+**Observability read** (`status`, `connections`, `queries`, `storage`,
+`topology`, `peers`): `CqlClient::connect(addr)` → one `SELECT` → `QueryResult`
+→ optional client-side sort → `print_table` (`tabled`, UTF-8 cells, `<binary>` /
+`NULL` fallbacks) or `print_empty`.
+
+**TUI** (`monitor`): one `CqlClient`, a synchronous `event_loop` polling
+crossterm with a 100 ms timeout, refreshing all three virtual tables every 2 s
+via the tokio runtime handle. A failed query becomes an `error_result` panel
+row, not a crash.
+
+**Cluster (HTTP)**: build URL + JSON body → `reqwest` → on success print
+server text; on `404`/`501` emit a "not yet wired" diagnostic with a spec
+pointer; on other non-2xx return the status+body as an error.
+
+**Offline SSTable**: `StorageEngine::list_generations_in_dir` enumerates gens;
+`StorageEngine::smoke_test_generation` is the **authoritative** OK/CORRUPT
+verdict (same call startup uses); the BTI `SSTableReader` supplies component
+sizes, partition counts, and the resilient `salvage` row reader. `reingest`
+additionally opens a live `CqlClient`, fetches the table layout, reconstructs
+rows preserving original timestamps, and re-inserts through the fixed write path.
+
+**Offline Raft**: `SledLogStore::{reset, inspect, truncate_from}` operate on a
+stopped node's sled dir; `reset` avoids opening sled (no flock contention).
+
+## Key invariants
+
+1. **ctl's corruption verdict equals the node's.** SSTable OK/CORRUPT is always
+   `StorageEngine::smoke_test_generation`; ctl never re-implements detection.
+2. **Destructive offline ops are gated.** `quarantine`/`reingest`/`s3-clean`
+   default to dry-run (`--apply`); `raft log-truncate` requires `--yes` and a
+   mandatory `--from`; quarantine moves files, never deletes.
+3. **Fail loud, never fake.** Unwired HTTP endpoints surface `404`/`501` with a
+   spec reference; a specified-but-unset `--admin-password-env` errors instead
+   of silently using the seed default; the server (not ctl) hashes passwords.
+4. **Two ports, one host.** `--host` is parsed to a `SocketAddr` for CQL; its IP
+   is reused with `--web-port` for HTTP. A bad `--host` exits 1 immediately.
+
+## Position in the dependency graph
+
+Leaf binary. **Runtime** deps: `ferrosa-cluster` (raft `SledLogStore`,
+`RaftGroupId`), `ferrosa-cql` (`CqlClient`, prepared statements),
+`ferrosa-sstable` (BTI reader/marshal), `ferrosa-storage`
+(`StorageEngine` smoke test + generation listing), `ferrosa-common`
+(`DecoratedKey`, `NO_TIMESTAMP`). **Dev-only** deps wiring the integration
+harness: `ferrosa-schema`, `ferrosa-session`, `ferrosa-udf`. Nothing depends on
+`ferrosa-ctl`. See the [root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-ctl/specs/roadmap.md
+++ b/ferrosa-ctl/specs/roadmap.md
@@ -1,0 +1,56 @@
+---
+crate: ferrosa-ctl
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-ctl — Roadmap
+
+Sourced from in-code "not yet" markers, the FMEA gaps ([fmea.md](fmea.md)), and
+the channel/dependency review.
+
+## Now (highest value)
+
+- **Wire the deferred web-API endpoints to the node, or label them clearly.**
+  `raft transfer-leader`, `cluster add-learner|promote-to-voter|demote-to-learner`,
+  and `snapshot`/`restore` POST to endpoints the node does not yet serve (they
+  return `404`/`501` with spec pointers: sprint-03-openraft-patches W3.8/W3.9,
+  sprint-08-learners-endurance W8.5). Until the server side lands, surface
+  "not yet implemented" in `--help`, not just at runtime (FMEA CTL-2).
+- **Surface a recovery-loss tally in `sstable reingest`.** Print salvaged vs.
+  unrecoverable rows per generation so a partial recovery cannot read as
+  complete (FMEA CTL-6). The counters (`reconstructed`, `inserted`, `failed`)
+  already exist internally — promote them into the summary and into `--json`.
+
+## Next
+
+- **TLS for CQL commands.** `auth set-password --ssl` errors out because
+  `CqlClient` has no TLS; every CQL command therefore sends credentials in
+  cleartext off-localhost (FMEA CTL-5). Add TLS to `CqlClient` and honor `--ssl`.
+- **Confirmation guard for `sstable s3-clean --apply`.** It's the only offline
+  command that *deletes* (durable S3 objects) and depends on the dir being named
+  exactly `<keyspace>.<table>`; add an interactive confirmation or `--yes` gate
+  to match `raft log-truncate` (FMEA CTL-3).
+- **Land `cluster bootstrap-dc` HTTP wire-up (Sprint 7).** Today it only derives
+  and prints the per-DC `RaftGroupId` (Sprint 6 scaffolding); connect it to the
+  node so it actually creates the group (FMEA CTL-8).
+
+## Later
+
+- **Multi-node `raft log-truncate` guard.** Truncation correctness depends on
+  the operator applying the right `--from` on every damaged node; explore a
+  cluster-wide inspect that reports which nodes share the same log damage
+  (FMEA CTL-1).
+- **Structured (`--json`) output for the observability commands.** `status`,
+  `connections`, `queries`, `storage`, `topology`, `peers` print human tables
+  only; a machine-readable mode would help scripting and monitoring.
+- **TUI panel parity with CLI.** The dashboard shows only Connections / Queries
+  / Storage; topology/peers/ring panels would unify the two surfaces.
+
+## Non-goals
+
+- Becoming a server. `ferrosa-ctl` stays a leaf client; node-side logic
+  (membership changes, PITR execution, password hashing) lives in the node,
+  reached over CQL or the web admin API — ctl never reimplements it.
+- Re-implementing corruption detection. SSTable verdicts must always delegate to
+  `StorageEngine::smoke_test_generation` so ctl can never diverge from startup.

--- a/ferrosa-flight/README.md
+++ b/ferrosa-flight/README.md
@@ -1,0 +1,113 @@
+# ferrosa-flight
+
+> Apache Arrow Flight (gRPC) query endpoint for Ferrosa. A client puts a CQL
+> `SELECT` in the Flight ticket; `ferrosa-cql` executes it and the result is
+> streamed back as Arrow record batches.
+
+## What this crate is
+
+`ferrosa-flight` exposes Ferrosa's data over the [Arrow Flight](https://arrow.apache.org/docs/format/Flight.html)
+gRPC protocol, so Arrow-native clients (pandas/Polars/DuckDB/Spark via
+`arrow-flight`) can read and write columnar data without going through the CQL
+native wire. The command carried by a Flight `Ticket`/`FlightDescriptor` is a
+CQL string: a `SELECT` for reads, executed by `ferrosa_cql::router::route_select_raw`
+and converted column-by-column to an Arrow [`RecordBatch`](src/convert.rs).
+
+Authentication is **bearer-token, never anonymous** (decision **D4**):
+`Handshake` validates CQL credentials and issues an HMAC-SHA256-signed token;
+every other RPC requires `authorization: Bearer <token>` and derives its
+`AuthContext` from the verified claims.
+
+## What's implemented
+
+- **`Handshake`** — validates `username\0password` via `Schema::authenticate`,
+  returns a signed bearer token (`token.rs`, HMAC-SHA256, absolute expiry, key
+  rotation overlap).
+- **`DoGet`** — streams a CQL `SELECT` result **one page at a time** (1024 rows
+  by default) via `futures::stream::unfold` over the CQL paging cursor, so peak
+  memory is bounded to a single page. Non-`SELECT` tickets are rejected up front.
+- **`GetFlightInfo`** — returns the Arrow schema plus Flight endpoints. On a
+  cluster topology with a known table it emits **one endpoint per ring token
+  range** (token-bounded `SELECT` ticket located on the owning replicas), so a
+  client can read ranges in parallel (`plan.rs`, W-002). Standalone / unknown
+  table falls back to a single self-endpoint.
+- **`GetSchema`** — returns just the Arrow schema (IPC-encoded) for a command.
+- **`DoPut`** — decodes inbound Arrow batches and writes each row into the
+  `ferrosa-table` (`keyspace.table` metadata header) as a generated CQL `INSERT`
+  routed through the normal write path; returns the rows-applied count.
+- **`DoExchange`** — bidirectional **upsert with per-batch ack**: consumes the
+  same inbound batches as `DoPut` and emits one `FlightData` ack (rows-applied
+  count in `app_metadata`) per batch, strictly ordered. (This is an upsert
+  channel, **not** a live CDC subscribe — see [FMEA](specs/fmea.md).)
+- **`ListFlights`** — enumerates queryable (non-system) tables as `FlightInfo`,
+  each with a `SELECT * FROM ks.t` ticket; optional `Criteria` prefix filter.
+- **`PollFlightInfo`** — resolves a descriptor to its `FlightInfo` and reports
+  it complete (`progress = 1.0`); synchronous (no long-running async poll yet).
+- **`DoAction` / `ListActions`** — `server.info` (name + crate version) and
+  `token.validate` (echo verified identity). The two stay in lock-step via
+  `SUPPORTED_ACTIONS`.
+
+Every RPC is implemented — there are **no `Unimplemented` stubs**.
+
+## How it works
+
+| Module | Responsibility |
+|--------|----------------|
+| `service` (`src/service.rs`) | `FerrosaFlight` — the `FlightService` impl: all RPCs, auth, `query_to_batch`, write-path `build_insert`/`write_batch`, endpoint assembly |
+| `convert` (`src/convert.rs`) | CQL result ↔ Arrow: `rows_to_record_batch` (full CQL type coverage) and `record_batch_to_rows` (scalar Arrow → CQL, fail-loud on the rest) |
+| `plan` (`src/plan.rs`) | Pure distributed-read planner: ring token ranges → token-bounded `SELECT` endpoints with replica locations (W-002) |
+| `token` (`src/token.rs`) | HMAC-SHA256 signed bearer tokens: `issue` / `verify` / `verify_with_keys` (key rotation) |
+| `server` (`src/server.rs`) | gRPC bootstrap: `flight_service` (mount on a `tonic` server) and `serve` (bind-and-run) |
+
+## Public API (key entry points)
+
+| Area | Items |
+|------|-------|
+| Service | `FerrosaFlight::new`, `.with_flight_advertise`, `.with_flight_port`, `.with_previous_keys`, `.with_token_ttl`, `.with_page_size` |
+| Server | `server::flight_service`, `server::serve`, `server::serve_service` |
+| Convert | `convert::rows_to_record_batch`, `convert::record_batch_to_rows`, `convert::cql_type_to_arrow`, `convert::ConvertError` |
+| Plan | `plan::distributed_endpoints`, `plan::ring_token_ranges`, `plan::token_bounded_select`, `plan::EndpointPlan` |
+| Token | `token::issue`, `token::verify`, `token::verify_with_keys`, `token::Claims`, `token::TokenError` |
+
+## Configuration
+
+| Env var | Effect |
+|---------|--------|
+| `FERROSA_FLIGHT_BROADCAST` | This node's externally-reachable Flight address advertised for ranges it owns. Unset → self-owned ranges advertise **no** location (client falls back to the queried connection) rather than faking an address. |
+| `FERROSA_FLIGHT_PORT` | Flight gRPC port combined with a remote replica's internode host to build its advertised location (default `50051`). |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-cql`** — `router::route_select_raw` (read), `router::route` (write),
+  the parser/AST, paging params, `SharedState`/`RequestContext`.
+- **`ferrosa-cluster`** — `ConsistencyLevel`, the `TokenRing` and
+  `ReplicationStrategy` used to plan per-range endpoints, `uuid_to_node_id`.
+- **`ferrosa-schema`** — `AuthContext`, `Schema::authenticate`, `is_system_keyspace`,
+  the schema snapshot used to enumerate tables and partition keys.
+- **`ferrosa-common`** — `CqlValue` / `CqlType` (the value model converted to Arrow).
+
+External: `arrow` + `arrow-flight` (53), `tonic` (0.12), `hmac`/`sha2`/`hex`
+(tokens), `futures`, `tokio`, `tracing`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa`** — the main binary mounts `flight_service` / calls `serve` to expose the endpoint.
+
+## Tests
+
+46 tests total — 25 unit (`convert` 11, `token` 7, `plan` 7) + 21 integration:
+
+- `tests/read_path.rs` (4) — `DoGet` streams a `SELECT` result as Arrow, paging across multiple pages, bearer required, non-`SELECT` rejected.
+- `tests/grpc_handshake.rs` (2) — full gRPC `Handshake` → `DoGet`; `DoPut` write then `DoGet` read-back over a real `tonic` channel.
+- `tests/exchange_path.rs` (2) — `DoExchange` upserts each batch and acks; requires a valid bearer.
+- `tests/minor_rpcs.rs` (11) — `ListFlights`, `PollFlightInfo`, `ListActions`, `DoAction` (`server.info` / `token.validate` / unknown / bearer).
+- `tests/distributed_endpoints.rs` (2) — standalone single endpoint; multi-range topology one endpoint per range.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, data flow
+- [FMEA / known issues](specs/fmea.md) — failure modes + real gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later
+- [Data flow](specs/data-flow.md) — Handshake → token → DoGet → CQL exec → Arrow stream

--- a/ferrosa-flight/specs/data-flow.md
+++ b/ferrosa-flight/specs/data-flow.md
@@ -1,0 +1,103 @@
+---
+crate: ferrosa-flight
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa-flight — Data Flow
+
+How a client goes from credentials to streamed Arrow: `Handshake` → bearer
+token → `DoGet` (CQL ticket) → `ferrosa-cql` execution → paged Arrow stream.
+Every RPC after `Handshake` carries `authorization: Bearer <token>` and is
+authenticated before it touches the query path (decision D4).
+
+## End-to-end: Handshake then DoGet
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Arrow Flight client
+    participant F as FerrosaFlight (service.rs)
+    participant T as token.rs (HMAC-SHA256)
+    participant S as ferrosa-schema (authenticate)
+    participant R as ferrosa-cql router (route_select_raw)
+    participant V as convert.rs (rows_to_record_batch)
+
+    Note over C,F: Handshake — establish a bearer token
+    C->>F: Handshake(payload = "username\0password")
+    F->>S: Schema::authenticate(user, pass)
+    S-->>F: AuthContext{role, is_superuser}
+    F->>T: issue(signing_key, Claims{role, is_superuser, expires_at})
+    T-->>F: signed token = hex(payload)"."hex(hmac)
+    F-->>C: HandshakeResponse{payload = token}
+
+    Note over C,F: DoGet — redeem a CQL SELECT ticket
+    C->>F: DoGet(Ticket = CQL SELECT, header: Bearer token)
+    F->>T: verify_with_keys(keys, token, now)
+    T-->>F: Claims (or Unauthenticated)
+    F->>F: parse ticket, require SELECT (else InvalidArgument)
+
+    loop one CQL page per step (unfold over paging cursor)
+        F->>R: route_select_raw(ctx{page_size=1024, paging_state})
+        R-->>F: page{column_types, rows: Vec&lt;Vec&lt;Option&lt;CqlValue&gt;&gt;&gt;, paging_state}
+        F->>V: rows_to_record_batch(names, types, rows)
+        V-->>F: Arrow RecordBatch
+        F-->>C: FlightData (Arrow IPC stream)
+    end
+    Note over F,C: stream ends when route_select_raw returns no paging_state
+```
+
+The first batch is always emitted (even for zero rows) so the client receives
+the schema. Peak server memory is bounded to a single page rather than the whole
+result set (FMEA FL-5).
+
+## GetFlightInfo — distributed read planning (W-002)
+
+```mermaid
+flowchart TD
+    A["GetFlightInfo(descriptor.cmd = CQL SELECT)"] --> B["authenticate(Bearer)"]
+    B --> C["query_to_batch(page_size=1) -> Arrow schema"]
+    C --> D{"cluster ring present<br/>and table known?"}
+    D -- "no (standalone / unknown)" --> E["single self-endpoint<br/>ticket = original CQL, no location"]
+    D -- "yes" --> F["plan::distributed_endpoints"]
+    F --> G["ring_token_ranges(ring, strategy)<br/>one (start, end] range per ring token"]
+    G --> H["per range: token-bounded SELECT ticket<br/>token(pk) &gt; start AND token(pk) &lt;= end"]
+    H --> I["resolve_flight_addr per replica<br/>local: FERROSA_FLIGHT_BROADCAST<br/>remote: ring host + FERROSA_FLIGHT_PORT"]
+    I --> J{"address resolved?"}
+    J -- "yes" --> K["add grpc://host:port location"]
+    J -- "no" --> L["omit location (never faked)<br/>endpoint still emitted"]
+    E --> M["FlightInfo{schema, endpoints}"]
+    K --> M
+    L --> M
+```
+
+A single whole-ring plan collapses back to the standalone single self-endpoint,
+since it is indistinguishable from the non-clustered case.
+
+## DoPut / DoExchange — write path
+
+```mermaid
+flowchart LR
+    A["inbound FlightData stream"] --> B["FlightRecordBatchStream<br/>-> RecordBatch"]
+    B --> C["convert::record_batch_to_rows<br/>(scalar Arrow types; fail-loud on rest)"]
+    C --> D["per row: build_insert<br/>INSERT INTO ks.t (...) VALUES (...)"]
+    D --> E{"column representable?<br/>(cql_literal)"}
+    E -- "no (NULL / non-finite / rich type)" --> F["column omitted from INSERT (FMEA FL-1)"]
+    E -- "yes" --> G["escaped literal added"]
+    F --> H["parse + ferrosa_cql::router::route"]
+    G --> H
+    H --> I{"RPC"}
+    I -- "DoPut" --> J["PutResult{app_metadata = total rows}"]
+    I -- "DoExchange" --> K["one FlightData ack per batch<br/>(rows-applied in app_metadata), strictly ordered"]
+```
+
+`DoExchange` here is an upsert-with-ack channel, **not** a live CDC subscribe
+stream (FMEA FL-3) — a real change-feed over `DoExchange` is post-v1.
+
+## Token format (token.rs)
+
+`token = hex(payload) "." hex(hmac_sha256(key, payload))`, where
+`payload = "{expires_at}:{is_superuser as 0|1}:{role}"`. `verify` checks the
+HMAC in constant time *before* trusting the payload, then checks expiry last (so
+a forged token never reports "expired"). `verify_with_keys` accepts a set of
+keys (current + recently retired) to give key rotation an overlap window.

--- a/ferrosa-flight/specs/fmea.md
+++ b/ferrosa-flight/specs/fmea.md
@@ -1,0 +1,49 @@
+---
+crate: ferrosa-flight
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-flight — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This crate is a network-facing read/write endpoint on the query
+path, so confidentiality and silent-wrong-data severities dominate.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| FL-1 | `DoPut` materializes each row to a CQL `INSERT` text string, re-parsed per row | Slow, lossy write path: only `cql_literal`-representable scalar values survive; NULL / non-finite floats / rich types are silently *omitted* from the INSERT (the column simply isn't written) | 7 | 5 | 6 | 210 | **Open gap.** `cql_literal` returns `None` (column dropped) for NULL, non-finite f32/f64, and any non-scalar `CqlValue`. Write a typed prepared-statement / direct-mutation path that carries NULLs and rich types instead of string interpolation. |
+| FL-2 | `record_batch_to_rows` (the `DoPut`/`DoExchange` reverse path) only decodes ~9 scalar Arrow types | An inbound batch containing List/Map/Struct/Date32/Time64/Interval/Decimal columns fails the whole write with `UnsupportedArrow` | 6 | 5 | 3 | 90 | **Partial / by design.** Fails loud (no silent drop) but the reverse type matrix is far narrower than the forward path — a `DoGet` batch (Date32, lists, structs) cannot be round-tripped back through `DoPut`. Track the supported-Arrow matrix; extend to match the forward path. |
+| FL-3 | `DoExchange` is an upsert-with-ack channel, **not** a live CDC / subscribe stream | Clients expecting a change-feed over `DoExchange` get only per-batch write acks; there is no server-initiated push of committed changes | 4 | 4 | 4 | 64 | **By design (post-v1).** Documented in `service.rs` ("Out of scope (post-v1): a live-subscribe channel over `DoExchange`"). A real CDC `DoExchange` is unwired — see roadmap. |
+| FL-4 | `GetFlightInfo` / `GetSchema` / `ListFlights` execute the real `SELECT` (page_size 1) just to learn the schema | A schema lookup runs a live single-row query: cost on an expensive predicate, and side effects of executing user CQL for metadata; `ListFlights` does this once per table | 5 | 4 | 5 | 100 | **Open gap.** Schema is derived by executing `query_to_batch` rather than from table metadata. Derive the Arrow schema from the schema snapshot (column types) without running the query. |
+| FL-5 | Whole result paged but a single page can still be large | Peak memory is one page (default 1024 rows); a row with huge blobs/collections makes one page heavy | 5 | 3 | 4 | 60 | **Mitigated.** Paged `DoGet` via the CQL cursor bounds memory to one page (vs. whole-set materialization). Page size is configurable (`with_page_size`); byte-budgeted paging is a refinement. |
+| FL-6 | Token signing key is process-held and supplied by the caller; no built-in rotation scheduler | A long-lived key compromise validates forged tokens until manually rotated | 7 | 2 | 5 | 70 | **Partial.** `verify_with_keys` supports a rotation overlap window (current + retired keys), HMAC-SHA256, constant-time verify, absolute expiry (default 1h). Key *provisioning/rotation cadence* is the embedder's responsibility (`ferrosa` binary). |
+| FL-7 | `serve` builds a plaintext `tonic` server with no TLS | Bearer tokens and query data traverse the wire in cleartext if the embedder does not add transport security | 8 | 3 | 4 | 96 | **By design / deferred to caller.** `flight_service` returns the bare service so the embedder can wrap it with TLS + their own incoming/shutdown wiring; the convenience `serve` is plaintext. Document that production must terminate TLS. |
+| FL-8 | `PollFlightInfo` is synchronous — always returns `progress = 1.0`, no continuation | A client polling a long-running query gets an immediate "complete" with the full info, with no genuine async progress | 3 | 3 | 5 | 45 | **By design (v1).** Results are ready synchronously; real long-running async polling is W-002 follow-up. |
+| FL-9 | Distributed endpoint planning needs explicit `FERROSA_FLIGHT_BROADCAST` per node | If self-broadcast is unset, self-owned ranges advertise no location; a non-co-located client must already be on the right connection | 4 | 4 | 3 | 48 | **Mitigated (fail-honest).** Unresolvable addresses are omitted, never faked; the endpoint is still emitted so data stays reachable via the queried connection. Operationally requires each node to set its broadcast addr. |
+
+## Top risks to act on
+
+1. **FL-1 (RPN 210)** — the write path stringifies rows into CQL `INSERT`s and
+   *silently omits* any column it cannot render (NULL, non-finite float, rich
+   types). A client writing such a column sees a successful `DoPut` with that
+   column missing. Replace text interpolation with a typed write path that
+   carries NULLs and the full type set.
+2. **FL-4 (RPN 100)** — schema discovery executes the user's query. Derive the
+   Arrow schema from table metadata so `GetSchema`/`GetFlightInfo`/`ListFlights`
+   do not run live queries.
+3. **FL-7 (RPN 96)** — the convenience `serve` is plaintext; production
+   deployments must wrap `flight_service` with TLS.
+
+## Detection assets
+
+- `tests/grpc_handshake.rs` — full gRPC `Handshake` → `DoGet` and a `DoPut`
+  write / `DoGet` read-back over a real `tonic` channel.
+- `tests/read_path.rs` — multi-page `DoGet`, bearer enforcement, non-`SELECT`
+  rejection.
+- `tests/exchange_path.rs` — `DoExchange` per-batch ack + bearer enforcement.
+- `convert.rs` unit tests — full forward type coverage and the fail-loud cases
+  (`TypeMismatch`, `UnsupportedArrow`).
+- `token.rs` unit tests — tamper/expiry/wrong-key/rotation precedence.
+- `plan.rs` unit tests — per-range tickets, RF>1 multi-location, unresolvable
+  address omitted (not faked).

--- a/ferrosa-flight/specs/overview.md
+++ b/ferrosa-flight/specs/overview.md
@@ -1,0 +1,94 @@
+---
+crate: ferrosa-flight
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  Apache Arrow Flight (gRPC) query endpoint for Ferrosa. A client carries a CQL
+  SELECT in the Flight ticket; ferrosa-cql executes it (route_select_raw) and the
+  result is streamed back as Arrow record batches, paged so peak memory is bounded
+  to one page. Bearer-token auth (decision D4): Handshake validates CQL credentials
+  and issues an HMAC-SHA256 token; every other RPC requires it. DoPut/DoExchange
+  write Arrow rows back as CQL INSERTs. GetFlightInfo plans one endpoint per ring
+  token range for parallel distributed reads (W-002). All Flight RPCs are
+  implemented — there are no Unimplemented stubs.
+---
+
+# ferrosa-flight — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-flight` is the Arrow Flight adapter over Ferrosa's CQL execution layer.
+Its boundary is deliberately thin: it owns gRPC framing, bearer-token auth, the
+CQL↔Arrow conversion, and distributed-read endpoint planning — and **nothing
+else**. Query execution, key/token derivation, consistency, and replication all
+belong to `ferrosa-cql`'s router and the layers beneath it; this crate calls
+`route_select_raw` (read) and `route` (write) and never reaches into storage
+directly.
+
+The command transported by a Flight `Ticket` / `FlightDescriptor.cmd` is a CQL
+string. Reads require a `SELECT`; writes (`DoPut` / `DoExchange`) carry Arrow
+batches plus a `ferrosa-table` (`keyspace.table`) metadata header and are
+materialized as generated CQL `INSERT`s.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `service` (`src/service.rs`, ~880 LoC) | `FerrosaFlight`: the full `FlightService` impl, per-RPC auth, `query_to_batch`, write-path `build_insert` / `write_batch`, endpoint assembly |
+| `convert` (`src/convert.rs`, ~980 LoC) | `rows_to_record_batch` (CQL result → Arrow, full type coverage incl. list/set/map/tuple/udt/vector/decimal) and `record_batch_to_rows` (Arrow → CQL, scalar subset, fail-loud) |
+| `plan` (`src/plan.rs`, ~320 LoC) | Pure distributed-read planner: ring token ranges → token-bounded `SELECT` endpoints + replica Flight locations (W-002) |
+| `token` (`src/token.rs`, ~230 LoC) | HMAC-SHA256 signed bearer tokens: `issue` / `verify` / `verify_with_keys` (rotation overlap) |
+| `server` (`src/server.rs`) | gRPC bootstrap: wrap in `FlightServiceServer`, bind-and-serve |
+| `lib` (`src/lib.rs`) | Module re-exports only |
+
+## Data flow
+
+**Auth (every session).** `Handshake` reads a `username\0password` payload,
+calls `Schema::authenticate`, and returns an HMAC-SHA256 token whose payload is
+`{expires_at}:{is_superuser}:{role}`. Every subsequent RPC calls
+`authenticate(metadata)`, which strips `Bearer `, runs `verify_with_keys`
+(constant-time signature check, then expiry), and builds the `AuthContext` from
+the verified claims. There is no anonymous path.
+
+**Read (`DoGet`).** Ticket bytes → UTF-8 CQL → parse, require `SELECT` →
+`stream::unfold` over a paging cursor: each step calls `route_select_raw` with
+`page_size = 1024` and the prior `paging_state`, converts the page's
+`column_types` + `Vec<Vec<Option<CqlValue>>>` to a `RecordBatch` via
+`rows_to_record_batch`, yields it, and advances the cursor until the CQL layer
+reports no continuation. The batches feed a `FlightDataEncoderBuilder` so the
+schema is taken from the first (always-emitted) batch. Peak memory is one page.
+
+**Discovery (`GetFlightInfo` / `GetSchema` / `ListFlights`).** These call
+`query_to_batch`, which executes the `SELECT` with `page_size = 1` purely to
+derive the Arrow schema. `GetFlightInfo` then asks `plan::distributed_endpoints`
+for one endpoint per ring token range (each ticket a `token(pk) > s AND
+token(pk) <= e` bounded `SELECT`, located on the owning replicas); a single
+whole-ring plan collapses to the standalone single self-endpoint.
+
+**Write (`DoPut` / `DoExchange`).** Inbound `FlightData` → `RecordBatch`es →
+`record_batch_to_rows` → for each row, `build_insert` emits
+`INSERT INTO ks.t (...) VALUES (...)` (column identifiers validated, string/blob
+literals escaped) → re-parsed and routed via `ferrosa_cql::router::route`.
+`DoPut` returns one `PutResult` with the total count; `DoExchange` emits one ack
+per batch, strictly ordered, stopping on the first error.
+
+## Key invariants
+
+1. **No anonymous access (D4).** Every RPC except `Handshake` calls
+   `authenticate` first; a missing/forged/expired token is `Unauthenticated`.
+2. **Bounded `DoGet` memory.** The result is paged through the CQL cursor; the
+   server never materializes a whole result set in one `RecordBatch`.
+3. **Fail loud on conversion.** An unsupported CQL type, an Arrow type with no
+   CQL mapping, or a value/column type mismatch returns a `ConvertError` (→
+   `Status`) — never silently-wrong data, never a dropped batch.
+4. **Never fabricate a Flight address.** When a replica's advertised Flight
+   address is unknown the endpoint is still emitted with *no* location (client
+   falls back to the queried connection); the planner does not invent a host.
+5. **Write injection guard.** Column/table identifiers interpolated into
+   generated `INSERT`s must pass `valid_ident`; values are escaped literals.
+
+## Position in the dependency graph
+
+A thin top-of-stack adapter: depends on `ferrosa-cql`, `ferrosa-cluster`,
+`ferrosa-schema`, `ferrosa-common`; depended on only by the `ferrosa` binary.
+See the [root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-flight/specs/roadmap.md
+++ b/ferrosa-flight/specs/roadmap.md
@@ -1,0 +1,62 @@
+---
+crate: ferrosa-flight
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-flight — Roadmap
+
+Sourced from the in-code design notes (`service.rs` / `plan.rs` doc comments),
+the FMEA gaps ([fmea.md](fmea.md)), and the dependency/usage review. The crate
+implements every Flight RPC today; the roadmap is about depth and hardening, not
+filling stubs.
+
+## Now (highest value)
+
+- **Typed write path for `DoPut` / `DoExchange` (FMEA FL-1).** Replace
+  per-row `INSERT` text interpolation (`build_insert` + `cql_literal`) with a
+  typed prepared-statement or direct-mutation path. Today NULL, non-finite
+  floats, and any non-scalar `CqlValue` are *silently omitted* from the
+  generated INSERT — a successful `DoPut` can drop a column. The write path must
+  carry NULLs and the full CQL type set, fail-loud on the genuinely
+  unrepresentable.
+- **Derive schema without executing the query (FMEA FL-4).** `GetSchema`,
+  `GetFlightInfo`, and `ListFlights` currently run the user's `SELECT` (page
+  size 1) just to learn its Arrow schema. Build the schema from the table's
+  declared column types in the schema snapshot so metadata RPCs do not execute
+  live queries.
+
+## Next
+
+- **Widen the reverse Arrow→CQL type matrix (FMEA FL-2).** `record_batch_to_rows`
+  covers ~9 scalar Arrow types; a batch produced by the forward path (Date32,
+  Time64, lists, maps, structs, intervals, decimal-as-text) cannot be written
+  back via `DoPut`. Extend the decoder to match the forward coverage so a
+  `DoGet` → `DoPut` round-trip works for the full type set.
+- **TLS for the convenience server (FMEA FL-7).** Document clearly that
+  `server::serve` is plaintext and production must wrap `flight_service` with
+  TLS; optionally add a `serve_tls` helper so the common case is secure by
+  default.
+- **`FixedSizeBinary(16)` for `uuid`/`timeuuid`.** The forward path emits UUIDs
+  as canonical text (`cql_type_to_arrow` notes this is a refinement target);
+  fixed-size binary is the more Arrow-native, compact representation.
+
+## Later
+
+- **Live CDC / subscribe channel over `DoExchange` (FMEA FL-3).** Today
+  `DoExchange` is an upsert-with-ack; a real change-feed (server pushes committed
+  changes to a subscribed client) is explicitly post-v1. Wire it to the CDC
+  source when that lands.
+- **Genuine async `PollFlightInfo` (FMEA FL-8, W-002).** Replace the synchronous
+  `progress = 1.0` response with real long-running query progress + a
+  continuation descriptor.
+- **Byte-budgeted `DoGet` paging (FMEA FL-5).** Bound a page by serialized bytes,
+  not just row count, so a page of wide blob/collection rows stays small.
+
+## Non-goals
+
+- Query planning / execution, key/token derivation, consistency, replication —
+  these belong to `ferrosa-cql` and the layers beneath it. This crate is the
+  Flight adapter: gRPC framing, auth, CQL↔Arrow conversion, and endpoint planning.
+- A second CQL value encoder. Conversion lives in `convert.rs`; the engine's row
+  codec lives in `ferrosa-row-bridge` / `ferrosa-cql`.

--- a/ferrosa-graph/README.md
+++ b/ferrosa-graph/README.md
@@ -1,0 +1,125 @@
+# ferrosa-graph
+
+> The property-graph query engine for ferrosa: a Cypher endpoint over data
+> stored in ordinary CQL tables, kept traversable by a system-managed
+> adjacency index.
+
+## What this crate is
+
+`ferrosa-graph` lets a ferrosa keyspace be queried as a property graph without
+a separate graph store. Vertices and edges live in **regular CQL tables** tagged
+with `extensions["graph.type"] = "vertex" | "edge"` (plus `graph.label`,
+`graph.source`, `graph.target`). Topology is made traversable by a
+**per-keyspace adjacency index** — a system table `system_graph_<ks>.adjacency`
+that the engine creates lazily and keeps consistent with the edge tables.
+
+The crate parses Cypher, validates + authorizes it against the schema, plans it
+into a physical traversal plan, and executes that plan against the storage
+engine through the cluster write path. It exposes the same query surface over
+three transports: an **HTTP/JSON** endpoint (port 7474), the **Bolt v5** wire
+protocol (port 7687, Neo4j-driver compatible), and direct in-process calls from
+the `ferrosa` binary.
+
+## What's implemented
+
+- **Cypher parser** — lexer + recursive-descent parser (`parser/`) covering
+  `MATCH` / `OPTIONAL MATCH`, `WHERE`, `WITH` pipelines, `RETURN` (DISTINCT,
+  `ORDER BY`, `LIMIT`), `CREATE` / `SET` / `REMOVE` / `DELETE` / `DETACH DELETE`,
+  `MERGE`, `UNWIND`, `UNION [ALL]`, `FOREACH`, correlated `CALL {}` subqueries,
+  `SUBSCRIBE` / `UNSUBSCRIBE`, variable-length paths `[*min..max]`, pattern
+  predicates/comprehensions, list comprehensions, and map projections.
+- **Logical planner** (`planner/logical.rs`) — resolves Cypher labels to tables
+  via `graph.label` extensions (case-insensitive), validates property refs, and
+  performs **per-statement authorization** (`check_permission`: `Select` for
+  reads, `Modify` for writes) against the `AuthContext` (threat T3).
+- **Physical planner** (`planner/physical.rs`) — anchor selection + `Expand` /
+  `ExpandVarLength` / `Create` / `Merge` / `Subscribe` / `Union` plans.
+- **Expand executor** (`executor/expand.rs`) — anchor lookup, per-hop adjacency
+  reads, property evaluation, aggregation, write clauses; honors DoS limits
+  (`max_fan_out_per_hop`, `max_result_rows`, `query_timeout`).
+- **Variable-length paths** (`executor/varpath.rs`, `leapfrog.rs`) — BFS over
+  `min..=max` hops with a visited set for cycle detection and a
+  `max_var_path_visited` vertex budget (threat T13).
+- **Aggregations** (`executor/aggregate.rs`) — `count`, `sum`, `avg`, `min`,
+  `max`, `collect`, with `max_groups` / `max_collect_size` caps.
+- **Adjacency index** (`adjacency/`) — `schema` (table layout + naming),
+  `observer` (synchronous index maintenance), `reconcile` (background safety net).
+- **SUBSCRIBE** (`executor/subscribe.rs`) — per-connection subscription registry
+  with a tunable per-connection cap (`FERROSA_GRAPH_MAX_SUBSCRIPTIONS`, default 8).
+- **Transports** — `http.rs` (axum, Basic auth, TLS, body-size limit, SSE for
+  SUBSCRIBE) and `bolt/` (Bolt v5 handshake, PackStream codec, message dispatch).
+- **Cluster-aware DDL** — adjacency keyspace/table creation routes through the
+  same `DdlPath` regular CQL `CREATE TABLE` uses, so every replica registers the
+  system table (`ClusterGraphSchemaCoordinator`); a local coordinator is the
+  single-node default.
+
+## How it works
+
+A query flows: **parse → bind params → validate + authorize → logical plan →
+physical plan → execute**. On the first query in a keyspace that touches edges,
+`ensure_adjacency_storage_for_keyspace` lazily creates
+`system_graph_<ks>.adjacency`, registers the `AdjacencyIndexObserver`, runs one
+synchronous reconcile pass, and (if configured) starts the background
+reconciliation loop.
+
+The **adjacency-consistency invariant** is the heart of the crate: every edge
+write must produce the matching OUT and IN adjacency entries. This is enforced
+**synchronously** — `AdjacencyIndexObserver` is a `WriteObserver` running in
+`ObserverMode::Sync`, so its derived adjacency mutations are applied in the same
+write as the edge row, not asynchronously. The background **reconciler** is the
+explicit, observable fallback: it scans edge tables to repair missing entries
+and scans the adjacency index to tombstone orphans, covering dropped-mutation
+and crash-recovery gaps. See [specs/data-flow.md](specs/data-flow.md).
+
+## Public API (key entry points)
+
+| Area | Item |
+|------|------|
+| Engine | `GraphEngine::new` / `new_with_coordinator`, `execute[_with_params]`, `explain`, `execute_subscribe`, `graph_schema`, `shutdown` |
+| Config | `GraphConfig`, `GraphEngineConfig` (DoS limits), `GraphHttpConfig`, `BoltConfig` |
+| DDL routing | `GraphSchemaCoordinator` (+ `Local` / `Cluster` impls) |
+| Adjacency | `adjacency_keyspace_name`, `adjacency_table_metadata`, `AdjacencyIndexObserver`, `reconcile_once`, `spawn_reconciliation` |
+| HTTP | `http::router`, `GraphHttpConfig` |
+| Bolt | `bolt::server::start_bolt_server`, `BoltConfig` |
+| Errors | `GraphError`, `Result` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-cluster`** — `WritePath` (read/range_read/write), `DdlPath` +
+  `DdlOperation` for replicated adjacency DDL, `ConsistencyLevel`,
+  `ReplicationStrategy`, `ClusterError`.
+- **`ferrosa-common`** — `DecoratedKey`, `PartitionKey`, `CellValue`, `Error`.
+- **`ferrosa-net`** — internode protocol types (`PeerManager`, `RpcServer`,
+  `Message`). **Used only by the integration test harness**
+  (`tests/graph_http_integration.rs`); it is a `[dev-dependencies]` entry, not a
+  production code path of this crate.
+- **`ferrosa-schema`** — `Schema`, `SchemaSnapshot`, `TableMetadata`,
+  `AuthContext`, `check_permission`, `VirtualTableRegistry`.
+- **`ferrosa-sstable`** — `Partition`, `Row`, `CellValue`, `LivenessInfo`,
+  `DeletionTime` (the storage row shapes it reads and builds).
+- **`ferrosa-storage`** — `StorageEngine`, `Mutation`, `TableId`,
+  `WriteObserver` / `ObserverMode` (the observer hook).
+
+External: `axum`/`axum-server`, `tokio`, `serde`/`serde_json`, `arc-swap`,
+`parking_lot`, `indexmap`, `phf`, `blake3`, `uuid`, `base64`, `hex`, `chrono`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa`** — the main binary wires the `GraphEngine`, HTTP endpoint, and
+  Bolt server alongside the CQL listener.
+
+## Tests
+
+353 in-crate unit/`tokio` tests plus three integration suites under `tests/`
+(`adjacency_replication.rs`, `graph_http_integration.rs`, `parser_proptest.rs`).
+No `#[ignore]`, no `TODO`/`FIXME` markers in source. Highest coverage:
+`parser/parse_impl.rs` (81), `executor/eval.rs` (47), `executor/expand.rs` (44).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, position
+- [FMEA / known issues](specs/fmea.md) — failure modes + real gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later
+- [Data flow](specs/data-flow.md) — MATCH expand + adjacency-consistent write

--- a/ferrosa-graph/specs/data-flow.md
+++ b/ferrosa-graph/specs/data-flow.md
@@ -1,0 +1,116 @@
+---
+crate: ferrosa-graph
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa-graph — Data Flow
+
+Two paths matter for understanding the crate: a **read** (a Cypher `MATCH` that
+expands through the adjacency index) and a **write** (an edge create that keeps
+the adjacency index consistent). Both go through the same composition root
+(`GraphEngine`) and delegate persistence to `ferrosa-cluster`'s `WritePath`.
+
+## 1. Read: a `MATCH` expand traversal
+
+`MATCH (a:Person {name:'alice'})-[:KNOWS]->(b) RETURN b.name`
+
+The engine resolves and authorizes the statement, looks up the anchor vertex,
+then reads `system_graph_<ks>.adjacency` once per hop to find neighbors — it never
+scans the edge table to traverse.
+
+```mermaid
+sequenceDiagram
+    participant C as Client (HTTP 7474 / Bolt 7687)
+    participant E as GraphEngine.execute
+    participant P as parser + planner
+    participant A as auth (check_permission)
+    participant X as expand executor
+    participant W as WritePath (ferrosa-cluster)
+    participant S as StorageEngine
+
+    C->>E: Cypher MATCH ... RETURN b.name
+    E->>P: parse + bind params
+    P->>A: validate: resolve labels, authorize (Select)
+    A-->>P: ok (AuthContext permits)
+    P->>P: logical plan then physical Expand plan
+    E->>X: execute(Expand, keyspace, config)
+    X->>W: range_read(Person)  %% anchor lookup
+    W->>S: read anchor partitions
+    S-->>X: anchor rows (filter name='alice')
+    loop each hop
+        X->>W: read(adjacency, key=src, dir=OUT, label=KNOWS)
+        W->>S: read adjacency partition
+        S-->>X: neighbor_id rows (capped by max_fan_out_per_hop)
+        X->>W: read(Person, key=neighbor_id)  %% hydrate b
+        W-->>X: b row then row_to_json
+    end
+    X-->>E: GraphResult (rows, columns, QueryStats)
+    E-->>C: JSON / Bolt RECORD stream
+```
+
+Notes: the anchor is read with `range_read`; each hop reads the adjacency index
+for `(direction, edge_label, neighbor_id)`. Limits (`max_fan_out_per_hop`,
+`max_result_rows`, `query_timeout`, and `max_var_path_visited` for `[*]`) bound
+cost. Because traversal reads the index rather than the edge table, an
+adjacency-index desync (FMEA G-1/G-2) shows up here as **missing rows, not an
+error** — which is exactly why the consistency invariant below matters.
+
+## 2. Write: an edge create keeping the adjacency index consistent
+
+`CREATE (a)-[:KNOWS]->(b)` (or any edge-table write)
+
+The edge row is written through `WritePath`. The `AdjacencyIndexObserver` is
+registered on the edge table as a **synchronous** `WriteObserver`, so the storage
+engine asks it to derive the matching adjacency mutations and applies them in the
+**same** write — the OUT row under `src` and the IN row under `tgt`. The index is
+therefore consistent with the committed edge, not eventually.
+
+```mermaid
+sequenceDiagram
+    participant E as GraphEngine (Create/Merge plan)
+    participant W as WritePath (ferrosa-cluster)
+    participant S as StorageEngine
+    participant O as AdjacencyIndexObserver (Sync)
+    participant R as reconciler (background fallback)
+
+    E->>W: write(edge_table, src, row, ts)
+    W->>S: apply edge mutation
+    S->>O: on_write(edge_table, mutation)
+    Note over O: requires graph.source + graph.target ext;<br/>else returns empty (FMEA G-2)
+    O-->>S: derived OUT row (under src) + IN row (under tgt)
+    S->>S: apply adjacency mutations in the same write
+    S-->>W: committed (edge + adjacency together)
+    W-->>E: ok
+
+    Note over R: fallback only - not the primary path
+    loop every reconciliation_interval (0 = disabled by default)
+        R->>W: range_read(edge_table)
+        R->>W: read(adjacency) per edge row
+        alt OUT/IN entry missing
+            R->>W: write make_adjacency_mutation (repair)
+        end
+        R->>W: range_read(adjacency) then read(edge_table)
+        alt adjacency row has no surviving edge
+            R->>W: write tombstone (remove orphan)
+        end
+    end
+```
+
+### The adjacency-consistency invariant
+
+For every live edge `(src)-[label]->(tgt)` the index holds exactly two rows:
+
+- OUT: partition `src`, clustering `(OUT, label, tgt)`
+- IN: partition `tgt`, clustering `(IN, label, src)`
+
+Each clustering component is wire-encoded as `[u16 BE length][bytes]` for
+`(direction:1B, edge_label:text, neighbor_id:blob)` — the layout the SSTable
+composite parser requires. The **synchronous observer** is the primary
+enforcement (index commits with the edge). The **reconciler is the fallback**: it
+repairs entries the observer missed (dropped mutation under backpressure, crash
+between edge and index visibility) and tombstones orphans whose edge is gone. It
+is idempotent and observable (`ReconcileMetrics`), but a safety net — never the
+source of truth. Caveat (FMEA): it is disarmed by the default config and repairs
+at hardcoded RF=1, so the fallback is currently weaker than the invariant it
+guards.

--- a/ferrosa-graph/specs/fmea.md
+++ b/ferrosa-graph/specs/fmea.md
@@ -1,0 +1,46 @@
+---
+crate: ferrosa-graph
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-graph — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This crate is on the read+write critical path and exposes two
+network listeners, so consistency and DoS modes dominate.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| G-1 | **Adjacency-index desync** — an edge write commits but its OUT/IN adjacency rows do not (observer mutation dropped under backpressure, or crash between edge + index apply) | Traversals silently miss neighbors: `MATCH (a)-[]->(b)` returns incomplete results — wrong answers, not an error | 9 | 4 | 7 | 252 | **Partially mitigated.** Observer runs `ObserverMode::Sync` so the index normally commits *with* the edge. The background `reconcile` loop is the fallback: it scans edge tables to repair missing entries and tombstones orphans, and is idempotent. **Gap:** reconciliation is only armed when `reconciliation_interval > 0`; with the default `GraphConfig` (`ZERO`, `enabled:false`) only the one-shot reconcile at keyspace registration runs — steady-state drift is undetected. There is no metric/alert on observed drift. |
+| G-2 | **Missing graph extensions ⇒ silent no-op** — an edge table lacks `graph.source` / `graph.target` (or `graph.label`) | `derive_adjacency_mutations` returns `vec![]`: the edge persists but is never indexed, so it is invisible to every traversal, with no error | 8 | 3 | 8 | 192 | **Open gap.** The observer early-returns on missing extensions by design (Phase-1 tables), and the reconciler skips the same tables. No validation warns that an edge table is unindexable. Should fail loud (or warn) when a `graph.type=edge` table lacks source/target. |
+| G-3 | **Reconciler writes at hardcoded RF=1** — `write_mutation` / `write_tombstone` use `ReplicationStrategy::Simple{replication_factor:1}` and `ConsistencyLevel::One` regardless of the keyspace's actual replication | On a multi-replica keyspace, reconciler-repaired adjacency rows land on one replica only; the index is repaired non-uniformly and may re-diverge per replica | 7 | 4 | 6 | 168 | **Open gap.** The expand executor derives the real strategy via `graph_replication_strategy(schema, ks)`, but the reconciler does not — it always uses RF=1. Wire the reconciler to the keyspace replication like the query path does. |
+| G-4 | **Variable-length path cost** — `[*min..max]` BFS fans out per hop; cost is bounded only by `max_var_path_visited` (default 100k) + `query_timeout` (30s), with no cost-based planning or per-partition index | A dense graph or large `max` exhausts the vertex budget / times out; a single query can pin a worker for the full timeout | 6 | 5 | 4 | 120 | **Mitigated, coarse.** Visited-set cycle detection + vertex budget + `max_fan_out_per_hop` (10k) cap blow-up and DoS (threat T13). **Gap:** budget is global, not cardinality-aware; no planner estimate of path cost, no early `EXPLAIN`-time rejection of unbounded `[*]`. |
+| G-5 | **Auth surface gaps** — authorization is per-statement in `validate` (Select/Modify), not per-label/edge-type; HTTP uses Basic auth, Bolt has an `auth_disabled` superuser mode | Coarser-than-Neo4j access control; a misconfigured `auth_disabled`/`auth-disabled` flag exposes the full graph; no property-level redaction | 8 | 2 | 5 | 80 | **Partially mitigated.** `check_permission` gates every statement against the `AuthContext` (T3); HTTP sanitizes internal errors (T8) and supports TLS (T11); body-size + panic-catch layers present. **Gap:** no per-relationship-type or property-level authz; `auth_disabled` must be operator-guarded. |
+| G-6 | **Orphan tombstone vs. concurrent edge write** — reconciler Phase 2 tombstones an adjacency row whose edge it cannot find, racing a concurrent edge create | A just-written edge's adjacency row could be tombstoned if the reconciler reads between edge-row visibility and observer apply | 7 | 2 | 6 | 84 | **Mitigated by Sync observer** (edge + adjacency commit together, shrinking the window) and timestamp ordering, but the reconciler does not take a snapshot/lock; a narrow TOCTOU window remains. |
+| G-7 | **Reconciler swallows read errors** — `range_read`/`read` failures are `continue`d or `unwrap_or_default()`ed | A transient storage error makes a pass silently under-repair (or skip orphan detection) while reporting success | 5 | 3 | 7 | 105 | **Open gap (fail-loud violation).** Errors are discarded without logging in several spots (`Err(_) => continue`, `unwrap_or_default()`). Should log + surface per-table failures and reflect them in `ReconcileMetrics`. |
+| G-8 | **SUBSCRIBE resource growth** — each subscription spawns a polling task re-executing the query | Many subscriptions × expensive queries amplify load | 5 | 3 | 4 | 60 | **Mitigated.** `SubscriptionRegistry` enforces a per-connection cap (`FERROSA_GRAPH_MAX_SUBSCRIPTIONS`, default 8, FMEA F5); `cancel_all` on disconnect; tasks are cancellation-token driven. |
+
+## Top risks to act on
+
+1. **G-1 (RPN 252)** — adjacency-index desync. The synchronous observer is the
+   real guarantee; the reconciler is the fallback but is **disarmed by default**
+   (`reconciliation_interval = ZERO`) and emits no drift metric. Arm background
+   reconciliation in production config and add an observable drift counter so the
+   fallback is detectable, not silent.
+2. **G-2 (RPN 192)** — an edge table missing `graph.source`/`graph.target`
+   indexes nothing and is invisible to traversals with no error. Fail loud at
+   schema-validation time when a `graph.type=edge` table is unindexable.
+3. **G-3 (RPN 168)** — the reconciler repairs at hardcoded RF=1, diverging from
+   the keyspace's real replication. Route reconciler writes through
+   `graph_replication_strategy` like the query path.
+
+## Detection assets
+
+- `adjacency/reconcile.rs` tests: repair-missing, idempotency, orphan-removal,
+  partial-direction repair, yield policy (`tests` module).
+- `tests/adjacency_replication.rs` — adjacency DDL/replication integration.
+- `tests/graph_http_integration.rs` — HTTP endpoint over a `ferrosa-net` harness.
+- Observer wire-format pin tests in `adjacency/observer.rs`.
+- `ReconcileMetrics { entries_checked, entries_repaired, orphans_removed }` logged
+  by `spawn_reconciliation` when non-zero (the only current drift signal).

--- a/ferrosa-graph/specs/overview.md
+++ b/ferrosa-graph/specs/overview.md
@@ -1,0 +1,99 @@
+---
+crate: ferrosa-graph
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The property-graph query engine for ferrosa. Parses Cypher, authorizes it
+  against the schema, plans and executes traversals over data stored in ordinary
+  CQL tables tagged graph.type=vertex|edge, and keeps a per-keyspace adjacency
+  index (system_graph_<ks>.adjacency) consistent with the edge tables via a
+  synchronous WriteObserver, with a background reconciler as the fallback. Served
+  over HTTP/JSON (7474) and Bolt v5 (7687).
+---
+
+# ferrosa-graph — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-graph` turns a ferrosa keyspace into a queryable property graph without
+a dedicated graph store. There is no separate graph storage engine: vertices and
+edges are **plain CQL tables** distinguished only by schema extensions
+(`graph.type`, `graph.label`, `graph.source`, `graph.target`). The single piece
+of graph-specific persisted state is the **adjacency index**, a system table
+`system_graph_<keyspace>.adjacency` that makes neighbor lookups O(adjacency-read)
+instead of a full edge-table scan.
+
+The boundary: this crate owns Cypher (parse/plan/execute), the adjacency-index
+contract, and the two graph transports. It does **not** own storage durability,
+replication, consensus, or the CQL value codec — it delegates all reads and
+writes to `ferrosa-cluster`'s `WritePath` and the `ferrosa-storage`
+`StorageEngine`, and all DDL to the same `DdlPath` regular CQL uses.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `parser` (`lexer`, `token`, `ast`, `parse_impl`, ~4.4k LoC) | Cypher lexing + recursive-descent parse to `Statement` AST |
+| `planner::logical` (~595 LoC) | label→table resolution, property validation, **per-statement authorization** (`check_permission`) |
+| `planner::physical` (~2.7k LoC) | anchor selection; `Expand` / `ExpandVarLength` / `Create` / `Merge` / `Subscribe` / `Union` plans |
+| `executor::expand` (~7.2k LoC) | anchor lookup, per-hop adjacency reads, eval, aggregation, write clauses, DoS limits |
+| `executor::varpath` + `leapfrog` | variable-length `[*min..max]` BFS with visited-set + vertex budget |
+| `executor::aggregate` | `count`/`sum`/`avg`/`min`/`max`/`collect` accumulators with caps |
+| `executor::eval` | expression evaluation, WHERE filtering, partition→JSON |
+| `executor::subscribe` | per-connection `SubscriptionRegistry` (cap enforcement) |
+| `adjacency::schema` | adjacency table metadata + keyspace naming + direction constants |
+| `adjacency::observer` | `AdjacencyIndexObserver` — synchronous index maintenance on edge writes |
+| `adjacency::reconcile` | background safety-net scan (repair missing, tombstone orphans) |
+| `engine` (~3.2k LoC) | composition root: orchestrates parse→plan→exec, lazy adjacency setup, FOREACH / CALL {} expansion, DDL coordinators |
+| `http` | axum HTTP/JSON endpoint, Basic auth, TLS, body limit, SSE for SUBSCRIBE |
+| `bolt` | Bolt v5 handshake, PackStream codec, message dispatch, TCP server |
+
+## Data flow (summary)
+
+**Query path:** `execute_with_params` → `parse` → `bind_statement_params` →
+(FOREACH / CALL {} expanded by the engine) → `validate` (resolve labels +
+authorize) → `plan` → `execute`. Anchor partitions are read via
+`WritePath::range_read`; each hop reads `system_graph_<ks>.adjacency` to find
+neighbors; results are evaluated/aggregated/sorted into a `GraphResult`.
+
+**Write path:** a `CREATE`/`MERGE`/`SET`/`DELETE` plan writes the edge/vertex row
+through `WritePath`. Because the `AdjacencyIndexObserver` is registered on the
+edge table as a `WriteObserver(Sync)`, the storage engine applies its derived
+OUT+IN adjacency mutations in the **same** write — so the index never lags a
+committed edge under normal operation. See [data-flow.md](data-flow.md) for the
+full sequence.
+
+## Key invariants
+
+1. **Adjacency-consistency invariant.** For every live edge `(src)-[label]->(tgt)`
+   there exist exactly two adjacency rows: an OUT row under `src` and an IN row
+   under `tgt`, both keyed by `(direction, edge_label, neighbor_id)`. This is
+   maintained **synchronously** by `AdjacencyIndexObserver` (`ObserverMode::Sync`),
+   so the index is consistent with a committed edge write, not eventually.
+2. **Reconciler is the explicit fallback, not the primary path.** The background
+   reconciler exists only to repair gaps the synchronous observer cannot cover
+   (dropped mutations under backpressure, crash-recovery windows). It is
+   observable (logs repaired/orphan counts) and idempotent. It is a safety net,
+   never the source of truth — fail-loud philosophy: the observer is expected to
+   keep the index correct; the reconciler quantifies and closes residual drift.
+3. **Adjacency clustering wire format is fixed.** Each clustering component is
+   `[u16 BE length][bytes]`: `(direction:1B, edge_label:text, neighbor_id:blob)`.
+   The SSTable writer's composite parser (`validate_clustering_shape`) rejects any
+   other layout, so observer + reconciler + expand executor must agree byte-for-byte.
+4. **Adjacency DDL goes through the cluster path.** Creating the adjacency
+   keyspace/table uses `DdlPath` (the same path as CQL `CREATE TABLE`) via
+   `GraphSchemaCoordinator`, so every replica registers the system table. Bypassing
+   it (direct `Schema::create_*_internal`) would leave replicas unable to accept
+   forwarded writes against the adjacency table.
+5. **Authorization at the logical layer.** `validate` calls `check_permission`
+   (Select for reads, Modify for writes) before planning — no plan executes for an
+   unauthorized statement (threat T3). Observer/reconciler writes are internal
+   system writes and run with system authority, not the caller's.
+
+## Position in the dependency graph
+
+Sits near the top of the stack: depends on `ferrosa-cluster`, `ferrosa-storage`,
+`ferrosa-schema`, `ferrosa-sstable`, `ferrosa-common` (and `ferrosa-net` for the
+integration test harness only). Depended on by the `ferrosa` binary, which mounts
+its HTTP + Bolt servers. See the [root crate index](../../specs/crates.md) for the
+full graph.

--- a/ferrosa-graph/specs/roadmap.md
+++ b/ferrosa-graph/specs/roadmap.md
@@ -1,0 +1,61 @@
+---
+crate: ferrosa-graph
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-graph — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), the code review (no in-source
+`TODO`/`FIXME` markers exist), and the adjacency-consistency design.
+
+## Now (highest value)
+
+- **Arm + observe adjacency reconciliation (FMEA G-1).** The synchronous observer
+  is the primary guarantee, but the background reconciler — the only thing that
+  catches dropped mutations and crash-recovery drift — is disabled by the default
+  `GraphConfig` (`reconciliation_interval = ZERO`). Ship a non-zero production
+  default and add an observable **adjacency-drift counter** (entries repaired per
+  pass), so the fallback firing is an alert, not a silent log line.
+- **Fail loud on unindexable edge tables (FMEA G-2).** When a `graph.type=edge`
+  table lacks `graph.source` / `graph.target`, the observer and reconciler skip it
+  silently and the edge is invisible to every traversal. Validate at registration
+  (or DDL) time and reject/warn instead of producing a silently broken graph.
+- **Route reconciler writes through the keyspace replication strategy (FMEA G-3).**
+  Replace the hardcoded `ReplicationStrategy::Simple{rf:1}` / `ConsistencyLevel::One`
+  in `write_mutation` / `write_tombstone` with `graph_replication_strategy(schema, ks)`,
+  matching the query path so multi-replica keyspaces are repaired uniformly.
+
+## Next
+
+- **Surface reconciler read errors (FMEA G-7).** Stop discarding `range_read` /
+  `read` failures via `Err(_) => continue` and `unwrap_or_default()`; log them and
+  reflect skipped tables/partitions in `ReconcileMetrics` so a degraded pass is
+  not reported as success (fail-loud).
+- **Cost-aware variable-length paths (FMEA G-4).** Add a planner estimate for
+  `[*min..max]` fan-out and reject/flag unbounded `[*]` at `EXPLAIN` time; make the
+  vertex budget cardinality-aware rather than a single global cap.
+- **Close the orphan-tombstone race (FMEA G-6).** Give Phase-2 orphan detection a
+  consistent snapshot or a grace window keyed on edge-write timestamps so a freshly
+  created edge's adjacency row cannot be tombstoned mid-flight.
+
+## Later
+
+- **Finer-grained authorization (FMEA G-5).** Per-relationship-type and
+  property-level authz beyond the current per-statement Select/Modify check;
+  property redaction in projections.
+- **Full column-name graph mapping.** The observer notes a "Phase 1" model
+  (partition key as source, clustering as target); complete the general
+  source/target column mapping for arbitrary edge-table shapes.
+- **Property-test the adjacency invariant.** A round-trip property: for any edge
+  mutation sequence, the derived adjacency set equals the reconciler's recomputed
+  set — an invariant regression net independent of the executor.
+
+## Non-goals
+
+- A separate graph storage engine — topology stays in CQL tables + the adjacency
+  index; this crate is a query/index layer, not a store.
+- Owning durability, replication, or consensus — those belong to `ferrosa-storage`
+  / `ferrosa-cluster`. This crate delegates all reads/writes to `WritePath`.
+- CQL value-codec ownership — handled upstream; the graph engine consumes
+  `Partition`/`Row`/`CellValue` as given.

--- a/ferrosa-index-builder/README.md
+++ b/ferrosa-index-builder/README.md
@@ -1,0 +1,116 @@
+# ferrosa-index-builder
+
+> A **standalone HTTP service binary** that offloads secondary-index
+> construction from the Ferrosa engine. The engine talks to it over HTTP when
+> `FERROSA_INDEX_BACKEND=remote`; it is **not** a library other crates link.
+
+## What this crate is
+
+`ferrosa-index-builder` is a `[[bin]]` service, not a reusable library. It reads
+SSTable components from S3, runs the engine's own
+[`ferrosa_storage::index::LocalBackend`] to build sidecar index files, and
+writes the sidecars back to S3 — keeping the CPU/IO of index construction off
+the engine nodes. The engine's `RemoteBackend` (in `ferrosa-storage`) is the
+client: it POSTs build requests to this service and consumes the JSON response.
+
+Because the coupling is **over HTTP**, no ferrosa crate has a cargo path-dep on
+this one. The wire contract (the `BuildRequest` / `BuildResponse` JSON shapes
+and the `/internal/index/build` route) *is* the interface — see
+[Public HTTP API](#public-http-api).
+
+## What's implemented
+
+- **Push mode** (default, `--mode push`): an `axum` HTTP server exposing
+  `POST /internal/index/build` and `GET /health`. The engine's `RemoteBackend`
+  drives builds synchronously over this route.
+- **Pull mode** (`--mode pull`): a manifest watcher for `backend=off`
+  deployments. Polls the engine's `GET /internal/manifest` endpoint on an
+  interval, diffs declared indexes against existing sidecars in S3, and enqueues
+  builds for the missing ones. Pull mode builds **`btree` indexes only** with no
+  partial predicate.
+- **Bounded worker pool** (`worker::WorkerPool`): a `tokio::sync::Semaphore`
+  caps concurrent builds (`--workers`, default 4). Each job downloads the six
+  SSTable components from S3 to a per-job temp dir, runs `LocalBackend::build()`
+  on a blocking thread, writes/uploads each sidecar, then cleans up. A
+  `max_temp_bytes` budget (default 10 GiB) guards local disk.
+- **Filtered (partial) index support**: a `filtered` build carries the
+  fully-encoded `FilterPredicate` on the wire and threads it into the
+  `IndexBuildJob`, so the remote sidecar contains exactly the matching rows —
+  never an unfiltered sidecar.
+- **Fail-closed for quantized vectors**: a `direct_upload` + `hvq_qvec` request
+  returns `status: "failed"` with an explicit "not implemented" message rather
+  than silently producing an unpublishable artifact.
+- **S3 client construction**: `AmazonS3Builder` with `ETagMatch` conditional
+  put, env-var configuration, optional static credentials (falls back to
+  instance profile), and `--s3-allow-http` for local MinIO.
+
+## How it works
+
+Four modules under a thin `lib.rs` + `main.rs`:
+
+| Module | Responsibility |
+|--------|----------------|
+| `main.rs` | `clap` CLI, tracing init, S3 client build, dispatch to push/pull |
+| `server` (`src/server.rs`) | `axum` router; `/internal/index/build` + `/health` handlers |
+| `worker` (`src/worker.rs`) | `WorkerPool`, `BuildRequest`/`BuildResponse`, download→build→upload→cleanup, type/priority parsing |
+| `pull` (`src/pull.rs`) | manifest poll loop, sidecar-existence diff, build enqueue |
+
+**Push flow**: engine `RemoteBackend` → `POST /internal/index/build` →
+`handle_build` → `WorkerPool::execute` (acquire permit → download components →
+`spawn_blocking(LocalBackend::build)` → `SidecarWriter::write` → S3 `put` →
+cleanup) → JSON `BuildResponse`.
+
+**Pull flow**: timer → `fetch_manifest` → for each declared index, `head` the
+sidecar key; on `NotFound`, spawn a `WorkerPool::execute` for it.
+
+## Public HTTP API
+
+This service has **no Rust public API surface that other crates link** — its
+contract is HTTP + JSON.
+
+| Route | Method | Body / Response |
+|-------|--------|-----------------|
+| `/internal/index/build` | POST | `BuildRequest` JSON in; `BuildResponse` JSON out, **always HTTP 200** for app-level outcomes |
+| `/health` | GET | `{status, workers_active, jobs_completed, jobs_failed}` |
+
+`BuildResponse.status` is `"completed"` or `"failed"`; the engine treats HTTP
+5xx as a transport error and `status: "failed"` as an application error. A
+`completed` vector/quantized build carries an `artifact_manifest_entry`; sidecar
+builds carry `sidecar_s3_path` + `entries_built`.
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — shared types.
+- **`ferrosa-index`** — `IndexType`, `FilterPredicate`/`FilterOp` (the index
+  taxonomy and the partial-index predicate carried on the wire).
+- **`ferrosa-sstable`** — SSTable component shapes consumed during a build.
+- **`ferrosa-storage`** — `LocalBackend`, `IndexBuildJob`, `BuildPriority`,
+  `SidecarWriter`, `ArtifactManifestEntry`, `upload::hex_prefix_for` (the actual
+  index-build engine this service wraps).
+
+External: `axum`, `tokio`, `object_store` (aws), `reqwest`, `clap`, `serde`,
+`serde_json`, `bytes`, `tracing`.
+
+**Called by** (cargo path-deps on this crate):
+
+- **NONE.** This is a standalone service binary, not a library. The Ferrosa
+  engine reaches it **over HTTP** via `ferrosa-storage`'s `RemoteBackend`
+  (`POST /internal/index/build`) when `FERROSA_INDEX_BACKEND=remote`. The HTTP
+  request/response JSON is the integration boundary, not a compile-time
+  dependency.
+
+## Tests
+
+7 in-crate unit/async tests (`src/server.rs`, `src/worker.rs`): the `/health`
+route, index-type and priority parsing, filter-predicate threading into the job,
+the quantized fail-closed path, and the quantized manifest response shape. There
+is **no `tests/` integration dir** and no end-to-end S3 download→build→upload
+test — a tracked gap (see [FMEA](specs/fmea.md), [roadmap](specs/roadmap.md)).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, data flow, invariants
+- [FMEA / known issues](specs/fmea.md) — failure modes + gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-index-builder/specs/fmea.md
+++ b/ferrosa-index-builder/specs/fmea.md
@@ -1,0 +1,52 @@
+---
+crate: ferrosa-index-builder
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-index-builder — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This is an out-of-engine service on the index-build path, so a
+silent-wrong-result failure is more dangerous than a crash (the engine sees a
+crash as HTTP 5xx and can retry; it cannot see a wrong sidecar).
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| IB-1 | No end-to-end test — the download→`LocalBackend::build`→sidecar→S3 path is never exercised in CI (no `tests/` dir; unit tests stop at request parsing and `/health`) | A regression in the actual build pipeline passes `cargo test -p ferrosa-index-builder` green; only caught in a live cluster | 8 | 4 | 7 | 224 | **Open gap.** Add an `object_store::memory` integration test that seeds components, runs `execute`, and asserts the sidecar bytes. |
+| IB-2 | Pull mode hard-codes `index_type = "btree"` for every manifest index | Non-btree indexes (hash, vector, fulltext, filtered, geo) are rebuilt as btree → wrong/unusable sidecar, or filtered indexes rebuilt with NO predicate → unfiltered superset | 9 | 5 | 6 | 270 | **Open gap.** `pull.rs` ignores per-index type and predicate; the manifest entry carries only `(name, col_pos)`. Either restrict pull mode to btree-only tables explicitly or extend the manifest to carry index type + predicate. |
+| IB-3 | App-level build failure returns HTTP 200 with `status:"failed"` (by design) | If the engine ever forgets the status split, a failed build looks like success | 8 | 2 | 4 | 64 | **Designed**: documented invariant; `RemoteBackend` checks `resp.status == "completed"`. Keep the two HTTP-vs-app error channels in sync. |
+| IB-4 | `temp_bytes_used` accounting races / leaks under concurrency | Disk budget under- or over-counts → either spurious "budget exceeded" rejects or unbounded temp growth | 6 | 4 | 6 | 144 | Partial: `fetch_add`/`fetch_sub` on an `AtomicU64`, decremented on each early-return path. But the add-then-check window is racy across workers and a `spawn_blocking` panic would leak the temp dir + the byte count. No periodic reconciliation. |
+| IB-5 | Orphaned temp files on crash / panic mid-build | Local disk fills across restarts; `max_temp_bytes` guard is per-process, not a startup sweep | 5 | 4 | 6 | 120 | **Open gap.** Cleanup is best-effort (`let _ = remove_dir_all`) on the happy/early-return paths only; no startup reaping of `ferrosa-index-builder/` temp dir. |
+| IB-6 | Quantized `.qvec` direct-upload unimplemented | Vector-index quantized artifacts cannot be built remotely | 6 | 3 | 2 | 36 | **Fail-closed (good).** `execute` returns an explicit "not implemented" failure; covered by `quantized_remote_builder_fails_closed_*` test. Tracked feature gap, not a silent bug. |
+| IB-7 | No auth / no TLS termination on `/internal/index/build` | Anyone who can reach the listen address can trigger arbitrary S3 reads/writes against the configured prefix | 7 | 3 | 5 | 105 | **Open gap.** The route is named `/internal/...` but the server enforces nothing; it relies entirely on network placement. No token, no mTLS. |
+| IB-8 | Pull mode swallows manifest/`head` errors and retries forever with no backoff cap | A persistently failing engine endpoint logs a `warn` every interval indefinitely; no alerting signal, no circuit-break | 4 | 5 | 5 | 100 | Partial: errors are logged (`tracing::warn!`), so it is observable, but there is no metric, no max-retry, no backoff. |
+| IB-9 | S3 build / `clap` startup uses `.expect()` (`build S3 client`, `bind listener`, `create temp dir`) | A misconfig panics the process on boot | 4 | 3 | 2 | 24 | Acceptable fail-loud at startup; crashes immediately with a clear message rather than running degraded. |
+
+## Top risks to act on
+
+1. **IB-2 (RPN 270)** — pull mode builds every index as `btree`. For any
+   deployment with non-btree or filtered indexes this produces wrong sidecars
+   *silently*. Either gate pull mode to btree-only or carry the index type +
+   predicate in the manifest.
+2. **IB-1 (RPN 224)** — the core build pipeline has zero automated coverage. The
+   green test suite only proves request parsing and the health route; a real
+   download/build/upload regression would ship undetected.
+
+## Detection assets
+
+- 7 in-crate unit/async tests: `/health`, `parse_index_type`, `parse_priority`,
+  filter-predicate threading (`build_request_threads_filter_predicate_into_job`),
+  the quantized fail-closed path, and the quantized manifest response shape.
+- `tracing` structured logs on every build (sstable_id, index_name, error) and
+  every pull-loop fetch.
+- Engine-side `RemoteBackend` tests in `ferrosa-storage/src/index/remote_backend.rs`
+  validate the client half of the contract.
+
+## Gaps without a test or metric
+
+- No integration test for the build pipeline (IB-1).
+- No metrics endpoint beyond `/health` counters (no Prometheus, no per-index-type
+  histograms); pull-loop failures are log-only (IB-8).
+- No startup temp-dir reaping (IB-5); no reconciliation of `temp_bytes_used`
+  against actual disk (IB-4).

--- a/ferrosa-index-builder/specs/overview.md
+++ b/ferrosa-index-builder/specs/overview.md
@@ -1,0 +1,96 @@
+---
+crate: ferrosa-index-builder
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  A standalone HTTP service binary that offloads secondary-index construction
+  from the Ferrosa engine. When FERROSA_INDEX_BACKEND=remote, the engine's
+  RemoteBackend (in ferrosa-storage) POSTs build requests to this service, which
+  downloads SSTable components from S3, runs the engine's own LocalBackend to
+  build sidecar index files, and uploads them back to S3. It is wired to the
+  engine over HTTP+JSON, not as a cargo dependency.
+---
+
+# ferrosa-index-builder — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-index-builder` exists to move the CPU and IO cost of building secondary
+indexes off the engine's hot path. It is a **service binary**, not a library:
+its only consumer reaches it over HTTP, so the JSON wire contract — not a Rust
+API — is its boundary.
+
+It knows how to: build an S3 client, download the six SSTable component files,
+invoke `ferrosa_storage::index::LocalBackend::build()`, write a sidecar with
+`SidecarWriter`, and upload it. It deliberately reuses the engine's *own*
+build code (`LocalBackend`) so a remote build is byte-identical to an in-process
+build — the service is plumbing around that shared core.
+
+## Module map
+
+| Module | LoC (approx) | Responsibility |
+|--------|--------------|----------------|
+| `main` (`src/main.rs`) | ~150 | `clap` CLI, tracing init, `AmazonS3Builder` construction, push/pull dispatch |
+| `server` (`src/server.rs`) | ~80 | `axum` router + `handle_build` / `handle_health` |
+| `worker` (`src/worker.rs`) | ~470 | `WorkerPool` (semaphore-bounded), `BuildRequest`/`BuildResponse`, download→build→upload→cleanup, type/priority parsing |
+| `pull` (`src/pull.rs`) | ~140 | manifest poll loop, sidecar diff, build enqueue |
+| `lib` (`src/lib.rs`) | ~17 | module declarations + crate docs |
+
+## Data flow
+
+**Push path** (engine-driven, default mode):
+
+```mermaid
+flowchart LR
+  EB[engine RemoteBackend in ferrosa-storage] -->|POST /internal/index/build BuildRequest JSON| H[handle_build]
+  H --> WP[WorkerPool::execute acquire permit]
+  WP --> DL[download 6 SSTable components from S3]
+  DL --> BJ[spawn_blocking LocalBackend::build]
+  BJ --> SW[SidecarWriter::write sidecar]
+  SW --> UP[object_store put sidecar to S3]
+  UP --> RESP[BuildResponse JSON HTTP 200]
+  RESP --> EB
+```
+
+**Pull path** (`backend=off` deployments): a timer fires `fetch_manifest`
+against the engine's `GET /internal/manifest`; for each declared
+`(index_name, column_position)` the watcher `head`s the expected sidecar key in
+S3; on `NotFound` it spawns a `WorkerPool::execute` for a default `btree` build.
+
+## BuildRequest / BuildResponse contract
+
+`BuildRequest` carries: `sstable_id`, `index_name`, `index_type`,
+optional `artifact_kind` + `direct_upload` (quantized vectors), S3 coordinates
+(`s3_endpoint` / `s3_bucket` / `s3_prefix`), `table` as a
+`(keyspace, table)` pair, `column_position`, `priority`, and an optional
+`filter_predicate` (`Option&lt;FilterPredicate&gt;`, present only for `filtered`
+builds).
+
+`BuildResponse` carries `status` (`"completed"` | `"failed"`), optional `error`,
+and on success either `sidecar_s3_path` + `entries_built` (sidecar builds) or an
+`artifact_manifest_entry` (quantized builds), plus `elapsed_ms`.
+
+## Key invariants
+
+1. **App errors are HTTP 200; transport errors are HTTP 5xx.** `handle_build`
+   always returns 200 with `status: "failed"` for an in-band build failure. The
+   engine relies on this split to distinguish a down service from a build that
+   ran and failed.
+2. **A `filtered` build must apply the predicate at build time.** The wire
+   `filter_predicate` is threaded through `build_job` into the `IndexBuildJob`
+   so `LocalBackend` filters rows; otherwise the remote sidecar would be an
+   UNFILTERED superset — a silent correctness bug.
+3. **Quantized `.qvec` direct-upload fails closed.** `is_quantized_direct_upload`
+   short-circuits to `status: "failed"` rather than emitting an unvalidated
+   artifact the engine cannot publish.
+4. **Remote build == in-process build.** The service wraps the engine's own
+   `LocalBackend`; it adds no second index encoder.
+5. **`CompressionInfo.db` is optional; every other component is mandatory.** A
+   missing mandatory component fails the job and cleans up the temp dir.
+
+## Position in the dependency graph
+
+A binary leaf: it depends on `ferrosa-common`, `ferrosa-index`,
+`ferrosa-sstable`, and `ferrosa-storage`, and **nothing depends on it via
+cargo**. Its sole consumer — the engine — is decoupled across an HTTP boundary.
+See the [root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-index-builder/specs/roadmap.md
+++ b/ferrosa-index-builder/specs/roadmap.md
@@ -1,0 +1,56 @@
+---
+crate: ferrosa-index-builder
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-index-builder — Roadmap
+
+Sourced from the code, the FMEA gaps ([fmea.md](fmea.md)), and the reference
+spec `specs/reference/remote-index-build-backend.md`.
+
+## Now (highest value)
+
+- **Fix pull-mode index typing** (FMEA IB-2). Pull mode hard-codes
+  `index_type = "btree"` for every manifest index, which silently produces wrong
+  sidecars for hash/vector/fulltext/filtered/geo indexes. Either (a) extend the
+  engine's `GET /internal/manifest` `ManifestEntry` to carry the real index type
+  + `filter_predicate`, or (b) explicitly restrict pull mode to btree-only
+  tables and reject the rest loudly.
+- **Add a build-pipeline integration test** (FMEA IB-1). Use
+  `object_store::memory::InMemory`, seed the six SSTable components, run
+  `WorkerPool::execute`, and assert the uploaded sidecar bytes (and the
+  filtered-vs-unfiltered entry count). Today the green suite never touches the
+  download→build→upload path.
+
+## Next
+
+- **Authn on `/internal/index/build`** (FMEA IB-7). The route is "internal" by
+  naming only; add a shared-secret/bearer token or mTLS so it is not an open S3
+  read/write trigger for anyone on the network.
+- **Temp-disk robustness** (FMEA IB-4, IB-5). Reconcile `temp_bytes_used`
+  against actual disk, reap the `ferrosa-index-builder/` temp dir on startup, and
+  ensure a `spawn_blocking` panic releases both the temp dir and the byte count.
+- **Observability beyond `/health`** (FMEA IB-8). Emit Prometheus counters
+  (builds completed/failed by index type, bytes downloaded, build latency) and a
+  metric for pull-loop fetch failures with backoff + a cap.
+
+## Later
+
+- **Quantized `.qvec` direct upload** (FMEA IB-6). Implement the streamed
+  build/upload with object-size + sha256 validation and return a populated
+  `artifact_manifest_entry`, replacing the current fail-closed stub.
+- **Concurrency-tunable downloads.** Components are fetched sequentially per job;
+  parallelizing the six-component fetch (bounded) would cut tail latency for
+  large SSTables.
+- **Graceful shutdown / drain.** On SIGTERM, stop accepting new builds, let
+  in-flight permits drain, and exit — so a rolling restart never abandons a
+  half-uploaded sidecar.
+
+## Non-goals
+
+- Owning the index encoding. This service wraps the engine's `LocalBackend`
+  on purpose; a second encoder would risk remote/in-process divergence.
+- Scheduling/priority policy. Which SSTables to index and when is the engine's
+  job (`ferrosa-storage` scheduler); this service just executes the jobs it is
+  handed.

--- a/ferrosa-index/README.md
+++ b/ferrosa-index/README.md
@@ -1,0 +1,154 @@
+# ferrosa-index
+
+> Secondary and vector index implementations for Ferrosa — the family of
+> on-disk index kinds that map indexed column value(s) to `RowPosition`s within
+> SSTables, plus the vector / full-text / geospatial search backends.
+
+## What this crate is
+
+`ferrosa-index` owns the **index data structures and their on-disk formats**. It
+is the substrate the engine, query layer, and the standalone index builder all
+build on: given a stream of rows (`partition_key`, `clustering_key`, `cells`),
+each index kind extracts the configured column(s), encodes a key, and records
+the row's position; at read time it answers point / range / nearest / scored
+queries.
+
+It is deliberately storage-shaped, not query-shaped: it knows `CellValue`
+(`ferrosa-common`) and byte-encoded keys, and nothing about CQL parsing,
+routing, schema DDL, or the SSTable file layout itself. Those callers
+(`ferrosa-cql`, `ferrosa-cluster`, `ferrosa-storage`, `ferrosa-index-builder`,
+`ferrosa-schema`, `ferrosa-sparql`, `ferrosa-worker`) drive it.
+
+## What's implemented
+
+The crate exposes **four distinct API surfaces** (an honest map matters here —
+they are not one uniform trait):
+
+### 1. Secondary indexes — the root `IndexFactory` / `IndexReader` traits
+
+Mature. Each implements `IndexBuilder` (`add_row` → `finish`) and `IndexReader`
+(`lookup` / `range` / `nearest` / `capabilities`):
+
+- **B-tree** (`btree`) — sorted length-prefixed entries; point lookup (binary
+  search) + range scan. `nearest` returns `Unsupported`.
+- **Hash** (`hash`) — `HashMap<key, Vec<RowPosition>>`; O(1) point lookup.
+  `range` and `nearest` return `Unsupported`.
+- **Composite** (`composite`) — multi-column key (`col_count | len | bytes …`);
+  full-key point lookup + prefix range scan.
+- **Phonetic** (`phonetic`) — fuzzy name match via Soundex, Metaphone, Double
+  Metaphone, or Caverphone; point lookup on the phonetic code. No range/nearest.
+- **Filtered** (`filtered`) — wraps any inner factory and applies a
+  `FilterPredicate` (conjunction of `FilterClause`s) at build time; delegates
+  reads to the inner reader. Also exports the planner soundness helpers
+  (`evaluate_predicate`, `query_constraint_implies_predicate`, …) used to prove
+  a query is covered by a partial index.
+
+### 2. Vector search — the `vector` subsystem (its own parallel traits)
+
+`vector` defines its **own** `IndexFactory` / `IndexReader` / `IndexBuilder`,
+`RowPosition`, and `IndexCapability` (separate from the crate-root ones, because
+vector search has a different query shape and result/capability model):
+
+- **HNSW** (`vector::hnsw`) — Hierarchical Navigable Small World graph for ANN;
+  serialized to JSON on disk, loaded whole into memory on open.
+- **IVFFlat** (`vector::ivfflat`) — k-means inverted-file + flat rerank; JSON on
+  disk, simpler/cheaper build than HNSW, accuracy tuned by `probes`.
+- **Quantized** (`vector::quantized`) — page-addressable `.qvec` artifacts:
+  scalar codec, a deterministic quantized-IVFFlat builder, and a **staged**
+  reader that range-reads centroid pages under a bounded page-read budget rather
+  than materializing the whole artifact. The **Q1 (1-bit) tier is explicitly
+  experimental** and self-labels its recall impact.
+- Distance metrics: `L2`, `Cosine`, `InnerProduct`. Dimension caps: 4096 (f32),
+  8192 (f16), perf warning above 2048.
+
+### 3. Full-text — the `fulltext` pipeline (its own builder/reader)
+
+Inverted-index pipeline for `column = fts_match(query)`: `analyzer` (Standard /
+Simple / Keyword + stemmer), `builder` (`FullTextIndexBuilder` → bytes),
+`reader` (`FullTextIndexReader`, BM25-scored queries returning `FtsHit`),
+`query` (query-string → `FtsQuery` tree), `scoring` (BM25), and `merge`
+(compaction-time merge of two FTI byte buffers). Does **not** implement the root
+`IndexFactory` traits — it has its own byte-buffer build/open API.
+
+### 4. Geospatial — the `geo` library (Phase 1, pure functions)
+
+A space-filling-curve **point** index: encode `(lat, lon)` to a sortable `u64`
+cell id (`encode`), cover a bbox/radius/k-NN query as contiguous cell-id ranges
+(`cover`, `knn`) over a **BTree sidecar**, then refine with exact
+distance/containment (`refine`, `geometry`, `predicate`, `rtree`). It is **pure
+— it never touches storage**; a geo-aware builder derives cell ids and writes
+them through the BTree index. Marked **Phase 1**: point indexing + bbox/radius/
+k-NN/ST_Contains/ST_Intersects; polygons-with-holes and some two-geometry
+predicate combinations are not yet exact.
+
+### Shared crate-root types
+
+`IndexType` (BTree / Hash / Composite / Phonetic / Filtered / Vector / FullText
+/ Geo, with stable bincode tags), `IndexConfig`, `IndexFiles`, `IndexKey`,
+`RowPosition`, `IndexCapabilities`, `IndexError` / `IndexResult`, the
+`FilterPredicate` / `FilterClause` / `FilterOp` model (with a back-compat custom
+`Serialize`/`Deserialize` accepting both the legacy flat single-clause shape and
+the v2 conjunction shape, in JSON and bincode), and the `vector<float, N>`
+big-endian codec (`bytes_to_vec_f32` / `vec_f32_to_bytes`).
+
+## How it works
+
+```text
+add_row(pk, ck, cells, column_positions)   ──build──▶  on-disk index file(s)
+                                                              │
+IndexKey / GeoPredicate / FtsQuery / query vec  ──read──▶  Vec<RowPosition> (+ score)
+```
+
+The engine streams rows into a builder during memtable flush / compaction (or
+the standalone `ferrosa-index-builder` does it out of process), `finish()`
+writes the artifact, and a reader is opened lazily to serve lookups. Secondary
+indexes use compact length-prefixed binary; HNSW/IVFFlat use JSON; quantized
+vectors use the paged `.qvec` container.
+
+## Public API (key entry points)
+
+| Area | Entry points |
+|------|--------------|
+| Root traits | `IndexFactory`, `IndexBuilder`, `IndexReader`, `IndexCapabilities` |
+| Secondary factories | `btree::BTreeIndexFactory`, `hash::HashIndexFactory`, `composite::CompositeIndexFactory`, `phonetic::PhoneticIndexFactory`, `filtered::FilteredIndexFactory` |
+| Filter model | `FilterPredicate`, `FilterClause`, `FilterOp`, `evaluate_predicate[_row]`, `query_constraint_implies_predicate[_clause]` |
+| Vector | `vector::{IndexFactory, IndexReader}`, `vector::hnsw::HnswFactory`, `vector::ivfflat::IvfFlatFactory`, `vector::quantized::*`, `DistanceMetric`, `bytes_to_vec_f32`, `vec_f32_to_bytes` |
+| Full-text | `fulltext::builder::FullTextIndexBuilder`, `fulltext::reader::FullTextIndexReader`, `fulltext::query::FtsQuery`, `fulltext::merge` |
+| Geo | `geo::{encode_point, cover_bbox, cover_radius, nearest_k, st_contains, st_intersects, GeoPredicate, CellRange, GeoCrs}` |
+| Core types | `IndexType`, `IndexConfig`, `IndexFiles`, `IndexKey`, `RowPosition`, `IndexError`, `IndexResult` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — `CellValue` (the storage cell model each builder reads
+  to extract indexed column bytes). This is the crate's only ferrosa dependency.
+
+External: `bincode`, `crc32fast`, `rand`, `serde`, `serde_json`, `tracing`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa-cluster`** — DDL/write/read paths and Raft state machine route index
+  builds and lookups.
+- **`ferrosa-cql`** — `IndexType`, `FilterOp`/`FilterClause`/`FilterPredicate`
+  construction from CQL, vector codec, geo `CellRange` cover ranges.
+- **`ferrosa-index-builder`** — standalone out-of-process index construction.
+- **`ferrosa-schema`** — index metadata / DDL.
+- **`ferrosa-sparql`** — index-backed lookups for the SPARQL endpoint.
+- **`ferrosa-storage`** — memtable / SSTable index pipeline.
+- **`ferrosa-worker`** — background index build tasks.
+
+## Tests
+
+251 in-crate `#[test]`s spread across every module (heaviest in `geo::geometry`,
+`vector::mod`, `filtered`, `fulltext::{query,reader}`, `composite`, `btree`).
+Coverage is uneven by kind — see [specs/fmea.md](specs/fmea.md): the quantized
+IVFFlat builder/reader and the FTI builder are comparatively thin, and there is
+no cross-kind property test of the `decode(encode(v)) == v` round-trip for the
+vector codec beyond a couple of unit cases.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, the four API surfaces, data flow, invariants
+- [FMEA / known issues](specs/fmea.md) — failure modes + gaps, RPN-ranked
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-index/specs/fmea.md
+++ b/ferrosa-index/specs/fmea.md
@@ -1,0 +1,47 @@
+---
+crate: ferrosa-index
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-index — FMEA / Known Issues
+
+Failure modes are ranked by **RPN = Severity × Occurrence × Detection** (1–10
+each; higher = worse). This crate sits on the index build/read path: a wrong
+index silently returns wrong query results, so detection difficulty (silent
+corruption) dominates the high scores.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| IDX-1 | Vector cell codec disagrees with CQL byte order | ANN ranks byte-swapped garbage; nearest-neighbour results silently wrong | 9 | 2 | 6 | 108 | `bytes_to_vec_f32`/`vec_f32_to_bytes` are big-endian and pinned by `lib.rs` tests that rebuild a CQL cell and compare. **Risk: only a few unit cases, no property test across the f32 space.** |
+| IDX-2 | Quantized vector recall loss accepted as correct (esp. Q1 1-bit tier) | Queries miss true neighbours; "experimental" tier used in prod unaware | 7 | 4 | 7 | 196 | Q1 self-labels `is_experimental()` and reports recall impact; codec round-trips within declared error bounds. **Gap: no recall floor enforced at the API boundary; a caller can build a Q1 index and get degraded results with no guardrail.** |
+| IDX-3 | `IndexType` bincode tag order changes | Persisted index metadata (`system_schema.indexes`, Raft log) fails to deserialize after upgrade → indexes unreadable | 9 | 1 | 4 | 36 | Tag order asserted in `bincode_index_type_variant_tag_stability`; enum is append-only by convention. |
+| IDX-4 | `FilterPredicate` wire incompatibility | Old partial-index rows fail to decode, or an empty conjunction silently indexes every row | 8 | 2 | 5 | 80 | Custom serde accepts legacy flat + v2 conjunction in JSON and bincode (round-trip tests); empty conjunction evaluates `false` (fail safe). |
+| IDX-5 | Composite key ordering assumption violated | Prefix range scans miss rows / return extra rows | 7 | 3 | 6 | 126 | Encoding documented; lexicographic ordering is exact only when component values are equal-length, otherwise only exact-prefix match holds. **Documented limitation, not fully test-guarded for variable-length components.** |
+| IDX-6 | Geo polygon / two-geometry predicates partial (Phase 1) | `ST_Contains`/`ST_Intersects` over polygons-with-holes or unsupported geometry combos return wrong or `PredicateError` | 6 | 4 | 4 | 96 | Single-ring polygons + bbox/radius/k-NN covered and tested (17 geometry + 10 predicate tests); holes / some combos explicitly unsupported and surfaced as `PredicateError` (fail loud), not silently wrong. |
+| IDX-7 | HNSW/IVFFlat JSON artifact loaded whole into memory | Large vector indexes spike RSS on open; no paging | 5 | 4 | 3 | 60 | Known design limit; the quantized `.qvec` staged reader is the page-budgeted alternative but does not yet cover HNSW/IVFFlat. |
+| IDX-8 | Thin test coverage on quantized IVF builder & FTI builder | A change passes `cargo test -p ferrosa-index` while breaking the artifact path | 7 | 4 | 6 | 168 | quantized `ivf.rs` has 1 test, `ivf_staged.rs` 3, `fulltext/builder.rs` 3. **Open gap** — uneven coverage relative to risk. |
+| IDX-9 | Index file truncation/corruption read as valid | Partial/garbage index served as real results | 8 | 2 | 5 | 80 | `crc32fast` available; container/codec readers fail loud on malformed pages. **Verify CRC is checked on every artifact kind, not just `.qvec`.** |
+| IDX-10 | `nearest`/`range` on an unsupported kind | Caller assumes empty result is "no matches" | 6 | 2 | 3 | 36 | Kinds return `IndexError::Unsupported` (fail loud) rather than `Ok(vec![])`; covered by per-kind unit tests. |
+
+## Top risks to act on
+
+1. **IDX-2 (RPN 196)** — quantized recall has no enforced floor. The experimental
+   Q1 tier is honestly labelled but nothing stops a caller building a Q1 index
+   and silently shipping degraded ANN. Add a recall guardrail / require explicit
+   opt-in for experimental tiers.
+2. **IDX-8 (RPN 168)** — the quantized IVF builder and FTI builder are the least
+   tested modules relative to their blast radius; green build is a weak signal
+   there. Add build→read round-trip + golden-artifact tests.
+3. **IDX-5 (RPN 126)** — composite prefix ordering is only exact for equal-length
+   components; variable-length component ordering needs a property test or a
+   documented prohibition enforced at construction.
+
+## Detection assets
+
+- `lib.rs` codec tests (big-endian vector round-trip vs a hand-built CQL cell).
+- `bincode_*` tests pinning `IndexType` tags and `FilterPredicate` legacy/v2 wire
+  shapes.
+- Per-kind `nearest_returns_unsupported` / `range` tests asserting fail-loud.
+- `geo` geometry + predicate suites (27 tests) for cover/refine/ST correctness.
+- quantized codec characterization test labelling Q1 experimental + recall impact.

--- a/ferrosa-index/specs/overview.md
+++ b/ferrosa-index/specs/overview.md
@@ -1,0 +1,123 @@
+---
+crate: ferrosa-index
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The Ferrosa index family: on-disk secondary indexes (B-tree, Hash, Composite,
+  Phonetic, Filtered) behind one root IndexFactory/IndexReader trait set, plus
+  three specialized subsystems with their own APIs — vector ANN (HNSW, IVFFlat,
+  quantized .qvec), full-text (inverted index + BM25), and a Phase-1 geospatial
+  point index over a BTree sidecar. It maps indexed column value(s) to SSTable
+  RowPositions and answers point/range/nearest/scored queries. Maturity is
+  honestly uneven: secondary + full-text are mature; the quantized Q1 vector
+  tier and geo polygon paths are explicitly experimental / partial.
+---
+
+# ferrosa-index — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-index` is the **index data-structure layer**. Its contract is narrow:
+ingest rows as `(partition_key, clustering_key, cells, column_positions)`,
+extract the configured column bytes, and persist a structure that resolves a key
+(or a query) back to a set of `RowPosition`s. It knows `CellValue`
+(`ferrosa-common`) and byte-encoded keys, and nothing about CQL grammar, query
+planning, schema DDL, replication, or the SSTable container format. Everything
+above it — the engine pipeline, the query router, the standalone builder —
+treats this crate as the place index *kinds* live.
+
+It depends on exactly **one** ferrosa crate (`ferrosa-common`), which keeps it
+near-leaf and lets `ferrosa-index-builder` build indexes out of process without
+pulling in the engine.
+
+## The four API surfaces (read this first)
+
+This crate is **not** one uniform trait. It hosts four parallel surfaces because
+the query shapes genuinely differ:
+
+| Surface | Trait/API | Kinds | Maturity |
+|---------|-----------|-------|----------|
+| Root secondary | `IndexFactory` / `IndexBuilder` / `IndexReader` (crate root) | B-tree, Hash, Composite, Phonetic, Filtered | Mature |
+| Vector | `vector::IndexFactory` / `IndexReader` / `IndexBuilder` (own copies, own `RowPosition`/`IndexCapability`) | HNSW, IVFFlat, quantized | HNSW/IVFFlat mature; quantized staged path new; Q1 tier experimental |
+| Full-text | `FullTextIndexBuilder` → bytes → `FullTextIndexReader` (byte-buffer, not the root traits) | inverted index + BM25 | Mature |
+| Geo | pure functions over a BTree sidecar (no factory) | point index, cover/refine | Phase 1 (point only; polygon paths partial) |
+
+The crate-root `IndexType` enum (BTree / Hash / Composite / Phonetic / Filtered
+/ Vector / FullText / Geo) is the shared discriminator callers route on; its
+bincode tag order is asserted stable (`lib.rs::bincode_index_type_variant_tag_stability`).
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `lib` (~611 LoC) | Root traits, `IndexType`/`IndexConfig`/`IndexFiles`/`IndexKey`/`RowPosition`, `IndexError`, the `FilterPredicate`/`FilterClause`/`FilterOp` model with dual-shape back-compat serde, and the big-endian vector codec |
+| `btree` (~466) | Sorted length-prefixed secondary index; point + range |
+| `hash` (~344) | `HashMap`-backed point-lookup index |
+| `composite` (~737) | Multi-column key; full-key + prefix scan |
+| `phonetic/*` (~431 + algos) | Soundex / Metaphone / Double Metaphone / Caverphone fuzzy-match index |
+| `filtered` (~840) | Predicate-at-build wrapper + planner soundness helpers |
+| `vector/hnsw` (~669) | HNSW graph ANN (JSON artifact) |
+| `vector/ivfflat` (~504) | k-means inverted-file ANN (JSON artifact) |
+| `vector/quantized/*` (~2200) | Paged `.qvec` container, scalar codec, deterministic quantized-IVF builder, staged page-budget reader |
+| `fulltext/*` (~2000) | Analyzer, builder, BM25 reader, query parser, scoring, compaction merge |
+| `geo/*` (~2300) | Cell-id encode, bbox/radius/k-NN cover, exact refine, R-tree, ST predicates |
+
+## Data flow
+
+```mermaid
+flowchart TD
+    subgraph build [Build path]
+        ROWS[rows: pk, ck, cells, column_positions] --> B[IndexBuilder.add_row]
+        B --> F[finish -- IndexFiles]
+    end
+    F --> ART[(on-disk artifact)]
+    subgraph read [Read path]
+        Q[IndexKey / GeoPredicate / FtsQuery / query vector] --> R[IndexReader]
+        R --> OUT[Vec of RowPosition -- optional score]
+    end
+    ART --> R
+    COMMON[ferrosa-common: CellValue] -. extract column bytes .-> B
+```
+
+**Build.** A caller streams rows into the builder during memtable flush or
+compaction (in process via `ferrosa-storage`/`ferrosa-cluster`, or out of process
+via `ferrosa-index-builder`). The builder extracts the bytes at
+`column_positions`, encodes a key, and on `finish()` writes the artifact(s):
+compact length-prefixed binary (secondary), JSON (HNSW / IVFFlat), or a paged
+`.qvec` container (quantized). Full-text serializes to a single byte buffer;
+geo writes cell ids through a BTree sidecar.
+
+**Read.** A reader is opened from `IndexFiles` and answers `lookup` /
+`range` / `nearest` (secondary), ANN search returning ranked `RowPosition`s
+(vector), BM25-scored `FtsHit`s (full-text), or cell-id ranges refined to exact
+geometry (geo).
+
+## Key invariants
+
+1. **Vector cell codec is big-endian and must match CQL.** `bytes_to_vec_f32` /
+   `vec_f32_to_bytes` decode/encode `vector<float, N>` cells big-endian, matching
+   `ferrosa_cql::types::encode_value`. A mismatch ranks byte-swapped garbage —
+   ANN results are silently wrong. Asserted in `lib.rs` tests.
+2. **`IndexType` bincode tags are stable.** Persisted index metadata
+   (`system_schema.indexes`, Raft log) decodes across upgrades; tag order is
+   pinned by test.
+3. **`FilterPredicate` accepts both wire shapes.** The custom serde decodes the
+   legacy flat single-clause form *and* the v2 conjunction form, in JSON and
+   bincode, so old schema rows / Raft entries keep deserializing. An empty
+   conjunction retains nothing (fail safe), never "match everything".
+4. **Capabilities are honest.** `nearest`/`range` return
+   `IndexError::Unsupported` on kinds that cannot serve them (B-tree `nearest`;
+   hash `range`+`nearest`; phonetic `range`+`nearest`) rather than faking an
+   empty result.
+5. **Geo is pure.** The `geo` module never performs I/O; it only computes cell
+   ids, ranges, and exact predicates. Storage wiring lives in the caller.
+6. **Quantized staged reads are page-bounded.** The staged IVF reader range-reads
+   centroid pages under a budget and rejects malformed pages loudly rather than
+   loading whole artifacts into memory.
+
+## Position in the dependency graph
+
+Near-leaf: depends only on `ferrosa-common`. Depended on by `ferrosa-cluster`,
+`ferrosa-cql`, `ferrosa-index-builder`, `ferrosa-schema`, `ferrosa-sparql`,
+`ferrosa-storage`, and `ferrosa-worker`. See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-index/specs/roadmap.md
+++ b/ferrosa-index/specs/roadmap.md
@@ -1,0 +1,54 @@
+---
+crate: ferrosa-index
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-index — Roadmap
+
+Sourced from the in-code module notes (quantized/geo "Phase" markers,
+`is_experimental` tier), the FMEA gaps ([fmea.md](fmea.md)), and the
+dependency/usage review.
+
+## Now (highest value)
+
+- **Guardrail the experimental quantized tiers** (FMEA IDX-2). The Q1 (1-bit)
+  tier self-labels experimental and reports recall impact, but nothing stops a
+  caller building and serving it unaware. Require explicit opt-in for
+  experimental tiers and/or enforce a recall floor at the build API boundary —
+  fail loud rather than silently degrade ANN quality.
+- **Close the quantized-IVF / FTI builder test gap** (FMEA IDX-8). Add
+  build→read round-trip and golden-artifact tests for `vector::quantized::ivf`,
+  `ivf_staged`, and `fulltext::builder`, which are the least-tested modules
+  relative to their blast radius.
+
+## Next
+
+- **Property-test the vector codec round-trip** (`decode(encode(v)) == v`) across
+  the f32 space, not just the two hand-built CQL-cell unit cases (FMEA IDX-1).
+- **Pin composite prefix-ordering semantics** (FMEA IDX-5). Either property-test
+  variable-length component ordering or reject/normalize at construction so the
+  "exact only for equal-length components" caveat can't silently bite range scans.
+- **Audit CRC coverage across artifact kinds** (FMEA IDX-9). Confirm every reader
+  (B-tree / hash / composite / HNSW / IVFFlat / FTI), not just the `.qvec`
+  container, validates integrity on open and fails loud on truncation.
+
+## Later
+
+- **Page-bounded HNSW / IVFFlat reads** (FMEA IDX-7). Extend the quantized staged
+  reader's page-budget model to the JSON-backed vector indexes so large indexes
+  no longer load whole into memory on open.
+- **Geo Phase 2** — polygons with holes, the currently-unsupported two-geometry
+  predicate combinations, and a true geo index *kind* wired to a factory rather
+  than the pure cover/refine library over a BTree sidecar.
+- **Unify or formally document the four API surfaces.** The root `IndexFactory`
+  traits, the parallel `vector::` traits, the `fulltext` byte-buffer API, and the
+  pure `geo` library are intentionally separate; either converge them behind a
+  common dispatch or document the split as a decision so callers aren't surprised.
+
+## Non-goals
+
+- CQL/SPARQL parsing, query planning, routing, replication, or the SSTable
+  container format — those belong to `ferrosa-cql`, `ferrosa-sparql`,
+  `ferrosa-cluster`, and `ferrosa-storage`. This crate stays the index
+  data-structure layer with a single `ferrosa-common` dependency.

--- a/ferrosa-jepsen/README.md
+++ b/ferrosa-jepsen/README.md
@@ -1,0 +1,116 @@
+# ferrosa-jepsen
+
+> Jepsen-style distributed correctness harness for Ferrosa: generate
+> concurrent workloads, inject faults (nemeses), record a history, and check
+> it for linearizability and membership-invariant violations.
+
+## What this crate is
+
+`ferrosa-jepsen` is a **test-harness crate** (library + `ferrosa-jepsen` binary),
+not part of the shipped database. It drives a real or simulated Ferrosa cluster
+through workload + fault-injection combinations, records an operation history,
+and runs correctness checkers over it. It is the home of the `tier-*` runs the
+project uses as correctness evidence.
+
+Nothing in the workspace depends on this crate — it is a leaf in the dependency
+graph. It calls `ferrosa-sim` for the simulator-backed endurance path.
+
+## What's implemented
+
+- **Orchestrator** (`orchestrator.rs`) — the run loop: for each topology it
+  provisions a cluster (Docker, see below), then iterates
+  topology × concurrency × driver × nemesis × workload, runs each combination,
+  records history, checks linearizability + workload invariants, and emits a
+  `RunReport` (JSON + HTML).
+- **Tiers / config** (`config.rs`) — `Tier` (`Smoke`, `Standard`, `Full`,
+  `Endurance`, `MultiDc`), `Topology` (T1 3-node, T2 5-node, T3 3+3 dual-DC,
+  T4 3+3+3 tri-DC), `Concurrency` (Low/Medium/High). Each tier resolves to a
+  topology set, concurrency set, and run duration.
+- **Workloads** (`workload/`) — `register` (single-value register),
+  `bank` (conservation-of-money), 16 `lwt-*` LWT patterns, plus the Sprint 2
+  membership/forwarding workloads `forward-probe`, `membership-churn`,
+  `late-join-flood`. 21 workloads in the `phase1` registry.
+- **Nemeses / fault injection** (`chaos/`) — `NemesisAction` trait
+  (`inject`/`heal`). Network (partition halves/ring/one, slow, jitter, packet
+  loss — via `iptables`/`tc` over SSH), process (kill minority/majority, pause),
+  clock (skew small/large, strobe), disk (slow/fail), WAN/cross-DC (`wan_bridge`),
+  and `composed` multi-fault nemeses. Registries: `phase1` (7), `phase2` (18),
+  `full` (25+ incl. WAN + composed).
+- **Checkers** (`checker/`):
+  - **Linearizability** — a native Rust WGL-style backtracking checker
+    (`check_linearizability`) with a register model (read/write/CAS/serial-read),
+    a 100k-node search bound, and minimal counterexamples. This is the checker
+    that actually runs in unit tests and CI.
+  - **Membership invariants** (`checker/membership.rs`) — structural checks
+    I-06–I-10, I-13 over per-node membership snapshots.
+  - **Knossos** (`checker/knossos.rs`) — shells out to Clojure/`lein`; only runs
+    when a `jepsen_dir` *and* a written history file are both supplied.
+  - **Elle** (`checker/elle.rs`) — types exist; `UnifiedChecker` always sets the
+    Elle result to `None` (not wired to a running checker).
+- **Drivers** (`driver/`) — `rust_driver` connects to a real cluster via the
+  `scylla` driver (`phase1`, the only wired driver). `ContainerDriver` shells out
+  to per-language Docker images (Python/Go/Node/Java/C#) — `phase2`, not used by
+  the default tier resolution.
+- **Cluster backends**:
+  - **Docker Compose** (`docker_provision.rs`) — the **wired** provisioning path.
+    The orchestrator provisions a 3-node cluster when `FERROSA_TEST_CONTAINERS`
+    is set and the topology has ≤3 nodes; otherwise it runs combinations against
+    an in-process `MockCqlSession`. Uses `container_runtime()` (docker→podman).
+  - **Firecracker** (`firecracker.rs`, `cluster.rs`) — microVM provisioning
+    primitives exist but are **not wired** into the orchestrator/run path;
+    `cluster.rs` is the only consumer and is itself unreferenced.
+  - **Fly.io** (`flyio.rs`) — machine-management types/primitives for the
+    multi-DC topologies (T3/T4) exist but are **not wired** into the run path.
+- **Endurance sim** (`endurance_sim.rs`) — the **sim-equivalent endurance run**
+  (W8.9, ADR-016). Drives `ferrosa_sim::multi_dc::DualDcBankSim` (voters +
+  per-DC learners) over a 24-simulated-hour horizon with periodic rolling-window
+  conservation + learner-divergence checks. This is the **headline acceptance
+  gate** used when Fly.io is unavailable, and it runs under default `cargo test`.
+- **History** (`history.rs`) — `Operation`/`Op`/`OpResult`, JSONL serialization,
+  per-key filtering. **CLI** (`main.rs`) — `run`, `report`, `tier-endurance-sim`.
+
+## CLI
+
+```bash
+ferrosa-jepsen run --tier smoke                 # run a tier
+ferrosa-jepsen run --tier multi-dc --output json
+ferrosa-jepsen tier-endurance-sim --smoke       # sim endurance (<1s)
+ferrosa-jepsen report list                       # (report subcommands are stubs)
+```
+
+## Tests
+
+- **232** in-crate unit tests (checker correctness, registries, config
+  resolution, the endurance-sim smoke + tri-DC headline runs, etc.) — these run
+  under default `cargo test -p ferrosa-jepsen`.
+- **30** integration test functions across `tests/`. The live-infra ones
+  (Docker mini-Jepsen, smoke tier, topology invariants, nemesis correctness)
+  are gated behind the `live-infra-tests` feature and `panic!` with setup
+  instructions when their `FERROSA_TEST_*` prerequisite is absent —
+  `live_infra_contract.rs` pins that contract. Zero `#[ignore]`.
+
+Local live-infra form:
+
+```bash
+FERROSA_TEST_CONTAINERS=1 cargo test -p ferrosa-jepsen \
+  --features live-infra-tests --test docker_mini_jepsen -- --nocapture
+```
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-sim`** — `multi_dc::DualDcBankSim`, the deterministic dual-DC bank
+  simulator that backs the sim-equivalent endurance run (`endurance_sim.rs`).
+
+External: `tokio`, `scylla` (CQL driver), `russh` (SSH for fault injection),
+`reqwest`, `clap`, `serde`/`serde_json`, `tracing`, `anyhow`.
+
+**Called by** (crates that depend on this):
+
+- **NONE** — this is a test-harness crate at the leaf of the dependency graph.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, run pipeline, data flow
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-jepsen/specs/overview.md
+++ b/ferrosa-jepsen/specs/overview.md
@@ -1,0 +1,111 @@
+---
+crate: ferrosa-jepsen
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  Jepsen-style distributed correctness harness for Ferrosa. Generates
+  concurrent workloads, injects faults (nemeses) over SSH, records an operation
+  history, and checks it for linearizability and membership-invariant
+  violations. Docker Compose is the wired cluster backend; Firecracker and
+  Fly.io primitives exist but are not yet wired into the run path. A
+  ferrosa-sim-backed endurance run is the headline acceptance gate when Fly.io
+  is unavailable. Leaf crate — nothing depends on it.
+---
+
+# ferrosa-jepsen — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-jepsen` is the project's **distributed-correctness test harness**. It
+is a library plus a `ferrosa-jepsen` binary; it is not part of the shipped
+database and nothing in the workspace depends on it. Its job is to subject a
+Ferrosa cluster (real, or a `ferrosa-sim` model) to concurrent workloads under
+fault injection, record a history of operations, and run correctness checkers
+over that history to produce pass/fail evidence.
+
+The boundary: it owns workload generation, nemesis/fault injection, history
+recording, the checkers, and cluster provisioning. It does **not** own the
+database internals — it talks to a cluster over CQL (`scylla` driver) and over
+SSH (`russh`) for fault injection, and to the simulator via `ferrosa-sim`.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `orchestrator` (`src/orchestrator.rs`) | Run loop: provision → iterate combinations → record → check → `RunReport`. Resolves real-cluster vs `MockCqlSession`. |
+| `config` (`src/config.rs`) | `Tier`, `Topology` (T1–T4), `Concurrency`, `RunConfig` and their tier-driven resolution. |
+| `workload` (`src/workload/`) | `Workload` trait + registry: `register`, `bank`, 16 `lwt-*`, `forward-probe`, `membership-churn`, `late-join-flood`. |
+| `chaos` (`src/chaos/`) | `NemesisAction` trait + registry: network, process, clock, disk, WAN/cross-DC, composed nemeses. Inject/heal via SSH (`iptables`/`tc`/signals). |
+| `checker` (`src/checker/`) | Linearizability (native WGL backtracking), membership invariants, Knossos (subprocess), Elle (stub). |
+| `driver` (`src/driver/`) | `rust_driver` (real `scylla` connection); `ContainerDriver` (per-language Docker images, not in default tiers). |
+| `docker_provision` (`src/docker_provision.rs`) | **Wired** cluster backend: Docker Compose 3-node cluster, `container_runtime()` (docker→podman). |
+| `firecracker` / `cluster` | microVM provisioning primitives — present but **not wired** into the run path. |
+| `flyio` (`src/flyio.rs`) | Fly.io machine management for T3/T4 — present but **not wired**. |
+| `endurance` / `endurance_sim` | `ferrosa-sim`-backed sim-equivalent 24h endurance run (W8.9, ADR-016). |
+| `history` (`src/history.rs`) | `Operation`/`Op`/`OpResult`, JSONL I/O, per-key filtering. |
+| `report` / `alert` / `archive` / `ssh` / `cql_session` / `test_env` | Reporting (JSON/HTML/timeline/anomaly/comparison), webhook alerting, run archiving, SSH client, CQL session, env helpers. |
+| `main` (`src/main.rs`) | CLI: `run`, `report` (stubs), `tier-endurance-sim`. |
+
+## Run pipeline
+
+```mermaid
+flowchart TD
+    CLI["ferrosa-jepsen run --tier T"] --> RESOLVE["config: resolve topologies x concurrency x drivers x nemeses x workloads"]
+    RESOLVE --> PROV{"FERROSA_TEST_CONTAINERS set and nodes &lt;= 3?"}
+    PROV -- yes --> DOCKER["provision_docker_cluster (Docker Compose)"]
+    PROV -- no --> MOCK["MockCqlSession (in-process, no I/O)"]
+    DOCKER --> COMB["run_single_combination"]
+    MOCK --> COMB
+    COMB --> WL["workload.setup + run -> HistoryRecorder"]
+    WL --> NEM["nemesis inject/heal over SSH"]
+    NEM --> HIST["history -> JSONL"]
+    HIST --> LIN["check_linearizability (native WGL)"]
+    HIST --> INV["workload.check_invariant"]
+    LIN --> REP["RunReport (results.json + report.html)"]
+    INV --> REP
+```
+
+The orchestrator currently provisions via Docker only; when no container
+runtime is requested it runs every combination against the in-process
+`MockCqlSession`, so unit-level combinations execute without infrastructure.
+Firecracker and Fly.io paths are not reached from this loop.
+
+## Checker stack
+
+```mermaid
+flowchart LR
+    H["History (Vec&lt;Operation&gt;)"] --> LIN["Linearizability: per-key WGL backtracking, RegisterModel, 100k-node bound"]
+    H --> MEM["Membership invariants I-06..I-10, I-13 over node snapshots"]
+    H --> KN["Knossos: lein subprocess (only if jepsen_dir + history file)"]
+    H --> EL["Elle: stub — result always None"]
+    LIN --> AGG["AllCheckResults.all_passed()"]
+    MEM --> AGG
+    KN --> AGG
+    EL --> AGG
+```
+
+Only the native linearizability checker and the membership-invariant checks run
+in default `cargo test`/CI. Knossos requires a Clojure/`lein` project and a
+written history; Elle is type-only (`elle_result = None`).
+
+## Key invariants
+
+1. **Fail loud on harness breakage.** A Knossos invocation failure is surfaced
+   as an explicit `checker-error` anomaly with `valid = false`, never silently
+   swallowed (`checker/mod.rs`).
+2. **No missing-infra body passes silently.** Live-infra tests are gated behind
+   the `live-infra-tests` feature and `panic!` with setup instructions when
+   their `FERROSA_TEST_*` prerequisite is absent; `live_infra_contract.rs`
+   pins that every such test carries the `cfg(feature)` attribute.
+3. **Mock vs real is an explicit decision.** `resolve_session_source` returns
+   `Real` only when a cluster was provisioned, else `Mock`; pinned by unit
+   tests after a Sprint 2 bug where the cluster argument was discarded.
+4. **Sim endurance is a real gate.** The tri-DC endurance sim must report zero
+   conservation failures, zero learner divergence, and final convergence — it
+   runs under default `cargo test`, not behind live-infra gating.
+
+## Position in the dependency graph
+
+Leaf test-harness crate. **Calls** `ferrosa-sim` (the dual-DC bank simulator
+for the endurance path). **Called by** nothing. See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-jepsen/specs/roadmap.md
+++ b/ferrosa-jepsen/specs/roadmap.md
@@ -1,0 +1,59 @@
+---
+crate: ferrosa-jepsen
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-jepsen — Roadmap
+
+Sourced from in-code TODOs/stubs, the wired-vs-aspirational gaps found in the
+run path, and the dependency/usage review. The harness's correctness logic
+(linearizability + membership checkers, registries, the sim endurance run) is
+implemented and tested; the gaps are mostly in cluster-backend wiring and the
+external checkers.
+
+## Now (highest value)
+
+- **Wire (or remove) the Firecracker/Fly.io cluster backends.** `firecracker.rs`
+  and `cluster.rs` (microVM provisioning) and `flyio.rs` (T3/T4 machines) are
+  implemented but unreachable from the orchestrator — `cluster.rs` itself has no
+  callers and carries a `// TODO: SSH into each node, run setup-guest.sh, start
+  ferrosa`. Today only Docker Compose (≤3 nodes) is wired, so T2/T3/T4 tiers fall
+  back to `MockCqlSession`. Either route the orchestrator through these backends
+  or drop the dead code (fail-loud: don't let a multi-node tier silently mock).
+- **Implement the `report` CLI subcommands.** `report list`/`compare`/`render`
+  log "not yet implemented" (`main.rs`) despite `report/{comparison,timeline,
+  anomaly}` modules existing. Finish wiring them to the archive.
+
+## Next
+
+- **Decide Elle's fate.** `checker/elle.rs` types exist but `UnifiedChecker`
+  hard-codes `elle_result = None`. Either wire Elle against a running Jepsen/lein
+  cluster or document it as explicitly out of scope so it isn't mistaken for an
+  active checker.
+- **Exercise the container drivers in a tier.** `phase2` registers
+  Python/Go/Node/Java/C# `ContainerDriver`s, but `resolve_driver_registry`
+  returns `phase1` (Rust only) for every tier. Add a tier (or flag) that runs
+  the polyglot drivers so the per-language Docker images are actually tested.
+- **Promote the linearizability search bound to a config.** `SEARCH_LIMIT` is a
+  hard-coded 100k-node cap; a long history that exceeds it is reported as
+  non-linearizable with a node-count explanation. Make the bound configurable
+  and distinguish "no linearization" from "search exhausted".
+
+## Later
+
+- **Real multi-DC (T3/T4) endurance on Fly.io.** The sim-equivalent endurance
+  run (`endurance_sim.rs`, ADR-016) stands in for the Fly.io tri-DC run; once
+  the Fly.io backend is wired, run the real 24h tier and compare against the
+  sim gate.
+- **Broaden checker models.** The native checker models a single-value register
+  (read/write/CAS/serial-read); the `bank` and LWT workloads rely on
+  workload-specific invariants. Consider a list/set/transactional model for
+  richer anomaly detection.
+
+## Non-goals
+
+- Database internals — this crate drives a cluster over CQL/SSH and the
+  simulator; it does not own storage, consensus, or query execution.
+- Replacing `ferrosa-sim` — the simulator is the modeling layer; this crate
+  consumes it for the endurance path.

--- a/ferrosa-loadgen/README.md
+++ b/ferrosa-loadgen/README.md
@@ -1,0 +1,112 @@
+# ferrosa-loadgen
+
+> UCS-compaction load/stress generator for Ferrosa: drives a property-based
+> read/write/update/delete workload against the storage engine (in-process) or a
+> live cluster (over CQL), tracks a ground-truth oracle, and asserts zero data
+> loss / zero corruption — with OS-level resource-leak detection and a live TUI.
+
+## What this crate is
+
+A **testing/tooling crate** — both a library and the `ferrosa-loadgen` binary. It
+exists to produce sustained, realistic load that exercises the full
+write → flush → compact → S3 pipeline (the Unified Compaction Strategy, UCS) and
+to *prove* correctness under that load by comparing every read against an
+in-memory ground-truth tracker. It is the load engine behind the UCS
+end-to-end and burn-in tests.
+
+It is a leaf of the dependency graph: **nothing depends on it**.
+
+## What's implemented
+
+- **Two run modes** (`src/main.rs`):
+  - **In-process** — constructs a `StorageEngine` directly (optionally S3-backed)
+    and drives it with native worker threads, no network.
+  - **Cluster** — `--node host:port[,…]` connects over CQL (`ferrosa-cql`
+    client), creates `load_test.data`, distributes workers round-robin across
+    nodes, and polls server-side metrics from each node's web API
+    (`/api/storage`).
+- **Five load profiles** (`src/profile.rs`): `read_heavy`, `balanced`,
+  `write_heavy`, `delete_update_heavy`, `compaction_stress` — each a fixed set of
+  read/write/update/delete ratios, key-space size, worker counts, flush/cache
+  thresholds, and fan factor. `--duration` / `--cache-max-bytes` override.
+- **Compaction soak** (`--compaction-soak`): instead of a load test, runs
+  `ferrosa_storage::compaction::validator::soak` for N reproducible iterations
+  (per `--soak-seed`), compacting deterministic corpora and diffing each against
+  the oracle. Exits non-zero on mismatch.
+- **Ground-truth oracle** (`src/ground_truth.rs`): 64-shard,
+  last-write-wins, timestamp-ordered map of expected key → value/tombstone.
+  Records writes/deletes and classifies each read as Match / Mismatch / Missing /
+  NotYetWritten.
+- **Integrity verification** (`src/integrity.rs`): full-table scan at end of run;
+  every ground-truth key must read back its latest value (or None if deleted).
+- **Resource-leak detection** (`src/resource_monitor.rs`): samples fds, RSS/VSZ,
+  TCP/unix sockets, threads, commit-log segments, SSTable count, tmp files;
+  flags monotonic growth as a probable leak and **aborts** before hard limits
+  (FD ulimit fraction, absolute RSS growth) are hit.
+- **Stats** (`src/stats.rs`): HDR-histogram latency percentiles (p50/95/99/100),
+  atomic throughput counters, periodic snapshots, final `LoadStats` report.
+- **Live TUI** (`src/tui.rs`, `--tui`): ratatui dashboard — throughput sparkline,
+  latency, storage metrics, leak warnings; `q`/`Ctrl-C` to stop, `p` to pause.
+
+## How it works
+
+The orchestrator (`src/orchestrator.rs`) spawns `num_writers + num_readers`
+scoped threads. Each picks an op by profile ratio (`choose_op`), a random key in
+the key space, and a random value; writes/deletes/reads go through the
+`StorageEngine` and are mirrored into the `GroundTruth` oracle. The main thread
+runs a 500 ms loop: periodic `flush`, `poll_compactions`, stats snapshot,
+resource sampling (abort on leak), and TUI render. At the end it does a final
+flush and a full integrity scan. The cluster path (`src/cluster.rs`) mirrors this
+shape over a CQL client with server-side metrics polled from the web API.
+
+## CLI (key entry points)
+
+| Flag | Effect |
+|------|--------|
+| `--profile <name>` | one of the five profiles (default `balanced`) |
+| `--duration <secs>` | override profile duration |
+| `--node <addr[,…]>` | cluster mode over CQL (else in-process) |
+| `--tui` | live dashboard |
+| `--list-profiles` | print profiles and exit |
+| `--compaction-soak` / `--soak-seed` / `--soak-iterations` | run the compaction validator soak instead of a load test |
+| `--data-dir`, `--s3-endpoint`/`--s3-bucket`/`--s3-access-key`/`--s3-secret-key`, `--cache-max-bytes`, `--cleanup` | in-process engine config |
+
+**Library exports** (`src/lib.rs`): `LoadProfile`, `GroundTruth`,
+`IntegrityVerifier`/`IntegrityReport`, `ResourceMonitor`/`ResourceSummary`,
+`LoadStats`/`StatsCollector`/`StatsSnapshot`, `run_load_test`,
+`run_load_test_with_tui`.
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-storage`** (with `compaction-validator` feature) — the
+  `StorageEngine` it drives in-process, compaction polling/metrics, and the
+  compaction soak validator.
+- **`ferrosa-common`** — `CellValue`, `DecoratedKey`, `PartitionKey`,
+  `TableSchema`/`ColumnDefinition` for the load-test row shape.
+- **`ferrosa-cql`** — the `CqlClient` used in cluster mode.
+- **`ferrosa-sstable`** — `Row`, `LivenessInfo`, `DeletionTime` for building the
+  in-process write rows.
+- **`ferrosa-schema`** — schema types for the test table.
+
+External: `clap`, `tokio`, `ratatui`/`crossterm`, `hdrhistogram`, `parking_lot`,
+`rand`, `reqwest`, `serde_json`, `uuid`, `hex`, `libc`. Dev: `proptest`,
+`tempfile`.
+
+**Called by**: **NONE** — this is a tooling binary; no crate depends on it.
+
+## Tests
+
+- **Unit tests** in-crate (`#[test]` across `src/`, incl. one `proptest!` block in
+  `generator.rs`): profile invariants, ground-truth LWW/concurrency correctness,
+  stats, resource-monitor leak logic, op-distribution.
+- **Integration tests** (`tests/`): `ucs_load_test.rs` (in-process E2E across
+  profiles), `ucs_load_s3_test.rs` (live cluster + RustFS S3, gated on
+  `FERROSA_TEST_CONTAINERS=1`), `binary_smoke.rs` (spawns the binary, gated on
+  `FERROSA_TEST_LOADGEN=1`).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, run modes, data flow
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-loadgen/specs/overview.md
+++ b/ferrosa-loadgen/specs/overview.md
@@ -1,0 +1,91 @@
+---
+crate: ferrosa-loadgen
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  UCS-compaction load/stress generator for Ferrosa. Drives a property-based
+  read/write/update/delete workload against the storage engine in-process (or a
+  live cluster over CQL), mirrors every mutation into a sharded ground-truth
+  oracle, and asserts zero data loss / zero corruption via a final integrity
+  scan — plus OS-level resource-leak detection, HDR-histogram latency stats, a
+  compaction-validator soak mode, and a live ratatui TUI. A tooling binary: no
+  other crate depends on it.
+---
+
+# ferrosa-loadgen — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-loadgen` is the **load engine and correctness oracle** for Ferrosa's
+Unified Compaction Strategy (UCS). Its job is to generate sustained, realistic
+mixed workloads that exercise the full write → flush → compact → S3 pipeline, and
+to *prove* the engine loses no data and corrupts nothing under that pressure by
+comparing every read against an in-memory ground truth.
+
+Its boundary is narrow and one-directional: it *consumes* the storage engine and
+CQL client; it owns no engine internals. It is a **leaf** of the dependency graph
+— nothing in the workspace depends on it.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `main` (`src/main.rs`) | CLI (`clap`), profile selection, in-process vs cluster dispatch, compaction-soak entry, exit codes |
+| `profile` (`src/profile.rs`) | `LoadProfile` — the five built-in workload mixes and their knobs |
+| `generator` (`src/generator.rs`) | op selection (`choose_op`), key/value generation, RSS sampling; one `proptest!` block |
+| `orchestrator` (`src/orchestrator.rs`) | in-process run loop: spawn workers, 500 ms flush/compact/stats/leak/TUI tick, final integrity scan |
+| `cluster` (`src/cluster.rs`) | cluster run loop over a CQL client; server metrics polled from each node's web API |
+| `ground_truth` (`src/ground_truth.rs`) | 64-shard, last-write-wins oracle; classifies reads (Match/Mismatch/Missing/NotYetWritten) |
+| `integrity` (`src/integrity.rs`) | full-table verification scan → `IntegrityReport` |
+| `resource_monitor` (`src/resource_monitor.rs`) | OS + engine resource sampling, monotonic-growth leak detection, hard-limit abort |
+| `stats` (`src/stats.rs`) | HDR-histogram latency percentiles, atomic counters, snapshots, final `LoadStats` |
+| `tui` (`src/tui.rs`) | live ratatui dashboard driven by the orchestrator's snapshot loop |
+
+## Run modes
+
+- **In-process** (default): `main` builds a `StorageEngineConfig` (optional
+  `ObjectStoreConfig` for S3) and a `StorageEngine`, then calls
+  `run_load_test[_with_tui]`. Workers call `engine.write`/`engine.read` directly.
+- **Cluster** (`--node`): connects over CQL (`CqlClient`), creates and truncates
+  `load_test.data`, distributes workers round-robin across nodes, and polls
+  server-side storage metrics (SSTables, S3 objects, pending compactions) from
+  the web API at the inferred port (CQL `9042+N` → web `9090+N`).
+- **Compaction soak** (`--compaction-soak`): bypasses the load loop entirely and
+  runs `ferrosa_storage::compaction::validator::soak::run` for N reproducible
+  iterations from `--soak-seed`, diffing compacted corpora against the oracle.
+
+## Data flow (in-process)
+
+1. **Setup** — register `load_test.data` schema; create `GroundTruth`,
+   `StatsCollector`, `ResourceMonitor`.
+2. **Workers** — `num_writers + num_readers` scoped threads. Each loop: pick op by
+   ratio (`choose_op`), random key in `0..key_space_size`, random value; route to
+   `engine.write` (live row), `engine.write` (tombstone row), or `engine.read`;
+   mirror the result into `GroundTruth` and record latency in `StatsCollector`.
+3. **Main tick (500 ms)** — `flush`, `discard_completed_commit_log_segments`,
+   `poll_compactions` (on a current-thread tokio runtime), take a stats snapshot,
+   sample resources (abort on leak verdict), render the TUI frame; stop when
+   `duration` elapses, target bytes reached, or the user quits.
+4. **Finalize** — final flush, full `IntegrityVerifier::verify_all` scan, assemble
+   `LoadStats`. The binary exits non-zero on missing keys / mismatches (1) or an
+   abort reason (2).
+
+## Key invariants
+
+1. **Ground truth is last-write-wins by timestamp.** A write only updates the
+   oracle entry when its timestamp `>=` the stored one; deletes set a tombstone
+   flag. This must mirror the engine's LWW so the integrity scan is meaningful.
+2. **Resource growth must terminate the run, not the machine.** The monitor aborts
+   at a fraction of the FD ulimit or after a bounded absolute RSS growth, after a
+   warmup window — fail loud rather than OOM the host.
+3. **Compaction must be polled every tick.** Without `poll_compactions`, SSTables
+   accumulate unboundedly and RSS grows until abort; the tick is load-bearing.
+4. **Soak corpora are reproducible per seed.** A given `--soak-seed` /
+   `--soak-iterations` pair must produce identical corpora so failures replay.
+
+## Position in the dependency graph
+
+Leaf binary. **Calls** `ferrosa-storage` (with `compaction-validator`),
+`ferrosa-common`, `ferrosa-cql`, `ferrosa-sstable`, `ferrosa-schema`.
+**Called by** nothing. See the [root crate index](../../specs/crates.md) for the
+full graph.

--- a/ferrosa-loadgen/specs/roadmap.md
+++ b/ferrosa-loadgen/specs/roadmap.md
@@ -1,0 +1,47 @@
+---
+crate: ferrosa-loadgen
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-loadgen — Roadmap
+
+Sourced from a read of the crate (no in-code `TODO`/`FIXME` markers exist today)
+plus the dependency/usage review. This is a testing/tooling crate, so the
+roadmap is intentionally small.
+
+## Now (highest value)
+
+- **Cluster-mode integrity parity.** The in-process path runs a full
+  `IntegrityVerifier::verify_all` scan at the end; confirm the cluster path
+  applies the same end-of-run oracle scan over CQL (re-reading every
+  ground-truth key) rather than relying only on inline `record_read`
+  classification. If it does not, add it — a load run that does not verify is not
+  evidence.
+
+## Next
+
+- **Custom profiles from the CLI.** Profiles are five hard-coded constructors;
+  only `--duration` and `--cache-max-bytes` are overridable. Allow ratios,
+  key-space size, and worker counts to be set on the command line (or loaded from
+  a file) for ad-hoc workloads without recompiling.
+- **Soak failure artifacts.** On a compaction-soak mismatch, persist the failing
+  corpus + seed (the work dir is currently removed unconditionally) so a failure
+  can be replayed and minimized offline.
+
+## Later
+
+- **Tombstone/GC-grace assertions.** The oracle currently accepts either outcome
+  for a deleted key during compaction (tombstone may or may not be applied yet).
+  Once GC-grace semantics are pinned, tighten the deleted-key check to assert the
+  expected post-grace state rather than accepting both.
+- **Latency budget gates.** `LoadStats` reports HDR percentiles but nothing fails
+  on them; optionally fail a run when p99 exceeds a per-profile budget so the tool
+  catches latency regressions, not just correctness ones.
+
+## Non-goals
+
+- Distributed-systems fault injection (partitions, node kills, clock skew) — that
+  is `ferrosa-jepsen`'s domain, not this crate's.
+- Being a benchmark of record — this is a correctness-under-load and
+  resource-leak tool first; throughput numbers are diagnostic, not certified.

--- a/ferrosa-net/README.md
+++ b/ferrosa-net/README.md
@@ -1,0 +1,125 @@
+# ferrosa-net
+
+> The internode transport: custom framed TCP wire protocol, PSK-HMAC handshake,
+> three priority lanes per peer, and a cancel-safe actor-based connection pool.
+
+## What this crate is
+
+`ferrosa-net` owns the **wire protocol and peer lifecycle** for ferrosa's
+node-to-node communication. It is *not* Cassandra wire-compatible — it is a
+purpose-built internode protocol. Higher layers (`ferrosa-cluster`,
+`ferrosa-cql`, `ferrosa-graph`, `ferrosa-session`, and the `ferrosa` binary)
+register typed message handlers and send messages; this crate moves the bytes,
+authenticates peers, multiplexes by priority, and keeps connections alive across
+peer restarts.
+
+It is a near-leaf in the dependency graph: it depends only on `ferrosa-common`
+(for the shared `TaskPool`), not on any cluster/storage/query crate.
+
+## What's implemented
+
+- **Framed wire protocol** (`codec`) — a fixed-size frame header
+  (`HEADER_SIZE = 44` bytes: `version(1) + flags(1) + lane(1) + msg_type(1) +
+  stream_id(4) + length(4) + trace_context(32)`) followed by a length-prefixed
+  body. `InternodeCodec` implements tokio-util `Encoder`/`Decoder`; it rejects
+  oversized frames (`FrameTooLarge`), unknown lanes/message types, and
+  version-mismatched frames.
+- **Distributed trace propagation** — every frame carries a 32-byte
+  `TraceContext` (`trace_id(16) + span_id(8) + flags(8)`); all-zero means no
+  active trace.
+- **Two frame formats** — `WireFrameFormat::Legacy` (v1) and
+  `CapnpEnvelope` (v2). The Cap'n Proto envelope (`protocol`) carries typed
+  cluster-control, recovery, bootstrap, and stream payloads plus a versioned
+  capability/feature negotiation; legacy message bodies ride as an append-only
+  `LegacyPayload` until peers negotiate the Cap'n Proto format.
+- **Message model** (`message`) — the `Message` enum with hand-rolled
+  length-prefixed encode/decode for lifecycle, Raft, mutation/read, repair,
+  streaming, pair-mode, batchlog, index, Accord, and bootstrap message types
+  (`MsgType` discriminants `0x01`..=`0x83`). Optional trailing fields decode to
+  `None` on pre-extension peers for backward compatibility.
+- **PSK-HMAC handshake** (`handshake`) — `initiate_handshake` /
+  `accept_handshake` exchange `Handshake`/`HandshakeAck`, verifying cluster name,
+  protocol version, and an `HMAC-SHA256(psk, cluster_name|host_id|nonce)` auth
+  token via the `hmac` crate's constant-time `verify_slice`. The handshake also
+  exchanges CQL- and internode-broadcast addresses.
+- **Priority lanes + actor pool** (`pool`, `lane_actor`) — `PriorityPool` holds
+  three TCP connections per peer, one per `Lane` (`Raft`, `Data`, `Bulk`). Each
+  lane is owned by a dedicated actor task that processes `LaneCommand`s
+  sequentially over an mpsc channel — eliminating the cancel-safety hazard of
+  holding a `tokio::Mutex` across network `await`s. The Raft lane can run on its
+  own OS thread/runtime so heartbeats are never starved by data-path saturation.
+- **Reconnect / dormancy lifecycle** (`reconnect`, `lane_actor`) — on disconnect
+  a lane retries with exponential backoff (`connect_with_retry_cancelable`); after
+  `MAX_RECONNECT_ATTEMPTS` it counts an exhaustion, and after
+  `DORMANT_AFTER_EXHAUSTIONS` it goes `Dormant`, probing once per
+  `DORMANT_PROBE_INTERVAL`. Reconnects re-resolve the peer's advertised hostname
+  so container IP churn is handled automatically.
+- **RPC server + handler registry** (`rpc`) — `RpcServer` accepts inbound
+  connections, runs the acceptor handshake, and dispatches frames through a
+  thread-safe `HandlerRegistry` (`MsgType` → `Arc<dyn RpcHandler>`) that supports
+  dynamic registration after start. Graceful drain via `CancellationToken` with a
+  bounded wait.
+- **TLS** (`tls`) — optional rustls (ring provider) `TlsAcceptor`/`TlsConnector`
+  built from PEM cert/key/CA paths; `require_tls` fails startup loudly when no
+  cert is configured.
+- **Streaming support** (`stream_router`, `idle_timeout`) — `StreamRouter`
+  dispatches multi-message streaming RPCs keyed by `request_id`; the idle-timeout
+  watchdog aborts a consumer only after the producer is quiet for longer than the
+  timeout (heartbeats reset the deadline).
+- **Failure detection + skew** (`peer`, `skew`) — per-peer RTT and clock-skew
+  tracking derived from heartbeats; the Accord protocol consumes `SkewMax`.
+- **Discovery** (`discovery`) — `SeedDiscovery` over a `Discovery` trait.
+- **Metrics** (`metrics`) — lane queue depth, in-flight RPCs, timeouts, dormant
+  peer counts, bandwidth.
+
+## Public API (key entry points)
+
+| Area | Types / functions |
+|------|-------------------|
+| Framing | `InternodeCodec`, `Frame`, `FrameHeader`, `Lane`, `MsgType`, `TraceContext`, `WireFrameFormat`, `HEADER_SIZE` |
+| Messages | `Message`, `accord_messages::AccordMessageType` |
+| Cap'n Proto envelope | `CapnpEnvelope`, `encode_message_envelope`, `decode_message_envelope`, `negotiate_capnp_capabilities` |
+| Handshake | `initiate_handshake`, `accept_handshake`, `compute_auth_token`, `verify_auth_token`, `HandshakePeer` |
+| Pool / lanes | `PriorityPool`, `LaneHandle`, `LaneOutcome`, `LaneStatusReport`, `spawn_lane_actor` |
+| RPC | `RpcServer`, `RpcClient`, `HandlerRegistry`, `RpcHandler`, `PeerId`, `InboundPeerCallback` |
+| Config / errors | `NetConfig`, `NetError`, `bind_failure_diagnostic` |
+| TLS | `tls::build_tls_acceptor`, `tls::build_tls_connector` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — re-exports `ferrosa_common::task_pool::TaskPool` as the
+  crate's `TaskPool` (`src/task_pool.rs`). This is the *only* in-workspace
+  dependency.
+
+External: `tokio`, `tokio-util`, `bytes`, `capnp`/`capnpc`, `rustls` +
+`tokio-rustls` + `rustls-pemfile`, `hmac` + `sha2`, `dashmap`, `parking_lot`,
+`arc-swap`, `futures`, `uuid`, `rand`, `lz4_flex`, `snap`, `tracing`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa`** — runs the `RpcServer`, builds `NetConfig`, wires runtimes.
+- **`ferrosa-cluster`** — registers Raft/repair/Accord handlers; reacts to peer
+  events; uses `PriorityPool` for outbound RPC.
+- **`ferrosa-cql`**, **`ferrosa-graph`**, **`ferrosa-session`** — send/receive
+  internode messages via the pool and handler registry.
+
+> Note: an internal `ARCHITECTURE.md` reference doc claimed `ferrosa-net` has **no**
+> `ferrosa-common` dependency. That is **incorrect** — `Cargo.toml` and
+> `src/task_pool.rs` show a real dependency on `ferrosa_common::task_pool`. The
+> truth is documented here; the reference doc should be corrected.
+
+## Tests
+
+~138 in-crate unit tests across the modules, plus ~27 integration tests in
+`tests/` (Cap'n Proto adapters/conformance/envelope framing/protocol,
+end-to-end `integration.rs`, and `reconnect_backoff.rs`). No `#[ignore]`, no
+`TODO`/`FIXME`/`unimplemented!` in `src/`.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, position
+- [Data flow](specs/data-flow.md) — frame / handshake / lane sequence diagram
+- [FMEA / known issues](specs/fmea.md) — failure modes + gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-net/specs/data-flow.md
+++ b/ferrosa-net/specs/data-flow.md
@@ -1,0 +1,91 @@
+---
+crate: ferrosa-net
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa-net — Data Flow
+
+This crate has two hot paths: **connection establishment** (TCP → handshake →
+lane actors) and **per-message send/receive** (`LaneHandle` → actor → wire →
+`HandlerRegistry`). The sequence below traces both for a single peer.
+
+> Diagram note: generic types are written with escaped brackets
+> (e.g. `mpsc::Sender&lt;LaneCommand&gt;`) so the Mermaid renderer does not treat
+> them as markup.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller as Caller (ferrosa-cluster)
+    participant Pool as PriorityPool
+    participant Client as RpcClient (per lane)
+    participant Codec as InternodeCodec
+    participant Net as TCP / TLS
+    participant Server as RpcServer (peer)
+    participant Reg as HandlerRegistry (peer)
+    participant Actor as lane_actor (local)
+
+    Note over Pool,Net: 1. Connect (one of 3 lanes: Raft / Data / Bulk)
+    Caller->>Pool: connect(config, host)
+    Pool->>Net: lookup_host + TCP connect
+    Pool->>Client: connect_with_tls_on_pool
+    Client->>Codec: Frame{ Handshake, lane=Raft }
+    Codec->>Net: 44-byte header + body
+    Net->>Server: bytes
+    Server->>Server: accept_handshake (verify cluster, version, HMAC-SHA256 token)
+    Server-->>Client: HandshakeAck{ accepted, host_id, broadcasts }
+    Client-->>Pool: HandshakePeer
+    Pool->>Actor: spawn lane_actor (owns LaneState, mpsc::Receiver&lt;LaneCommand&gt;)
+    Note over Pool,Actor: Raft lane may spawn on a dedicated OS thread + runtime
+
+    Note over Caller,Reg: 2. Send (request/response on a lane)
+    Caller->>Pool: send(Message, lane)
+    Pool->>Actor: LaneHandle.reserve().await + permit.send(LaneCommand::Send)
+    Actor->>Actor: enforce stream window + Data-lane in-flight cap
+    alt window has capacity
+        Actor->>Client: client.send_with_timeout(msg, lane, timeout)
+        Client->>Codec: encode Frame (Legacy or CapnpEnvelope)
+        Codec->>Net: header + body
+        Net->>Server: bytes
+        Server->>Codec: decode Frame (version must match negotiated format)
+        Server->>Reg: dispatch(peer_id, msg_type, Message)
+        Reg-->>Server: Option&lt;Message&gt; (None = fire-and-forget)
+        Server-->>Client: response Frame (stream_id correlated)
+        Client-->>Actor: LaneCommand::SendComplete(Result&lt;Message&gt;)
+        Actor-->>Caller: Result&lt;Message&gt;
+    else window full / pending cap exceeded
+        Actor-->>Caller: Err(NetError::Overloaded)
+    end
+
+    Note over Actor,Net: 3. Disconnect -> reconnect lifecycle
+    Net--xClient: TCP drop
+    Client->>Actor: alive watcher fires
+    Actor->>Actor: spawn_reconnect (connect_with_retry_cancelable, backoff)
+    alt reconnect succeeds
+        Actor->>Actor: LaneState = Connected(new client); re-attach alive watcher
+    else MAX_RECONNECT_ATTEMPTS exhausted
+        Actor->>Actor: exhaustion_count += 1
+        alt exhaustion_count &lt; DORMANT_AFTER_EXHAUSTIONS
+            Actor->>Actor: schedule retry cycle (sleep 5s)
+        else
+            Actor->>Actor: LaneState = Dormant; probe every DORMANT_PROBE_INTERVAL
+        end
+    end
+    Note over Caller,Actor: while reconnecting -> Err(Reconnecting); dormant probe can wake to Connected
+```
+
+## Notes on the path
+
+- **Three lanes, three connections.** `Raft`, `Data`, and `Bulk` each get their
+  own TCP connection and actor, with distinct default timeouts (1 s / 10 s /
+  60 s) so a slow bulk transfer cannot delay a Raft heartbeat.
+- **Cancel safety.** The caller never holds a lock across the network round-trip;
+  it only owns a `oneshot` receiver. If the caller future is dropped mid-send,
+  the reserved mpsc permit is released and no half-sent state remains.
+- **Backpressure is explicit.** The actor enforces a per-lane stream window
+  (`max_streams_per_lane`) and a process-wide `data_lane_max_in_flight` cap;
+  overflow returns `NetError::Overloaded` rather than queuing unboundedly.
+- **Frame format negotiation.** Legacy (v1) and Cap'n Proto envelope (v2) frames
+  coexist; the codec is pinned to the negotiated `WireFrameFormat` and rejects a
+  mismatched version instead of misparsing it.

--- a/ferrosa-net/specs/fmea.md
+++ b/ferrosa-net/specs/fmea.md
@@ -1,0 +1,55 @@
+---
+crate: ferrosa-net
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-net — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This crate sits on the critical internode path: a transport
+fault can stall consensus or silently drop cluster traffic, so severities run
+high. Several entries are regression-hardened by existing tests; those that are
+not are flagged as open gaps.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| NET-1 | A `MsgType` byte tag is added to the enum but not to the `TryFrom<u8>` decoder | Peers serialise the frame fine but reject it on receipt with `UnknownMessageType` — e.g. repair sessions converge **zero** partitions, silently | 9 | 4 | 7 | 252 | **Partially mitigated.** A regression test pins the repair tags `0x29..=0x2E` and the streaming tags `0x36..=0x3A`, but there is **no exhaustive test** asserting every declared `MsgType` round-trips. New tags can still slip through. Add an enumerate-all round-trip test. |
+| NET-2 | Lane actor holds work behind a network round-trip and the caller future is cancelled | Half-sent state / leaked in-flight slot / wrong correlation | 9 | 2 | 6 | 108 | **Structural.** Lane state is owned by one actor; callers use `reserve().await` + `permit.send()`, so cancellation drops the permit cleanly. Central design invariant; covered by lane_actor tests. |
+| NET-3 | Frame format mismatch (legacy frame on a Cap'n Proto connection or vice versa) | Body misparse → corrupt `Message` or hung stream | 8 | 2 | 4 | 64 | **Mitigated.** `InternodeCodec::decode` checks `header.version` against the negotiated `WireFrameFormat` and returns a descriptive `Protocol` error rather than misparsing. Covered by `capnp_envelope_framing` tests. |
+| NET-4 | Lane reconnect pinned to a frozen IP; peer restarts with a new container IP | Lane retries a dead address forever; peer never rejoins (P3) | 8 | 3 | 5 | 120 | **Mitigated.** `pick_reconnect_host` prefers the peer's advertised re-resolvable internode-broadcast hostname; DNS re-resolved on every attempt. Unit-tested. Residual risk: peers that advertise no broadcast still pin the connect-time host. |
+| NET-5 | Handler not yet registered when a Raft/vote frame arrives during mode transition | `dispatch` returns `None`; sender times out; election stalls (BUG-RAFT-HANDLER-RACE) | 8 | 3 | 5 | 120 | **Open / cross-crate.** `HandlerRegistry` supports dynamic registration, but the registration-vs-arrival race is owned by `ferrosa-cluster`. A test in `rpc/handler.rs` documents the bug (asserts the drop) but the fix is upstream. Track closure. |
+| NET-6 | All lanes to a peer go `Dormant` after exhausting reconnects | No traffic to that peer until a 5-minute dormant probe succeeds; slow recovery | 7 | 3 | 4 | 84 | **By design, observable.** Dormancy bounds reconnect cost; `inc/dec_dormant_peer_count` metrics expose it. Risk is the 5-minute `DORMANT_PROBE_INTERVAL` latency on a genuine transient outage. |
+| NET-7 | Inbound flood: many half-open connections or oversized frames | Resource exhaustion / OOM | 7 | 2 | 4 | 56 | **Mitigated.** `max_connections` (512), `handshake_timeout` (5 s), and `max_frame_body_size` (256 MiB, enforced as `FrameTooLarge`) bound the surface. |
+| NET-8 | `require_tls=false` (default) → internode traffic is plaintext | Eavesdrop / MITM on the internode network if operator forgets to enable TLS | 8 | 4 | 6 | 192 | **Fail-loud only when opted in.** `require_tls` errors at startup when set with no cert, but TLS is **off by default** and there is no mutual-TLS client-auth (`with_no_client_auth`). Operators must explicitly enable + provide a CA. Document as a deployment gap. |
+| NET-9 | PSK unset (default `psk: None`) → handshake authenticates cluster-name only | Any host knowing the cluster name can join the internode mesh | 8 | 3 | 6 | 144 | **Optional auth.** HMAC-SHA256 token verification is constant-time and correct *when a PSK is set*, but PSK is `None` by default. Pair with NET-8: secure internode requires both PSK and TLS configured. |
+| NET-10 | Streaming chunk frames dispatched out of wire order | Coordinator's contiguous-`seq` check trips → `ChannelClosedBeforeDone` mid-stream | 7 | 2 | 5 | 70 | **Mitigated.** `is_ordered_stream_response` keeps chunk/heartbeat/done on the ordered lane path; documented at length in `codec.rs`. Surfaced only for multi-chunk responses (wide partitions). |
+
+## Top risks to act on
+
+1. **NET-1 (RPN 252)** — the highest risk is a *non-exhaustive* `MsgType`
+   round-trip test. The failure mode (peers silently dropping a whole class of
+   frames) has already bitten repair. Add a test that iterates every declared
+   variant through `TryFrom<u8>` so a new tag cannot ship undecodable.
+2. **NET-8 (RPN 192) + NET-9 (RPN 144)** — secure-by-default gap: internode TLS
+   and PSK auth are both **off by default**, and there is no mutual TLS. For any
+   untrusted-network deployment this is a real exposure; capture as a hardening
+   item and document the required `FERROSA_INTERNODE_TLS_*` + `FERROSA_INTERNODE_PSK`
+   configuration.
+3. **NET-5 (RPN 120)** — the handler-registration race is documented but the fix
+   lives in `ferrosa-cluster`; track to closure so the documented bug-asserting
+   test can be flipped to assert success.
+
+## Detection assets
+
+- `codec.rs` unit tests — frame round-trip, oversize rejection, repair- and
+  streaming-tag round-trips, trace-context propagation.
+- `tests/capnp_*` — Cap'n Proto envelope encode/decode, conformance, framing,
+  version/feature negotiation.
+- `handshake.rs` tests — PSK accept/reject, cluster/version mismatch, broadcast
+  exchange, backward compat.
+- `lane_actor.rs` / `pool.rs` tests — reconnect-host selection, exhaustion →
+  dormant transition, stale `MarkFailed` rejection, cancel-safe send.
+- `tests/reconnect_backoff.rs`, `tests/integration.rs` — end-to-end reconnect and
+  send/receive.
+- `metrics` — lane queue depth, in-flight RPCs, RPC timeouts, dormant peer count.

--- a/ferrosa-net/specs/overview.md
+++ b/ferrosa-net/specs/overview.md
@@ -1,0 +1,107 @@
+---
+crate: ferrosa-net
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The internode transport for ferrosa: a custom framed TCP wire protocol with a
+  44-byte header, a PSK-HMAC handshake, three priority lanes (Raft/Data/Bulk) per
+  peer, and a cancel-safe actor-based connection pool with backoff/dormancy
+  reconnect. Higher layers register typed RPC handlers; this crate moves bytes,
+  authenticates peers, multiplexes by priority, propagates trace context, and
+  keeps connections alive across peer IP churn. Near-leaf: depends only on
+  ferrosa-common (for TaskPool).
+---
+
+# ferrosa-net — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-net` is the **node-to-node transport substrate**. Its boundary is the
+wire: it knows how to frame, authenticate, prioritise, and deliver `Message`s
+between peers, and how to keep those connections alive — and nothing about Raft
+semantics, query planning, storage, or cluster membership policy. Those live in
+`ferrosa-cluster` and above, which plug in via the `HandlerRegistry` /
+`RpcHandler` seam.
+
+It is deliberately a **near-leaf**: its only in-workspace dependency is
+`ferrosa-common`, from which it re-exports `task_pool::TaskPool`. (An internal
+`ARCHITECTURE.md` reference doc states it has *no* `ferrosa-common` dependency;
+that is wrong — see `Cargo.toml` and `src/task_pool.rs`.)
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `codec` | Frame model: `FrameHeader` (44-byte), `Frame`, `Lane`, `MsgType`, `TraceContext`, `InternodeCodec` (tokio-util `Encoder`/`Decoder`), `WireFrameFormat` |
+| `message` | `Message` enum + hand-rolled length-prefixed encode/decode for all `MsgType`s |
+| `protocol` | Generated Cap'n Proto envelope (v2) + adapter types, capability/feature negotiation, `encode/decode_message_envelope` |
+| `accord_messages` | `AccordMessageType` discriminants (Accord payloads carried as opaque `Bytes`) |
+| `handshake` | PSK-HMAC handshake (`initiate_handshake` / `accept_handshake`), `compute/verify_auth_token`, `HandshakePeer` |
+| `pool` | `PriorityPool`: 3 lanes per peer, connect/send/fire/shutdown, reconnect-host selection |
+| `lane_actor` | Per-lane actor task, `LaneHandle`, `LaneCommand`, stream-window dispatch, reconnect/dormant driving |
+| `reconnect` | `LaneState`, backoff constants, `connect_with_retry_cancelable`, alive watcher, dormant counters |
+| `rpc/server` | `RpcServer`: accept loop, acceptor handshake, dispatch, graceful drain, TLS acceptor |
+| `rpc/client` | `RpcClient`: outbound connection, frame reader/writer loops, bandwidth metrics |
+| `rpc/handler` | `HandlerRegistry` (`MsgType`→handler, dynamic), `RpcHandler` trait, `PingHandler` |
+| `tls` | rustls (ring) `TlsAcceptor`/`TlsConnector` from PEM paths; `require_tls` enforcement |
+| `stream_router` | Per-`request_id` dispatch for multi-message streaming RPCs |
+| `idle_timeout` | Producer-quiet watchdog for streaming consumers (heartbeats reset the deadline) |
+| `peer` | Per-peer registry, liveness/heartbeat state |
+| `skew` | Per-peer RTT + clock-skew tracking; feeds Accord `SkewMax` |
+| `discovery` | `Discovery` trait + `SeedDiscovery` |
+| `metrics` | Lane queue depth, in-flight RPCs, timeouts, dormant peers, bandwidth |
+| `config` / `error` | `NetConfig` (env-driven), `NetError`, `bind_failure_diagnostic` |
+
+## Wire frame layout
+
+```
+byte:  0      1      2      3      4..8        8..12      12..44
+     ┌──────┬──────┬──────┬──────┬───────────┬──────────┬───────────────┐
+     │ ver  │flags │ lane │ type │ stream_id │  length  │ trace_context │  body[length]
+     └──────┴──────┴──────┴──────┴───────────┴──────────┴───────────────┘
+       u8     u8     u8     u8      u32 BE      u32 BE       32 bytes
+```
+
+`HEADER_SIZE = 44`. `version` is `1` (Legacy) or `2` (Cap'n Proto envelope);
+the codec is constructed per-connection with the negotiated `WireFrameFormat`
+and rejects frames whose version does not match. `length` is bounded by
+`max_frame_body_size` (default 256 MiB).
+
+## Data flow (summary)
+
+- **Connect**: `PriorityPool::connect` resolves the peer, builds a shared TLS
+  connector, opens 3 `RpcClient`s (one per lane), each running its handshake,
+  then spawns a `lane_actor` per lane. See [data-flow.md](data-flow.md).
+- **Send**: a caller calls `pool.send(msg, lane)`; the `LaneHandle` reserves an
+  mpsc slot (cancel-safe), the actor enforces the per-lane stream window and the
+  process-wide Data-lane in-flight cap, then dispatches on the `RpcClient`.
+- **Receive**: `RpcServer` accepts, runs `accept_handshake`, then reads frames
+  and routes each through `HandlerRegistry::dispatch`; streaming responses are
+  fanned out by `StreamRouter` keyed on `request_id`.
+
+## Key invariants
+
+1. **No `Mutex` held across network `await`.** Lane state is owned exclusively by
+   a single actor task; callers interact only via `LaneHandle` (mpsc). This is
+   the crate's central cancel-safety guarantee (`lane_actor`).
+2. **Frame version matches the negotiated format.** `InternodeCodec::decode`
+   rejects a legacy frame on a Cap'n Proto connection and vice versa, rather than
+   misparsing.
+3. **`MsgType` byte tags must round-trip.** Every serialised discriminant must
+   decode via `TryFrom<u8>`; a missing arm makes peers silently drop frames
+   (regression-tested for the repair RPC tags `0x29..=0x2E`).
+4. **Ordered streaming responses dispatch in wire order.** Chunk/heartbeat/done
+   frames for one stream are processed in order; out-of-order dispatch trips the
+   coordinator's contiguous-`seq` check (`MsgType::is_ordered_stream_response`).
+5. **Reconnect targets a re-resolvable hostname, not a frozen IP.** Lanes prefer
+   the peer's advertised internode-broadcast hostname so a peer that restarts on
+   a new container IP is reconnected (P3 fix in `pool::pick_reconnect_host`).
+6. **Fail loud on bad auth / require_tls.** PSK mismatch rejects the handshake;
+   `require_tls` with no cert errors at startup rather than silently running
+   plaintext.
+
+## Position in the dependency graph
+
+Near-leaf. **Calls:** `ferrosa-common` (only). **Called by:** `ferrosa`,
+`ferrosa-cluster`, `ferrosa-cql`, `ferrosa-graph`, `ferrosa-session`. See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-net/specs/roadmap.md
+++ b/ferrosa-net/specs/roadmap.md
@@ -1,0 +1,60 @@
+---
+crate: ferrosa-net
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-net — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), the in-code design notes, and
+the dependency/usage review. There are no `TODO`/`FIXME` markers in `src/`, so
+this roadmap is gap- and risk-driven rather than scraped from the code.
+
+## Now (highest value)
+
+- **Exhaustive `MsgType` round-trip test** (FMEA NET-1). Today only the repair
+  (`0x29..=0x2E`) and streaming (`0x36..=0x3A`) tags are pinned. Add a test that
+  iterates *every* declared `MsgType` variant through `TryFrom<u8>` and back, so a
+  newly-added discriminant cannot ship without a matching decoder arm. This is the
+  cheapest fix for the crate's top failure mode (peers silently dropping frames).
+- **Document the secure-internode deployment contract** (FMEA NET-8, NET-9).
+  TLS and PSK are both off by default and there is no mutual TLS. Write the
+  required `FERROSA_INTERNODE_TLS_CERT/KEY/CA` + `FERROSA_INTERNODE_REQUIRE_TLS` +
+  `FERROSA_INTERNODE_PSK` configuration and surface it in the operator runbook so
+  untrusted-network deployments don't silently run plaintext, anonymous mesh.
+
+## Next
+
+- **Mutual TLS (client auth)** (FMEA NET-8). Both `build_tls_acceptor` and
+  `build_tls_connector` use `with_no_client_auth`. Add an opt-in mTLS mode that
+  verifies the peer certificate against the configured CA, so TLS authenticates
+  *both* directions instead of only encrypting.
+- **Track the handler-registration race to closure** (FMEA NET-5). The
+  `rpc/handler.rs` test currently asserts the *bug* (a `RaftVote` arriving before
+  registration is dropped). Once the `ferrosa-cluster` fix lands, flip the
+  assertion to expect successful dispatch and remove the documented-bug comment.
+- **Tunable dormant probe interval.** `DORMANT_PROBE_INTERVAL` is a hard-coded
+  5 minutes; a genuine transient outage incurs up to that latency before a lane
+  re-probes. Make it env-tunable like the lane channel/stream capacities already are.
+
+## Later
+
+- **Property-test frame and `Message` codec round-trips.** `proptest` is already a
+  dev-dependency; add `decode(encode(m)) == m` coverage across the `Message` and
+  `FrameHeader`/`TraceContext` space as a format-stability net independent of the
+  integration tests.
+- **Complete the Cap'n Proto v2 cutover.** Legacy bodies still ride inside a
+  `LegacyPayload` envelope until peers negotiate the Cap'n Proto frame format.
+  Once all peers negotiate v2, retire the legacy frame path behind a deprecation
+  window.
+- **Connection-pool observability pass.** Surface per-peer lane state
+  (Connected/Reconnecting/Dormant) and stream-window saturation as first-class
+  metrics/health-check fields, building on the existing `metrics` counters.
+
+## Non-goals
+
+- Raft/Accord/repair *semantics*, query planning, storage, and membership policy
+  — those belong to `ferrosa-cluster` and above; this crate only frames,
+  authenticates, prioritises, and delivers their messages.
+- Cassandra internode wire compatibility — ferrosa intentionally runs its own
+  internode protocol (CQL client compatibility is a separate concern).

--- a/ferrosa-postgres/README.md
+++ b/ferrosa-postgres/README.md
@@ -1,0 +1,140 @@
+# ferrosa-postgres
+
+> The PostgreSQL v3 wire-protocol front-end for ferrosa (developer preview) —
+> SCRAM auth, the simple + extended query protocols, and SELECT/INSERT/UPDATE/
+> DELETE over live ferrosa storage, differential-tested against real PostgreSQL 16.
+
+## What this crate is
+
+A Postgres frontend/backend (v3) listener that lets unmodified Postgres drivers
+(`tokio-postgres`, JDBC, psql, ORMs) talk to ferrosa. It owns the wire codec, the
+connection/SCRAM state machine, and the query lowering that turns a SQL string
+into reads/writes against the ferrosa `StorageEngine`. It is **not** the
+relational query engine — planning/binding/operators live in `ferrosa-sql`; this
+crate is the protocol skin plus the storage glue.
+
+Decision **D10**: the storage row codec is shared with the CQL front-end via the
+neutral `ferrosa-row-bridge` crate, so a row written through Postgres decodes
+byte-identically over CQL — without `ferrosa-postgres` ever depending on the
+~54k-LOC `ferrosa-cql` crate.
+
+This is a **developer preview**. See [specs/fmea.md](specs/fmea.md) for the exact
+supported-vs-not surface (key gaps: `$N` params in DML, `RETURNING`, `ON
+CONFLICT`, and real transaction atomicity via Accord are all still in progress).
+
+## What's implemented
+
+- **Wire protocol (v3)** — startup (incl. `SSLRequest`, declined with `N` since
+  TLS is not wired), the sans-IO [`Connection`] phase machine
+  (`AwaitingStartup → Authenticating → Ready → Closed`), and message framing
+  (`codec` / `messages`).
+- **Authentication** — SCRAM-SHA-256 (`scram` + `handshake`), driven against the
+  live `ferrosa-schema` role store via [`SchemaVerifierStore`]. Fail loud: an
+  unknown role / bad proof never authenticates.
+- **Simple query protocol (`Q`)** — `execute_query` lowers one SQL string:
+  `SELECT` (incl. a single `JOIN`, `WHERE`, `GROUP BY`, `ORDER BY`, `LIMIT`),
+  no-`FROM` scalar selects (`SELECT 1`, `SELECT version()`,
+  `current_database()`), and single-row `INSERT` / `UPDATE` / `DELETE`.
+- **Extended query protocol** — `Parse`/`Bind`/`Describe`/`Execute`/`Sync`/`Close`
+  with a per-connection [`Session`] (prepared statements + portals), `$N`
+  parameter type inference (`ParameterDescription`), text + binary parameter and
+  result encodings, and Postgres error-skip-until-`Sync` semantics. **Only
+  `SELECT`** (and no-`FROM` expression selects) can be prepared.
+- **Transaction protocol state** — `BEGIN`/`COMMIT`/`ROLLBACK` drive the
+  `ReadyForQuery` status byte `I`/`T`/`E`; an error inside a block aborts it
+  (`T → E`) and only `COMMIT`/`ROLLBACK` are then accepted (`25P02`). **Atomicity
+  is not yet real** — the front-end commit seam is wired but writes are not yet
+  routed through Accord (blueprint D11).
+- **DML execution** — INSERT/UPDATE/DELETE build storage rows through the shared
+  `ferrosa-row-bridge` encoder and `engine.write_atomic_batch`. UPDATE/DELETE are
+  Cassandra-style blind upserts/tombstones keyed by a full-primary-key equality
+  `WHERE` (reported as `UPDATE 1` / `DELETE 1`).
+- **`pg_catalog` projection** — `catalog` projects `pg_namespace`/`pg_class`/
+  `pg_attribute`/`pg_type` from live schema metadata with deterministic OIDs.
+- **TCP server** — `serve` / `QueryContext`: one spawned task per connection over
+  a tokio `TcpListener`, sharing the auth store and the storage+schema context.
+
+## Data flow
+
+**Read (`SELECT`):** `Q`/`Execute` → `ferrosa_sql::parse_statement` →
+`load_catalog` materializes each referenced table (the async
+`StorageEngine::range_iter` stream is drained up front and decomposed via the
+shared `ferrosa_row_bridge::partition_to_rows_with_storage_mapping`) into an
+`InMemoryTable` → `ferrosa_sql::execute` runs the sync operators →
+`RowDescription` + `DataRow`s + `CommandComplete "SELECT n"`.
+
+**Write (`INSERT`/`UPDATE`/`DELETE`):** parse → resolve each value to a
+`CqlValue` by the column's CQL type (`value_to_cql`) → `build_decorated_key` +
+`build_row`/`build_delete_row` (the SAME `ferrosa-row-bridge` encoder CQL uses) →
+`engine.write_atomic_batch` → `CommandComplete`.
+
+See [specs/data-flow.md](specs/data-flow.md) for the sequence diagrams.
+
+## Public API (key entry points)
+
+| Area | Items |
+|------|-------|
+| Server | `server::serve`, `server::QueryContext`, `server::handle_connection` |
+| Connection | `connection::Connection`, `ConnError` |
+| Auth | `handshake::Handshake`, `VerifierStore`, `store::SchemaVerifierStore`, `scram::{ScramVerifier, ScramServerFirst, server_first, verify_client_final}` |
+| Simple query | `query::execute_query` |
+| Extended query | `extended::Session` (`on_parse`/`on_bind`/`on_close`/`on_sync`), `query::decode_param`/`encode_value` |
+| Storage glue | `storage_provider::load_table`, `cql_to_value`, `LoadError` |
+| Catalog | `catalog::{type_oid, …}` |
+| Codec / messages | `codec::{read_startup, read_frontend, MAX_MESSAGE_LEN}`, `messages::{FrontendMessage, BackendMessage, TransactionStatus, …}` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — `CqlValue`, `CqlType`, `DecoratedKey`, `PartitionKey`,
+  `CellValue` (the shared value/key model).
+- **`ferrosa-row-bridge`** — the canonical row codec and partition→row
+  decomposition (`build_decorated_key`, `build_row`, `build_delete_row`,
+  `partition_to_rows_with_storage_mapping`, `parse_cql_type_in_keyspace`). D10:
+  the SAME code `ferrosa-cql` uses, so there is no row-ordering divergence and no
+  dependency on `ferrosa-cql`.
+- **`ferrosa-schema`** — keyspace/table metadata, column kinds, the role store
+  (`scram_credential`) the verifier reads.
+- **`ferrosa-sql`** — the bespoke relational engine: `parse_statement`,
+  `execute`, `describe`, `infer_param_types`, `MapCatalog`, `Value`/`Column`.
+- **`ferrosa-sstable`** — names the `Partition` type `range_iter` streams.
+- **`ferrosa-storage`** — `StorageEngine` (`range_iter`, `write_atomic_batch`),
+  `Mutation`, `TableId`.
+
+**Notably does NOT depend on `ferrosa-cql`** (decision D10).
+
+**Called by**:
+
+- **`ferrosa`** — the main binary mounts the Postgres listener.
+
+## Tests
+
+~111 in-crate unit tests (codec/messages/scram/handshake/connection/extended/
+query/storage_provider/catalog/store) run with no infrastructure, plus
+integration tests:
+
+- `tests/m1_join_live.rs` (5) — full stack over a real `tokio-postgres` driver
+  in-process: SCRAM → JOIN, parameterized extended query, GROUP BY/ORDER
+  BY/LIMIT, error-recovery-after-`Sync`. Local temp engine, no Docker.
+- `tests/scram_live.rs` (3) — real-driver SCRAM + `SELECT 1`, extended
+  expression select, wrong-password rejection. In-process loopback.
+- `tests/differential_oracle.rs` (3, `#[cfg(feature = "live-infra-tests")]`) —
+  runs a fixed corpus + DML against BOTH real PostgreSQL 16 (container) and
+  ferrosa over the same data and asserts agreement. Gated; panics with setup
+  instructions if `FERROSA_TEST_CONTAINERS=1` is unset (never a silent skip).
+
+```bash
+cargo test -p ferrosa-postgres                       # unit + in-process integration
+FERROSA_TEST_CONTAINERS=1 cargo test -p ferrosa-postgres \
+  --features live-infra-tests --test differential_oracle -- --nocapture
+```
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, data flow
+- [FMEA / known issues](specs/fmea.md) — supported-vs-not surface + RPN-ranked gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later
+- [Data flow](specs/data-flow.md) — SELECT + INSERT sequence diagrams
+
+Public marketing page: `docs/database/postgres.html` (ferrosadb.com).

--- a/ferrosa-postgres/specs/data-flow.md
+++ b/ferrosa-postgres/specs/data-flow.md
@@ -1,0 +1,97 @@
+---
+crate: ferrosa-postgres
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa-postgres — Data Flow
+
+How one `SELECT` and one `INSERT` travel from the Postgres wire, through
+`parse → execute → storage`, and back. Both paths share the canonical
+`ferrosa-row-bridge` codec (decision D10), so Postgres-written rows are
+byte-identical to CQL.
+
+## SELECT (read path)
+
+A simple `Q` query for `SELECT ... FROM t [JOIN ...] WHERE ...`. Tables are
+materialized from the async storage scan up front, then the sync engine runs.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Drv as Postgres driver
+    participant Srv as server::query_loop
+    participant Q as query::execute_query
+    participant SP as storage_provider::load_table
+    participant Eng as ferrosa-storage StorageEngine
+    participant RB as ferrosa-row-bridge
+    participant SQL as ferrosa-sql::execute
+
+    Drv->>Srv: Query 'Q' (SELECT ...)
+    Srv->>Q: execute_query(engine, schema, sql)
+    Q->>Q: parse_statement(sql) (err =&gt; 42601)
+    Q->>SP: load_catalog: load_table per FROM/JOIN
+    Note over SP: R15 guard — schema metadata decides<br/>existence (missing =&gt; 42P01, not empty)
+    SP->>Eng: range_iter(table_id) (async stream of Partition)
+    Eng-->>SP: Partition*
+    SP->>RB: partition_to_rows_with_storage_mapping
+    RB-->>SP: Vec&lt;Vec&lt;Option&lt;CqlValue&gt;&gt;&gt;
+    SP->>SP: cql_to_value per cell =&gt; InMemoryTable
+    SP-->>Q: MapCatalog (sync-scannable snapshot)
+    Q->>SQL: execute(select, catalog, params)
+    SQL-->>Q: QueryResult (columns + rows)
+    Q->>Q: render_result =&gt; RowDescription + DataRow* + CommandComplete "SELECT n"
+    Q-->>Srv: Vec&lt;BackendMessage&gt;
+    Srv->>Drv: RowDescription, DataRow*, CommandComplete, ReadyForQuery
+```
+
+Notes:
+
+- The async `range_iter` stream is fully drained **before** the sync operators
+  run — the engine is synchronous and must never `block_on` the runtime.
+- Column order follows the table's declared (DDL) order via the shared bridge,
+  matching the CQL `route_select` read path exactly.
+- On any failure exactly one `ErrorResponse` is emitted (`42601` parse, `42P01`
+  undefined table, `58000` storage, `42703`/`42702` column) — never a fake empty
+  result.
+
+## INSERT (write path)
+
+A single-row `INSERT INTO t (cols...) VALUES (literals...)`. Values are resolved
+to `CqlValue` by the target column's CQL type, then encoded with the SAME
+`ferrosa-row-bridge` builders the engine and CQL decode.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Drv as Postgres driver
+    participant Srv as server::query_loop
+    participant Q as query::execute_insert
+    participant Sch as ferrosa-schema (TableMetadata)
+    participant RB as ferrosa-row-bridge
+    participant Eng as ferrosa-storage StorageEngine
+
+    Drv->>Srv: Query 'Q' (INSERT ...)
+    Srv->>Q: execute_query =&gt; execute_insert
+    Q->>Sch: snapshot().tables.get(ks, table) (missing =&gt; 42P01)
+    Q->>Q: per column: parse_cql_type_in_keyspace + value_to_cql
+    Note over Q: type mismatch =&gt; 42804<br/>out of range =&gt; 22003<br/>missing key col =&gt; 23502<br/>$N param =&gt; 0A000 (preview gap)
+    Q->>RB: build_decorated_key(pk_values)
+    Q->>RB: build_row(regular_cells, ck_values, ts)
+    RB-->>Q: storage Row (cells sorted by storage index)
+    Q->>Eng: write_atomic_batch([Mutation])
+    Eng-->>Q: Ok (or 58000 on write error)
+    Q-->>Srv: CommandComplete "INSERT 0 1"
+    Srv->>Drv: CommandComplete, ReadyForQuery
+```
+
+Notes:
+
+- `UPDATE` and `DELETE` follow the same shape: a full-primary-key equality
+  `WHERE` identifies the row; `UPDATE` writes regular/static cells (blind
+  upsert), `DELETE` writes a row-level tombstone (`build_delete_row`). Both
+  report `1` because the Cassandra-style write has no match count.
+- Inside a `BEGIN`/`COMMIT` block the write currently applies immediately — the
+  Accord commit seam exists but is not yet wired (see [fmea.md](fmea.md) PG-1).
+- The encoder is the single canonical `ferrosa-row-bridge` codec, so the row is
+  byte-identical whether written via Postgres or CQL (no second encoder, D10).

--- a/ferrosa-postgres/specs/fmea.md
+++ b/ferrosa-postgres/specs/fmea.md
@@ -1,0 +1,77 @@
+---
+crate: ferrosa-postgres
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-postgres — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This is a **developer-preview** front-end on the client-facing
+data path, so correctness/atomicity gaps dominate. The table is grounded in the
+actual code (`src/query.rs`, `src/server.rs`, `src/storage_provider.rs`,
+`src/connection.rs`).
+
+## Supported surface (what works today)
+
+- **DML/DQL:** `SELECT` (single `JOIN`, `WHERE`, `GROUP BY`, `ORDER BY`,
+  `LIMIT`, aggregates), no-`FROM` scalar selects, and **single-row** `INSERT` /
+  `UPDATE` / `DELETE` (key-equality `WHERE`, Cassandra-style blind
+  upsert/tombstone).
+- **Protocols:** simple (`Q`) and extended (`Parse`/`Bind`/`Describe`/`Execute`/
+  `Sync`/`Close`); `SELECT`-only prepared statements; text + binary param/result
+  formats; `$N` type inference for `SELECT`.
+- **Auth:** SCRAM-SHA-256 against the live schema role store.
+- **Catalog:** `pg_catalog` namespace/class/attribute/type projection.
+
+## Not yet supported (fail-loud gaps)
+
+- `$N` parameters in `INSERT`/`UPDATE`/`DELETE` (DML is literal-only) → `0A000`.
+- `RETURNING`, `ON CONFLICT` (upsert), multi-row `INSERT ... VALUES (...),(...)`.
+- `UPDATE`/`DELETE` with a non-key or range `WHERE` (only full-PK equality).
+- Real transaction **atomicity** — `BEGIN`/`COMMIT`/`ROLLBACK` drive protocol
+  state but writes are not yet routed through Accord.
+- `SET`/`RESET` session GUCs (simple-query path returns `0A000`).
+- Function calls in DML `VALUES`; most scalar functions beyond
+  `version()`/`current_database()`/`current_schema()`.
+- Preparing non-`SELECT` statements via the extended protocol.
+- TLS (`SSLRequest` is declined with `N`); query cancellation (`BackendKeyData`
+  is a `(0,0)` placeholder).
+- Binary `numeric` result/param (falls back to text).
+- CQL `Duration` + collections (`List`/`Set`/`Map`/`Tuple`/`Udt`/`Vector`) read
+  as NULL.
+
+## Failure modes
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| PG-1 | **Transaction atomicity is not real** — `BEGIN`/`COMMIT` move the `I`/`T`/`E` status but the commit seam has an empty write-set; DML inside a block applies immediately and is not rolled back by `ROLLBACK` | A driver in a transaction sees PG-shaped status bytes but writes are NOT atomic/isolated — partial visibility / no rollback (silent correctness gap if a client relies on it) | 9 | 5 | 7 | 315 | **Open, top gap.** Accord commit seam is wired (`execute_simple`, blueprint D11) but writes are not yet accumulated/committed through Accord. Simple `SELECT 1` txn path is exercised; DML-in-txn atomicity is NOT. Document loudly as preview. |
+| PG-2 | **`$N` params unsupported in DML** — `INSERT`/`UPDATE`/`DELETE` with a `ScalarValue::Param` fail loud `0A000` | Every parameterized write from a real driver (the common path) is rejected; only literal DML works | 7 | 8 | 2 | 112 | Fail-loud `0A000` (no silent wrong write). `SELECT` params DO work via the extended path; extending inference to DML is roadmap Now. |
+| PG-3 | **No `RETURNING` / `ON CONFLICT`** — parser/executor do not accept them | ORMs/`INSERT ... RETURNING id` patterns fail | 6 | 7 | 2 | 84 | Fail-loud at parse (`42601`) — never a wrong row. Roadmap Next. |
+| PG-4 | **Lossy CQL→Value: `Duration`/collections read as NULL** | A `SELECT` over a table with a duration/list/map column silently shows NULL for that column | 6 | 4 | 6 | 144 | Documented in `storage_provider::cql_to_value` (code comment, never a panic). Detectable only by inspection — no error is raised. Widen `Value` (roadmap Later). |
+| PG-5 | **Row-codec divergence from CQL/engine** — a write encodes differently than the canonical codec | Postgres-written rows read back wrong/invisible over CQL or the engine (silent corruption) | 10 | 1 | 4 | 40 | **Structural (D10):** INSERT/UPDATE/DELETE use `ferrosa-row-bridge` `build_row`/`build_delete_row`/`build_decorated_key` — the SAME code CQL uses. Reinforced by the differential oracle (PG vs real PG) + the M1 live tests. |
+| PG-6 | **Missing table served as empty relation** | A typo'd table silently returns zero rows instead of erroring | 8 | 1 | 3 | 24 | **R15 guard:** `load_table` checks schema metadata first → `NoSuchTable` (`42P01`), distinct from an existing empty table. Covered by `load_table_missing_table_is_no_such_table`. |
+| PG-7 | **Binary `numeric` out of scope** — a client requesting binary results for a numeric column gets text bytes under a numeric OID | A strict binary-only driver could mis-decode a numeric column | 5 | 2 | 5 | 50 | Documented fallback in `encode_value`/`decode_param_binary`; the oracle uses text (`simple_query`) so the gate never exercises it. Implement binary numeric (roadmap Next). |
+| PG-8 | **No TLS / no query cancel** — `SSLRequest` declined; `BackendKeyData` is `(0,0)` | Cleartext-only on the wire; `CancelRequest` closes the connection but cannot target a running query | 6 | 3 | 2 | 36 | Declined explicitly (`N`), not faked. Wire TLS + a real cancel key (roadmap). Threat-model note: `UnknownRole` is a user-enumeration oracle (run dummy verifier — follow-up). |
+| PG-9 | **Float/numeric text-format parity with Postgres** — floats use Rust `{}` shortest-form | A benign formatting difference vs PG (`1.5` vs `1.5000…`) | 3 | 4 | 4 | 48 | The differential oracle compares `f64`-parseable cells numerically with tolerance, so this is not a false alarm; exact text parity is follow-up. |
+| PG-10 | **UPDATE/DELETE report `1` row unconditionally** — Cassandra blind upsert/tombstone has no match count | A driver reading the affected-row count sees `1` even when no matching row existed | 4 | 5 | 5 | 100 | Documented Cassandra semantics (`execute_update`/`execute_delete`). Differs from PG's real match count; surface in docs / revisit with read-before-write. |
+
+## Top risks to act on
+
+1. **PG-1 (RPN 315)** — transaction atomicity is the single most consequential
+   gap: the protocol *looks* transactional but writes are not yet Accord-backed.
+   Either wire the Accord commit seam or document the preview limitation
+   prominently so no client relies on rollback/isolation.
+2. **PG-4 (RPN 144)** — lossy-NULL for `Duration`/collections is undetectable at
+   runtime (no error). Make these fail loud where queried, or widen `Value`.
+3. **PG-2 (RPN 112)** — `$N` params in DML block the most common write path from
+   real drivers; extend the extended-protocol inference to DML.
+
+## Detection assets
+
+- `tests/differential_oracle.rs` — corpus + DML vs real PostgreSQL 16 (gated on
+  `live-infra-tests` + `FERROSA_TEST_CONTAINERS=1`).
+- `tests/m1_join_live.rs`, `tests/scram_live.rs` — full-stack over `tokio-postgres`,
+  no external infra.
+- ~111 in-crate unit tests for codecs, SQLSTATE mapping, SCRAM vectors, the R15
+  guard, and the transaction state machine.

--- a/ferrosa-postgres/specs/overview.md
+++ b/ferrosa-postgres/specs/overview.md
@@ -1,0 +1,117 @@
+---
+crate: ferrosa-postgres
+status: developer-preview
+last_updated: 2026-06-19
+executive_summary: >
+  The PostgreSQL v3 wire-protocol front-end for ferrosa. Implements the
+  frontend/backend protocol (startup, SCRAM-SHA-256, simple + extended query),
+  and lowers SQL onto the bespoke ferrosa-sql relational engine over live
+  ferrosa storage. SELECT (incl. one JOIN) and single-row INSERT/UPDATE/DELETE
+  are supported; it shares the storage row codec with CQL via ferrosa-row-bridge
+  (D10) and is differential-tested against real PostgreSQL 16. Developer preview:
+  $N params in DML, RETURNING, ON CONFLICT, and Accord-backed transaction
+  atomicity are still in progress.
+---
+
+# ferrosa-postgres — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-postgres` is the **protocol skin + storage glue** that lets unmodified
+Postgres drivers speak to ferrosa. Its boundary is deliberately narrow:
+
+- It owns the **wire** (codec, message types), the **connection/auth state
+  machine** (startup, SCRAM), the **session** (prepared statements, portals,
+  transaction status), and the **lowering** of a parsed statement to engine
+  reads/writes.
+- It does **not** own query planning, binding, or operators — those are
+  `ferrosa-sql`. It does **not** own the storage row encoding — that is
+  `ferrosa-row-bridge` (the same codec CQL uses, **D10**).
+
+## Module map
+
+| Module | LoC | Responsibility |
+|--------|-----|----------------|
+| `codec` (`src/codec.rs`) | ~684 | Frame/parse the v3 wire: `read_startup`, `read_frontend`, backend encode, `MAX_MESSAGE_LEN` |
+| `messages` (`src/messages.rs`) | ~423 | `FrontendMessage`/`BackendMessage`/`StartupFrame`, `FieldDescription`, `TransactionStatus` |
+| `scram` (`src/scram.rs`) | ~281 | SCRAM-SHA-256 primitives: `ScramVerifier`, `server_first`, `verify_client_final` |
+| `handshake` (`src/handshake.rs`) | ~299 | Sans-IO SCRAM phase machine + `VerifierStore` trait |
+| `store` (`src/store.rs`) | ~170 | `SchemaVerifierStore`: bridge the handshake to the live `ferrosa-schema` role store |
+| `connection` (`src/connection.rs`) | ~337 | Sans-IO `Connection`: startup/SSL/SASL → `Ready`; `take_inbuf` for pipelined first query |
+| `extended` (`src/extended.rs`) | ~453 | Per-connection `Session`: Parse/Bind/Close/Sync, prepared statements + portals, txn `I`/`T`/`E` |
+| `query` (`src/query.rs`) | ~1927 | `execute_query`, DML (INSERT/UPDATE/DELETE), value codecs (text+binary), SQLSTATE mapping, `load_catalog` |
+| `storage_provider` (`src/storage_provider.rs`) | ~758 | `load_table`: async-materialize a storage scan into a sync `InMemoryTable`; `cql_to_value`; R15 guard |
+| `catalog` (`src/catalog.rs`) | ~537 | `pg_catalog` projection (`pg_namespace`/`pg_class`/`pg_attribute`/`pg_type`) with deterministic OIDs |
+| `server` (`src/server.rs`) | ~540 | tokio TCP front-end: `serve`, `QueryContext`, `handle_connection`, the post-auth query loop |
+| `lib` (`src/lib.rs`) | ~37 | Module wiring + public re-exports |
+
+## Connection lifecycle
+
+```text
+TCP accept (server::serve)
+  → handle_connection
+     Phase 1: Connection::on_bytes drives startup + SCRAM until ReadyForQuery
+       SSLRequest        → 'N' (TLS declined; not wired)
+       Startup           → AuthenticationSASL (SCRAM-SHA-256)
+       SASLInitial/Final → AuthenticationOk + ParameterStatus* + BackendKeyData + ReadyForQuery
+     Phase 2: query_loop frames Q / Parse / Bind / Describe / Execute / Sync / Close / Terminate
+```
+
+Note: the sans-IO `connection::Connection` also contains a minimal `Ready`-phase
+fallback (it answers `Q` with `0A000` "not yet implemented"); the **real**
+post-auth path is `server::query_loop`, which is what every driver test and the
+differential oracle exercise.
+
+## Data flow
+
+**Read path (`SELECT`):** SQL string → `ferrosa_sql::parse_statement` →
+`query::load_catalog` resolves every referenced table (FROM + optional JOIN) by
+draining `StorageEngine::range_iter` (async) up front and decomposing each
+`Partition` with the shared `ferrosa_row_bridge::partition_to_rows_with_storage_mapping`
+into an `InMemoryTable` → `ferrosa_sql::execute` runs the sync operators →
+`render_result` emits `RowDescription` + `DataRow`s (per the result formats) +
+`CommandComplete "SELECT n"`. The caller appends one `ReadyForQuery`.
+
+**Write path (`INSERT`/`UPDATE`/`DELETE`):** parse → resolve each value to a
+`CqlValue` driven by the target column's `CqlType` (`value_to_cql`, fail-loud on
+type mismatch `42804` / out-of-range `22003`) → `build_decorated_key` +
+`build_row`/`build_delete_row` (the SAME `ferrosa-row-bridge` encoder the engine
+and CQL decode) → `Mutation` → `engine.write_atomic_batch` → `CommandComplete
+"INSERT 0 1"` / `"UPDATE 1"` / `"DELETE 1"`.
+
+See [data-flow.md](data-flow.md) for the sequence diagrams.
+
+## Type model & wire parity
+
+`query` renders/parses each `ferrosa_sql::Value` to/from its exact Postgres text
+form and (for most) the binary form, with OIDs/sizes advertised in
+`RowDescription`: `Int→int4(23)`, `Text→text(25)`, `Bool→bool(16)`,
+`Float→float8(701)`, `Uuid→uuid(2950)`, `Bytea→bytea(17)`,
+`Timestamp→timestamp(1114)`, `Date→date(1082)`, `Time→time(1083)`,
+`Inet→inet(869)`, `Numeric→numeric(1700)`. Binary `numeric` is out of scope (it
+falls back to text bytes — documented). The storage value bridge
+(`cql_to_value`) maps CQL scalars onto this model; `Duration` and collections
+(`List`/`Set`/`Map`/`Tuple`/`Udt`/`Vector`) are known-lossy and read as NULL.
+
+## Key invariants
+
+1. **Fail loud, never fake.** Every failure maps to a concrete SQLSTATE + one
+   `ErrorResponse`; the front-end never returns a fake empty result on error
+   (parse `42601`, undefined table `42P01`, storage `58000`, etc.).
+2. **Missing table ≠ empty table (R15 guard).** `load_table` decides existence
+   from schema metadata, not from an empty stream, so a typo'd table errors
+   (`42P01`) instead of silently scanning nothing.
+3. **One storage row encoder.** All reads/writes route through
+   `ferrosa-row-bridge`, so Postgres-written rows are byte-identical to CQL.
+4. **No `ferrosa-cql` dependency (D10).** Structural — enforced by the crate
+   graph.
+5. **Async storage, sync engine.** The scan is materialized up front
+   (`load_table` awaits the stream); the sync operators never `block_on` the
+   runtime.
+
+## Position in the dependency graph
+
+Depends on `ferrosa-common`, `ferrosa-row-bridge`, `ferrosa-schema`,
+`ferrosa-sql`, `ferrosa-sstable`, `ferrosa-storage`. Depended on by `ferrosa`
+(the main binary). See the [root crate index](../../specs/crates.md) for the full
+graph.

--- a/ferrosa-postgres/specs/roadmap.md
+++ b/ferrosa-postgres/specs/roadmap.md
@@ -1,0 +1,55 @@
+---
+crate: ferrosa-postgres
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-postgres — Roadmap
+
+Sourced from in-code fail-loud `0A000`/preview gaps, the FMEA
+([fmea.md](fmea.md)), and the dependency/usage review. There are no `TODO`/
+`FIXME` markers in the source — the open work is encoded as fail-loud
+`feature_not_supported` paths and documented lossy fallbacks instead.
+
+## Now (highest value)
+
+- **Accord-backed transaction atomicity** (FMEA PG-1). Accumulate a `T`-block's
+  writes and commit them through Accord at `COMMIT` (the seam in
+  `execute_simple` / blueprint D11), with real `ROLLBACK`. Until then, document
+  the preview limitation prominently so no client relies on isolation/rollback.
+- **`$N` parameters in DML** (FMEA PG-2). Extend the extended-protocol path so
+  `INSERT`/`UPDATE`/`DELETE` accept bound parameters (today literal-only,
+  `0A000`). Reuse `decode_param` + the existing `$N` inference.
+
+## Next
+
+- **`RETURNING` and `ON CONFLICT`** (FMEA PG-3) — the common ORM insert idioms.
+- **Multi-row `INSERT ... VALUES`** and richer `UPDATE`/`DELETE` `WHERE`
+  (range/non-key predicates), which today are restricted to single-row, full-PK
+  equality.
+- **Binary `numeric`** result/param encoding (FMEA PG-7), removing the
+  text-bytes fallback.
+- **TLS on the wire + real query cancellation** (FMEA PG-8) — handle
+  `SSLRequest` instead of declining; mint a real `BackendKeyData` cancel key.
+- **Harden the SCRAM unknown-role oracle** — run the exchange against a dummy
+  verifier so `UnknownRole` is not a user-enumeration signal (threat-model note
+  in `handshake.rs`).
+
+## Later
+
+- **CQL `Duration` + collections** (`List`/`Set`/`Map`/`Tuple`/`Udt`/`Vector`)
+  support (FMEA PG-4) — widen `ferrosa_sql::Value` and the
+  `cql_to_value`/`value_to_cql` bridges, or fail loud where queried instead of
+  reading NULL.
+- **Exact float/numeric text-format parity** with Postgres (FMEA PG-9).
+- **Real affected-row counts** for `UPDATE`/`DELETE` (FMEA PG-10) — read-before-
+  write so the count reflects matches rather than always reporting `1`.
+- **Session GUCs** (`SET`/`RESET`) and a broader scalar-function surface
+  (`now()`, etc.).
+- **More `pg_catalog`/`information_schema` coverage** as drivers/ORMs demand it.
+
+## Non-goals
+
+- Query planning / binding / relational operators — those live in `ferrosa-sql`.
+- The storage row encoding — that is `ferrosa-row-bridge` (shared with CQL, D10).
+- Cassandra wire compatibility — that is the CQL front-end (`ferrosa-cql`).

--- a/ferrosa-row-bridge/README.md
+++ b/ferrosa-row-bridge/README.md
@@ -1,0 +1,82 @@
+# ferrosa-row-bridge
+
+> The single canonical CQL row codec + `Partition`→row decomposition, shared
+> byte-for-byte by both query front-ends (`ferrosa-cql` and `ferrosa-postgres`).
+
+## What this crate is
+
+A small, dependency-light crate that owns the **storage-row encode/decode** and
+the **`Partition` → result-row decomposition** that the CQL and Postgres
+front-ends *must* agree on exactly. The logic originally lived inside
+`ferrosa-cql`; it was extracted here (decision **D10**) so `ferrosa-postgres`
+can reuse the *identical* encoder/decoder **without** depending on the ~54k-LOC
+`ferrosa-cql` crate. Duplicating this logic would risk silently-divergent row
+ordering — the top FMEA risk for the SQL front-end — so it lives here once.
+
+## What's implemented
+
+- **CQL wire codec** — `encode_value` / `decode_value` for the scalar CQL types
+  (int family, text/ascii, bool, float/double, uuid/timeuuid, blob, timestamp,
+  date, time, inet, decimal, varint).
+- **CQL type-name parser** — `parse_cql_type` / `parse_cql_type_in_keyspace`.
+- **Write-direction row assembly** — `build_decorated_key` (single + composite
+  partition keys), `build_row`, `build_delete_row`, `encode_clustering`.
+- **Read-direction decomposition** — `partition_to_rows`,
+  `partition_to_rows_with_storage_mapping`, `partition_to_rows_with_clustering`,
+  `write_partition_raw_rows_with_storage_mapping`, plus `decode_pk` /
+  `decode_clustering` and the liveness helpers `cell_is_live` / `ldt_is_expired`.
+- **`RowBridgeError`** — a minimal stand-in error; `ferrosa-cql` provides
+  `From<RowBridgeError> for CqlError` at its re-export boundary.
+
+## How it works
+
+Two modules:
+
+- **`codec`** (`src/codec.rs`) — value ↔ CQL wire bytes + the type-name parser.
+- **`row`** (`src/row.rs`) — partition/clustering key decoders, the read-path
+  decomposition (tombstone/TTL skipping, storage-order → table-order mapping),
+  and the write-path row builders.
+
+`ferrosa-cql` re-exports these at their original public paths
+(`ferrosa_cql::types::{encode_value, decode_value}`,
+`ferrosa_cql::bridge::{build_decorated_key, build_row, …}`), so its internal
+callers are unaffected. `ferrosa-postgres` calls them directly.
+
+## Public API (key entry points)
+
+| Area | Functions |
+|------|-----------|
+| Codec | `encode_value`, `decode_value`, `parse_cql_type`, `parse_cql_type_in_keyspace` |
+| Write rows | `build_decorated_key`, `build_row`, `build_delete_row`, `encode_clustering` |
+| Read rows | `partition_to_rows[_with_storage_mapping|_with_clustering]`, `decode_pk`, `decode_clustering` |
+| Liveness | `cell_is_live`, `ldt_is_expired` |
+| Error | `RowBridgeError` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — `CqlValue`, `CqlType`, `DecoratedKey`, `PartitionKey`,
+  `CellValue` (the shared type model it encodes/decodes).
+- **`ferrosa-sstable`** — `Partition`, `Row`, `LivenessInfo`, `DeletionTime` (the
+  storage row shapes it builds and decomposes).
+- **`ferrosa-schema`** — keyspace/type resolution for `parse_cql_type_in_keyspace`.
+
+External: `num-bigint`, `uuid`, `tracing`. **Never** depends on `ferrosa-cql`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa-cql`** — re-exports the codec + decomposition at their original paths.
+- **`ferrosa-postgres`** — reuses the exact write/read codec for its DML + reads.
+
+## Tests
+
+The canonical codec/row unit tests currently live in `ferrosa-cql`'s `bridge`
+module (they were not moved with the functions). In-crate test coverage is a
+tracked gap — see [specs/fmea.md](specs/fmea.md) and [specs/roadmap.md](specs/roadmap.md).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, data flow
+- [FMEA / known issues](specs/fmea.md) — failure modes + gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-row-bridge/specs/fmea.md
+++ b/ferrosa-row-bridge/specs/fmea.md
@@ -1,0 +1,34 @@
+---
+crate: ferrosa-row-bridge
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-row-bridge — FMEA / Known Issues
+
+Failure modes are ranked by **RPN = Severity × Occurrence × Detection** (1–10
+each; higher = worse). This crate is small but on the critical data path, so
+severities are high.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| RB-1 | Encoder divergence — a front-end encodes a row differently than the shared codec | Rows written by one front-end read back wrong/invisible via the other (silent corruption) | 10 | 2 | 6 | 120 | **Structural**: both front-ends call this crate; no second encoder exists (D10). Reinforced by the Postgres differential oracle (PG write → CQL read agree). |
+| RB-2 | Cells emitted out of storage-column-index order | SSTable reader misreads cells → parse drift → row data loss | 10 | 1 | 7 | 70 | `build_row` sorts cells by index before returning; documented invariant. |
+| RB-3 | NULL written as a live empty cell instead of a tombstone | Reads return `""`/`0` instead of NULL | 7 | 2 | 4 | 56 | `build_row`/`build_delete_row` emit tombstones for `Null`; covered by the PG NULL differential case. |
+| RB-4 | In-crate test coverage gap — canonical codec/row tests live in `ferrosa-cql`, not here | A change to this crate can pass `cargo test -p ferrosa-row-bridge` while breaking the real encoding | 8 | 4 | 7 | 224 | **Open gap.** Move/duplicate the codec + row builder unit tests into this crate. See roadmap. |
+| RB-5 | Composite partition-key encoding mismatch vs the engine's key format | Wrong partition routing / unreadable keys | 9 | 1 | 6 | 54 | `build_decorated_key` uses the documented `[2-byte len][bytes][0x00]` composite format; exercised by CQL + PG round-trips. |
+| RB-6 | Lossy/unsupported CQL types decoded as NULL silently | Data appears as NULL rather than erroring | 5 | 3 | 5 | 75 | Documented known gap (Duration, collections, UDT, tuple, vector decode to NULL in some paths). Track which types are in scope per front-end. |
+
+## Top risks to act on
+
+1. **RB-4 (RPN 224)** — the highest risk is *test placement*: this crate's own
+   test suite does not exercise its core functions, so its green build is not a
+   real safety signal. Move the bridge codec/row unit tests in-crate.
+2. **RB-1 (RPN 120)** — encoder divergence is severe but well-mitigated
+   structurally + by the differential oracle; keep the "no second encoder" rule.
+
+## Detection assets
+
+- Postgres differential oracle (`ferrosa-postgres/tests/differential_oracle.rs`)
+  — PG-written rows must read identically over CQL.
+- `ferrosa-cql` bridge unit tests (build_decorated_key/build_row/encode_clustering).

--- a/ferrosa-row-bridge/specs/overview.md
+++ b/ferrosa-row-bridge/specs/overview.md
@@ -1,0 +1,66 @@
+---
+crate: ferrosa-row-bridge
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The canonical CQL row codec and Partition→row decomposition, extracted from
+  ferrosa-cql (decision D10) so the CQL and Postgres front-ends share one
+  byte-identical encoder/decoder. A divergent copy is the top SQL-front-end FMEA
+  risk, so this logic lives here exactly once.
+---
+
+# ferrosa-row-bridge — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-row-bridge` is the **single source of truth** for translating between
+the in-memory CQL value model and the on-disk/wire storage-row representation.
+Its boundary is deliberately narrow: it knows about `CqlValue`/`CqlType`
+(`ferrosa-common`) and the SSTable `Partition`/`Row` shapes (`ferrosa-sstable`),
+and nothing about either front-end's protocol framing, planning, or transport.
+
+It exists because **two** front-ends (`ferrosa-cql`, `ferrosa-postgres`) must
+produce and consume *byte-identical* storage rows. Decision **D10**: extract the
+shared logic into a leaf-ish crate that `ferrosa-postgres` can depend on without
+pulling in the large `ferrosa-cql` crate.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `codec` (`src/codec.rs`, ~690 LoC) | `encode_value`/`decode_value` (CQL wire bytes), `parse_cql_type[_in_keyspace]` |
+| `row` (`src/row.rs`, ~489 LoC) | partition/clustering key decode, `Partition`→row decomposition, write-path row builders |
+| `lib` (`src/lib.rs`) | `RowBridgeError`, public re-exports |
+
+## Data flow
+
+**Write path** (front-end → storage): a parsed value → `encode_value` → cell
+bytes; partition-key values → `build_decorated_key` (single bare; composite
+length-prefixed `[2-byte len][bytes][0x00]`); regular cells + clustering →
+`build_row` / `build_delete_row`. The result is a storage `Row` the engine
+persists. `ferrosa-cql` and `ferrosa-postgres` call the *same* functions, so a
+row written via Postgres decodes identically over CQL.
+
+**Read path** (storage → front-end): a storage `Partition` →
+`partition_to_rows_with_storage_mapping` → `Vec<Vec<Option<CqlValue>>>`,
+applying tombstone + TTL-expiry skipping and the storage-column-order →
+table-column-order mapping. Variants pair rows with raw clustering bytes (for
+paging cursors) or emit raw byte slices.
+
+## Key invariants
+
+1. **Byte-identical encoding across front-ends.** `encode_value` and the row
+   builders must be the only encoder; both front-ends route through them.
+2. **Cells sorted by storage column index.** `build_row` sorts cells by index —
+   the SSTable reader reads them in index order, so out-of-order cells corrupt
+   reads (100% data loss for that row). Enforced in `build_row`.
+3. **NULL is a tombstone, not an empty cell.** An explicit `Null` value emits a
+   cell tombstone so reads return NULL, not `""`/`0`.
+4. **No dependency on `ferrosa-cql`.** Enforced structurally (it would create a
+   cycle: `ferrosa-cql` → `ferrosa-row-bridge`).
+
+## Position in the dependency graph
+
+Leaf-adjacent: depends only on `ferrosa-common`, `ferrosa-sstable`,
+`ferrosa-schema`. Depended on by `ferrosa-cql` and `ferrosa-postgres`. See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-row-bridge/specs/roadmap.md
+++ b/ferrosa-row-bridge/specs/roadmap.md
@@ -1,0 +1,40 @@
+---
+crate: ferrosa-row-bridge
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-row-bridge — Roadmap
+
+Sourced from in-code TODOs, the FMEA gaps ([fmea.md](fmea.md)), and the
+dependency/usage review.
+
+## Now (highest value)
+
+- **Move the codec + row-builder unit tests in-crate** (FMEA RB-4). Today the
+  canonical tests live in `ferrosa-cql`'s `bridge` module, so
+  `cargo test -p ferrosa-row-bridge` does not exercise this crate's core. Bring
+  `build_decorated_key` / `build_row` / `build_delete_row` / `encode_clustering`
+  / `encode_value` / `decode_value` round-trip tests here.
+
+## Next
+
+- **Enumerate the supported-type matrix per front-end.** Make explicit which CQL
+  types `encode_value`/`decode_value` round-trip vs. which decode to NULL
+  (Duration, collections, UDT, tuple, vector). Surface unsupported types as
+  fail-loud where a front-end requires them, rather than silent NULL.
+- **De-duplicate `ferrosa-cql`'s remaining metadata decomposition variants** that
+  still live in `ferrosa-cql` but reuse this crate's liveness helpers — fold them
+  here so all row decomposition has one home.
+
+## Later
+
+- **Property-test the round-trip** (`decode(encode(v)) == v`) across the scalar
+  type space as a regression net independent of the front-ends.
+- **Collections / UDT / tuple / vector** encode+decode support, once a consuming
+  front-end needs them over the shared path.
+
+## Non-goals
+
+- Protocol framing, query planning, or transport — those belong to the front-ends
+  (`ferrosa-cql` / `ferrosa-postgres`), not here.

--- a/ferrosa-schema/README.md
+++ b/ferrosa-schema/README.md
@@ -1,0 +1,110 @@
+# ferrosa-schema
+
+> The authority for schema state: keyspaces, tables, columns, roles, grants,
+> indexes, UDTs/UDFs/UDAs, the system keyspaces, the audit pipeline, and
+> startup security validation. Every mutation is auth-checked (ADR-006) and
+> emits an audit event (ADR-008).
+
+## What this crate is
+
+`ferrosa-schema` owns the in-memory **schema registry** — the single
+point-in-time view of all DDL and RBAC state in a Ferrosa node. The central
+type is [`Schema`](src/registry.rs): it holds an immutable
+[`SchemaSnapshot`](src/registry.rs) behind an `ArcSwap` so reads are lock-free,
+and serialises mutations behind a `write_lock` (clone → mutate → swap → bump
+version → emit audit). It is consumed by nearly every other crate in the
+workspace (CQL/Postgres/Flight front-ends, the cluster Raft state machine, the
+graph engine, `ferrosa-ctl`, storage).
+
+This crate is **policy + metadata**, not storage. It decides *whether* a DDL or
+auth operation is allowed and what the resulting schema state is; the durable
+SSTable rows for `system_schema.*` / `system_auth.*` are written by
+`ferrosa-storage` from the column-index contract this crate publishes in
+`system::persistence`.
+
+## What's implemented
+
+- **Metadata model** ([`metadata/`](src/metadata)) — `KeyspaceMetadata`,
+  `TableMetadata` (with `TableParams`, `TableFlag`, `CachingParams`, graph
+  `extensions`, `is_system`), `ColumnMetadata` (`ColumnKind`,
+  `ClusteringOrder`, `ColumnMask` for dynamic data masking), `IndexMetadata`,
+  `UserTypeMetadata`, `UserFunctionMetadata`, `UserAggregateMetadata`.
+- **Schema registry** ([`registry.rs`](src/registry.rs), ~3.9k LoC) — the
+  `Schema` type with auth-checked CRUD (`create_keyspace`, `create_table`,
+  `alter_table`, `drop_*`, `create_index`, `create_role`, `create_role_hashed`,
+  `alter_role`, `grant`/`revoke`, `grant_role`/`revoke_role`, UDT/UDF/UDA ops)
+  **plus** `*_internal` variants that bypass auth/audit for Raft/pair-mode
+  replication. `apply_snapshot` bulk-loads a snapshot (skips system keyspaces).
+- **Auth / RBAC** ([`auth/`](src/auth)) — `AuthContext`, `RoleMetadata`,
+  Cassandra-style `Permission` (9 variants) and `Resource` hierarchy
+  (`AllKeyspaces > Keyspace > Table`, `AllRoles > Role`),
+  recursive `check_permission` with superuser bypass + role-hierarchy
+  inheritance + cycle-safe traversal. Password hashing (`bcrypt` cost-12 default
+  or `argon2id`) with auto-rehash on login, `PasswordPolicy` (incl.
+  `iso27001()`), per-username `AuthRateLimiter`, and SCRAM-SHA-256 verifier
+  derivation (`scram`, decision D4) for Postgres login.
+- **System keyspaces** ([`system/`](src/system)) — query builders for
+  `system.local`, `system.peers(_v2)`, `system_schema.{keyspaces,tables,columns,
+  aggregates}`, `system_auth.*`, plus `persistence.rs` (column-index contract +
+  `SystemTableMutation` bridging DDL to storage writes).
+- **Audit** ([`audit/`](src/audit)) — `AuditSink` trait, `LogAuditSink`,
+  `SystemTableAuditSink`, `CompositeSink` fan-out, `TestAuditSink`, and a typed
+  `AuditEventKind` enum.
+- **Virtual tables** ([`virtual_table.rs`](src/virtual_table.rs),
+  [`virtual_registry.rs`](src/virtual_registry.rs)) — `VirtualTable` trait for
+  live, code-backed observability tables; `VirtualTableRegistry` (lock-free,
+  `ArcSwap`).
+- **Validation & startup** ([`validation.rs`](src/validation.rs),
+  [`startup.rs`](src/startup.rs)) — identifier/PK validation;
+  `DeploymentMode` + `validate_production_requirements` security gate.
+- **Storage bridge** ([`convert.rs`](src/convert.rs)) — `cql_to_marshal_type`
+  and `TableMetadata → TableSchema` conversion for `ferrosa-common`.
+- **Secrets** ([`secrets/`](src/secrets)) — `SecretsProvider` trait +
+  `EnvSecretsProvider`.
+
+## Public API (key entry points)
+
+| Area | Types / functions |
+|------|-------------------|
+| Registry | `Schema`, `SchemaSnapshot`, `SchemaConfig`, `AuthMethod`, `is_system_keyspace` |
+| Metadata | `KeyspaceMetadata`, `TableMetadata`, `ColumnMetadata`, `IndexMetadata`, `UserTypeMetadata`, `UserFunctionMetadata`, `UserAggregateMetadata` |
+| Auth | `AuthContext`, `Permission`, `Resource`, `RoleMetadata`, `GrantEntry`, `check_permission`, `PasswordHasher`, `PasswordPolicy`, `AuthRateLimiter`, `ScramCredential` |
+| Audit | `AuditSink`, `AuditEvent`, `AuditEventKind`, `LogAuditSink`, `SystemTableAuditSink`, `CompositeSink` |
+| Virtual tables | `VirtualTable`, `VirtualTableRegistry`, `VirtualRow`, `RowPredicate` |
+| System | `query_local`, `query_peers`, `query_keyspaces/tables/columns`, `query_roles/role_members/role_permissions` |
+| Startup | `DeploymentMode`, `validate_production_requirements`, `ProductionViolation` |
+| Error | `SchemaError`, `Result` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — `CqlType`, `CellValue`, `DataType`, and
+  `schema::{TableSchema, ColumnDefinition}` (the conversion target in `convert`).
+- **`ferrosa-index`** — index type definitions used by `IndexMetadata`.
+- **`ferrosa-sstable`** — SSTable shapes referenced by system-table persistence.
+
+External: `arc-swap`, `bcrypt`, `argon2`, `pbkdf2`, `hmac`, `sha2`,
+`password-hash`, `uuid`, `serde`/`serde_json`, `indexmap`, `rand`, `tracing`.
+
+**Called by** (crates that depend on this):
+
+- `ferrosa`, `ferrosa-cluster`, `ferrosa-cql`, `ferrosa-ctl`, `ferrosa-flight`,
+  `ferrosa-graph`, `ferrosa-loadgen`, `ferrosa-postgres`, `ferrosa-row-bridge`,
+  `ferrosa-session`, `ferrosa-storage`, `ferrosa-view`.
+
+## Tests
+
+354 in-crate `#[test]` functions plus 19 integration tests
+(`tests/{auth_integration,integration,property_tests}.rs`). Coverage is strong
+for permission checks, password hashing, error display, and production
+validation. Live gaps are tracked in [specs/fmea.md](specs/fmea.md).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, position
+- [FMEA / known issues](specs/fmea.md) — failure modes + real gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later
+- [Data flow](specs/data-flow.md) — DDL apply + auth-check sequence
+</content>
+</invoke>

--- a/ferrosa-schema/specs/data-flow.md
+++ b/ferrosa-schema/specs/data-flow.md
@@ -1,0 +1,78 @@
+---
+crate: ferrosa-schema
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa-schema — Data Flow
+
+This documents the two flows that define the crate: an **auth-checked DDL apply**
+(`Schema::create_table`) and the **permission check** it depends on. Both run
+against the lock-free `ArcSwap<SchemaSnapshot>`.
+
+## DDL apply + auth check (CREATE TABLE)
+
+A front-end submits a parsed `TableMetadata` plus the caller's `AuthContext`.
+The registry authorises, validates, swaps a new snapshot atomically, and audits.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FE as Front-end (CQL / Postgres / Flight)
+    participant S as Schema (registry.rs)
+    participant P as auth::check_permission
+    participant Snap as ArcSwap&lt;SchemaSnapshot&gt;
+    participant V as validation + graph rules
+    participant A as AuditSink
+
+    FE->>S: create_table(table, auth)
+    S->>P: check_permission(auth, Create, Keyspace(ks))
+    alt superuser
+        P-->>S: Ok (bypass)
+    else non-superuser
+        P->>Snap: load() grants + roles
+        Note over P: walk grants, resource hierarchy,<br/>member_of chain (cycle-safe via visited set)
+        alt has matching grant
+            P-->>S: Ok
+        else no grant
+            P-->>S: Err(PermissionDenied)
+            S-->>FE: Err(PermissionDenied)
+        end
+    end
+
+    S->>S: reject if is_system_keyspace(ks)
+    S->>S: acquire write_lock (serialise writers)
+    S->>Snap: load() then deep-clone snapshot
+    S->>V: validate_table + validate_graph_extensions
+    alt invalid
+        V-->>S: Err(InvalidSchema)
+        S-->>FE: Err(InvalidSchema)
+    else valid
+        S->>S: insert (ks,table); version = Uuid::new_v4()
+        S->>Snap: store(Arc::new(new_snapshot))
+        Note over Snap: atomic swap — concurrent readers see<br/>old or new snapshot, never a partial state
+        S->>A: emit_audit_with_actor(TableCreated, auth)
+        S-->>FE: Ok
+    end
+```
+
+## How the replication path differs
+
+The Raft / pair-mode path does **not** re-run auth or audit. It calls
+`create_table_internal(table)` (or `apply_snapshot`), which clones, inserts
+idempotently, and stores — but skips steps 2–6 above and does **not** bump
+`version` (the Raft state machine calls `set_schema_version` separately so all
+nodes converge). It also does **not** register the table with the
+`StorageEngine`; the caller must do that (see FMEA SC-3).
+
+## Notes on concurrency
+
+- **Reads are lock-free.** `snapshot()` / `schema_ref()` load from `ArcSwap`
+  without taking `write_lock`; hot-path callers (routers, observers) never block
+  on a concurrent DDL.
+- **Writes are serialised.** `write_lock: Mutex&lt;()&gt;` guarantees only one
+  clone-mutate-swap runs at a time, so two concurrent `create_table` calls cannot
+  lose each other's change.
+- **Auth reads the same snapshot atom** the mutation will clone, so a permission
+  decision is consistent with the schema state it is gating.
+</content>

--- a/ferrosa-schema/specs/fmea.md
+++ b/ferrosa-schema/specs/fmea.md
@@ -1,0 +1,48 @@
+---
+crate: ferrosa-schema
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-schema — FMEA / Known Issues
+
+Failure modes are ranked by **RPN = Severity × Occurrence × Detection** (1–10
+each; higher = worse). This crate is the auth + DDL authority, so security
+failure modes dominate the high-RPN band. Rows reflect the **actual** code, not
+aspirations.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| SC-1 | Well-known default credentials shipped | Bootstrap superuser defaults to password `"cassandra"`; `auth::bootstrap` seeds `ferrosa_admin`/`ferrosa_user` with passwords equal to their names. An operator who never rotates them leaves a trivially-guessable superuser/admin. | 9 | 6 | 4 | 216 | Partial. Bootstrap flags the default superuser `must_change` and emits `SuperuserPasswordMustChange`; `validate_production_requirements` flags `DefaultSuperuserPassword`. But the seed *admin/app* roles are not covered by that check, and nothing *forces* rotation. |
+| SC-2 | Production TLS checks are stubs | `validate_production_requirements` has `CqlTlsNotConfigured` / `InternodeTlsNotConfigured` variants but the comment at `startup.rs:138` states the CQL/internode TLS checks are "stubs (added when those crates land)". Production mode passes TLS validation even with TLS fully disabled — a silent gap that contradicts fail-loud. | 8 | 5 | 7 | 280 | **Open gap.** The variants exist and `Display` works, but no code path ever pushes them. Wire the checks to real CQL/internode TLS config. |
+| SC-3 | `apply_snapshot` / `create_table_internal` skip StorageEngine registration | These mutators update the in-memory snapshot but the doc-comment notes the caller MUST separately call `engine.register_table()`. A caller that forgets leaves a table visible in schema but unservable by storage — silent divergence. | 7 | 3 | 6 | 126 | Documented in the method doc-comment; not enforced in code. Relies on caller discipline (cluster catch-up path). |
+| SC-4 | `HASHED PASSWORD` roles cannot use Postgres SCRAM | `create_role_hashed` / `alter_role` with `HASHED PASSWORD` store the hash verbatim and set `scram = None` (a bcrypt/argon2 hash can't derive a SCRAM verifier). Such roles silently fail Postgres SCRAM login until a plaintext reset. | 5 | 4 | 5 | 100 | Documented D4 gap in `registry.rs` / `scram.rs`. `alter_role` clears the stale verifier so it fails closed; CQL login still works. |
+| SC-5 | Concurrent role-grant cycle race | `grant_role_internal` checks `would_create_cycle` against current state only. Two independently-committed grants (`GRANT a TO b`, `GRANT b TO a`) could in principle form a cycle. | 6 | 2 | 5 | 60 | Mitigated: Raft applies entries serially, so the second grant sees the first edge already present and is rejected. `check_permission` is additionally cycle-safe via a `visited` set, so even a leaked cycle cannot hang traversal. |
+| SC-6 | Full-snapshot clone on every mutation | Each DDL/grant clones the entire `SchemaSnapshot` (all keyspaces, tables, roles, grants, indexes, types, functions, aggregates) under `write_lock`. On a very large schema this makes every write O(schema size). | 4 | 4 | 3 | 48 | Accepted trade-off for lock-free reads via `ArcSwap`. Reads (hot path) are unaffected. Revisit if schema cardinality grows large. |
+| SC-7 | Auto-rehash on login swallows failures silently | In `authenticate`, the hash-upgrade block uses `if let Ok(new_hash) = ...` and on error simply leaves the old hash; there is no log line when the rehash fails. | 3 | 3 | 6 | 54 | Login still succeeds with the old hash (fail-safe), but a persistently-failing rehash is invisible. Add a `tracing::warn!` on the error arm. |
+| SC-8 | Identifier validation is ASCII-only and length-capped at 48 | `validate_table`/`validate_keyspace` reject anything but `[A-Za-z0-9_]{1,48}`. Quoted/Unicode identifiers that Cassandra permits are rejected. | 3 | 3 | 2 | 18 | Intentional conservative subset; low risk, surfaces a clear `InvalidSchema` error (fail-loud). |
+
+## Top risks to act on
+
+1. **SC-2 (RPN 280)** — production TLS validation is a stub. The security gate
+   *looks* complete (the violation variants exist) but never fires, so a
+   `FERROSA_MODE=production` deployment with TLS off passes. This is the most
+   dangerous kind of gap: a safety check that silently no-ops. Wire it to real
+   config.
+2. **SC-1 (RPN 216)** — default/seed credentials. The superuser path is
+   partially mitigated (must-change flag + production check), but the seeded
+   `ferrosa_admin` / `ferrosa_user` roles ship with password == username and are
+   not covered by `validate_production_requirements`. Extend the production check
+   to flag unrotated seed roles, or generate random seed passwords in production.
+
+## Detection assets
+
+- `auth/permission.rs` tests — superuser bypass, direct/keyspace/role-hierarchy
+  grants, cycle-safety, deny-by-default.
+- `startup.rs` tests — production violations for default password, weak policy,
+  S3 HTTP, env secrets (but **not** TLS — see SC-2).
+- `auth/password.rs` + `scram.rs` tests — hash round-trip, rehash detection,
+  hash-format validation, SCRAM derivation.
+- 354 in-crate tests + 19 integration tests
+  (`tests/{auth_integration,integration,property_tests}.rs`).
+</content>

--- a/ferrosa-schema/specs/overview.md
+++ b/ferrosa-schema/specs/overview.md
@@ -1,0 +1,104 @@
+---
+crate: ferrosa-schema
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The authority for schema state in a Ferrosa node: keyspaces, tables, columns,
+  roles, grants, indexes, UDTs/UDFs/UDAs, the system keyspaces, the audit
+  pipeline, and startup security validation. The central Schema type holds an
+  immutable SchemaSnapshot behind an ArcSwap (lock-free reads) and serialises
+  mutations behind a write lock (clone-mutate-swap-bump-audit). Every
+  user-facing mutation is auth-checked (ADR-006) and emits an audit event
+  (ADR-008); *_internal variants bypass both for Raft/pair-mode replication.
+---
+
+# ferrosa-schema — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-schema` is the **policy and metadata authority** for a node. It answers
+two questions for every DDL/DML-gating operation:
+
+1. *Is this operation permitted?* — via `check_permission` over the RBAC grant
+   and role-hierarchy graph.
+2. *What is the resulting schema state?* — via an atomically-swapped
+   `SchemaSnapshot`.
+
+Its boundary stops at **durability**: this crate never writes SSTables. It
+publishes the column-index contract (`system::persistence`) and a
+`SystemTableMutation` type so that `ferrosa-storage` can persist
+`system_schema.*` / `system_auth.*` rows, and the cluster layer can replicate
+schema changes through Raft. The in-memory registry is the cache; the persisted
+rows are the source of truth on reboot.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `registry` (`src/registry.rs`, ~3.9k LoC) | `Schema`, `SchemaSnapshot`, `SchemaConfig`, `AuthMethod`; all auth-checked + `*_internal` CRUD; `apply_snapshot`; `would_create_cycle` |
+| `metadata/` | `KeyspaceMetadata`, `TableMetadata`/`TableParams`/`TableFlag`, `ColumnMetadata`/`ColumnKind`/`ColumnMask`, `IndexMetadata`, `UserTypeMetadata`, `UserFunctionMetadata`, `UserAggregateMetadata` |
+| `auth/` | `AuthContext`, `RoleMetadata`, `Permission`/`Resource`, recursive `check_permission`; `PasswordHasher` (bcrypt/argon2id), `PasswordPolicy`, `AuthRateLimiter`, `scram` (D4), `bootstrap` seed roles |
+| `audit/` | `AuditSink` trait + `LogAuditSink`/`SystemTableAuditSink`/`CompositeSink`/`TestAuditSink`; `AuditEvent`/`AuditEventKind` |
+| `system/` | Query builders for `system.local`, `system.peers(_v2)`, `system_schema.*`, `system_auth.*`; `persistence` column-index contract + `SystemTableMutation` |
+| `virtual_table` + `virtual_registry` | `VirtualTable` trait for code-backed observability tables; lock-free `VirtualTableRegistry` |
+| `validation` | Identifier / partition-key / replication validation for DDL |
+| `startup` | `DeploymentMode`, `validate_production_requirements`, `ProductionViolation` |
+| `convert` | `cql_to_marshal_type`, `TableMetadata → ferrosa_common::schema::TableSchema` |
+| `secrets` | `SecretsProvider` trait + `EnvSecretsProvider` |
+| `error` | `SchemaError` (`#[non_exhaustive]`), `Result` alias |
+
+## Data flow
+
+See [data-flow.md](data-flow.md) for the full sequence diagram. In brief:
+
+**Auth-checked DDL** (front-end → registry): a request carries an `AuthContext`
+→ `Schema::create_table` calls `check_permission(auth, Create, Keyspace(ks))`
+→ rejects system keyspaces → takes `write_lock` → clones the current snapshot →
+validates (`validate_table`, graph-extension rules) → inserts → bumps
+`version = Uuid::new_v4()` → `ArcSwap::store` → `emit_audit_with_actor`. Readers
+on other threads see either the old or new snapshot atomically; no read ever
+blocks.
+
+**Replication path** (Raft/pair-mode → registry): the leader-applied entry calls
+the matching `*_internal` method, which skips `check_permission` and audit and
+applies the change idempotently. `set_schema_version` is then called so all
+nodes converge on one `version` UUID. Note: `apply_snapshot` and
+`create_table_internal` do **not** register the table with the `StorageEngine` —
+the caller must do that separately.
+
+**Auth path** (login): `Schema::authenticate` checks the rate limiter *before*
+hashing (DoS guard), verifies the password against the role's `salted_hash`
+(with a decoy hash on miss to defeat timing side-channels), auto-rehashes if the
+configured algorithm differs, and returns an `AuthContext`.
+
+## Key invariants
+
+1. **Atomic snapshot swaps.** Every mutation clones the whole `SchemaSnapshot`,
+   mutates the clone, and `ArcSwap::store`s it under `write_lock`. Readers never
+   observe a partially-applied DDL.
+2. **Version bump per user mutation.** Auth-checked mutations set
+   `version = Uuid::new_v4()` so CQL clients (cqlsh) detect schema changes.
+   `*_internal` paths deliberately do **not** bump; the Raft state machine sets
+   the version explicitly via `set_schema_version` for cross-node convergence.
+3. **System keyspaces/tables are protected.** `is_system_keyspace` and
+   `TableMetadata::is_system` reject user DDL on `system`, `system_schema`,
+   `system_auth`, `system_observability`.
+4. **No SCRAM verifier without cleartext.** A bcrypt/argon2 hash cannot derive a
+   SCRAM verifier, so `HASHED PASSWORD` roles get `scram = None` (D4 gap — see
+   FMEA SC-4).
+5. **Role hierarchy is acyclic.** `would_create_cycle` rejects grants that would
+   form a cycle; `check_permission` is additionally cycle-safe via a `visited`
+   set.
+6. **Mutations are auth-checked + audited; replication is not.** Public methods
+   take `&AuthContext` and emit audit; `*_internal` methods are the only
+   un-audited mutators and exist solely for trusted replication.
+
+## Position in the dependency graph
+
+A mid-layer crate: depends only on `ferrosa-common`, `ferrosa-index`,
+`ferrosa-sstable`, and is depended on by 12 crates (`ferrosa`,
+`ferrosa-cluster`, `ferrosa-cql`, `ferrosa-ctl`, `ferrosa-flight`,
+`ferrosa-graph`, `ferrosa-loadgen`, `ferrosa-postgres`, `ferrosa-row-bridge`,
+`ferrosa-session`, `ferrosa-storage`, `ferrosa-view`). See the
+[root crate index](../../specs/crates.md) for the full graph.
+</content>

--- a/ferrosa-schema/specs/roadmap.md
+++ b/ferrosa-schema/specs/roadmap.md
@@ -1,0 +1,64 @@
+---
+crate: ferrosa-schema
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-schema — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), in-code doc-comments
+(D4 SCRAM, `apply_snapshot` registration caveat, the TLS-stub comment at
+`startup.rs:138`), and the dependency/usage review. No `TODO`/`FIXME` markers
+exist in the source — the gaps below come from code review, not grep.
+
+## Now (highest value)
+
+- **Wire the production TLS checks** (FMEA SC-2). `validate_production_requirements`
+  already owns `CqlTlsNotConfigured`, `CqlMutualTlsNotConfigured`,
+  `InternodeTlsNotConfigured`, `InternodeMutualTlsNotConfigured` and
+  `UnencryptedLocalStorage`, but none is ever pushed. Thread real CQL/internode
+  TLS config into `ProductionCheckConfig` so a `FERROSA_MODE=production` node
+  with TLS disabled actually fails the gate. This is a silent safety no-op today.
+
+- **Close the seed-credential gap** (FMEA SC-1). Extend
+  `validate_production_requirements` (or `auth::bootstrap`) to either generate
+  random passwords for `ferrosa_admin` / `ferrosa_user` in production, or flag
+  them as a `ProductionViolation` when they still equal the default. The
+  superuser path is half-covered; the seed roles are not covered at all.
+
+## Next
+
+- **Enforce StorageEngine registration after `apply_snapshot`** (FMEA SC-3).
+  Today the in-memory snapshot and the storage table set can silently diverge if
+  a caller forgets `engine.register_table()`. Either return the list of tables
+  that need registration, or surface a check/assertion so the divergence is
+  loud.
+
+- **Populate SCRAM verifiers for `HASHED PASSWORD` roles** (FMEA SC-4, D4).
+  Decide a policy: reject `HASHED PASSWORD` for roles that need Postgres login,
+  or document the plaintext-reset requirement at the DDL boundary so operators
+  aren't surprised by a silently-unauthenticatable Postgres role.
+
+- **Log auto-rehash failures** (FMEA SC-7). Add `tracing::warn!` to the error
+  arm of the login-time hash upgrade so a persistently-failing rehash is visible.
+
+## Later
+
+- **Bound the snapshot-clone cost** (FMEA SC-6). If schema cardinality grows
+  large, the per-mutation full clone becomes O(schema size). Consider a
+  copy-on-write structural-sharing layout (e.g. persistent maps) so writes only
+  clone touched sub-trees while keeping lock-free reads.
+
+- **Widen identifier validation** (FMEA SC-8) to match Cassandra's
+  quoted/Unicode identifier rules if a front-end needs them.
+
+## Non-goals
+
+- **Durability / SSTable writes** — this crate publishes the column-index
+  contract and `SystemTableMutation`; persisting rows belongs to
+  `ferrosa-storage`.
+- **Raft replication mechanics** — the `*_internal` mutators are the trusted
+  apply surface; the consensus and convergence logic lives in `ferrosa-cluster`.
+- **Wire-protocol framing / query planning** — those belong to the front-ends
+  (`ferrosa-cql`, `ferrosa-postgres`, `ferrosa-flight`).
+</content>

--- a/ferrosa-session/README.md
+++ b/ferrosa-session/README.md
@@ -1,0 +1,101 @@
+# ferrosa-session
+
+> The protocol-agnostic **engine-state bundle** (`SessionCore`) shared by every
+> Ferrosa query front-end, so a new front-end can reuse the neutral state without
+> depending on the ~54k-LOC `ferrosa-cql` crate.
+
+## What this crate is
+
+A tiny crate (one module, ~69 LoC) that owns a single struct, [`SessionCore`] —
+the neutral subset of the former `ferrosa-cql` `SharedState`: the storage engine,
+schema, node config, cluster-mode routing (`write_path` / `ddl_path` /
+`cluster_state`), UDF executor, HA mode controller, the Accord HLC, and the peer
+manager. It was carved out per blueprint decision **D10** so that
+`ferrosa-postgres` (and any future front-end) can share the *identical* engine
+state via composition, without pulling in `ferrosa-cql`'s protocol machinery.
+
+## Extraction status (honest, current state)
+
+**This is a partial extraction, in progress** — tracked on the board as "land
+ferrosa-session extraction as standalone soaked PR".
+
+- **Extracted here:** only the *neutral field bundle* — the `SessionCore` struct
+  plus the single method `accord_enabled()`. That is the entire crate.
+- **Still in `ferrosa-cql`:** all *behavior*. `SharedState` (which now wraps
+  `Arc<SessionCore>` and `Deref`s to it) still lives in `ferrosa-cql/src/router.rs`,
+  along with every request handler, the prepared-statement cache, the EVENT
+  broadcast channel, CQL metrics, full-scan / index-usage trackers, and the
+  client topology policy. None of the routing, write-path, or DDL *logic* moved —
+  only the field that *holds* those handles.
+- **No constructor:** there is no `SessionCore::new`. Every consumer builds the
+  struct with a literal (12+ call sites across `ferrosa`, `ferrosa-cql`,
+  `ferrosa-ctl`, and their tests). Field construction is therefore duplicated
+  rather than centralized — see [specs/fmea.md](specs/fmea.md).
+- **`accord_enabled()` has no in-tree callers yet.** It is documented as the
+  precondition the Postgres front-end will check (D11, explicit `BEGIN…COMMIT`
+  routed to Accord) but nothing calls it today.
+
+## Public API
+
+| Item | Kind | Notes |
+|------|------|-------|
+| `SessionCore` | struct (11 pub fields) | neutral engine state; built by literal at each call site |
+| `SessionCore::accord_enabled(&self) -> bool` | method | `peer_manager.is_some() && accord_clock.is_some()`; no callers yet |
+
+### `SessionCore` fields
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `engine` | `Arc<StorageEngine>` | local read/write path (memtable, SSTable, S3) |
+| `schema` | `Arc<Schema>` | keyspace/table/role metadata + authorization |
+| `node_config` | `Arc<NodeConfig>` | node identity, replication policy, cluster settings |
+| `cluster_state` | `Arc<ArcSwap<ClusterStateHolder>>` | Standalone / Pair / Cluster topology |
+| `write_path` | `Arc<ArcSwap<WritePath>>` | direct vs Accord-coordinated write routing |
+| `ddl_path` | `Arc<ArcSwap<DdlPath>>` | direct / pair / Raft DDL replication routing |
+| `udf_executor` | `Arc<UdfExecutor>` | WASM UDF execution |
+| `mode_controller` | `Arc<ModeController>` | pair-mode HA readiness |
+| `auth_warn` | `bool` | soak mode: log+allow permission failures instead of deny |
+| `peer_manager` | `Option<Arc<PeerManager>>` | Accord fan-out; `None` standalone/unit-test |
+| `accord_clock` | `Option<Arc<HybridLogicalClock>>` | monotone txn timestamps; `None` when no peer manager |
+
+The three `ArcSwap`-wrapped paths are hot-swappable so cluster-mode transitions
+(Standalone → Pair → Cluster) can re-point routing without rebuilding the struct.
+
+## How it's consumed
+
+`ferrosa-cql`'s `SharedState` holds an `Arc<SessionCore>` and implements
+`Deref<Target = SessionCore>`, so existing CQL handlers reach neutral fields
+(`self.engine`, `self.schema`, …) unchanged. CQL-specific state is composed
+*alongside* the core, not mixed into it.
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-cluster`** — `ClusterStateHolder`, `WritePath`, `DdlPath`, `ModeController`.
+- **`ferrosa-common`** — `accord::HybridLogicalClock`.
+- **`ferrosa-net`** — `peer::PeerManager`.
+- **`ferrosa-schema`** — `Schema`, `NodeConfig`.
+- **`ferrosa-storage`** — `StorageEngine`.
+- **`ferrosa-udf`** — `UdfExecutor`.
+
+External: `arc-swap`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa`** — builds the `SessionCore` literal in `main.rs` when wiring up the node.
+- **`ferrosa-cql`** — wraps it in `SharedState` and `Deref`s to it.
+- **`ferrosa-ctl`** — constructs it in integration tests.
+
+## Tests
+
+**Zero in-crate tests.** `ferrosa-session` has no `#[test]`/`mod tests` of its own —
+the struct is exercised only transitively through `ferrosa-cql` / `ferrosa` /
+`ferrosa-ctl` tests that construct it. This is a tracked gap; see
+[specs/fmea.md](specs/fmea.md) and [specs/roadmap.md](specs/roadmap.md).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — boundary, field map, data flow
+- [FMEA / known issues](specs/fmea.md) — extraction-completeness and coupling gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-session/specs/fmea.md
+++ b/ferrosa-session/specs/fmea.md
@@ -1,0 +1,38 @@
+---
+crate: ferrosa-session
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-session — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). The crate is tiny and data-only, so most risk is in *extraction
+completeness* and *coupling* rather than runtime logic.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| SE-1 | **No constructor** — `SessionCore` is built by literal at 12+ call sites (`ferrosa::main`, `ferrosa-cql` server/test_util/connection/subscribe/router, `ferrosa-ctl` + `ferrosa-cql` tests) | A new field, or a changed invariant (e.g. `accord_clock`↔`peer_manager`), must be fixed at every site; drift is easy and silent | 7 | 6 | 6 | 252 | **Open gap.** Add a `SessionCore::new(...)` / builder that centralizes construction and enforces invariants. See roadmap (Now). |
+| SE-2 | **Zero in-crate tests** — no `#[test]`/`mod tests` in `ferrosa-session` | A change here can pass `cargo test -p ferrosa-session` (which runs nothing) while breaking real wiring; green build is not a safety signal | 7 | 5 | 7 | 245 | **Open gap.** Add at least `accord_enabled()` truth-table tests + an invariant test once a constructor exists. |
+| SE-3 | **`accord_clock`↔`peer_manager` invariant unenforced** — doc says clock is `None` whenever peer manager is `None`, but nothing checks it; a literal could set clock without a peer manager | `accord_enabled()` is reliable, but downstream code assuming "clock present ⇒ peer manager present" could panic/misroute | 6 | 3 | 6 | 108 | Documented invariant only. A constructor (SE-1) would make it structural; until then it is convention. |
+| SE-4 | **Extraction incomplete — coupling stays in `ferrosa-cql`** | `SharedState`, all handlers, and the `Deref` bridge still live in `ferrosa-cql`; `ferrosa-postgres` cannot yet reuse anything beyond the field bundle, so the D10 goal is only partially realized | 5 | 5 | 3 | 75 | **Known, by design (in progress).** Tracked as "land ferrosa-session extraction as standalone soaked PR." Detectable: the crate is visibly thin. |
+| SE-5 | **`accord_enabled()` has no callers** — dead-on-arrival API | The method could rot or drift from the Postgres front-end's actual D11 check before anything exercises it | 4 | 4 | 5 | 80 | Documented as a forward-looking precondition for `ferrosa-postgres`. Add a test (SE-2) to pin its semantics now. |
+| SE-6 | **Wide dependency fan-in for a "neutral" crate** — depends on 6 ferrosa crates (cluster, common, net, schema, storage, udf) | Any breaking change in those crates' re-exported types (`WritePath`, `DdlPath`, `ClusterStateHolder`, `PeerManager`, …) ripples through `SessionCore` and every call site | 4 | 4 | 4 | 64 | Inherent to being the shared engine-state bundle. Bounded by keeping the struct field-only (no logic to break). |
+| SE-7 | **Scope creep — a CQL/PG-specific field added here** | Re-tangles the front-ends and defeats the D10 separation | 6 | 2 | 5 | 60 | Invariant #2 in [overview.md](overview.md): "would a second front-end need this with identical semantics?" Enforced by review only. |
+
+## Top risks to act on
+
+1. **SE-1 (RPN 252)** — the missing constructor is the highest-leverage gap:
+   12+ duplicated literals mean every future field or invariant change is a
+   multi-site edit with no compiler help on the invariant. Add `SessionCore::new`
+   (or a builder) and migrate the call sites.
+2. **SE-2 (RPN 245)** — the crate has no tests of its own, so its build is not a
+   real safety signal. Add `accord_enabled()` truth-table tests and (after SE-1)
+   a constructor-invariant test.
+
+## Detection assets
+
+- **None in-crate.** `SessionCore` is exercised only transitively by
+  `ferrosa-cql` / `ferrosa` / `ferrosa-ctl` integration and unit tests that
+  construct it. There is no `cargo test -p ferrosa-session` coverage today —
+  this is precisely SE-2.

--- a/ferrosa-session/specs/overview.md
+++ b/ferrosa-session/specs/overview.md
@@ -1,0 +1,96 @@
+---
+crate: ferrosa-session
+status: partial-extraction-in-progress
+last_updated: 2026-06-19
+executive_summary: >
+  The protocol-agnostic engine-state bundle (SessionCore) shared by Ferrosa query
+  front-ends, carved out of ferrosa-cql's SharedState per decision D10 so a new
+  front-end (ferrosa-postgres) can reuse the neutral state without depending on
+  the ~54k-LOC ferrosa-cql crate. Today the extraction covers only the field
+  bundle plus accord_enabled(); all request-handling behavior still lives in
+  ferrosa-cql, and the crate has no constructor and no in-crate tests.
+---
+
+# ferrosa-session — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-session` owns exactly one thing: `SessionCore`, the **neutral subset of
+engine state** that every query front-end needs regardless of wire protocol.
+Its boundary is deliberately data-only — it holds `Arc` handles to the storage
+engine, schema, cluster-mode routing, UDF executor, Accord clock and peer
+manager, and exposes one derived predicate (`accord_enabled`). It contains no
+request handling, no protocol framing, and no routing *logic* — only the handles
+that such logic dereferences.
+
+It exists because **more than one** front-end must share *identical* engine
+state. Decision **D10**: extract the neutral fields into a leaf-adjacent crate
+that `ferrosa-postgres` can depend on without pulling in `ferrosa-cql`'s protocol
+machinery (prepared-statement cache, EVENT channel, CQL metrics, trackers).
+
+## Extraction status
+
+This is an **in-progress extraction** (board item: "land ferrosa-session
+extraction as standalone soaked PR"). What has and has not moved:
+
+| Concern | Location today |
+|---------|----------------|
+| Neutral field bundle (`SessionCore`) | **extracted → `ferrosa-session`** |
+| `accord_enabled()` predicate | **extracted → `ferrosa-session`** (no callers yet) |
+| `SharedState` wrapper + `Deref` | still in `ferrosa-cql/src/router.rs` |
+| Request handlers / routing logic | still in `ferrosa-cql` |
+| Prepared-statement cache, EVENT channel, CQL metrics, trackers, topology policy | still in `ferrosa-cql` (intentionally CQL-specific) |
+| Construction of `SessionCore` | duplicated literal at 12+ call sites; no constructor here |
+
+## Module map
+
+| Module | LoC | Responsibility |
+|--------|-----|----------------|
+| `lib` (`src/lib.rs`) | ~69 | `SessionCore` struct (11 pub fields) + `accord_enabled()` |
+
+There is a single module. No submodule tree, no constructor, no tests.
+
+## Data flow
+
+`ferrosa-session` is passive — it is *held*, not *driven*. The lifecycle:
+
+1. A front-end host (`ferrosa::main`, or a `ferrosa-cql` test harness) builds a
+   `SessionCore` literal from already-constructed engine/schema/cluster handles.
+2. It wraps it: `Arc&lt;SessionCore&gt;` inside `ferrosa-cql`'s `SharedState`.
+3. `SharedState` `Deref`s to `SessionCore`, so request handlers reach
+   `self.engine`, `self.schema`, `self.write_path`, etc. transparently.
+4. On cluster-mode transitions, the host swaps `write_path` / `ddl_path` /
+   `cluster_state` via their `ArcSwap` wrappers — no rebuild of `SessionCore`.
+
+```mermaid
+flowchart TD
+    Host["ferrosa::main / test harness"] -->|builds literal| SC["SessionCore (Arc)"]
+    SC -->|wrapped + Deref| SS["ferrosa-cql SharedState"]
+    SS -->|handlers Deref to neutral fields| H["CQL request handlers"]
+    PG["ferrosa-postgres (future)"] -.->|will share| SC
+    SC --> ENG["Arc&lt;StorageEngine&gt;"]
+    SC --> SCH["Arc&lt;Schema&gt;"]
+    SC --> WP["Arc&lt;ArcSwap&lt;WritePath&gt;&gt;"]
+```
+
+## Key invariants
+
+1. **Acyclic dependency direction.** `ferrosa-cql` / `ferrosa-postgres` →
+   `ferrosa-session` → `ferrosa-cluster` / `ferrosa-storage` / `ferrosa-schema` /
+   `ferrosa-net` / `ferrosa-udf` / `ferrosa-common`. `ferrosa-session` must
+   **never** depend on a front-end crate (it would create a cycle).
+2. **Neutral-only.** No CQL- or Postgres-specific state may be added here. The
+   test is: "would a second front-end need this field with identical semantics?"
+   If not, it stays in the front-end.
+3. **`accord_clock` implies `peer_manager`.** `accord_clock` is `None` whenever
+   `peer_manager` is `None`; `accord_enabled()` checks both. This is a documented
+   invariant on the fields, **not currently enforced by a constructor or test.**
+4. **Hot-swappable routing.** `write_path` / `ddl_path` / `cluster_state` are
+   `ArcSwap`-wrapped so mode transitions re-point routing in place.
+
+## Position in the dependency graph
+
+Mid-graph, not a leaf: it sits *above* the engine/cluster/schema crates and
+*below* the front-ends. Depended on by `ferrosa`, `ferrosa-cql`, `ferrosa-ctl`
+(and, by design, the in-progress `ferrosa-postgres`). See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-session/specs/roadmap.md
+++ b/ferrosa-session/specs/roadmap.md
@@ -1,0 +1,54 @@
+---
+crate: ferrosa-session
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-session — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), the code review (one 69-LoC
+module, no constructor, no tests), and the board item "land ferrosa-session
+extraction as standalone soaked PR." There are no in-code TODO/FIXME markers in
+the crate.
+
+## Now (highest value)
+
+- **Add a `SessionCore::new` / builder** (FMEA SE-1). Replace the 12+ duplicated
+  struct literals in `ferrosa`, `ferrosa-cql`, and `ferrosa-ctl` with a single
+  constructor that takes the handles and **enforces the `accord_clock` ⇔
+  `peer_manager` invariant** (both `Some` together, or both `None`). This makes
+  the invariant structural instead of convention.
+- **Add in-crate tests** (FMEA SE-2 / SE-5). At minimum: an `accord_enabled()`
+  truth table over the four `(peer_manager, accord_clock)` combinations, and —
+  once the constructor exists — a test that the constructor rejects the illegal
+  "clock without peer manager" combination. Gives `cargo test -p ferrosa-session`
+  real meaning.
+
+## Next
+
+- **Finish the soaked extraction PR.** Land `ferrosa-session` as the standalone,
+  soaked PR it is tracked as, so the neutral state is a stable shared dependency
+  before `ferrosa-postgres` builds on it.
+- **Wire `accord_enabled()` into `ferrosa-postgres`** (FMEA SE-5). Have the
+  Postgres front-end's D11 transaction-routing check actually call it, so the
+  method stops being dead-on-arrival and its semantics are pinned by a real
+  consumer.
+
+## Later
+
+- **Evaluate moving the `Deref` bridge pattern into a shared trait.** If
+  `ferrosa-postgres` ends up duplicating `SharedState`'s `Deref<Target =
+  SessionCore>` shape, consider a small shared accessor trait so both front-ends
+  reach neutral fields uniformly (FMEA SE-4 follow-up). Only do this once a
+  second front-end actually exists and the shape is proven.
+- **Tighten the dependency fan-in** (FMEA SE-6). If a re-exported type from
+  `ferrosa-cluster` / `ferrosa-net` churns, consider whether `SessionCore` should
+  hold a narrower interface than the concrete type.
+
+## Non-goals
+
+- Request handling, protocol framing, query planning, prepared-statement caching,
+  EVENT channels, or metrics — those are front-end concerns and stay in
+  `ferrosa-cql` / `ferrosa-postgres`, never here (overview.md invariant #2).
+- Becoming a dumping ground for "shared-ish" state. A field belongs here only if
+  a second front-end needs it with identical semantics.

--- a/ferrosa-sim/README.md
+++ b/ferrosa-sim/README.md
@@ -1,47 +1,126 @@
 # ferrosa-sim
 
-Deterministic simulator + TLA+ refinement check for the Ferrosa Raft
-layer.  Sprint 5 (ADR-016, ADR-017).
+> Deterministic, single-threaded discrete-event simulator for the Ferrosa Raft
+> layer, plus a Rust-side TLA+ refinement check. A seed in, a checkable trace out.
+> Sprint 5 (ADR-016, ADR-017).
+
+## What this crate is
+
+A small, **dependency-free** testing crate — it depends on *no* other ferrosa
+crate (only `serde` + `tracing`). It models the *protocol-level* state of the
+Raft layer — terms, votes, roles, election timeouts, heartbeats, PreVote,
+joint-consensus membership — and a separate multi-DC Accord-apply bank workload,
+all under a seeded integer clock. The same seed always produces the same
+`Trace`, so a failing run is reproducible and its trace can be replayed against
+the TLA+ spec.
+
+It is an **in-house** simulator (decision **ADR-017**) rather than Madsim:
+`ferrosa-cluster` pulls in openraft 0.9 + sled + a custom network stack that
+would all need shimming, and Sprint 5's headline goal — a TLA+ refinement check
+— needs a *protocol-level* model, not a full process simulator. This crate
+models only the variables the spec at `specs/tla/raft.tla` cares about; the real
+`FerrosRaft` (sled, networking, schema replay) is exercised by the in-process
+harness in `ferrosa-cluster/tests/`, not here.
 
 ## Determinism contract
 
-Two `SimulatedCluster` runs constructed with the **same seed** and
-the **same voter count** produce **byte-identical traces**.  The
-contract holds because:
+Two `SimulatedCluster` runs constructed with the **same seed** and the **same
+voter count** produce **byte-identical traces**. The contract holds because:
 
-1. **No wall-clock reads.**  All time is `Tick`, an integer counter
-   advanced by the event loop.  No `std::time::Instant`, no
-   `tokio::time::Instant`.
-2. **Single-threaded event loop.**  No `tokio::spawn`, no scheduling
-   choice that depends on the OS scheduler.
-3. **Seeded RNG.**  `crate::rng::SeededRng` is a splitmix64
-   generator owned by the `SimulatedCluster`.  Election-timeout
-   randomization is the only source of non-determinism, and it
-   draws from this generator alone.
-4. **Stable event ordering.**  The event queue is a
-   `BinaryHeap<Scheduled>` keyed by `(deadline, monotonic seq)`.
-   Two events with the same deadline fire in insertion order — never
-   in pointer-address or hash order.
-5. **`BTreeMap`, never `HashMap`.**  All per-node state and peer
-   iteration uses ordered maps so that the spawn order of
-   `RequestVote`s broadcast to peers is independent of the build's
-   `RandomState` seed.
+1. **No wall-clock reads.** All time is `Tick`, an integer counter advanced by
+   the event loop. No `std::time::Instant`, no `tokio::time::Instant`.
+2. **Single-threaded event loop.** No `tokio::spawn`, no scheduling choice that
+   depends on the OS scheduler.
+3. **Seeded RNG.** `rng::SeededRng` is a splitmix64 generator owned by the
+   `SimulatedCluster`. Election-timeout randomization is the only source of
+   non-determinism, and it draws from this generator alone.
+4. **Stable event ordering.** The event queue is a `BinaryHeap&lt;Scheduled&gt;`
+   keyed by `(deadline, monotonic seq)`. Two events with the same deadline fire
+   in insertion order — never in pointer-address or hash order.
+5. **`BTreeMap`, never `HashMap`.** All per-node state and peer iteration uses
+   ordered maps so the broadcast order of `RequestVote`s is independent of the
+   build's `RandomState` seed.
 
-The W5.4 unit test `same_seed_produces_same_trace` pins the contract
-in CI.
+The W5.4 test `same_seed_produces_same_trace` pins the contract in CI.
 
-## Sprint 5 status
+## What's implemented
 
-See `specs/archive/project-plans/raft-correctness-sprints/sprint-05-progress.md` for per-WI status and
-the `specs/tla/raft.tla` spec the refinement check (W5.10) verifies
-the simulator against.
+- **Seeded PRNG** (`rng`) — a splitmix64; same seed = same stream, no global
+  state, no allocation.
+- **Protocol node + cluster** (`node`, `cluster`) — `SimulatedNode` (term, vote,
+  role, log length, commit index) and `SimulatedCluster`, an N-voter
+  discrete-event loop over `ElectionTimeout`, `RequestVote`/`Reply`,
+  `PreVoteRequest`/`Reply`, `Heartbeat` events. Drivers: `run_until_leader`,
+  `run_for`, `schedule_leader_heartbeat`.
+- **Nemeses** (`nemesis`) — `PartitionHalves`, `KillMinority`, `AddNode`
+  implementing an `apply`/`heal` trait, over the cluster mutators
+  (`partition_pair`, `kill`/`revive`, `add_voter`/`remove_voter`).
+- **PreVote** (`cluster::with_pre_vote`) — election timeouts run a
+  non-term-bumping PreVote round before real candidacy, suppressing term
+  inflation in a minority partition.
+- **Joint-consensus membership** (`propose_membership`/`commit_membership`/
+  `is_joint_quorum`) — a Cold+Cnew joint phase requiring a majority in *both* sets.
+- **Bootstrap-phase model** (`bootstrap`) — an 8-phase pre/post-condition
+  pipeline mirroring `ferrosa-cluster`'s `BootstrapPhase` enum, run against the
+  sim cluster.
+- **Trace + refinement** (`trace`, `refinement`, `spec`) — every transition is
+  recorded as a named `TlaAction`; `check_trace` replays it through a Rust
+  interpreter of the spec, and `spec::check_all` runs the snapshot safety
+  invariants (`ElectionSafety`, `LeaderAppendOnly`, `StateMachineSafety`, …).
+- **Multi-DC bank workload** (`multi_dc`) — a *separate* model: two DCs with
+  per-DC HLC-ordered reorder buffers + idempotent ledgers, a mocked Accord
+  coordinator, a `dc-partition` nemesis, optional learner replicas, and bank
+  balance-conservation / convergence invariants. This is the module
+  `ferrosa-jepsen` consumes.
+
+## Public API (key entry points)
+
+| Area | Items |
+|------|-------|
+| RNG | `SeededRng::{new, next_u64, gen_range}` |
+| Node | `SimulatedNode`, `NodeId`, `Role` |
+| Cluster | `SimulatedCluster::{with_voters, with_pre_vote, run_until_leader, run_for, leader, deployment_mode, partition_pair, kill, revive, add_voter, propose_membership, commit_membership, is_joint_quorum, trace}` |
+| Nemesis | `Nemesis` trait, `PartitionHalves`, `KillMinority`, `AddNode` |
+| Bootstrap | `BootstrapPhase`, `BootstrapState`, `run_phase`, `run_full_bootstrap` |
+| Trace | `Trace`, `TraceEntry`, `TlaAction` |
+| Refinement | `check_trace`, `check_step`, `AbstractState`, `RefinementError` |
+| Invariants | `spec::{election_safety, leader_append_only, state_machine_safety, check_all, InvariantResult}` |
+| Multi-DC | `DualDcBankSim`, `DcApplyState`, `AccordCoord`, `Transfer`, `AccordEntry` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on): **none.** This crate deliberately
+depends on *no* other ferrosa crate — the whole point of ADR-017's in-house
+choice. Where it needs a shape from `ferrosa-cluster` (e.g. `DeploymentMode`, the
+bootstrap phases, the multi-DC apply types) it **mirrors** the enum/struct by
+hand and keeps it in lock-step manually. External deps: `serde` (trace
+serialization), `tracing`, and `proptest` (dev-only).
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa-jepsen`** — `ferrosa-jepsen/src/endurance_sim.rs` consumes
+  `ferrosa_sim::multi_dc::DualDcBankSim` for its endurance workload.
+
+## Tests
+
+39 in-crate `#[test]`s across the modules, plus seed-sweep loops
+(`refinement_holds_across_1000_seeds`, `sim_full_bootstrap_seed_sweep`,
+multi-DC long-horizon / endurance). No legitimately ignored tests. The
+`seed_throughput` example (`cargo run --release --example seed_throughput -p
+ferrosa-sim -- <n>`) reports seeds/min. The `spec`/`refinement` tests assert the
+external files `specs/tla/raft.tla` and `.github/workflows/nightly-sim.yml`
+exist — so removing either breaks `cargo test`.
 
 ## Why not Madsim?
 
-ADR-017 grants the implementer authority to fall back from Madsim if
-integration friction is too high.  Sprint 5 elects the in-house
-fallback up-front: the headline goal of Sprint 5 is the **TLA+
-refinement check**, which requires a *protocol-level* simulator, not
-a full process simulator over openraft + sled.  Madsim adoption
-remains an option for a future sprint if in-process integration
-tests in `ferrosa-cluster/tests/` grow hard-to-reproduce flakes.
+ADR-017 grants the implementer authority to fall back from Madsim if integration
+friction is too high. Sprint 5 elects the in-house fallback up-front: the
+headline goal is the TLA+ refinement check, which requires a protocol-level
+simulator, not a full process simulator over openraft + sled. Madsim adoption
+remains an option for a future sprint if the in-process integration tests in
+`ferrosa-cluster/tests/` grow hard-to-reproduce flakes.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, the event loop, invariants, what's modelled vs. not
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-sim/specs/overview.md
+++ b/ferrosa-sim/specs/overview.md
@@ -1,0 +1,115 @@
+---
+crate: ferrosa-sim
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  Deterministic, single-threaded discrete-event simulator for the Ferrosa Raft
+  layer plus a Rust-side TLA+ refinement check (Sprint 5, ADR-017). Models
+  protocol-level Raft (terms, votes, roles, PreVote, joint-consensus membership)
+  and a separate multi-DC Accord-apply bank workload, all reproducible from a
+  single u64 seed. Depends on no other ferrosa crate by design; consumed by
+  ferrosa-jepsen for its endurance workload.
+---
+
+# ferrosa-sim — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-sim` is a **testing/simulation** crate. Its job is to make Raft-layer
+behaviour *reproducible* and *checkable*: a single `u64` seed drives a
+deterministic event loop, every transition is recorded as a named `TlaAction`,
+and the resulting `Trace` is replayed against a Rust interpretation of the TLA+
+spec at `specs/tla/raft.tla`.
+
+Its boundary is deliberately narrow and **self-contained**: it depends on no
+other ferrosa crate (decision **ADR-017**). It models only the *protocol-level*
+variables the spec cares about — term, vote, role, log length, commit index,
+membership — and **mirrors** any shape it needs from `ferrosa-cluster`
+(`DeploymentMode`, the bootstrap phases, the multi-DC apply types) by hand,
+keeping the copies in lock-step manually. The full `FerrosRaft` (sled,
+networking, schema replay) is *not* run here; that belongs to the in-process
+harness in `ferrosa-cluster/tests/`.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `rng` (`src/rng.rs`) | `SeededRng` — splitmix64, the only source of randomness; no global state |
+| `node` (`src/node.rs`) | `SimulatedNode`, `NodeId`, `Role` — one Raft participant's protocol state |
+| `cluster` (`src/cluster.rs`) | `SimulatedCluster` — the N-voter discrete-event loop, election/vote/heartbeat/PreVote handling, nemesis mutators, joint-consensus membership |
+| `nemesis` (`src/nemesis.rs`) | `Nemesis` trait + `PartitionHalves`, `KillMinority`, `AddNode` |
+| `bootstrap` (`src/bootstrap.rs`) | 8-phase `BootstrapPhase` pre/post-condition pipeline mirroring `ferrosa-cluster` |
+| `trace` (`src/trace.rs`) | `Trace`, `TraceEntry`, `TlaAction` — the append-only action log |
+| `refinement` (`src/refinement.rs`) | `check_trace`/`check_step` — Rust interpreter of the spec's transitions |
+| `spec` (`src/spec.rs`) | snapshot safety invariants (`ElectionSafety`, `LeaderAppendOnly`, …); pins the spec + workflow file paths |
+| `multi_dc` (`src/multi_dc.rs`) | `DualDcBankSim` — a *separate* cross-DC Accord-apply bank model (the part ferrosa-jepsen consumes) |
+| `deployment` (`src/deployment.rs`) | `DeploymentMode` mirror of `ferrosa-cluster::mode::DeploymentMode` |
+
+## The event loop
+
+`SimulatedCluster::with_voters(n, seed)` builds an `n`-voter cluster, each voter
+armed with a randomized election deadline drawn from the seeded RNG. Progress
+comes from the drivers `run_until_leader(deadline)` and `run_for(duration)`,
+which repeatedly call `step()`:
+
+```mermaid
+flowchart TD
+    A[with_voters n, seed] --> B[BinaryHeap of Scheduled events]
+    B --> C{step: pop earliest deadline, seq}
+    C -->|queue empty| Z[steady state]
+    C -->|event_dropped?| C
+    C --> D{dispatch by Event}
+    D -->|ElectionTimeout| E[start candidacy / PreVote]
+    D -->|RequestVote| F[grant or reject, maybe step down]
+    D -->|RequestVoteReply| G{majority?}
+    D -->|Heartbeat| H[reset election timer]
+    E --> B
+    F --> B
+    G -->|yes| I[become_leader, broadcast heartbeat]
+    G -->|no| C
+    H --> C
+    I --> J[push TlaAction to Trace]
+    F --> J
+    E --> J
+    J --> C
+```
+
+Each dispatched transition pushes a `TlaAction` onto the `Trace`. The
+`refinement` module replays that trace; `spec` checks the live cluster snapshot.
+
+The `multi_dc::DualDcBankSim` is a separate model that does **not** use this
+event loop — it drives a mocked Accord coordinator and per-DC HLC-ordered apply
+buffers directly, exercising cross-DC apply ordering, idempotence, and balance
+conservation under a `dc-partition` nemesis.
+
+## Key invariants
+
+1. **Determinism: same seed = same `Trace`.** Integer-only clock, single thread,
+   seeded splitmix64, `(deadline, seq)`-keyed event queue, `BTreeMap`/`BTreeSet`
+   everywhere — never `HashMap`. Pinned by `same_seed_produces_same_trace`.
+2. **Refinement: every simulated transition is a legal TLA+ step.** `check_trace`
+   rejects term regressions and two-leaders-at-the-same-term (Election Safety);
+   verified across a 1000-seed sweep (`refinement_holds_across_1000_seeds`).
+3. **Bank conservation (multi-DC).** Each DC — and each learner replica — totals
+   `n_accounts × initial` at every step, holding through partition + heal, with
+   idempotent replay never double-spending.
+4. **No dependency on any ferrosa crate.** Structural; mirrored shapes are kept
+   in lock-step by hand (a tracked drift risk — see roadmap).
+
+## What is modelled vs. not
+
+**Modelled:** leader election, term/vote bookkeeping, PreVote, heartbeats,
+crash/partition/add-node nemeses, joint-consensus membership change, the 8-phase
+bootstrap pipeline, and cross-DC Accord apply ordering/idempotence.
+
+**Not modelled (yet):** AppendEntries *log replication* (the cluster carries
+`log_len` as a counter, not a `Vec<LogEntry>`), snapshots/InstallSnapshot, and
+Apalache-driven model checking (the refinement check is a Rust re-implementation
+of the spec; `specs/tla/raft.tla` is the canonical artifact but is not run under
+Apalache in CI).
+
+## Position in the dependency graph
+
+A leaf: depends on no ferrosa crate (only `serde`, `tracing`, dev-only
+`proptest`). Depended on by `ferrosa-jepsen`. See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-sim/specs/roadmap.md
+++ b/ferrosa-sim/specs/roadmap.md
@@ -1,0 +1,56 @@
+---
+crate: ferrosa-sim
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-sim — Roadmap
+
+Sourced from the in-code module docs (each carries its Sprint 5/7/8 work-item
+provenance), the dependency/usage review, and the "what is modelled vs. not"
+section of [overview.md](overview.md). There are no `TODO`/`FIXME` markers in the
+source.
+
+## Now (highest value)
+
+- **Close the mirror-drift gap.** `deployment::DeploymentMode`,
+  `bootstrap::BootstrapPhase`, and `multi_dc`'s apply types are hand-copies of
+  `ferrosa-cluster` shapes kept in lock-step *manually*. Nothing fails loudly if
+  the originals change. Add a compile-time or test-time assertion that pins each
+  mirror to its source (e.g. a `ferrosa-cluster` test that imports the sim enum,
+  or a shared definition lifted into `ferrosa-common` — the `deployment` module
+  doc already floats this).
+
+## Next
+
+- **Model AppendEntries log replication.** Today `SimulatedNode::log_len` is a
+  counter and `commit_index` is never advanced by the loop, so `LogMatching`,
+  `LeaderCompleteness`, and the non-degenerate `StateMachineSafety` /
+  `LeaderAppendOnly` invariants can only be checked in snapshot/degenerate form.
+  Extend the cluster to a real `Vec<LogEntry>` so the spec's replication
+  invariants get exercised end-to-end.
+- **Wire the Apalache path.** The refinement check is currently a Rust
+  re-implementation of `specs/tla/raft.tla`. Add the optional
+  `apalache-mc check --simulate` export (the `refinement` module doc describes
+  the intended `apalache.json` hand-off) so the canonical model checker and the
+  Rust interpreter are cross-validated.
+
+## Later
+
+- **Expand the nemesis catalogue.** ADR-017 lists 19 nemeses; three are
+  implemented (`PartitionHalves`, `KillMinority`, `AddNode`). Add the rest
+  (clock skew, message duplication/delay, asymmetric partitions) as the Raft
+  model grows.
+- **Drive nemeses from the event loop.** The `Nemesis` trait is applied manually
+  between `run_for` calls in tests; a scheduled nemesis injector keyed off the
+  seed would let the nightly sweep explore fault timing automatically.
+- **Property-test the determinism contract** with `proptest` (already a
+  dev-dependency) over random seeds and voter counts, beyond the current
+  hand-picked `same_seed`/`different_seed` cases.
+
+## Non-goals
+
+- Running the real `FerrosRaft` (sled, networking, schema replay) — that is the
+  job of the in-process harness in `ferrosa-cluster/tests/`, not this crate.
+- Depending on any other ferrosa crate — ADR-017's in-house choice is load-bearing;
+  the mirror-drift work above is the price of keeping this boundary.

--- a/ferrosa-sparql/README.md
+++ b/ferrosa-sparql/README.md
@@ -1,0 +1,111 @@
+# ferrosa-sparql
+
+> SPARQL 1.1 Query + Update endpoint for ferrosa, built on `spargebra`/`oxrdf`,
+> translating algebra trees into reads and writes against a single CQL-backed
+> `rdf_triples` table.
+
+## What this crate is
+
+`ferrosa-sparql` is the W3C SPARQL front-end. It parses SPARQL with `spargebra`,
+plans the algebra into storage operations against ferrosa's `rdf_triples` table
+(`((graph, subject), predicate, object)`), executes them via the cluster write
+path, and serializes results with hand-written JSON / XML / N-Triples / Turtle
+encoders. The HTTP surface implements the SPARQL 1.1 Protocol over `axum`.
+
+Its model is **one RDF graph per keyspace**: the `graph` partition-key component
+is the keyspace name, and there is exactly one `rdf_triples` table per keyspace.
+Operations that would address a *different* named graph (the `ADD`/`MOVE`/`COPY`
+desugaring, `GRAPH <g> { … }` reads, named-graph insert/delete targets) are
+**rejected fail-loud** rather than silently retargeted to the default graph.
+
+## What's implemented
+
+- **Query forms** — `SELECT`, `ASK`, `CONSTRUCT`, `DESCRIBE` (both
+  `DESCRIBE <iri>` and `DESCRIBE ?var WHERE { … }`).
+- **Graph-pattern coverage** — BGPs, `PROJECT`, `DISTINCT`/`REDUCED`,
+  `SLICE` (LIMIT/OFFSET), `ORDER BY` (over arbitrary supported expressions),
+  `FILTER`, `UNION` (concatenated), property paths. Multi-pattern joins run as a
+  nested-loop join with binding-compatibility checks.
+- **Property paths** — `+` (OneOrMore), `*` (ZeroOrMore), `?` (ZeroOrOne),
+  reverse (`^`) over a single predicate, evaluated by in-memory BFS with cycle
+  detection (`src/property_path.rs`).
+- **FILTER** — equality/comparison, `&&`/`||`/`!`, `BOUND`, `sameTerm`, `IF`,
+  arithmetic (`+ - * /`), and the functions `STR`, `UCASE`, `LCASE`, `STRLEN`,
+  `ABS`, `CEIL`, `FLOOR`, `ROUND`. Unsupported FILTER sub-forms evaluate to Null.
+- **Update** — `INSERT DATA`, `DELETE DATA`, `DELETE WHERE`,
+  `DELETE/INSERT … WHERE`, `CLEAR`, `DROP`, `CREATE` (no-op). All deletes funnel
+  through one tombstone primitive. `LOAD` and named-graph ops fail loud; the
+  whole request is validated up-front for atomicity (no partial mutation).
+- **RDF\* (SPARQL-star)** — quoted triples `<< s p o >>` **parse** (via the
+  `sparql-12` feature) but annotation evaluation is **not implemented**: the
+  planner rejects quoted triples in subject/object position fail-loud.
+- **Serialization** — SPARQL Results JSON, SPARQL Results XML (W3C shape),
+  N-Triples, Turtle (currently an N-Triples subset). Content negotiation via the
+  `Accept` header.
+- **HTTP** — `POST /sparql`, `GET /sparql?query=…`, `POST /sparql/update`,
+  `GET /sparql/health`, with a 1 MiB request-body limit.
+
+## How it works
+
+Five-stage pipeline: **parse** (`spargebra`) → **plan**
+(`planner::plan_query` → `QueryPlan` of `TripleOp`s) → **execute**
+(`executor::execute`, nested-loop join, then FILTER → ORDER BY → DISTINCT →
+LIMIT/OFFSET) → **shape** (ASK boolean / CONSTRUCT+DESCRIBE graph assembly in
+`engine.rs`) → **serialize** (`results.rs`).
+
+Each triple pattern is planned into the cheapest storage access it can prove:
+`SubjectLookup` (point read on the partition key) when the subject is bound,
+`PredicateScan`/`FullScan` (range read) otherwise, `ObjectScan` (secondary index
+on `object`, falling back to range scan) when only the object is bound, or
+`PropertyPath` (BFS) for closure operators.
+
+## Public API (key entry points)
+
+| Area | Items |
+|------|-------|
+| Engine | `SparqlEngine::{new, execute, execute_update}`, `SparqlConfig`, `SparqlResult`, `ConstructedTriple` |
+| HTTP | `start_sparql_http`, `build_router` (internal), `SparqlHttpConfig`, `AppState` |
+| Planner | `plan_query`, `plan_where`, `QueryPlan`, `TripleOp`, `GraphQueryMode`, `OrderCondition` |
+| Executor | `execute`, `execute_bindings`, `extract_subject_from_key`, `clustering_component` |
+| Update | `execute_update`, `UpdateResult` |
+| Triple store | `rdf_triples_schema`, `triples_table_id`, `partition_key`, `RdfTriple`, `ObjectType` |
+| Results | `SparqlJsonResults`, `Binding`, `SparqlAskResult`, `ResultFormat` |
+| Errors | `SparqlError` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-cluster`** — `write_path::WritePath` for all reads
+  (`read`, `range_read`, `index_read`) on the query/path side.
+- **`ferrosa-storage`** — `engine::StorageEngine` (`write`, `register_table`) for
+  the UPDATE write/tombstone path; `TableId`.
+- **`ferrosa-common`** — `CellValue`, `DecoratedKey`/`PartitionKey`, schema
+  types (`TableSchema`, `ColumnDefinition`), error type.
+- **`ferrosa-sstable`** — `Partition`, `Row`, `LivenessInfo`, `DeletionTime`
+  (the storage row shapes it reads and writes).
+- **`ferrosa-index`** — `IndexKey` for the `rdf_triples_object_idx` ObjectScan.
+- **`ferrosa-schema`** — `Schema` carried in `AppState`.
+
+External: `spargebra`, `sparesults`, `oxrdf` (all with `sparql-12`/`rdf-12`),
+`axum`, `tokio`, `tower-http`, `serde`/`serde_json`, `serde_urlencoded`,
+`base64` (declared, currently unused), `uuid`, `tracing`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa`** — the main binary mounts the SPARQL HTTP endpoint.
+
+## Tests
+
+110 tests: 79 in-crate unit tests (executor 21, planner 14, property_path 11,
+results 11, engine 8, filter 7, plus rdf_star/update/triple_store/namespace) and
+31 integration tests (`sparql_m3_completeness` 14, `sparql_update_s02_mgmt` 11,
+`sparql_update_pattern_delete` 6). Coverage gaps — OPTIONAL, real UNION
+semantics, auth, property-path cost — are tracked in
+[specs/fmea.md](specs/fmea.md).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, data flow, invariants
+- [FMEA / known issues](specs/fmea.md) — failure modes + real gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-sparql/specs/fmea.md
+++ b/ferrosa-sparql/specs/fmea.md
@@ -1,0 +1,48 @@
+---
+crate: ferrosa-sparql
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-sparql — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This crate is a public-facing query endpoint with broad SPARQL
+surface area, so both correctness-coverage and security gaps dominate.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| SP-1 | **No authentication or authorization.** `SparqlError::AccessDenied` and `AppState::auth_disabled` exist but no handler ever checks credentials; `base64` is a declared-but-unused dep. `auth_disabled` only toggles health-check verbosity. | Any network client can `SELECT`, `INSERT DATA`, `DELETE WHERE`, or `DROP` against any keyspace. Full read+write data exposure. | 10 | 8 | 3 | **240** | **Open gap.** No mitigation in this crate. The `X-Keyspace` header is attacker-controlled. Must add an auth layer (token/mTLS) before any untrusted exposure. |
+| SP-2 | **OPTIONAL (LeftJoin) right side silently dropped.** `collect_ops` evaluates only the left side of a `LeftJoin` and logs `warn!`; the optional pattern never binds. | `OPTIONAL { … }` returns rows missing the optional variables — a silent wrong (incomplete) result, not an error. | 8 | 6 | 7 | **336** | **Open gap.** Only a `tracing::warn!` fires; the HTTP client sees a 200 with wrong bindings. Should fail loud or implement the left-join. |
+| SP-3 | **UNION is concatenation, not a true two-branch union.** Both `Union` arms append their `TripleOp`s into one flat `ops` list, then run through the same nested-loop join. | UNION of two BGPs is joined rather than unioned; cross-branch variable bindings can over- or under-constrain. Wrong result set for any non-trivial UNION. | 8 | 5 | 7 | **280** | **Open gap.** Tested only for parse/plan, not for join semantics. Needs branch-isolated evaluation then set union. |
+| SP-4 | **Property paths load the entire predicate adjacency into memory.** `fetch_triples_for_predicate` does a full `range_read` of the table, filters by predicate in-process, then BFS. No bound on adjacency size; `range_read` itself is capped at 10k partitions elsewhere but not here. | A `knows+` over a large graph buffers all `knows` edges in a `Vec` and BFS over them — unbounded memory + latency; a single query can OOM or stall the node. | 7 | 5 | 5 | **175** | **Partial.** BFS has cycle detection and is correct; cost is unbounded. Needs a hop/row cap and index-driven neighbor fetch (violates Power-of-10 Rule 2/3). |
+| SP-5 | **Scan results truncated at a 10k row cap, returning partial answers as success.** `SCAN_ROW_CAP = 10_000`; on `PredicateScan`/`FullScan`/ObjectScan fallback the executor logs `warn!` and returns the truncated set. | A query over >10k partitions returns an incomplete result with a 200 OK — silent under-reporting. | 7 | 4 | 7 | **196** | **Partial.** Logged, but not surfaced to the client. Should return a "results truncated" signal or paginate. |
+| SP-6 | **Multi-pattern joins are O(rows^patterns) nested-loop with no index-driven join.** `evaluate_standard_op` cross-products existing bindings against every fetched row per pattern. | A 3+ pattern BGP over moderate data degrades quadratically/cubically; latency spikes, possible request timeout. | 6 | 5 | 5 | **150** | **Open gap.** Correct but not scalable. No join reordering or hash join. |
+| SP-7 | **RDF\* annotation queries unsupported but parseable.** `<< s p o >> :prop ?v` parses (sparql-12) but `plan_triple_pattern` / `rdf_star.rs` reject it. | Users expecting RDF-star annotations get a 400. Feature appears available (parses) but is not. | 4 | 3 | 2 | **24** | **By design, fail-loud.** Documented in `rdf_star.rs`; returns `SparqlError::Plan`, never a silent wrong binding. Lowest-risk gap. |
+| SP-8 | **Turtle output is an N-Triples subset; CONSTRUCT XML is ad-hoc RDF/XML.** `to_turtle` delegates to `to_ntriples`; CONSTRUCT XML is hand-built, not via `oxrdf`/`sparesults` serializers. | Clients requesting `text/turtle` get valid-but-unprefixed/ungrouped output; RDF/XML may mishandle literals with special structure. | 3 | 5 | 4 | **60** | **Partial.** Output is valid N-Triples (a valid Turtle subset). Full Turtle/RDF-XML deferred. |
+| SP-9 | **`datatype`/`language` columns read with `from_utf8_lossy`; lossy on non-UTF-8 bytes.** Object/predicate/datatype decoding uses `String::from_utf8_lossy` throughout the executor. | A non-UTF-8 stored value is silently mangled (replacement chars) rather than erroring. | 4 | 2 | 6 | **48** | **Partial.** RDF terms are UTF-8 by construction here, so occurrence is low; still a silent-corruption path. |
+| SP-10 | **`ObjectScan` index fallback can't distinguish empty index from no-index.** `fetch_by_object_index` treats an empty `index_read` as "no index" and falls back to a full scan. | If the object genuinely has no matches, the engine still pays for a full range scan; correctness OK, cost surprise. | 3 | 4 | 5 | **60** | **Partial.** Documented in code; performance-only, not a correctness bug. |
+
+## Top risks to act on
+
+1. **SP-2 (RPN 336) — OPTIONAL silently dropped.** The highest-RPN correctness
+   bug: a common, well-formed query returns wrong (incomplete) results with a
+   200. Either implement the left-join or fail loud like the other gaps.
+2. **SP-1 (RPN 240) — no auth.** Severity-10 security gap: the endpoint is fully
+   unauthenticated read+write across keyspaces. The `X-Keyspace` header is the
+   only tenancy boundary and it is client-supplied.
+3. **SP-3 (RPN 280) — UNION semantics.** Plausible queries silently get join
+   instead of union semantics.
+
+## Detection assets
+
+- `tests/sparql_m3_completeness.rs` (14) — CONSTRUCT/DESCRIBE, INSERT WHERE,
+  ORDER BY expressions, RDF\* fail-loud, XML/ASK serialization shape.
+- `tests/sparql_update_pattern_delete.rs` (6) — DELETE WHERE / DELETE-INSERT,
+  LOAD fail-loud.
+- `tests/sparql_update_s02_mgmt.rs` (11) — CLEAR/DROP/CREATE, atomicity,
+  cross-graph rejection.
+- 79 in-crate unit tests (executor join/decode, planner access selection,
+  property-path BFS, filter evaluation).
+- **No** test today covers OPTIONAL semantics, true UNION semantics, auth, or
+  property-path memory bounds — the SP-1/2/3/4 blind spots.

--- a/ferrosa-sparql/specs/overview.md
+++ b/ferrosa-sparql/specs/overview.md
@@ -1,0 +1,111 @@
+---
+crate: ferrosa-sparql
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The SPARQL 1.1 Query + Update endpoint for ferrosa. Parses SPARQL with
+  spargebra/oxrdf, plans algebra into TripleOps over a single CQL-backed
+  rdf_triples table per keyspace, executes via the cluster write path with a
+  nested-loop join, and serializes results as SPARQL JSON/XML/N-Triples/Turtle
+  over an axum HTTP surface. The model is one RDF graph per keyspace; cross-graph
+  operations fail loud rather than silently retarget. Significant gaps remain:
+  no authentication, no OPTIONAL/MINUS, UNION is concat-only, and property paths
+  load the full predicate adjacency into memory.
+---
+
+# ferrosa-sparql — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-sparql` is the W3C SPARQL front-end. It owns SPARQL parsing, algebra →
+storage planning, query execution, SPARQL UPDATE, and result serialization. It
+does **not** own storage durability, replication, indexing, or schema — it
+delegates reads to `ferrosa-cluster`'s `WritePath` and writes to
+`ferrosa-storage`'s `StorageEngine`.
+
+The RDF data model is mapped onto exactly one CQL table per keyspace:
+
+```
+rdf_triples : ((graph, subject), predicate, object)
+              regular cols: object_type, datatype, language
+```
+
+The partition key is the composite `(graph, subject)` where `graph` is the
+keyspace name — so there is **one logical RDF graph per keyspace**. This is the
+crate's defining boundary: anything that addresses a distinct named graph is
+rejected, never silently mapped onto the default graph.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `engine` (`src/engine.rs`, ~600 LoC) | `SparqlEngine`: parse→plan→execute orchestration, `SparqlResult`, ASK/CONSTRUCT/DESCRIBE graph assembly, JSON/XML/NT/Turtle dispatch |
+| `planner` (`src/planner.rs`, ~770 LoC) | `spargebra` algebra → `QueryPlan` of `TripleOp`s; per-pattern access-method selection; CONSTRUCT/DESCRIBE mode detection |
+| `executor` (`src/executor.rs`, ~970 LoC) | Nested-loop join over triple patterns, FILTER/ORDER BY/DISTINCT/LIMIT, composite-key decode, tombstone skipping, ObjectScan index |
+| `update` (`src/update.rs`, ~730 LoC) | INSERT/DELETE DATA, DELETE WHERE, DELETE/INSERT WHERE, CLEAR, DROP, CREATE; up-front atomicity validation; one shared tombstone primitive |
+| `property_path` (`src/property_path.rs`, ~420 LoC) | `+ * ? ^` evaluation via in-memory BFS with cycle detection |
+| `filter` (`src/filter.rs`, ~490 LoC) | `Expression` evaluation: comparisons, boolean ops, arithmetic, a function subset; `unsupported_expr` gate for ORDER BY fail-loud |
+| `results` (`src/results.rs`, ~415 LoC) | `Binding`, `SparqlJsonResults`, `ResultFormat`; JSON / W3C XML / N-Triples serializers |
+| `http` (`src/http.rs`, ~234 LoC) | axum router, content negotiation, 1 MiB body limit, error→status mapping |
+| `triple_store` (`src/triple_store.rs`) | `rdf_triples` schema, composite partition-key encoding, `ObjectType` |
+| `rdf_star` (`src/rdf_star.rs`) | RDF\* annotation evaluation stub — fail-loud, not implemented |
+| `namespace` (`src/namespace.rs`) | Standard prefix table (rdf, rdfs, owl, xsd, foaf, …) |
+
+## Data flow
+
+```mermaid
+flowchart TD
+    HTTP["axum handlers<br/>POST/GET /sparql, /sparql/update"] --> ENG["SparqlEngine::execute / execute_update"]
+    ENG --> PARSE["spargebra parse<br/>query / update"]
+    PARSE --> PLAN["planner::plan_query<br/>algebra to Vec&lt;TripleOp&gt;"]
+    PLAN --> EXEC["executor::execute<br/>nested-loop join"]
+    EXEC --> WP["ferrosa-cluster WritePath<br/>read / range_read / index_read"]
+    WP --> POST["FILTER to ORDER BY to DISTINCT to LIMIT/OFFSET"]
+    POST --> SHAPE{"query form?"}
+    SHAPE -->|SELECT| SER["results.rs serialize"]
+    SHAPE -->|ASK| BOOL["boolean from non-empty bindings"]
+    SHAPE -->|CONSTRUCT/DESCRIBE| GRAPH["instantiate template / SubjectLookup per IRI"]
+    BOOL --> SER
+    GRAPH --> SER
+    SER --> RESP["JSON / XML / N-Triples / Turtle"]
+    ENG -->|UPDATE| UVAL["update::validate_update<br/>up-front atomicity check"]
+    UVAL --> UWRITE["StorageEngine write / tombstone"]
+```
+
+**Read path.** A bound subject plans to `SubjectLookup` (point read on the
+partition key); a bound predicate to `PredicateScan` (range read + filter); a
+bound object to `ObjectScan` (secondary index `rdf_triples_object_idx`, falling
+back to a capped range scan); nothing bound to `FullScan`. The executor folds
+each `TripleOp`'s rows into the running binding set with a compatibility check on
+both value and `binding_type`.
+
+**Write path.** UPDATE first validates **every** operation (atomicity), then
+applies them sequentially. Inserts write a live row; every delete form funnels
+through one `tombstone_triple` primitive that writes a deletion-marker row with
+`LivenessInfo::NONE` and clustering identical to the live row it must shadow.
+
+## Key invariants
+
+1. **One graph per keyspace.** The `graph` partition-key component equals the
+   keyspace. Operations addressing a different named graph fail loud, never
+   retarget (`check_quad_graph_pattern`, `check_pattern_graph_reads`).
+2. **UPDATE atomicity by up-front rejection.** Because execution has no rollback,
+   `validate_update` rejects the whole request before any mutation if any op is
+   unaddressable — preventing a desugared `Drop` from wiping data before a later
+   op fails.
+3. **Tombstone clustering must shadow the live row exactly.** Inserts and deletes
+   share `encode_triple_clustering` (strict `[u16 len][bytes]`, no separator), so
+   a tombstone matches the row it deletes; `LivenessInfo::NONE` prevents
+   resurrection.
+4. **Fail loud over silent wrong answers.** RDF\* annotation, `LOAD`,
+   cross-graph ops, and unsupported ORDER BY expressions return
+   `SparqlError::Plan`, not approximate results.
+5. **Deleted rows never surface.** The executor skips any row whose deletion
+   marker is non-live (URS-QEC-D05).
+
+## Position in the dependency graph
+
+Front-end leaf: depends on `ferrosa-cluster`, `ferrosa-storage`,
+`ferrosa-common`, `ferrosa-sstable`, `ferrosa-index`, `ferrosa-schema`; depended
+on only by the `ferrosa` binary. See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-sparql/specs/roadmap.md
+++ b/ferrosa-sparql/specs/roadmap.md
@@ -1,0 +1,58 @@
+---
+crate: ferrosa-sparql
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-sparql — Roadmap
+
+Sourced from the code (planner/executor gaps, in-code `warn!`s and fail-loud
+stubs), the FMEA ([fmea.md](fmea.md)), and the dependency/usage review.
+
+## Now (highest value)
+
+- **Authentication + authorization (FMEA SP-1).** The endpoint is fully
+  unauthenticated read+write. Wire a real auth layer (token / mTLS), make
+  `auth_disabled` actually gate request handling, and return
+  `SparqlError::AccessDenied` (already defined) on failure. Decide whether
+  `X-Keyspace` is authorized per-principal rather than client-asserted.
+- **Fix OPTIONAL (FMEA SP-2).** `LeftJoin` drops its right side with only a
+  `warn!`. Either implement the optional join (bind right-side vars where
+  compatible, keep left rows otherwise) or fail loud — a silent incomplete
+  result is the worst outcome.
+- **True UNION semantics (FMEA SP-3).** Evaluate each branch independently and
+  set-union the solutions instead of concatenating `TripleOp`s into one join.
+
+## Next
+
+- **Bound property-path cost (FMEA SP-4).** Replace the full-adjacency
+  `range_read` + in-memory BFS with index-driven neighbor expansion and a
+  hop/row cap; surface truncation instead of OOM risk.
+- **Surface scan truncation (FMEA SP-5).** When a scan hits `SCAN_ROW_CAP`,
+  return a machine-readable "results truncated" signal (or paginate) rather than
+  a 200 OK with a silently partial body.
+- **Join planning (FMEA SP-6).** Add pattern reordering (most-selective first)
+  and a hash join to escape the nested-loop O(rows^patterns) blowup.
+
+## Later
+
+- **Full Turtle / RDF-XML serialization (FMEA SP-8).** Route CONSTRUCT/DESCRIBE
+  output through `oxrdf`/`sparesults` for prefixed, grouped Turtle and correct
+  RDF/XML instead of the current N-Triples-subset and ad-hoc XML.
+- **RDF\* annotation evaluation (FMEA SP-7).** Requires a storage encoding for
+  quoted-triple terms in key position, insert support for quoted-triple
+  subjects, and a join planner that binds the inner pattern before the outer
+  annotation property. Today it fails loud (correct, but unimplemented).
+- **Aggregation / GROUP BY / sub-SELECT.** `GraphPattern::Group` and friends are
+  not handled by `collect_ops` and currently hit the catch-all
+  `unsupported graph pattern` error.
+- **Named-graph support.** Lift the one-graph-per-keyspace restriction so
+  `GRAPH <g> { … }`, `ADD`/`MOVE`/`COPY`, and named-graph insert/delete targets
+  work instead of failing loud.
+
+## Non-goals
+
+- Storage durability, replication, secondary-index construction, or schema
+  management — owned by `ferrosa-cluster` / `ferrosa-storage` / `ferrosa-schema`.
+- Cassandra wire compatibility for RDF — this is an HTTP SPARQL endpoint, not a
+  CQL surface.

--- a/ferrosa-sql/README.md
+++ b/ferrosa-sql/README.md
@@ -1,0 +1,106 @@
+# ferrosa-sql
+
+> The bespoke relational query engine (parser + planner + physical operators)
+> behind Ferrosa's Postgres front-end. **No DataFusion / Arrow** (decision **D3**)
+> — it owns its own value model, three-valued NULL logic, and C-collation
+> ordering.
+
+## What this crate is
+
+A self-contained relational engine for a **deliberately small SQL subset**: a
+hand-written lexer + recursive-descent parser, a binder/planner that resolves
+references against a `Catalog`, and a set of Volcano-style physical operators
+(scan, filter, project, hash join, sort, hash aggregate, limit/offset). It was
+written from scratch rather than embedding DataFusion (decision **D3**) so the
+type model, NULL semantics, and row ordering are owned and auditable end-to-end.
+
+`ferrosa-postgres` lowers each incoming SQL statement onto this engine. The
+engine knows nothing about the Postgres wire protocol, transactions, or storage
+framing — it operates over an abstract `TableProvider` / `Catalog`, backed by an
+in-memory table in tests and by Ferrosa storage in production.
+
+## What's implemented
+
+**Parser** (`parse`, `parse_statement`):
+
+- `SELECT [DISTINCT] <* | items> FROM t [alias] [INNER JOIN t2 [alias] ON a.x = b.y]
+  [WHERE <bool-expr>] [GROUP BY ...] [HAVING <bool-expr>]
+  [ORDER BY ... [ASC|DESC]] [LIMIT n] [OFFSET m]` — one inner equi-join only.
+- No-`FROM` scalar selects: `SELECT 1`, `SELECT version()` (zero-arg func),
+  `SELECT $1`, `SELECT TRUE`.
+- DML (single-row, key-equality WHERE): `INSERT INTO t (cols) VALUES (...)`,
+  `UPDATE t SET ... WHERE k = v [AND ...]`, `DELETE FROM t WHERE k = v [AND ...]`.
+- Transaction / session statements **parsed** (not executed here): `BEGIN`/`START`,
+  `COMMIT`/`END`, `ROLLBACK`/`ABORT`, `SET`, `RESET`.
+- WHERE/HAVING boolean expressions: `AND` / `OR` / `NOT` with parentheses and
+  the six comparison operators `= != <> < <= > >=`. RHS is a literal or `$N`.
+- Aggregates: `COUNT(*)`, `COUNT(col)`, `SUM`, `MIN`, `MAX`, `AVG`.
+- Literals: int, float, string (with `''` escape), `TRUE`/`FALSE`/`NULL`, `$N`
+  params, and typed literals `TIMESTAMP/DATE/TIME/INET/NUMERIC(=DECIMAL) '...'`.
+
+**Value model** (`types`): `Null`, `Int(i64)`, `Text`, `Bool`,
+`Float(OrderedFloat<f64>)`, `Uuid`, `Bytea`, `Timestamp(i64 µs)`, `Date(i32 days)`,
+`Time(i64 µs)`, `Inet(IpAddr)`, `Numeric { unscaled: BigInt, scale }` (normalized,
+arbitrary precision). `Value::sql_cmp` implements three-valued comparison (NULL or
+type-mismatch or NaN ⇒ UNKNOWN), with Int↔Float promotion and value-aligned
+numeric compare.
+
+**Operators** (`exec`): `seq_scan`, `filter`, `project`, `hash_join` (inner
+equi-join; NULL keys never match), `sort` (stable, multi-key, Postgres NULL
+placement: ASC⇒NULLS LAST, DESC⇒NULLS FIRST), `hash_aggregate` (first-seen group
+order; ungrouped-empty yields one row), `limit_offset`.
+
+**Planner** (`plan`): `execute`, `describe` (RowDescription shape without running
+operators), `infer_param_types` (extended-protocol ParameterDescription).
+Fail-loud binding: unknown table/column, ambiguous unqualified column, unknown
+qualifier, non-grouped column, aggregate-in-WHERE, invalid ORDER BY ordinal, and
+missing `$N` parameter all return a typed `ExecError`.
+
+## How it works
+
+```
+parse_statement ─▶ Statement (ast)
+                     └─ Select(SelectStmt) ─▶ execute(stmt, catalog, schema, params)
+                                                 │ resolve_scope (bind via Catalog)
+                                                 │ seq_scan [→ hash_join] → filter
+                                                 │ → simple project | hash_aggregate
+                                                 │ → sort → limit_offset
+                                                 ▼
+                                              QueryResult { columns, rows }
+```
+
+## Public API (key entry points)
+
+| Area | Items |
+|------|-------|
+| Parse | `parse`, `parse_statement`, `ParseError` |
+| AST | `Statement`, `SelectStmt`, `InsertStmt`, `UpdateStmt`, `DeleteStmt`, `Expr`, `Operand`, `Term`, `Projection`, `SelectItem`, `OrderItem`, `ScalarItem`, `ScalarValue`, `AggArg` |
+| Plan | `execute`, `describe`, `infer_param_types`, `QueryResult`, `ExecError` |
+| Operators | `seq_scan`, `filter`, `project`, `hash_join`, `sort`, `hash_aggregate`, `limit_offset`, `Predicate`, `CmpOp`, `AggFunc`, `SortKey`, `SortDir`, `RowStream` |
+| Catalog | `Catalog`, `MapCatalog`, `SharedTable`, `TableProvider`, `InMemoryTable` |
+| Types | `Value`, `Row`, `Column`, `ColumnType`, `RelSchema` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on): **none.** `Cargo.toml` lists no
+`ferrosa-*` path dependencies — not even `ferrosa-common`. The engine carries its
+own `Value`/`Row`/`RelSchema` model so it stays a standalone leaf. External crates
+only: `ordered-float` (total-order `f64` for join/group keys), `num-bigint`
+(arbitrary-precision `Numeric`), `uuid`, `chrono` (std-only, typed temporal
+literal parsing).
+
+**Called by**: `ferrosa-postgres` — lowers parsed SQL onto this engine's
+operators and serves results over the Postgres wire.
+
+## Tests
+
+In-crate unit tests (no `#[ignore]`, no live-infra): `exec.rs` (24), `parser.rs`
+(44), `plan.rs` (42), `types.rs` (15), `catalog.rs` (2) — ~127 total. They cover
+NULL/Kleene logic, sort NULL placement, aggregate edge cases, numeric
+normalization, join key resolution, and binder fail-loud paths.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, data flow
+- [FMEA / known issues](specs/fmea.md) — supported surface vs gaps, ranked by RPN
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-sql/specs/fmea.md
+++ b/ferrosa-sql/specs/fmea.md
@@ -1,0 +1,58 @@
+---
+crate: ferrosa-sql
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-sql — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This engine is a deliberately small SQL subset (D3, bespoke,
+no DataFusion); the dominant risk class is **unsupported SQL surface** — a query
+a real Postgres client sends that the parser rejects or the planner cannot
+express. Those are mostly *fail-loud* (a `ParseError` / `ExecError`), which is the
+correct behavior, but each is a coverage gap a consumer may hit.
+
+## Supported surface (for reference)
+
+`SELECT [DISTINCT]`, `*` / column / aggregate projection, one `INNER JOIN ... ON
+a=b`, `WHERE`/`HAVING` with `AND`/`OR`/`NOT` + `= != <> < <= > >=`, `GROUP BY`,
+`ORDER BY [ASC|DESC]` (column, output name, or ordinal), `LIMIT`/`OFFSET`,
+`COUNT/SUM/MIN/MAX/AVG`, `$N` params, typed literals
+`TIMESTAMP/DATE/TIME/INET/NUMERIC '...'`; single-row `INSERT`/`UPDATE`/`DELETE`
+with key-equality WHERE; `BEGIN/COMMIT/ROLLBACK/SET/RESET` parsed for the
+front-end.
+
+## Failure modes
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| SQL-1 | **`IS NULL` / `IS NOT NULL` not parsed.** WHERE only supports the six comparison operators; `IS` is not a token. `col = NULL` is UNKNOWN under Kleene logic, so NULL filtering is impossible via SQL. | Common NULL queries fail to parse (or silently return zero rows if a client rewrites to `= NULL`); a fundamental SQL predicate is missing | 8 | 7 | 4 | 224 | **Open gap.** Add `IS [NOT] NULL` to the lexer/grammar and an `IsNull`/`IsNotNull` predicate. Top roadmap item. |
+| SQL-2 | **Subqueries, CTEs (`WITH`), `UNION`/`INTERSECT`/`EXCEPT`, and window functions unsupported.** None are in the grammar; the FROM is a single table + at most one join. | Whole query classes rejected with `ParseError`; clients/ORMs depending on them break | 8 | 6 | 3 | 144 | **Open gap (fail-loud).** Out of M1 scope by design; each is a separate large effort. Document the boundary so consumers degrade gracefully. |
+| SQL-3 | **Only INNER equi-join, exactly one, equality on a single column.** No LEFT/RIGHT/FULL/CROSS, no multi-table FROM, no `ON` with `AND`/inequality, no join-then-join. | Multi-table reporting queries and outer joins rejected | 7 | 6 | 3 | 126 | **Open gap (fail-loud).** `Join` AST models exactly `t ON a=b`. Widen to a join list + richer `ON` predicate. |
+| SQL-4 | **No arithmetic / scalar expressions / functions in projection or predicates** (`a + b`, `UPPER(x)`, `col || 'x'`, `CASE`). Projection is a bare column or aggregate; comparison LHS is a column or aggregate, RHS is a literal/`$N`. | Computed columns and expression predicates rejected | 6 | 6 | 3 | 108 | **Open gap (fail-loud).** Needs an expression evaluator over `Value`. |
+| SQL-5 | **Hash join + sort + aggregate fully materialize.** `hash_join` builds the right side and collects all output; `sort`/`hash_aggregate` take `Vec<Row>`. No spill-to-disk, no bound on group/build cardinality (violates Power-of-10 rule 3). | Large joins/sorts/aggregations can exhaust memory (OOM) on big inputs | 7 | 3 | 5 | 105 | **Known, documented** in `exec.rs`. Storage-backed provider should push down predicates/projection to shrink inputs; bounded spill is a follow-up. |
+| SQL-6 | **`SUM`/`AVG` over `Int` accumulate into `i64` with no overflow check** (`int_sum += n`). Numeric/decimal columns are not summed (only `Int`/`Float` feed `add_numeric`). | Large integer sums can wrap (panic in debug, silent wrap in release); SUM/AVG over a `Numeric` column silently yields NULL | 6 | 3 | 6 | 108 | **Open gap.** Promote integer SUM to `BigInt`/checked add; route `Numeric` through `add_numeric`. |
+| SQL-7 | **DML is single-row with key-equality WHERE only.** `INSERT` takes one `VALUES` tuple; `UPDATE`/`DELETE` WHERE is `col = val [AND ...]` (no ranges, no `IN`, no multi-row). Cassandra-style upsert assumption. | Bulk DML and range deletes rejected; an `UPDATE ... WHERE x > 5` won't parse | 5 | 5 | 3 | 75 | **By design (M1).** Documented; widen when the front-end needs set-based DML. |
+| SQL-8 | **Numeric/temporal values only reach predicates via *typed literals*.** A bare `'2024-01-01'` lexes as `Text`; comparing it to a `Date` column is UNKNOWN (no implicit cast). The client must write `DATE '...'`/`NUMERIC '...'`. | Naturally-written date/decimal predicates silently match nothing | 6 | 4 | 5 | 120 | **Partial.** Typed-literal syntax works and fails loud on bad bodies; implicit string→typed coercion against the column type is the gap. |
+| SQL-9 | **No `ORDER BY ... NULLS FIRST/LAST` override, no `COLLATE`, no explicit `ASC NULLS ...`.** NULL placement is fixed (ASC⇒LAST, DESC⇒FIRST); text ordering is `String`'s byte/`Ord` (C-collation), not locale-aware. | Queries needing a specific NULL placement or locale collation get a different order than Postgres | 4 | 4 | 5 | 80 | **By design.** C-collation + fixed NULL placement match the documented invariant; surface as a known difference. |
+| SQL-10 | **Unsupported `Value` types decode/compare as UNKNOWN/absent.** Collections (List/Set/Map/Tuple/UDT/Vector) and binary-format numeric are out of scope; cross-type `sql_cmp` is UNKNOWN, not an error. | A column the provider can't map to a supported `Value` compares as no-match rather than erroring | 5 | 3 | 6 | 90 | **Documented in `types.rs`.** Widen the type set as the storage provider needs; consider fail-loud on unmappable types. |
+| SQL-11 | **`describe`/`execute`/`infer_param_types` derive column shape independently.** They share `resolve_scope`, but projection/aggregate column derivation is duplicated; drift would make `RowDescription` disagree with the actual rows. | Postgres client desync (wrong column metadata vs data) | 7 | 2 | 6 | 84 | **Mitigated**: both call the same `simple_projection`/aggregate-column helpers; covered by plan tests. Keep them sharing one derivation. |
+
+## Top risks to act on
+
+1. **SQL-1 (RPN 224)** — `IS NULL`/`IS NOT NULL` is missing and unworkaroundable
+   in SQL given Kleene `= NULL`. Highest-value parser gap.
+2. **SQL-2 (RPN 144)** — subquery / CTE / `UNION` / window absence is the broadest
+   class of rejected queries; the boundary must be documented so `ferrosa-postgres`
+   returns a clear "unsupported" rather than a confusing parse error.
+3. **SQL-3 / SQL-8 (RPN 126 / 120)** — single-INNER-join and the typed-literal-only
+   path for dates/decimals are the next most likely real-client surprises.
+
+## Detection assets
+
+- In-crate unit tests: `parser.rs` (44), `plan.rs` (42), `exec.rs` (24),
+  `types.rs` (15), `catalog.rs` (2) — exercise Kleene logic, NULL sort placement,
+  aggregate edge cases, numeric normalization, and binder fail-loud paths.
+- `ferrosa-postgres` integration tests drive the engine end-to-end over the wire
+  (the real consumer-facing surface check).

--- a/ferrosa-sql/specs/overview.md
+++ b/ferrosa-sql/specs/overview.md
@@ -1,0 +1,95 @@
+---
+crate: ferrosa-sql
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The bespoke relational query engine (lexer + recursive-descent parser, binder/
+  planner, Volcano-style physical operators) behind Ferrosa's Postgres front-end.
+  Decision D3: NO DataFusion / Arrow — the crate owns its own value model,
+  three-valued NULL (Kleene) logic, and C-collation ordering so semantics are
+  auditable end-to-end. It is a standalone leaf with no ferrosa-* dependencies.
+---
+
+# ferrosa-sql — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-sql` turns a SQL string into a `QueryResult` over an abstract row
+source. Its boundary is narrow and explicit: it knows the SQL **subset** it
+parses, a `Value`/`Row`/`RelSchema` model it computes over, and a `Catalog` /
+`TableProvider` contract for pulling rows. It knows **nothing** about the Postgres
+wire protocol, transactions (those route through Accord in the front-end),
+storage framing, or S3 — those belong to `ferrosa-postgres` and the storage
+layer.
+
+Decision **D3**: build a bespoke engine rather than embed DataFusion, so the type
+system, NULL semantics, and row ordering are owned. The engine is deliberately
+small — a first-milestone (M1) slice centered on single-table scans plus one
+inner equi-join — and widens outward.
+
+## Module map
+
+| Module | LoC | Responsibility |
+|--------|-----|----------------|
+| `types` (`src/types.rs`) | ~488 | `Value` enum, `Row`, `Column`, `ColumnType`, `RelSchema`; `Value::sql_cmp` three-valued comparison + numeric normalization |
+| `exec` (`src/exec.rs`) | ~791 | Physical operators: `seq_scan`, `filter`, `project`, `hash_join`, `sort`, `hash_aggregate`, `limit_offset`; `Predicate`, `CmpOp`, `AggFunc` |
+| `parser` (`src/parser.rs`) | ~1752 | Hand-written lexer + recursive-descent parser; `parse`, `parse_statement`, `ParseError`, typed-literal parsing |
+| `plan` (`src/plan.rs`) | ~1598 | Binder + planner: `execute`, `describe`, `infer_param_types`; scope resolution, Kleene WHERE/HAVING eval, `ExecError` |
+| `ast` (`src/ast.rs`) | ~207 | Logical AST: `Statement`, `SelectStmt`, DML statements, `Expr`, `Operand`, `Projection`, `OrderItem` |
+| `catalog` (`src/catalog.rs`) | ~81 | `Catalog` trait + `MapCatalog`; name → provider resolution (fail-loud on miss) |
+| `provider` (`src/provider.rs`) | ~39 | `TableProvider` scan contract + `InMemoryTable` |
+
+## Data flow
+
+**Execute path** (table query):
+
+```mermaid
+flowchart TD
+  SQL["SQL string"] --> P["parse_statement"]
+  P --> ST["Statement::Select(SelectStmt)"]
+  ST --> EX["execute(stmt, catalog, schema, params)"]
+  EX --> SC["resolve_scope: bind FROM/JOIN via Catalog"]
+  SC --> SCAN["seq_scan(from)"]
+  SCAN --> J["hash_join(scan(join))  (optional inner equi-join)"]
+  J --> F["filter: Kleene WHERE eval, keep Some(true)"]
+  F --> A{"aggregate mode?"}
+  A -->|yes| AGG["hash_aggregate + HAVING + project"]
+  A -->|no| PRJ["project (DISTINCT dedup if asked)"]
+  AGG --> SRT["sort (ORDER BY)"]
+  PRJ --> SRT
+  SRT --> LO["limit_offset"]
+  LO --> QR["QueryResult { columns, rows }"]
+```
+
+Aggregate mode is entered iff `GROUP BY` is present, `HAVING` is present, or any
+select item is an aggregate. `describe` and `infer_param_types` reuse
+`resolve_scope` to derive the output column shape / parameter types **without**
+scanning rows — so the Postgres extended-query path can answer `RowDescription`
+and `ParameterDescription` before binding parameters.
+
+## Key invariants
+
+1. **Three-valued (Kleene) NULL logic.** `Value::sql_cmp` returns `None`
+   (UNKNOWN) for NULL operands, type mismatches, or NaN. WHERE keeps only
+   `Some(true)`; `AND`/`OR`/`NOT` follow Kleene tables (`kleene_and`/`kleene_or`).
+   NULL join keys never match; `NULL = NULL` is UNKNOWN, not true.
+2. **C-collation / total ordering for sort + keys.** `sort` is stable and
+   multi-key with Postgres NULL placement (ASC ⇒ NULLS LAST, DESC ⇒ NULLS FIRST).
+   `Float` is wrapped in `OrderedFloat` so `Value` keeps `Eq`/`Hash`/`Ord` and is
+   usable as a hash-join / group key.
+3. **Normalized `Numeric` equality.** `Value::numeric` strips trailing decimal
+   zeros so `1.50` and `1.5` are the same `Value` (correct GROUP BY / DISTINCT /
+   join-key behavior); `sql_cmp` aligns scales via `BigInt` (no float).
+4. **Fail loud at the binder, never empty-on-missing.** A missing table/column,
+   ambiguous unqualified column, aggregate-in-WHERE, non-grouped column, or
+   unbound `$N` returns a typed `ExecError` — the catalog must not substitute an
+   empty relation for a missing table.
+5. **No second SQL engine / no DataFusion.** Decision D3 — the value model and
+   semantics live here once.
+
+## Position in the dependency graph
+
+True leaf: **zero** `ferrosa-*` dependencies (verified against `Cargo.toml` —
+only `ordered-float`, `num-bigint`, `uuid`, `chrono`). Depended on by
+`ferrosa-postgres`. See the [root crate index](../../specs/crates.md) for the
+full graph.

--- a/ferrosa-sql/specs/roadmap.md
+++ b/ferrosa-sql/specs/roadmap.md
@@ -1,0 +1,56 @@
+---
+crate: ferrosa-sql
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-sql — Roadmap
+
+Sourced from the supported-subset review, the FMEA gaps ([fmea.md](fmea.md)), and
+the `ferrosa-postgres` consumer needs. The engine is intentionally an M1 slice
+(D3, bespoke, no DataFusion); the roadmap is mostly *widening the SQL surface*
+toward the Postgres queries real clients send.
+
+## Now (highest value)
+
+- **`IS NULL` / `IS NOT NULL`** (FMEA SQL-1). Add the `IS`/`NOT NULL` tokens and
+  grammar plus an `IsNull` predicate path. Today NULL filtering is impossible in
+  SQL because `col = NULL` is UNKNOWN under Kleene logic. Top gap.
+- **Implicit string → typed coercion in predicates** (FMEA SQL-8). Coerce a
+  `Text` RHS to the column's type (`Date`/`Timestamp`/`Numeric`/`Inet`) at bind
+  time so naturally-written `where d = '2024-01-01'` works, not only
+  `DATE '2024-01-01'`. Fail loud on an uncoercible body.
+- **Integer SUM/AVG overflow safety + `Numeric` aggregation** (FMEA SQL-6).
+  Promote integer running sums to `BigInt`/checked add and feed `Numeric`
+  columns through `add_numeric`.
+
+## Next
+
+- **Richer joins** (FMEA SQL-3): `LEFT`/`RIGHT`/`FULL` outer joins, a multi-table
+  FROM / join list, and `ON` predicates beyond a single `a = b` (AND-of-equalities,
+  inequality join conditions).
+- **Scalar expressions** (FMEA SQL-4): an expression evaluator over `Value` for
+  projection arithmetic/functions (`a + b`, `UPPER(x)`, `||`, `CASE`) and
+  expression predicates (LHS/RHS richer than column-vs-literal).
+- **Set-based DML** (FMEA SQL-7): multi-row `INSERT ... VALUES`, range/`IN`
+  predicates in `UPDATE`/`DELETE` WHERE.
+- **Bounded operators** (FMEA SQL-5): cap or spill `hash_join` build side, `sort`,
+  and `hash_aggregate` input to satisfy Power-of-10 rule 3; lean on
+  predicate/projection pushdown into the storage-backed provider.
+
+## Later
+
+- **Subqueries, CTEs (`WITH`), `UNION`/`INTERSECT`/`EXCEPT`, window functions**
+  (FMEA SQL-2) — each a separate large effort; sequence by `ferrosa-postgres`
+  client demand.
+- **Collections / UDT / tuple / vector value types** (FMEA SQL-10) once a
+  consuming query needs them over this path.
+- **Property-test the round-trip and Kleene tables** as a regression net
+  independent of `ferrosa-postgres`.
+
+## Non-goals
+
+- Postgres wire framing, transaction execution (Accord), and storage/S3 framing —
+  those belong to `ferrosa-postgres` and the storage layer, not here.
+- Embedding DataFusion / Arrow (decision **D3**) — the bespoke value model and
+  semantics stay owned in this crate.

--- a/ferrosa-sstable/README.md
+++ b/ferrosa-sstable/README.md
@@ -1,0 +1,124 @@
+# ferrosa-sstable
+
+> The Cassandra-compatible **BTI SSTable** reader/writer — the crate's on-disk
+> data layer. Reads and writes the 7-component BTI (Big Trie-Indexed) format
+> over backing-store-agnostic positional I/O traits.
+
+## What this crate is
+
+`ferrosa-sstable` owns the binary, on-disk SSTable format. It reads and writes
+the **BTI (Big Trie-Indexed)** format that is the default in Apache Cassandra
+5.x — trie-indexed partition/row indexes, delta-encoded rows against a
+serialization header, LZ4/Zstd compression, and a Cassandra-compatible bloom
+filter. All I/O is synchronous and routes through the `ReadAt`/`WriteAt` traits,
+so the same reader/writer logic runs over a local file (`FileReadAt`) or an S3
+object (`S3ReadAt`, which lives in `ferrosa-storage`) without a runtime
+dependency in this crate.
+
+The crate is deliberately format-only: it knows about partitions, rows, cells,
+liveness, and deletion markers, but nothing about CQL planning, schema
+resolution beyond the serialization header, or cluster routing.
+
+## What's implemented
+
+- **BTI write** — `SSTableWriter` accepts partitions in token order and emits
+  all 7 components (Data.db, Partitions.db, Rows.db, Filter.db,
+  CompressionInfo.db / CRC.db, Statistics.db, TOC.txt) either as in-memory
+  buffers (`SSTableOutput`) or staged files (`SSTableOutputFiles`). A
+  self-readback verification pass (`WriteOptions::verify_output`, default on)
+  reopens the finished table and checks the partition count.
+- **BTI read** — `SSTableReader` opens a table from component handles and serves
+  point lookups (`get_partition`, `get_partition_limited_rows`,
+  `get_clustering_row`), bloom/bounds pre-checks (`may_contain_key`), and
+  streaming iteration in token order (`partitions_iter` → `PartitionIter`) with
+  token-seek (`seek_to_token`) and projection variants.
+- **Trie index** — on-disk trie walker + builder (`trie/`) backing the partition
+  index (Partitions.db) and the row index (Rows.db) for wide clustered
+  partitions.
+- **Compression** — `Compression::{None, Lz4, Zstd { level }}` with per-chunk
+  CRC32 validation on read.
+- **Bloom filter** — Cassandra-compatible double-hashing over the Murmur3
+  `h1`/`h2` pair from `ferrosa-common`.
+- **Corruption resilience** — `validate_data_extent` (index-vs-data truncation
+  check), `salvage` (best-effort per-partition recovery with `SalvageStats`),
+  and a hard `MAX_VALUE_LEN` ceiling that rejects bogus on-disk lengths before
+  they drive a pathological allocation.
+- **Tooling binaries** — `ferrosa-sstable-dump` and `ferrosa-sstable-import`.
+
+## What is NOT implemented (honest scope)
+
+- **Big-format (legacy `*-big-*`) reading** — out of scope; the crate targets
+  BTI only. There is no Big-format read path (deferred per ADR-004).
+- **Range tombstone markers** — not encoded by the writer; the reader skips
+  them. Documented in `data.rs` / `writer.rs` as deferred.
+- **Complex columns** (collections, UDTs, frozen/tuple types) — deferred in the
+  Data.db row codec.
+- **Snappy / Deflate compression** — only None / LZ4 / Zstd are supported.
+
+## How it works
+
+| Module | Responsibility |
+|--------|----------------|
+| `io` | `ReadAt`/`WriteAt` positional traits, `FileReadAt`/`FileWriteAt`, bounded block cache (`CachedReadAt`) |
+| `reader` | `SSTableReader`, `PartitionIter`, point lookup, salvage, token-summary seek index |
+| `writer` | `SSTableWriter`, `WriteOptions`, `SSTableOutput[Files]` |
+| `data` | Data.db row/cell codec (delta-encoded against the header) |
+| `trie` | On-disk trie node, walker, builder |
+| `partition_index` / `row_index` | Trie-backed Partitions.db / Rows.db |
+| `compression` | `Compression` enum, chunk compress/decompress |
+| `bloom` | Cassandra-compatible bloom filter |
+| `statistics` | Statistics.db + `SerializationHeader` |
+| `byte_comparable` | Byte-comparable key encoding for the index |
+| `varint` / `marshal` | VInt codec + Cassandra `AbstractType` marshalling |
+| `toc` | TOC.txt read/write + standard component lists |
+| `types` | `Partition`, `Row`, `CellValue` shapes, `LivenessInfo`, `DeletionTime` |
+
+**Write path**: caller adds `Partition`s in token order → cells delta-encoded
+against the `SerializationHeader` → Data.db, with bloom + partition trie +
+(for wide partitions) row trie built alongside → `finish()` emits all components
+and (by default) self-verifies.
+
+**Read path**: `get_partition` checks the bloom filter, walks the partition trie
+to a Data.db offset, then decodes the partition (decompressing chunks through a
+bounded LRU when compressed). Streaming reads walk Data.db directly with
+constant per-partition memory.
+
+## Public API (key entry points)
+
+| Area | Items |
+|------|-------|
+| I/O traits | `ReadAt`, `WriteAt`, `FileReadAt`, `FileWriteAt` |
+| Reader | `SSTableReader::{open, get_partition, get_clustering_row, may_contain_key, partitions_iter, seek_to_token, salvage, validate_data_extent}`, `SSTableComponents` |
+| Writer | `SSTableWriter::{new, new_file_backed, add_partition, finish, finish_to_directory}`, `WriteOptions`, `SSTableOutput`, `SSTableOutputFiles` |
+| Types | `Partition`, `Row`, `LivenessInfo`, `DeletionTime`, `Compression` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — `Token`, `DecoratedKey`, `PartitionKey`, `CellValue`,
+  Murmur3 hashing, `Error`/`Result` (the shared types the format encodes).
+
+External: `crc32fast`, `lru`, `lz4_flex`, `memmap2`, `rayon`, `zstd`. **No async
+runtime** — positional I/O is synchronous; S3 wrappers live in `ferrosa-storage`.
+
+**Called by** (crates that depend on this):
+
+- `ferrosa-cdc`, `ferrosa-cluster`, `ferrosa-cql`, `ferrosa-ctl`, `ferrosa-graph`,
+  `ferrosa-index-builder`, `ferrosa-loadgen`, `ferrosa-postgres`,
+  `ferrosa-row-bridge`, `ferrosa-schema`, `ferrosa-sparql`, `ferrosa-storage`,
+  `ferrosa-worker`.
+
+## Tests
+
+In-crate unit tests across every module (trie, data codec, varint, bloom,
+byte-comparable, statistics, reader/writer round-trips) plus integration suites:
+`tests/cassandra_compat.rs` (binary-exact oracle vs Cassandra fixtures),
+`tests/property_tests.rs` (proptest round-trips), and
+`tests/p0_production_disk_replay.rs` (real on-disk replay regression).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, data flow, invariants
+- [FMEA / known issues](specs/fmea.md) — failure modes + scope gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-sstable/specs/fmea.md
+++ b/ferrosa-sstable/specs/fmea.md
@@ -1,0 +1,46 @@
+---
+crate: ferrosa-sstable
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-sstable — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This crate is the on-disk format layer on the engine's
+critical read/write path, so corruption and compatibility failures carry high
+severity — a wrong byte here is silent, durable data loss.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| ST-1 | BTI encoding diverges from Cassandra 5.x byte layout | SSTables written here are unreadable by Cassandra (or vice-versa); silent corruption across the compat boundary | 10 | 2 | 6 | 120 | `tests/cassandra_compat.rs` is a binary-exact oracle against fixtures generated from the Cassandra submodule; trie/VInt/byte-comparable have dense unit tests. |
+| ST-2 | Range tombstone markers in a Data.db row stream | Reader silently skips them; deletes within a range are not reflected on read (incorrect results) | 9 | 3 | 7 | 189 | **Known scope gap.** Writer never emits them; reader skips. Documented in `data.rs`/`writer.rs`. Must be tracked so the engine does not rely on range deletes through this path. See roadmap. |
+| ST-3 | Complex columns (collections, UDT, tuple, frozen) written/read | Deferred codec mishandles or drops complex cell data | 8 | 3 | 6 | 144 | **Known scope gap.** Data.db codec handles simple cells only; complex columns deferred. Surface to callers that need them rather than silently degrading. |
+| ST-4 | Big-format (legacy `*-big-*`) SSTable presented to the reader | No Big-format read path exists; the table cannot be opened | 6 | 2 | 3 | 36 | **Out of scope by design** (ADR-004, BTI-only). Open fails loudly rather than misreading; not a silent corruption. |
+| ST-5 | Corrupt on-disk length prefix drives a huge allocation | A bogus multi-TB varint length OOMs the process | 9 | 2 | 2 | 36 | `MAX_VALUE_LEN` (256 MiB) hard ceiling rejects oversized buffers before allocating; covered in `data.rs`. |
+| ST-6 | Data.db truncated by a non-atomic flush (index claims N, fewer reachable) | Partitions silently missing on read | 9 | 2 | 4 | 72 | `validate_data_extent` compares index `key_count` vs walkable partitions and errors loudly; `verify_output` self-readback (default on) catches the count mismatch at write time. |
+| ST-7 | Intra-partition parse drift / bitmap under-count corruption | One bad row cascades and loses the rest of the table | 9 | 2 | 4 | 72 | `salvage` decodes each partition independently at its indexed offset (no cross-partition cascade), returns `SalvageStats` with partial/complete counts. |
+| ST-8 | Compressed chunk CRC mismatch or non-monotonic offsets | Silent bit-rot read as valid data | 9 | 2 | 3 | 54 | Per-chunk CRC32 validated on read; chunk-offset monotonicity and decompressed-length bounds checked in `read_compressed_chunk`. |
+| ST-9 | Partitions added out of token order to the writer | Corrupt partition trie → wrong/missing lookups | 9 | 2 | 6 | 108 | Documented precondition (`add_partition` requires token order). Not currently asserted at the API boundary — a debug-assert on monotonic keys would lower detection cost. |
+| ST-10 | `seek_to_token` resident index scales with partition count | Repair Merkle scan over a multi-GB table OOMs | 8 | 2 | 3 | 48 | Fixed: `build_token_summary` downsamples to a hard `PARTITION_TOKEN_SUMMARY_MAX_ENTRIES` (65 536) ceiling; small tables keep a full stride-1 index. |
+| ST-11 | Bloom filter false-positive / hash mismatch vs Cassandra | Extra Data.db reads (perf) or, if hashes diverge, missed keys | 7 | 2 | 5 | 70 | Cassandra-compatible double-hashing over Murmur3 `h1`/`h2` from `ferrosa-common`; FP rate tunable via `WriteOptions::bloom_fp_chance`. |
+
+## Top risks to act on
+
+1. **ST-2 (RPN 189) — range tombstone skip.** The reader silently drops range
+   tombstone markers, so range deletes are invisible through this path. This is
+   the highest-RPN item because the effect is *incorrect query results*, not a
+   loud failure. Either implement range tombstones or make the engine guarantee
+   it never routes range deletes through BTI, and add a fail-loud guard.
+2. **ST-3 (RPN 144) — complex columns.** Collections/UDT/tuple are deferred;
+   any consumer that needs them must not silently get degraded data.
+3. **ST-1 (RPN 120) — BTI byte compatibility.** Severe but well-mitigated by the
+   binary-exact Cassandra oracle; keep the fixture suite green on every change.
+
+## Detection assets
+
+- `tests/cassandra_compat.rs` — binary-exact round-trip vs Cassandra fixtures.
+- `tests/property_tests.rs` — proptest round-trips over the codec surface.
+- `tests/p0_production_disk_replay.rs` — real on-disk replay regression.
+- `validate_data_extent` + `WriteOptions::verify_output` — truncation/partial-write guards.
+- `salvage` / `SalvageStats` — best-effort recovery + observability on corrupt tables.

--- a/ferrosa-sstable/specs/overview.md
+++ b/ferrosa-sstable/specs/overview.md
@@ -1,0 +1,147 @@
+---
+crate: ferrosa-sstable
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The Cassandra-compatible BTI (Big Trie-Indexed) SSTable reader and writer —
+  the engine's on-disk data layer. Reads and writes the 7-component BTI format
+  over synchronous, backing-store-agnostic ReadAt/WriteAt positional I/O traits,
+  with trie-indexed partition/row indexes, delta-encoded rows, LZ4/Zstd
+  compression, and a Cassandra-compatible bloom filter. BTI only; legacy
+  Big-format reading, range tombstones, and complex columns are out of scope.
+---
+
+# ferrosa-sstable — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-sstable` is the **on-disk format layer** of the storage engine. It is
+the single place that understands the byte layout of a BTI SSTable: the trie
+indexes, the delta-encoded Data.db rows, the compression chunk framing, the
+bloom filter, and the Statistics.db serialization header.
+
+Its boundary is narrow and downward-facing. It depends only on
+`ferrosa-common` for the shared key/value/hash types and produces/consumes the
+format-specific shapes (`Partition`, `Row`, `LivenessInfo`, `DeletionTime`)
+defined in its own `types` module. It knows nothing about CQL planning, schema
+DDL, cluster routing, or transports — those live in the crates that call it.
+
+All I/O is **synchronous** and flows through the `ReadAt`/`WriteAt` traits, so
+the identical reader/writer code runs over a local file or an S3 object. The
+async/S3 wrapper (`S3ReadAt`) deliberately lives one layer up in
+`ferrosa-storage`, keeping this crate runtime-free.
+
+## Format scope (what BTI-only means)
+
+| Capability | Status |
+|------------|--------|
+| BTI write (all 7 components) | Implemented |
+| BTI read (point + streaming) | Implemented |
+| Legacy Big format (`*-big-*`) read | **Out of scope** (deferred, ADR-004) |
+| Range tombstone markers | **Deferred** — writer does not emit, reader skips |
+| Complex columns (collections/UDT/tuple/frozen) | **Deferred** in Data.db codec |
+| Compression | None / LZ4 / Zstd (Snappy/Deflate not supported) |
+
+## Module map
+
+| Module | LoC (approx) | Responsibility |
+|--------|------|----------------|
+| `reader` (`src/reader.rs`) | ~3130 | `SSTableReader`, `PartitionIter`, point lookup, salvage, bounded token-summary seek index |
+| `writer` (`src/writer.rs`) | ~3650 | `SSTableWriter`, `WriteOptions`, `SSTableOutput[Files]`, self-readback verify |
+| `data` (`src/data.rs`) | ~2700 | Data.db row/cell codec, delta-decode vs header |
+| `io` (`src/io.rs`) | ~1165 | `ReadAt`/`WriteAt`, `FileReadAt`/`FileWriteAt`, `CachedReadAt` block cache |
+| `trie/{node,builder,walker,mod}` | ~2160 | On-disk trie used by both indexes |
+| `statistics` (`src/statistics.rs`) | ~1006 | Statistics.db, `SerializationHeader` |
+| `partition_index` / `row_index` | ~875 | Trie-backed Partitions.db / Rows.db |
+| `byte_comparable` | ~347 | Byte-comparable key encoding for the index |
+| `compression` | ~348 | `Compression` enum, chunk compress/decompress + CRC |
+| `varint` / `marshal` | ~473 | Cassandra VInt codec, `AbstractType` marshalling |
+| `bloom` | ~293 | Cassandra-compatible double-hashing bloom filter |
+| `toc` | ~156 | TOC.txt read/write, standard component lists |
+| `types` | ~237 | `Partition`, `Row`, `LivenessInfo`, `DeletionTime` |
+
+## Component layout
+
+A BTI SSTable is 7 files (compressed variant uses `CompressionInfo.db`;
+uncompressed uses `CRC.db`):
+
+```mermaid
+graph TB
+    subgraph API["Public API"]
+        Reader[SSTableReader]
+        Writer[SSTableWriter]
+    end
+    subgraph Comp["Components"]
+        Data[Data.db &mdash; delta-encoded rows]
+        Part[Partitions.db &mdash; partition trie]
+        Rows[Rows.db &mdash; row trie, wide partitions]
+        Filter[Filter.db &mdash; bloom]
+        CI[CompressionInfo.db / CRC.db]
+        Stats[Statistics.db &mdash; header]
+        TOC[TOC.txt]
+    end
+    subgraph IO["I/O Abstraction"]
+        ReadAt[ReadAt trait]
+        WriteAt[WriteAt trait]
+        FileImpl[FileReadAt / FileWriteAt]
+    end
+    Reader --> Part
+    Reader --> Filter
+    Reader --> Stats
+    Reader --> Data
+    Writer --> Data
+    Writer --> Part
+    Writer --> Rows
+    Writer --> Filter
+    Writer --> CI
+    Writer --> Stats
+    Writer --> TOC
+    Reader --> ReadAt
+    Writer --> WriteAt
+    FileImpl -.-> ReadAt
+    FileImpl -.-> WriteAt
+```
+
+## Data flow
+
+**Write path** (engine memtable/compaction → disk): the caller adds `Partition`
+values in token order via `add_partition`. Cell timestamps, TTLs, and local
+deletion times are **delta-encoded** as unsigned VInts against the baseline in
+the `SerializationHeader`. The writer builds the bloom filter, the partition
+trie, and — for wide clustered partitions past `ROW_INDEX_MIN_ROWS` — the row
+trie alongside Data.db. `finish()` emits all components; by default
+(`verify_output`) it reopens the result and asserts the partition count
+(self-readback Gate B).
+
+**Read path** (disk → engine): `SSTableReader::open` parses the bloom filter,
+compression info, and statistics header, and opens the partition trie.
+`get_partition` checks the bloom filter, walks the trie to a Data.db offset, and
+decodes the partition — decompressing only the needed chunks through a bounded
+LRU (`decompressed_chunks`) when compressed. `partitions_iter` streams in token
+order with constant per-partition memory; `seek_to_token` uses a **bounded,
+downsampled** token summary so a reader's resident seek index is O(max_entries),
+not O(num_partitions) — the fix for a repair-scan OOM.
+
+## Key invariants
+
+1. **Byte-exact BTI compatibility.** The trie, VInt, and row encodings must
+   match Cassandra 5.x exactly; verified by `tests/cassandra_compat.rs` against
+   fixtures generated from the Cassandra submodule.
+2. **Partitions added in token order.** `SSTableWriter::add_partition` assumes
+   sorted input; out-of-order input corrupts the index.
+3. **Cells delta-encoded against the header.** Read and write must share the
+   same `SerializationHeader` baseline or every timestamp/TTL decodes wrong.
+4. **Bounded allocation on read.** Any length-prefixed buffer over
+   `MAX_VALUE_LEN` (256 MiB) is rejected as corruption before allocating.
+5. **No async dependency.** Positional I/O is synchronous; the S3/runtime
+   wrapper lives in `ferrosa-storage`.
+
+## Position in the dependency graph
+
+A near-leaf crate: it calls only `ferrosa-common`. It is one of the most
+widely-depended-on crates in the workspace — `ferrosa-cdc`, `ferrosa-cluster`,
+`ferrosa-cql`, `ferrosa-ctl`, `ferrosa-graph`, `ferrosa-index-builder`,
+`ferrosa-loadgen`, `ferrosa-postgres`, `ferrosa-row-bridge`, `ferrosa-schema`,
+`ferrosa-sparql`, `ferrosa-storage`, and `ferrosa-worker` all consume its
+reader/writer or `types`. See the [root crate index](../../specs/crates.md) for
+the full graph.

--- a/ferrosa-sstable/specs/roadmap.md
+++ b/ferrosa-sstable/specs/roadmap.md
@@ -1,0 +1,51 @@
+---
+crate: ferrosa-sstable
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-sstable — Roadmap
+
+Sourced from in-code deferral notes (`data.rs`, `writer.rs`), the FMEA gaps
+([fmea.md](fmea.md)), the existing topic spec, and the dependency/usage review.
+
+## Now (highest value)
+
+- **Close the range-tombstone gap (FMEA ST-2).** The reader silently skips range
+  tombstone markers and the writer never emits them, so range deletes are
+  invisible through BTI. Either implement encode/decode for range tombstone
+  markers, or add a **fail-loud guard** so the engine cannot route a range
+  delete through this path undetected. Highest-RPN correctness item.
+- **Assert token order at the writer boundary (FMEA ST-9).** `add_partition`
+  documents but does not enforce its token-order precondition. Add a
+  debug-assert (or cheap monotonic-key check) so out-of-order input fails loudly
+  in tests instead of producing a silently corrupt trie.
+
+## Next
+
+- **Complex-column support (FMEA ST-3).** Implement collections / UDT / tuple /
+  frozen cell encode+decode in the Data.db codec, or surface unsupported complex
+  columns as an explicit error to any consuming crate that needs them.
+- **Snappy / Deflate compression.** Currently only None / LZ4 / Zstd are
+  supported. Add the remaining Cassandra algorithms behind the `Compression`
+  enum for broader fixture compatibility.
+- **Bloom filter sizing.** `SSTableWriter::new` sizes the bloom filter for a
+  fixed 10 000-key default with a "production would resize" note. Make the size
+  derive from the actual partition count (builder pattern or post-hoc resize) so
+  the FP rate holds for large tables.
+
+## Later
+
+- **Big-format (legacy `*-big-*`) read support.** Out of scope today (ADR-004,
+  BTI-only). Revisit only if importing legacy Cassandra Big-format SSTables
+  becomes a requirement; until then `open` fails loudly on Big format rather
+  than misreading.
+- **Broaden salvage coverage.** Extend `salvage` / `SalvageStats` with
+  index-corruption recovery (today it relies on the partition-index walk for
+  boundaries) so a damaged Partitions.db can still be partially recovered.
+
+## Non-goals
+
+- Async / S3 I/O — lives in `ferrosa-storage` behind the `ReadAt`/`WriteAt`
+  traits; this crate stays synchronous and runtime-free.
+- CQL planning, schema DDL, or cluster routing — belong to the calling crates.

--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -1,0 +1,111 @@
+# ferrosa-storage
+
+> The single-node storage engine: memtable → commit log → flush → SSTable →
+> S3 write-behind, plus compaction, local cache, NVMe pinning, secondary-index
+> pipeline, snapshot/PITR, and the corruption quarantine + self-heal controller.
+
+## What this crate is
+
+`ferrosa-storage` is the **storage substrate** of the platform — the largest and
+most critical crate in the workspace (~73k LoC across ~95 source files). It owns
+the full single-node data lifecycle: writes land in an in-memory memtable, are
+made durable through a write-ahead commit log, are flushed to BTI SSTables on
+local NVMe, and are then asynchronously uploaded to S3 (the durable store).
+Local disk is a write-behind cache; S3 is authoritative.
+
+Every query front-end (CQL, Postgres, SPARQL, Graph) and the cluster layer reach
+data through this crate, almost always via the `Arc<dyn DataStore>` indirection
+(`LocalDataStore` in standalone/pair mode; a cluster-routing impl otherwise).
+
+## What's implemented
+
+- **Memtable** — sharded write buffer behind the `Memtable` trait. Default build
+  uses `SkipListMemtable` (crossbeam skiplist, feature `skiplist-memtable`);
+  `ShardedBTreeMemtable` (64 `parking_lot::RwLock` shards) is the alternative.
+  Per-partition merge-on-write (cell-level LWW, tombstone merge).
+- **Commit log** (`commitlog/`) — segmented WAL with CAS-based lock-free
+  allocation, forward-linked sync markers, crash-recovery replay, CDC reader,
+  S3 archiver for PITR, and per-table checkpoints. Three sync strategies
+  (`Batch`, `Periodic`, `Group`); **default is `Periodic`** → a bounded
+  durability window (see FMEA).
+- **Flush** (`flush.rs`, `store.rs`) — `TableStore` composes active/flushing
+  memtables + SSTable descriptors behind a single `ArcSwap<StoreView>`. Flush is
+  serialized by a per-table `Mutex`; reads/writes are never blocked. Optional
+  `write_verify` self-readback after every flush.
+- **Compaction** (`compaction/`) — `CompactionExecutor` on dedicated
+  `std::thread` workers behind a global `CompactionGate`. STCS (default) and UCS
+  (CEP-26 density-based) strategies. A compaction validator (oracle + differential
+  checks) gates correctness.
+- **S3 write-behind** (`upload/`) — `UploadManager` tokio task + bounded mpsc;
+  SHA-256 integrity metadata; pending-upload log + replay for crash safety;
+  separate flush vs. compaction upload managers. **Wired into the flush path.**
+- **Local cache** (`cache.rs`) — LRU eviction with manifest-pinned entries that
+  are never evicted.
+- **NVMe pinning** (`pin_config.rs`) — `PinMode::NvMe` keeps a table local and
+  skips S3 upload; pin/unpin transitions reconcile the S3 lifecycle.
+- **Secondary-index pipeline** (`index/`, `memtable/eager_index.rs`) —
+  per-index state tracker, channel-based build scheduler, local/remote/off
+  backends, FTI + vector (HNSW/IVFFlat) sidecars, artifact manifest.
+- **Snapshot / PITR** (`snapshot/`, `restore/`, `commitlog/archiver.rs`) —
+  S3 snapshot manager, commit-log archiving, restore manager with validation.
+- **Quarantine + self-heal** (`quarantine.rs`, `self_heal/`) — malformed rows
+  found at flush/replay are written to a durable `quarantine/*.jsonl` sidecar
+  instead of crashing; the self-heal controller detects corrupt SSTables and
+  quarantines them under a safety rail.
+- **Accord** (`accord/`) — per-shard conflict index + protocol log for
+  strict-serializable transactions.
+- **Time-series** (`timeseries/`) — ring-buffer aggregation, late-data handling,
+  WASM aggregate execution, materialization queues.
+- **Virtual tables / observability** (`virtual_tables.rs`, `metrics.rs`) —
+  `system_observability.storage_stats`, `system_views.secondary_indexes`.
+
+## Public API (key entry points)
+
+| Area | Items |
+|------|-------|
+| Engine | `StorageEngine`, `StorageEngineConfig`, `new`/`open`, `register_table[_with_indexes]`, `shutdown` |
+| Write | `write`, `batch_write`, `write_atomic_batch`, `apply_batch`, `begin_batch`/`BatchTxn`/`BatchOp`, `replay_mutations` |
+| Read | `read`, `read_range`, `read_token_range[_bounded]`, `range_iter[_projected|_fragmented]`, `count_range`, `read_by_index`, `ann_search`, `fulltext_search`, `walk_token_range[_for_digest]` |
+| Maintenance | `flush`, `flush_if_needed`, `flush_all`, `poll_compactions`, `truncate`, `sync_sstables_to_s3` |
+| Snapshot/PITR | `create_snapshot_with_store`, `open_from_snapshot_with_store`, `list/delete_snapshot_with_store` |
+| Abstraction | `DataStore` / `LocalDataStore` (the `Arc<dyn DataStore>` boundary) |
+| Config types | `CommitLogConfig`, `SyncStrategyConfig`, `CompactionConfig`, `ObjectStoreConfig`, `Mutation`, `TableId` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-cdc`** — `CdcBus` for change-data-capture emission on the write path.
+- **`ferrosa-common`** — `Token`, `DecoratedKey`, `PartitionKey`, `CellValue`,
+  `TableSchema`, `Result`/`Error`, cell/clustering validation.
+- **`ferrosa-index`** — secondary index builders (BTree/Hash/FullText/Vector),
+  FTI sidecar merge.
+- **`ferrosa-schema`** — table/keyspace metadata and system schema persistence.
+- **`ferrosa-sstable`** — `Partition`, `Row`, `SSTableReader`/`SSTableWriter`,
+  BTI format I/O.
+
+External: `object_store` (aws), `tokio`, `arc-swap`, `parking_lot`,
+`crossbeam-skiplist`, `crc32fast`, `sha2`, `dashmap`, `serde`, `bytes`, `fs2`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa`** (main binary), **`ferrosa-cluster`**, **`ferrosa-cql`**,
+  **`ferrosa-ctl`**, **`ferrosa-graph`**, **`ferrosa-index-builder`**,
+  **`ferrosa-loadgen`**, **`ferrosa-postgres`**, **`ferrosa-session`**,
+  **`ferrosa-sparql`**.
+
+## Tests
+
+~1010 test functions across in-module `#[test]`/`#[tokio::test]` and 17
+integration files (`tests/`), including proptest property suites
+(`engine_property`, `compaction_property`, `commitlog_property`,
+`property_tests`) and the repair fuzz harness (`repair_fuzz.rs`, gated behind
+`test-generators`/`fuzz-fileio`). Live-infra tests are behind the
+`live-infra-tests` feature + `FERROSA_TEST_*` env vars. No `#[ignore]`.
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, position
+- [Data flow](specs/data-flow.md) — write path and read path (mermaid)
+- [FMEA / known issues](specs/fmea.md) — failure modes ranked by RPN
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-storage/specs/data-flow.md
+++ b/ferrosa-storage/specs/data-flow.md
@@ -1,0 +1,95 @@
+---
+crate: ferrosa-storage
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa-storage — Data Flow
+
+Two canonical paths: the **write path** (memtable → commit log → flush → S3) and
+the **read path** (memtable → cache → S3). All view transitions are
+`ArcSwap<StoreView>` swaps, so reads are wait-free and only flushes contend (on a
+per-table `Mutex`).
+
+## Write path
+
+A write is made durable by the commit log first, then applied to the memtable.
+A memtable that crosses the flush / backpressure thresholds is sealed and flushed
+to a BTI SSTable, which is then uploaded to S3 as write-behind.
+
+```mermaid
+flowchart TD
+    FE["Front-end / cluster<br/>Arc&lt;dyn DataStore&gt;"] --> W["StorageEngine::write / write_atomic_batch"]
+    W --> ADM{"admission:<br/>local_disk_free_reserve_bytes OK?"}
+    ADM -- no --> FAIL["fail closed<br/>(before commit-log append)"]
+    ADM -- yes --> CL["CommitLog::append<br/>CAS alloc into active segment"]
+    CL --> SYNC{"SyncStrategyConfig"}
+    SYNC -- Batch --> FSYNC["fsync every write<br/>(zero loss window)"]
+    SYNC -- "Periodic (default)" --> TIMER["background fsync on timer<br/>(up to sync_interval loss window)"]
+    SYNC -- Group --> GRP["batched fsync<br/>(bounded by max_wait)"]
+    FSYNC --> PUT
+    TIMER --> PUT
+    GRP --> PUT
+    PUT["ArcSwap::load StoreView<br/>active.put → one memtable shard<br/>(cell-level merge-on-write)"] --> CDC["WriteObserver / CdcBus emit"]
+    PUT --> BP{"memtable_size &gt;= backpressure_bytes?"}
+    BP -- yes --> FL
+    BP -- no --> DONE["ack write"]
+
+    subgraph FlushPath["Flush (per-table Mutex; reads/writes continue)"]
+      FL["flush_guard.lock<br/>swap in fresh memtable<br/>old → flushing"] --> SER["snapshot + sort<br/>build_serialization_header"]
+      SER --> WR["FlushTarget::flush → BTI SSTable<br/>(+ FTI / vector sidecars)"]
+      WR --> VERIFY{"write_verify?"}
+      VERIFY -- yes --> RB["reopen + self-readback"]
+      VERIFY -- no --> PUB
+      RB --> PUB["ArcSwap: prepend SstableDescriptor<br/>clear flushing"]
+      PUB --> COMP["maybe_compact (STCS / UCS)"]
+      PUB --> UP["UploadManager: submit components"]
+    end
+
+    UP --> S3["S3 (object_store)<br/>SHA-256 integrity meta<br/>authoritative durable store"]
+    UP --> PLOG["pending-upload log<br/>(replayed after crash)"]
+    UP --> MAN["Manifest: etag CAS update"]
+    PUB -. "PinMode::NvMe → skip S3 upload" .-> CACHEPIN["LocalCache pinned set"]
+```
+
+## Read path
+
+A read loads an immutable `StoreView`, checks the in-memory tiers, then opens
+only the SSTables whose key/token bounds could contain the key — filling pages
+from the local cache and falling back to S3. Results are merged newest-first with
+cell-level last-write-wins.
+
+```mermaid
+flowchart TD
+    R["StorageEngine::read / read_range / read_token_range"] --> LOAD["ArcSwap::load StoreView<br/>(wait-free)"]
+    LOAD --> MEM["check active memtable<br/>→ Option&lt;Arc&lt;Partition&gt;&gt;"]
+    LOAD --> FLM["check flushing memtable<br/>(if mid-flush)"]
+    LOAD --> PRUNE["prune SSTable descriptors<br/>by key / token bounds"]
+    PRUNE --> POOL["ReaderPool::get_or_open<br/>engine-wide LRU, cap 256"]
+    POOL --> CACHE{"LocalCache hit?"}
+    CACHE -- yes --> RD["SSTableReader::get_partition<br/>(bloom filter internal)"]
+    CACHE -- "miss / cold page" --> FETCH["fetch from S3<br/>verify SHA-256"]
+    FETCH --> REG["register in LocalCache<br/>(pinned entries never evicted)"]
+    REG --> RD
+    MEM --> MERGE
+    FLM --> MERGE
+    RD --> MERGE["merge_partitions<br/>cell-level LWW, newest-first<br/>tombstone suppression"]
+    MERGE --> OUT["Option&lt;Partition&gt; / Vec&lt;Partition&gt; → front-end"]
+    FETCH -. "integrity mismatch" .-> ERR["IntegrityError → re-fetch once,<br/>then fatal for that component"]
+```
+
+## Notes
+
+- **Durability boundary.** A write is durable only after its commit-log entry is
+  fsynced. Under the default `Periodic` strategy that fsync is deferred up to
+  `sync_interval`, so an acked write can be lost on an unclean stop (FMEA ST-1).
+  `Batch` closes the window at a latency cost.
+- **S3 is authoritative.** Local NVMe is a write-behind cache. Cache eviction
+  removes only local copies of remotely-durable objects; manifest-pinned entries
+  are never evicted, and `PinMode::NvMe` tables deliberately keep no S3 copy.
+- **Crash recovery.** On `open`, the engine loads `schema.json`, replays
+  commit-log segments into memtables (bounded), and replays the pending-upload
+  log so in-flight S3 uploads complete.
+- **Quarantine.** A row that fails cell/clustering validation at flush or replay
+  is written to a durable `quarantine/*.jsonl` sidecar and skipped; the flush
+  continues and `FLUSH_QUARANTINED_ROWS_TOTAL` increments.

--- a/ferrosa-storage/specs/fmea.md
+++ b/ferrosa-storage/specs/fmea.md
@@ -1,0 +1,46 @@
+---
+crate: ferrosa-storage
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-storage — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This crate is the durable substrate, so most severities are at
+the top of the scale: a defect here is silent data loss or corruption.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| ST-1 | **Durability window under the default `Periodic` sync strategy** — writes acked before fsync are lost on power-loss/crash | Up to `sync_interval` (default 10 ms) of acked writes lost on an unclean stop; replay cannot recover what was never fsynced | 9 | 4 | 6 | 216 | **Designed window, not a bug.** `BatchSync` gives zero loss at a latency cost; `Group` bounds it. macOS uses `F_FULLFSYNC` by default (`macos-fullfsync`) because plain fsync is not a hardware flush. Document the window per deployment; choose `Batch` for zero-loss tables. |
+| ST-2 | **Compaction drops/duplicates/reorders rows** vs. its inputs | Silent permanent data loss or resurrection of deleted data | 10 | 2 | 5 | 100 | Compaction validator (oracle + differential row-equivalence) gates outputs; `compaction-validator` feature exports it to the loadgen soak; `compaction_property.rs` proptest. Residual risk under UCS density edge cases. |
+| ST-3 | **SSTable / S3 object corruption read back as valid data** | Wrong query results or a crash mid-scan | 10 | 2 | 5 | 100 | SHA-256 integrity metadata verified on S3 read; `write_verify` self-readback after flush; corrupt-SSTable detector + `scan_table_dir_for_corrupt` → quarantine. Residual: silent bit-rot on local NVMe between flush and first read. |
+| ST-4 | **S3 write-behind backlog → local disk fills before upload drains** | Local NVMe ENOSPC; flushes stall; writes fail closed | 8 | 3 | 5 | 120 | `local_disk_free_reserve_bytes` admission check fails writes closed *before* the commit-log append; bounded upload mpsc applies backpressure; pending-upload log replays after crash. Residual: no proactive disk-pressure-driven flush throttle beyond the reserve gate. |
+| ST-5 | **Pinned (NVMe) table loses its only copy** — cache eviction or pin/unpin races delete the sole local copy with no S3 backup | Permanent data loss for a pinned table | 9 | 2 | 6 | 108 | Manifest-pinned entries are never LRU-evicted; pin→unpin enqueues S3 upload before relying on remote durability; `pin_max_bytes` evicts oldest from the pinned set only (still LRU-eligible, still local). Residual: pinned tables have no remote copy by design — node loss = data loss. |
+| ST-6 | **Malformed row wedges flush or replay** (e.g. truncated timeuuid from `now()`) | Without quarantine, the flush task or node crashes in a loop | 9 | 2 | 4 | 72 | **Mitigated**: rows failing cell/clustering validation are quarantined to `quarantine/*.jsonl`; flush continues. `FLUSH_QUARANTINED_ROWS_TOTAL` non-zero is a steady-state alert (means a write bypassed the `Memtable::put` guard). |
+| ST-7 | **Commit-log replay OOM** — unbounded pending mutations buffered when no schema is loaded | Node OOM on crash recovery | 8 | 2 | 5 | 80 | `max_pending_replay_mutations_without_schema` caps the legacy no-schema buffer and fails closed; normal recovery preloads `schema.json` and streams replay into registered tables. |
+| ST-8 | **Reader-pool fan-in blow-up under full token overlap** (repair digests) | Memory growth → OOM under the fmem cgroup | 7 | 3 | 5 | 105 | Engine-wide LRU reader pool caps resident readers (`sstable_reader_cache_cap`, default 256); compaction acquires a `CompactionGate` permit; range/digest walks stream one partition per source. Residual: strict open-reader bound under *fully* overlapping repair remains a separate acceptance gate, not enforced in-engine. |
+| ST-9 | **Manifest CAS conflict loses an SSTable from the live set** | An uploaded SSTable is not advertised → invisible data after restart | 8 | 2 | 5 | 80 | Etag-based `PutMode::Update` conditional put; conflict → reload + retry. Residual: verify retry is bounded and surfaces a loud error rather than silently dropping the entry. |
+| ST-10 | **Snapshot / PITR restore applies an inconsistent point** | Restored database missing or duplicating writes around the cut | 9 | 2 | 6 | 108 | Restore manager + `restore/validation.rs` validate the snapshot + archived commit-log segments before applying; archiver ships segments to S3. Residual: end-to-end PITR coverage is still maturing (see suite-level active work). |
+| ST-11 | **Lost write under memtable backpressure deadlock** | Sustained-write workload stalls or a second unbounded memtable grows | 7 | 2 | 4 | 56 | Synchronous in-line flush in `write()` on `memtable_backpressure_bytes`; `flush_guard` serializes so a runaway writer waits rather than growing a second memtable. `test_config` sets the threshold to `u64::MAX` so tiny-threshold tests do not deadlock. |
+
+## Top risks to act on
+
+1. **ST-1 (RPN 216)** — the default `Periodic` sync strategy means acked writes
+   are not durable for up to `sync_interval`. This is the single most important
+   thing for an operator to understand and tune per workload; it is correct by
+   design but high-impact if assumed away.
+2. **ST-4 (RPN 120)** / **ST-8 (RPN 105)** — local-disk and reader-pool memory
+   pressure are the resource-exhaustion paths most likely to cause a node-level
+   outage; both are bounded but the bounds depend on correct config + the repair
+   fan-in acceptance gate landing.
+
+## Detection assets
+
+- Compaction validator (`compaction/validator/`, oracle + differential).
+- `write_verify` post-flush self-readback; SHA-256 S3 integrity verification.
+- Corrupt-SSTable detector + `quarantine_corrupt_generation` (`self_heal/`).
+- Property/fuzz suites: `engine_property`, `compaction_property`,
+  `commitlog_property`, `repair_fuzz` (`test-generators`/`fuzz-fileio`).
+- Metrics: `FLUSH_QUARANTINED_ROWS_TOTAL`, compaction pool/running gauges, pin
+  gauges, `sstable_read_errors`.

--- a/ferrosa-storage/specs/overview.md
+++ b/ferrosa-storage/specs/overview.md
@@ -1,0 +1,97 @@
+---
+crate: ferrosa-storage
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The single-node storage engine and durable substrate of the platform:
+  memtable, write-ahead commit log, flush to BTI SSTables, S3 write-behind
+  upload, STCS/UCS compaction, local NVMe cache + pinning, the secondary-index
+  build pipeline, snapshot/PITR, and the corruption quarantine + self-heal
+  controller. Every front-end and the cluster layer read and write through it,
+  almost always via the Arc&lt;dyn DataStore&gt; boundary. Local disk is a
+  write-behind cache; S3 is the authoritative durable store.
+---
+
+# ferrosa-storage — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-storage` owns the **complete single-node data lifecycle**. It accepts
+writes into an in-memory memtable, makes them durable through a segmented
+write-ahead commit log, flushes to on-disk BTI SSTables, and asynchronously
+uploads SSTable components to S3 for durability. Reads merge across memtable,
+flushing memtable, and SSTables with cell-level last-write-wins semantics.
+
+Its upstream boundary is the `DataStore` trait: front-ends hold
+`Arc<dyn DataStore>` rather than `Arc<StorageEngine>`, so the same call sites
+serve standalone (`LocalDataStore`) and cluster-routed deployments. Its downstream
+boundary is `ferrosa-sstable` (BTI I/O) and `object_store` (S3). It knows nothing
+about CQL/SQL protocol framing or query planning — those belong to the front-ends.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `engine` (`src/engine.rs`, ~18.8k LoC) | `StorageEngine` + `StorageEngineConfig`: composition root; write/read/range/batch API, registration, snapshot/PITR orchestration, maintenance |
+| `store` (`src/store.rs`, ~9.2k LoC) | `TableStore`: lock-free `ArcSwap<StoreView>` per table; flush serialization; reader-pool wiring; index/FTI sidecar flush |
+| `memtable/` | `Memtable` trait; `SkipListMemtable` (default), `ShardedBTreeMemtable`; eager-index + vector-index hooks |
+| `commitlog/` | Segmented WAL: `segment` (CAS alloc), `sync` (Batch/Periodic/Group), `reader` (replay), `archiver` (S3/PITR), `cdc`, `checkpoint`, `manifest` |
+| `flush` | `FlushTarget` trait + `FileFlushTarget`/`InMemoryFlushTarget`; serialization-header construction |
+| `merge`, `range_merger` | Read-path cell-level LWW merge; streaming range/token-range merge |
+| `compaction/` | `CompactionExecutor`, STCS + UCS strategies, `CompactionGate`, validator (oracle + differential) |
+| `upload/` | `UploadManager` (tokio task), `ObjectStoreConfig`, pending-upload log + replay |
+| `cache`, `pin_config` | `LocalCache` LRU + pinning; NVMe `PinMode` |
+| `index/` | Index state tracker, build scheduler, local/remote/off backends, artifact manifest, virtual table |
+| `snapshot/`, `restore/` | S3 snapshot manager + restore manager + validation (PITR) |
+| `quarantine`, `self_heal/` | Malformed-row quarantine sidecar; deterministic self-heal control loop + corrupt-SSTable detector |
+| `accord/` | Per-shard conflict index + protocol log for Accord transactions |
+| `timeseries/` | Ring aggregation, late-data, WASM aggregates, materialization |
+| `data_store` | `DataStore` trait + `LocalDataStore` |
+| `metrics`, `virtual_tables`, `observer`, `subscription_observer` | Prometheus metrics; system virtual tables; write observers (CDC/SUBSCRIBE) |
+| `batchlog` | Batchlog manager for atomic multi-partition batches |
+
+## Data flow
+
+**Write path** (front-end → durable): build a `Mutation` → `commit_log.append`
+(CAS allocation into the active segment, durability governed by the sync
+strategy) → `ArcSwap::load` the `StoreView` → `active.put` into one memtable
+shard (cell-level merge-on-write). When the active memtable crosses
+`memtable_backpressure_bytes`, `write()` performs a synchronous in-line flush
+before returning. On flush: a per-table `Mutex` serializes; a fresh memtable is
+swapped in and the old one becomes `flushing` (writes resume immediately); the
+flushing snapshot is serialized to a BTI SSTable via `FlushTarget`; the new
+descriptor is prepended; index/FTI sidecars are built; the SSTable components are
+submitted to `UploadManager` for S3 write-behind; STCS/UCS is evaluated.
+
+**Read path** (durable → front-end): `ArcSwap::load` (wait-free) a `StoreView` →
+check active memtable → check flushing memtable → prune SSTable descriptors by
+key/token bounds → open only candidate readers through the engine-wide LRU
+reader pool (filling cold pages from `LocalCache`, falling back to S3) →
+`merge_partitions` cell-level LWW newest-first. See [data-flow.md](data-flow.md)
+for the mermaid diagrams.
+
+## Key invariants
+
+1. **S3 is authoritative; local disk is a write-behind cache.** Cache eviction
+   must never delete the only copy — manifest-pinned entries are never evicted.
+2. **Reads are wait-free; flush never blocks reads/writes.** All view
+   transitions go through `ArcSwap`; only flushes contend, on a per-table `Mutex`.
+3. **Cell-level last-write-wins everywhere.** Memtable merge-on-write, read-path
+   merge, and compaction all resolve conflicts by `(column_index, timestamp)`;
+   tombstones (partition/row/cell) suppress older data by `marked_for_delete_at`.
+4. **Durability is governed by the sync strategy.** Only `Batch` fsyncs every
+   write; the **default `Periodic`** has a bounded loss window (`sync_interval`).
+5. **Malformed data is quarantined, not dropped or crashed on.** A row that
+   fails cell/clustering validation at flush/replay is written to a durable
+   `quarantine/*.jsonl` and the counter `FLUSH_QUARANTINED_ROWS_TOTAL`
+   increments — non-zero in steady state is an alert.
+6. **Compaction correctness is gated by a validator.** Oracle + differential
+   checks confirm a compaction output is row-equivalent to its inputs.
+
+## Position in the dependency graph
+
+A heavyweight internal hub. Depends on `ferrosa-cdc`, `ferrosa-common`,
+`ferrosa-index`, `ferrosa-schema`, `ferrosa-sstable`. Depended on by `ferrosa`,
+`ferrosa-cluster`, `ferrosa-cql`, `ferrosa-ctl`, `ferrosa-graph`,
+`ferrosa-index-builder`, `ferrosa-loadgen`, `ferrosa-postgres`,
+`ferrosa-session`, `ferrosa-sparql`. See the root crate index for the full graph.

--- a/ferrosa-storage/specs/roadmap.md
+++ b/ferrosa-storage/specs/roadmap.md
@@ -1,0 +1,61 @@
+---
+crate: ferrosa-storage
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-storage — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), the suite-level active-work
+notes, in-code module markers (`self_heal`/`index` extension points), and the
+dependency/usage review. The crate has **no in-source `TODO`/`FIXME`** markers —
+open work lives in specs and the items below.
+
+## Now (highest value)
+
+- **Operator-facing durability guidance (FMEA ST-1).** The default `Periodic`
+  sync strategy trades a bounded loss window for throughput. Make the per-table /
+  per-deployment choice explicit (when to pick `Batch`/`Group`), and surface the
+  active strategy + observed sync interval in metrics/health so the window is
+  never assumed away.
+- **Strict reader fan-in bound under full token overlap (FMEA ST-8).** Resident
+  readers are pooled and digest walks stream, but the strict open-reader bound
+  for fully-overlapping repair digests is still a separate acceptance gate rather
+  than enforced in-engine. Land the gate so anti-entropy repair cannot blow the
+  fmem cgroup.
+
+## Next
+
+- **Proactive disk-pressure flush throttle (FMEA ST-4).** Beyond the
+  `local_disk_free_reserve_bytes` fail-closed admission gate, add an earlier
+  signal that throttles/accelerates flush+upload as local NVMe usage climbs, so
+  writes degrade gracefully instead of hitting the hard reserve.
+- **Self-heal controller: drain + converge actions.** The control loop +
+  quarantine action (the first vertical slice) are implemented; compaction-driven
+  drain, anti-entropy converge, and divergence detection are marked as explicit
+  follow-ups in `self_heal/mod.rs`. Each remediation must stay bounded before the
+  controller runs without an operator.
+- **End-to-end PITR hardening (FMEA ST-10).** Snapshot/restore + commit-log
+  archiving exist; broaden restore validation coverage and the fork/branch
+  orchestration consumed by `ferrosa-dbaas`.
+
+## Later
+
+- **TWCS / TTL-aware compaction levels.** STCS and UCS are implemented; a
+  time-window strategy (or UCS with TTL-aware levels) for time-series tables.
+- **Local NVMe bit-rot detection.** S3 objects are SHA-256-verified on read and
+  flush self-readback exists, but there is no background scrub of local SSTables
+  between flush and first read (FMEA ST-3 residual).
+- **HVQ S3 spill-tier vector artifacts.** Page/range-readable `.qvec` resolver so
+  vector artifacts need not fit on the compute node (per the storage topic spec's
+  HVQ contract); current vector sidecars are whole-blob.
+- **Grace-period GC + orphan sweep.** Confirm superseded-SSTable deletion grace
+  and a periodic sweep of unreferenced S3 objects are bounded and observable.
+
+## Non-goals
+
+- Query parsing, planning, protocol framing, or transport — those belong to the
+  front-ends (`ferrosa-cql`, `ferrosa-postgres`, `ferrosa-sparql`,
+  `ferrosa-graph`).
+- Cluster routing/consensus — owned by `ferrosa-cluster`; this crate exposes the
+  `DataStore` seam it routes through.

--- a/ferrosa-udf/README.md
+++ b/ferrosa-udf/README.md
@@ -1,0 +1,121 @@
+# ferrosa-udf
+
+> WASM-sandboxed execution for CQL User-Defined Functions and Aggregates, plus
+> an optional inline AssemblyScript→WASM compiler. All Wasmtime internals are
+> encapsulated here — callers see only `UdfExecutor`.
+
+## What this crate is
+
+The execution substrate for CQL `CREATE FUNCTION` / `CREATE AGGREGATE`. It owns
+the Wasmtime Component Model engine, a compiled-component registry, an instance
+pool, and the bidirectional conversion between `ferrosa_common::CqlValue` and the
+WIT `cql-value` ABI. Callers (`ferrosa-cql`, `ferrosa-session`, `ferrosa-ctl`,
+`ferrosa`) hand it WASM component bytes plus a CQL signature and get back a typed
+result — they never touch Wasmtime, fuel, or the WIT encoding directly.
+
+A UDF is a WASM **component** exporting `invoke(list<cql-value>) -> result<cql-value, string>`.
+A streaming aggregate is a component exporting `init` / `update(f64)` / `finalize() -> f64`,
+gated behind a `ferrosa:streaming-aggregate:v1` custom-section marker.
+
+## What's implemented
+
+- **`UdfExecutor`** — Wasmtime Component Model engine with fuel metering + epoch
+  interruption. Compiles, caches, resolves, invalidates, and invokes components.
+  Thread-safe (`Arc`-shareable).
+- **Scalar UDF invocation** — `compile`, `resolve`/`call`/`call_by_key`. The
+  conversion chain is `CqlValue` → `WitCqlValue` → `Val::Variant` → WASM →
+  `Val::Result` → `WitCqlValue` → `CqlValue`.
+- **Streaming aggregates** — `compile_streaming_aggregate`,
+  `call_streaming_aggregate`, `start_streaming_aggregate` →
+  `StreamingAggregateInvocation::{update, finalize}` (the RRD-rollup `f64` path).
+- **UDA instances** — `create_uda_instance[_by_key]` return a raw
+  `(Store, Instance)` for the caller (`ferrosa-cql`) to drive `init`/`accumulate`/
+  `merge`/`serialize-state`/`finalize` per the `uda` WIT world.
+- **Registry** — `SlotMap`-backed `(keyspace, name, arg_types)` → component,
+  O(1) `FunctionKey` lookup on the hot path; CREATE-OR-REPLACE and DROP semantics
+  (`invalidate` drains the pool so stale code is never reused).
+- **Instance pool** — up to 8 warm `(Store, Instance)` pairs per function;
+  acquire/release on `call()` to amortise instantiation.
+- **Type conversion** (`convert`) — `cql_to_wit` / `wit_to_cql` for all 26
+  `CqlValue` cases (scalars, collections, tuple, UDT; `Vector` maps to a list of
+  floats).
+- **Sandbox limits** (`SandboxConfig`) — memory, per-call fuel, per-aggregate
+  fuel, wall-clock timeout (epoch), cache capacity, max WASM upload size.
+- **Inline AssemblyScript compiler** (feature `asc-udf`, modules `asc` +
+  `component`) — runs the `asc`+`binaryen` JS toolchain inside QuickJS with a
+  wasmtime-backed `WebAssembly` shim, then componentizes the core module to the
+  `udf` WIT world via `wit-component`. Powers `CREATE FUNCTION ... LANGUAGE assemblyscript`.
+
+## How it works
+
+| Module | Responsibility |
+|--------|----------------|
+| `executor` (`src/executor.rs`, ~1.9k LoC) | `UdfExecutor`, registry, instance pool, `Val`↔`WitCqlValue` encode/decode, fuel/epoch wiring |
+| `convert` (`src/convert.rs`, ~750 LoC) | `WitCqlValue` enum + `cql_to_wit` / `wit_to_cql` (type-directed) |
+| `sandbox` (`src/sandbox.rs`) | `SandboxConfig` resource limits |
+| `arena` (`src/arena.rs`) | `UdfArena` per-query bump allocator for arg lowering |
+| `error` (`src/error.rs`) | `UdfError` |
+| `asc` (`src/asc.rs`, feature `asc-udf`) | inline AssemblyScript→core-WASM compiler (QuickJS + wasmtime shim) |
+| `component` (`src/component.rs`, feature `asc-udf`) | core-WASM → `udf`-world component (adapter codegen + `wit-component`) |
+
+The WIT `cql-value` variant is **recursive** (list/set/map/tuple/udt contain
+`cql-value`), so `wasmtime::component::bindgen!` cannot be used. The executor
+hand-encodes `Val::Variant` by kebab-case discriminant name instead. The WIT
+contract lives at `src/wit/ferrosa-udf.wit` (worlds `udf` and `uda`).
+
+## Public API (key entry points)
+
+| Area | Items |
+|------|-------|
+| Executor | `UdfExecutor::new`, `compile`, `compile_streaming_aggregate`, `resolve`, `get_kind`, `invalidate` |
+| Scalar invoke | `call`, `call_by_key` |
+| Aggregate | `call_streaming_aggregate`, `start_streaming_aggregate`, `StreamingAggregateInvocation`, `create_uda_instance[_by_key]`, `wasm_declares_streaming_aggregate_abi` |
+| Config / types | `SandboxConfig`, `FunctionKind`, `UdfArena`, `UdfError` |
+| Conversion | `convert::{WitCqlValue, cql_to_wit, wit_to_cql}` |
+| AssemblyScript (`asc-udf`) | `asc::compile_assemblyscript`, `component::{compile_to_component, componentize}`, `asc::AscError` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-common`** — `CqlValue`, `CqlType` (the type model it converts to/from
+  the WIT ABI).
+
+External: `wasmtime` (component-model), `slotmap`, `num-bigint`, `uuid`, `bumpalo`,
+`thiserror`, `tracing`. Under `asc-udf`: `rquickjs`, `tokio`, `wit-component`,
+`wit-parser`.
+
+**Called by** (crates that depend on this):
+
+- **`ferrosa`** — constructs the process-wide `UdfExecutor`.
+- **`ferrosa-cql`** — DDL replication of `CREATE FUNCTION`/`AGGREGATE`, query-time
+  invocation, the streaming-aggregate driver (`wasm_aggregate.rs`), the
+  AssemblyScript compile path (`router.rs`), and `From<UdfError> for CqlError`.
+- **`ferrosa-ctl`** — cluster/UDF management surface.
+- **`ferrosa-session`** — holds the shared `Arc<UdfExecutor>` in session context.
+
+## Tests
+
+89 `#[test]` functions in-crate. Default `cargo test -p ferrosa-udf` (no features)
+runs the conversion round-trips (`convert`), the executor registry/pool/encoding
+tests (`executor`), and the `SandboxConfig` tests (`sandbox`).
+
+The `asc`/`component` end-to-end tests are feature-gated: the componentization
+pipeline tests build under `--features asc-udf`; the tests that actually run the
+15 MB asc+binaryen toolchain require `--features 'asc-udf live-infra-tests'` and
+`FERROSA_ASC_BUNDLE` pointing at a bundle built by
+`examples/asc-poc/build-bundle.sh` (they `panic!` with setup instructions if it
+is absent, per repo test policy — no silent skips).
+
+```bash
+cargo test -p ferrosa-udf
+cargo test -p ferrosa-udf --features asc-udf
+FERROSA_ASC_BUNDLE=/tmp/asc-host/asc-bundle.mjs \
+  cargo test -p ferrosa-udf --features 'asc-udf live-infra-tests'
+```
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, ABI, invariants, data flow
+- [FMEA / known issues](specs/fmea.md) — failure modes + gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-udf/specs/fmea.md
+++ b/ferrosa-udf/specs/fmea.md
@@ -1,0 +1,47 @@
+---
+crate: ferrosa-udf
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-udf — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). This crate runs untrusted guest code on the hot query path, so
+sandbox-escape and determinism failures dominate the top of the table.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| UDF-1 | Non-deterministic UDF result (guest reads wall-clock-ish host state, or relies on f32/f64 NaN-bit or rounding differences) | Same row yields different values across replicas/reruns → divergent reads, broken UDA merge | 9 | 5 | 8 | 360 | **Open gap.** No host-side determinism enforcement beyond the sandbox having no clock/RNG imports wired in `Linker::new` (an *empty* linker — guest gets no imports). There is no positive determinism test, no float-mode pinning, and no audit that a compiled component imports nothing. Add a "component imports must be empty" check at `compile` and a cross-instance determinism test. |
+| UDF-2 | Epoch ticker interval == `max_execution_time`, so the wall-clock timeout can overshoot by up to ~2× | A runaway guest can run nearly twice the configured budget before the epoch deadline (`set_epoch_deadline(1)`) fires | 6 | 6 | 6 | 216 | **Known.** `udf-epoch-ticker` sleeps `max_execution_time` then increments once; with deadline=1 the worst case is two intervals. Fuel (`max_fuel`) is the primary bound; epoch is the backstop. Tighten by ticking at a fraction of the timeout. |
+| UDF-3 | Error-message string matching to classify traps (`msg.contains("fuel")` / `"epoch"`) | A Wasmtime version or locale change to trap text silently reclassifies `ResourceExhausted` as `ExecutionFailed` (or vice versa) | 5 | 4 | 7 | 140 | **Open gap.** `map_component_call_error` + the inline closures in `call`/`call_by_key` parse `e.to_string()`. Prefer `e.downcast_ref::<wasmtime::Trap>()` and match `Trap::OutOfFuel` / interrupt explicitly. |
+| UDF-4 | asc-compiled UDF restricted to numeric/text/ascii/blob; collection/temporal/decimal args silently unavailable | `CREATE FUNCTION ... LANGUAGE assemblyscript` over a `list`/`map`/`decimal`/`timestamp` arg is rejected at compile | 4 | 5 | 3 | 60 | **By design, documented.** `component.rs::abi_type` returns a clear `AscError::Compile` naming the type; the reduced WIT world drops recursive cases. Fails loud, not silent. A msgpack-blob bridge is the planned path (roadmap). |
+| UDF-5 | Pooled instance reuse carries guest mutable globals across calls | A scalar UDF that mutates a WASM global sees state from a prior invocation → non-deterministic / leaked data between rows or tenants | 8 | 3 | 7 | 168 | **Partial.** `call()` resets fuel + epoch on the warm store but does **not** reset guest linear memory or globals; correctness relies on the canonical post-return `__reset` (asc adapter) and well-behaved guests. Hand-written components that hold global state would observe carryover. No test asserts pool-reuse isolation. |
+| UDF-6 | `max_memory_bytes` in `SandboxConfig` is not enforced on the `Store` | A guest can grow linear memory past the configured cap (up to Wasmtime/OS limits) → host memory pressure | 7 | 3 | 6 | 126 | **Open gap.** `SandboxConfig.max_memory_bytes` (default 16 MB) is defined and tested for its value, but no `StoreLimits`/`ResourceLimiter` is installed in `new`/`call`. Wire `Store::limiter` to enforce it. |
+| UDF-7 | Lock poisoning on the registry `RwLock` panics every subsequent call | A panic while holding the registry write lock takes down all UDF execution process-wide | 7 | 1 | 4 | 28 | **Accepted.** `.expect("registry lock poisoned")` is fail-loud per repo policy; the held critical sections are small and panic-free. |
+| UDF-8 | UDA `merge`/`serialize-state` correctness depends entirely on the guest | Distributed aggregation produces wrong results if the guest's serialize/merge is not associative/commutative | 8 | 3 | 8 | 192 | **Out of crate scope but undertested here.** The `uda` world is exposed via raw `(Store, Instance)` (`create_uda_instance`); this crate has **no** in-crate UDA round-trip or merge test — all UDA driving + coverage lives in `ferrosa-cql`. |
+| UDF-9 | asc compiler thread is process-lifetime and never dropped (by design) | QuickJS runtime + 15 MB binaryen held for process life; a wedged compile job blocks the single `sync_channel(0)` serially | 4 | 3 | 5 | 60 | **By design, documented in `asc.rs`.** The runtime cannot be safely dropped (GC cycle assertion); a persistent thread amortises init. Compiles are serialized — a slow/hostile source delays others. No per-compile timeout. |
+
+## Top risks to act on
+
+1. **UDF-1 (RPN 360)** — determinism is the highest risk and is essentially
+   unguarded today. The empty `Linker` denies host imports (good), but nothing
+   asserts a component imports nothing, pins float behaviour, or proves
+   cross-instance reproducibility. This directly threatens replica convergence
+   and UDA correctness.
+2. **UDF-2 (RPN 216)** — the wall-clock timeout can overshoot ~2×; tighten the
+   ticker cadence relative to the deadline.
+3. **UDF-8 (RPN 192)** / **UDF-5 (RPN 168)** — UDA correctness and pool-reuse
+   isolation have **no in-crate test**; the green build is not a real safety
+   signal for those paths.
+
+## Detection assets
+
+- In-crate: 42 conversion round-trip tests (`convert`), 36 executor tests
+  (registry/pool lifecycle, `Val` encode/decode round-trips, fuel/epoch engine
+  config, streaming-aggregate stddev end-to-end), 2 `SandboxConfig` tests.
+- `asc`/`component`: componentization-pipeline tests under `--features asc-udf`;
+  full toolchain tests under `--features 'asc-udf live-infra-tests'` +
+  `FERROSA_ASC_BUNDLE` (panic with setup instructions if absent).
+- Out-of-crate: `ferrosa-cql` exercises DDL replication, query-time invocation,
+  the UDA driver (`wasm_aggregate.rs`), and the asc compile path (`router.rs`).

--- a/ferrosa-udf/specs/overview.md
+++ b/ferrosa-udf/specs/overview.md
@@ -1,0 +1,120 @@
+---
+crate: ferrosa-udf
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  WASM-sandboxed execution for CQL User-Defined Functions and Aggregates. Owns
+  the Wasmtime Component Model engine, a SlotMap-backed component registry, an
+  instance pool, and the CqlValue <-> WIT cql-value conversion. Fuel metering and
+  epoch interruption bound every invocation. An optional asc-udf feature adds an
+  inline AssemblyScript -> WASM compiler so CREATE FUNCTION ... LANGUAGE
+  assemblyscript needs no external toolchain.
+---
+
+# ferrosa-udf — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-udf` is the **execution sandbox** for CQL UDFs/UDAs. Its boundary is
+deliberately narrow: it knows about `CqlValue`/`CqlType` (`ferrosa-common`) and
+WASM components, and nothing about CQL parsing, schema metadata, DDL replication,
+or query planning. Callers own those concerns and hand this crate compiled
+component bytes plus a CQL signature; it returns a typed `CqlValue` or a
+`UdfError`. All Wasmtime internals (engine config, fuel, epoch, `Val` encoding)
+are encapsulated so no caller depends on Wasmtime directly.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `executor` (`src/executor.rs`, ~1868 LoC) | `UdfExecutor`, `FunctionRegistry` (SlotMap), `InstancePool`, fuel/epoch wiring, `Val` `<->` `WitCqlValue` encode/decode, streaming-aggregate driver |
+| `convert` (`src/convert.rs`, ~754 LoC) | `WitCqlValue` enum + type-directed `cql_to_wit` / `wit_to_cql` (all 26 cases) |
+| `sandbox` (`src/sandbox.rs`) | `SandboxConfig` resource limits (memory, fuel, epoch timeout, cache, upload size) |
+| `arena` (`src/arena.rs`) | `UdfArena` per-query bump allocator |
+| `error` (`src/error.rs`) | `UdfError` |
+| `asc` (`src/asc.rs`, feature `asc-udf`) | inline AssemblyScript -> core-WASM via QuickJS + wasmtime-backed `WebAssembly` shim |
+| `component` (`src/component.rs`, feature `asc-udf`) | adapter codegen + `wit-component` core-module -> `udf`-world component |
+| `src/wit/ferrosa-udf.wit` | the `udf` and `uda` WIT worlds (the host/guest contract) |
+
+## The ABI
+
+The WIT `cql-value` variant is **recursive** — `list-val`, `set-val`, `map-val`,
+`tuple-val`, and `udt-val` all carry `cql-value` payloads. The Component Model's
+`bindgen!` macro rejects recursive types, so the executor uses the **dynamic
+`Val` API** and encodes each case as `Val::Variant(discriminant, payload)` with
+the WIT kebab-case name. Two worlds exist:
+
+- `udf`: `export invoke: func(args: list&lt;cql-value&gt;) -> result&lt;cql-value, string&gt;`
+- `uda`: `init` / `accumulate` / `merge` / `serialize-state` / `finalize`, driven
+  by `ferrosa-cql` via the raw `(Store, Instance)` from `create_uda_instance`.
+
+The componentization path in `component.rs` uses a **reduced** WIT world that
+drops the recursive collection cases (WIT's topological resolver cannot encode
+them), so asc-compiled UDFs currently support numeric / text / ascii / blob
+signatures only.
+
+## Data flow
+
+```mermaid
+flowchart TD
+  subgraph caller [ferrosa-cql / ferrosa-session / ferrosa]
+    DDL[CREATE FUNCTION / AGGREGATE]
+    Q[query-time call]
+  end
+
+  subgraph udf [ferrosa-udf]
+    EX[UdfExecutor]
+    REG[(FunctionRegistry SlotMap)]
+    POOL[(InstancePool: warm Store+Instance)]
+    CONV[convert: CqlValue and WitCqlValue]
+    ENC[executor: WitCqlValue and Val::Variant]
+    ENG[Wasmtime engine: fuel + epoch]
+  end
+
+  ASC[asc + component: AssemblyScript to component] -. feature asc-udf .-> DDL
+
+  DDL -->|component bytes + signature| EX
+  EX -->|compile / invalidate| REG
+  EX -->|ensure / drain| POOL
+  Q -->|args: Vec of CqlValue| EX
+  EX --> CONV --> ENC --> ENG
+  ENG -->|result Val| ENC --> CONV --> EX
+  EX -->|CqlValue or UdfError| Q
+```
+
+**Compile path**: caller supplies `(keyspace, name, arg_types, wasm_bytes)`.
+`compile` rejects oversized binaries, validates via `Component::new`, registers
+in the SlotMap (replacing any prior entry — CREATE OR REPLACE), and pre-allocates
+a pool slot. `compile_streaming_aggregate` additionally requires the
+`ferrosa:streaming-aggregate:v1` marker.
+
+**Call path**: `call` looks up the component, acquires a warm instance from the
+pool (or instantiates fresh on miss), resets fuel + epoch deadline, converts args
+through `cql_to_wit` -> `Val::Variant`, invokes `invoke`, decodes the
+`result<cql-value, string>` back through `wit_to_cql`, and returns the instance to
+the pool only on success.
+
+## Key invariants
+
+1. **Every invocation is resource-bounded.** Each `Store` gets `max_fuel` (or
+   `max_aggregate_fuel`) and `epoch_deadline_trap` + `set_epoch_deadline(1)`. A
+   background `udf-epoch-ticker` thread increments the engine epoch every
+   `max_execution_time`, so a CPU-bound guest traps as `OutOfFuel` or on the
+   epoch deadline rather than hanging the host.
+2. **Stale code is never reused.** `invalidate` removes the registry slot *and*
+   drains the instance pool for that key; instances are returned to the pool only
+   on a successful call (errors discard the instance).
+3. **The conversion is total and type-directed.** `cql_to_wit` handles all 26
+   `CqlValue` cases; `wit_to_cql` reconstructs collections/UDT/tuple using the
+   declared `CqlType`, and errors loudly (`TypeMismatch`) on a shape mismatch or
+   an unparseable uuid/inet rather than silently returning NULL.
+4. **No second encoder.** The host-side `cql-value` `Val::Variant` encoding in
+   `executor.rs` is the only one; the asc adapter in `component.rs` writes the
+   same canonical-ABI layout.
+
+## Position in the dependency graph
+
+Leaf-adjacent: depends only on `ferrosa-common` (plus external Wasmtime/QuickJS
+toolchain crates). Depended on by `ferrosa`, `ferrosa-cql`, `ferrosa-ctl`, and
+`ferrosa-session`. See the [root crate index](../../specs/crates.md) for the full
+graph.

--- a/ferrosa-udf/specs/roadmap.md
+++ b/ferrosa-udf/specs/roadmap.md
@@ -1,0 +1,51 @@
+---
+crate: ferrosa-udf
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-udf — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), the in-code design notes
+(`asc.rs`, `component.rs`), and the dependency/usage review. No in-code
+`TODO`/`FIXME` markers exist; the items below come from the gap analysis.
+
+## Now (highest value)
+
+- **Enforce + prove determinism** (FMEA UDF-1). Assert at `compile` that a
+  registered component imports nothing (the `Linker` is already empty, so any
+  import is a latent failure), and add a cross-instance test that the same args
+  yield the same result. This guards replica convergence and UDA merge.
+- **Classify traps structurally, not by string** (FMEA UDF-3). Replace
+  `e.to_string().contains("fuel"/"epoch")` in `call`, `call_by_key`, and
+  `map_component_call_error` with `e.downcast_ref::<wasmtime::Trap>()` matches on
+  `OutOfFuel` / interrupt so trap-text changes can't silently reclassify errors.
+
+## Next
+
+- **Enforce `max_memory_bytes`** (FMEA UDF-6). Install a `Store` limiter
+  (`ResourceLimiter` / `StoreLimits`) so the configured per-invocation memory cap
+  is actually applied — today it is config-only.
+- **Tighten the epoch timeout** (FMEA UDF-2). Tick the engine epoch at a fraction
+  of `max_execution_time` (or raise the deadline count) so the wall-clock bound
+  cannot overshoot ~2×.
+- **In-crate UDA + pool-isolation coverage** (FMEA UDF-8, UDF-5). Add round-trip
+  tests for the `uda` world (`init`/`accumulate`/`merge`/`serialize-state`/
+  `finalize`) and a test that a pooled scalar instance does not leak guest global
+  state across calls. Both paths are currently only exercised from `ferrosa-cql`.
+
+## Later
+
+- **Collection/temporal/decimal asc UDFs** (FMEA UDF-4). The reduced
+  componentization WIT world drops recursive cases; bridge `list`/`set`/`map`/
+  `tuple`/`udt` (and temporal/decimal) across the canonical ABI — the design note
+  in `component.rs` points at a msgpack-blob `collection-val` approach.
+- **Bounded inline-compile** (FMEA UDF-9). Add a per-compile timeout/cancellation
+  around the serialized asc compiler thread so a slow or hostile source cannot
+  stall the single-job channel indefinitely.
+
+## Non-goals
+
+- CQL parsing, schema metadata, DDL replication, or query planning — those belong
+  to `ferrosa-cql` / `ferrosa-session`, which orchestrate this crate.
+- Languages other than WASM components and (behind `asc-udf`) AssemblyScript.

--- a/ferrosa-view/README.md
+++ b/ferrosa-view/README.md
@@ -1,0 +1,108 @@
+# ferrosa-view
+
+> The protocol-agnostic, I/O-free **core** of ferrosa materialized views:
+> view metadata, DDL validation, and pure view-delta computation.
+
+## What this crate is
+
+A small, pure crate that owns the three conflict-free primitives every
+materialized-view code path agrees on:
+
+1. **Metadata** — the schema-replicated description of a view (`ViewMetadata`).
+2. **DDL validation** — the single gatekeeper (`validate_view_def`) every
+   frontend calls before a view is created.
+3. **Delta computation** — the pure incremental-maintenance state machine
+   (`compute_view_delta`) that turns a base-row transition into the view
+   mutations needed to keep the view consistent with its base.
+
+It is deliberately **pure**: it depends only on `ferrosa-schema` and never on
+`ferrosa-storage`, `ferrosa-cluster` (Accord), or any protocol frontend. Keeping
+this logic free of I/O is what makes the strict-serializable maintenance
+guarantee reproducible and unit-testable.
+
+## Status — island, not yet wired in
+
+**This crate is an "island."** The conflict-free primitives have landed with
+unit tests, but the engine/Accord wiring that would *drive* them is tracked
+separately and is **not yet integrated**.
+
+- **No other crate depends on `ferrosa-view`.** It is not a path dependency of
+  any crate in the workspace — confirmed by an explicit scan. Nothing calls
+  `validate_view_def` or `compute_view_delta` in production paths yet.
+- The read-before-write that produces a `prior` snapshot, the Accord-coordinated
+  base+view commit, the predicate (`ViewPredicate::extra`) and UDF evaluators,
+  and the schema-replication of `ViewMetadata` all live in the engine layer and
+  are **pending**. See [specs/roadmap.md](specs/roadmap.md).
+
+Document, build, and test this crate as a self-contained core — but do not
+mistake a green `cargo test -p ferrosa-view` for end-to-end materialized views.
+
+## What's implemented
+
+- **`ViewMetadata`** and supporting types (`ViewKind`, `ViewColumn`,
+  `ColumnSource`, `ViewPredicate`) — serde-serializable, with `primary_key()`
+  and `source_of()` helpers. Only `ViewKind::Incremental` exists; `Snapshot`
+  (Postgres-style `REFRESH`) is intentionally reserved but absent (decision D1).
+- **`validate_view_def`** — a pure function over `(base TableMetadata, view
+  ViewMetadata, base_is_view)` enforcing the Cassandra-baseline + ferrosa rules:
+  view PK covers base PK; at most one extra PK column; `IS NOT NULL` on every
+  view-PK column; no aggregates; no static columns; no counter base; no chained
+  views; deterministic-only UDF columns; no computed column in the view PK.
+  Returns the first violated rule as a typed `ViewDefError`.
+- **`compute_view_delta`** — the pure transition `(prior, next, timestamp) →
+  Vec<ViewDelta>`. Handles insert into / out of the predicate, non-PK updates,
+  view-PK changes (delete-old + insert-new), and deletes/tombstones. Stamps the
+  originating base timestamp on every emitted delta.
+
+## What's NOT implemented (in this crate)
+
+- **Predicate evaluation beyond `IS NOT NULL`.** `ViewPredicate::extra` is a
+  placeholder string; `compute_view_delta` projects on the `IS NOT NULL`
+  baseline only.
+- **UDF / aggregate column projection.** `projected_columns` emits base columns
+  only; `Udf`/`Aggregate` sources project to nothing here (deferred to the
+  udf-eval cycle).
+- **Any I/O, storage row types, Accord coordination, or schema replication.** By
+  design — these are forbidden dependency edges and live in the engine layer.
+
+## Public API
+
+| Area | Items |
+|------|-------|
+| Metadata | `ViewMetadata`, `ViewKind`, `ViewColumn`, `ColumnSource`, `ViewPredicate` |
+| Validation | `validate_view_def`, `ViewDefError` |
+| Delta | `compute_view_delta`, `ViewDelta`, `RowSnapshot` |
+
+## Dependencies
+
+**Calls** (ferrosa crates this depends on):
+
+- **`ferrosa-schema`** — `TableMetadata`, `ColumnMetadata`, `ColumnKind`,
+  `TableFlag` (the base-table shapes `validate_view_def` reads).
+
+External: `serde`, `uuid`. Dev: `serde_json`, `indexmap`, `proptest`.
+
+**Called by** (crates that depend on this):
+
+- **NONE yet.** `ferrosa-view` is an island awaiting integration — no crate in
+  the workspace lists it as a path dependency. This is intentional and tracked;
+  see [specs/overview.md](specs/overview.md) and [specs/roadmap.md](specs/roadmap.md).
+
+## Tests
+
+25 in-crate unit tests, all co-located with the code:
+
+- `metadata` — 3 (`ViewKind` round-trip, reserved-discriminator encoding, PK
+  iteration order).
+- `validate` — 12 (one accept case plus every rejection rule).
+- `delta` — 10 (predicate flips, PK change, update, delete, TTL/tombstone,
+  determinism).
+
+`proptest` is declared as a dev-dependency but not yet exercised — a tracked gap
+(see [specs/fmea.md](specs/fmea.md)).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, invariants, data flow
+- [FMEA / known issues](specs/fmea.md) — failure modes + integration gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-view/specs/fmea.md
+++ b/ferrosa-view/specs/fmea.md
@@ -1,0 +1,40 @@
+---
+crate: ferrosa-view
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-view — FMEA / Known Issues
+
+Failure modes ranked by **RPN = Severity × Occurrence × Detection** (1–10 each;
+higher = worse). The dominant theme is **integration risk**: the primitives are
+correct in isolation but nothing drives them yet, so the most severe failure
+modes are about the *missing* engine wiring, not bugs in the present code.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| MV-1 | **Island never integrated** — `compute_view_delta` / `validate_view_def` are not called by any crate; the engine/Accord maintenance path is unwritten | Materialized views do not exist end-to-end; a green build implies a feature that is not wired in | 9 | 8 | 3 | 216 | **Open, known.** Documented as an island in README + overview. Engine integration tracked separately (roadmap "Now"). Detection is easy (no callers), hence low D. |
+| MV-2 | **Maintenance correctness unverifiable in-crate** — strict-serializable base+view consistency depends on the engine's read-before-write + Accord commit, none of which is exercised here | A subtly wrong integration (lost `prior`, wrong timestamp ordering, non-atomic commit) corrupts the view silently | 9 | 5 | 7 | 315 | **Open.** Pure-core tests prove the delta math; they cannot prove the commit. Needs engine-level integration + Jepsen-style tests once wired. Highest RPN. |
+| MV-3 | **Predicate `extra` silently ignored** — `ViewPredicate::extra` is a placeholder string; `compute_view_delta` projects on `IS NOT NULL` only | A view defined with a `WHERE` beyond `IS NOT NULL` would include rows it should exclude | 7 | 6 | 6 | 252 | **Open by design.** Documented placeholder; `validate_view_def` accepts `extra` without enforcing it. Must become fail-loud or be evaluated before the predicate cycle integrates. |
+| MV-4 | **UDF / aggregate columns project to nothing** — `projected_columns` emits only `Base` columns; `Udf`/`Aggregate` sources yield no value | A deterministic UDF column passes validation but its value never appears in the view delta | 6 | 6 | 6 | 216 | **Open by design.** Deferred to the udf-eval cycle. Validation already rejects non-deterministic UDFs and aggregates; deterministic UDF projection is a gap. |
+| MV-5 | **Property-test net absent** — `proptest` is a declared dev-dependency but unused; coverage is example-based only | Edge cases in projection / PK-change logic (empty values, duplicate PK names, many extra columns) may be untested | 5 | 5 | 6 | 150 | **Open.** Add `proptest` round-trip / invariant tests (delete-before-insert ordering on PK change, projection monotonicity). Listed in roadmap. |
+| MV-6 | **`view_pk_values` substitutes empty bytes for an absent PK column** — `row.get(c).cloned().unwrap_or_default()` defaults to `vec![]` | If called on a non-projected row, an empty `Vec<u8>` masquerades as a real key value | 7 | 2 | 7 | 98 | **Mitigated by contract.** Callers gate on `projects()` first, so PK columns are always present; the `unwrap_or_default` is unreachable in correct use but is a fail-silent default rather than an assert. Consider a debug assert. |
+| MV-7 | **`ColumnSource::Base` name vs. view-column name confusion** — projection keys output by `vc.name`, sourced by `base_col`; a rename mapping bug would mislabel a column | View column shows another column's value | 8 | 2 | 5 | 80 | Covered by `validate`/`delta` unit tests using distinct base vs. view names; low occurrence. |
+| MV-8 | **`ViewKind` forward-compat regression** — a future edit changes the serde encoding of `Incremental`, breaking stored schema | Existing view metadata fails to deserialize after upgrade | 8 | 1 | 4 | 32 | Guarded by `serialized_form_reserves_kind_discriminator` test (gate G1). |
+
+## Top risks to act on
+
+1. **MV-2 (RPN 315)** — the real correctness guarantee lives in the *unwritten*
+   engine integration. The pure core cannot prove strict-serializable view
+   maintenance; that requires the Accord-coordinated commit plus integration /
+   Jepsen tests. This is the risk that matters most once integration begins.
+2. **MV-3 (RPN 252)** — the `extra` predicate is accepted at DDL time but never
+   enforced. Until the predicate evaluator lands, a view with a non-trivial
+   `WHERE` would over-include rows. Make this fail-loud rather than silent.
+
+## Detection assets
+
+- 25 in-crate unit tests (3 metadata, 12 validate, 10 delta) — prove the pure
+  primitives.
+- **Missing:** any cross-crate caller, any integration test, any property test.
+  The absence of callers is itself the detection signal for MV-1.

--- a/ferrosa-view/specs/overview.md
+++ b/ferrosa-view/specs/overview.md
@@ -1,0 +1,119 @@
+---
+crate: ferrosa-view
+status: island-not-integrated
+last_updated: 2026-06-19
+executive_summary: >
+  The protocol-agnostic, I/O-free core for ferrosa materialized views: view
+  metadata, DDL validation, and pure view-delta computation. The conflict-free
+  primitives have landed with 25 unit tests, but the crate is an island — no
+  other workspace crate depends on it, and the engine/Accord maintenance wiring
+  that would drive it is tracked separately and NOT yet integrated.
+---
+
+# ferrosa-view — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-view` is the **pure core** of ferrosa materialized views. It owns three
+things every materialized-view code path must agree on, kept free of I/O:
+
+1. the schema-replicated **description** of a view (`ViewMetadata`),
+2. the **DDL validation** gate (`validate_view_def`), and
+3. the **incremental-maintenance** state machine (`compute_view_delta`).
+
+Its boundary is deliberately narrow. It depends only on `ferrosa-schema` (for
+the base `TableMetadata` it validates against) and **never** on
+`ferrosa-storage`, `ferrosa-cluster` (Accord), or any protocol frontend. The
+`#![forbid(unsafe_code)]` and the absence of storage/transport types are
+structural enforcement of that boundary — see
+`specs/materialized-views/dsm-coupling.md` and `dsm-proposed.md` for the
+forbidden-edge rules.
+
+## Integration status — island
+
+This crate is an **island**: the primitives exist and are tested, but they are
+not yet consumed.
+
+- **No crate depends on `ferrosa-view`.** A workspace scan finds it in no other
+  crate's `Cargo.toml` and no `use ferrosa_view` in production code.
+- The maintenance *execution* — the read-before-write that produces a `prior`
+  `RowSnapshot`, the Accord-coordinated base+view commit, predicate/UDF
+  evaluation, and schema-replication of `ViewMetadata` — lives in the engine
+  layer and is **pending**.
+
+The crate is therefore correct to document as a standalone core. Its green test
+suite proves the primitives, not end-to-end materialized views.
+
+## Module map
+
+| Module | LoC (with tests) | Responsibility |
+|--------|------------------|----------------|
+| `metadata` (`src/metadata.rs`) | ~162 | `ViewMetadata`, `ViewKind`, `ViewColumn`, `ColumnSource`, `ViewPredicate`; `primary_key()` / `source_of()` |
+| `validate` (`src/validate.rs`) | ~465 | `validate_view_def`, `ViewDefError`; the per-rule check functions |
+| `delta` (`src/delta.rs`) | ~302 | `compute_view_delta`, `ViewDelta`, `RowSnapshot`; the pure transition state machine |
+| `lib` (`src/lib.rs`) | ~27 | module wiring + public re-exports |
+
+## Data flow
+
+The crate models the maintenance pipeline but does not run it. Two pure stages:
+
+**Validation stage** (DDL time): a frontend parses `CREATE MATERIALIZED VIEW`
+into a `ViewMetadata`, then calls `validate_view_def(base, view, base_is_view)`.
+On `Ok(())` the frontend would hand the `ViewMetadata` to schema replication
+(not in this crate); on `Err` it surfaces the typed `ViewDefError`.
+
+**Maintenance stage** (write time): the engine observes a base-row transition.
+It builds a `prior` and `next` `RowSnapshot` (from the read-before-write it owns)
+and calls `compute_view_delta(view, prior, next, timestamp)`. The returned
+`Vec&lt;ViewDelta&gt;` (`Upsert` / `Delete`, each carrying the base timestamp) is
+translated by the engine into real storage mutations under Accord. The
+read-before-write and the commit are **the engine's job, not this crate's.**
+
+```mermaid
+flowchart TD
+    DDL["frontend: CREATE MATERIALIZED VIEW"] --> VM["ViewMetadata"]
+    VM --> VAL["validate_view_def(base, view, base_is_view)"]
+    VAL -->|Ok| REPL["schema replication (engine, pending)"]
+    VAL -->|Err| ERR["ViewDefError"]
+    WRITE["engine: base-row mutation (pending)"] --> SNAP["prior / next: RowSnapshot"]
+    SNAP --> DELTA["compute_view_delta(view, prior, next, ts)"]
+    DELTA --> OUT["Vec&lt;ViewDelta&gt;: Upsert / Delete"]
+    OUT --> COMMIT["Accord base+view commit (engine, pending)"]
+```
+
+## Projection model
+
+A base row is *projected* into the view iff **every view primary-key column is
+non-null** (the Cassandra `IS NOT NULL` baseline). `compute_view_delta` derives
+the four outcomes from whether the row was projected before vs. after:
+
+| before \ after | not projected | projected |
+|----------------|---------------|-----------|
+| **not projected** | no delta | `Upsert` |
+| **projected** | `Delete` | `Upsert` (same PK) or `Delete`+`Upsert` (PK changed) |
+
+The optional ferrosa-extension predicate (`ViewPredicate::extra`) and UDF-column
+projection are **not** evaluated here — they are deferred to later engine cycles.
+
+## Key invariants
+
+1. **Purity.** No I/O, no storage row types, no Accord. `RowSnapshot` is a plain
+   `BTreeMap<String, Vec<u8>>` precisely so storage types never leak in (a
+   forbidden dependency edge).
+2. **One validation gate.** `validate_view_def` is the single place the
+   Cassandra-baseline + ferrosa rules are enforced; every frontend routes
+   through it. No second validator exists.
+3. **Deterministic deltas.** `compute_view_delta` is a pure function of its
+   inputs; the same transition yields the same deltas (test
+   `delta_is_deterministic`). This underpins the strict-serializable guarantee
+   (D2) once the engine drives it.
+4. **`ViewKind` discriminator is forward-stable.** Name-tagged serde encoding so
+   adding `Snapshot` later is a non-breaking schema change (gate G1, D1).
+5. **No dependency on `ferrosa-cql`/storage/cluster.** Structural; enforced by
+   the dependency graph.
+
+## Position in the dependency graph
+
+Leaf-adjacent: depends only on `ferrosa-schema`. Depended on by **no crate yet**
+— it is an island awaiting the engine integration. See the
+[root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-view/specs/roadmap.md
+++ b/ferrosa-view/specs/roadmap.md
@@ -1,0 +1,53 @@
+---
+crate: ferrosa-view
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-view — Roadmap
+
+Sourced from the code (what is and isn't implemented), the FMEA gaps
+([fmea.md](fmea.md)), and the island/integration status. The headline is that
+this crate's *primitives* are done; its *value* is unrealized until the engine
+consumes it.
+
+## Now (highest value)
+
+- **Integrate the island into the engine** (FMEA MV-1, MV-2). Wire
+  `compute_view_delta` into the storage observer / write path and have the
+  Accord-coordinated commit apply base+view atomically. This is the single
+  highest-value step — until it lands, materialized views do not exist
+  end-to-end. Track the read-before-write that produces `prior` and the
+  schema-replication of `ViewMetadata` as the first consumers.
+- **Make the `extra` predicate fail-loud** (FMEA MV-3). Today
+  `ViewPredicate::extra` is accepted at validation and ignored at maintenance.
+  Until an evaluator exists, reject (or loudly flag) views whose `WHERE` exceeds
+  `IS NOT NULL`, rather than silently over-including rows.
+
+## Next
+
+- **Predicate evaluator** beyond `IS NOT NULL` — compile and evaluate
+  `ViewPredicate::extra` inside the projection check so `compute_view_delta`
+  honours the full `WHERE`.
+- **UDF-computed column projection** (FMEA MV-4) — wire the udf-eval cycle so
+  `projected_columns` emits deterministic `Udf` column values, not just `Base`
+  projections. Validation already enforces determinism (gate G2).
+- **Property tests** (FMEA MV-5) — put the declared but unused `proptest`
+  dev-dependency to work: invariants like delete-before-insert ordering on a
+  PK change, projection monotonicity, and `ViewMetadata` serde round-trip.
+
+## Later
+
+- **`ViewKind::Snapshot`** — the Postgres-style `REFRESH MATERIALIZED VIEW`
+  maintenance model (D1, board task t_02a5a95c). The discriminator is already
+  forward-stable so adding it is non-breaking.
+- **Debug-assert PK presence** in `view_pk_values` (FMEA MV-6) — replace the
+  silent `unwrap_or_default` with an assertion that the row is projected, so a
+  contract violation crashes loudly instead of emitting an empty key.
+
+## Non-goals
+
+- I/O, storage row types, Accord coordination, schema replication, or protocol
+  framing — those belong to the engine and the frontends, and are forbidden
+  dependency edges for this crate (see `dsm-proposed.md`). `ferrosa-view` stays
+  a pure, leaf-adjacent core.

--- a/ferrosa-worker/README.md
+++ b/ferrosa-worker/README.md
@@ -1,0 +1,108 @@
+# ferrosa-worker
+
+> A standalone, stateless task-executor **binary** — input task descriptor →
+> compute → output result. Currently nascent: the one task type (`IndexBuild`)
+> is a parsed-but-stubbed placeholder.
+
+## What this crate is
+
+`ferrosa-worker` is a small command-line **binary** (no library target) intended
+to offload heavy background work — secondary-index builds, and eventually
+compaction — from the main engine into a short-lived external process. Its
+design contract is deliberate and narrow, per the module doc comment:
+
+> No cluster membership, no Raft, no persistent state. Pure function:
+> input → compute → output.
+
+The worker reads a JSON **`TaskDescriptor`** from `argv[1]`, executes it, and
+prints a JSON **`TaskResult`** to stdout (logs go to stderr via `tracing`). The
+exit code is non-zero on any failure.
+
+## What's implemented (the honest picture)
+
+This crate is **early/nascent**. Today it is a ~160-line `main.rs` with three
+unit tests plus three CLI integration tests. Concretely, what works:
+
+- **CLI envelope** — argument parsing, a usage error when no task is given, and
+  a structured-JSON error (still printed as a `TaskResult`) on malformed input.
+- **`TaskDescriptor` enum** — internally-tagged (`#[serde(tag = "type")]`) with a
+  single variant, `IndexBuild`, carrying S3 paths, keyspace/table/index names,
+  and JSON-encoded index + table-schema blobs.
+- **`TaskResult` struct** — `{ success, output_paths, error }`, serialized to
+  stdout in every code path.
+- **`tracing` setup** — env-filtered subscriber writing to stderr.
+
+What is **not** implemented (explicitly stubbed in code):
+
+- The actual `IndexBuild` execution. The match arm logs
+  `"IndexBuild task received (stub -- not yet implemented)"` and returns
+  `success: false, error: "IndexBuild not yet implemented"`. The comment reads:
+  *"actual S3 read + index build will be wired in a follow-up."*
+- Reading a task from **stdin or an S3 path**, and writing results to **S3** —
+  promised in the module doc comment but not coded; only `argv[1]` in / stdout
+  out exist today.
+- **Compaction offloading** — named in the package description, no code yet.
+- Any **registry, scheduling, or background task management** — there is none;
+  the worker runs exactly one task and exits.
+
+## How it works
+
+```
+$ ferrosa-worker '{"type":"IndexBuild", ...}'
+  → parse argv[1] as TaskDescriptor (serde_json)
+  → match on variant → execute (IndexBuild: stub)
+  → print TaskResult JSON to stdout
+  → exit(0) on success, exit(1) otherwise
+```
+
+A single module, `src/main.rs`. There is no `src/lib.rs`, so the types are not
+importable by other crates — they are private to the binary.
+
+## Public API (binary types)
+
+| Type | Shape |
+|------|-------|
+| `TaskDescriptor` | `enum` tagged on `type`; variant `IndexBuild { sstable_s3_paths, keyspace, table, index_name, index_metadata_json, table_schema_json, output_s3_prefix }` |
+| `TaskResult` | `struct { success: bool, output_paths: Vec<String>, error: Option<String> }` |
+
+> These are `pub` inside the binary crate but, absent a `lib` target, are not
+> consumable as a library API.
+
+## Dependencies
+
+**Calls** (ferrosa crates declared as path dependencies):
+
+- **`ferrosa-common`**, **`ferrosa-index`**, **`ferrosa-sstable`** — declared in
+  `Cargo.toml` in anticipation of the real index-build path.
+
+> **Reality check:** none of these three crates is referenced anywhere in
+> `src/` or `tests/` yet — the code that would use them (S3 read + index build)
+> is stubbed. They are present so the wiring compiles when the follow-up lands.
+
+External: `serde`/`serde_json` (descriptor codec), `tokio` (`features=["full"]`,
+declared but the current `main` is synchronous), `tracing` /
+`tracing-subscriber`.
+
+**Called by** (crates that depend on this):
+
+- **NONE.** No ferrosa crate lists `ferrosa-worker` as a path dependency. Its
+  only appearance outside its own manifest is the workspace `members` array in
+  the root `Cargo.toml`. It may be invoked **out-of-process** (the engine's
+  `FERROSA_INDEX_BACKEND=remote`/external-builder mode shells out to a worker
+  binary), or it may simply be nascent and not yet wired. Documenting the truth
+  from the dependency matrix: no compile-time reverse dependency exists.
+
+## Tests
+
+- `src/main.rs` unit tests (3): `TaskDescriptor`/`TaskResult` serde round-trips.
+- `tests/cli_test.rs` (3): no-args usage error, invalid-JSON rejection, and the
+  `IndexBuild` stub (parses correctly, returns the not-implemented failure).
+
+All six tests exercise the **envelope**, not real index work — appropriate,
+since the work itself is a stub. See [specs/fmea.md](specs/fmea.md).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — module map, contract, data flow
+- [FMEA / known issues](specs/fmea.md) — failure modes + gaps
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-worker/specs/fmea.md
+++ b/ferrosa-worker/specs/fmea.md
@@ -1,0 +1,41 @@
+---
+crate: ferrosa-worker
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa-worker — FMEA / Known Issues
+
+Failure modes are ranked by **RPN = Severity × Occurrence × Detection** (1–10
+each; higher = worse). This crate is **nascent**, so the dominant risks are
+*absent functionality* and *unwired dependencies*, not subtle data-path bugs.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| WK-1 | `IndexBuild` is a stub — the worker's sole task type does no work | Any caller that spawns the worker to build an index gets `success:false, "not yet implemented"`; the feature is non-functional | 8 | 10 | 2 | 160 | **Open, by design.** Clearly stubbed in code and logged; detection is trivial (immediate failure). Implement the real S3-read + `ferrosa-index` build path. |
+| WK-2 | Declared deps (`ferrosa-common`, `ferrosa-index`, `ferrosa-sstable`) are unused | Cargo carries three heavy path deps that contribute nothing; misleads readers into thinking the work is wired | 3 | 10 | 3 | 90 | **Open.** Either implement the path that uses them (preferred) or drop them until needed. Flagged here so the gap is visible. |
+| WK-3 | No `lib` target — types are private to the binary | Any in-process caller wanting to construct a `TaskDescriptor` or assert on `TaskResult` must duplicate the structs; the descriptor schema can silently drift between producer and worker | 6 | 6 | 5 | 180 | **Open.** Extract `TaskDescriptor`/`TaskResult` into a `lib` (or a shared protocol crate) so producer and worker share one definition. |
+| WK-4 | Promised stdin / S3 task sources and S3 result sink are undocumented-as-absent | The module doc advertises stdin/S3 I/O that does not exist; an integrator wires against a contract that isn't there | 5 | 7 | 4 | 140 | **Open.** Doc comment over-promises vs. code (argv-in/stdout-out only). Either implement the I/O modes or correct the doc comment. |
+| WK-5 | `.unwrap()` on `serde_json::to_string(&result)` in every output path | If result serialization ever fails, the worker panics instead of emitting a structured error | 4 | 1 | 6 | 24 | Low risk: `TaskResult` is trivially serializable today. Still violates fail-loud-with-context; prefer an explicit error path. |
+| WK-6 | No idempotency / partial-output cleanup design for the (future) real build | A retried IndexBuild could leave or collide with half-written S3 sidecars | 7 | 1 | 7 | 49 | **Not yet applicable** (work is stubbed). Must be designed before WK-1 is implemented: deterministic output paths + overwrite/cleanup semantics. |
+| WK-7 | `tokio = { features=["full"] }` declared but `main` is synchronous | Dead async runtime in the dependency tree; future async work has no `#[tokio::main]` wiring | 2 | 8 | 4 | 64 | Cosmetic today. Add `#[tokio::main]` (or trim the dep) when S3 I/O lands. |
+
+## Top risks to act on
+
+1. **WK-3 (RPN 180)** — *no shared type definition.* The descriptor/result
+   schema lives only inside the binary, so any producer must hand-copy it and can
+   drift. Extracting a `lib`/protocol crate is the cheapest high-value fix and
+   unblocks in-process testing of the contract.
+2. **WK-1 (RPN 160)** — the core feature is a stub; the crate does not yet do its
+   job. High severity/occurrence, but detection is trivial (it fails loudly), so
+   it is a *missing-work* risk, not a *silent-corruption* risk.
+3. **WK-4 (RPN 140)** — doc/code mismatch on input/output modes; fix the doc or
+   the code so integrators aren't misled.
+
+## Detection assets
+
+- `tests/cli_test.rs` — confirms the envelope (usage error, invalid-JSON
+  rejection, IndexBuild-stub-parses-and-fails).
+- `src/main.rs` unit tests — `TaskDescriptor`/`TaskResult` serde round-trips.
+- **Gap:** no test exercises a *successful* task, because none exists yet; the
+  green build is a signal about the envelope only, not about real index work.

--- a/ferrosa-worker/specs/overview.md
+++ b/ferrosa-worker/specs/overview.md
@@ -1,0 +1,101 @@
+---
+crate: ferrosa-worker
+status: nascent
+last_updated: 2026-06-19
+executive_summary: >
+  A standalone, stateless CLI binary that takes a JSON task descriptor, computes,
+  and emits a JSON result — designed to offload index builds (and later compaction)
+  out-of-process from the engine. Today it is ~160 LoC: the CLI envelope and serde
+  types are real, but the one task type (IndexBuild) is parsed-then-stubbed. No
+  library target, no scheduler/registry, and no compile-time reverse dependency.
+---
+
+# ferrosa-worker — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa-worker` is the **standalone task-executor binary** for the workspace.
+Its stated design contract (from the `main.rs` doc comment) is intentionally
+minimal:
+
+> No cluster membership, no Raft, no persistent state.
+> Pure function: input → compute → output.
+
+The intent is to move expensive, embarrassingly-parallel background work — first
+secondary-index construction, eventually compaction — out of the main engine
+process into a short-lived child process that reads a descriptor, does one unit
+of work, prints a result, and exits. This pairs with the engine's
+`FERROSA_INDEX_BACKEND` modes (`local` / `remote` / `off`), where an external
+builder offloads index construction.
+
+**Boundary:** it knows only how to (a) parse a `TaskDescriptor`, (b) dispatch on
+its variant, and (c) emit a `TaskResult`. It owns no persistence, no networking,
+no scheduling. It is a leaf, executable component.
+
+## Maturity: nascent
+
+This crate is at an early stage and the docs say so plainly. The CLI envelope
+and the serde types are implemented and tested; the **work itself is a stub**.
+The single `IndexBuild` arm logs "not yet implemented" and returns a failure
+result. Treat this overview as describing the *contract and skeleton*, not a
+working index builder.
+
+## Module map
+
+| Module | LoC | Responsibility |
+|--------|-----|----------------|
+| `main` (`src/main.rs`) | ~159 | `TaskDescriptor` / `TaskResult` types, `tracing` init, argv parsing, dispatch, JSON I/O, exit codes |
+| `tests/cli_test.rs` | ~59 | Black-box CLI integration tests over the built binary |
+
+There is **no `src/lib.rs`** — the types are private to the binary.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  CLI["argv[1] : task JSON"] --> P["serde_json::from_str → TaskDescriptor"]
+  P -->|parse error| ERR["TaskResult{success:false, error} → stdout, exit 1"]
+  P -->|ok| M{"match variant"}
+  M -->|IndexBuild| STUB["STUB: log 'not yet implemented'<br/>return failure result"]
+  STUB --> OUT["TaskResult JSON → stdout"]
+  OUT --> EX["exit 0 if success else 1"]
+  L["tracing → stderr"]
+```
+
+**Today's path:** `argv[1]` in, stdout out, stderr logs. The doc comment also
+promises **stdin** and **S3** as task sources and **S3** as a result sink; those
+are not yet coded.
+
+## Types
+
+- `TaskDescriptor` — internally-tagged enum (`#[serde(tag = "type")]`). One
+  variant: `IndexBuild` with `sstable_s3_paths: Vec&lt;String&gt;`, `keyspace`,
+  `table`, `index_name`, `index_metadata_json`, `table_schema_json`, and
+  `output_s3_prefix`. The two `*_json` fields carry opaque JSON blobs (an
+  `IndexMetadata` and a `TableSchema`) rather than typed structs — a deliberate
+  decoupling so the worker need not link the schema crate to *parse* a task.
+- `TaskResult` — `{ success: bool, output_paths: Vec&lt;String&gt;, error: Option&lt;String&gt; }`.
+  Emitted on every path, including parse failures, so the caller always gets
+  machine-readable output.
+
+## Key invariants / contract
+
+1. **Always emit a `TaskResult` to stdout**, even on usage/parse errors. The
+   caller never has to distinguish "no output" from "failure".
+2. **Exit code mirrors `success`.** Non-zero exit on any failure; this is what an
+   out-of-process orchestrator keys on.
+3. **Logs to stderr, results to stdout.** Clean separation so stdout is always
+   parseable JSON.
+4. **Stateless.** No Raft, no membership, no disk state — re-running a descriptor
+   must be safe (idempotency of the *real* work is a future concern, see FMEA).
+
+## Position in the dependency graph
+
+**Calls:** `ferrosa-common`, `ferrosa-index`, `ferrosa-sstable` — declared as
+path dependencies (for the forthcoming real index build) but **not yet
+referenced** in source.
+
+**Called by:** none. No ferrosa crate lists `ferrosa-worker` as a path
+dependency; it appears only in the workspace `members` list. It is expected to
+be driven **out-of-process** (spawned as a child binary) rather than linked. See
+the [root crate index](../../specs/crates.md) for the full graph.

--- a/ferrosa-worker/specs/roadmap.md
+++ b/ferrosa-worker/specs/roadmap.md
@@ -1,0 +1,54 @@
+---
+crate: ferrosa-worker
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa-worker — Roadmap
+
+Sourced from the in-code stub comments, the FMEA gaps ([fmea.md](fmea.md)), and
+the dependency/usage review. This crate is **nascent**; the roadmap is mostly
+"build the thing it promises to be."
+
+## Now (highest value)
+
+- **Implement the real `IndexBuild` path** (FMEA WK-1). Wire the stubbed match
+  arm to: read the SSTables at `sstable_s3_paths`, deserialize
+  `index_metadata_json` + `table_schema_json`, build the index via
+  `ferrosa-index` over `ferrosa-sstable` partitions, write sidecars under
+  `output_s3_prefix`, and return real `output_paths`. This is also what justifies
+  the three currently-unused path dependencies (FMEA WK-2).
+- **Extract `TaskDescriptor` / `TaskResult` into a shared `lib` or protocol
+  crate** (FMEA WK-3). Today they are private to the binary, so any in-process
+  producer must hand-copy them and can silently drift. One definition, shared by
+  producer and worker.
+
+## Next
+
+- **Reconcile I/O modes with the doc comment** (FMEA WK-4). The module doc
+  advertises stdin and S3 as task sources and S3 as a result sink; only
+  argv-in / stdout-out exist. Either implement stdin/S3 I/O or correct the doc.
+- **Add async wiring when S3 lands** (FMEA WK-7). The `tokio` "full" dependency
+  is dead until `main` becomes `#[tokio::main]`; add it with the S3 work or trim
+  it meanwhile.
+- **Replace output `.unwrap()`s with an explicit error path** (FMEA WK-5) so a
+  serialization failure fails loud with context instead of panicking.
+
+## Later
+
+- **Idempotency + partial-output semantics for index builds** (FMEA WK-6).
+  Deterministic output paths and overwrite/cleanup rules so retried tasks don't
+  collide or strand half-written sidecars. Must precede production use.
+- **Compaction-offload task type.** The package description promises "compaction
+  offloading"; add a second `TaskDescriptor` variant once the index path proves
+  the model.
+- **Wire a real caller.** No ferrosa crate currently spawns or depends on the
+  worker. Connect it to the engine's external/remote index-build backend
+  (`FERROSA_INDEX_BACKEND`) so the binary is actually exercised end-to-end, and
+  add an integration test that drives a *successful* task.
+
+## Non-goals
+
+- Cluster membership, Raft, or persistent state — the worker is, by contract, a
+  stateless `input → compute → output` process. Orchestration, retries, and
+  scheduling belong to whatever spawns it, not here.

--- a/ferrosa/README.md
+++ b/ferrosa/README.md
@@ -1,0 +1,147 @@
+# ferrosa
+
+> The top-level binary and **composition root**: it constructs every subsystem
+> crate, wires them together (one `StorageEngine`, one `Schema`, one
+> `ModeController`, one `PeerManager`, one `CdcBus`), and starts every network
+> listener. Nothing depends on this crate — it is where the platform comes alive.
+
+## What this crate is
+
+`ferrosa` is the `[[bin]]` that becomes the running database. It owns **no
+domain logic of its own** — it imports the engine (`ferrosa-storage`), the
+metadata layer (`ferrosa-schema`), the cluster control plane
+(`ferrosa-cluster`), the internode transport (`ferrosa-net`), the change-data
+bus (`ferrosa-cdc`), the session core (`ferrosa-session`), and every query
+front-end (`ferrosa-cql`, `ferrosa-postgres`, `ferrosa-graph`, `ferrosa-sparql`,
+`ferrosa-flight`, plus `ferrosa-udf`), then composes them in a fixed startup
+order in `src/main.rs`. Its job is **wiring, ordering, configuration resolution,
+and lifecycle** — not re-implementing any subsystem.
+
+It is the only crate in the workspace that depends on all the front-ends at once.
+
+## Process layout (`src/`)
+
+| Module | Responsibility |
+|--------|----------------|
+| `main.rs` (~2.8k LoC) | The whole startup sequence: config → host_id → storage → schema → cluster → listeners → maintenance loop → graceful shutdown |
+| `runtime.rs` | `RuntimeManager` — dedicated tokio runtimes (raft, data, cql, background) so subsystems don't contend on one shared pool |
+| `repair_wiring.rs` | `BinaryRepairContext` / `build_repair_executor` — binds the self-heal + anti-entropy repair scheduler to the live ring |
+| `cql_broadcast.rs` | `parse_cql_broadcast` — resolves the externally-advertised CQL address/port for `system.local` |
+| `web/` | Axum observability console + cluster REST API + auth middleware + readiness probe + WebSocket + embedded UI + PITR snapshot/restore endpoints |
+
+The `web/` subtree is the only HTTP surface that lives *in this crate*; all other
+listeners are owned by their subsystem crates and merely started here.
+
+## Listeners & ports
+
+Ports are resolved as **env var → TOML (`/etc/ferrosa/ferrosa.toml`) → default**.
+Defaults below are what ships with no config.
+
+| Listener | Default bind | Owning crate | Enable / config |
+|----------|--------------|--------------|-----------------|
+| Internode RPC | `0.0.0.0:17000` | `ferrosa-net` | `FERROSA_INTERNODE_BIND` / `[internode].bind` — note **17000**, not Cassandra's 7000 (BUG-001: 7000 collides with macOS ControlCenter) |
+| CQL native v5 | `0.0.0.0:9042` | `ferrosa-cql` | `FERROSA_CQL_BIND` / `[cql].bind` |
+| Postgres wire | `0.0.0.0:5432` | `ferrosa-postgres` | `FERROSA_POSTGRES_BIND` — always started; query execution is a fail-loud stub until the relational engine lands |
+| Arrow Flight (gRPC) | `0.0.0.0:8815` | `ferrosa-flight` | **`--features flight`** + `FERROSA_FLIGHT_BIND`; per-RPC signed bearer tokens |
+| Graph HTTP | `:7474` | `ferrosa-graph` | only if graph enabled (`FERROSA_GRAPH_ENABLED` / `[graph].enabled`) |
+| Bolt v5 | `0.0.0.0:7687` | `ferrosa-graph` | only if graph enabled; `FERROSA_BOLT_PORT` / `[graph].bolt_port` |
+| SPARQL HTTP | `0.0.0.0:8080` | `ferrosa-sparql` | only if `FERROSA_SPARQL_ENABLED=true`; `FERROSA_SPARQL_BIND` |
+| Web console + `/metrics` | `0.0.0.0:9090` | this crate (`web/`) | `FERROSA_WEB_BIND` |
+
+## Startup order (`main`)
+
+The sequence is strict because later steps consume the handles produced earlier
+(the engine before schema restore, the `PeerManager` before the self-heal
+cluster view, the `SharedState` before the CQL/Flight servers). See
+[specs/data-flow.md](specs/data-flow.md) for the full diagram.
+
+1. **Tracing** — non-blocking writer (`tracing-appender`); optional OTel layer when `FERROSA_TELEMETRY_ENABLED=true` (`--features otel`).
+2. **Config** — load `FERROSA_CONFIG` TOML (default `/etc/ferrosa/ferrosa.toml`); env always wins over file.
+3. **host_id** — load/generate/validate `{data_dir}/host_id` (`classify_host_id_state`: loaded / override / empty-regenerated / invalid-regenerated / generated-new — each path logs a breadcrumb, BUG-008).
+4. **StorageEngine** — `open()` (replay commit log) if segments exist, else `new()`; probe S3 CAS; **attach `CdcBus`** (capacity 1024) to the commit log; register system tables; replay pending S3 uploads.
+5. **Schema** — `Schema::new` (composes audit sinks); seed default roles if auth enabled; restore schema from local `schema.json` → S3 bootstrap → fresh; re-register secondary indexes, UDTs, UDFs, role permissions from `system_schema.*`; replay pending commit-log mutations.
+6. **ModeController** — `ClusterConfig`/`NetConfig` (with TOML overrides, BUG-006); build the `HandlerRegistry` (ping, pair-catchup, mutation/truncate forward, three repair handlers); construct controller in standalone mode.
+7. **PeerManager** — wire as `ModeController`'s `PeerEventListener`; start the heartbeat loop; spawn the self-heal controller with a **live** peer-health probe.
+8. **Internode RPC** (`:17000`) — `RpcServer::start_and_get_addr`.
+9. **CQL server** (`:9042`) — build `SharedState` (`SessionCore` + Accord HLC + prepared cache + observability trackers + virtual tables) and `start_background`.
+10. **Arrow Flight** (`:8815`, `flight` feature) — signing key from `FERROSA_FLIGHT_SIGNING_KEY` (ephemeral if unset — warns).
+11. **Web console** (`:9090`).
+12. **Automatic repair** — self-heal controller with verified-replica cluster view + quarantine→refill trigger; periodic anti-entropy scheduler.
+13. **Graph** (HTTP `:7474` + Bolt `:7687`) if enabled; **Postgres** (`:5432`); **SPARQL** (`:8080`) if enabled.
+14. **Seeds** — background connect to `FERROSA_SEED` peers with exponential backoff.
+15. **Maintenance loop** — periodic + urgent flush, compaction polling, commit-log GC, schema persist (local + S3).
+16. **Shutdown** — `SIGINT`/`SIGTERM` → 30 s graceful drain: stop cluster tasks → drain internode → flush memtables → persist schema (local + S3).
+
+## How the subsystems compose
+
+- **One engine, one schema, one cluster brain.** A single `Arc<StorageEngine>`,
+  `Arc<Schema>`, `Arc<ModeController>`, and `Arc<PeerManager>` are shared by
+  every front-end and background task — so a row written over Postgres is read
+  over CQL, and a DDL over CQL replicates over the same `DdlPath` the graph
+  engine uses.
+- **CdcBus injection.** The `ferrosa-cdc` bus is attached to the engine's commit
+  log at step 4, *before* any front-end starts, so live CQL `SUBSCRIBE` and the
+  Arrow Flight stream observe the same change events.
+- **SessionCore as the execution hub.** `ferrosa-session::SessionCore` bundles
+  engine + schema + write/DDL paths + UDF executor + `ModeController` + peer
+  manager + Accord HLC; the CQL router and the Flight service share one instance.
+- **Per-subsystem runtimes.** `RuntimeManager` gives raft / data / cql /
+  background their own tokio runtimes; the main runtime stays supervisor-only so
+  bulk CQL writes can't starve Raft heartbeats.
+
+## Feature flags
+
+| Feature | Effect |
+|---------|--------|
+| `flight` *(off by default)* | Pulls in `ferrosa-flight` and starts the Arrow Flight gRPC endpoint on `:8815` |
+| `otel` *(off by default)* | Pulls in OpenTelemetry/OTLP and installs the tracing export layer |
+
+Allocator: on non-MSVC targets the binary links **jemalloc** with
+`dirty_decay_ms:0,muzzy_decay_ms:0` (immediate page return to the OS — keeps RSS
+flat under tight cgroups; override with `MALLOC_CONF`).
+
+## Key environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `FERROSA_CONFIG` | TOML config path (default `/etc/ferrosa/ferrosa.toml`) |
+| `FERROSA_DATA_DIR` | data directory (default `/var/lib/ferrosa`) — holds `host_id`, `schema.json`, commit log, hints |
+| `FERROSA_HOST_ID` | authoritative host-id override (wins over disk) |
+| `FERROSA_AUTH_ENABLED` | single source of truth for CQL role auth (TOML `[cql].auth_enabled` as fallback) |
+| `FERROSA_AUTH_DISABLED` | **deprecated** direct override — honored with a warning |
+| `FERROSA_SEED` | comma-separated seed peers (`host:port`, DNS-resolved) |
+| `FERROSA_GRAPH_ENABLED` / `FERROSA_SPARQL_ENABLED` | enable graph (HTTP+Bolt) / SPARQL front-ends |
+| `FERROSA_FLIGHT_BIND` / `FERROSA_FLIGHT_SIGNING_KEY` / `FERROSA_FLIGHT_TOKEN_TTL_SECS` | Flight endpoint (when `flight` feature is built) |
+| `FERROSA_TELEMETRY_ENABLED` | install the OTel tracing layer (when `otel` feature is built) |
+| `FERROSA_SELFHEAL_ENABLED` | self-heal quarantine controller (default on) |
+| `FERROSA_FLUSH_INTERVAL_SECS`, `FERROSA_URGENT_*` | maintenance-loop cadences |
+
+See `ferrosa.example.toml` for the file form (`[cql] [internode] [storage] [s3]
+[graph] [web]`).
+
+## Dependencies
+
+**Calls** (subsystem crates this composes — verbatim):
+`ferrosa-cdc`, `ferrosa-cluster`, `ferrosa-common`, `ferrosa-cql`,
+`ferrosa-flight`, `ferrosa-graph`, `ferrosa-net`, `ferrosa-postgres`,
+`ferrosa-schema`, `ferrosa-session`, `ferrosa-sparql`, `ferrosa-storage`,
+`ferrosa-udf`.
+
+**Called by**: **NONE** — it is the top-level binary.
+
+## Tests
+
+~265 in-crate tests (`src/main.rs` + `web/*` + `cql_broadcast.rs` +
+`repair_wiring.rs`). They cover the *pure* composition helpers — config
+precedence (env → TOML → default), `host_id` classification, internode/graph/auth
+TOML resolution, hinted-handoff dir resolution, schema local persist/load, web
+config and auth bypass. The end-to-end boot path itself is exercised by the
+cluster/integration suites, not from here. One in-code `TODO` remains
+(`web/api.rs:475`). See [specs/fmea.md](specs/fmea.md).
+
+## Specs
+
+- [Architecture overview](specs/overview.md) — composition-root model
+- [Data flow](specs/data-flow.md) — startup sequence wiring the crates + listeners
+- [FMEA / known issues](specs/fmea.md) — startup-ordering, auth kill-switch, port-binding, partial-boot risks
+- [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa/specs/data-flow.md
+++ b/ferrosa/specs/data-flow.md
@@ -1,0 +1,134 @@
+---
+crate: ferrosa
+doc: data-flow
+last_updated: 2026-06-19
+---
+
+# ferrosa — Startup & Composition Data Flow
+
+This is the binary's composition root: it constructs each subsystem crate in a
+fixed order and binds every listener. The diagrams below trace that sequence and
+the shared instances that flow between subsystems. All shared services are
+`Arc`-wrapped and cloned into consumers — exactly one of each per process.
+
+## Startup sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Main as main()
+    participant Cfg as config (env then TOML)
+    participant Store as ferrosa-storage
+    participant Cdc as ferrosa-cdc CdcBus
+    participant Schema as ferrosa-schema
+    participant Cluster as ferrosa-cluster ModeController
+    participant Net as ferrosa-net PeerManager + RPC
+    participant Front as front-end listeners
+
+    Main->>Main: init tracing (non-blocking; OTel if enabled)
+    Main->>Cfg: load FERROSA_CONFIG TOML (env wins)
+    Main->>Main: load/generate host_id (classify state)
+    Main->>Store: open() replay commitlog OR new()
+    Main->>Store: probe S3 CAS; register system tables
+    Main->>Cdc: CdcBus::new(1024)
+    Cdc-->>Store: set_cdc_bus() attach to commit log
+    Main->>Schema: Schema::new(config)
+    Schema->>Schema: seed roles if auth; restore local then S3 then fresh
+    Schema->>Store: re-register indexes, UDTs, UDFs, perms
+    Main->>Store: replay pending commitlog mutations
+    Main->>Cluster: ModeController::new(cfg, net_cfg, host_id, store, schema, registry)
+    Main->>Net: PeerManager::new(net_cfg, host_id, mode_controller)
+    Net-->>Cluster: PeerManager set as PeerEventListener
+    Main->>Net: spawn heartbeat loop; spawn self-heal (live peer probe)
+    Main->>Net: RpcServer.start_and_get_addr() bind :17000
+    Main->>Front: build SessionCore (store, schema, paths, HLC, peer mgr)
+    Main->>Front: CqlServer.start_background() bind :9042
+    Main->>Front: Arrow Flight bind :8815 (feature flight)
+    Main->>Front: web console bind :9090
+    Main->>Cluster: spawn auto-repair (verified replica view + scheduler)
+    Main->>Front: graph HTTP :7474 + Bolt :7687 (if enabled)
+    Main->>Front: Postgres :5432; SPARQL :8080 (if enabled)
+    Main->>Net: background connect to FERROSA_SEED peers (backoff)
+    Main->>Store: spawn maintenance loop (flush, compact, GC, schema persist)
+    Main->>Main: await SIGINT or SIGTERM
+    Main->>Main: graceful drain (cluster, internode, flush, persist) within 30s
+```
+
+## Shared-instance wiring
+
+Each box below is constructed once and shared. Edges are `Arc` clones. Note the
+`CdcBus` feeding both live-CQL `SUBSCRIBE` and the Flight stream, and the single
+`SessionCore` behind both the CQL router and the Flight service.
+
+```mermaid
+flowchart TD
+    HOSTID[host_id Uuid]
+    STORE["Arc&lt;StorageEngine&gt;"]
+    CDC["CdcBus capacity 1024"]
+    SCHEMA["Arc&lt;Schema&gt;"]
+    MODE["Arc&lt;ModeController&gt;"]
+    PEER["Arc&lt;PeerManager&gt;"]
+    CORE["SessionCore (engine + schema + write/ddl paths + UDF + HLC)"]
+
+    CDC -->|attached to commit log| STORE
+    HOSTID --> MODE
+    STORE --> MODE
+    SCHEMA --> MODE
+    MODE --> PEER
+    STORE --> CORE
+    SCHEMA --> CORE
+    MODE --> CORE
+    PEER --> CORE
+
+    CORE --> CQL["CQL :9042 (ferrosa-cql)"]
+    CORE --> FLIGHT["Arrow Flight :8815 (ferrosa-flight, feature)"]
+    STORE --> PG["Postgres :5432 (ferrosa-postgres)"]
+    SCHEMA --> PG
+    SCHEMA --> GRAPH["Graph HTTP :7474 + Bolt :7687 (ferrosa-graph)"]
+    STORE --> GRAPH
+    STORE --> SPARQL["SPARQL :8080 (ferrosa-sparql)"]
+    SCHEMA --> SPARQL
+    SCHEMA --> WEB["Web console :9090 (web/)"]
+    MODE --> WEB
+    STORE --> WEB
+
+    CDC -.live change events.-> CQL
+    CDC -.live change events.-> FLIGHT
+```
+
+## Listener / runtime placement
+
+```mermaid
+flowchart LR
+    subgraph RT["RuntimeManager (runtime.rs)"]
+      RAFT[raft runtime]
+      DATA[data runtime]
+      CQLRT[cql runtime]
+      BG[background runtime]
+    end
+
+    RAFT --> HB[heartbeat loop]
+    RAFT --> RPC[internode RPC :17000]
+    DATA --> REPAIR[repair RPC probes]
+    CQLRT --> CQLSRV[CQL server :9042]
+    BG --> FLIGHTSRV[Flight :8815]
+    BG --> GRAPHSRV[graph + Bolt]
+    BG --> PGSRV[Postgres :5432]
+    BG --> SPARQLSRV[SPARQL :8080]
+    BG --> SEEDS[seed connect loop]
+    BG --> MAINT[maintenance loop: flush / compact / GC / schema persist]
+```
+
+The main tokio runtime stays supervisor-only; routing subsystems to dedicated
+runtimes keeps bulk CQL writes from starving Raft heartbeats.
+
+## Notes
+
+- **Config precedence** at every resolver: env var, then TOML
+  (`/etc/ferrosa/ferrosa.toml`), then hard default.
+- **Auth flag** (`auth_disabled`) is derived once from
+  `FERROSA_AUTH_ENABLED` / `[cql].auth_enabled` and threaded into CQL, web,
+  graph HTTP, and Bolt so the kill-switch is uniform.
+- **Graceful shutdown** order on SIGINT/SIGTERM: cancel cluster tasks, drain
+  internode, flush memtables, persist schema (local + S3) — within a 30 s
+  timeout.

--- a/ferrosa/specs/fmea.md
+++ b/ferrosa/specs/fmea.md
@@ -1,0 +1,43 @@
+---
+crate: ferrosa
+doc: fmea
+last_updated: 2026-06-19
+---
+
+# ferrosa — FMEA / Known Issues
+
+Failure modes are ranked by **RPN = Severity × Occurrence × Detection** (1–10
+each; higher = worse). As the composition root, this crate's failures are
+*startup, ordering, lifecycle, and configuration* faults — the subsystem crates
+own their own internal FMEAs.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
+|----|--------------|--------|---|---|---|-----|---------------------|
+| FE-1 | **Partial-boot: a non-critical listener fails to bind but the process keeps running.** Graph/Bolt/SPARQL/Flight servers are `spawn`-ed and a bind error is only logged (`tracing::error!`), never propagated. | Node looks "up" (CQL serving) but a front-end the operator expects is silently absent. No health signal distinguishes "disabled" from "failed to bind". | 7 | 4 | 7 | 196 | **Open gap.** Bind failures log loudly but the process does not crash or surface them in `/readyz`. Add a startup readiness aggregate that fails loud when an *enabled* listener didn't bind. |
+| FE-2 | **Startup ordering regression.** A future edit registers a listener or replay step before its dependency (engine before CdcBus, mutation replay before table registration, SessionCore before PeerManager). | Recovery breaks silently — e.g. "table not registered: system_schema.*" during Raft replay drops persistence; or LWT returns ServerError because peer_manager was None. | 9 | 2 | 6 | 108 | The order is encoded only as imperative `main` code + comments. Mitigated by integration/cluster suites; **no in-crate guard test asserts the order.** |
+| FE-3 | **Auth kill-switch resolves open in production.** Storage default is `auth_enabled=false`; if neither `FERROSA_AUTH_ENABLED` nor `[cql].auth_enabled` is set, `resolve_auth_disabled` returns `auth_disabled=true` for CQL **and** the web/graph/Bolt/SPARQL consoles (which inherit the same flag). | An operator who forgets the switch ships an unauthenticated cluster *and* an open admin console (`/admin/*`, cluster promote/decommission) — but drivers connect, so it looks fine. | 9 | 3 | 5 | 135 | Documented as "single source of truth" + a 5-minute default-password WARN when auth *is* on. **Gap:** the default is permissive and silent; consider failing loud (or defaulting closed) in `DeploymentMode::Production`. |
+| FE-4 | **Flight signing key ephemeral when unset.** With `--features flight` and no `FERROSA_FLIGHT_SIGNING_KEY`, a random per-process key is used. | Bearer tokens don't survive a restart and don't validate across nodes; clients see sudden auth failures after any bounce. | 5 | 4 | 4 | 80 | Loud WARN at startup naming the env var; functional but fragile. Make it fail-loud (refuse to start) when `DeploymentMode::Production`. |
+| FE-5 | **host_id silently regenerated.** A corrupt/empty/missing `host_id` file regenerates a new UUID; if this node was a cluster member, its identity (and ring position) is lost. | New identity ⇒ orphaned data, ring imbalance, ghost membership. | 8 | 2 | 4 | 64 | **Mitigated (BUG-008):** `classify_host_id_state` emits a distinct ERROR/WARN per case naming the path + bad content + new id. Detection now depends on log review, not silence. |
+| FE-6 | **Internode bind on the wrong port.** Default is `17000`; a config that re-introduces `7000` collides with macOS ControlCenter (BUG-001) or another service. | Opaque `EADDRINUSE` crash, or peers can't connect. | 6 | 2 | 3 | 36 | Default moved to 17000 with an explicit code comment + a `ferrosa-net` guard test (`default_bind_port_is_not_7000`). Invalid TOML bind is logged and ignored, never fatal. |
+| FE-7 | **Shutdown timeout drops un-flushed data.** The 30 s graceful drain (`mode_controller.shutdown` → internode drain → memtable flush → schema persist) can exceed the window under heavy flush/S3 load. | Memtables not flushed ⇒ data loss on restart for anything not yet in an SSTable or commit log. | 8 | 2 | 5 | 80 | SIGTERM is handled (not just SIGINT) so container stops drain; timeout logs "shutdown timed out after 30s". **Gap:** the timeout is fixed and the partial-flush case is not surfaced as a metric. |
+| FE-8 | **S3 bootstrap / index-UDT-UDF replay failures are non-fatal.** On cold start, schema bootstrap and the `system_schema.*` re-registration steps log a WARN and continue on error. | A node can come up "fresh" or missing secondary indexes / UDTs / UDFs that exist in S3, serving incomplete schema without crashing. | 7 | 3 | 6 | 126 | Each step logs the failure with table/keyspace context; designed as best-effort with local→S3→fresh priority. **Gap:** no readiness gate distinguishes "fresh by design" from "bootstrap failed". |
+| FE-9 | **Maintenance-loop sub-task panics swallowed.** Flush/S3-sync run on detached `std::thread`s; the schema-sync path `continue`s on flush failure to avoid persisting schema ahead of data. | A persistently failing flush silently stops schema persistence; a panicked sync thread is logged but the loop continues. | 6 | 3 | 6 | 108 | Failures are logged per tick; the "skip schema persist if flush failed" guard is correct fail-loud-ish behavior. **Gap:** no escalation/metric if a tick keeps failing. |
+
+## Top risks to act on
+
+1. **FE-1 (RPN 196) — partial boot.** A failed bind of an *enabled* front-end
+   should fail loud (crash or fail `/readyz`), not log-and-continue. Today a node
+   can serve CQL while its Postgres/Flight/graph listener never came up, with no
+   health distinction from "disabled."
+2. **FE-3 (RPN 135) — auth resolves open by default.** The permissive default is
+   silent; in production mode the composition root should default closed or
+   refuse to start without an explicit auth decision, since the same flag also
+   opens the admin REST surface.
+
+## Detection assets
+
+- In-crate unit tests for every config resolver (env→TOML→default), `host_id`
+  classification, hinted-handoff dir, schema persist/load, web auth bypass.
+- `/readyz` (un-authenticated) and `/metrics` on the web console.
+- Per-step structured WARN/ERROR logs across bootstrap, replay, and shutdown.
+- `ferrosa-net` `default_bind_port_is_not_7000` guard (FE-6).

--- a/ferrosa/specs/overview.md
+++ b/ferrosa/specs/overview.md
@@ -1,0 +1,110 @@
+---
+crate: ferrosa
+status: implemented
+last_updated: 2026-06-19
+executive_summary: >
+  The top-level binary and composition root. It constructs one StorageEngine,
+  one Schema, one ModeController, one PeerManager, and one CdcBus, then wires
+  every query front-end (CQL, Postgres, Arrow Flight, graph HTTP+Bolt, SPARQL)
+  and the web console onto them in a fixed startup order. It owns no domain
+  logic of its own — its responsibility is wiring, configuration resolution,
+  port binding, and process lifecycle. Nothing depends on this crate.
+---
+
+# ferrosa — Architecture Overview
+
+## Purpose & boundary
+
+`ferrosa` is the `[[bin]]` target that becomes the running database. Its
+boundary is deliberately thin: it imports the subsystem crates and **composes**
+them. The hard correctness work — storage, schema, consensus, transport, query
+execution — lives in those crates. This crate decides *what order* they come up
+in, *which* shared instances they share, *what config* they read, and *how* they
+drain on shutdown.
+
+It is the single place in the workspace where all front-ends meet, so it is also
+the only natural home for cross-cutting wiring: the `CdcBus` that feeds both CQL
+`SUBSCRIBE` and Arrow Flight, the `SessionCore` shared by the CQL router and the
+Flight service, and the per-subsystem tokio runtimes that keep Raft heartbeats
+off the bulk-write path.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `main.rs` (~2.8k LoC) | The full startup sequence + the maintenance loop + graceful shutdown; pure config/host_id helpers are unit-tested here |
+| `runtime.rs` | `RuntimeManager` — dedicated `raft` / `data` / `cql` / `background` tokio runtimes |
+| `repair_wiring.rs` | `BinaryRepairContext`, `build_repair_executor` — binds self-heal + anti-entropy repair to the live ring/peer manager |
+| `cql_broadcast.rs` | `parse_cql_broadcast` — externally-advertised CQL address for `system.local` |
+| `web/` | Axum console: `api`, `auth`, `debug`, `observability`, `readiness`, `snapshots`, `static_files`, `ws` |
+
+## Composition model
+
+```
+                 ┌──────────── Arc<StorageEngine> ────────────┐
+ CdcBus ───────► │  (write-behind cache + S3 + commit log)    │
+                 └───────────────┬────────────────────────────┘
+                                 │ shared Arc
+   Arc<Schema> ──────────────────┼───────────────► virtual tables, DDL
+   Arc<ModeController> ──────────┤
+   Arc<PeerManager> ─────────────┤
+                                 ▼
+                       ferrosa-session::SessionCore
+                                 │
+        ┌────────────┬───────────┼───────────┬────────────┐
+       CQL        Postgres     Flight       Graph        SPARQL
+      :9042        :5432       :8815      :7474/:7687     :8080
+```
+
+A single `Arc` of each core service is cloned into every consumer. There is
+exactly one engine, one schema, one cluster brain, one peer map, and one HLC per
+process — which is what makes cross-front-end reads consistent and DDL
+replication uniform.
+
+## Key invariants
+
+1. **Strict startup ordering.** The engine must exist before schema restore;
+   schema (system tables + user tables + indexes/UDTs/UDFs) must be registered
+   before commit-log mutations are replayed; the `PeerManager` must exist before
+   the self-heal cluster view (which reads live membership) and before
+   `SessionCore` (so LWT routes over real peers). Re-ordering silently breaks
+   recovery (e.g. "table not registered" during Raft replay).
+2. **Single CdcBus, attached pre-listener.** The change bus is attached to the
+   commit log in step 4, before any front-end binds, so no early write is missed
+   by `SUBSCRIBE`/Flight consumers.
+3. **Config precedence is env → TOML → default, everywhere.** All resolvers
+   (`config_val`, `apply_internode_toml_overrides`, `resolve_graph_enabled`,
+   `resolve_auth_enabled_toml`) honor this order; BUG-006 was TOML being ignored
+   for internode/graph/auth.
+4. **Auth is driven from one switch.** `FERROSA_AUTH_ENABLED` (or
+   `[cql].auth_enabled`) is the source of truth; `resolve_auth_disabled` derives
+   the CQL/web/graph/Bolt `auth_disabled` flag. `FERROSA_AUTH_DISABLED` is a
+   deprecated override that logs a warning.
+5. **Graceful shutdown flushes before exit.** `SIGTERM` (container stop) and
+   `SIGINT` both trigger a 30 s drain that flushes memtables and persists schema
+   — skipping it is 100 % data loss on restart.
+
+## Configuration resolution
+
+`config_val` / `config_val_opt` implement the env→TOML→default ladder and are
+the most-tested code here. `host_id` resolution is a pure state machine
+(`classify_host_id_state` → `HostIdResolution`) so a corrupt/empty/missing id
+file produces an actionable log line instead of a silent identity change
+(BUG-008). Internode, graph-enabled, and auth-enabled each have a dedicated
+TOML-aware resolver (BUG-006).
+
+## Lifecycle
+
+Boot wires everything (see [data-flow.md](data-flow.md)); a background
+maintenance loop on the `background` runtime handles periodic + urgent flush,
+compaction polling, commit-log GC, and schema persistence (local + S3); shutdown
+drains cluster tasks → internode → memtables → schema in a 30 s timeout window.
+
+## Position in the dependency graph
+
+**Root.** Depends on `ferrosa-cdc`, `ferrosa-cluster`, `ferrosa-common`,
+`ferrosa-cql`, `ferrosa-flight` (feature `flight`), `ferrosa-graph`,
+`ferrosa-net`, `ferrosa-postgres`, `ferrosa-schema`, `ferrosa-session`,
+`ferrosa-sparql`, `ferrosa-storage`, `ferrosa-udf`. Depended on by nothing — it
+is the binary. See the [root crate index](../../specs/crates.md) for the full
+graph.

--- a/ferrosa/specs/roadmap.md
+++ b/ferrosa/specs/roadmap.md
@@ -1,0 +1,51 @@
+---
+crate: ferrosa
+doc: roadmap
+last_updated: 2026-06-19
+---
+
+# ferrosa — Roadmap
+
+Sourced from the FMEA gaps ([fmea.md](fmea.md)), the in-code `TODO`
+(`web/api.rs:475`), and the composition review of `main.rs`.
+
+## Now (highest value)
+
+- **Fail loud on partial boot (FMEA FE-1).** When an *enabled* listener
+  (Postgres, Flight, graph HTTP, Bolt, SPARQL) fails to bind, the node must
+  either crash or report not-ready via `/readyz` — not log-and-continue. Add a
+  startup readiness aggregate that distinguishes "disabled by config" from
+  "enabled but failed to bind."
+- **Default-closed auth in production mode (FMEA FE-3).** When
+  `DeploymentMode::Production`, refuse to start (or default `auth_enabled=true`)
+  unless the operator made an explicit auth decision, because the same
+  `auth_disabled` flag also opens the web `/admin/*` cluster-control surface.
+
+## Next
+
+- **Guard test for startup ordering (FMEA FE-2).** Extract the boot sequence
+  into an asserted, testable form (or add an integration test) so a re-ordering
+  that breaks recovery (engine/CdcBus, table-registration/replay,
+  PeerManager/SessionCore) fails in CI rather than in a live cold start.
+- **Readiness gate for bootstrap integrity (FMEA FE-8).** Surface "S3 bootstrap
+  failed / index reload failed / UDT-UDF replay failed" as a not-ready signal so
+  a node that came up with incomplete schema is visibly degraded.
+- **Refuse ephemeral Flight key in production (FMEA FE-4).** With the `flight`
+  feature and `DeploymentMode::Production`, require `FERROSA_FLIGHT_SIGNING_KEY`.
+- **Wire the deferred web API handler** (`web/api.rs:475` TODO — storage/schema/
+  peer_manager/local_node_id into that endpoint).
+
+## Later
+
+- **Configurable, observable shutdown drain (FMEA FE-7).** Make the 30 s drain
+  timeout configurable and emit a metric/alert when a flush is left incomplete.
+- **Maintenance-loop escalation (FMEA FE-9).** Track consecutive flush/S3-sync
+  failures and escalate (metric + alert) instead of silently retrying each tick.
+- **Split `main.rs`.** ~2.8k LoC in one file; extract the bootstrap, listener
+  wiring, and maintenance loop into focused modules to keep each unit reviewable.
+
+## Non-goals
+
+- Re-documenting or re-implementing subsystem internals (storage, schema,
+  cluster, transport, query front-ends). Those live in their own crates with
+  their own specs — this crate only composes them.

--- a/specs/README.md
+++ b/specs/README.md
@@ -25,10 +25,18 @@ specs/
   todo/          Genuinely open + partial work with remaining implementation
   decisions/     Architecture Decision Records (ADRs), carried over wholesale
   security/      Threat models — re-status against code before citing as evidence
+  crates.md          Crate-centric index → every crate's README + per-crate specs/
   README.md          This index
   ROADMAP.md         Now / Next / Later, grounded in the audit
   SECURITY-STATUS.md Honest security posture (deferred / unconfirmed items)
 ```
+
+> **Per-crate documentation.** Each of the 25 workspace crates carries its own
+> `README.md` (what's implemented, how it works, dependencies) and a `specs/`
+> directory (overview / FMEA / roadmap). [`crates.md`](crates.md) is the
+> crate-centric map + the runtime dependency graph; the detail lives with each
+> crate. Updating a crate's docs is part of the definition of done for any change
+> to it (see [`../CLAUDE.md`](../CLAUDE.md) / [`../AGENTS.md`](../AGENTS.md)).
 
 ## Taxonomy
 

--- a/specs/crates.md
+++ b/specs/crates.md
@@ -1,0 +1,194 @@
+# Ferrosa Crates — Index
+
+> Crate-centric overview of the 25-crate workspace. Each crate carries its own
+> `README.md` (what's implemented, how it works, dependencies) and a `specs/`
+> directory (overview / FMEA / roadmap). This page is the map; the detail lives
+> with each crate. Cross-cutting topic specs live under [`reference/`](reference/).
+
+> **Process rule:** changing a crate's behavior, public API, or dependencies is
+> not done until that crate's `README.md` + `specs/` are updated to match. See
+> [`CLAUDE.md`](../CLAUDE.md) / [`AGENTS.md`](../AGENTS.md).
+
+## Crates by layer
+
+### Front-ends & query
+
+| Crate | Purpose | Runtime deps | Docs |
+|-------|---------|--------------|------|
+| `ferrosa-cql` | CQL native-protocol v4/v5 server — parse, route, LWT/Accord, prepared, SUBSCRIBE | ferrosa-cdc, ferrosa-cluster, ferrosa-common, ferrosa-index, ferrosa-net, ferrosa-row-bridge, ferrosa-schema, ferrosa-session, ferrosa-sstable, ferrosa-storage, ferrosa-udf | [README](../ferrosa-cql/README.md) · [specs](../ferrosa-cql/specs/) |
+| `ferrosa-postgres` | PostgreSQL v3 wire front-end (preview) — SELECT/DML/transactions, SCRAM | ferrosa-common, ferrosa-row-bridge, ferrosa-schema, ferrosa-sql, ferrosa-sstable, ferrosa-storage | [README](../ferrosa-postgres/README.md) · [specs](../ferrosa-postgres/specs/) |
+| `ferrosa-flight` | Apache Arrow Flight gRPC endpoint — CQL SELECT -> Arrow batches, bearer auth | ferrosa-cluster, ferrosa-common, ferrosa-cql, ferrosa-schema | [README](../ferrosa-flight/README.md) · [specs](../ferrosa-flight/specs/) |
+| `ferrosa-graph` | Property-graph engine — Cypher, Bolt v5, HTTP, adjacency index | ferrosa-cluster, ferrosa-common, ferrosa-schema, ferrosa-sstable, ferrosa-storage | [README](../ferrosa-graph/README.md) · [specs](../ferrosa-graph/specs/) |
+| `ferrosa-sparql` | SPARQL 1.1 endpoint (Query + Update, RDF*, property paths) | ferrosa-cluster, ferrosa-common, ferrosa-index, ferrosa-schema, ferrosa-sstable, ferrosa-storage | [README](../ferrosa-sparql/README.md) · [specs](../ferrosa-sparql/specs/) |
+| `ferrosa-sql` | Bespoke relational engine (D3, no DataFusion) backing the Postgres front-end | — | [README](../ferrosa-sql/README.md) · [specs](../ferrosa-sql/specs/) |
+| `ferrosa-udf` | User-defined functions — Wasmtime sandbox, fuel/epoch limits, AssemblyScript | ferrosa-common | [README](../ferrosa-udf/README.md) · [specs](../ferrosa-udf/specs/) |
+| `ferrosa-row-bridge` | The single canonical CQL row codec shared by both front-ends (D10) | ferrosa-common, ferrosa-schema, ferrosa-sstable | [README](../ferrosa-row-bridge/README.md) · [specs](../ferrosa-row-bridge/specs/) |
+
+### Consensus & cluster
+
+| Crate | Purpose | Runtime deps | Docs |
+|-------|---------|--------------|------|
+| `ferrosa-cluster` | Raft metadata consensus, tunable CL, routing, repair, hinted handoff, Accord | ferrosa-cdc, ferrosa-common, ferrosa-index, ferrosa-net, ferrosa-schema, ferrosa-sstable, ferrosa-storage | [README](../ferrosa-cluster/README.md) · [specs](../ferrosa-cluster/specs/) |
+| `ferrosa-session` | Connection/session state extracted for reuse across front-ends (extraction WIP) | ferrosa-cluster, ferrosa-common, ferrosa-net, ferrosa-schema, ferrosa-storage, ferrosa-udf | [README](../ferrosa-session/README.md) · [specs](../ferrosa-session/specs/) |
+
+### Storage & schema
+
+| Crate | Purpose | Runtime deps | Docs |
+|-------|---------|--------------|------|
+| `ferrosa-storage` | Write-behind S3 engine — memtable, commit log, compaction, cache, PITR | ferrosa-cdc, ferrosa-common, ferrosa-index, ferrosa-schema, ferrosa-sstable | [README](../ferrosa-storage/README.md) · [specs](../ferrosa-storage/specs/) |
+| `ferrosa-schema` | Table/keyspace metadata, DDL, system keyspaces, auth/RBAC, audit, virtual tables | ferrosa-common, ferrosa-index, ferrosa-sstable | [README](../ferrosa-schema/README.md) · [specs](../ferrosa-schema/specs/) |
+| `ferrosa-index` | Secondary + vector (HNSW/IVFFlat) + full-text + geo indexes | ferrosa-common | [README](../ferrosa-index/README.md) · [specs](../ferrosa-index/specs/) |
+| `ferrosa-cdc` | Bounded change-data-capture bus (WrittenOnNode + CommittedToCluster streams) | ferrosa-common, ferrosa-sstable | [README](../ferrosa-cdc/README.md) · [specs](../ferrosa-cdc/specs/) |
+| `ferrosa-sstable` | Read/write Cassandra-compatible BTI SSTables; ReadAt/WriteAt I/O boundary | ferrosa-common | [README](../ferrosa-sstable/README.md) · [specs](../ferrosa-sstable/specs/) |
+
+### Foundation
+
+| Crate | Purpose | Runtime deps | Docs |
+|-------|---------|--------------|------|
+| `ferrosa-common` | Shared leaf types (Token, keys, CellValue, CqlType/CqlValue, Accord HLC/TxnId) | — | [README](../ferrosa-common/README.md) · [specs](../ferrosa-common/specs/) |
+| `ferrosa-net` | Custom internode protocol — framing, PSK-HMAC, priority lanes, TLS | ferrosa-common | [README](../ferrosa-net/README.md) · [specs](../ferrosa-net/specs/) |
+
+### Binary & tooling
+
+| Crate | Purpose | Runtime deps | Docs |
+|-------|---------|--------------|------|
+| `ferrosa` | Main binary / composition root — wires every subsystem + listeners | ferrosa-cdc, ferrosa-cluster, ferrosa-common, ferrosa-cql, ferrosa-flight, ferrosa-graph, ferrosa-net, ferrosa-postgres, ferrosa-schema, ferrosa-session, ferrosa-sparql, ferrosa-storage, ferrosa-udf | [README](../ferrosa/README.md) · [specs](../ferrosa/specs/) |
+| `ferrosa-ctl` | CLI + ratatui TUI — cluster mgmt, snapshot/restore, monitoring over CQL | ferrosa-cluster, ferrosa-common, ferrosa-cql, ferrosa-sstable, ferrosa-storage | [README](../ferrosa-ctl/README.md) · [specs](../ferrosa-ctl/specs/) |
+| `ferrosa-index-builder` | Standalone HTTP service to offload secondary-index construction | ferrosa-common, ferrosa-index, ferrosa-sstable, ferrosa-storage | [README](../ferrosa-index-builder/README.md) · [specs](../ferrosa-index-builder/specs/) |
+| `ferrosa-worker` | Background task runner (nascent; IndexBuild task is a stub) | ferrosa-common, ferrosa-index, ferrosa-sstable | [README](../ferrosa-worker/README.md) · [specs](../ferrosa-worker/specs/) |
+| `ferrosa-view` | Materialized-view primitives (island; not yet wired into the engine) | ferrosa-schema | [README](../ferrosa-view/README.md) · [specs](../ferrosa-view/specs/) |
+| `ferrosa-loadgen` | Load/stress tool — UCS compaction soak, ground-truth integrity checks | ferrosa-common, ferrosa-cql, ferrosa-schema, ferrosa-sstable, ferrosa-storage | [README](../ferrosa-loadgen/README.md) · [specs](../ferrosa-loadgen/specs/) |
+
+### Testing & simulation
+
+| Crate | Purpose | Runtime deps | Docs |
+|-------|---------|--------------|------|
+| `ferrosa-jepsen` | Distributed-testing harness (Docker/Firecracker), live-infra-gated | ferrosa-sim | [README](../ferrosa-jepsen/README.md) · [specs](../ferrosa-jepsen/specs/) |
+| `ferrosa-sim` | Deterministic Raft/cluster simulation harness + TLA+ refinement | — | [README](../ferrosa-sim/README.md) · [specs](../ferrosa-sim/specs/) |
+
+## Runtime dependency graph
+
+Edges are **runtime** `[dependencies]` (dev-dependencies omitted — e.g. `ferrosa-graph`→`ferrosa-net` and `ferrosa-ctl`→`schema/session/udf` are test-only).
+
+```mermaid
+graph TD
+    ferrosa_session[ferrosa-session]
+    ferrosa_cdc[ferrosa-cdc]
+    ferrosa_postgres[ferrosa-postgres]
+    ferrosa_view[ferrosa-view]
+    ferrosa_net[ferrosa-net]
+    ferrosa_sparql[ferrosa-sparql]
+    ferrosa_loadgen[ferrosa-loadgen]
+    ferrosa_flight[ferrosa-flight]
+    ferrosa_index_builder[ferrosa-index-builder]
+    ferrosa_cql[ferrosa-cql]
+    ferrosa_jepsen[ferrosa-jepsen]
+    ferrosa_row_bridge[ferrosa-row-bridge]
+    ferrosa_graph[ferrosa-graph]
+    ferrosa_storage[ferrosa-storage]
+    ferrosa_common[ferrosa-common]
+    ferrosa_schema[ferrosa-schema]
+    ferrosa_index[ferrosa-index]
+    ferrosa_udf[ferrosa-udf]
+    ferrosa_worker[ferrosa-worker]
+    ferrosa_ctl[ferrosa-ctl]
+    ferrosa_sim[ferrosa-sim]
+    ferrosa_sstable[ferrosa-sstable]
+    ferrosa_cluster[ferrosa-cluster]
+    ferrosa[ferrosa]
+    ferrosa_sql[ferrosa-sql]
+    ferrosa --> ferrosa_cdc
+    ferrosa --> ferrosa_cluster
+    ferrosa --> ferrosa_common
+    ferrosa --> ferrosa_cql
+    ferrosa --> ferrosa_flight
+    ferrosa --> ferrosa_graph
+    ferrosa --> ferrosa_net
+    ferrosa --> ferrosa_postgres
+    ferrosa --> ferrosa_schema
+    ferrosa --> ferrosa_session
+    ferrosa --> ferrosa_sparql
+    ferrosa --> ferrosa_storage
+    ferrosa --> ferrosa_udf
+    ferrosa_cdc --> ferrosa_common
+    ferrosa_cdc --> ferrosa_sstable
+    ferrosa_cluster --> ferrosa_cdc
+    ferrosa_cluster --> ferrosa_common
+    ferrosa_cluster --> ferrosa_index
+    ferrosa_cluster --> ferrosa_net
+    ferrosa_cluster --> ferrosa_schema
+    ferrosa_cluster --> ferrosa_sstable
+    ferrosa_cluster --> ferrosa_storage
+    ferrosa_cql --> ferrosa_cdc
+    ferrosa_cql --> ferrosa_cluster
+    ferrosa_cql --> ferrosa_common
+    ferrosa_cql --> ferrosa_index
+    ferrosa_cql --> ferrosa_net
+    ferrosa_cql --> ferrosa_row_bridge
+    ferrosa_cql --> ferrosa_schema
+    ferrosa_cql --> ferrosa_session
+    ferrosa_cql --> ferrosa_sstable
+    ferrosa_cql --> ferrosa_storage
+    ferrosa_cql --> ferrosa_udf
+    ferrosa_ctl --> ferrosa_cluster
+    ferrosa_ctl --> ferrosa_common
+    ferrosa_ctl --> ferrosa_cql
+    ferrosa_ctl --> ferrosa_sstable
+    ferrosa_ctl --> ferrosa_storage
+    ferrosa_flight --> ferrosa_cluster
+    ferrosa_flight --> ferrosa_common
+    ferrosa_flight --> ferrosa_cql
+    ferrosa_flight --> ferrosa_schema
+    ferrosa_graph --> ferrosa_cluster
+    ferrosa_graph --> ferrosa_common
+    ferrosa_graph --> ferrosa_schema
+    ferrosa_graph --> ferrosa_sstable
+    ferrosa_graph --> ferrosa_storage
+    ferrosa_index --> ferrosa_common
+    ferrosa_index_builder --> ferrosa_common
+    ferrosa_index_builder --> ferrosa_index
+    ferrosa_index_builder --> ferrosa_sstable
+    ferrosa_index_builder --> ferrosa_storage
+    ferrosa_jepsen --> ferrosa_sim
+    ferrosa_loadgen --> ferrosa_common
+    ferrosa_loadgen --> ferrosa_cql
+    ferrosa_loadgen --> ferrosa_schema
+    ferrosa_loadgen --> ferrosa_sstable
+    ferrosa_loadgen --> ferrosa_storage
+    ferrosa_net --> ferrosa_common
+    ferrosa_postgres --> ferrosa_common
+    ferrosa_postgres --> ferrosa_row_bridge
+    ferrosa_postgres --> ferrosa_schema
+    ferrosa_postgres --> ferrosa_sql
+    ferrosa_postgres --> ferrosa_sstable
+    ferrosa_postgres --> ferrosa_storage
+    ferrosa_row_bridge --> ferrosa_common
+    ferrosa_row_bridge --> ferrosa_schema
+    ferrosa_row_bridge --> ferrosa_sstable
+    ferrosa_schema --> ferrosa_common
+    ferrosa_schema --> ferrosa_index
+    ferrosa_schema --> ferrosa_sstable
+    ferrosa_session --> ferrosa_cluster
+    ferrosa_session --> ferrosa_common
+    ferrosa_session --> ferrosa_net
+    ferrosa_session --> ferrosa_schema
+    ferrosa_session --> ferrosa_storage
+    ferrosa_session --> ferrosa_udf
+    ferrosa_sparql --> ferrosa_cluster
+    ferrosa_sparql --> ferrosa_common
+    ferrosa_sparql --> ferrosa_index
+    ferrosa_sparql --> ferrosa_schema
+    ferrosa_sparql --> ferrosa_sstable
+    ferrosa_sparql --> ferrosa_storage
+    ferrosa_sstable --> ferrosa_common
+    ferrosa_storage --> ferrosa_cdc
+    ferrosa_storage --> ferrosa_common
+    ferrosa_storage --> ferrosa_index
+    ferrosa_storage --> ferrosa_schema
+    ferrosa_storage --> ferrosa_sstable
+    ferrosa_udf --> ferrosa_common
+    ferrosa_view --> ferrosa_schema
+    ferrosa_worker --> ferrosa_common
+    ferrosa_worker --> ferrosa_index
+    ferrosa_worker --> ferrosa_sstable
+```


### PR DESCRIPTION
## Per-crate documentation + crate-centric specs + architect review

Restructures docs to be **crate-centric**: every one of the 25 workspace crates now
carries its own `README.md` (what's implemented, how it works, dependencies +
dependents) and a `specs/` directory (`overview.md` / `fmea.md` / `roadmap.md`, plus
`data-flow.md` for heavier crates). The root [`specs/crates.md`](specs/crates.md)
is the index + runtime dependency graph. A thorough architect review per crate
surfaced real issues — captured in each crate's FMEA.

### What's here
- **25 crates documented** (1 hand-written exemplar `ferrosa-row-bridge`, 24 via per-crate architect agents).
- **`specs/crates.md`** — crate index by layer + validated runtime dependency graph (dev-deps excluded).
- **Process rule** in `CLAUDE.md` + new **`AGENTS.md`**: changing a crate's behavior/API/deps is *not done* until its `README.md` + `specs/` are updated.
- Dependency facts derived mechanically from `Cargo.toml` (runtime vs dev split); the review **corrected** several errors in the existing reference docs (e.g. `ferrosa-net` *does* depend on `ferrosa-common`; the binary's internode RPC port is **17000**, not 7000; `ferrosa-graph`→`net` and `ferrosa-ctl`→`schema/session/udf` are dev-only).

### Issues the architect review surfaced (now in the per-crate FMEAs)
A sample of the higher-severity findings (each crate's `specs/fmea.md` has the full RPN-scored list):
- **`ferrosa-schema`** — production TLS checks are no-ops: a `FERROSA_MODE=production` node passes the security gate with TLS fully off. Plus well-known default/seed credentials.
- **`ferrosa-sparql`** — no authentication on any endpoint; `OPTIONAL` silently dropped and `UNION` is concat-not-union (silent wrong answers).
- **`ferrosa-postgres`** — `BEGIN/COMMIT/ROLLBACK` drive status bytes but DML applies immediately and isn't rolled back (transactions look atomic but aren't); `$N` params unsupported in DML.
- **`ferrosa` (binary)** — partial-boot silence (a front-end bind failure is only logged, node stays "ready"); auth resolves open by default for CQL *and* the web `/admin/*` surface.
- **`ferrosa-cql`** — unsigned `paging_state` cursor (forgeable → cross-partition read); `router.rs` is a 22k-LoC monolith with permission checks enforced by convention.
- **`ferrosa-cluster`** — no external/public Jepsen validation; correctness rests on in-crate deterministic tests; election-storm mitigations can't be removed until that lands.
- **`ferrosa-index-builder`** — pull-mode hard-codes `index_type=btree`, silently building the wrong sidecar for hash/vector/fulltext/filtered/geo.
- **`ferrosa-graph`** — the adjacency reconciler (drift safety net) is disabled by default.
- **`ferrosa-udf`** — determinism is unguarded (replica-convergence risk). **`ferrosa-view`** — island never wired into the engine. **`ferrosa-worker`** — `IndexBuild` task is a stub.

### Verification
- All 25 crates have README + specs/ (coverage check passes).
- Every crate-doc Mermaid block passes the angle-bracket render scan + `mermaid_validate` (no `<Type>` render-breakers).
- Runtime dependency graph generated + validated from `Cargo.toml`.

Docs-only PR (markdown) — no code changes.

### Follow-up
The FMEA findings above are real and several are security/correctness ship-blockers worth triaging into the board.
