### PR TITLE
fix(cluster): tolerate empty partial fulltext results

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -69,7 +69,10 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   repair in background* (LOCKED DESIGN). Also hosts the index scatter-gathers:
   `coordinate_index_read` (secondary index) and `coordinate_fulltext_search`
   (`fts_match` — fans out to every node's local FTI and unions/de-dupes the
-  matching keys, since full-text hits span all token ranges; BUG-F-007).
+  matching keys, since full-text hits span all token ranges; BUG-F-007). FTI
+  scatter-gather is partial-failure tolerant: if at least one node completes, the
+  union is returned even when it is empty, so a transient remote stream failure
+  does not turn a valid no-hit search into a user-visible error.
 - `coordinator/cl_routing.rs` — W8.4 learner-aware routing (voter-only quorums,
   leader-only serial, cross-DC Accord routing).
 - `coordinator/batch.rs` — 3-phase logged batchlog (write → fan out → delete only

--- a/ferrosa-cluster/specs/overview.md
+++ b/ferrosa-cluster/specs/overview.md
@@ -67,9 +67,11 @@ to a healthy replica and enqueues a background anti-entropy refill.
 **Full-text scatter-gather.** `coordinate_fulltext_search` fans an `fts_match`
 index lookup out to every node — its hits span all token ranges (there is no
 partition key) — running each node's local FTI via a `FulltextSearchRequest` RPC
-and unioning/de-duping the matching keys (partial-failure tolerant). Routed
-through `WritePath::fulltext_search` (Direct/Pair resolve locally). Fixes the
-coordinator-local non-determinism of BUG-F-007.
+and unioning/de-duping the matching keys. Partial failures degrade only if every
+node fails; if at least one node completes, the union is returned even when it is
+empty, so transient remote stream faults do not convert legitimate no-hit queries
+into errors. Routed through `WritePath::fulltext_search` (Direct/Pair resolve
+locally). Fixes the coordinator-local non-determinism of BUG-F-007.
 
 **DDL / membership.** Mutations are wrapped as `RaftOp`, proposed via
 `raft.client_write` (forwarded to the leader if needed via `raft_forward`),

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -1731,7 +1731,7 @@ impl ClusterCoordinator {
         }
 
         if let Some(err) = first_error {
-            if all_keys.is_empty() {
+            if failed_nodes == total_nodes {
                 tracing::error!(
                     failed_nodes,
                     "coordinate_fulltext_search: all nodes failed, returning error"
@@ -2231,6 +2231,58 @@ mod tests {
         );
 
         server.shutdown(std::time::Duration::from_millis(50)).await;
+    }
+
+    /// A remote FTI failure must not turn a legitimate empty local result into
+    /// a user-visible query failure. The fmem hybrid_search path fans out
+    /// `fts_match` and can hit transient remote stream failures such as
+    /// `ChannelClosedBeforeDone`; if at least one node completed, the result is
+    /// a partial union, even when that union is empty. Only all nodes failing is
+    /// fatal.
+    #[tokio::test]
+    async fn coordinate_fulltext_search_degrades_to_empty_when_some_nodes_fail() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+        let table_id = TableId::new("test_ks", "test_tbl");
+        storage.add_fulltext_index(&table_id, "val_fti", 0).unwrap();
+
+        let pm = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            Uuid::new_v4(),
+            Arc::new(NoopListener),
+        ));
+
+        let local_node_id = 1u64;
+        let mut local = make_node("127.0.0.1:7000");
+        local.host_id = Uuid::new_v4();
+        let remote_host_id = Uuid::new_v4();
+        let mut remote = make_node("127.0.0.1:1");
+        remote.host_id = remote_host_id;
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, local);
+        ring.add_node(2u64, remote);
+        ring.assign_tokens(local_node_id, &[42]);
+        ring.assign_tokens(2u64, &[142]);
+
+        let coordinator = make_coordinator(
+            ring,
+            pm,
+            local_node_id,
+            storage,
+            2,
+            ConsistencyLevel::Quorum,
+        );
+
+        let keys = coordinator
+            .coordinate_fulltext_search(&table_id, "val_fti", "no-such-token")
+            .await
+            .expect("one successful empty FTI shard should degrade remote failure to empty union");
+
+        assert!(
+            keys.is_empty(),
+            "expected an empty partial union when local FTI succeeds and remote FTI fails"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Executive Summary

This fixes a Ferrosa full-text scatter-gather edge case exposed by ferrosa-memory PR #81, which now relies on native `fts_match` as the sole retrieval path.

A successful FTI shard returning zero matches is still a completed shard. Before this patch, `coordinate_fulltext_search` treated `all_keys.is_empty()` plus any remote error as a total failure, so a valid no-hit query could become a user-visible error when one remote FTI/stream request failed transiently.

## Changes

- Change `coordinate_fulltext_search` to fail only when `failed_nodes == total_nodes`.
- Preserve partial-failure tolerance even when the partial union is empty.
- Add regression coverage for local empty FTI success plus remote failure.
- Update `ferrosa-cluster` README/spec overview to document the empty partial-union behavior.

## Why now

ferrosa-memory PR #81 removed its local term-table BM25 workaround and adopted native `fts_match`. That is the right direction, but it makes native FTS failures visible in interactive search. This patch removes one false-failure mode without weakening the all-nodes-failed error path.

## Test Plan

- [x] `CARGO_TARGET_DIR=/tmp/ferrosa-channelclosed-target cargo test -p ferrosa-cluster coordinate_fulltext_search -- --nocapture`
  - `2 passed; 0 failed`
- [x] `CARGO_TARGET_DIR=/tmp/ferrosa-channelclosed-target cargo test -p ferrosa-cluster stream -- --nocapture`
  - `108 passed; 0 failed`
- [x] `CARGO_TARGET_DIR=/tmp/ferrosa-channelclosed-target cargo fmt --check`
- [x] `CARGO_TARGET_DIR=/tmp/ferrosa-channelclosed-release cargo build --release -p ferrosa`
  - `Finished release profile`

## Notes

This does not claim to solve all `ChannelClosedBeforeDone` cases. It specifically fixes the FTI scatter-gather behavior where at least one shard completed successfully but returned an empty match set.
