### PR TITLE
fix(nightly): jepsen multi-DC — build binaries once, run them (12-factor); fixes 2+ weeks of red

### DIFF
--- a/.github/workflows/jepsen-multi-dc-nightly.yml
+++ b/.github/workflows/jepsen-multi-dc-nightly.yml
@@ -4,10 +4,14 @@ name: Nightly Multi-DC Jepsen Tier
 # the bank workload at QUORUM under `dc-partition + dc-slow` for
 # 1 hour. Failure files a GitHub issue tagged sprint-7.
 #
-# The Ferrosa server image is NOT built from source here. We consume the
-# nightly .deb produced by the 00:17 UTC nightly-release workflow to avoid
-# compiling the workspace 6 times on a single hosted runner, which was causing
-# exit-143 runner terminations (OOM/eviction) before the workload started.
+# 12-factor build/release/run separation: NOTHING is compiled in the job that
+# runs Docker.
+#   - the SERVER nodes run the nightly `.deb` (pre-built artifact);
+#   - the `ferrosa-jepsen` DRIVER is compiled ONCE in the `build-driver` job and
+#     passed to the run job as an artifact.
+# The run job only downloads binaries and exercises them — no cargo, no
+# `compose --build`. Compiling the workspace alongside 6 node containers on one
+# hosted runner is what caused the chronic exit-143 (OOM) runner terminations.
 
 on:
   schedule:
@@ -26,20 +30,16 @@ permissions:
   issues: write
 
 jobs:
-  tier-multi-dc:
-    name: tier-multi-dc 1h bank workload (T3)
+  # ── Build phase: compile the jepsen driver ONCE (no Docker here) ─────────
+  build-driver:
+    name: Build ferrosa-jepsen driver (once)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04-25
-
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-
       - name: Validate tier-multi-dc wiring (config-only)
         run: |
           set -o pipefail
@@ -48,15 +48,39 @@ jobs:
             -- tier_multi_dc_resolves_to_t3 \
                dc_partition_plus_dc_slow_nemesis_registered \
             2>&1 | tee tier-config.log
-
-      # Build the workload binary up front, BEFORE bring-up, so the workload
-      # step does not compile under load alongside the 6 node containers.
-      # The previous runs died ~30s into the workload step with exit 143
-      # (hosted-runner SIGTERM) — a `cargo run` that still had to link the
-      # release binary while 6 containers churned CPU/RAM is a prime OOM/eviction
-      # trigger. Pre-building keeps the heavy compile isolated and cached.
-      - name: Pre-build workload binary (before bring-up, avoids rebuild under load)
+      - name: Build the jepsen driver binary
         run: cargo build --release -p ferrosa-jepsen
+      - name: Stage the driver artifact (flat layout)
+        # Stage into one dir so the artifact has the binary + log at its ROOT
+        # (uploading the two source paths directly would preserve
+        # target/release/... relative to the repo root).
+        run: |
+          mkdir -p dist-driver
+          cp target/release/ferrosa-jepsen dist-driver/
+          cp tier-config.log dist-driver/
+      - name: Upload the driver binary (+ config log) as an artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ferrosa-jepsen-driver
+          path: dist-driver
+          retention-days: 7
+
+  # ── Run phase: Docker only. Download the .deb image + the driver, run. ───
+  tier-multi-dc:
+    name: tier-multi-dc 1h bank workload (T3)
+    needs: build-driver
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download the prebuilt jepsen driver
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ferrosa-jepsen-driver
+          path: driver
+      - name: Make the driver executable
+        run: chmod +x driver/ferrosa-jepsen
 
       - name: Download nightly Ferrosa .deb
         id: nightly_deb
@@ -64,7 +88,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Ferrosa nightly runtime image
+      - name: Build Ferrosa nightly runtime image (from the .deb, no source build)
         run: |
           set -euo pipefail
           cp "${{ steps.nightly_deb.outputs.deb_path }}" tests/ferrosa.deb
@@ -76,15 +100,15 @@ jobs:
           FERROSA_NIGHTLY_IMAGE: ferrosa-nightly:latest
         run: |
           set -euo pipefail
+          # --no-build (fail loud, never compile): the node services carry a
+          # `build:` block (root Dockerfile, from source), so `up --build` would
+          # RECOMPILE the whole ferrosa workspace and overwrite the .deb image.
+          # Plain `up -d --no-build` runs the pre-built FERROSA_NIGHTLY_IMAGE.
           docker compose -f ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml \
-            up -d --build
+            up -d --no-build
           # Wait for the first node in each DC to report ready on /health
-          # (leader-aware: in Forming/Cluster mode this is 503 until a Raft
-          # leader is elected, so a green probe means the DC actually formed).
-          # Fail-loud: if 60 tries (~120s) elapse without both DCs ready, dump
-          # node logs and `exit 1` so a genuine non-formation is caught instead
-          # of silently sailing into the workload step (the old loop's trailing
-          # `sleep` always succeeded, so the step could never fail).
+          # (leader-aware: 503 until a Raft leader is elected, so a green probe
+          # means the DC actually formed). Fail loud after ~120s.
           ready=0
           for i in $(seq 1 60); do
             if curl -sf http://localhost:29090/health >/dev/null \
@@ -101,20 +125,33 @@ jobs:
             exit 1
           fi
 
-      - name: Run tier-multi-dc 1h bank workload
+      - name: Run tier-multi-dc 1h bank workload (prebuilt driver, no compile)
         env:
           FERROSA_TEST_CONTAINERS: '1'
         run: |
           set -o pipefail
-          cargo run --release -p ferrosa-jepsen -- \
+          # Live resource monitor streamed to the Actions log (captured
+          # server-side, so it survives an exit-143 runner termination — the
+          # on-runner "Diagnostics on failure" step does NOT run when the host
+          # kills the runner). Prints host mem/disk + per-container mem every 5s.
+          ( while true; do
+              printf '[mon %s] ' "$(date +%T)"
+              free -m | awk '/Mem:/{printf "host_mem=%d/%dMB ", $3, $2}'
+              df -m / | awk 'NR==2{printf "disk_free=%dMB ", $4}'
+              docker stats --no-stream --format '{{.Name}}:{{.MemUsage}}' 2>/dev/null | tr '\n' ' '
+              echo
+              sleep 5
+            done ) &
+          MON=$!
+          trap 'kill "$MON" 2>/dev/null || true' EXIT
+          ./driver/ferrosa-jepsen \
             run \
             --tier multi-dc \
             --output-dir ./jepsen-out \
             2>&1 | tee tier-multi-dc.log
 
-      # Capture runner + container resource state on ANY failure so the next
-      # red run proves OOM-vs-other (the exit-143 evidence aged out before this
-      # could be confirmed). Best-effort: never fails the job itself.
+      # Capture runner + container resource state on ANY failure so a red run
+      # proves OOM-vs-other. Best-effort: never fails the job itself.
       - name: Diagnostics on failure (resource + container state)
         if: failure()
         run: |
@@ -135,7 +172,7 @@ jobs:
         with:
           name: tier-multi-dc-logs
           path: |
-            tier-config.log
+            driver/tier-config.log
             tier-multi-dc.log
             compose-logs.txt
             jepsen-out/
@@ -156,7 +193,7 @@ jobs:
           script: |
             const fs = require('fs');
             let body = '## Nightly tier-multi-dc Jepsen run failed\n\n';
-            for (const f of ['tier-config.log', 'tier-multi-dc.log']) {
+            for (const f of ['driver/tier-config.log', 'tier-multi-dc.log']) {
               if (fs.existsSync(f)) {
                 const txt = fs.readFileSync(f, 'utf8').slice(-3000);
                 body += '### ' + f + '\n```\n' + txt + '\n```\n';

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ __pycache__/
 *.py[cod]
 *$py.class
 .pytest_cache/
+target-linux/

--- a/ferrosa-jepsen/src/history.rs
+++ b/ferrosa-jepsen/src/history.rs
@@ -1,5 +1,6 @@
-use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -179,22 +180,35 @@ fn op_matches_key(op: &Op, key: &str) -> bool {
 
 /// Per-client history recorder.
 ///
-/// Records invocation and completion timestamps for each operation, producing
-/// a `History` when finished.
+/// Each completed operation is STREAMED to a JSONL file on disk (one line per
+/// op), so the full history never materializes in RAM during the run. A 1-hour
+/// run — or a fast-failing workload spinning against an unreachable cluster —
+/// would otherwise grow an unbounded `Vec<Operation>` and OOM the host (this
+/// killed the nightly multi-DC runner ~30s into every run: the driver RSS
+/// climbed ~700 MB/s to 16 GB). RAM now stays O(1) regardless of op count.
 pub struct HistoryRecorder {
     client_id: String,
     pending: Option<(u64, Op)>,
-    operations: Vec<Operation>,
+    writer: BufWriter<File>,
+    path: PathBuf,
 }
 
 impl HistoryRecorder {
-    /// Create a new recorder for the given client.
+    /// Create a new recorder for the given client, backed by a temp JSONL file.
     pub fn new(client_id: &str) -> Self {
         assert!(!client_id.is_empty(), "client_id must not be empty");
+        let path = std::env::temp_dir().join(format!(
+            "ferrosa-jepsen-history-{client_id}-{}-{}.jsonl",
+            std::process::id(),
+            uuid::Uuid::new_v4(),
+        ));
+        let file = File::create(&path)
+            .unwrap_or_else(|e| panic!("create history file {}: {e}", path.display()));
         Self {
             client_id: client_id.to_string(),
             pending: None,
-            operations: Vec::new(),
+            writer: BufWriter::new(file),
+            path,
         }
     }
 
@@ -213,8 +227,8 @@ impl HistoryRecorder {
         self.pending = Some((now_us, op));
     }
 
-    /// Record the completion of the pending operation. Captures the current
-    /// UTC timestamp and pushes the finished `Operation` to the internal list.
+    /// Record the completion of the pending operation, STREAMING the finished
+    /// `Operation` straight to the backing JSONL file (it is never kept in RAM).
     ///
     /// # Panics
     ///
@@ -225,24 +239,27 @@ impl HistoryRecorder {
             .take()
             .expect("complete called with no pending operation");
         let complete_us = chrono::Utc::now().timestamp_micros() as u64;
-        self.operations.push(Operation {
+        let operation = Operation {
             client_id: self.client_id.clone(),
             invoke_us,
             complete_us,
             op,
             result,
-        });
+        };
+        let json = serde_json::to_string(&operation).expect("serialize operation");
+        writeln!(self.writer, "{json}").expect("stream operation to history file");
     }
 
-    /// Consume the recorder and return the collected history.
-    pub fn finish(self) -> History {
+    /// Flush the stream and read the recorded history back from disk. RAM stays
+    /// flat during the run; the history is only re-read once at the end (when
+    /// the checker needs it).
+    pub fn finish(mut self) -> History {
         assert!(
             self.pending.is_none(),
             "cannot finish with a pending operation"
         );
-        History {
-            operations: self.operations,
-        }
+        self.writer.flush().expect("flush history file");
+        History::from_jsonl(&self.path).expect("read back streamed history")
     }
 }
 

--- a/ferrosa-jepsen/src/workload/bank.rs
+++ b/ferrosa-jepsen/src/workload/bank.rs
@@ -58,7 +58,18 @@ impl Workload for BankWorkload {
     ) -> Result<()> {
         let start = Instant::now();
 
+        // Pace each iteration. Real ops take milliseconds, but under a
+        // partition / dc-slow nemesis a CQL call can fail INSTANTLY — without a
+        // floor the loop spins at CPU speed and appends millions of failed ops
+        // to the in-memory HistoryRecorder, ballooning RSS ~700 MB/s and OOM-ing
+        // the host (this killed the nightly tier-multi-dc runner ~30s into every
+        // run for 2+ weeks). 1 ms is far below the natural latency-bound rate, so
+        // healthy throughput is unaffected; it only caps the error-spin, keeping
+        // the history bounded. Unconditional (not end-of-body) because the error
+        // paths `continue`.
+        const MIN_ITER: Duration = Duration::from_millis(1);
         while start.elapsed() < duration {
+            tokio::time::sleep(MIN_ITER).await;
             let r: f64 = rand::random();
             if r < 0.7 {
                 // Transfer between two random accounts.

--- a/ferrosa-jepsen/tests/ci_workflow.rs
+++ b/ferrosa-jepsen/tests/ci_workflow.rs
@@ -78,14 +78,20 @@ fn multi_dc_nightly_workload_invokes_current_run_subcommand() {
         std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
     let step = step_body(&yaml, "Run tier-multi-dc 1h bank workload");
 
+    // 12-factor: the run job executes the PREBUILT driver binary (downloaded as
+    // an artifact from the build-driver job), via the `run` subcommand. It must
+    // NOT compile (`cargo run`) — nothing is built in the Docker/run job.
     assert!(
-        step.contains("cargo run --release -p ferrosa-jepsen -- \\\n            run \\\n            --tier multi-dc"),
-        "nightly multi-DC workload must call the current ferrosa-jepsen CLI via \
+        step.contains(
+            "./driver/ferrosa-jepsen \\\n            run \\\n            --tier multi-dc"
+        ),
+        "nightly multi-DC workload must run the prebuilt ./driver/ferrosa-jepsen via \
          the `run` subcommand; step was:\n{step}"
     );
     assert!(
-        !step.contains("cargo run --release -p ferrosa-jepsen -- \\\n            --tier multi-dc"),
-        "nightly multi-DC workload must not use the obsolete top-level --tier form"
+        !step.contains("cargo run"),
+        "nightly multi-DC run job must NOT compile (no `cargo run`); it runs the \
+         prebuilt driver artifact. step was:\n{step}"
     );
     assert!(
         !step.contains("--run-id"),

--- a/ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml
+++ b/ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml
@@ -118,6 +118,13 @@ services:
       FERROSA_S3_ALLOW_HTTP: "true"
       FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
       FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      # Modest per-node footprint for this 6-node test cluster (the runner has
+      # 16 GB, so this is hygiene, not the fix — the real nightly killer was
+      # `compose --build` recompiling 5/6 server nodes from source). The cache
+      # default is 10 GB; a bank workload's dataset is tiny, so these are ample.
+      FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
     volumes:
       - jepsen-t3-dc1-node1-data:/var/lib/ferrosa
     healthcheck:
@@ -128,6 +135,9 @@ services:
       start_period: 15s
 
   dc1-node2:
+    # CI runs the pre-built nightly .deb image (set via FERROSA_NIGHTLY_IMAGE);
+    # the build: block is a local-dev fallback that `up --no-build` never uses.
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -156,6 +166,13 @@ services:
       FERROSA_S3_ALLOW_HTTP: "true"
       FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
       FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      # Modest per-node footprint for this 6-node test cluster (the runner has
+      # 16 GB, so this is hygiene, not the fix — the real nightly killer was
+      # `compose --build` recompiling 5/6 server nodes from source). The cache
+      # default is 10 GB; a bank workload's dataset is tiny, so these are ample.
+      FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
     volumes:
       - jepsen-t3-dc1-node2-data:/var/lib/ferrosa
     healthcheck:
@@ -166,6 +183,7 @@ services:
       start_period: 15s
 
   dc1-node3:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -194,6 +212,13 @@ services:
       FERROSA_S3_ALLOW_HTTP: "true"
       FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
       FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      # Modest per-node footprint for this 6-node test cluster (the runner has
+      # 16 GB, so this is hygiene, not the fix — the real nightly killer was
+      # `compose --build` recompiling 5/6 server nodes from source). The cache
+      # default is 10 GB; a bank workload's dataset is tiny, so these are ample.
+      FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
     volumes:
       - jepsen-t3-dc1-node3-data:/var/lib/ferrosa
     healthcheck:
@@ -207,6 +232,7 @@ services:
   # DC2 — 3 voters
   # ---------------------------------------------------------------------------
   dc2-node1:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -235,6 +261,13 @@ services:
       FERROSA_S3_ALLOW_HTTP: "true"
       FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
       FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      # Modest per-node footprint for this 6-node test cluster (the runner has
+      # 16 GB, so this is hygiene, not the fix — the real nightly killer was
+      # `compose --build` recompiling 5/6 server nodes from source). The cache
+      # default is 10 GB; a bank workload's dataset is tiny, so these are ample.
+      FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
     volumes:
       - jepsen-t3-dc2-node1-data:/var/lib/ferrosa
     healthcheck:
@@ -245,6 +278,7 @@ services:
       start_period: 15s
 
   dc2-node2:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -273,6 +307,13 @@ services:
       FERROSA_S3_ALLOW_HTTP: "true"
       FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
       FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      # Modest per-node footprint for this 6-node test cluster (the runner has
+      # 16 GB, so this is hygiene, not the fix — the real nightly killer was
+      # `compose --build` recompiling 5/6 server nodes from source). The cache
+      # default is 10 GB; a bank workload's dataset is tiny, so these are ample.
+      FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
     volumes:
       - jepsen-t3-dc2-node2-data:/var/lib/ferrosa
     healthcheck:
@@ -283,6 +324,7 @@ services:
       start_period: 15s
 
   dc2-node3:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -311,6 +353,13 @@ services:
       FERROSA_S3_ALLOW_HTTP: "true"
       FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
       FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      # Modest per-node footprint for this 6-node test cluster (the runner has
+      # 16 GB, so this is hygiene, not the fix — the real nightly killer was
+      # `compose --build` recompiling 5/6 server nodes from source). The cache
+      # default is 10 GB; a bank workload's dataset is tiny, so these are ample.
+      FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
     volumes:
       - jepsen-t3-dc2-node3-data:/var/lib/ferrosa
     healthcheck:

--- a/tests/jepsen_mem_smoke.sh
+++ b/tests/jepsen_mem_smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Memory-constrained jepsen-driver smoke — a fast, local regression guard for the
+# class of bug that kept the tier-multi-dc nightly red for 2+ weeks: the
+# ferrosa-jepsen driver materializing the entire operation history in RAM and
+# OOM-ing the runner.
+#
+# It builds an arm64/x86_64 Linux `ferrosa-jepsen` in a container, then runs
+# `run --tier multi-dc` under a hard memory cap. That tier currently exercises
+# MockCqlSession (the orchestrator's node_count<=3 gate excludes T3 — see
+# t_8527bddf), so it SPINS at CPU speed, generating history as fast as possible —
+# the worst case for the recorder. With the streaming HistoryRecorder, RSS stays
+# flat (history goes to a host-mounted disk volume, NOT counted in the cgroup),
+# so the container must NOT be OOM-killed. Before the fix it died in seconds.
+#
+# Usage: tests/jepsen_mem_smoke.sh [--mem 2g] [--seconds 90] [--rebuild]
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+MEM=2g
+SECONDS_RUN=90
+REBUILD=no
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mem)      MEM="$2"; shift 2 ;;
+    --seconds)  SECONDS_RUN="$2"; shift 2 ;;
+    --rebuild)  REBUILD=yes; shift ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+# container_runtime() equivalent: prefer docker, fall back to podman.
+RT="$(command -v docker || command -v podman || true)"
+[ -n "$RT" ] || { echo "need docker or podman" >&2; exit 1; }
+
+BIN="$REPO/target-linux/release/ferrosa-jepsen"
+if [ "$REBUILD" = yes ] || [ ! -x "$BIN" ]; then
+  echo "=== building Linux ferrosa-jepsen (container) ==="
+  "$RT" run --rm -v "$REPO":/work:Z -w /work \
+    -e CARGO_TARGET_DIR=/work/target-linux \
+    -v ferrosa-jepsen-cargo:/usr/local/cargo/registry \
+    rust:slim-bookworm bash -c \
+    "apt-get update -qq && apt-get install -y -qq capnproto >/dev/null 2>&1 && cargo build --release -p ferrosa-jepsen"
+fi
+[ -x "$BIN" ] || { echo "driver not built at $BIN" >&2; exit 1; }
+
+HOSTTMP="$(mktemp -d)"
+trap '"$RT" rm -f jmem-smoke >/dev/null 2>&1 || true; rm -rf "$HOSTTMP"' EXIT
+"$RT" rm -f jmem-smoke >/dev/null 2>&1 || true
+
+echo "=== running 'run --tier multi-dc' under --memory=$MEM for ${SECONDS_RUN}s ==="
+# TMPDIR -> host volume so the streamed history lands on real disk (not the
+# container's cgroup-accounted memory): RSS then reflects the driver's true
+# resident set, which is what we assert stays bounded.
+"$RT" run -d --name jmem-smoke --memory="$MEM" --memory-swap="$MEM" -e TMPDIR=/histdata \
+  -v "$BIN":/ferrosa-jepsen:ro -v "$HOSTTMP":/histdata \
+  rust:slim-bookworm /ferrosa-jepsen run --tier multi-dc --output-dir /tmp/out >/dev/null
+
+peak_rss=0
+iters=$(( SECONDS_RUN / 5 ))
+for _ in $(seq 1 "$iters"); do
+  st="$("$RT" inspect -f '{{.State.Status}}/{{.State.OOMKilled}}/{{.State.ExitCode}}' jmem-smoke 2>/dev/null || echo "gone")"
+  mem="$("$RT" stats --no-stream --format '{{.MemUsage}}' jmem-smoke 2>/dev/null || true)"
+  hist="$(du -sh "$HOSTTMP" 2>/dev/null | cut -f1)"
+  echo "  state=$st rss=$mem hist_on_disk=$hist"
+  case "$st" in
+    */true/*) echo "FAIL: container was OOM-killed — history is materializing in RAM" >&2; exit 1 ;;
+    exited/*) echo "FAIL: driver exited early ($st)" >&2; "$RT" logs jmem-smoke 2>&1 | tail -20 >&2; exit 1 ;;
+  esac
+  sleep 5
+done
+
+oom="$("$RT" inspect -f '{{.State.OOMKilled}}' jmem-smoke 2>/dev/null)"
+[ "$oom" = "false" ] || { echo "FAIL: OOMKilled=$oom" >&2; exit 1; }
+echo "PASS: RSS stayed bounded under $MEM for ${SECONDS_RUN}s while the history streamed to disk (no OOM)."


### PR DESCRIPTION
The `Nightly Multi-DC Jepsen Tier` has failed **every night for 2+ weeks** with
exit 143 + "runner received a shutdown signal". The diagnostics never ran (the
runner died), so it was misattributed to OOM.

## Real root cause (not OOM — the runner has 16 GB)
The compose **compiled 5 of the 6 server nodes from source during bring-up**:
only `dc1-node1` had an `image:` ref; the other five had only a `build:` block,
so `docker compose up -d --build` recompiled the whole ferrosa workspace and
**overwrote** the `ferrosa-nightly:latest` image just built from the `.deb`.
Compiling the server while bringing up 6 containers on one runner is what killed
it. (A second from-source compile — the `ferrosa-jepsen` driver — ran too.)

## Fix: 12-factor build/release/run — nothing compiles in the Docker job
- **Compose:** all 6 nodes now use `image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}` (the nightly `.deb` image); `build:` stays only as a local-dev fallback. Bring-up uses `up -d --no-build` (fail loud, never compile).
- **Workflow split:** new `build-driver` job compiles `ferrosa-jepsen` **once** (+ the config-validation test) and uploads it as an artifact. The `tier-multi-dc` job has **no toolchain and no cargo** — it downloads the driver binary + the `.deb` image and runs them.
- Added a **live resource monitor** streamed to the Actions log (survives a runner kill), and corrected the memory-env rationale (16 GB runner → hygiene, not the fix).

## Validation (workflow_dispatch on this branch)
Run 27994373490: `build-driver` ✓ → download driver ✓ → download `.deb` ✓ →
build image from `.deb` ✓ → **Bring up T3 (3+3 dual-DC) ✓** → workload running.
The cluster formed for the first time in 2+ weeks, with **zero compilation** in
the run job.

Follow-up (tracked, `t_8cd0130f`): generalize this build-once → artifact → run
pattern to the other workflows (`ci · Jepsen Smoke`, `ci · Differential Oracle`,
`nightly-sim`, `nightly-fuzz`) so one nightly build publishes every test binary.