### PR TITLE
feat(accord): dep-order the replica apply path (Phase 0, multi-key Accord)

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -113,8 +113,15 @@ strict-serializable multi-key / cross-shard transactions and LWT.
 
 ### Accord transactions (`accord/`)
 - `coordinator.rs` / `state_machine.rs` — PreAccept → {fast path | Accept} →
-  Commit → Apply, fast/slow quorum math, HLC timestamps + `TxnId`.
+  Commit → Apply, fast/slow quorum math, HLC timestamps + `TxnId`. The replica
+  apply path is **dep-ordered**: `handle_apply` routes every real write through
+  `apply.rs`'s `DepWaitApplier`, so a mutation persists only once all of its
+  dependencies have applied locally (otherwise it parks and the cascade applies
+  it in order).
 - `recovery.rs` — Paxos-style recovery selecting by highest `accepted_ballot`.
+- `apply.rs` — `DepWaitApplier` (dep-wait + `StorageApplier` seam, idempotent on
+  `(txn_id, t)`) + `EngineStorageApplier`/`EngineStorageReader` (real persistence
+  and linearizable read-at-`t`).
 - `dep_wait.rs` — waits-for graph with deterministic cycle-breaking.
 - `cross_shard.rs` / `cross_dc_adapter.rs` — multi-shard atomicity, cross-DC glue.
 - `electorate.rs` / `epoch.rs` — JoinElectorate membership gates, epoch tracking.

--- a/ferrosa-cluster/specs/roadmap.md
+++ b/ferrosa-cluster/specs/roadmap.md
@@ -11,15 +11,29 @@ reference/decision specs, and the dependency/usage review. Ordered by value.
 
 ## Recently addressed
 
+- **Replica apply path is now dep-ordered (Phase 0, t_59629c9b).** `handle_apply`
+  used to call the storage applier **directly**, ignoring the transaction's
+  dependency set — so an `Apply(B)` delivered before its dependency `A` applied
+  would persist `B` out of order. It now routes every real write through the
+  `DepWaitApplier`: a mutation persists only once all of its dependencies have
+  applied on this replica, otherwise it parks and the cascade applies it (in
+  dependency order) when the last dependency lands. `try_apply`/`cascade`/
+  `notify_applied` return the `(txn_id, data)` of every transaction actually
+  persisted, and the state machine runs its post-apply bookkeeping
+  (`bookkeep_applied`: protocol-log marker → `Applied` flag → conflict-index GC →
+  ReadVote wake) for exactly those. The storage write precedes the marker and the
+  applier is idempotent on `(txn_id, t)`, so a crash between them is recovered by
+  the per-txn Apply retry — never a falsely-`Applied` txn. This is the single-key
+  prerequisite for the multi-key/multi-partition transaction work (Phases 1+).
+  Regression test: `sm_apply_is_dep_ordered_parks_until_dependency_applies`.
 - **Dep-wait cascade replayed queued txns with empty data — fixed (PR #159).**
   `DepWaitApplier` parked dependency waiters but never stored their mutation, so
   when the last dependency resolved the cascade re-applied each waiter with
   `ApplyMutation { data: vec![] }` — silently dropping the write. It now parks the
   real mutation and replays it (transitively); applier errors fail loud rather than
   committing a lost write. `NoopStorageApplier` now records payloads so this is
-  regression-tested. *Still open:* route `handle_apply` itself through
-  `DepWaitApplier` so dep-ordering is enforced at the state-machine apply path
-  (today it applies directly via `EngineStorageApplier`) — see Next / t_59629c9b.
+  regression-tested. (The previously-open follow-up — route `handle_apply` itself
+  through `DepWaitApplier` — is now done; see the dep-ordered apply entry above.)
 - **Cluster-wide `fts_match` scatter-gather (BUG-F-007 / t_0d08aa43).** `fts_match`
   carries no partition key, so its hits span every token range, but the served
   path consulted only the coordinator's local FTI — returning 0/1

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -579,7 +579,7 @@ impl DepWaitApplier {
     /// row write (a no-write LWT finalize) or when a remote coordinator
     /// acknowledges its apply (via `ApplyOK`). Unblocks any waiting transactions
     /// and returns the `(txn_id, mutation_data)` of every waiter that was
-    /// actually persisted as a result, in apply order (see [`cascade`](Self::cascade)).
+    /// actually persisted as a result, in apply order (see the `cascade` helper).
     pub fn notify_applied(&self, txn_id: TxnId) -> Vec<(TxnId, Vec<u8>)> {
         // Mark the externally-applied dependency and apply any waiters it
         // unblocks, using their real parked mutations (see `cascade`).

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -472,15 +472,26 @@ impl DepWaitApplier {
     /// Attempt to apply a committed transaction.
     ///
     /// If all dependencies in `deps` are already applied, calls `applier.apply`
-    /// immediately and propagates the "applied" signal through the graph.
+    /// immediately and propagates the "applied" signal through the graph,
+    /// transitively waking any parked waiters this resolves.
     ///
     /// If any dependencies are not yet applied, registers this transaction as
-    /// a waiter and returns `Ok(false)`. The transaction will be applied
-    /// automatically when the last dependency calls `notify_applied`.
+    /// a waiter and returns an empty `Vec`. The transaction will be applied
+    /// automatically when the last dependency calls
+    /// [`notify_applied`](Self::notify_applied) or [`try_apply`](Self::try_apply).
     ///
-    /// Returns `Ok(true)` if the transaction was applied immediately, or
-    /// `Ok(false)` if it was queued to wait.
-    pub fn try_apply(&self, txn_id: TxnId, mutation: ApplyMutation) -> Result<bool, ApplyError> {
+    /// Returns the `(txn_id, mutation_data)` of every transaction that was
+    /// **actually persisted** by this call, in apply order — the primary first,
+    /// then each cascade-woken waiter. The caller (the Accord state machine) uses
+    /// this list to advance exactly those transactions to `Applied` and fire
+    /// their post-apply bookkeeping (protocol-log marker, conflict-index GC,
+    /// dep-wait wake). An **empty** `Vec` means the transaction parked behind an
+    /// unapplied dependency and must NOT be marked applied.
+    pub fn try_apply(
+        &self,
+        txn_id: TxnId,
+        mutation: ApplyMutation,
+    ) -> Result<Vec<(TxnId, Vec<u8>)>, ApplyError> {
         let deps: Vec<TxnId> = mutation.deps.clone();
 
         // Fast path: check all deps without holding the lock.
@@ -506,24 +517,32 @@ impl DepWaitApplier {
             // last dependency resolves — not an empty placeholder.
             drop(graph);
             self.pending.lock().insert(txn_id, mutation);
-            return Ok(false);
+            return Ok(Vec::new());
         }
 
         drop(graph);
 
         // All deps satisfied — apply now, then cascade to any waiters whose
-        // last dependency this transaction resolves.
+        // last dependency this transaction resolves. Capture the payload before
+        // the mutation is moved into the applier so we can report it back.
+        let data = mutation.data.clone();
         self.applier.apply(txn_id, mutation)?;
-        self.cascade(txn_id);
-
-        Ok(true)
+        let mut applied = vec![(txn_id, data)];
+        applied.extend(self.cascade(txn_id));
+        Ok(applied)
     }
 
     /// Mark `just_applied` as applied and apply — in dependency order — every
     /// transaction whose *last* remaining dependency this resolves, using each
     /// waiter's parked mutation (its real data). Cascades transitively, since a
     /// woken waiter may itself unblock further waiters.
-    fn cascade(&self, just_applied: TxnId) {
+    ///
+    /// Returns the `(txn_id, mutation_data)` of every waiter that was actually
+    /// persisted, in apply order — so the caller can advance exactly those to
+    /// `Applied`. A waiter whose apply *fails* is left un-applied and is NOT in
+    /// the returned list (fail loud; its dependents stay parked).
+    fn cascade(&self, just_applied: TxnId) -> Vec<(TxnId, Vec<u8>)> {
+        let mut applied: Vec<(TxnId, Vec<u8>)> = Vec::new();
         let mut queue: VecDeque<TxnId> = self
             .graph
             .lock()
@@ -536,6 +555,7 @@ impl DepWaitApplier {
             // mutation — there is nothing to persist; still mark it applied so
             // its own waiters proceed.
             if let Some(mutation) = self.pending.lock().remove(&waiter) {
+                let data = mutation.data.clone();
                 if let Err(e) = self.applier.apply(waiter, mutation) {
                     // Fail loud: the parked write did not persist. Do NOT mark
                     // applied or cascade past it — its dependents stay parked
@@ -544,21 +564,26 @@ impl DepWaitApplier {
                     tracing::error!(%e, txn = waiter.0.time, "accord dep-cascade: applier failed for parked waiter — leaving it un-applied");
                     continue;
                 }
+                applied.push((waiter, data));
             }
             for woken in self.graph.lock().mark_applied(waiter) {
                 queue.push_back(woken);
             }
         }
+        applied
     }
 
     /// Notify the applier that `txn_id` has been applied externally.
     ///
-    /// Called when a dependency transaction's apply is acknowledged by the
-    /// remote coordinator (via `ApplyOK`). Unblocks any waiting transactions.
-    pub fn notify_applied(&self, txn_id: TxnId) {
+    /// Called when a dependency transaction reaches `Applied` without a local
+    /// row write (a no-write LWT finalize) or when a remote coordinator
+    /// acknowledges its apply (via `ApplyOK`). Unblocks any waiting transactions
+    /// and returns the `(txn_id, mutation_data)` of every waiter that was
+    /// actually persisted as a result, in apply order (see [`cascade`](Self::cascade)).
+    pub fn notify_applied(&self, txn_id: TxnId) -> Vec<(TxnId, Vec<u8>)> {
         // Mark the externally-applied dependency and apply any waiters it
         // unblocks, using their real parked mutations (see `cascade`).
-        self.cascade(txn_id);
+        self.cascade(txn_id)
     }
 
     /// Check if a transaction has been applied.
@@ -666,7 +691,11 @@ mod tests {
         let txn = txn_id(1, 1000);
         let result = applier.try_apply(txn, mutation(vec![])).unwrap();
 
-        assert!(result, "transaction with no deps must apply immediately");
+        assert_eq!(
+            result.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![txn],
+            "transaction with no deps must apply immediately and be reported"
+        );
         assert!(
             noop.was_applied(&txn),
             "noop applier must record the application"
@@ -702,7 +731,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            result,
+            !result.is_empty(),
             "transaction with already-applied dep must apply immediately"
         );
         assert!(noop.was_applied(&txn));
@@ -732,14 +761,23 @@ mod tests {
             )
             .unwrap();
 
-        assert!(!result, "transaction with pending dep must be queued");
+        assert!(
+            result.is_empty(),
+            "transaction with pending dep must be queued (empty applied list)"
+        );
         assert!(
             !noop.was_applied(&txn),
             "txn must not be applied while dep is pending"
         );
 
-        // Dep becomes available — notify the applier.
-        applier.notify_applied(dep);
+        // Dep becomes available — notify the applier. The woken waiter is
+        // returned so the caller can advance it to Applied.
+        let woken = applier.notify_applied(dep);
+        assert_eq!(
+            woken.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![txn],
+            "notify_applied must report the cascaded waiter"
+        );
 
         // Txn should now be applied (woken from the dep-wait graph).
         // The waiter should have been called via cascade in notify_applied.
@@ -771,10 +809,11 @@ mod tests {
                 },
             )
             .unwrap();
-        assert!(!queued, "B must be queued behind A");
+        assert!(queued.is_empty(), "B must be queued behind A");
         assert!(!noop.was_applied(&b));
 
-        // A applies (no deps) → cascade wakes B.
+        // A applies (no deps) → cascade wakes B. The returned list reports A
+        // then B in dependency order.
         let applied = applier
             .try_apply(
                 a,
@@ -785,7 +824,11 @@ mod tests {
                 },
             )
             .unwrap();
-        assert!(applied, "A applies immediately");
+        assert_eq!(
+            applied.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![a, b],
+            "A applies immediately then cascades to B, in dependency order"
+        );
 
         assert!(
             noop.was_applied(&b),
@@ -809,7 +852,7 @@ mod tests {
         let (a, b, c) = (txn_id(1, 100), txn_id(2, 200), txn_id(3, 300));
 
         // Queue C (waits on B) and B (waits on A); both park.
-        assert!(!applier
+        assert!(applier
             .try_apply(
                 c,
                 ApplyMutation {
@@ -818,8 +861,9 @@ mod tests {
                     deps: vec![b]
                 }
             )
-            .unwrap());
-        assert!(!applier
+            .unwrap()
+            .is_empty());
+        assert!(applier
             .try_apply(
                 b,
                 ApplyMutation {
@@ -828,18 +872,26 @@ mod tests {
                     deps: vec![a]
                 }
             )
-            .unwrap());
-        // A applies → B unblocks → C unblocks, each with its own data.
-        assert!(applier
-            .try_apply(
-                a,
-                ApplyMutation {
-                    data: b"A".to_vec(),
-                    t: ts(100),
-                    deps: vec![]
-                }
-            )
-            .unwrap());
+            .unwrap()
+            .is_empty());
+        // A applies → B unblocks → C unblocks, each with its own data, reported
+        // in transitive dependency order.
+        assert_eq!(
+            applier
+                .try_apply(
+                    a,
+                    ApplyMutation {
+                        data: b"A".to_vec(),
+                        t: ts(100),
+                        deps: vec![]
+                    }
+                )
+                .unwrap()
+                .iter()
+                .map(|(id, _)| *id)
+                .collect::<Vec<_>>(),
+            vec![a, b, c],
+        );
 
         assert_eq!(noop.applied_data(&a).as_deref(), Some(b"A".as_slice()));
         assert_eq!(noop.applied_data(&b).as_deref(), Some(b"B".as_slice()));
@@ -891,7 +943,10 @@ mod tests {
                 },
             )
             .unwrap();
-        assert!(result, "txn_b must apply immediately (dep already applied)");
+        assert!(
+            !result.is_empty(),
+            "txn_b must apply immediately (dep already applied)"
+        );
         assert!(noop.was_applied(&txn_b));
 
         // Verify apply log order.

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -34,7 +34,9 @@ use ferrosa_storage::accord::conflict_index::{ConflictIndex, InFlightWrite, TxnS
 use ferrosa_storage::accord::sync_writer::SyncWriter;
 use tokio::sync::Notify;
 
-use crate::accord::apply::{ApplyMutation, NoopStorageApplier, StorageApplier, StorageReader};
+use crate::accord::apply::{
+    ApplyMutation, DepWaitApplier, NoopStorageApplier, StorageApplier, StorageReader,
+};
 
 // ---------------------------------------------------------------------------
 // Response types
@@ -88,11 +90,15 @@ pub struct AccordStateMachine {
     committed_txns: HashSet<TxnId>,
     /// Notified waiters from the last commit (for test inspection).
     last_notified: Vec<TxnId>,
-    /// Storage integration seam: persists the committed mutation to the local
-    /// `StorageEngine` during `handle_apply`. Defaults to [`NoopStorageApplier`]
-    /// for protocol-only tests; production wires a real engine-backed applier
-    /// via [`AccordStateMachine::with_applier`].
-    applier: Arc<dyn StorageApplier>,
+    /// Dep-ordered apply engine: wraps the storage [`StorageApplier`] in a
+    /// [`DepWaitApplier`] so a committed transaction is persisted only after all
+    /// of its dependencies have applied on this replica. `handle_apply` routes
+    /// every real write through this (never the raw applier directly), which is
+    /// what enforces dependency order at the replica apply path — the prerequisite
+    /// for serializable multi-key transactions. The inner applier defaults to
+    /// [`NoopStorageApplier`] for protocol-only tests; production wires a real
+    /// engine-backed applier via [`AccordStateMachine::with_applier`].
+    apply_engine: Arc<DepWaitApplier>,
     /// Optional storage read seam for the generic-`IF` linearizable read-at-`t`
     /// (Gap 4). `None` keeps the conflict-index existence path used by
     /// `INSERT IF NOT EXISTS`. Production wires an engine-backed reader via
@@ -126,7 +132,7 @@ impl AccordStateMachine {
             dep_waiters: HashMap::new(),
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
-            applier: Arc::new(NoopStorageApplier::new()),
+            apply_engine: Arc::new(DepWaitApplier::new(Arc::new(NoopStorageApplier::new()))),
             reader: None,
             applied_notify: Arc::new(Notify::new()),
         }
@@ -148,7 +154,7 @@ impl AccordStateMachine {
             dep_waiters: HashMap::new(),
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
-            applier: Arc::new(NoopStorageApplier::new()),
+            apply_engine: Arc::new(DepWaitApplier::new(Arc::new(NoopStorageApplier::new()))),
             reader: None,
             applied_notify: Arc::new(Notify::new()),
         }
@@ -172,7 +178,7 @@ impl AccordStateMachine {
             dep_waiters: HashMap::new(),
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
-            applier,
+            apply_engine: Arc::new(DepWaitApplier::new(applier)),
             reader: None,
             applied_notify: Arc::new(Notify::new()),
         }
@@ -199,7 +205,7 @@ impl AccordStateMachine {
             dep_waiters: HashMap::new(),
             committed_txns: HashSet::new(),
             last_notified: Vec::new(),
-            applier,
+            apply_engine: Arc::new(DepWaitApplier::new(applier)),
             reader: Some(reader),
             applied_notify: Arc::new(Notify::new()),
         }
@@ -547,16 +553,27 @@ impl AccordStateMachine {
     // Apply handler
     // -----------------------------------------------------------------------
 
-    /// Handle an Apply (fire-and-forget).
+    /// Handle an Apply (fire-and-forget) — **dep-ordered** at the replica.
     ///
-    /// 1. Idempotent no-op if already Applied.
-    /// 2. Persist the protocol-log marker BEFORE applying (recovery ordering).
-    /// 3. Persist the real mutation to local storage via the [`StorageApplier`]
-    ///    — closes the phantom-write gap (`bug-accord-lwt-acks-phantom-write.md`):
-    ///    the row must be durably written to the engine, not merely logged.
-    /// 4. Only after the mutation is durable do we set the Applied flag and mark
-    ///    the conflict index — so a crash before the storage write leaves the txn
-    ///    recoverable (re-Apply), never falsely Applied (persist-before-Applied).
+    /// 1. Idempotent no-op if already Applied; ignore an unknown txn.
+    /// 2. No-write finalize (empty payload): an LWT whose IF condition did NOT
+    ///    hold still *commits* but writes no row. It touches no storage, so there
+    ///    is no dependency order to respect — advance it to `Applied` directly,
+    ///    then ask the apply engine which parked waiters this unblocks and
+    ///    advance them too (so a later read at `t' > t` does not block on this
+    ///    phantom dependency until its dep-wait timeout).
+    /// 3. Real write: route the mutation through the [`DepWaitApplier`]. If every
+    ///    dependency has already applied on this replica, it persists the row
+    ///    immediately and cascades to any waiters this unblocks; otherwise it
+    ///    parks the mutation and returns an empty list — and we must NOT advance
+    ///    the txn to `Applied`. Routing through the engine (never the raw applier)
+    ///    is what enforces dependency order at the replica apply path.
+    /// 4. For every transaction the engine actually persisted (the primary plus
+    ///    any cascade-woken waiters), run [`bookkeep_applied`](Self::bookkeep_applied):
+    ///    the protocol-log marker, `Applied` flag, conflict-index GC, and the
+    ///    dep-wait wake. The storage write precedes the marker; the applier is
+    ///    idempotent on `(txn_id, t)`, so a crash between them is recovered by the
+    ///    per-txn Apply retry (never a falsely-`Applied` txn).
     pub fn handle_apply(&mut self, txn_id: TxnId, result_data: Vec<u8>) -> SmResponse {
         // Read the agreed timestamp + deps from committed state BEFORE mutating,
         // so the mutation we hand to storage carries the real `(t, deps)`.
@@ -572,39 +589,75 @@ impl AccordStateMachine {
             None => return SmResponse::None,
         };
 
-        // Persist the protocol-log marker BEFORE applying the mutation.
-        let data = format!("Applied:{}", txn_id.0.time);
-        if !self.sync_writer.write_and_sync(data.as_bytes()).is_ok() {
-            // Fsync failed: do NOT apply or set the applied flag.
+        // No-write finalize (empty payload): nothing to persist and no dependency
+        // ordering to respect. Advance it to Applied, then advance any waiters it
+        // unblocks in the dep-wait graph.
+        if result_data.is_empty() {
+            if self.bookkeep_applied(txn_id, Vec::new()).is_err() {
+                // Marker fsync failed — fail loud, leave Committed; Apply retries.
+                return SmResponse::None;
+            }
+            for (woken_id, woken_data) in self.apply_engine.notify_applied(txn_id) {
+                // Best-effort: a fsync failure here leaves that waiter Committed,
+                // and its own Apply retry re-drives it (storage apply is
+                // idempotent). Never a falsely-Applied txn.
+                let _ = self.bookkeep_applied(woken_id, woken_data);
+            }
             return SmResponse::None;
         }
 
-        // No-write finalize: an LWT whose IF condition did NOT hold still
-        // *commits* (it is ordered by Accord), but applies NO row write — the
-        // coordinator sends an Apply with an EMPTY payload to finalize it. We
-        // must still advance the txn to `Applied` (and wake dep-waiters / GC the
-        // conflict index) so it stops being a phantom dependency: a later read at
-        // `t' > t` that waited on this conflict would otherwise block until its
-        // dep-wait timeout. We deliberately skip the storage applier (there is no
-        // row to write), which also avoids decoding empty bytes as a Mutation.
-        if !result_data.is_empty() {
-            // Persist the real mutation to local storage. The applier is
-            // idempotent on (txn_id, t) and must durably write before returning
-            // Ok. If it fails we MUST NOT advance to Applied — fail loud, never
-            // fake success: the coordinator gets no implicit ack and the Apply
-            // can be retried.
-            let mutation = ApplyMutation {
-                data: result_data.clone(),
-                t,
-                deps,
-            };
-            if let Err(e) = self.applier.apply(txn_id, mutation) {
+        // Real write: route through the dep-ordered apply engine. The engine
+        // persists the row (idempotent on `(txn_id, t)`) only once every
+        // dependency has applied on this replica; otherwise it parks the mutation.
+        let mutation = ApplyMutation {
+            data: result_data,
+            t,
+            deps,
+        };
+        let applied = match self.apply_engine.try_apply(txn_id, mutation) {
+            Ok(applied) => applied,
+            Err(e) => {
+                // Storage apply failed: do NOT advance to Applied — fail loud,
+                // never fake success. The coordinator gets no implicit ack and
+                // the Apply can be retried.
                 tracing::error!(%e, "accord: storage applier failed — not advancing to Applied");
                 return SmResponse::None;
             }
+        };
+
+        if applied.is_empty() {
+            // Parked behind an unapplied dependency. This txn advances to Applied
+            // later, when its last dependency's `handle_apply` cascades to it.
+            return SmResponse::None;
         }
 
-        // Durable in storage — now safe to mark Applied and GC the conflict index.
+        // Persisted: the primary plus any cascade-woken waiters, in apply order.
+        for (applied_id, applied_data) in applied {
+            // Best-effort bookkeep (see the no-write branch): a per-txn Apply
+            // retry re-drives any whose marker fsync failed.
+            let _ = self.bookkeep_applied(applied_id, applied_data);
+        }
+
+        SmResponse::None
+    }
+
+    /// Post-apply bookkeeping for a transaction the apply engine has **already
+    /// persisted** (or a no-write finalize): persist the protocol-log marker,
+    /// advance the in-memory state to `Applied`, GC the conflict index, and wake
+    /// any `ReadVote` dep-wait parked on this transaction.
+    ///
+    /// Returns `Err(())` if the marker fsync fails — the caller must then leave
+    /// the txn `Committed` (never falsely `Applied`); the per-txn Apply retry
+    /// re-drives it, and because the storage applier is idempotent on
+    /// `(txn_id, t)` the re-driven apply is a no-op on storage.
+    fn bookkeep_applied(&mut self, txn_id: TxnId, result_data: Vec<u8>) -> Result<(), ()> {
+        // Persist the protocol-log marker. Fail loud (return Err) on fsync
+        // failure so the caller does not advance a non-durable apply.
+        let data = format!("Applied:{}", txn_id.0.time);
+        if !self.sync_writer.write_and_sync(data.as_bytes()).is_ok() {
+            return Err(());
+        }
+
         if let Some(state) = self.txn_states.get_mut(&txn_id) {
             state.apply(result_data);
         }
@@ -615,7 +668,7 @@ impl AccordStateMachine {
         // the lock); see [`Self::applied_notify`].
         self.applied_notify.notify_waiters();
 
-        SmResponse::None
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -1543,6 +1596,52 @@ mod tests {
         assert_eq!(
             *got_t, t,
             "applier must receive the agreed execution timestamp"
+        );
+    }
+
+    /// RED (Phase 0, t_59629c9b): the replica apply path must be DEP-ORDERED.
+    /// Two committed txns on the same key, B depends on A. If Apply(B) is
+    /// delivered before Apply(A), B's mutation must NOT hit storage until A has
+    /// applied — then both apply in dependency order. Today `handle_apply` calls
+    /// the applier DIRECTLY (no dep-wait at the state-machine apply path), so B
+    /// applies immediately and out of order — this test fails until the apply
+    /// path routes through dep-ordered application.
+    #[test]
+    fn sm_apply_is_dep_ordered_parks_until_dependency_applies() {
+        let writer = Arc::new(MockSyncWriter::new());
+        let applier = Arc::new(CapturingApplier::new());
+        let mut sm = AccordStateMachine::with_applier(1, writer.clone(), applier.clone());
+
+        let a = txn(1, 1000);
+        let b = txn(2, 2000);
+        let ta = ts(1001);
+        let tb = ts(2001);
+        let key = b"shared-key";
+
+        // Commit A (no deps) and B (deps = [A]) on the same key.
+        sm.handle_preaccept(a, ts(1000), key, BallotNumber(0), 0);
+        sm.handle_accept(a, ts(1000), ta, vec![], BallotNumber(1));
+        sm.handle_commit(a, ts(1000), ta, vec![]);
+
+        sm.handle_preaccept(b, ts(2000), key, BallotNumber(0), 0);
+        sm.handle_accept(b, ts(2000), tb, vec![a], BallotNumber(1));
+        sm.handle_commit(b, ts(2000), tb, vec![a]);
+
+        // Deliver Apply(B) BEFORE Apply(A). B depends on A (not yet applied), so
+        // B must PARK — its write must not reach storage out of dependency order.
+        sm.handle_apply(b, b"write-b".to_vec());
+        assert!(
+            applier.captured().is_empty(),
+            "B must not apply before its dependency A (dep-ordered apply)"
+        );
+
+        // Now apply A → the cascade must then apply B, in dependency order.
+        sm.handle_apply(a, b"write-a".to_vec());
+        let ids: Vec<_> = applier.captured().iter().map(|(id, _, _)| *id).collect();
+        assert_eq!(
+            ids,
+            vec![a, b],
+            "after A applies, A then B must apply in dependency order"
         );
     }
 

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -569,7 +569,7 @@ impl AccordStateMachine {
     ///    the txn to `Applied`. Routing through the engine (never the raw applier)
     ///    is what enforces dependency order at the replica apply path.
     /// 4. For every transaction the engine actually persisted (the primary plus
-    ///    any cascade-woken waiters), run [`bookkeep_applied`](Self::bookkeep_applied):
+    ///    any cascade-woken waiters), run the `bookkeep_applied` helper:
     ///    the protocol-log marker, `Applied` flag, conflict-index GC, and the
     ///    dep-wait wake. The storage write precedes the marker; the applier is
     ///    idempotent on `(txn_id, t)`, so a crash between them is recovered by the


### PR DESCRIPTION
## Phase 0 of multi-key Accord transactions — single-key, behavior-preserving

The replica apply path (`AccordStateMachine::handle_apply`) called the storage
applier **directly**, ignoring a committed transaction's dependency set. So an
`Apply(B)` delivered before its dependency `A` had applied would persist `B`
out of dependency order at that replica. This is the prerequisite to fix before
multi-key / multi-partition transactions can be serializable.

### What changed
- **`apply.rs`** — `DepWaitApplier::{try_apply, cascade, notify_applied}` now
  return `Vec<(TxnId, Vec<u8>)>`: the `(txn_id, mutation_data)` of every
  transaction **actually persisted** by the call, in apply order (primary first,
  then cascade-woken waiters). An empty `Vec` means the txn parked behind an
  unapplied dependency.
- **`state_machine.rs`** — the `applier: Arc<dyn StorageApplier>` field becomes
  `apply_engine: Arc<DepWaitApplier>` (constructors wrap the injected applier, so
  their signatures are unchanged). `handle_apply` now routes every real write
  through the engine and runs a new `bookkeep_applied` helper (protocol-log
  marker → `Applied` flag → conflict-index GC → ReadVote wake) for exactly the
  txns the engine reports persisted. No-write finalize (empty payload) advances
  directly and unblocks its parked waiters.

### Correctness notes
- **Persist-before-Applied is preserved.** The storage write (idempotent on
  `(txn_id, t)`) precedes the marker; a crash between them is recovered by the
  per-txn Apply retry — never a falsely-`Applied` txn. Fail-loud on apply error
  (no fake `ApplyOK`) is unchanged.
- **Single-key behavior is unchanged** — a txn with no/already-applied deps still
  applies immediately. Only the previously-missing dep-wait at this path is added.

### Tests
- RED→GREEN: `sm_apply_is_dep_ordered_parks_until_dependency_applies` (B-deps-on-A,
  `Apply(B)` first → B parks until A applies; then A then B in order).
- Full `ferrosa-cluster` suite green (982 lib + integration, **0 ignored**),
  including the crash/persist, idempotency, and production-wiring apply tests.
- `cargo clippy --workspace --all-targets`, `cargo fmt --check` clean.

### Docs
- `ferrosa-cluster/README.md` + `specs/roadmap.md` updated (the roadmap's
  previously-open "route `handle_apply` through `DepWaitApplier`" follow-up is
  now closed).

Tracking: task `t_59629c9b` / board #31. Plan: `async-popping-breeze.md`
(Phases 1–8 follow: multi-key types + V2 wire, per-shard quorum, multi-key apply,
recovery over the write-set, CQL + Postgres `BEGIN/COMMIT`, autocommit policy,
verification).