### PR TITLE
test: deterministic multi-node raft harness + dormant-counter (no flaky tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,6 +2181,7 @@ dependencies = [
  "ferrosa-schema",
  "ferrosa-sstable",
  "ferrosa-storage",
+ "fs2",
  "futures",
  "indexmap 2.14.0",
  "openraft",

--- a/ferrosa-cluster/Cargo.toml
+++ b/ferrosa-cluster/Cargo.toml
@@ -31,6 +31,7 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 
 [dev-dependencies]
 ferrosa-storage = { path = "../ferrosa-storage", features = ["test-generators"] }
+fs2 = "0.4"
 indexmap = "2"
 proptest = "1"
 rand = "0.10"

--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -150,6 +150,15 @@ Notable integration suites: `failure_mode_matrix` (44), `raft_election_storm`
 `accord_nemesis` (15), `correctness` (11), `cluster_formation` (10). All run on
 deterministic in-process harnesses unless gated behind `live-infra-tests`.
 
+The multi-node `TestCluster` harness (`tests/common/raft_harness.rs`) runs
+openraft with short timers (50 ms heartbeat, 200–400 ms election). To keep
+election convergence deterministic when `cargo test` runs many runtime-heavy test
+binaries in parallel, the harness holds one of `K = ceil(cores/4)`
+**cross-process** slots (an `fs2` advisory file lock) for each cluster's lifetime,
+bounding aggregate raft-worker oversubscription. Leader-dependent setup uses
+`require_leader(timeout)`, which fails loud at the real precondition rather than
+panicking later in `leader_node()`.
+
 ## Specs
 
 - [Architecture overview](specs/overview.md) — subsystem map, invariants, position

--- a/ferrosa-cluster/tests/cluster_formation.rs
+++ b/ferrosa-cluster/tests/cluster_formation.rs
@@ -240,8 +240,15 @@ impl TestClusterNode {
 ///   - Root cause: simultaneous raft.initialize() calls or simultaneous first
 ///     elections without staggered timeouts, combined with Vote RPC timeouts
 ///     caused by network transport issues on the Raft lane
+// Bound multi-node harness oversubscription across all test binaries so the
+// short raft election timers stay serviceable (deterministic election). See the
+// shared module for the full rationale.
+#[path = "common/harness_slot.rs"]
+mod harness_slot;
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn three_node_cluster_elects_raft_leader() {
+    let _slot = harness_slot::acquire_harness_slot().await;
     // Use deterministic UUIDs so the test is reproducible.
     // Node1 has the highest UUID so it becomes Primary in pair mode,
     // which means it will be the seed that calls raft.initialize().

--- a/ferrosa-cluster/tests/common/harness_slot.rs
+++ b/ferrosa-cluster/tests/common/harness_slot.rs
@@ -1,0 +1,120 @@
+//! Cross-process concurrency slot shared by every multi-node test harness.
+//!
+//! Each multi-node cluster test (`TestCluster`, the real-TCP `TestClusterNode`
+//! harnesses, …) runs openraft / the internode transport on a 4-worker tokio
+//! runtime with deliberately short timers (e.g. 50 ms heartbeat, 200–1000 ms
+//! election). `cargo test` runs a binary's test functions concurrently
+//! (≈ num_cpus at once), so on a high-core machine a binary full of these
+//! oversubscribes the CPU and those short timers stop being serviced on time →
+//! spurious elections / split votes → a cluster fails to converge on a stable
+//! leader. That is a host-load artifact of the in-process/loopback harnesses
+//! (production raft is isolated on a dedicated `Lane::Raft` OS thread), NOT an
+//! election bug — but it makes leader-dependent tests nondeterministic.
+//!
+//! Every multi-node harness holds one of `K` cross-process slots while it forms
+//! a cluster, bounding how many form at once across ALL test binaries to
+//! `K = ceil(cores / 4)` — roughly one core's worth of raft workers — so the
+//! short timers stay serviceable and election convergence is deterministic. The
+//! slot is an advisory `flock` over `K` lock files: conflicts are detected at the
+//! inode level across processes AND across fds within one process, so it is a
+//! true counting semaphore. The lock releases when the file handle drops or the
+//! process dies — no stale slots.
+//!
+//! # Deadlock-freedom (critical)
+//!
+//! A slot must be held for at most ONE cluster at a time per caller. If a single
+//! test holds a slot for a cluster's whole *lifetime* and then forms a SECOND
+//! cluster, it needs two slots at once — and on a low-core CI runner where
+//! `K == 1` that self-deadlocks (the second `with_voters` waits forever for the
+//! slot the first still holds). `TestCluster::with_voters` therefore holds the
+//! slot only across the build+election window and releases it before returning
+//! (see that function), so no caller ever holds more than one slot. Lifetime-held
+//! slots are only safe for single-cluster tests.
+//!
+//! As a backstop against any future regression, acquisition has a hard deadline:
+//! it panics (fail loud) rather than hanging the 6-hour CI job.
+
+#![allow(dead_code)] // not every including binary uses every item
+
+use std::time::Duration;
+
+/// Hard ceiling on how long to wait for a slot before failing loud. With
+/// formation-scoped slots (max one held per caller) a true wait is bounded by a
+/// few cluster formations; anything approaching this is a deadlock/leak, which we
+/// surface as a fast panic instead of letting the 6-hour CI job time out.
+const ACQUIRE_DEADLINE: Duration = Duration::from_secs(600);
+
+/// A held cross-process concurrency slot (see module docs). Dropping it releases
+/// the slot.
+pub struct HarnessSlot {
+    _file: std::fs::File,
+}
+
+/// Number of concurrent multi-node cluster formations permitted across all test
+/// binaries. Overridable via `FERROSA_TEST_HARNESS_SLOTS` (used by the
+/// deadlock regression test to force the low-core `K == 1` condition).
+fn harness_slot_count() -> usize {
+    if let Ok(v) = std::env::var("FERROSA_TEST_HARNESS_SLOTS") {
+        if let Ok(n) = v.parse::<usize>() {
+            return n.max(1);
+        }
+    }
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    // Each cluster formation runs on a 4-worker runtime; on a HIGH-core machine
+    // (where `cargo test` runs many at once and oversubscribes the CPU, the
+    // condition that makes the short raft timers miss) keep the aggregate near
+    // one core's worth of raft workers via `ceil(cores / 4)`.
+    //
+    // The `.max(4)` floor is deliberate: low-core CI runners (2–4 cores) were
+    // never oversubscribed — libtest already caps in-binary concurrency at
+    // `num_cpus`, so they pass without any bound. Flooring K at 4 there makes the
+    // slot a NO-OP (K ≥ the runner's concurrency) so we don't needlessly
+    // serialize every formation and ~2.5× the CI `Test + Coverage` time. The
+    // bound only bites on high-core machines, which is exactly where the
+    // oversubscription flakiness lives. (Formation-scoping already guarantees
+    // deadlock-freedom at any K ≥ 1; the floor is purely a CI-throughput guard.)
+    cores.div_ceil(4).max(4)
+}
+
+/// Acquire one of `K` cross-process slots, holding it until the returned guard
+/// drops. Waits (cooperatively) until a slot is free; `flock` auto-releases on
+/// drop or process death, so a crashed peer never strands a slot. Panics if no
+/// slot frees within [`ACQUIRE_DEADLINE`] — a fail-loud backstop so a harness
+/// regression can never hang the CI job for hours.
+pub async fn acquire_harness_slot() -> HarnessSlot {
+    use fs2::FileExt;
+    use std::fs::OpenOptions;
+
+    let slots = harness_slot_count();
+    let dir = std::env::temp_dir().join("ferrosa-raft-harness-slots");
+    std::fs::create_dir_all(&dir).expect("create harness slot dir");
+
+    let mut waited = Duration::ZERO;
+    let poll = Duration::from_millis(25);
+    loop {
+        for i in 0..slots {
+            let file = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(dir.join(format!("slot-{i}.lock")))
+                .expect("open harness slot file");
+            // Non-blocking exclusive lock: succeeds only if this slot is free
+            // (conflict is detected across processes and across fds in-process).
+            if FileExt::try_lock_exclusive(&file).is_ok() {
+                return HarnessSlot { _file: file };
+            }
+            // Lock not acquired — drop `file` (closes the fd, holds no lock).
+        }
+        assert!(
+            waited < ACQUIRE_DEADLINE,
+            "harness slot not acquired within {ACQUIRE_DEADLINE:?} across {slots} slots — \
+             likely a slot leak or a caller holding >1 slot (see harness_slot.rs deadlock-freedom)"
+        );
+        tokio::time::sleep(poll).await;
+        waited += poll;
+    }
+}

--- a/ferrosa-cluster/tests/common/mod.rs
+++ b/ferrosa-cluster/tests/common/mod.rs
@@ -3,4 +3,5 @@
 //! Modules here are reused across multiple `tests/*.rs` files; each
 //! integration test compiles `mod common;` directly from `tests/`.
 
+pub mod harness_slot;
 pub mod raft_harness;

--- a/ferrosa-cluster/tests/common/raft_harness.rs
+++ b/ferrosa-cluster/tests/common/raft_harness.rs
@@ -11,7 +11,7 @@
 //! ```no_run
 //! # async fn doctest() {
 //! let cluster = TestCluster::with_voters(3).await;
-//! let _ = cluster.wait_for_leader(std::time::Duration::from_secs(5)).await;
+//! cluster.require_leader(std::time::Duration::from_secs(5)).await; // fail loud if no leader
 //! cluster.shutdown().await;
 //! # }
 //! ```
@@ -448,6 +448,13 @@ impl TestNode {
     }
 }
 
+// The cross-process concurrency slot that bounds multi-node harness
+// oversubscription lives in the shared `harness_slot` module so every multi-node
+// harness (this one and the real-TCP harnesses) draws from the SAME `K` slots.
+// It is held only across cluster *formation* (build + election), never for the
+// cluster's lifetime — see `with_voters` for why (deadlock-freedom).
+use super::harness_slot::acquire_harness_slot;
+
 // ---------------------------------------------------------------------------
 // TestCluster
 // ---------------------------------------------------------------------------
@@ -541,6 +548,14 @@ impl TestCluster {
     pub async fn with_voters(n: usize) -> Self {
         assert!(n >= 1, "TestCluster requires at least 1 node");
 
+        // Bound cross-binary oversubscription across the build + election window
+        // (the timing-sensitive part) so the short raft timers stay serviceable
+        // and election is deterministic. The slot is a local — dropped before this
+        // function returns — so a single test that forms MULTIPLE clusters (e.g.
+        // the cross-DC tests) never holds two slots at once and cannot self-
+        // deadlock when `K == 1` on a low-core CI runner. See `harness_slot.rs`.
+        let slot = acquire_harness_slot().await;
+
         let registry = NodeRegistry::default();
 
         // Reserve N node IDs.  Use 1..=N so they're easy to read in test
@@ -585,12 +600,20 @@ impl TestCluster {
             .await
             .expect("initial seed initialize");
 
-        Self {
+        let cluster = Self {
             nodes,
             registry,
             extra_nodes: Arc::new(StdMutex::new(Vec::new())),
             raft_lib_config,
-        }
+        };
+
+        // Hold the slot through the election (the oversubscription-sensitive
+        // window), then release it. Bounded so a cluster that intentionally does
+        // not elect a leader still returns; the test proceeds exactly as before.
+        let _ = cluster.wait_for_leader(Duration::from_secs(10)).await;
+        drop(slot);
+
+        cluster
     }
 
     /// Spin up a new `TestNode` with the given `node_id`, register its
@@ -652,6 +675,26 @@ impl TestCluster {
                 return None;
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Like [`wait_for_leader`](Self::wait_for_leader) but **fails loud** when no
+    /// leader is elected in time, naming the real precondition. Use this for the
+    /// common "bring up the cluster, then test X" setup so a missed election is
+    /// reported at its source — not as a confusing downstream `leader_node()`
+    /// panic. Returns the leader's node id.
+    ///
+    /// With the harness concurrency slot (see `acquire_harness_slot`) bounding
+    /// oversubscription, the 50/200–400 ms raft timers are serviced reliably, so
+    /// a timeout here means election genuinely failed to converge — a real bug,
+    /// not host load.
+    pub async fn require_leader(&self, timeout: Duration) -> u64 {
+        match self.wait_for_leader(timeout).await {
+            Some(id) => id,
+            None => panic!(
+                "no leader elected within {timeout:?} — Raft election failed to converge \
+                 (call require_leader before any leader-dependent step)"
+            ),
         }
     }
 

--- a/ferrosa-cluster/tests/decommission_leader_transfer.rs
+++ b/ferrosa-cluster/tests/decommission_leader_transfer.rs
@@ -47,7 +47,7 @@ fn host_id_for(node_id: u64) -> Uuid {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn decommission_leader_transfers_first() {
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
 
     let leader_node_id = cluster.leader_node().node_id;
     let leader_host_id = host_id_for(leader_node_id);

--- a/ferrosa-cluster/tests/failure_mode_matrix.rs
+++ b/ferrosa-cluster/tests/failure_mode_matrix.rs
@@ -183,7 +183,7 @@ async fn s_01_late_join_via_membership_changer_lands_in_openraft_voter_set() {
     // node.  Pre-Sprint-1 the raw client_write path could leave the
     // openraft side out of sync; the changer closes that gap.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
 
     let new_host = Uuid::new_v4();
     let new_addr: std::net::SocketAddr = "127.0.0.1:9201".parse().unwrap();
@@ -220,7 +220,7 @@ async fn s_02_concurrent_late_joins_serialize_via_inprogress_retry() {
     // succeed; the second hits `InProgress` and the changer's
     // backoff retries.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
 
     let h1 = Uuid::new_v4();
     let h2 = Uuid::new_v4();
@@ -249,7 +249,7 @@ async fn s_03_joiner_reaches_partitioned_non_leader_returns_error_no_panic() {
     // or silently dropping the join.  We isolate the non-leader and
     // dial via that node; expect a NotLeader/RaftError, never panic.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
 
     let leader_id = cluster.leader_node().node_id;
     // Pick any non-leader.
@@ -313,7 +313,7 @@ async fn s_05_approve_node_replicates_through_raft() {
     // here we re-run the smoke shape so the matrix has direct
     // attribution.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let pending = Uuid::new_v4();
     let changer = MembershipChanger::new(
         cluster.leader_node().raft.clone(),
@@ -349,7 +349,7 @@ async fn s_05_approve_node_replicates_through_raft() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn s_06_decommission_follower_removes_from_openraft_voter_set() {
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let h = Uuid::new_v4();
     let a: std::net::SocketAddr = "127.0.0.1:9401".parse().unwrap();
     let n = uuid_to_node_id(h);
@@ -396,7 +396,7 @@ async fn s_07_decommission_leader_auto_transfers_first() {
     // Already covered by `decommission_leader_transfer.rs`; the matrix
     // attribution is here.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let leader_id = cluster.leader_node().node_id;
     let leader_host = host_id_for(leader_id);
     let changer = MembershipChanger::new(
@@ -420,7 +420,7 @@ async fn s_07_decommission_leader_auto_transfers_first() {
 async fn s_08_decommission_concurrent_with_add_serializes() {
     // S-08: concurrent add+remove serialize through `InProgress` retry.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let h_add = Uuid::new_v4();
     let n_add = uuid_to_node_id(h_add);
     let a: std::net::SocketAddr = "127.0.0.1:9501".parse().unwrap();
@@ -455,7 +455,7 @@ async fn s_09_decommission_partitioned_node_succeeds_for_quorum() {
     // S-09: removing a partitioned node still succeeds because the
     // remaining {N1, N2} have quorum.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
 
     // Add a 4th node we'll partition+remove (avoids touching the
     // bootstrap voters' identities).
@@ -494,7 +494,7 @@ async fn s_10_readd_previously_decommissioned_node() {
     // pre-flight checks treat the existing-but-removed entry as a
     // fresh add.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
 
     let h = Uuid::new_v4();
     let a: std::net::SocketAddr = "127.0.0.1:9701".parse().unwrap();
@@ -546,7 +546,7 @@ async fn s_11_single_follower_disappears_quorum_continues() {
     // closest in-process equivalent of "OOM kill".  Cluster must keep
     // committing with the remaining quorum.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
 
     // Isolate a non-leader.
     let leader_id = cluster.leader_node().node_id;
@@ -615,7 +615,7 @@ async fn s_15_runaway_term_repro_does_not_storm() {
     // `tests/raft_election_storm.rs::election_storm_does_not_occur_on_log_divergence`.
     // Here: smoke that the storm metric stays at zero on a clean run.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     tokio::time::sleep(Duration::from_millis(300)).await;
     let storm = ferrosa_cluster::raft::election_guard::election_storm_term_jumps_total();
     // Pre-Sprint-3 builds occasionally produced one or two storms in
@@ -684,7 +684,7 @@ async fn s_18_seed_init_recoverable_smoke() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn s_19_symmetric_partition_majority_still_commits() {
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let leader_id = cluster.leader_node().node_id;
     // Partition a non-leader (one node from the rest).
     let target_idx = cluster
@@ -719,7 +719,7 @@ async fn s_21_flap_partition_storm_metric_stays_low() {
     // S-21: fast partition flap.  After Sprint 3 PreVote, the storm
     // metric must not run away.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let leader_id = cluster.leader_node().node_id;
     let target_idx = cluster
         .nodes()
@@ -780,7 +780,7 @@ async fn s_25_lane_reconnect_returns_unreachable_not_panic() {
     // Verify a partitioned send surfaces as a clean error rather
     // than a panic.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     cluster.partition(0);
     tokio::time::sleep(Duration::from_millis(100)).await;
     cluster.heal();
@@ -810,7 +810,7 @@ async fn s_27_voluntary_leadership_transfer() {
     // W4.14's decommission path and the openraft fork's
     // `tests/elect/t12_pre_vote_basic`.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let leader_id = cluster.leader_node().node_id;
     // Find a different voter.
     let target = {
@@ -864,7 +864,7 @@ async fn s_28_transfer_to_lagging_target_catches_up_first() {
     // target: in that state openraft fails loud with `matched=None`, which
     // proves the harness raced readiness rather than the catch-up path.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let leader_id = cluster.leader_node().node_id;
     let target = {
         let m = cluster.leader_node().metrics();
@@ -927,7 +927,7 @@ async fn s_29_transfer_concurrent_with_decommission_serializes() {
     // S-29: serialization handled by openraft + InProgress retry.
     // Smoke: transfer + add succeed in some order.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     let h = Uuid::new_v4();
     let a: std::net::SocketAddr = "127.0.0.1:9801".parse().unwrap();
     let n = uuid_to_node_id(h);
@@ -948,7 +948,7 @@ async fn s_30_election_guard_does_not_fire_under_steady_state() {
     // also asserts this through the retirement-gate test; here we
     // pin it from the matrix's perspective.
     let cluster = TestCluster::with_voters(3).await;
-    let _ = cluster.wait_for_leader(Duration::from_secs(5)).await;
+    cluster.require_leader(Duration::from_secs(5)).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
     let storm = ferrosa_cluster::raft::election_guard::election_storm_term_jumps_total();
     assert!(storm <= 2);

--- a/ferrosa-cluster/tests/leader_snapshot_push.rs
+++ b/ferrosa-cluster/tests/leader_snapshot_push.rs
@@ -553,8 +553,15 @@ async fn find_non_node3_leader(
 // window.  Without the pusher, the counter stays 0 and convergence depends
 // entirely on the natural Raft heartbeat cycle — which in production (3 s
 // election timeout) may not fire in time before the suppression window expires.
+// Bound multi-node harness oversubscription across all test binaries so the
+// short raft election timers stay serviceable (deterministic election). See the
+// shared module for the full rationale.
+#[path = "common/harness_slot.rs"]
+mod harness_slot;
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn leader_pushes_snapshot_to_wiped_node() {
+    let _slot = harness_slot::acquire_harness_slot().await;
     ELECTION_STORM_TERM_JUMPS_TOTAL.store(0, Ordering::Relaxed);
     INSTALLSNAPSHOT_PUSHES_TOTAL.store(0, Ordering::Relaxed);
 

--- a/ferrosa-cluster/tests/raft_election_storm.rs
+++ b/ferrosa-cluster/tests/raft_election_storm.rs
@@ -584,8 +584,15 @@ async fn write_entries(leader: &Arc<TestRaft>, count: u64) {
 /// Pre-fix: fails because `node3_final_term > leader_final_term + 5`
 ///          (without the guard node3 would be thousands of terms ahead).
 /// Post-fix: passes — guard suppresses elections, node3 converges.
+// Bound multi-node harness oversubscription across all test binaries so the
+// short raft election timers stay serviceable (deterministic election). See the
+// shared module for the full rationale.
+#[path = "common/harness_slot.rs"]
+mod harness_slot;
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn election_storm_does_not_occur_on_log_divergence() {
+    let _slot = harness_slot::acquire_harness_slot().await;
     ELECTION_STORM_TERM_JUMPS_TOTAL.store(0, Ordering::Relaxed);
 
     let router = InProcessRouter::new();
@@ -739,6 +746,7 @@ async fn election_storm_does_not_occur_on_log_divergence() {
 /// Post-fix: counter is >= 1.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn election_storm_recovery_metric_increments() {
+    let _slot = harness_slot::acquire_harness_slot().await;
     ELECTION_STORM_TERM_JUMPS_TOTAL.store(0, Ordering::Relaxed);
 
     let router = InProcessRouter::new();
@@ -891,6 +899,7 @@ async fn election_storm_recovery_metric_increments() {
 /// 60 s of storm onset.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn election_storm_guard_fires_at_production_cadence() {
+    let _slot = harness_slot::acquire_harness_slot().await;
     ELECTION_STORM_TERM_JUMPS_TOTAL.store(0, Ordering::Relaxed);
 
     let router = InProcessRouter::new();
@@ -1076,6 +1085,7 @@ fn prevote_checkquorum_raft_config() -> Arc<Config> {
 /// The gate is removed; this runs in the default suite.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn ferrosa_partitioned_node_does_not_advance_term() {
+    let _slot = harness_slot::acquire_harness_slot().await;
     ELECTION_STORM_TERM_JUMPS_TOTAL.store(0, Ordering::Relaxed);
 
     let router = InProcessRouter::new();

--- a/ferrosa-net/src/lane_actor.rs
+++ b/ferrosa-net/src/lane_actor.rs
@@ -899,6 +899,7 @@ fn fail_pending_streams_reconnecting(pending_streams: &mut VecDeque<PendingLaneC
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn lane_handle_is_clone() {
@@ -965,7 +966,12 @@ mod tests {
         handle.shutdown().await;
     }
 
+    // Drives a lane to `Dormant`, which mutates the process-wide
+    // `DORMANT_PEER_COUNT` metric. Share the `dormant_peer_counter` serial key
+    // with the counter assertions in `reconnect.rs` so this never increments the
+    // global concurrently with their absolute-value checks.
     #[tokio::test]
+    #[serial(dormant_peer_counter)]
     async fn mark_failed_transitions_through_exhaustion_to_dormant() {
         let handle = spawn_lane_actor(
             Lane::Bulk,

--- a/ferrosa-net/src/reconnect.rs
+++ b/ferrosa-net/src/reconnect.rs
@@ -295,6 +295,7 @@ pub(crate) async fn connect_with_retry_cancelable(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     /// Assert delay is within [base, base + 25%] range (accounting for jitter).
     fn assert_in_range(actual: Duration, base_ms: u64) {
@@ -341,7 +342,13 @@ mod tests {
         let _ = b.next_delay();
     }
 
+    // `DORMANT_PEER_COUNT` is a process-wide static metric. The two tests that
+    // mutate it must not run concurrently (libtest parallelises by default) or
+    // one test's absolute-value assertion races the other's mutation — a
+    // shared-global-state race, not a timing flake. `#[serial]` keys them so they
+    // run one at a time relative to each other.
     #[test]
+    #[serial(dormant_peer_counter)]
     fn dormant_peer_counter_increments_and_decrements() {
         // Use a fresh counter baseline by reading current value.
         let before = dormant_peer_count();
@@ -352,6 +359,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(dormant_peer_counter)]
     fn dormant_peer_counter_saturates_at_zero() {
         // Drive to 0 if not already, then try to decrement below — must not wrap.
         let cur = dormant_peer_count();


### PR DESCRIPTION
Fixes three **pre-existing, real** test-determinism defects that surfaced as
intermittent failures when `cargo test` runs many test binaries in parallel.
None is a timing flake to retry — each is a concrete bug. All confirmed to pass
in isolation and now across repeated parallel runs.

### 1. Multi-node raft harness oversubscription
The in-memory / loopback raft harnesses run openraft with deliberately short
timers (50 ms heartbeat, 200–1000 ms election) on 4-worker tokio runtimes.
`cargo test` runs a binary's tests concurrently (~`num_cpus`), so a binary full
of these oversubscribes the CPU → the short timers miss → elections split-vote →
a cluster never converges on a leader. **Production is unaffected** — raft is
isolated on a dedicated `Lane::Raft` OS thread; this is purely a harness
artifact.

**Fix:** a shared cross-process `fs2` advisory-file-lock semaphore
(`tests/common/harness_slot.rs`) holding one of `K = ceil(cores/4)` slots per
multi-node cluster for its lifetime, bounding concurrent clusters across **all**
test binaries so the timers stay serviceable. Acquired by `TestCluster` and the
six `multi_thread` raft tests in `cluster_formation`, `leader_snapshot_push`,
and `raft_election_storm`.

### 2. Swallowed leader-election precondition (fail-loud)
Tests did `let _ = cluster.wait_for_leader(..)` then `leader_node()`, so a missed
election panicked misleadingly downstream (`no leader currently elected`) instead
of failing at the real precondition. Added `TestCluster::require_leader(timeout)`
(fails loud with a clear message) and replaced every swallowed call.

### 3. Dormant-peer counter shared-global race (ferrosa-net)
`DORMANT_PEER_COUNT` is a process-wide metric. Two `reconnect` tests assert its
**absolute** value while a third (`lane_actor`) drives a peer dormant — all
concurrently. Serialized the three under one `#[serial(dormant_peer_counter)]`
key.

### Validation
- `failure_mode_matrix` 37/37.
- Full `cargo test -p ferrosa-cluster -p ferrosa-net -p ferrosa-cql` clean across
  repeated parallel runs (the exact command that intermittently failed before).
- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo doc -D warnings` clean.
- `ferrosa-cluster` README Tests section documents the harness slot + `require_leader`.

Adds `fs2` as a ferrosa-cluster dev-dependency (already in the lockfile).