### PR TITLE
ci(release): build and push container image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,59 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
+  # ── Container image (GHCR) ───────────────────────────────────────────
+  # Builds and pushes a runtime container image from the x86_64 musl static
+  # binary artifact so deployable images come from the release process, not
+  # hand-built. Independent of the `release` job — it must not block the
+  # GitHub release. Uses only already-pinned actions + shell `docker` so the
+  # actions-pin-guard stays green (no new action pins introduced).
+  build-image:
+    name: Build & push container image
+    needs: build-linux-x86_64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download x86_64 musl tarball
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: tarball-x86_64-unknown-linux-musl
+          path: dist
+
+      - name: Extract binaries and write runtime Dockerfile
+        run: |
+          mkdir -p build
+          tar -xzf dist/*.tar.gz -C build/
+          cp deploy/fly-bench/ferrosa-entrypoint.sh build/ferrosa-entrypoint.sh
+          chmod 755 build/ferrosa build/ferrosa-ctl build/ferrosa-entrypoint.sh
+          cat > build/Dockerfile <<'DOCKERFILE'
+          FROM debian:trixie-slim
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends ca-certificates curl \
+              && rm -rf /var/lib/apt/lists/*
+          COPY ferrosa /usr/local/bin/ferrosa
+          COPY ferrosa-ctl /usr/local/bin/ferrosa-ctl
+          COPY ferrosa-entrypoint.sh /usr/local/bin/ferrosa-entrypoint.sh
+          EXPOSE 9042 7000 9090
+          ENV FERROSA_DATA_DIR=/var/lib/ferrosa
+          ENTRYPOINT ["ferrosa-entrypoint.sh"]
+          CMD ["ferrosa"]
+          DOCKERFILE
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push image
+        run: |
+          OWNER="$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          IMAGE="ghcr.io/${OWNER}/ferrosa"
+          docker build -t "${IMAGE}:${GITHUB_REF_NAME}" -t "${IMAGE}:latest" build/
+          docker push "${IMAGE}:${GITHUB_REF_NAME}"
+          docker push "${IMAGE}:latest"
+
   # ── Linux aarch64 (musl static, cross-compiled) ──────────────────────
   build-linux-aarch64:
     name: Build Linux aarch64 (musl, cross)


### PR DESCRIPTION
## Summary

Adds a `build-image` job to the release workflow so deployable container images come from the release process instead of being hand-built.

The job builds a runtime image from the existing **x86_64 musl static binary** artifact (`tarball-x86_64-unknown-linux-musl`) and pushes it to GHCR.

- **Image:** `ghcr.io/<owner>/ferrosa` (owner lowercased)
- **Tags:** the release ref (`${GITHUB_REF_NAME}`) **and** `latest`
- **Trigger:** same as the rest of the workflow — tag push (`v*`) or `workflow_dispatch`. On a tag push the image is built automatically.
- **Base:** `debian:trixie-slim` + `ca-certificates curl`
- **Contents:** `ferrosa`, `ferrosa-ctl`, and `deploy/fly-bench/ferrosa-entrypoint.sh` (maps `AWS_*` -> `FERROSA_S3_*` and `FLY_PRIVATE_IP` broadcasts)
- `EXPOSE 9042 7000 9090`, `ENV FERROSA_DATA_DIR=/var/lib/ferrosa`, `ENTRYPOINT ["ferrosa-entrypoint.sh"]`, `CMD ["ferrosa"]`

## Design notes

- `needs: build-linux-x86_64` only — it consumes that job's tarball artifact.
- **Independent of the `release` job** — it must not block the GitHub release.
- `permissions: { contents: read, packages: write }` so it can push to GHCR.

## Supply-chain / pin-guard

Uses **only** the already-pinned `actions/checkout` and `actions/download-artifact` (same SHAs already in this file). Registry login, build, and push are shell `docker` commands — **no new action pins** are introduced. `check-actions-pinned.sh` passes locally.

## Note for reviewers

Pushing to GHCR with the default `GITHUB_TOKEN` requires the org/repo to allow GitHub Actions to write packages (GHCR package visibility / Actions permissions). If the first release run fails at `docker push` with a 403, that org setting needs to be enabled — flagging since it can't be verified from the repo.