### PR TITLE
fix(install): bind /dev/tty for the admin-password prompt under curl|bash

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -242,9 +242,18 @@ do_password() {
     say "run later: $BIN_DIR/ferrosa-ctl auth set-password"
     return
   fi
+  # Under `curl … | bash` this script's stdin is the pipe, not a terminal, so
+  # ferrosa-ctl's masked prompt (rpassword reads stdin) can't disable echo —
+  # the password echoes in cleartext and the read never completes (hang). Bind
+  # the controlling terminal explicitly so the prompt + confirmation work.
+  if [ ! -r /dev/tty ]; then
+    say "no controlling terminal — skipping interactive password setup"
+    say "run later from a terminal: $BIN_DIR/ferrosa-ctl auth set-password --user ferrosa_admin"
+    return
+  fi
   say "set ferrosa_admin password (current default: ferrosa_admin)"
   # Exact flag shape pinned to the auth set-password CLI from PR (Task #8 re-brief)
-  "$BIN_DIR/ferrosa-ctl" auth set-password --user ferrosa_admin
+  "$BIN_DIR/ferrosa-ctl" auth set-password --user ferrosa_admin < /dev/tty
 }
 
 # Password is a first-install concern. On upgrade we never re-prompt (the

--- a/docs/setup.sh
+++ b/docs/setup.sh
@@ -166,8 +166,17 @@ do_password() {
     say "run later: $BIN_DIR/ferrosa-ctl auth set-password"
     return
   fi
+  # Under `curl … | bash` this script's stdin is the pipe, not a terminal, so
+  # ferrosa-ctl's masked prompt (rpassword reads stdin) can't disable echo —
+  # the password echoes in cleartext and the read never completes (hang). Bind
+  # the controlling terminal explicitly so the prompt + confirmation work.
+  if [ ! -r /dev/tty ]; then
+    say "no controlling terminal — skipping interactive password setup"
+    say "run later from a terminal: $BIN_DIR/ferrosa-ctl auth set-password --user ferrosa_admin"
+    return
+  fi
   say "set ferrosa_admin password (current default: ferrosa_admin)"
-  "$BIN_DIR/ferrosa-ctl" auth set-password --user ferrosa_admin
+  "$BIN_DIR/ferrosa-ctl" auth set-password --user ferrosa_admin < /dev/tty
 }
 
 case "$WANT_PASSWORD" in


### PR DESCRIPTION
## Bug (reported)
During `curl … | bash` install, the ferrosa_admin password step: **no prompt label, typed password echoed in cleartext, no confirmation, hung until ^C.**

## Root cause
The installer ran `ferrosa-ctl auth set-password` with the script's **stdin = the curl pipe**, not a terminal. `rpassword` 7.x reads the password from **stdin** and can only disable echo when stdin is a tty — on a pipe it can't mask, and the read blocks. The masked / double-prompt / validate logic in `ferrosa-ctl` is correct and already ships in v0.15.0; it just never received a terminal.

## Fix
Feed `< /dev/tty` to the `set-password` subprocess in both `do_password()` paths (`install.sh` + `setup.sh`), with a **fail-loud guard**: when no controlling terminal exists, skip with run-later instructions instead of hanging.

```bash
if [ ! -r /dev/tty ]; then
  say "no controlling terminal — skipping interactive password setup"
  say "run later from a terminal: $BIN_DIR/ferrosa-ctl auth set-password --user ferrosa_admin"
  return
fi
"$BIN_DIR/ferrosa-ctl" auth set-password --user ferrosa_admin < /dev/tty
```

`bash -n` + `shellcheck -S warning` clean.

Follow-up (separate): harden `ferrosa-ctl auth set-password` itself to read `/dev/tty` directly and fail loud (not hang) when run with non-tty stdin.