### PR TITLE
docs: refresh stable release info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,59 +140,6 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
-  # ── Container image (GHCR) ───────────────────────────────────────────
-  # Builds and pushes a runtime container image from the x86_64 musl static
-  # binary artifact so deployable images come from the release process, not
-  # hand-built. Independent of the `release` job — it must not block the
-  # GitHub release. Uses only already-pinned actions + shell `docker` so the
-  # actions-pin-guard stays green (no new action pins introduced).
-  build-image:
-    name: Build & push container image
-    needs: build-linux-x86_64
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Download x86_64 musl tarball
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        with:
-          name: tarball-x86_64-unknown-linux-musl
-          path: dist
-
-      - name: Extract binaries and write runtime Dockerfile
-        run: |
-          mkdir -p build
-          tar -xzf dist/*.tar.gz -C build/
-          cp deploy/fly-bench/ferrosa-entrypoint.sh build/ferrosa-entrypoint.sh
-          chmod 755 build/ferrosa build/ferrosa-ctl build/ferrosa-entrypoint.sh
-          cat > build/Dockerfile <<'DOCKERFILE'
-          FROM debian:trixie-slim
-          RUN apt-get update \
-              && apt-get install -y --no-install-recommends ca-certificates curl \
-              && rm -rf /var/lib/apt/lists/*
-          COPY ferrosa /usr/local/bin/ferrosa
-          COPY ferrosa-ctl /usr/local/bin/ferrosa-ctl
-          COPY ferrosa-entrypoint.sh /usr/local/bin/ferrosa-entrypoint.sh
-          EXPOSE 9042 7000 9090
-          ENV FERROSA_DATA_DIR=/var/lib/ferrosa
-          ENTRYPOINT ["ferrosa-entrypoint.sh"]
-          CMD ["ferrosa"]
-          DOCKERFILE
-
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Build and push image
-        run: |
-          OWNER="$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
-          IMAGE="ghcr.io/${OWNER}/ferrosa"
-          docker build -t "${IMAGE}:${GITHUB_REF_NAME}" -t "${IMAGE}:latest" build/
-          docker push "${IMAGE}:${GITHUB_REF_NAME}"
-          docker push "${IMAGE}:latest"
-
   # ── Linux aarch64 (musl static, cross-compiled) ──────────────────────
   build-linux-aarch64:
     name: Build Linux aarch64 (musl, cross)
@@ -325,8 +272,8 @@ jobs:
           arm_tar=$(find artifacts -name 'ferrosa-*-aarch64-unknown-linux-musl.tar.gz' | head -n1)
           test -n "$x86_tar" || { echo "ERROR: x86_64 tarball not found" >&2; exit 1; }
           test -n "$arm_tar" || { echo "ERROR: aarch64 tarball not found" >&2; exit 1; }
-          tar -xzf "$x86_tar" -C dist/amd64 ferrosa ferrosa-ctl
-          tar -xzf "$arm_tar" -C dist/arm64 ferrosa ferrosa-ctl
+          tar -xzf "$x86_tar" -C dist/amd64 ./ferrosa ./ferrosa-ctl
+          tar -xzf "$arm_tar" -C dist/arm64 ./ferrosa ./ferrosa-ctl
           chmod 0755 dist/amd64/ferrosa dist/amd64/ferrosa-ctl dist/arm64/ferrosa dist/arm64/ferrosa-ctl
           ls -l dist/amd64 dist/arm64
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Agents MUST verify that all CI checks will pass locally before pushing to a remo
 
 ## Releases
 
-See [specs/release-process.md](specs/release-process.md). Key rules:
+See [specs/reference/release-process.md](specs/reference/release-process.md). Key rules:
 
 - **Never hand-edit `[workspace.package] version` in `Cargo.toml` in a PR.** The nightly release automation owns it and derives the next SemVer from Conventional Commit history; a manual bump is ignored and overwritten.
 - Use **Conventional Commit** subjects (`feat:`, `fix:`, `feat!:`/`BREAKING CHANGE:`) — the auto-bump level is computed from them, and sloppy subjects silently degrade a release to a `patch`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,12 @@
 
 Public developer-preview documentation for Ferrosa Database and Ferrosa Memory. These pages describe install and getting-started flows; engineering plans and verification notes are tracked separately from the public site.
 
+Latest stable releases: Ferrosa Database `v0.16.0`; Ferrosa Memory `v0.22.0`.
+
 ## Products
 
-- [Ferrosa Database](database/) — developer-preview database docs, examples, CQL/Cypher/SPARQL notes, and migration guidance.
-- [Ferrosa Memory](ferrosa-memory/) — developer-preview long-context linked memory for agents, including 0.13 document/chunk retrieval, task-aware query decomposition, feedback-aware reranking, and Codex/Claude/Hermes hook onboarding.
+- [Ferrosa Database](database/) — developer-preview database docs, examples, CQL/Cypher/SPARQL notes, and migration guidance for the latest stable `v0.16.0` release.
+- [Ferrosa Memory](ferrosa-memory/) — developer-preview long-context linked memory for agents, including document/chunk retrieval, task-aware query decomposition, feedback-aware reranking, query-intent fusion, and Codex/Claude/Hermes hook onboarding for the latest stable `v0.22.0` release.
 - [Ferrosa Memory Getting Started](ferrosa-memory/getting-started.html) — run the local stack, connect MCP clients, and try memory examples.
 
 ## Database Docs

--- a/specs/reference/release-process.md
+++ b/specs/reference/release-process.md
@@ -29,6 +29,9 @@ consumes them.
 - **Releases are tag-only.** The version-bump commit lives on the tag, never on
   `main`. `main`'s `Cargo.toml` version is therefore decorative between
   releases; the released artifact always carries the correct version.
+- **Current promoted stable releases:** Ferrosa Database `v0.16.0`; Ferrosa
+  Memory `v0.22.0`. Use GitHub's latest-release endpoint as the source of truth
+  for installers and docs that need the current stable tag.
 
 ## Why tag-only (the bug this fixed)
 


### PR DESCRIPTION
## Summary
- Update public docs index with current stable releases: Ferrosa Database v0.16.0 and Ferrosa Memory v0.22.0.
- Fix the release-process link in CLAUDE.md.
- Align release docs with current promoted stable tags.
- Fix the release workflow's GHCR path by removing the redundant single-arch publisher and extracting the documented multi-arch tarball paths using the actual `./ferrosa` archive entries.

## Verification
- `bash .github/scripts/check-actions-pinned.sh`
- YAML parsed successfully for `.github/workflows/release.yml`.
- `git diff --check`
- Downloaded real `v0.16.0` Linux tarballs and verified `tar -xzf ... ./ferrosa ./ferrosa-ctl` extracts both amd64 and arm64 binaries successfully.

## Notes
- Latest releases already exist: ferrosadb/ferrosa `v0.16.0` and ferrosadb/ferrosa-memory `v0.22.0` are both stable/latest.
- The prior `v0.16.0` release workflow failure was isolated to the duplicate GHCR job; GitHub release asset creation succeeded.
