### PR TITLE
feat(accord): multi-key V2 wire foundation + new_multi API (Phase 1)

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -125,6 +125,13 @@ strict-serializable multi-key / cross-shard transactions and LWT.
 - `apply.rs` — `DepWaitApplier` (dep-wait + `StorageApplier` seam, idempotent on
   `(txn_id, t)`) + `EngineStorageApplier`/`EngineStorageReader` (real persistence
   and linearizable read-at-`t`).
+- `wire.rs` — bincode payloads for each protocol message. **Multi-key (Phase 1):**
+  `WriteSetEntry` + `ApplyV2Payload` back the additive `AccordPreAcceptV2`/
+  `AccordApplyV2` wire codes; `AccordCoordinatorDriver::new_multi(write_set)` is
+  the multi-key constructor (`new` is the one-entry degenerate case). Multi-key
+  *execution* fails loud (`AccordDriverError::MultiKeyNotYetExecutable`) until the
+  participant set/per-shard quorum (Phase 2) and `(txn_id, key)` apply keying
+  (Phase 3) land — never a silently-dropped write.
 - `dep_wait.rs` — waits-for graph with deterministic cycle-breaking.
 - `cross_shard.rs` / `cross_dc_adapter.rs` — multi-shard atomicity, cross-DC glue.
 - `electorate.rs` / `epoch.rs` — JoinElectorate membership gates, epoch tracking.

--- a/ferrosa-cluster/specs/roadmap.md
+++ b/ferrosa-cluster/specs/roadmap.md
@@ -11,6 +11,20 @@ reference/decision specs, and the dependency/usage review. Ordered by value.
 
 ## Recently addressed
 
+- **Multi-key Accord — additive V2 wire foundation + `new_multi` API (Phase 1).**
+  Multi-key (multi-partition) transactions will travel on new
+  `AccordPreAcceptV2`/`AccordApplyV2` message codes (bincode is not
+  self-describing, so the single-key payloads keep their exact bytes). Landed so
+  far: `WriteSetEntry` + `ApplyV2Payload` wire types, the reserved net message
+  codes (round-trip tested in `ferrosa-net`), and
+  `AccordCoordinatorDriver::new_multi(write_set)` (with `new` delegating as the
+  one-entry degenerate case) so the CQL/Postgres front-ends can be built against
+  the API in parallel. Multi-key *execution* is **deliberately fail-loud for now**
+  (`AccordDriverError::MultiKeyNotYetExecutable`): a `(txn_id, t)`-idempotent
+  applier would no-op writes 2..N of one transaction, so correct multi-key apply
+  needs the participant-set/per-shard quorum (Phase 2) and the `(txn_id, key)`
+  apply keying (Phase 3) before it can run — fail loud rather than silently drop
+  writes. Single-key LWT is unchanged.
 - **Replica apply path is now dep-ordered (Phase 0, t_59629c9b).** `handle_apply`
   used to call the storage applier **directly**, ignoring the transaction's
   dependency set — so an `Apply(B)` delivered before its dependency `A` applied

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -378,6 +378,21 @@ pub enum AccordDriverError {
     },
     /// F+1 apply acknowledgements were not received within the timeout.
     ApplyQuorumUnavailable,
+    /// A multi-key (multi-partition) transaction was driven, but multi-key
+    /// *execution* is not yet wired: the multi-shard participant set + per-shard
+    /// quorum (Phase 2) and the multi-key replica apply with `(txn_id, key)`
+    /// idempotency keying (Phase 3) are still to come. Until then a multi-key
+    /// write-set fails loud here rather than silently dropping writes — both over
+    /// the single-key wire (remote) and at the `(txn_id, t)`-idempotent applier
+    /// (which would no-op writes 2..N of one transaction at the same agreed `t`).
+    /// The additive V2 wire + `new_multi` API exist now so the front-ends can be
+    /// built against them in parallel.
+    MultiKeyNotYetExecutable {
+        /// Number of keys in the write-set.
+        keys: usize,
+        /// Number of replicas in the participant list.
+        replicas: usize,
+    },
 }
 
 impl std::fmt::Display for AccordDriverError {
@@ -388,6 +403,11 @@ impl std::fmt::Display for AccordDriverError {
             Self::Codec(e) => write!(f, "Accord codec error: {e}"),
             Self::ConditionNotMet { .. } => write!(f, "Accord LWT condition not met"),
             Self::ApplyQuorumUnavailable => write!(f, "Accord apply quorum unavailable"),
+            Self::MultiKeyNotYetExecutable { keys, replicas } => write!(
+                f,
+                "multi-key Accord execution not yet wired: {keys} keys across {replicas} replicas \
+                 (additive V2 wire + new_multi exist; fan-out is Phase 2, multi-key apply is Phase 3)"
+            ),
         }
     }
 }
@@ -432,6 +452,14 @@ pub struct AccordCoordinatorDriver {
     /// for Accord conflict ordering). An empty vector means "no mutation"
     /// (read-only / protocol-only transactions).
     mutation: Vec<u8>,
+    /// The transaction's full write-set: one `(key, mutation)` entry per
+    /// partition written. A single-key transaction (the [`Self::new`] path) has
+    /// exactly one entry whose `mutation` equals [`Self::mutation`] above; a
+    /// multi-key transaction ([`Self::new_multi`]) has several. The coordinator's
+    /// own-replica Apply iterates this set so every key it owns is persisted.
+    /// Multi-shard fan-out over this set is Phase 2/3 (see
+    /// [`AccordDriverError::MultiKeyNotYetExecutable`]).
+    write_set: Vec<crate::accord::wire::WriteSetEntry>,
     /// How replicas should answer the Gap-4 read-vote: existence semantics for
     /// `INSERT IF NOT EXISTS` (the default) or a generic read-row-at-`t` whose
     /// IF predicate this coordinator evaluates after collecting F+1 agreed rows.
@@ -522,11 +550,53 @@ impl AccordCoordinatorDriver {
         key: Vec<u8>,
         mutation: Vec<u8>,
     ) -> Self {
+        // A single-key transaction is the degenerate one-entry write-set.
+        Self::new_multi(
+            node_id,
+            replica_ids,
+            peers,
+            is_leaseholder,
+            clock,
+            vec![(key, mutation)],
+        )
+    }
+
+    /// Build a driver for a multi-key (multi-partition) transaction.
+    ///
+    /// `write_set` is one `(partition_key, encoded_mutation)` per key the
+    /// transaction writes; it must be non-empty. The first key drives Accord
+    /// conflict ordering for now (single-shard); the full multi-shard participant
+    /// set + per-shard quorum is Phase 2. The coordinator applies every entry it
+    /// owns locally during the Apply phase, so an RF=1 / coordinator-is-sole-
+    /// replica multi-key transaction commits all keys atomically today. A
+    /// multi-key transaction with remote replicas fails loud
+    /// ([`AccordDriverError::MultiKeyNotYetExecutable`]) rather than silently
+    /// dropping the other keys' writes over the single-key wire.
+    pub fn new_multi(
+        node_id: u64,
+        replica_ids: Vec<uuid::Uuid>,
+        peers: Arc<PeerManager>,
+        is_leaseholder: bool,
+        clock: &HybridLogicalClock,
+        write_set: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> Self {
         let rf = replica_ids.len();
         assert!(rf > 0, "replica_ids must be non-empty");
+        assert!(!write_set.is_empty(), "write_set must be non-empty");
 
         let t0 = clock.now();
         let txn_id = TxnId::new(node_id, t0);
+
+        // Representative key for conflict ordering (the inner coordinator is
+        // single-key for now); the per-key union is Phase 2.
+        let key = write_set[0].0.clone();
+        // Keep `mutation` = the first entry so the single-key wire path (PreAccept
+        // key, v1 Apply payload) is byte-identical for a one-entry write-set.
+        let mutation = write_set[0].1.clone();
+        let write_set: Vec<crate::accord::wire::WriteSetEntry> = write_set
+            .into_iter()
+            .map(|(key, mutation)| crate::accord::wire::WriteSetEntry { key, mutation })
+            .collect();
 
         let coordinator = AccordCoordinator::new(txn_id, t0, key, node_id, rf, is_leaseholder);
 
@@ -549,6 +619,7 @@ impl AccordCoordinatorDriver {
             replica_ids,
             self_id,
             mutation,
+            write_set,
             read_predicate: crate::accord::wire::ReadPredicate::NotExists,
             last_read_row: None,
             local_reader: None,
@@ -658,6 +729,18 @@ impl AccordCoordinatorDriver {
         bincode::serialize(&apply_payload).map_err(|e| AccordDriverError::Codec(e.to_string()))
     }
 
+    /// The multi-key Apply payload for this transaction: the full write-set the
+    /// coordinator (and, once Phase 2 wires fan-out, each replica) applies. The
+    /// coordinator's own-replica Apply iterates `writes`; the single-key path is
+    /// the degenerate one-entry case. This is the canonical in-memory form that
+    /// Phase 2 will serialize onto [`Message::AccordApplyV2`](ferrosa_net::Message).
+    fn apply_v2_payload(&self) -> crate::accord::wire::ApplyV2Payload {
+        crate::accord::wire::ApplyV2Payload {
+            txn_id: self.coordinator.txn_id,
+            writes: self.write_set.clone(),
+        }
+    }
+
     /// Finalize this transaction as a *no-write* commit across the cluster after
     /// the IF condition was found NOT to hold.
     ///
@@ -748,6 +831,16 @@ impl AccordCoordinatorDriver {
             AcceptOkPayload, AcceptPayload, ApplyOkPayload, CommitPayload, PreAcceptOkPayload,
             PreAcceptPayload, ReadVoteOkPayload, ReadVotePayload,
         };
+
+        // Multi-key execution is not yet wired (Phase 2 fan-out + Phase 3 apply
+        // keying). Fail loud before any side effect rather than silently dropping
+        // writes 2..N. Single-key (the `new` path, one write-set entry) proceeds.
+        if self.write_set.len() > 1 {
+            return Err(AccordDriverError::MultiKeyNotYetExecutable {
+                keys: self.write_set.len(),
+                replicas: self.replica_ids.len(),
+            });
+        }
 
         let txn_id = self.coordinator.txn_id;
         let t0 = self.coordinator.t0;
@@ -1173,20 +1266,33 @@ impl AccordCoordinatorDriver {
         // handle_apply) before counting the implicit ack. Without this the
         // coordinator node never persists what it coordinates. Fail loud: a local
         // apply error must abort, never fake the implicit ack.
-        if self_is_replica && !self.mutation.is_empty() {
+        if self_is_replica {
             if let Some(applier) = &self.local_applier {
-                applier
-                    .apply(
-                        txn_id,
-                        crate::accord::apply::ApplyMutation {
-                            data: self.mutation.clone(),
-                            t: commit_t,
-                            deps: commit_deps.iter().copied().collect(),
-                        },
-                    )
-                    .map_err(|e| {
-                        AccordDriverError::Network(format!("coordinator local apply failed: {e}"))
-                    })?;
+                // Apply every write in the transaction's write-set that this
+                // node owns. For a single-key txn this is exactly one entry
+                // (== `self.mutation`); the write-set form is what the multi-key
+                // path (guarded above until Phase 2/3) will iterate.
+                let apply = self.apply_v2_payload();
+                let deps: Vec<TxnId> = commit_deps.iter().copied().collect();
+                for write in &apply.writes {
+                    if write.mutation.is_empty() {
+                        continue; // no-write entry (read-only / protocol-only)
+                    }
+                    applier
+                        .apply(
+                            txn_id,
+                            crate::accord::apply::ApplyMutation {
+                                data: write.mutation.clone(),
+                                t: commit_t,
+                                deps: deps.clone(),
+                            },
+                        )
+                        .map_err(|e| {
+                            AccordDriverError::Network(format!(
+                                "coordinator local apply failed: {e}"
+                            ))
+                        })?;
+                }
             }
         }
 
@@ -2059,6 +2165,131 @@ mod tests {
             decoded.result_data, key,
             "Apply result_data must NOT be the raw partition key — that is the \
              phantom-write bug this increment closes"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 1 (multi-key Accord): the additive `new_multi` API + V2 wire.
+    // -----------------------------------------------------------------------
+
+    struct NoopListener;
+    impl ferrosa_net::peer::PeerEventListener for NoopListener {
+        fn on_peer_connected(&self, _: ferrosa_net::rpc::handler::PeerId) {}
+        fn on_peer_disconnected(&self, _: ferrosa_net::rpc::handler::PeerId) {}
+        fn on_peer_suspected(&self, _: ferrosa_net::rpc::handler::PeerId) {}
+        fn on_peer_recovered(&self, _: uuid::Uuid) {}
+        fn on_peer_failed(&self, _: uuid::Uuid) {}
+    }
+
+    /// Build (node_id, self_uuid, peers) for a single-node driver test.
+    fn single_node_peers() -> (
+        u64,
+        uuid::Uuid,
+        std::sync::Arc<ferrosa_net::peer::PeerManager>,
+    ) {
+        use ferrosa_net::config::NetConfig;
+        use ferrosa_net::peer::PeerManager;
+        use std::sync::Arc;
+        let self_uuid = uuid::Uuid::new_v4();
+        let node_id =
+            u64::from_be_bytes(self_uuid.as_bytes()[..8].try_into().expect("uuid 16 bytes"));
+        let peers = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            self_uuid,
+            Arc::new(NoopListener),
+        ));
+        (node_id, self_uuid, peers)
+    }
+
+    /// A single-key transaction is the degenerate one-entry write-set: `new`
+    /// delegates to `new_multi`, the V2 Apply payload has exactly one write, and
+    /// the v1 Apply wire bytes still carry that single mutation unchanged.
+    #[test]
+    fn new_multi_single_entry_is_degenerate_single_key() {
+        use crate::accord::wire::ApplyPayload;
+        use ferrosa_common::accord::HybridLogicalClock;
+
+        let (node_id, self_uuid, peers) = single_node_peers();
+        let clock = HybridLogicalClock::new(node_id, 0);
+        let key = b"pk-bytes".to_vec();
+        let mutation = b"ENCODED-MUTATION".to_vec();
+
+        let via_new = AccordCoordinatorDriver::new(
+            node_id,
+            vec![self_uuid],
+            peers.clone(),
+            true,
+            &clock,
+            key.clone(),
+            mutation.clone(),
+        );
+        let via_multi = AccordCoordinatorDriver::new_multi(
+            node_id,
+            vec![self_uuid],
+            peers,
+            true,
+            &clock,
+            vec![(key.clone(), mutation.clone())],
+        );
+
+        for driver in [&via_new, &via_multi] {
+            let v2 = driver.apply_v2_payload();
+            assert_eq!(
+                v2.writes.len(),
+                1,
+                "single-key txn has a one-entry write-set"
+            );
+            assert_eq!(v2.writes[0].key, key);
+            assert_eq!(v2.writes[0].mutation, mutation);
+
+            // v1 Apply wire bytes are byte-identical in shape: result_data == mutation.
+            let bytes = driver
+                .apply_payload_bytes()
+                .expect("apply payload serializes");
+            let decoded: ApplyPayload =
+                bincode::deserialize(&bytes).expect("apply payload round-trips");
+            assert_eq!(decoded.result_data, mutation);
+        }
+    }
+
+    /// A genuine multi-key transaction must FAIL LOUD until multi-key execution
+    /// is wired (Phase 2 fan-out + Phase 3 apply keying) — never silently drop
+    /// writes. No write reaches the local applier before the error.
+    #[tokio::test]
+    async fn multi_key_run_transaction_fails_loud_before_any_apply() {
+        use crate::accord::apply::NoopStorageApplier;
+        use ferrosa_common::accord::HybridLogicalClock;
+        use std::sync::Arc;
+
+        let (node_id, self_uuid, peers) = single_node_peers();
+        let clock = HybridLogicalClock::new(node_id, 0);
+        let applier = Arc::new(NoopStorageApplier::new());
+
+        let mut driver = AccordCoordinatorDriver::new_multi(
+            node_id,
+            vec![self_uuid],
+            peers,
+            true,
+            &clock,
+            vec![
+                (b"key-1".to_vec(), b"mutation-1".to_vec()),
+                (b"key-2".to_vec(), b"mutation-2".to_vec()),
+            ],
+        )
+        .with_local_applier(applier.clone());
+
+        let result = driver.run_transaction().await;
+        match result {
+            Err(AccordDriverError::MultiKeyNotYetExecutable { keys, replicas }) => {
+                assert_eq!(keys, 2, "error reports the write-set key count");
+                assert_eq!(replicas, 1, "error reports the participant count");
+            }
+            other => panic!("multi-key txn must fail loud, got {other:?}"),
+        }
+        assert_eq!(
+            applier.apply_count(),
+            0,
+            "fail-loud must precede any write — no partial multi-key apply"
         );
     }
 }

--- a/ferrosa-cluster/src/accord/wire.rs
+++ b/ferrosa-cluster/src/accord/wire.rs
@@ -55,6 +55,49 @@ pub(crate) struct RecoverPayload {
 }
 
 // ---------------------------------------------------------------------------
+// Multi-key (multi-partition) transactions — additive V2 wire family.
+//
+// bincode is NOT self-describing, so we cannot append fields to the shipped
+// single-key payloads above without breaking the wire format. Multi-key
+// transactions therefore travel on NEW message variants
+// (`AccordPreAcceptV2`/`AccordApplyV2`) carrying V2 payloads. The single-key
+// path keeps its exact bytes; a single-key transaction is the degenerate
+// `writes.len() == 1` case of the multi-key path. The intermediate
+// Accept/Commit phases carry only `txn_id`/`t`/`deps`, which are
+// key-independent, so they REUSE the v1 [`AcceptPayload`] / [`CommitPayload`]
+// rather than introducing redundant V2 twins.
+//
+// Only the types with a consumer in *this* phase are defined here:
+// [`WriteSetEntry`] + [`ApplyV2Payload`] back the single-node multi-key apply
+// path. `PreAcceptV2Payload` (the key-union PreAccept) lands with the Phase 2
+// multi-shard PreAccept fan-out that first constructs it; the wire code
+// `AccordPreAcceptV2` is reserved now (round-trip tested in `ferrosa-net`).
+// ---------------------------------------------------------------------------
+
+/// One write in a multi-key transaction's write-set: the raw partition-key
+/// bytes (used for Accord conflict ordering and replica/shard routing) paired
+/// with the encoded commit-log `Mutation` to apply for that key.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct WriteSetEntry {
+    /// Raw partition-key bytes for this write (conflict ordering + routing).
+    pub(crate) key: Vec<u8>,
+    /// Encoded self-describing commit-log `Mutation` to apply for this key.
+    pub(crate) mutation: Vec<u8>,
+}
+
+/// Apply request for a multi-key transaction.
+///
+/// Carries the full write-set; each replica applies the mutations for the keys
+/// it owns (in dependency order via the `DepWaitApplier`). The single-key
+/// [`ApplyPayload`] is the degenerate one-entry case.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ApplyV2Payload {
+    pub(crate) txn_id: TxnId,
+    /// All `(key, mutation)` writes for this transaction.
+    pub(crate) writes: Vec<WriteSetEntry>,
+}
+
+// ---------------------------------------------------------------------------
 // Replica → Coordinator
 // ---------------------------------------------------------------------------
 
@@ -236,6 +279,46 @@ mod tests {
                 keyspace: "ks".into(),
                 table: "t".into(),
             },
+        });
+    }
+
+    #[test]
+    fn multikey_v2_payloads_roundtrip_including_single_key_degenerate_case() {
+        let txn_id = txn(7, 1_000, 2, 11);
+
+        // Two-key write-set: distinct keys, distinct mutation bytes.
+        assert_bincode_roundtrip(&ApplyV2Payload {
+            txn_id,
+            writes: vec![
+                WriteSetEntry {
+                    key: b"key-alpha".to_vec(),
+                    mutation: b"mutation-for-alpha".to_vec(),
+                },
+                WriteSetEntry {
+                    key: b"key-beta\0bin".to_vec(),
+                    mutation: b"mutation-for-beta".to_vec(),
+                },
+            ],
+        });
+
+        // Degenerate single-key case: a one-entry V2 write-set round-trips and
+        // carries exactly the same key+mutation a single-key txn would.
+        let single = ApplyV2Payload {
+            txn_id,
+            writes: vec![WriteSetEntry {
+                key: b"only-key".to_vec(),
+                mutation: b"only-mutation".to_vec(),
+            }],
+        };
+        assert_bincode_roundtrip(&single);
+        assert_eq!(single.writes.len(), 1);
+        assert_eq!(single.writes[0].key, b"only-key");
+        assert_eq!(single.writes[0].mutation, b"only-mutation");
+
+        // Empty write-set (read-only / protocol-only) round-trips too.
+        assert_bincode_roundtrip(&ApplyV2Payload {
+            txn_id,
+            writes: vec![],
         });
     }
 

--- a/ferrosa-cluster/tests/accord_nemesis.rs
+++ b/ferrosa-cluster/tests/accord_nemesis.rs
@@ -331,6 +331,9 @@ enum BatchAtomicityResult {
     NetworkError,
     /// Codec error (should not happen).
     CodecError,
+    /// Multi-key execution not yet wired — must NOT occur for these single-key
+    /// batch LWTs; if it does it signals a bug (like `CodecError`).
+    MultiKeyNotYetExecutable,
 }
 
 impl BatchAtomicityResult {
@@ -342,13 +345,17 @@ impl BatchAtomicityResult {
             Err(AccordDriverError::ApplyQuorumUnavailable) => Self::ApplyQuorumUnavailable,
             Err(AccordDriverError::Network(_)) => Self::NetworkError,
             Err(AccordDriverError::Codec(_)) => Self::CodecError,
+            Err(AccordDriverError::MultiKeyNotYetExecutable { .. }) => {
+                Self::MultiKeyNotYetExecutable
+            }
         }
     }
 
     /// Whether this result is valid under nemesis (no partial visibility).
     fn is_atomically_valid(&self) -> bool {
-        // Codec errors indicate a bug, not nemesis-induced failure.
-        !matches!(self, Self::CodecError)
+        // Codec errors (and an unexpected multi-key path for these single-key
+        // batches) indicate a bug, not a nemesis-induced failure.
+        !matches!(self, Self::CodecError | Self::MultiKeyNotYetExecutable)
     }
 }
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1388,6 +1388,14 @@ async fn finish_lwt_via_accord(
         Err(AccordDriverError::Codec(msg)) => {
             Err(CqlError::ServerError(format!("Accord codec error: {msg}")))
         }
+        Err(AccordDriverError::MultiKeyNotYetExecutable { keys, replicas }) => {
+            // The single-key LWT path never builds a multi-key write-set, so this
+            // is unreachable here today; surface it loudly rather than silently if
+            // a future caller routes a multi-key transaction through this path.
+            Err(CqlError::ServerError(format!(
+                "Accord multi-key execution not yet wired ({keys} keys, {replicas} replicas)"
+            )))
+        }
     }
 }
 

--- a/ferrosa-net/README.md
+++ b/ferrosa-net/README.md
@@ -34,8 +34,10 @@ It is a near-leaf in the dependency graph: it depends only on `ferrosa-common`
   `LegacyPayload` until peers negotiate the Cap'n Proto format.
 - **Message model** (`message`) — the `Message` enum with hand-rolled
   length-prefixed encode/decode for lifecycle, Raft, mutation/read, repair,
-  streaming, pair-mode, batchlog, index (incl. full-text scatter-gather), Accord,
-  and bootstrap message types
+  streaming, pair-mode, batchlog, index (incl. full-text scatter-gather), Accord
+  (incl. the additive multi-key `AccordPreAcceptV2` `0x7B` / `AccordApplyV2` `0x7C`
+  codes — bincode is not self-describing, so multi-key transactions get new codes
+  rather than extending the single-key payloads), and bootstrap message types
   (`MsgType` discriminants `0x01`..=`0x83`). Optional trailing fields decode to
   `None` on pre-extension peers for backward compatibility.
 - **PSK-HMAC handshake** (`handshake`) — `initiate_handshake` /

--- a/ferrosa-net/src/accord_messages.rs
+++ b/ferrosa-net/src/accord_messages.rs
@@ -105,6 +105,41 @@ mod tests {
     }
 
     #[test]
+    fn accord_v2_multikey_message_roundtrip() {
+        // The additive multi-key V2 variants encode/decode through the codec and
+        // report the right MsgType, exactly like the single-key family.
+        let payload = Bytes::from_static(b"multikey-v2-opaque-payload");
+        let variants = [
+            (
+                MsgType::AccordPreAcceptV2,
+                Message::AccordPreAcceptV2(payload.clone()),
+            ),
+            (
+                MsgType::AccordApplyV2,
+                Message::AccordApplyV2(payload.clone()),
+            ),
+        ];
+        for (msg_type, msg) in variants {
+            assert_eq!(
+                msg.msg_type(),
+                msg_type,
+                "msg_type() mismatch for {msg_type:?}"
+            );
+            let mut buf = BytesMut::new();
+            msg.encode(&mut buf).expect("encode should succeed");
+            let decoded =
+                Message::decode(msg_type, &mut buf.freeze()).expect("decode should succeed");
+            assert_eq!(decoded, msg, "roundtrip mismatch for {msg_type:?}");
+        }
+        // V2 codes are distinct from each other and from the single-key Apply.
+        assert_ne!(
+            MsgType::AccordPreAcceptV2 as u8,
+            MsgType::AccordApplyV2 as u8
+        );
+        assert_ne!(MsgType::AccordApplyV2 as u8, MsgType::AccordApply as u8);
+    }
+
+    #[test]
     fn accord_message_type_codes_unique() {
         let accord_codes: Vec<u8> = vec![
             MsgType::AccordPreAccept as u8,

--- a/ferrosa-net/src/codec.rs
+++ b/ferrosa-net/src/codec.rs
@@ -159,6 +159,9 @@ pub enum MsgType {
     AccordApplyOK = 0x78,
     AccordRecover = 0x79,
     AccordRecoverOK = 0x7A,
+    // Multi-key Accord (additive V2 — see message.rs)
+    AccordPreAcceptV2 = 0x7B,
+    AccordApplyV2 = 0x7C,
     // Bootstrap coordination
     BootstrapComplete = 0x80,
     BootstrapCompleteAck = 0x81,
@@ -280,6 +283,8 @@ impl TryFrom<u8> for MsgType {
             0x78 => Ok(Self::AccordApplyOK),
             0x79 => Ok(Self::AccordRecover),
             0x7A => Ok(Self::AccordRecoverOK),
+            0x7B => Ok(Self::AccordPreAcceptV2),
+            0x7C => Ok(Self::AccordApplyV2),
             0x80 => Ok(Self::BootstrapComplete),
             0x81 => Ok(Self::BootstrapCompleteAck),
             0x82 => Ok(Self::ClusterMembershipForward),

--- a/ferrosa-net/src/message.rs
+++ b/ferrosa-net/src/message.rs
@@ -267,6 +267,12 @@ pub enum Message {
     AccordApplyOK(Bytes),
     AccordRecover(Bytes),
     AccordRecoverOK(Bytes),
+    // Multi-key (multi-partition) Accord — additive V2 variants carrying the
+    // multi-key PreAccept (key union) and Apply (write-set) payloads. The
+    // single-key variants above keep their exact bytes; the intermediate
+    // Accept/Commit/Read phases are key-agnostic and reuse the v1 variants.
+    AccordPreAcceptV2(Bytes),
+    AccordApplyV2(Bytes),
 
     // Bootstrap coordination
     /// Sent by a non-leader node to the leader after bootstrap streaming completes.
@@ -373,6 +379,8 @@ impl Message {
             Self::AccordApplyOK(_) => MsgType::AccordApplyOK,
             Self::AccordRecover(_) => MsgType::AccordRecover,
             Self::AccordRecoverOK(_) => MsgType::AccordRecoverOK,
+            Self::AccordPreAcceptV2(_) => MsgType::AccordPreAcceptV2,
+            Self::AccordApplyV2(_) => MsgType::AccordApplyV2,
             Self::BootstrapComplete { .. } => MsgType::BootstrapComplete,
             Self::BootstrapCompleteAck => MsgType::BootstrapCompleteAck,
             Self::ClusterMembershipForward(_) => MsgType::ClusterMembershipForward,
@@ -526,6 +534,8 @@ impl Message {
             | Self::AccordApplyOK(b)
             | Self::AccordRecover(b)
             | Self::AccordRecoverOK(b)
+            | Self::AccordPreAcceptV2(b)
+            | Self::AccordApplyV2(b)
             | Self::ClusterMembershipForward(b)
             | Self::ClusterMembershipForwardAck(b) => buf.put_slice(b),
             Self::BootstrapComplete { node_id } => buf.put_slice(node_id.as_bytes()),
@@ -752,6 +762,8 @@ impl Message {
             MsgType::AccordApplyOK => Self::AccordApplyOK(body.split_to(body.remaining())),
             MsgType::AccordRecover => Self::AccordRecover(body.split_to(body.remaining())),
             MsgType::AccordRecoverOK => Self::AccordRecoverOK(body.split_to(body.remaining())),
+            MsgType::AccordPreAcceptV2 => Self::AccordPreAcceptV2(body.split_to(body.remaining())),
+            MsgType::AccordApplyV2 => Self::AccordApplyV2(body.split_to(body.remaining())),
             MsgType::BootstrapComplete => {
                 let mut id_bytes = [0u8; 16];
                 if body.remaining() >= 16 {

--- a/ferrosa-net/src/protocol.rs
+++ b/ferrosa-net/src/protocol.rs
@@ -1592,7 +1592,9 @@ fn message_family_for_kind(kind: u16) -> MessageFamily {
             | MsgType::AccordApply
             | MsgType::AccordApplyOK
             | MsgType::AccordRecover
-            | MsgType::AccordRecoverOK,
+            | MsgType::AccordRecoverOK
+            | MsgType::AccordPreAcceptV2
+            | MsgType::AccordApplyV2,
         ) => MessageFamily::Accord,
         Ok(MsgType::BootstrapComplete | MsgType::BootstrapCompleteAck) => MessageFamily::Bootstrap,
         Ok(MsgType::ClusterMembershipForward | MsgType::ClusterMembershipForwardAck) => {


### PR DESCRIPTION
Phase 1 of multi-key (multi-partition) Accord transactions — the **additive
wire foundation**. Single-key LWT is byte-for-byte unchanged.

bincode is not self-describing, so multi-key transactions travel on NEW message
codes rather than extending the shipped single-key payloads.

### What lands
- **`ferrosa-cluster/accord/wire.rs`**: `WriteSetEntry { key, mutation }` +
  `ApplyV2Payload { txn_id, writes }`. (Only types with a consumer in this phase;
  `PreAcceptV2` arrives with the Phase 2 fan-out that first constructs it.)
- **`ferrosa-net`**: reserved `AccordPreAcceptV2` (`0x7B`) / `AccordApplyV2`
  (`0x7C`) message variants + `MsgType` codes + `MessageFamily::Accord`
  classification; codec round-trip tested.
- **`AccordCoordinatorDriver::new_multi(write_set)`** — the multi-key constructor
  the CQL/Postgres front-ends (Phases 5–6) will call; `new()` delegates to it as
  the one-entry degenerate case. The coordinator's own-replica Apply iterates the
  write-set via `apply_v2_payload()`.

### Fail-loud, not silently wrong
Multi-key *execution* is **deliberately gated** with
`AccordDriverError::MultiKeyNotYetExecutable`: a `(txn_id, t)`-idempotent applier
would no-op writes 2..N of one transaction, so correct multi-key apply needs the
participant-set/per-shard quorum (Phase 2) and the `(txn_id, key)` apply keying
(Phase 3). Until then a multi-key write-set fails loud rather than dropping
writes. The API + wire exist now so the front-ends can be built in parallel.

### Tests
- wire + net codec round-trips (incl. the single-key degenerate case).
- `new_multi` one-entry equivalence to `new` (same Apply bytes).
- multi-key `run_transaction` fails loud **before any apply** (no partial write).

### Verification
`cargo fmt --check`, `cargo clippy --all-targets`, `cargo doc -D warnings`, and
`cargo test -p ferrosa-cluster -p ferrosa-net -p ferrosa-cql` all clean.

Follow-ups tracked: bound the ApplyV2 write-set payload size (`t_9768f08b`).
Next phases: #33 participant set + per-shard quorum, #34 multi-key apply keying.