### PR TITLE
fix(install): stop daemon panicking on first start + honor [storage].data_dir (#172)

### DIFF
--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -8442,6 +8442,36 @@ mod tests {
     use ferrosa_sstable::statistics::{CompactionMetadata, StatsMetadata};
     use ferrosa_sstable::types::{DeletionTime, LivenessInfo};
 
+    /// Regression (issue #172): a fresh install passes its data dir via
+    /// `[storage].data_dir` in the TOML, which `main` resolves and exports as
+    /// `FERROSA_DATA_DIR` before building the engine config. `from_env` must
+    /// honor that env for the data dir AND every path derived from it (the
+    /// commit log, here) — otherwise the engine writes under the unwritable
+    /// `/var/lib/ferrosa` default and a non-root install (e.g. macOS
+    /// `~/.ferrosa/data`) fails to create its data dir.
+    #[test]
+    #[serial_test::serial(ferrosa_data_dir_env)]
+    fn from_env_routes_paths_through_data_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let prev = std::env::var("FERROSA_DATA_DIR").ok();
+        std::env::set_var("FERROSA_DATA_DIR", dir.path());
+        let cfg = StorageEngineConfig::from_env().expect("from_env");
+        match prev {
+            Some(v) => std::env::set_var("FERROSA_DATA_DIR", v),
+            None => std::env::remove_var("FERROSA_DATA_DIR"),
+        }
+        assert_eq!(
+            cfg.data_dir,
+            dir.path(),
+            "data_dir must honor FERROSA_DATA_DIR"
+        );
+        assert!(
+            cfg.commit_log.log_dir.starts_with(dir.path()),
+            "commit-log dir must be derived from the configured data_dir, got {:?}",
+            cfg.commit_log.log_dir
+        );
+    }
+
     /// Return "docker" or "podman" — whichever container runtime is in PATH.
     /// Panics if neither is found.
     #[cfg(feature = "live-infra-tests")]

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -628,6 +628,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(&data_dir)?;
     let host_id = load_or_generate_host_id(Path::new(&data_dir));
 
+    // Pin the data dir the storage engine will use to the one we just resolved
+    // from env / `[storage].data_dir` TOML / default (issue #172). Without this,
+    // `StorageEngineConfig::from_env()` below independently re-defaults `data_dir`
+    // to `/var/lib/ferrosa` and derives the commit-log + compaction paths from
+    // it, IGNORING `[storage].data_dir` in the config file. On a non-root install
+    // (e.g. macOS `~/.ferrosa/data`) that default is not writable, so the engine
+    // failed to create it — and before the upload-runtime fix that error unwound
+    // through `main` and surfaced as the tokio "drop a runtime" panic instead of
+    // a clear message. Setting the env the builder reads keeps every derived path
+    // consistent with the host_id/data dir created just above. (Edition 2021:
+    // `set_var` is safe; this runs at the very start of `main`, before anything
+    // else reads `FERROSA_DATA_DIR`.)
+    std::env::set_var("FERROSA_DATA_DIR", &data_dir);
+
     // 3. Create StorageEngine — use open() on restart to replay commit log
     let mut storage_config = ferrosa_storage::StorageEngineConfig::from_env()?;
     // Allow TOML to override the memtable shard count. `from_env`
@@ -667,15 +681,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|threads| *threads > 0)
         .unwrap_or(4);
-    let _storage_upload_runtime = Arc::new(
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(storage_upload_threads)
-            .thread_name("storage-upload-rt")
-            .enable_all()
-            .build()
-            .expect("storage upload runtime"),
-    );
-    let storage_upload_handle = _storage_upload_runtime.handle().clone();
+    // Dedicated multi-thread runtime for S3 uploads, isolated from the main
+    // serving runtime. It must outlive the whole process. Critically, it must
+    // NEVER be dropped from within this `#[tokio::main]` async context: dropping
+    // a tokio `Runtime` inside an async context panics ("Cannot drop a runtime
+    // in a context where blocking is not allowed"). Held as a plain local (as it
+    // was, via `Arc`), it dropped at the end of `main` — and on any early
+    // error-unwind path — firing that panic *before any listener bound* and
+    // masking the real error (issue #172). We instead leak it for the process
+    // lifetime; the OS reclaims it at exit. Only a `Handle` is handed out, which
+    // does not keep the runtime alive on its own, so the leak is what guarantees
+    // the upload runtime stays up for as long as the engine needs it.
+    let storage_upload_runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(storage_upload_threads)
+        .thread_name("storage-upload-rt")
+        .enable_all()
+        .build()
+        .expect("storage upload runtime");
+    let storage_upload_handle = storage_upload_runtime.handle().clone();
+    std::mem::forget(storage_upload_runtime);
     let has_commitlog_segments = storage_config.commit_log.log_dir.exists()
         && std::fs::read_dir(&storage_config.commit_log.log_dir)
             .map(|entries| {


### PR DESCRIPTION
Fixes #172 — the prebuilt daemon panics on first start on a fresh script install
(macOS arm64 and Linux), exit 101, **before binding any listener**:

> `thread 'main' panicked at tokio-1.52.2/.../blocking/shutdown.rs:51:21:`
> `Cannot drop a runtime in a context where blocking is not allowed.`

## Root cause — two bugs, the first masking the second

**1. A tokio `Runtime` dropped inside the async context.** `main` is a
`#[tokio::main]` async fn that creates a *second* multi-thread runtime for S3
uploads, held as a local `Arc<Runtime>`. On any early error-unwind — and at
clean shutdown — that runtime drops from *within* the outer runtime's async
context, which tokio 1.52 panics on. Because it fired during unwind it also
**masked the real startup error**.

**2. `[storage].data_dir` from the config was ignored.** `main` resolves the
data dir from env/TOML/default and creates it (host_id lands there), but then
builds `StorageEngineConfig::from_env()`, which independently re-defaults
`data_dir` to `/var/lib/ferrosa` and derives the commit-log/compaction paths
from it. On a non-root install (`~/.ferrosa/data`) that default isn't writable,
so the engine failed to create it — the real error the panic was hiding.

## Fix
- Own the upload runtime and `std::mem::forget` it: it must live the whole
  process and is reclaimed at exit, and is **never dropped in an async context**
  on any path. Only a `Handle` is handed out.
- Pin `FERROSA_DATA_DIR` to the resolved data dir before `from_env()`, so every
  derived path (data dir, commit log, compaction) agrees with the configured /
  host_id dir.

## Verification
Built the binary and ran it with a config mirroring the installer's
`ferrosa.example.toml` (incl. the empty `[s3]` section). **Before:** panic at
`shutdown.rs:51`. **After:** clean startup — CQL + web + internode listeners
bind, and the data dir is created under the configured path
(`.../data/{commitlog,sstables,host_id,...}`). No panic.

Regression test: `from_env_routes_paths_through_data_dir` (guards that
`from_env` routes data dir + derived paths through `FERROSA_DATA_DIR`).
`cargo fmt --check`, `clippy --all-targets`, `doc -D warnings` clean.

## Separate follow-up (not in this hotfix)
The reporter's secondary finding is real and precisely located:
`[cql].auth_enabled = true` in the TOML is ignored — the engine reads
`auth_enabled` directly from the `FERROSA_AUTH_ENABLED` env (`engine.rs` ~489)
and never consults `config.auth_enabled`. This is a security-behavior change, so
it's tracked separately (auth-open security item) rather than bundled into an
install-crash hotfix.