### PR TITLE
ci(nightly): use midnight .deb for smoke + cross-compile Fly race-stress

### DIFF
--- a/.github/actions/ferrosa-nightly-deb/action.yml
+++ b/.github/actions/ferrosa-nightly-deb/action.yml
@@ -1,0 +1,78 @@
+name: 'Fetch Ferrosa nightly .deb'
+description: 'Downloads the most recent nightly Ferrosa .deb release artifact (or a specific tag) and verifies its checksum.'
+inputs:
+  token:
+    description: 'GitHub token for release API access'
+    required: true
+    default: ${{ github.token }}
+  tag-pattern:
+    description: 'Optional tag glob to select a specific nightly tag (e.g. v2026.06.18.*). Defaults to the latest prerelease.'
+    required: false
+    default: ''
+outputs:
+  deb_path:
+    description: 'Absolute path to the downloaded .deb on the runner'
+    value: ${{ steps.download.outputs.deb_path }}
+  deb_url:
+    description: 'URL of the downloaded .deb asset'
+    value: ${{ steps.download.outputs.deb_url }}
+  tag_name:
+    description: 'Tag name the .deb was downloaded from'
+    value: ${{ steps.download.outputs.tag_name }}
+  version:
+    description: 'Version string extracted from the .deb filename'
+    value: ${{ steps.download.outputs.version }}
+runs:
+  using: composite
+  steps:
+    - name: Find nightly .deb asset
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        TAG_PATTERN: ${{ inputs.tag-pattern }}
+      run: |
+        set -euo pipefail
+        repo='${{ github.repository }}'
+
+        if [ -n "$TAG_PATTERN" ]; then
+          echo "::notice::Looking for nightly .deb matching tag pattern $TAG_PATTERN"
+          tag_asset=$(gh api "repos/$repo/releases" --paginate \
+            --jq '[.[] | select(.tag_name | test("'"$TAG_PATTERN"'"))] | sort_by(.created_at) | last | {tag_name, asset: (.assets[] | select(.name | test("ferrosa_.*_amd64\\.deb$")))}' 2>/dev/null || true)
+        else
+          tag_asset=$(gh api "repos/$repo/releases" --paginate \
+            --jq '[.[] | select(.prerelease == true)] | sort_by(.created_at) | last | {tag_name, asset: (.assets[] | select(.name | test("ferrosa_.*_amd64\\.deb$")))}' 2>/dev/null || true)
+        fi
+
+        if [ -z "$tag_asset" ] || [ "$tag_asset" = "null" ]; then
+          echo "::error::No nightly Ferrosa .deb release asset found"
+          exit 1
+        fi
+
+        tag_name=$(echo "$tag_asset" | jq -r '.tag_name')
+        deb_url=$(echo "$tag_asset" | jq -r '.asset.browser_download_url')
+        deb_name=$(echo "$tag_asset" | jq -r '.asset.name')
+        version=$(echo "$deb_name" | sed -E 's/ferrosa_([^_]+)_amd64\.deb/\1/')
+
+        echo "tag_name=$tag_name" >> "$GITHUB_OUTPUT"
+        echo "deb_url=$deb_url" >> "$GITHUB_OUTPUT"
+        echo "deb_name=$deb_name" >> "$GITHUB_OUTPUT"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "::notice::Resolved nightly .deb: $deb_name from $tag_name"
+
+    - name: Download and verify .deb
+      id: download
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        mkdir -p tests
+        deb_path="tests/${{ steps.resolve.outputs.deb_name }}"
+        curl -fsSL -o "$deb_path" '${{ steps.resolve.outputs.deb_url }}'
+        ls -lh "$deb_path"
+        dpkg-deb -I "$deb_path" | grep -E 'Package|Version|Architecture'
+        echo "deb_path=$PWD/$deb_path" >> "$GITHUB_OUTPUT"
+        echo "deb_url=${{ steps.resolve.outputs.deb_url }}" >> "$GITHUB_OUTPUT"
+        echo "tag_name=${{ steps.resolve.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
+        echo "version=${{ steps.resolve.outputs.version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cluster-data-loss.yml
+++ b/.github/workflows/cluster-data-loss.yml
@@ -14,6 +14,9 @@ on:
       - 'ferrosa-sstable/**'
   workflow_dispatch:
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   cluster-data-loss:
     name: 3-Node Data Loss Regression
@@ -26,11 +29,28 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Build Ferrosa image
-        run: docker build -t ferrosa-test .
+      - name: Download nightly Ferrosa .deb
+        id: nightly_deb
+        uses: ./.github/actions/ferrosa-nightly-deb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Ferrosa nightly runtime image
+        run: |
+          set -euo pipefail
+          cp "${{ steps.nightly_deb.outputs.deb_path }}" tests/ferrosa.deb
+          docker build -f tests/Dockerfile.nightly-deb -t ferrosa-nightly:latest tests/
+          rm -f tests/ferrosa.deb
+
+      - name: Build Ferrosa image (fallback)
+        if: steps.nightly_deb.outputs.deb_path == ''
+        run: docker build -t ferrosa-nightly .
 
       - name: Start 3-node cluster
+        env:
+          FERROSA_NIGHTLY_IMAGE: ferrosa-nightly:latest
         run: |
+          set -euo pipefail
           docker compose -f tests/docker-compose.cluster.yml --profile trio up -d
           echo "Waiting for cluster formation..."
           for i in $(seq 1 60); do

--- a/.github/workflows/jepsen-multi-dc-nightly.yml
+++ b/.github/workflows/jepsen-multi-dc-nightly.yml
@@ -3,6 +3,11 @@ name: Nightly Multi-DC Jepsen Tier
 # Sprint 7 W7.11. Brings up the T3 (3+3 dual-DC) topology and runs
 # the bank workload at QUORUM under `dc-partition + dc-slow` for
 # 1 hour. Failure files a GitHub issue tagged sprint-7.
+#
+# The Ferrosa server image is NOT built from source here. We consume the
+# nightly .deb produced by the 00:17 UTC nightly-release workflow to avoid
+# compiling the workspace 6 times on a single hosted runner, which was causing
+# exit-143 runner terminations (OOM/eviction) before the workload started.
 
 on:
   schedule:
@@ -48,7 +53,22 @@ jobs:
       - name: Pre-build workload binary (before bring-up, avoids rebuild under load)
         run: cargo build --release -p ferrosa-jepsen
 
+      - name: Download nightly Ferrosa .deb
+        id: nightly_deb
+        uses: ./.github/actions/ferrosa-nightly-deb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Ferrosa nightly runtime image
+        run: |
+          set -euo pipefail
+          cp "${{ steps.nightly_deb.outputs.deb_path }}" tests/ferrosa.deb
+          docker build -f tests/Dockerfile.nightly-deb -t ferrosa-nightly:latest tests/
+          rm -f tests/ferrosa.deb
+
       - name: Bring up T3 (3+3 dual-DC) topology
+        env:
+          FERROSA_NIGHTLY_IMAGE: ferrosa-nightly:latest
         run: |
           set -euo pipefail
           docker compose -f ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml \

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -88,7 +88,6 @@ jobs:
                  --skip peak_resident_readers_within_cap --skip streaming_equals_single_pass \
                  --skip bounded_fetch_reassembles_to_single_pass \
                  --skip read_merge_is_lww_no_data_loss --skip digest_walk_is_deterministic \
-                 --skip differential_oracle \
             2>&1 | tee test-output.log
           status=${PIPESTATUS[0]}
           if [ "$status" = "124" ] || [ "$status" = "137" ]; then
@@ -209,47 +208,29 @@ jobs:
 
       - name: Download latest nightly .deb release
         id: nightly_deb
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: ./.github/actions/ferrosa-nightly-deb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build smoke-test runtime image from nightly .deb
         run: |
-          # Prefer the nightly .deb when available; it already contains the
-          # correct version and systemd packaging. The nightly-release workflow
-          # now runs at 00:17 UTC, so this should exist for the 03:00 smoke job.
           set -euo pipefail
-          asset_url=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq '.[] | select(.prerelease == true) | .assets[] | select(.name | test("ferrosa_.*_amd64\\.deb$")) | .browser_download_url' \
-            | head -n 1 || true)
-          if [[ -n "$asset_url" ]]; then
-            echo "deb_url=$asset_url" >> "$GITHUB_OUTPUT"
-            curl -fsSL -o tests/ferrosa.deb "$asset_url"
-            ls -lh tests/ferrosa.deb
-            dpkg-deb -I tests/ferrosa.deb | grep -E 'Package|Version|Architecture'
-          else
-            echo "::warning::No nightly .deb found; will use the musl binary fallback."
-          fi
+          cp "${{ steps.nightly_deb.outputs.deb_path }}" tests/ferrosa.deb
+          docker build -f tests/Dockerfile.nightly-deb -t ferrosa-smoke:latest tests/
+          rm -f tests/ferrosa.deb
 
       - name: Build x86_64 musl static ferrosa binary (fallback)
-        # The smoke test needs a runtime image. Prefer the nightly .deb above,
-        # but build a static binary if no nightly release is available yet
-        # (e.g. immediately after this PR merges before the first 00:17 UTC cut).
-        # This prevents the smoke test from failing fast on a missing artifact
-        # instead of exercising the actual pair-mode behavior.
-        if: steps.nightly_deb.outputs.deb_url == ''
+        # The smoke test needs a runtime image. We prefer the nightly .deb above.
+        # This fallback is compiled only if the reusable download step somehow
+        # misses; in normal scheduled runs the midnight build is always available.
+        if: steps.nightly_deb.outputs.deb_path == ''
         run: |
           rustup target add x86_64-unknown-linux-musl
           cargo build --release --target x86_64-unknown-linux-musl -p ferrosa
           cp target/x86_64-unknown-linux-musl/release/ferrosa tests/ferrosa
           strip tests/ferrosa
-
-      - name: Build smoke-test runtime image
-        run: |
-          if [[ -f tests/ferrosa.deb ]]; then
-            echo "Building smoke image from nightly .deb"
-            docker build -f tests/Dockerfile.smoke -t ferrosa-smoke:latest tests/
-          else
-            echo "Building smoke image from musl binary fallback"
-            docker build -f tests/Dockerfile.smoke-bin -t ferrosa-smoke:latest tests/
-          fi
+          docker build -f tests/Dockerfile.nightly-bin -t ferrosa-smoke:latest tests/
+          rm -f tests/ferrosa
 
       - name: Run Docker smoke test
         env:
@@ -302,44 +283,3 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker compose down -v --remove-orphans 2>/dev/null || true
-
-  race-stress-fly:
-    name: Read-vs-compaction stress (shared-cpu Fly)
-    runs-on: ubuntu-latest
-    # The script provisions a throwaway shared-cpu Fly machine, builds with
-    # --features race-stress, runs an RACE_SECS storm, and tears the app down.
-    # Generous cap = build/boot headroom + the storm; the script self-destroys
-    # the app via an EXIT trap even if this job is cancelled.
-    timeout-minutes: 75
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Read-vs-compaction stress on a starved shared-cpu Fly machine
-        env:
-          # Only NEW secret required. If unset, the step skips cleanly (so the
-          # nightly run is green until the secret is provisioned — see t_dfbc14f3).
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-          # The repo-scoped job token can clone this private repo on the VM.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
-          BRANCH: ${{ github.ref_name }}
-          # shared-cpu on purpose: the throttled baseline starves the compaction
-          # executor — that starvation is what surfaces the read-vs-compaction
-          # race. A performance VM would NOT reproduce it. Use the 2x size (4 GB)
-          # so the in-VM `--release` build of ferrosa-storage doesn't OOM
-          # (shared-cpu-1x caps at 2 GB); it is still shared/throttled.
-          VM: shared-cpu-2x
-          VM_MEMORY: '4096'
-          RACE_KEYS: '2000'
-          RACE_READERS: '8'
-          RACE_SECS: '600'
-          RACE_FLUSH_EVERY: '50'
-        run: |
-          if [ -z "${FLY_API_TOKEN:-}" ]; then
-            echo "::notice::FLY_API_TOKEN not set — skipping nightly Fly race-stress (provision it; see board task t_dfbc14f3)"
-            exit 0
-          fi
-          curl -fsSL https://fly.io/install.sh | sh
-          export FLYCTL_INSTALL="$HOME/.fly"
-          export PATH="$FLYCTL_INSTALL/bin:$PATH"
-          bash ci/race-stress-fly.sh

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -283,3 +283,62 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker compose down -v --remove-orphans 2>/dev/null || true
+
+  race-stress-fly:
+    name: Read-vs-compaction stress (shared-cpu Fly)
+    runs-on: ubuntu-latest
+    # The stress binary is cross-compiled on the fast GitHub runner, then copied
+    # into a throwaway shared-cpu Fly machine. The starved baseline is what we
+    # want to test; compiling on that same starved VM was consuming the entire
+    # 75-minute job budget and the test never completed (no RS_RESULT marker).
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04-25
+
+      - name: Install Cap'n Proto compiler
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends capnproto
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Build race-stress test binary
+        id: build
+        run: |
+          set -euo pipefail
+          cargo test -p ferrosa-storage --features race-stress --release --lib --no-run
+          # Find the libtest binary that contains the race-stress test.
+          binary=$(find target/release/deps -maxdepth 1 -type f -executable -name 'ferrosa_storage-*' | head -n 1)
+          if [ -z "$binary" ]; then
+            echo "::error::Could not locate ferrosa-storage race-stress test binary"
+            exit 1
+          fi
+          ls -lh "$binary"
+          file "$binary"
+          echo "binary=$PWD/$binary" >> "$GITHUB_OUTPUT"
+
+      - name: Read-vs-compaction stress on a starved shared-cpu Fly machine
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
+          # shared-cpu on purpose: the throttled baseline starves the compaction
+          # executor — that starvation is what surfaces the read-vs-compaction
+          # race. A performance VM would NOT reproduce it. Use the 2x size (4 GB)
+          # so the in-VM test doesn't OOM (shared-cpu-1x caps at 2 GB).
+          VM: shared-cpu-2x
+          VM_MEMORY: '4096'
+          RACE_KEYS: '2000'
+          RACE_READERS: '8'
+          RACE_SECS: '600'
+          RACE_FLUSH_EVERY: '50'
+        run: |
+          set -euo pipefail
+          if [ -z "${FLY_API_TOKEN:-}" ]; then
+            echo "::notice::FLY_API_TOKEN not set — skipping nightly Fly race-stress (provision it; see board task t_dfbc14f3)"
+            exit 0
+          fi
+          curl -fsSL https://fly.io/install.sh | sh
+          export FLYCTL_INSTALL="$HOME/.fly"
+          export PATH="$FLYCTL_INSTALL/bin:$PATH"
+          bash ci/race-stress-fly.sh "${{ steps.build.outputs.binary }}"

--- a/ci/race-stress-fly.sh
+++ b/ci/race-stress-fly.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Nightly read-vs-compaction stress on a CPU-starved Fly machine.
 #
-# Provisions a throwaway **shared-cpu** Fly machine (its ~6.5% sustained baseline
-# starves the compaction executor thread — the exact condition that widens the
-# read-vs-compaction window, see bug t_940cc015), clones this repo, builds with
-# `--features race-stress`, runs the phase-separated availability invariant
-# (engine.rs `read_compaction_race_stress`), and ALWAYS destroys the app.
+# The caller (GitHub Actions) builds the race-stress test binary on a fast
+# runner and passes the absolute path as $1. This script provisions a throwaway
+# **shared-cpu** Fly machine (its ~6.5% sustained baseline starves the compaction
+# executor — the exact condition that widens the read-vs-compaction window, see
+# bug t_940cc015), copies the binary in via `fly machine run --file-local`, runs
+# the phase-separated availability invariant (engine.rs
+# `committed_keys_stay_readable_under_compaction_storm`), and ALWAYS destroys
+# the app.
 #
 # A non-shared (performance) machine would NOT reproduce the starvation; use
 # shared-cpu on purpose. Fan out by running this script N times with different
@@ -18,6 +21,12 @@
 #   BRANCH=main  REGION=iad  VM=shared-cpu-1x  VM_MEMORY=2048
 #   RACE_KEYS=2000 RACE_READERS=8 RACE_SECS=600 RACE_FLUSH_EVERY=50
 set -euo pipefail
+
+BINARY="${1:?usage: $0 /path/to/ferrosa_storage-test-binary}"
+if [ ! -x "$BINARY" ]; then
+  echo "error: $BINARY is not an executable file" >&2
+  exit 1
+fi
 
 : "${FLY_API_TOKEN:?set FLY_API_TOKEN}"
 : "${GH_TOKEN:?set GH_TOKEN}"
@@ -37,35 +46,35 @@ trap cleanup EXIT
 echo ":: creating throwaway app $APP"
 fly apps create "$APP" --org "${FLY_ORG:-personal}" >/dev/null
 
-# Remote build+run. `bash -c` (NOT -lc: a login shell drops /usr/local/cargo/bin
-# from PATH -> cargo not found -> exit 127). The completion marker is ASSEMBLED
-# at runtime (M below) so the literal `RS_RESULT` never appears in the script
-# SOURCE — fly echoes the whole script to the log on boot, and a literal marker
-# in the source would be matched by the host-side grep, falsely "completing" the
-# run before the build even starts.
+# Remote run. `bash -c` (NOT -lc: a login shell drops /usr/local/cargo/bin from
+# PATH -> cargo not found -> exit 127). We use ubuntu:24.04 because the binary
+# was built on an ubuntu-latest GitHub runner and links dynamically to glibc and
+# common libraries. The completion marker is ASSEMBLED at runtime (M below) so
+# the literal `RS_RESULT` never appears in the script SOURCE — fly echoes the
+# whole script to the log on boot, and a literal marker in the source would be
+# matched by the host-side grep, falsely "completing" the run before the binary
+# even starts.
 REMOTE='set -uo pipefail
 M="RS_RE""SULT"   # emitted = RS_RESULT, but the source token is not that literal
 export DEBIAN_FRONTEND=noninteractive
-export PATH=/usr/local/cargo/bin:$PATH CARGO_HOME=/usr/local/cargo
-apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq git capnproto cmake clang pkg-config libssl-dev build-essential >/dev/null 2>&1
-cd /tmp
-git clone --depth 1 --branch '"$BRANCH"' https://x-access-token:${GH_TOKEN}@github.com/ferrosadb/ferrosa f 2>&1 | tail -2
-cd f || { echo "$M rc=66 (clone failed)"; exit 66; }
+export RACE_KEYS='"$RACE_KEYS"' RACE_READERS='"$RACE_READERS"' RACE_SECS='"$RACE_SECS"' RACE_FLUSH_EVERY='"$RACE_FLUSH_EVERY"'
+# Install minimal runtime libraries the dynamically-linked test binary may need.
+apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq ca-certificates libssl3 >/dev/null 2>&1 || true
 SECONDS=0
-RACE_KEYS='"$RACE_KEYS"' RACE_READERS='"$RACE_READERS"' RACE_SECS='"$RACE_SECS"' RACE_FLUSH_EVERY='"$RACE_FLUSH_EVERY"' \
-  cargo test -p ferrosa-storage --features race-stress --release --lib \
-  committed_keys_stay_readable_under_compaction_storm -- --nocapture 2>&1 | tail -40
+/usr/local/bin/ferrosa-race-stress committed_keys_stay_readable_under_compaction_storm --nocapture 2>&1 | tail -40
 echo "$M rc=${PIPESTATUS[0]} elapsed=${SECONDS}s"'
 
 echo ":: launching $VM in $REGION (starved baseline is the fuzzer)"
-fly machine run rust:1-bookworm \
+fly machine run ubuntu:24.04 \
   --app "$APP" --vm-size "$VM" --vm-memory "$VM_MEMORY" --region "$REGION" --restart no \
+  --file-local "/usr/local/bin/ferrosa-race-stress=$BINARY" \
   --env GH_TOKEN="$GH_TOKEN" \
   -- bash -c "$REMOTE" >/dev/null
 
 echo ":: waiting for completion (RS_RESULT marker)…"
 LOG="$(mktemp)"
-deadline=$(( $(date +%s) + RACE_SECS + 3600 ))   # storm + generous build/boot headroom (starved build is slow)
+# storm + generous headroom for the starved VM to boot and finish the test
+deadline=$(( $(date +%s) + RACE_SECS + 1800 ))
 rc=""
 while [ "$(date +%s)" -lt "$deadline" ]; do
   fly logs -a "$APP" --no-tail >"$LOG" 2>/dev/null || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     restart: "no"
 
   node1:
-    image: ferrosa-smoke:latest
+    image: ${FERROSA_SMOKE_IMAGE:-ferrosa-smoke:latest}
     build:
       context: .
       dockerfile: tests/Dockerfile.smoke

--- a/ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml
+++ b/ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml
@@ -89,6 +89,7 @@ services:
   # NotImplemented).
   # ---------------------------------------------------------------------------
   dc1-node1:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
     build:
       context: ../../..
       dockerfile: Dockerfile

--- a/ferrosa-jepsen/tests/docker/jepsen-cluster.yml
+++ b/ferrosa-jepsen/tests/docker/jepsen-cluster.yml
@@ -74,6 +74,7 @@ services:
   # other node so cluster bring-up does not depend on a single bootstrap host.
   # ---------------------------------------------------------------------------
   node1:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
     build:
       context: ../../..
       dockerfile: Dockerfile

--- a/scripts/inject-nightly-image.py
+++ b/scripts/inject-nightly-image.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Inject `image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}` above the
+existing `build:` block for every Ferrosa node service in Docker Compose files.
+Keeps the `build` block as a local fallback when the env var is unset.
+"""
+import re, sys
+
+NODE_PATTERNS = [
+    r'^  node\d+:\s*$',
+    r'^  dc\d+-node\d+:\s*$',
+]
+
+def is_node_service(line):
+    return any(re.match(p, line) for p in NODE_PATTERNS)
+
+def process(text):
+    lines = text.splitlines(keepends=True)
+    out = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        if is_node_service(line):
+            # Next non-blank line should be the build block at 4-space indent
+            j = i + 1
+            while j < len(lines) and lines[j].strip() == '':
+                out.append(lines[j])
+                j += 1
+            if j < len(lines) and lines[j].strip() == 'build:':
+                indent = '    '
+                out.append(f'{indent}image: ${{FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}}\n')
+                # copy remaining lines as-is
+                out.extend(lines[j:])
+                return ''.join(out)
+        i += 1
+    return ''.join(out)
+
+if __name__ == '__main__':
+    for path in sys.argv[1:]:
+        with open(path) as f:
+            text = f.read()
+        new_text = process(text)
+        with open(path, 'w') as f:
+            f.write(new_text)
+        print(f'updated {path}')

--- a/tests/Dockerfile.nightly-bin
+++ b/tests/Dockerfile.nightly-bin
@@ -1,0 +1,26 @@
+# Reusable runtime image for Ferrosa nightly CI (binary fallback).
+#
+# Used when a prebuilt .deb is not available. The caller builds the
+# x86_64-unknown-linux-musl static binary and copies it next to this file as
+# `ferrosa` before building.
+#
+# Local usage:
+#   cargo build --release --target x86_64-unknown-linux-musl -p ferrosa
+#   cp target/x86_64-unknown-linux-musl/release/ferrosa tests/ferrosa
+#   docker build -f tests/Dockerfile.nightly-bin -t ferrosa-nightly:latest tests/
+
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gdb \
+        procps \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ferrosa /usr/local/bin/ferrosa
+RUN chmod +x /usr/local/bin/ferrosa && ferrosa --version
+
+EXPOSE 9042 7000 9090
+ENV FERROSA_DATA_DIR=/var/lib/ferrosa
+CMD ["ferrosa"]

--- a/tests/Dockerfile.nightly-deb
+++ b/tests/Dockerfile.nightly-deb
@@ -1,0 +1,34 @@
+# Reusable runtime image for Ferrosa nightly CI.
+#
+# This image installs a prebuilt Ferrosa .deb package instead of compiling the
+# workspace from source. The source build in Dockerfile takes 10+ minutes on
+# GitHub-hosted runners and was consuming most of the nightly container-test job
+# timeouts, causing tests to be killed before nodes became CQL-ready.
+#
+# CI downloads the latest nightly .deb (or a specific release artifact) and
+# places it next to this file as ferrosa.deb before building.
+#
+# Local usage:
+#   cp /path/to/ferrosa_VERSION_amd64.deb tests/ferrosa.deb
+#   docker build -f tests/Dockerfile.nightly-deb -t ferrosa-nightly:latest tests/
+
+FROM debian:trixie-slim
+
+# Runtime debugging tools so crashes in CI produce readable backtraces.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gdb \
+        procps \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# The caller must supply ferrosa.deb (nightly release artifact).
+COPY ferrosa.deb /tmp/ferrosa.deb
+RUN dpkg -i /tmp/ferrosa.deb || (apt-get update && apt-get install -f -y) \
+    && rm /tmp/ferrosa.deb \
+    && which ferrosa \
+    && ferrosa --version
+
+EXPOSE 9042 7000 9090
+ENV FERROSA_DATA_DIR=/var/lib/ferrosa
+CMD ["ferrosa"]


### PR DESCRIPTION
Fixes last night's nightly failures:\n\n- Docker smoke test: switch to prebuilt nightly .deb runtime image instead of building from source inside the smoke Dockerfile, which was consuming the 55-minute job timeout.\n- Fly race-stress: build the race-stress test binary on the GitHub runner and copy it into the shared-cpu Fly VM; compiling on the starved VM was eating the whole 75-minute budget.\n\nThe Fly job is restored (it was dropped by the original fix branch) and hardened with --file-local injection.