### PR TITLE
fix(storage): fts_match falls back to scanning sidecar-less SSTables (BUG-F-007)

### DIFF
--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -46,6 +46,11 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
 - **Secondary-index pipeline** (`index/`, `memtable/eager_index.rs`) —
   per-index state tracker, channel-based build scheduler, local/remote/off
   backends, FTI + vector (HNSW/IVFFlat) sidecars, artifact manifest.
+- **Full-text search** (`fulltext_search`) — searches the memtable FTI + each
+  per-SSTable `-FTI-{index}.db` sidecar, and **falls back to scanning any live
+  SSTable whose sidecar is transiently missing** (the async index-rebuild window
+  after compaction), so a stable row is never dropped from `fts_match`
+  (BUG-F-007 / t_0455c0a1).
 - **Snapshot / PITR** (`snapshot/`, `restore/`, `commitlog/archiver.rs`) —
   S3 snapshot manager, commit-log archiving, restore manager with validation.
 - **Quarantine + self-heal** (`quarantine.rs`, `self_heal/`) — malformed rows

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -5760,7 +5760,7 @@ impl StorageEngine {
         query: &str,
     ) -> ferrosa_common::Result<Vec<Vec<u8>>> {
         use ferrosa_index::fulltext::reader::FullTextIndexReader;
-        use std::collections::HashMap;
+        use std::collections::{HashMap, HashSet};
 
         let table_dir = self
             .config
@@ -5769,19 +5769,23 @@ impl StorageEngine {
             .join(table_id.to_string());
         let fti_suffix = format!("-FTI-{index_name}.db");
 
-        let fti_files: Vec<std::path::PathBuf> = std::fs::read_dir(&table_dir)
-            .into_iter()
-            .flatten()
-            .filter_map(|e| e.ok())
-            .filter_map(|e| {
-                let name = e.file_name().to_str()?.to_string();
-                if name.ends_with(&fti_suffix) {
-                    Some(e.path())
-                } else {
-                    None
+        // Collect the on-disk FTI sidecar files AND the set of SSTable
+        // generations they cover, so we can fall back to scanning any LIVE
+        // SSTable that is (transiently) missing its sidecar — e.g. during the
+        // async index rebuild window after compaction (BUG-F-007 / t_0455c0a1).
+        let mut fti_files: Vec<std::path::PathBuf> = Vec::new();
+        let mut covered_gens: HashSet<String> = HashSet::new();
+        if let Ok(entries) = std::fs::read_dir(&table_dir) {
+            for e in entries.flatten() {
+                let Some(name) = e.file_name().to_str().map(|s| s.to_string()) else {
+                    continue;
+                };
+                if let Some(gen) = name.strip_suffix(&fti_suffix) {
+                    covered_gens.insert(gen.to_string());
+                    fti_files.push(e.path());
                 }
-            })
-            .collect();
+            }
+        }
 
         let mut score_map: HashMap<Vec<u8>, f64> = HashMap::new();
         {
@@ -5824,6 +5828,25 @@ impl StorageEngine {
                 let entry = score_map.entry(hit.partition_key).or_insert(0.0);
                 if hit.score > *entry {
                     *entry = hit.score;
+                }
+            }
+        }
+
+        // Fallback: scan any LIVE SSTable whose on-disk FTI sidecar is missing
+        // (the transient compaction / async-rebuild window) so a stable row is
+        // never dropped from full-text search (BUG-F-007 / t_0455c0a1).
+        {
+            let tables = self.tables.read();
+            if let Some(state) = tables.get(table_id) {
+                for (partition_key, score) in state.store.fulltext_sstable_scan_missing_sidecar(
+                    index_name,
+                    query,
+                    &covered_gens,
+                )? {
+                    let entry = score_map.entry(partition_key).or_insert(0.0);
+                    if score > *entry {
+                        *entry = score;
+                    }
                 }
             }
         }
@@ -18366,6 +18389,79 @@ mod tests {
             keys,
             vec!["doc_0000".to_string()],
             "fts_match must still find the probe row after compaction (compaction must rebuild the FTI sidecar)"
+        );
+    }
+
+    /// Regression for t_0455c0a1 (BUG-F-007, read-side robustness): a live
+    /// SSTable whose on-disk `-FTI-{index}.db` sidecar is MISSING — e.g. during
+    /// the window after compaction swaps in the merged SSTable but before its
+    /// FTI sidecar is (re)built (the eager index build is async in production),
+    /// or after a transient sidecar build/write failure — must NOT make the
+    /// SSTable's rows invisible to `fts_match`. The row's text lives in the
+    /// SSTable data; `fulltext_search` must fall back to scanning a sidecar-less
+    /// SSTable so a stable row is never transiently dropped from full-text
+    /// search. (On a multi-node cluster, every replica hitting this window at
+    /// once made the scatter-gather union empty → non-deterministic 0 rows.)
+    #[tokio::test]
+    async fn fts_match_finds_row_when_sidecar_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        engine.add_fulltext_index(&tid, "idx_body", 0).unwrap();
+
+        const PROBE: &str = "ferrosaftssidecarmissing";
+        let key = make_key("doc_0000");
+        engine
+            .write(
+                &tid,
+                &key,
+                make_row(format!("{PROBE} distributed database").as_bytes(), 1),
+                1,
+            )
+            .unwrap();
+        engine.flush(&tid).unwrap();
+
+        // Sanity: found via the freshly written FTI sidecar.
+        assert_eq!(
+            engine
+                .fulltext_search(&tid, "idx_body", PROBE)
+                .unwrap()
+                .len(),
+            1,
+            "probe must be found via the FTI sidecar right after flush"
+        );
+
+        // Simulate the missing-sidecar window: delete every on-disk FTI sidecar
+        // for this index. The SSTable data files are left untouched.
+        let table_dir = dir.path().join("sstables").join(tid.to_string());
+        let mut removed = 0usize;
+        for entry in std::fs::read_dir(&table_dir).unwrap().flatten() {
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .contains("-FTI-idx_body")
+            {
+                std::fs::remove_file(entry.path()).unwrap();
+                removed += 1;
+            }
+        }
+        assert!(
+            removed > 0,
+            "test must have deleted at least one FTI sidecar"
+        );
+
+        // The row MUST still be found — a missing sidecar cannot hide a live row.
+        let hits = engine.fulltext_search(&tid, "idx_body", PROBE).unwrap();
+        let keys: Vec<String> = hits
+            .iter()
+            .map(|pk| String::from_utf8_lossy(pk).to_string())
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["doc_0000".to_string()],
+            "fts_match must find the row even when its SSTable has no FTI sidecar"
         );
     }
 

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -4477,6 +4477,120 @@ impl<F: FlushTarget> TableStore<F> {
             .collect())
     }
 
+    /// Full-text search over LIVE SSTables that have NO on-disk FTI sidecar.
+    ///
+    /// `covered_gens` are the SSTable generations that already have a
+    /// `{gen}-FTI-{index}.db` sidecar on disk (searched directly by the engine).
+    /// For every other live SSTable the sidecar may be missing transiently — e.g.
+    /// after compaction swaps in the merged SSTable but before its sidecar is
+    /// (re)built (the eager index build is async in production), or after a
+    /// sidecar write failure. Without this fallback those rows are invisible to
+    /// `fts_match`, which on a multi-node cluster made every replica's
+    /// scatter-gather union empty at once → non-deterministic 0 rows
+    /// (BUG-F-007 / t_0455c0a1). We build a transient FTI over each such
+    /// SSTable's indexed column and run the same query, so a stable row is never
+    /// transiently dropped from full-text search.
+    pub fn fulltext_sstable_scan_missing_sidecar(
+        &self,
+        index_name: &str,
+        query: &str,
+        covered_gens: &std::collections::HashSet<String>,
+    ) -> ferrosa_common::Result<Vec<(Vec<u8>, f64)>> {
+        use ferrosa_index::fulltext::builder::{serialize_fti, FullTextIndexBuilder};
+        use ferrosa_index::fulltext::query::parse_fts_query;
+        use ferrosa_index::fulltext::reader::FullTextIndexReader;
+
+        let Some((_, col_pos)) = self
+            .fulltext_indexes
+            .iter()
+            .find(|(name, _)| name == index_name)
+        else {
+            return Ok(vec![]);
+        };
+        let col_pos = *col_pos;
+
+        let parsed_query = parse_fts_query(query).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!("fts_match query error: {e}"))
+        })?;
+
+        let schema = self.schema.load();
+        let guard = self.view.load();
+        let mut builder = FullTextIndexBuilder::new();
+        let mut any_docs = false;
+        for desc in guard.sstables.iter() {
+            // SSTables with a sidecar are already covered by the engine's direct
+            // sidecar search; only scan the ones that are (transiently) missing.
+            if covered_gens.contains(&desc.gen) || self.is_sstable_quarantined(&desc.gen) {
+                continue;
+            }
+            let sstable = match self.open_reader(desc) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(%e, gen = %desc.gen, "fts sidecar-less scan: open reader failed");
+                    continue;
+                }
+            };
+            let mapping = ColumnOrdinalMapping::for_header(&schema, sstable.header());
+            let mut iter = match sstable.partitions_iter() {
+                Ok(it) => it,
+                Err(e) => {
+                    tracing::warn!(%e, gen = %desc.gen, "fts sidecar-less scan: broken iterator");
+                    continue;
+                }
+            };
+            loop {
+                match iter.next_partition() {
+                    Ok(Some(mut p)) => {
+                        mapping.remap_partition(&mut p);
+                        let pk_bytes = p.key.key.as_bytes().to_vec();
+                        let mut text = String::new();
+                        for row in &p.rows {
+                            for (col_idx, cell) in &row.cells {
+                                if *col_idx as usize == col_pos {
+                                    if let Some(ref val) = cell.value {
+                                        if let Ok(s) = std::str::from_utf8(val) {
+                                            text.push_str(s);
+                                            text.push(' ');
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if !text.is_empty() {
+                            builder.add_document(pk_bytes, text.trim());
+                            any_docs = true;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        tracing::warn!(%e, gen = %desc.gen, "fts sidecar-less scan: decode error");
+                        break;
+                    }
+                }
+            }
+        }
+        drop(guard);
+
+        if !any_docs {
+            return Ok(vec![]);
+        }
+        let fti = builder.build();
+        if fti.doc_count == 0 {
+            return Ok(vec![]);
+        }
+        let bytes = serialize_fti(&fti).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!("fts_match sstable index error: {e}"))
+        })?;
+        let reader = FullTextIndexReader::open(bytes).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!("fts_match sstable index error: {e}"))
+        })?;
+        Ok(reader
+            .search(&parsed_query)
+            .into_iter()
+            .map(|hit| (hit.partition_key, hit.score))
+            .collect())
+    }
+
     /// Register a full-text index for this table.
     pub fn add_fulltext_index(&mut self, index_name: String, column_position: usize) {
         if !self.fulltext_indexes.iter().any(|(n, _)| n == &index_name) {

--- a/specs/bug-fts-match-nondeterministic-multinode.md
+++ b/specs/bug-fts-match-nondeterministic-multinode.md
@@ -1,0 +1,110 @@
+# BUG · P1 · `fts_match` is non-deterministic on a multi-node cluster
+
+**Filed:** 2026-06-20 | **Component:** ferrosa (CQL served path + full-text index)
+**Downstream:** ferrosa-memory BUG-F-007
+
+## Summary
+
+On a 3-node cluster (RF=3), `SELECT ... WHERE col = fts_match('<token>')` returns
+**0 or 1 rows non-deterministically for a single, stable, never-changing row**,
+while a normal scan of the same table consistently returns the row. The result
+depends on which node coordinates the query and/or on background full-text-index
+(FTI) rebuild timing — so native FTS is unusable for lexical recall on a cluster.
+
+The single-node, in-process tests `fulltext_index_fts_match_end_to_end` and
+`fulltext_index_fts_match_reads_unflushed_memtable_row`
+(`ferrosa-cql/src/router.rs`) **pass** — they do not exercise the served
+multi-node path, so they do not catch this.
+
+## Reproduce (live 3-node cluster, RF=3)
+
+```sql
+CREATE KEYSPACE ftsprobe WITH replication = {'class':'NetworkTopologyStrategy','datacenter1':'3'};
+CREATE TABLE ftsprobe.t (tenant_id uuid, id uuid, body text, PRIMARY KEY ((tenant_id), id));
+CREATE INDEX ON ftsprobe.t (body) USING 'fulltext';
+INSERT INTO ftsprobe.t (tenant_id, id, body) VALUES (<tid>, <id>, '<token> native fts probe body');
+-- repeat with a round-robin client; same stable row:
+SELECT id FROM ftsprobe.t WHERE tenant_id = <tid> AND body = fts_match('<token>') LIMIT 5 ALLOW FILTERING;
+```
+
+Observed `fts_match` row count over time for one inserted row (client round-robining
+across the 3 coordinators), normal scan = 1 throughout:
+
+| t      | 0s | 10s | 30s | 60s | 90s |
+|--------|----|-----|-----|-----|-----|
+| rows   | 0  | 1   | 0   | 0   | 1   |
+
+Verified against ferrosa `main` (image build `3cec99cc6127`, freshly rebuilt
+cluster). Memtable-only reads work (immediate insert often returns 1); the
+flapping appears once flush + the **background per-SSTable FTI rebuild**
+(`eager_index_build_job` / index-build scheduler) is in play.
+
+## Hypotheses (for the investigating agent)
+
+1. **Coordinator-local evaluation.** The served `fts_match` path may evaluate the
+   match only against the coordinator node's local FTI rather than scatter-gathering
+   across the token-range replicas. With RF=3 and round-robin, different coordinators
+   then return different answers. Check the router/planner `fts_match` execution in
+   `ferrosa-cql/src/router.rs` / `planner.rs` — does it route per-token-range like a
+   normal indexed read, or run locally?
+2. **FTI rebuild swap is not atomic.** Post-flush, the per-SSTable FTI is rebuilt in
+   the background; if `fts_match` reads return empty while the new FTI is being
+   swapped in (instead of serving the previous FTI until the new one is ready),
+   queries during the rebuild window return 0. Check `ferrosa-index/src/fulltext/`
+   reader/merge + the index-build scheduler swap.
+
+## Definition of done
+
+- A **multi-node served-path** regression test (the existing single-node in-process
+  tests cannot catch this) asserting `fts_match` deterministically returns an
+  inserted+flushed row across all coordinators and across an FTI rebuild.
+- Consistent cross-replica `fts_match` evaluation and/or atomic FTI swap so a stable
+  row is never transiently invisible.
+
+## Workaround (downstream, in place)
+
+ferrosa-memory keeps its `document_terms` / `context_segment_terms` fallback enabled
+and does not treat native FTS zero-row responses as proof of no match.
+
+---
+
+## ROOT CAUSE FOUND (2026-06-23) — compaction FTI visibility window
+
+Hypothesis 1 (coordinator-local lookup) is **already fixed**: `fts_match` now
+scatter-gathers across all nodes and unions (`coordinate_fulltext_search`,
+ferrosa-cluster/src/coordinator/read.rs), and the post-match partition fetch is a
+distributed `coordinate_read` (ferrosa-cql/src/router.rs:3418 →
+write_path.rs `read` → Cluster→coordinate_read). Both are robust. The test still
+flaps, so the residual cause is hypothesis 2 — **non-atomic FTI on compaction**:
+
+- FLUSH builds the FTI sidecar **synchronously** before the SSTable is live
+  (ferrosa-storage/src/store.rs flush "Step 5c", ~:2236 → write_fti_sidecar).
+- COMPACTION does **not**. ferrosa-storage/src/engine.rs:6478-6534:
+  1. opens the merged output SSTable,
+  2. `swap_compacted_sstables` makes it LIVE and **deletes the input SSTables +
+     their `-FTI-*.db` sidecars** — the new SSTable has **no FTI sidecar yet**,
+  3. the FTI is (re)built by an **async** `eager_index_build_job`
+     (`scheduler.submit`, :6521-6534).
+- `engine.fulltext_search` finds rows only via memtable (active+flushing) FTI +
+  the on-disk `-FTI-<index>.db` sidecar files. During the window between (2) and
+  (3) the compacted SSTable's rows are in **no** FTI → `fts_match` returns empty
+  for them. On RF=3 with replicas compacting together, the **union** goes empty →
+  `fts_match` = 0 rows ⇒ the flaky `fts_match_returns_flushed_row_...` failure.
+  A normal scan is unaffected (it reads SSTable data directly), matching the
+  spec's "normal scan = 1 throughout".
+
+### Fix options
+- **A (preferred — mirror flush):** build the FTI sidecar **synchronously** for the
+  compacted output (from the opened `reader`) BEFORE `swap_compacted_sstables`
+  makes it live (engine.rs ~:6484). Keep the async `eager_index_build_job` as a
+  backstop. Closes the window; reads stay fast.
+- **C (read-side robustness, complementary):** in `engine.fulltext_search`, for any
+  LIVE SSTable lacking an FTI sidecar, build a transient FTI from its text column
+  on the fly (same approach as `fulltext_memtable_search`). Guarantees a row is
+  never invisible regardless of build timing; unit-testable without a cluster
+  (SSTable with no sidecar must still return via fts_match). Slower only during the
+  build window.
+
+DoD additions: a unit test that an SSTable with NO FTI sidecar still returns its
+rows via fts_match (covers C and the compaction window), plus the existing live
+`fts_match_returns_flushed_row_from_each_live_cluster_node`.


### PR DESCRIPTION
## What

Fixes the on-disk half of the non-deterministic `fts_match` bug (BUG-F-007 / `t_0455c0a1`): on a multi-node RF=3 cluster, `fts_match` returned **0/1 rows non-deterministically** for a single stable row, while a normal scan always returned it.

## Root cause

The coordinator-local half was already fixed (scatter-gather + union). The residual cause: `engine.fulltext_search` found rows only via the **memtable FTI** + the on-disk **`-FTI-{index}.db` sidecars**. After compaction swaps in a merged SSTable, its FTI sidecar is (re)built by an **async** eager index build — so for a window the live SSTable has **no sidecar** and its rows vanish from `fts_match`. On RF=3 with replicas compacting together, every replica's union went empty at once → 0 rows. (A normal scan reads SSTable data directly, so it was unaffected — matching the observed "scan = 1 throughout, fts_match flaps".)

## Fix (read-side robustness)

`fulltext_search` now tracks which SSTable generations have an on-disk sidecar and calls the new `TableStore::fulltext_sstable_scan_missing_sidecar`, which builds a transient FTI over the indexed column of any live SSTable **lacking** a sidecar and runs the same query. A stable row is therefore **never** invisible, regardless of sidecar build timing (compaction window, async rebuild lag, or a sidecar write failure).

## Test (TDD, red-first)

`fts_match_finds_row_when_sidecar_missing`: write+flush a row, **delete its on-disk FTI sidecar**, assert `fts_match` still returns it.
- Before: `left: []` (FAIL)
- After: returns `["doc_0000"]` (PASS)

Existing `fts_match_survives_compaction` + 251 index/compaction/scan tests stay green. fmt + clippy clean.

Closes the last source of merge-queue ejection flakiness for jepsen/storage PRs.