### PR TITLE
fix(cql,cluster): scatter-gather fts_match across cluster nodes (BUG-F-007)

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -66,7 +66,10 @@ strict-serializable multi-key / cross-shard transactions and LWT.
 - `coordinator/read.rs` — two-phase digest reads, inline read repair on digest
   mismatch (fail-loud `ReadTimeout` rather than serve stale), corrupt-SSTable
   failover feeding the bounded `AntiEntropyRepairQueue` (cap 1024) — *serve now,
-  repair in background* (LOCKED DESIGN).
+  repair in background* (LOCKED DESIGN). Also hosts the index scatter-gathers:
+  `coordinate_index_read` (secondary index) and `coordinate_fulltext_search`
+  (`fts_match` — fans out to every node's local FTI and unions/de-dupes the
+  matching keys, since full-text hits span all token ranges; BUG-F-007).
 - `coordinator/cl_routing.rs` — W8.4 learner-aware routing (voter-only quorums,
   leader-only serial, cross-DC Accord routing).
 - `coordinator/batch.rs` — 3-phase logged batchlog (write → fan out → delete only

--- a/ferrosa-cluster/specs/overview.md
+++ b/ferrosa-cluster/specs/overview.md
@@ -64,6 +64,13 @@ digest reads, then resolves. On digest mismatch it fail-loud re-fetches the newe
 copy and repairs stale replicas inline; on a corrupt local SSTable it fails over
 to a healthy replica and enqueues a background anti-entropy refill.
 
+**Full-text scatter-gather.** `coordinate_fulltext_search` fans an `fts_match`
+index lookup out to every node — its hits span all token ranges (there is no
+partition key) — running each node's local FTI via a `FulltextSearchRequest` RPC
+and unioning/de-duping the matching keys (partial-failure tolerant). Routed
+through `WritePath::fulltext_search` (Direct/Pair resolve locally). Fixes the
+coordinator-local non-determinism of BUG-F-007.
+
 **DDL / membership.** Mutations are wrapped as `RaftOp`, proposed via
 `raft.client_write` (forwarded to the leader if needed via `raft_forward`),
 committed, and applied deterministically into `RaftState` on every node.

--- a/ferrosa-cluster/specs/roadmap.md
+++ b/ferrosa-cluster/specs/roadmap.md
@@ -20,6 +20,16 @@ reference/decision specs, and the dependency/usage review. Ordered by value.
   regression-tested. *Still open:* route `handle_apply` itself through
   `DepWaitApplier` so dep-ordering is enforced at the state-machine apply path
   (today it applies directly via `EngineStorageApplier`) — see Next / t_59629c9b.
+- **Cluster-wide `fts_match` scatter-gather (BUG-F-007 / t_0d08aa43).** `fts_match`
+  carries no partition key, so its hits span every token range, but the served
+  path consulted only the coordinator's local FTI — returning 0/1
+  non-deterministically depending on which node coordinated. Added a
+  `FulltextSearchRequest`/`Response` internode RPC + `FulltextSearchHandler`, a
+  `ClusterCoordinator::coordinate_fulltext_search` that fans out to every node and
+  unions/de-dupes the matching keys, and `WritePath::fulltext_search`
+  (Direct/Pair → local, Cluster → fan-out). The CQL router now routes the FTI
+  lookup through the write path. In-process 2-node fan-out + dedup test in
+  `coordinator/read.rs`.
 
 ## Now (highest value)
 

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -57,8 +57,8 @@ use crate::ddl_path::{execute_via_raft, ClusterDdlForwardHandler, DdlPath};
 use crate::mode::DeploymentMode;
 use crate::pair::ddl::DdlOperation;
 use crate::raft::handlers::{
-    IndexReadHandler, RaftAppendHandler, RaftSnapshotHandler, RaftVoteHandler, RangeReadHandler,
-    ReadRequestHandler,
+    FulltextSearchHandler, IndexReadHandler, RaftAppendHandler, RaftSnapshotHandler,
+    RaftVoteHandler, RangeReadHandler, ReadRequestHandler,
 };
 use crate::raft::log_store::SledLogStore;
 use crate::raft::network::FerrosRaftNetworkFactory;
@@ -1079,6 +1079,10 @@ impl ModeController {
         let index_read_handler = Arc::new(IndexReadHandler::new(self.storage.clone()));
         self.registry
             .register(MsgType::IndexReadRequest, index_read_handler);
+
+        let fulltext_search_handler = Arc::new(FulltextSearchHandler::new(self.storage.clone()));
+        self.registry
+            .register(MsgType::FulltextSearchRequest, fulltext_search_handler);
 
         let read_handler = Arc::new(ReadRequestHandler::new(self.storage.clone()));
         self.registry.register(MsgType::ReadRequest, read_handler);

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -34,8 +34,9 @@ use crate::consistency::ConsistencyLevel;
 use crate::error::ClusterError;
 use crate::pair::coordinator::encode_mutation;
 use crate::raft::handlers::{
-    partition_from_wire, IndexReadRequestPayload, IndexReadResponsePayload,
-    RangeReadRequestPayload, RangeReadResponsePayload, ReadRequestPayload, ReadResponsePayload,
+    partition_from_wire, FulltextSearchRequestPayload, FulltextSearchResponsePayload,
+    IndexReadRequestPayload, IndexReadResponsePayload, RangeReadRequestPayload,
+    RangeReadResponsePayload, ReadRequestPayload, ReadResponsePayload,
 };
 use crate::raft::IndexNodeStatus;
 
@@ -1607,6 +1608,147 @@ impl ClusterCoordinator {
 
         Ok(deduped)
     }
+
+    /// Fan out a full-text (`fts_match`) lookup to every node and union the
+    /// matching partition keys.
+    ///
+    /// `fts_match` carries no partition key, so its hits span all token ranges;
+    /// consulting only the coordinator's local FTI returned 0/1
+    /// non-deterministically depending on which node coordinated the query
+    /// (BUG-F-007). Querying every node and de-duplicating the keys makes the
+    /// result coordinator-independent. Partial failures degrade to a partial
+    /// union (logged); only an all-nodes-failed-and-empty result errors.
+    pub async fn coordinate_fulltext_search(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        query: &str,
+    ) -> crate::error::Result<Vec<Vec<u8>>> {
+        let ring = self.ring.load();
+        let node_ids = ring.node_ids();
+        let nodes: Vec<(u64, Option<(uuid::Uuid, String)>)> = node_ids
+            .iter()
+            .map(|&id| (id, ring.get_node(id).map(|n| (n.host_id, n.addr.clone()))))
+            .collect();
+        drop(ring);
+
+        let req_payload = FulltextSearchRequestPayload {
+            keyspace: table_id.keyspace.clone(),
+            table: table_id.table.clone(),
+            index_name: index_name.to_string(),
+            query: query.to_string(),
+        };
+        let req_body = Bytes::from(bincode::serialize(&req_payload).unwrap_or_default());
+
+        let local_id = self.local_node_id;
+        let storage = self.storage.clone();
+        let table_id_clone = table_id.clone();
+        let index_name_owned = index_name.to_string();
+        let query_owned = query.to_string();
+        let total_nodes = nodes.len();
+
+        let mut futs: FuturesUnordered<_> = nodes
+            .into_iter()
+            .map(|(node_id, remote)| {
+                let storage = storage.clone();
+                let table_id = table_id_clone.clone();
+                let index_name = index_name_owned.clone();
+                let query = query_owned.clone();
+                let req_body = req_body.clone();
+                let coordinator = self;
+
+                async move {
+                    if node_id == local_id {
+                        storage
+                            .fulltext_search(&table_id, &index_name, &query)
+                            .map_err(ClusterError::Storage)
+                    } else {
+                        let (hid, addr) = remote.ok_or_else(|| {
+                            ClusterError::Internal(format!(
+                                "fulltext search: node {node_id} has no host_id"
+                            ))
+                        })?;
+
+                        let resp = coordinator
+                            .send_remote_with_reconnect_timeout(
+                                hid,
+                                &addr,
+                                Message::FulltextSearchRequest(req_body),
+                                Lane::Bulk,
+                                Self::BULK_READ_TIMEOUT,
+                            )
+                            .await
+                            .map_err(|e| {
+                                ClusterError::Internal(format!(
+                                    "fulltext search from node {node_id} ({hid}) via {addr}: {e}"
+                                ))
+                            })?;
+
+                        match resp {
+                            Message::FulltextSearchResponse(b) => {
+                                let payload =
+                                    bincode::deserialize::<FulltextSearchResponsePayload>(&b)
+                                        .map_err(|e| {
+                                            ClusterError::Internal(format!(
+                                                "fulltext search: failed to decode response \
+                                                 from node {node_id} ({hid}): {e}"
+                                            ))
+                                        })?;
+                                Ok(payload.matching_keys)
+                            }
+                            other => Err(ClusterError::Internal(format!(
+                                "fulltext search: unexpected response {:?} from node {node_id} ({hid})",
+                                other.msg_type()
+                            ))),
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        let mut seen: std::collections::HashSet<Vec<u8>> = std::collections::HashSet::new();
+        let mut all_keys: Vec<Vec<u8>> = Vec::new();
+        let mut first_error: Option<ClusterError> = None;
+        let mut failed_nodes = 0usize;
+
+        while let Some(result) = futs.next().await {
+            match result {
+                Ok(keys) => {
+                    for k in keys {
+                        if seen.insert(k.clone()) {
+                            all_keys.push(k);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("coordinate_fulltext_search: {e}");
+                    failed_nodes += 1;
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
+                }
+            }
+        }
+
+        if let Some(err) = first_error {
+            if all_keys.is_empty() {
+                tracing::error!(
+                    failed_nodes,
+                    "coordinate_fulltext_search: all nodes failed, returning error"
+                );
+                return Err(err);
+            }
+            tracing::warn!(
+                failed_nodes,
+                keys_received = all_keys.len(),
+                %err,
+                "coordinate_fulltext_search: {failed_nodes}/{total_nodes} node(s) failed, \
+                 returning partial union",
+            );
+        }
+
+        Ok(all_keys)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2001,6 +2143,94 @@ mod tests {
         let server = Arc::new(RpcServer::new(config, server_id, registry));
         let addr = server.start_and_get_addr().await.unwrap();
         (server, addr, server_id)
+    }
+
+    struct StaticFulltextSearchHandler {
+        keys: Vec<Vec<u8>>,
+    }
+
+    #[async_trait::async_trait]
+    impl RpcHandler for StaticFulltextSearchHandler {
+        async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
+            let Message::FulltextSearchRequest(_) = msg else {
+                return None;
+            };
+            let payload = crate::raft::handlers::FulltextSearchResponsePayload {
+                matching_keys: self.keys.clone(),
+            };
+            Some(Message::FulltextSearchResponse(Bytes::from(
+                bincode::serialize(&payload).unwrap(),
+            )))
+        }
+    }
+
+    /// fts_match fan-out (BUG-F-007 / t_0d08aa43): the coordinator must query
+    /// every node's local FTI and union the matching partition keys, de-duping
+    /// a key returned by more than one replica. Reproduces the multi-node served
+    /// path in-process: local node has an FTI hit; a remote node returns the
+    /// same key plus a remote-only key.
+    #[tokio::test]
+    async fn coordinate_fulltext_search_unions_and_dedups_across_nodes() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+        let table_id = TableId::new("test_ks", "test_tbl");
+
+        // Local node: an FTI row whose text matches → local returns key [1,2,3].
+        storage.add_fulltext_index(&table_id, "val_fti", 0).unwrap();
+        storage
+            .write(&table_id, &test_key(), test_row(1000), 1000)
+            .unwrap();
+
+        // Remote node: returns the SAME local key (must dedup) plus a
+        // remote-only key [9,9,9].
+        let (server, addr, remote_host_id) = start_rpc_server(
+            MsgType::FulltextSearchRequest,
+            Arc::new(StaticFulltextSearchHandler {
+                keys: vec![vec![1, 2, 3], vec![9, 9, 9]],
+            }),
+        )
+        .await;
+
+        let pm = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            Uuid::new_v4(),
+            Arc::new(NoopListener),
+        ));
+
+        let local_node_id = 1u64;
+        let mut local = make_node("127.0.0.1:7000");
+        local.host_id = Uuid::new_v4();
+        let mut remote = make_node(&addr.to_string());
+        remote.host_id = remote_host_id;
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, local);
+        ring.add_node(2u64, remote);
+        ring.assign_tokens(local_node_id, &[42]);
+        ring.assign_tokens(2u64, &[142]);
+
+        let coordinator = make_coordinator(
+            ring,
+            pm.clone(),
+            local_node_id,
+            storage,
+            2,
+            ConsistencyLevel::Quorum,
+        );
+
+        let mut keys = coordinator
+            .coordinate_fulltext_search(&table_id, "val_fti", "hello")
+            .await
+            .unwrap();
+        keys.sort();
+
+        assert_eq!(
+            keys,
+            vec![vec![1u8, 2, 3], vec![9, 9, 9]],
+            "fan-out must union local + remote FTI hits and de-duplicate the shared key"
+        );
+
+        server.shutdown(std::time::Duration::from_millis(50)).await;
     }
 
     // -----------------------------------------------------------------------

--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -1321,6 +1321,83 @@ impl RpcHandler for IndexReadHandler {
     }
 }
 
+/// Payload for a remote full-text search request (fts_match lookup on one node).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FulltextSearchRequestPayload {
+    pub keyspace: String,
+    pub table: String,
+    pub index_name: String,
+    pub query: String,
+}
+
+/// Payload for a remote full-text search response: the matching partition keys
+/// (raw `PartitionKey` bytes) found in this node's local FTI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FulltextSearchResponsePayload {
+    pub matching_keys: Vec<Vec<u8>>,
+}
+
+/// Handles inbound `FulltextSearchRequest` RPCs from remote coordinators.
+///
+/// Runs `fulltext_search` on local storage and returns the matching partition
+/// keys. `fts_match` has no partition key, so the coordinator fans this out to
+/// every node and unions the results — fixing the coordinator-local lookup that
+/// made `fts_match` non-deterministic on a cluster (BUG-F-007).
+pub struct FulltextSearchHandler {
+    storage: Arc<StorageEngine>,
+}
+
+impl FulltextSearchHandler {
+    pub fn new(storage: Arc<StorageEngine>) -> Self {
+        Self { storage }
+    }
+}
+
+#[async_trait]
+impl RpcHandler for FulltextSearchHandler {
+    async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
+        let bytes = match msg {
+            Message::FulltextSearchRequest(b) => b,
+            _ => return None,
+        };
+
+        let req: FulltextSearchRequestPayload = bincode::deserialize(&bytes)
+            .map_err(|e| {
+                tracing::warn!("FulltextSearchHandler: failed to deserialize request: {e}");
+                e
+            })
+            .ok()?;
+
+        let table_id = ferrosa_storage::TableId::new(&req.keyspace, &req.table);
+
+        let matching_keys =
+            match self
+                .storage
+                .fulltext_search(&table_id, &req.index_name, &req.query)
+            {
+                Ok(keys) => keys,
+                Err(e) => {
+                    tracing::warn!("FulltextSearchHandler: fulltext_search failed: {e}");
+                    vec![]
+                }
+            };
+
+        let payload = FulltextSearchResponsePayload { matching_keys };
+        let resp_bytes = match bincode::serialize(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("FulltextSearchHandler: failed to serialize response: {e}");
+                bincode::serialize(&FulltextSearchResponsePayload {
+                    matching_keys: vec![],
+                })
+                .unwrap_or_default()
+            }
+        };
+
+        Some(Message::FulltextSearchResponse(Bytes::from(resp_bytes)))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -765,6 +765,37 @@ impl WritePath {
         }
     }
 
+    /// Full-text (`fts_match`) index lookup, returning matching partition keys.
+    ///
+    /// In standalone/pair mode this hits local storage. In cluster mode the
+    /// coordinator fans out to every node and unions the matching keys, because
+    /// `fts_match` carries no partition key and its hits span all token ranges —
+    /// a coordinator-local lookup made the result non-deterministic (BUG-F-007).
+    pub async fn fulltext_search(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        query: &str,
+    ) -> crate::error::Result<Vec<Vec<u8>>> {
+        match self {
+            Self::Direct(engine) => engine
+                .fulltext_search(table_id, index_name, query)
+                .map_err(crate::error::ClusterError::Storage),
+            Self::Pair(coordinator) => coordinator
+                .local_storage()
+                .fulltext_search(table_id, index_name, query)
+                .map_err(crate::error::ClusterError::Storage),
+            Self::Cluster(coordinator) => {
+                coordinator
+                    .coordinate_fulltext_search(table_id, index_name, query)
+                    .await
+            }
+            Self::Unavailable => Err(crate::error::ClusterError::Internal(
+                "fulltext search unavailable: write path is in degraded mode".into(),
+            )),
+        }
+    }
+
     /// Truncate a table. In standalone/pair mode this truncates local storage.
     /// In cluster mode the coordinator fans out to all nodes.
     pub async fn truncate(&self, table_id: &TableId) -> ferrosa_common::Result<()> {

--- a/ferrosa-cql/specs/overview.md
+++ b/ferrosa-cql/specs/overview.md
@@ -77,6 +77,13 @@ storage, decomposes them to rows via the re-exported
 column mapping), applies projection/LIMIT/paging, and `result.rs` encodes the
 Rows RESULT frame (with `paging_state` when more pages remain).
 
+Full-text predicates (`WHERE col = fts_match('...')`) take a dedicated branch:
+it resolves the matching partition keys through the cluster write path
+(`WritePath::fulltext_search`) — which scatter-gathers across every node's local
+FTI and unions the keys — then fetches and post-filters those partitions. A
+coordinator-local index lookup previously made `fts_match` non-deterministic on a
+cluster (BUG-F-007); standalone/pair still resolve locally.
+
 See [data-flow.md](data-flow.md) for the sequence diagrams.
 
 ## Key invariants

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -3388,9 +3388,16 @@ async fn route_select_user_table(
             .index_usage_tracker
             .record(ks, &s.table, index_name, "FullText");
 
+        // Route the FTI lookup through the write path so it scatter-gathers
+        // across the cluster. `fts_match` carries no partition key, so its hits
+        // span all token ranges; a coordinator-local lookup returned 0/1
+        // depending on which node served the query (BUG-F-007 / t_0d08aa43).
+        // Standalone/pair still resolves locally via the same call.
         let matching_pks = state
-            .engine
+            .write_path
+            .load()
             .fulltext_search(&table_id, index_name, fts_query)
+            .await
             .map_err(|e| CqlError::Invalid(format!("fts_match search failed: {e}")))?;
 
         // Fetch each matching partition and apply post-filter.

--- a/ferrosa-net/README.md
+++ b/ferrosa-net/README.md
@@ -34,7 +34,8 @@ It is a near-leaf in the dependency graph: it depends only on `ferrosa-common`
   `LegacyPayload` until peers negotiate the Cap'n Proto format.
 - **Message model** (`message`) — the `Message` enum with hand-rolled
   length-prefixed encode/decode for lifecycle, Raft, mutation/read, repair,
-  streaming, pair-mode, batchlog, index, Accord, and bootstrap message types
+  streaming, pair-mode, batchlog, index (incl. full-text scatter-gather), Accord,
+  and bootstrap message types
   (`MsgType` discriminants `0x01`..=`0x83`). Optional trailing fields decode to
   `None` on pre-extension peers for backward compatibility.
 - **PSK-HMAC handshake** (`handshake`) — `initiate_handshake` /

--- a/ferrosa-net/src/codec.rs
+++ b/ferrosa-net/src/codec.rs
@@ -144,6 +144,9 @@ pub enum MsgType {
     // Secondary index scatter-gather
     IndexReadRequest = 0x62,
     IndexReadResponse = 0x63,
+    // Full-text index scatter-gather (fts_match across every node's local FTI)
+    FulltextSearchRequest = 0x64,
+    FulltextSearchResponse = 0x65,
     // Accord consensus
     AccordPreAccept = 0x70,
     AccordPreAcceptOK = 0x71,
@@ -264,6 +267,8 @@ impl TryFrom<u8> for MsgType {
             0x61 => Ok(Self::IndexBuildComplete),
             0x62 => Ok(Self::IndexReadRequest),
             0x63 => Ok(Self::IndexReadResponse),
+            0x64 => Ok(Self::FulltextSearchRequest),
+            0x65 => Ok(Self::FulltextSearchResponse),
             0x70 => Ok(Self::AccordPreAccept),
             0x71 => Ok(Self::AccordPreAcceptOK),
             0x72 => Ok(Self::AccordAccept),

--- a/ferrosa-net/src/message.rs
+++ b/ferrosa-net/src/message.rs
@@ -251,6 +251,10 @@ pub enum Message {
     IndexReadRequest(Bytes),
     IndexReadResponse(Bytes),
 
+    // Full-text index scatter-gather (fts_match across every node's local FTI)
+    FulltextSearchRequest(Bytes),
+    FulltextSearchResponse(Bytes),
+
     // Accord consensus — opaque payloads, ferrosa-cluster interprets
     AccordPreAccept(Bytes),
     AccordPreAcceptOK(Bytes),
@@ -356,6 +360,8 @@ impl Message {
             Self::IndexBuildComplete(_) => MsgType::IndexBuildComplete,
             Self::IndexReadRequest(_) => MsgType::IndexReadRequest,
             Self::IndexReadResponse(_) => MsgType::IndexReadResponse,
+            Self::FulltextSearchRequest(_) => MsgType::FulltextSearchRequest,
+            Self::FulltextSearchResponse(_) => MsgType::FulltextSearchResponse,
             Self::AccordPreAccept(_) => MsgType::AccordPreAccept,
             Self::AccordPreAcceptOK(_) => MsgType::AccordPreAcceptOK,
             Self::AccordAccept(_) => MsgType::AccordAccept,
@@ -507,6 +513,8 @@ impl Message {
             | Self::IndexBuildComplete(b)
             | Self::IndexReadRequest(b)
             | Self::IndexReadResponse(b)
+            | Self::FulltextSearchRequest(b)
+            | Self::FulltextSearchResponse(b)
             | Self::AccordPreAccept(b)
             | Self::AccordPreAcceptOK(b)
             | Self::AccordAccept(b)
@@ -727,6 +735,12 @@ impl Message {
             }
             MsgType::IndexReadRequest => Self::IndexReadRequest(body.split_to(body.remaining())),
             MsgType::IndexReadResponse => Self::IndexReadResponse(body.split_to(body.remaining())),
+            MsgType::FulltextSearchRequest => {
+                Self::FulltextSearchRequest(body.split_to(body.remaining()))
+            }
+            MsgType::FulltextSearchResponse => {
+                Self::FulltextSearchResponse(body.split_to(body.remaining()))
+            }
             MsgType::AccordPreAccept => Self::AccordPreAccept(body.split_to(body.remaining())),
             MsgType::AccordPreAcceptOK => Self::AccordPreAcceptOK(body.split_to(body.remaining())),
             MsgType::AccordAccept => Self::AccordAccept(body.split_to(body.remaining())),

--- a/ferrosa-net/src/protocol.rs
+++ b/ferrosa-net/src/protocol.rs
@@ -1577,7 +1577,9 @@ fn message_family_for_kind(kind: u16) -> MessageFamily {
             MsgType::IndexBuildRequest
             | MsgType::IndexBuildComplete
             | MsgType::IndexReadRequest
-            | MsgType::IndexReadResponse,
+            | MsgType::IndexReadResponse
+            | MsgType::FulltextSearchRequest
+            | MsgType::FulltextSearchResponse,
         ) => MessageFamily::Index,
         Ok(
             MsgType::AccordPreAccept

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -18267,6 +18267,66 @@ mod tests {
         );
     }
 
+    /// Regression for t_0d08aa43 (BUG-F-007): `fts_match` returned 0/1
+    /// non-deterministically on a cluster. Root cause (on-disk half): FTI
+    /// sidecars are built ONLY on flush — compaction merges SSTables and
+    /// removes the old per-gen FTI sidecars WITHOUT writing one for the merged
+    /// generation, so a compacted node silently loses the row from full-text
+    /// search. A row found via FTI before compaction must still be found after.
+    #[tokio::test]
+    async fn fts_match_survives_compaction() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        engine.add_fulltext_index(&tid, "idx_body", 0).unwrap();
+
+        // 5 flushed batches → ≥4 SSTables (each with its own FTI sidecar), so
+        // STCS will compact them. A unique probe term lives in the first row.
+        const PROBE: &str = "ferrosaftscompactprobe";
+        for batch in 0..5u64 {
+            for i in 0..25u64 {
+                let n = batch * 25 + i;
+                let key = make_key(&format!("doc_{n:04}"));
+                let text = if n == 0 {
+                    format!("{PROBE} distributed database")
+                } else {
+                    format!("filler distributed database row {n}")
+                };
+                let ts = (n as i64) + 1;
+                engine
+                    .write(&tid, &key, make_row(text.as_bytes(), ts), ts)
+                    .unwrap();
+            }
+            engine.flush(&tid).unwrap();
+        }
+
+        // Before compaction: the probe is found via the per-gen FTI sidecars.
+        let before = engine.fulltext_search(&tid, "idx_body", PROBE).unwrap();
+        assert_eq!(
+            before.len(),
+            1,
+            "probe must be found via FTI before compaction"
+        );
+
+        // Compact (STCS triggers at ≥4 SSTables): merges gens, removing the old
+        // per-gen FTI sidecars.
+        engine.poll_compactions().await;
+
+        // After compaction the probe MUST still be found.
+        let after = engine.fulltext_search(&tid, "idx_body", PROBE).unwrap();
+        let keys: Vec<String> = after
+            .iter()
+            .map(|pk| String::from_utf8_lossy(pk).to_string())
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["doc_0000".to_string()],
+            "fts_match must still find the probe row after compaction (compaction must rebuild the FTI sidecar)"
+        );
+    }
+
     /// Concurrent writes + flushes + compaction — reproduces the loadgen data loss.
     #[tokio::test]
     async fn concurrent_write_flush_compact_no_data_loss() {


### PR DESCRIPTION
## fix: scatter-gather `fts_match` across cluster nodes (BUG-F-007 / t_0d08aa43)

`fts_match` returned `0/1` non-deterministically for a stable row on a 3-node RF=3 cluster (timeline `0,1,0,0,1`), while a normal scan was consistently `1`. Native FTS was unusable on the cluster.

### Root cause (coordinator-local index lookup)
The served path did the FTI index lookup on the **coordinator's local engine**, but the partition fetch on the very next line — and normal scans — correctly fan out to owning replicas:
```
router.rs   state.engine.fulltext_search(...)   ← LOCAL node's FTI only
router.rs   state.write_path.load().read(...)   ← cluster-aware
```
`fts_match` carries **no partition key**, so its matching keys span **all** token ranges. A query coordinated by a node that doesn't own a row's token finds nothing locally → `0`; an owning-replica coordinator → `1`; the coordinator rotates → the observed oscillation. (I first hypothesized a non-atomic FTI rebuild during compaction and wrote `fts_match_survives_compaction` — it **passes**, ruling that out. Kept as an invariant guard.)

### Fix — route the FTI lookup through the write path so it scatter-gathers
- **`ferrosa-net`**: `FulltextSearchRequest`/`Response` messages (`0x64`/`0x65`) + codec + message-family.
- **`ferrosa-cluster`**: `FulltextSearch{Request,Response}Payload` + `FulltextSearchHandler` (runs local `engine.fulltext_search`), `ClusterCoordinator::coordinate_fulltext_search` (fans out to **every** node, unions + de-dupes the matching keys, partial-failure tolerant — like `coordinate_index_read`), `WritePath::fulltext_search` (Direct/Pair → local, Cluster → fan-out), handler registration.
- **`ferrosa-cql`**: the router routes `fts_match`'s FTI lookup through `write_path.fulltext_search`; standalone/pair still resolve locally via the same call (no behavior change off-cluster).

### Tests
- **New in-process 2-node fan-out + dedup test** (`coordinator/read.rs::coordinate_fulltext_search_unions_and_dedups_across_nodes`): local FTI hit + a remote node returning the same key plus a remote-only key → result is the de-duplicated union. Exercises the real RPC + coordinator logic, runs in CI.
- `fts_match_survives_compaction` invariant guard.
- **149 `ferrosa-net` + 980 `ferrosa-cluster` lib tests pass**; `ferrosa-cql` fts router tests pass; `clippy --all-targets` + `fmt` clean.

### Notes / follow-ups
- Modeled directly on the existing secondary-index scatter-gather (`coordinate_index_read`).
- A full live-cluster CQL e2e (3 real nodes) would further harden this; the in-process fan-out test covers the coordinator logic and runs without live infra.
- Orphaned-FTI-sidecar cleanup after compaction is a separate minor concern (not a correctness bug — sidecars linger, so data is found).
