### PR TITLE
chore(hooks): per-crate docs reminder pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,20 @@ repos:
 
   - repo: local
     hooks:
+      # Pre-commit: remind that crates with staged code changes also need their
+      # docs updated (the per-crate-docs rule in CLAUDE.md / AGENTS.md — a crate
+      # change is not done until its README + specs reflect it). Fast: it diffs
+      # the staged file list and lists each crate with a staged `src/**.rs`
+      # change but no staged `README.md`/`specs/*.md`. Warns by default (some
+      # changes are genuinely doc-neutral); set FERROSA_CRATE_DOCS_STRICT=1 to
+      # make it block.
+      - id: crate-docs-reminder
+        name: per-crate docs reminder (changed crates need README/specs updates)
+        entry: bash scripts/crate-docs-reminder.sh
+        language: system
+        types: [rust]
+        pass_filenames: false
+
       # Pre-commit: format check only. Anything slower belongs on pre-push.
       - id: cargo-fmt
         name: cargo fmt --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@ known-issue/roadmap status is **not finished until that crate's `README.md` +
 implementation and dependency set. Treat stale crate docs the same as a failing
 test — do not open a PR with code changes whose crate docs are out of date.
 
+The `crate-docs-reminder` pre-commit hook (`.pre-commit-config.yaml` →
+`scripts/crate-docs-reminder.sh`) flags this automatically: on commit it lists
+each crate with a staged `src/**.rs` change but no staged `README.md`/`specs/*.md`
+update. It warns by default; `FERROSA_CRATE_DOCS_STRICT=1` makes it block.
+
 The crate-centric map (all crates + the runtime dependency graph) lives at
 [`specs/crates.md`](specs/crates.md). Cross-cutting topic specs live under
 [`specs/reference/`](specs/reference/).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,12 @@ are updated to match.** A crate's docs must reflect its *current* implementation
 and dependency set — stale crate docs are treated like a failing check. The
 crate-centric index lives at [`specs/crates.md`](specs/crates.md).
 
+The `crate-docs-reminder` pre-commit hook (in `.pre-commit-config.yaml`, script
+`scripts/crate-docs-reminder.sh`) enforces this at commit time: it lists every
+crate with a staged `src/**.rs` change but no staged `README.md`/`specs/*.md`
+update. It warns by default (some changes are genuinely doc-neutral); set
+`FERROSA_CRATE_DOCS_STRICT=1` to make it block.
+
 ### CI must pass before pushing
 
 Agents MUST verify that all CI checks will pass locally before pushing to a remote branch or creating a PR. This means running `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` across the full workspace — not just the crate you touched. A CI failure that could have been caught locally is a wasted round-trip. Do not push and hope.

--- a/scripts/crate-docs-reminder.sh
+++ b/scripts/crate-docs-reminder.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Per-crate docs reminder (pre-commit).
+#
+# The per-crate-docs rule (CLAUDE.md / AGENTS.md): changing a crate's behavior,
+# public API, dependency set, or known-issue/roadmap status is NOT done until
+# that crate's README.md + specs/ are updated to match. This hook looks at what
+# is staged and INDICATES which workspace crates have staged code changes
+# (`<crate>/src/**.rs`) without any staged doc change (`<crate>/README.md` or
+# `<crate>/specs/*.md`), so the docs don't silently drift from the code.
+#
+# Default: WARN (non-blocking) — it is a reminder, since some changes (test-only,
+# trivial internal refactors) genuinely need no doc update.
+# Strict:  set FERROSA_CRATE_DOCS_STRICT=1 to make it BLOCK the commit.
+#
+# Bash 3.2 compatible (macOS system bash). No associative arrays.
+#
+# Testable: set CRATE_DOCS_STAGED_OVERRIDE to a newline-separated file list to
+# bypass `git diff` (used by the unit test below the marker).
+
+set -euo pipefail
+
+staged="${CRATE_DOCS_STAGED_OVERRIDE-$(git diff --cached --name-only --diff-filter=ACMR)}"
+[ -n "$staged" ] || exit 0
+
+# Crates with a staged Rust source change, deduplicated.
+code_crates="$(printf '%s\n' "$staged" | sed -n 's#^\([^/][^/]*\)/src/.*\.rs$#\1#p' | sort -u)"
+[ -n "$code_crates" ] || exit 0
+
+missing=""
+while IFS= read -r crate; do
+  [ -n "$crate" ] || continue
+  # Only consider real workspace crates (a Cargo.toml at the crate root).
+  [ -f "$crate/Cargo.toml" ] || continue
+  # Did any doc for this crate get staged in the same commit?
+  if ! printf '%s\n' "$staged" | grep -qE "^${crate}/(README\.md|specs/.*\.md)$"; then
+    missing="${missing}${crate}
+"
+  fi
+done <<EOF
+$code_crates
+EOF
+
+[ -n "$missing" ] || exit 0
+
+printf '\n\033[1;33m⚠  per-crate docs reminder\033[0m — staged code changes with no staged doc update:\n\n'
+printf '%s' "$missing" | while IFS= read -r crate; do
+  [ -n "$crate" ] || continue
+  printf '   • \033[1m%s\033[0m — update %s/README.md and/or %s/specs/{overview,fmea,roadmap}.md\n' \
+    "$crate" "$crate" "$crate"
+done
+printf '\nPer-crate-docs rule (CLAUDE.md): a crate change is not done until its README +\n'
+printf 'specs reflect the new status, public API, dependency set, and roadmap/FMEA.\n'
+printf 'Test-only or trivial internal changes can ignore this — it is a reminder.\n'
+
+if [ "${FERROSA_CRATE_DOCS_STRICT:-0}" = "1" ]; then
+  printf '\n\033[1;31mFERROSA_CRATE_DOCS_STRICT=1 → blocking.\033[0m Update the docs or `git commit --no-verify`.\n'
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## chore: per-crate docs reminder pre-commit hook

Enforces the **per-crate-docs rule** (CLAUDE.md / AGENTS.md — *a crate change isn't done until its `README.md` + `specs/` reflect it*) at commit time, so crate docs stop silently drifting from code.

### What it does
On commit, it diffs the staged file list and lists every workspace crate that has a staged `src/**.rs` change **without** any staged `README.md` / `specs/*.md` update:

```
⚠  per-crate docs reminder — staged code changes with no staged doc update:

   • ferrosa-net — update ferrosa-net/README.md and/or ferrosa-net/specs/{overview,fmea,roadmap}.md

Per-crate-docs rule (CLAUDE.md): a crate change is not done until its README +
specs reflect the new status, public API, dependency set, and roadmap/FMEA.
Test-only or trivial internal changes can ignore this — it is a reminder.
```

### Design
- **Warns by default** (exit 0) — some changes (test-only, trivial internal refactors) are genuinely doc-neutral, so a hard block on every crate-touch would be too noisy. Set **`FERROSA_CRATE_DOCS_STRICT=1`** to make it block (exit 1).
- **Fast** — pure `git diff --cached` + `sed`/`grep`, fits the pre-commit <5 s budget. `types: [rust]` so it only runs when a `.rs` file is staged.
- **Bash 3.2 compatible** (macOS system bash) — no associative arrays.
- **Tested** — `CRATE_DOCS_STAGED_OVERRIDE` lets the logic be exercised without real staging; verified across 5 cases (code-only warns, code+docs silent, mixed, strict blocks, docs-only silent).

### Files
- `scripts/crate-docs-reminder.sh` (new)
- `.pre-commit-config.yaml` — registers `crate-docs-reminder` as a pre-commit hook
- `CLAUDE.md` / `AGENTS.md` — document the hook under the per-crate-docs rule

Install: `pre-commit install --hook-type pre-commit --hook-type pre-push` (already the documented setup).
