### PR TITLE
fix(cql): report auth state from the resolved value, not the pre-TOML env (#172)

### DIFF
--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -8442,6 +8442,36 @@ mod tests {
     use ferrosa_sstable::statistics::{CompactionMetadata, StatsMetadata};
     use ferrosa_sstable::types::{DeletionTime, LivenessInfo};
 
+    /// Regression (issue #172): a fresh install passes its data dir via
+    /// `[storage].data_dir` in the TOML, which `main` resolves and exports as
+    /// `FERROSA_DATA_DIR` before building the engine config. `from_env` must
+    /// honor that env for the data dir AND every path derived from it (the
+    /// commit log, here) — otherwise the engine writes under the unwritable
+    /// `/var/lib/ferrosa` default and a non-root install (e.g. macOS
+    /// `~/.ferrosa/data`) fails to create its data dir.
+    #[test]
+    #[serial_test::serial(ferrosa_data_dir_env)]
+    fn from_env_routes_paths_through_data_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let prev = std::env::var("FERROSA_DATA_DIR").ok();
+        std::env::set_var("FERROSA_DATA_DIR", dir.path());
+        let cfg = StorageEngineConfig::from_env().expect("from_env");
+        match prev {
+            Some(v) => std::env::set_var("FERROSA_DATA_DIR", v),
+            None => std::env::remove_var("FERROSA_DATA_DIR"),
+        }
+        assert_eq!(
+            cfg.data_dir,
+            dir.path(),
+            "data_dir must honor FERROSA_DATA_DIR"
+        );
+        assert!(
+            cfg.commit_log.log_dir.starts_with(dir.path()),
+            "commit-log dir must be derived from the configured data_dir, got {:?}",
+            cfg.commit_log.log_dir
+        );
+    }
+
     /// Return "docker" or "podman" — whichever container runtime is in PATH.
     /// Panics if neither is found.
     #[cfg(feature = "live-infra-tests")]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -486,29 +486,17 @@ impl StorageEngineConfig {
         // itself out. When true, the CQL server requires SASL PLAIN
         // authentication and the router consults
         // `ferrosa_schema::check_permission`.
+        // `from_env` only sees the env var; the authoritative `auth_enabled`
+        // also honors `[cql].auth_enabled` in the TOML, which the binary applies
+        // to this config AFTER `from_env` returns. So the auth-state startup logs
+        // are emitted by the binary once the final value is known (via
+        // `log_cql_auth_state` + `log_auth_warn_state`) — NOT here, where they
+        // would report the pre-TOML env default and mislead operators into
+        // thinking `auth_enabled = true` in the config was ignored (issue #172).
         let auth_enabled = matches!(
             std::env::var("FERROSA_AUTH_ENABLED").ok().as_deref(),
             Some("true" | "1" | "on" | "yes")
         );
-        tracing::info!(
-            auth_enabled,
-            source = if std::env::var_os("FERROSA_AUTH_ENABLED").is_some() {
-                "FERROSA_AUTH_ENABLED env"
-            } else {
-                "default"
-            },
-            "storage-engine: CQL role auth is {} — {}",
-            if auth_enabled { "ENABLED" } else { "DISABLED" },
-            if auth_enabled {
-                "CQL STARTUP requires SASL PLAIN, router enforces permission \
-                 checks, web :9090 requires tokens on writes/admin"
-            } else {
-                "CQL accepts every STARTUP without credentials, router permits \
-                 everything — matches legacy behavior; set \
-                 FERROSA_AUTH_ENABLED=true to enforce"
-            }
-        );
-        log_auth_warn_state(auth_enabled, auth_warn);
 
         let write_verify = !matches!(
             std::env::var("FERROSA_WRITE_VERIFY").ok().as_deref(),
@@ -578,6 +566,30 @@ impl StorageEngineConfig {
             memtable_num_shards: 64,
         }
     }
+}
+
+/// Emit the startup log describing whether CQL role auth is enforced, and where
+/// the decision came from. Emitted by the binary AFTER it has resolved
+/// `auth_enabled` from env → `[cql].auth_enabled` TOML → default, so the line
+/// reflects the value actually in force (not the pre-TOML env default that
+/// `from_env` alone would see — issue #172). `source` is a human label like
+/// `"FERROSA_AUTH_ENABLED env"`, `"config file ([cql].auth_enabled)"`, or
+/// `"default"`.
+pub fn log_cql_auth_state(auth_enabled: bool, source: &str) {
+    tracing::info!(
+        auth_enabled,
+        source,
+        "storage-engine: CQL role auth is {} — {}",
+        if auth_enabled { "ENABLED" } else { "DISABLED" },
+        if auth_enabled {
+            "CQL STARTUP requires SASL PLAIN, router enforces permission \
+             checks, web :9090 requires tokens on writes/admin"
+        } else {
+            "CQL accepts every STARTUP without credentials, router permits \
+             everything — matches legacy behavior; set auth_enabled = true in \
+             [cql] (or FERROSA_AUTH_ENABLED=true) to enforce"
+        }
+    );
 }
 
 /// Emit the startup log line describing the current `(auth_enabled,

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -628,6 +628,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(&data_dir)?;
     let host_id = load_or_generate_host_id(Path::new(&data_dir));
 
+    // Pin the data dir the storage engine will use to the one we just resolved
+    // from env / `[storage].data_dir` TOML / default (issue #172). Without this,
+    // `StorageEngineConfig::from_env()` below independently re-defaults `data_dir`
+    // to `/var/lib/ferrosa` and derives the commit-log + compaction paths from
+    // it, IGNORING `[storage].data_dir` in the config file. On a non-root install
+    // (e.g. macOS `~/.ferrosa/data`) that default is not writable, so the engine
+    // failed to create it — and before the upload-runtime fix that error unwound
+    // through `main` and surfaced as the tokio "drop a runtime" panic instead of
+    // a clear message. Setting the env the builder reads keeps every derived path
+    // consistent with the host_id/data dir created just above. (Edition 2021:
+    // `set_var` is safe; this runs at the very start of `main`, before anything
+    // else reads `FERROSA_DATA_DIR`.)
+    std::env::set_var("FERROSA_DATA_DIR", &data_dir);
+
     // 3. Create StorageEngine — use open() on restart to replay commit log
     let mut storage_config = ferrosa_storage::StorageEngineConfig::from_env()?;
     // Allow TOML to override the memtable shard count. `from_env`
@@ -667,15 +681,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|threads| *threads > 0)
         .unwrap_or(4);
-    let _storage_upload_runtime = Arc::new(
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(storage_upload_threads)
-            .thread_name("storage-upload-rt")
-            .enable_all()
-            .build()
-            .expect("storage upload runtime"),
-    );
-    let storage_upload_handle = _storage_upload_runtime.handle().clone();
+    // Dedicated multi-thread runtime for S3 uploads, isolated from the main
+    // serving runtime. It must outlive the whole process. Critically, it must
+    // NEVER be dropped from within this `#[tokio::main]` async context: dropping
+    // a tokio `Runtime` inside an async context panics ("Cannot drop a runtime
+    // in a context where blocking is not allowed"). Held as a plain local (as it
+    // was, via `Arc`), it dropped at the end of `main` — and on any early
+    // error-unwind path — firing that panic *before any listener bound* and
+    // masking the real error (issue #172). We instead leak it for the process
+    // lifetime; the OS reclaims it at exit. Only a `Handle` is handed out, which
+    // does not keep the runtime alive on its own, so the leak is what guarantees
+    // the upload runtime stays up for as long as the engine needs it.
+    let storage_upload_runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(storage_upload_threads)
+        .thread_name("storage-upload-rt")
+        .enable_all()
+        .build()
+        .expect("storage upload runtime");
+    let storage_upload_handle = storage_upload_runtime.handle().clone();
+    std::mem::forget(storage_upload_runtime);
     let has_commitlog_segments = storage_config.commit_log.log_dir.exists()
         && std::fs::read_dir(&storage_config.commit_log.log_dir)
             .map(|entries| {

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -178,6 +178,20 @@ where
         .and_then(|v| v.as_bool())
 }
 
+/// Human label for where the effective `auth_enabled` value came from, for the
+/// startup log. Env wins, then `[cql].auth_enabled` in the config file, then the
+/// built-in default. (Issue #172: the log used to always say `"default"` even
+/// when the config file set it.)
+fn auth_source_label(env_set: bool, toml_has_auth_key: bool) -> &'static str {
+    if env_set {
+        "FERROSA_AUTH_ENABLED env"
+    } else if toml_has_auth_key {
+        "config file ([cql].auth_enabled)"
+    } else {
+        "default"
+    }
+}
+
 /// Load TOML configuration from disk. Returns an empty table if the file does not exist.
 fn load_config(path: &str) -> Result<toml::Value, Box<dyn std::error::Error>> {
     if std::path::Path::new(path).exists() {
@@ -676,6 +690,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // var is unset; see Sprint A of
     // specs/decisions/design-cql-role-auth-rollout.md.
     let storage_auth_enabled = storage_config.auth_enabled;
+
+    // Emit the auth-state startup logs now that the authoritative value is
+    // resolved (env → `[cql].auth_enabled` TOML → default). `from_env` no longer
+    // logs these: it only saw the env default and mislabeled a TOML
+    // `auth_enabled = true` as `source="default"`, making operators think the
+    // config was ignored (issue #172). Report the value actually in force, and
+    // where it came from.
+    let auth_source = auth_source_label(
+        std::env::var_os("FERROSA_AUTH_ENABLED").is_some(),
+        file_config
+            .get("cql")
+            .and_then(|c| c.get("auth_enabled"))
+            .is_some(),
+    );
+    ferrosa_storage::engine::log_cql_auth_state(storage_auth_enabled, auth_source);
+    ferrosa_storage::engine::log_auth_warn_state(storage_auth_enabled, storage_auth_warn);
+
     let storage_upload_threads = std::env::var("FERROSA_STORAGE_UPLOAD_THREADS")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
@@ -2396,6 +2427,25 @@ mod tests {
     fn resolve_auth_enabled_toml_returns_none_when_unspecified() {
         let toml = empty_config();
         assert_eq!(resolve_auth_enabled_toml(&toml, |_| None), None);
+    }
+
+    /// Regression (issue #172): the startup auth log used to always report
+    /// `source="default"`, hiding the fact that `[cql].auth_enabled` in the
+    /// config file was in force. `auth_source_label` must attribute a config-file
+    /// value to the config file (not "default"), env to env, and only fall back
+    /// to "default" when neither is set.
+    #[test]
+    fn auth_source_label_attributes_config_file_not_default() {
+        // env unset, [cql].auth_enabled present in TOML -> config file
+        assert_eq!(
+            auth_source_label(false, true),
+            "config file ([cql].auth_enabled)"
+        );
+        // env set -> env wins regardless of TOML
+        assert_eq!(auth_source_label(true, true), "FERROSA_AUTH_ENABLED env");
+        assert_eq!(auth_source_label(true, false), "FERROSA_AUTH_ENABLED env");
+        // neither set -> default
+        assert_eq!(auth_source_label(false, false), "default");
     }
 
     #[test]


### PR DESCRIPTION
Fixes the secondary bug in #172. **Stacked on #175** (base will auto-retarget to
`main` once #175 merges).

## Bug
`[cql].auth_enabled = true` in `ferrosa.toml` was applied to the engine config
and **enforced** (CQL SASL + the router's `check_permission` run off the resolved
value), but the **startup log said the opposite**:

> `storage-engine: CQL role auth is DISABLED ... auth_enabled=false source="default"`
> `... router permits everything ...`

The log is emitted inside `StorageEngineConfig::from_env()`, which only sees the
`FERROSA_AUTH_ENABLED` env var — **before** the binary applies the TOML override
(env → `[cql].auth_enabled` → default). So operators were told auth was off even
when the config turned it on — reads as a security hole, and is what the reporter
flagged.

## Fix (logging/reporting only — enforcement unchanged)
Emit the auth-state startup logs from the binary, once the authoritative value is
resolved, with an accurate source:
- new `ferrosa_storage::engine::log_cql_auth_state(auth_enabled, source)` — the
  "CQL role auth is ENABLED/DISABLED" line (removed from `from_env`).
- `log_auth_warn_state(..)` now called by the binary with the resolved value.
- new `auth_source_label(env_set, toml_has_key)` — labels the source
  `FERROSA_AUTH_ENABLED env` / `config file ([cql].auth_enabled)` / `default`.

## Verification
With `[cql].auth_enabled = true` and **no env var**, startup now logs:

> `CQL role auth is ENABLED — CQL STARTUP requires SASL PLAIN, router enforces`
> `permission checks ... auth_enabled=true source="config file ([cql].auth_enabled)"`

…and the superuser/seed-role bootstrap runs (`SuperuserPasswordMustChange`),
confirming auth is genuinely enforced. Enforcement behavior is unchanged — this
corrects the misleading report only.

Tests: `auth_source_label_attributes_config_file_not_default` (+ existing
`resolve_auth_enabled_toml_*`). `fmt --check`, `clippy --all-targets`,
`doc -D warnings` clean.