### PR TITLE
feat(accord): per-shard quorum for multi-key transactions — foundation (Phase 2)

### DIFF
--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -29,6 +29,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use crate::accord::transport::AccordTransport;
 use bytes::Bytes;
 use ferrosa_common::accord::{BallotNumber, HybridLogicalClock, Timestamp, TxnId};
 use ferrosa_net::codec::Lane;
@@ -433,7 +434,8 @@ pub type ConditionGate = Box<dyn Fn(Option<&[u8]>) -> bool + Send + Sync>;
 /// The driver is single-use: one instance per transaction.
 pub struct AccordCoordinatorDriver {
     coordinator: AccordCoordinator,
-    peers: Arc<PeerManager>,
+    /// Network seam: `PeerManager` in production, a mock in tests.
+    peers: Arc<dyn AccordTransport>,
     /// IDs of the replicas for this transaction's token range.
     replica_ids: Vec<uuid::Uuid>,
     /// UUID of this coordinator node (used to identify self-sends).
@@ -576,6 +578,30 @@ impl AccordCoordinatorDriver {
         node_id: u64,
         replica_ids: Vec<uuid::Uuid>,
         peers: Arc<PeerManager>,
+        is_leaseholder: bool,
+        clock: &HybridLogicalClock,
+        write_set: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> Self {
+        // Coerce the concrete PeerManager into the transport seam; all driver
+        // logic is shared with the test-injectable `new_multi_with_transport`.
+        let transport: Arc<dyn AccordTransport> = peers;
+        Self::new_multi_with_transport(
+            node_id,
+            replica_ids,
+            transport,
+            is_leaseholder,
+            clock,
+            write_set,
+        )
+    }
+
+    /// Like [`Self::new_multi`] but takes the [`AccordTransport`] seam directly,
+    /// so tests can inject a mock that returns controllable per-node responses
+    /// (exercising the multi-node Commit/Apply quorum logic without a network).
+    pub(crate) fn new_multi_with_transport(
+        node_id: u64,
+        replica_ids: Vec<uuid::Uuid>,
+        peers: Arc<dyn AccordTransport>,
         is_leaseholder: bool,
         clock: &HybridLogicalClock,
         write_set: Vec<(Vec<u8>, Vec<u8>)>,

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -1028,33 +1028,22 @@ impl AccordCoordinatorDriver {
             .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
         let commit_msg = Message::AccordCommit(Bytes::from(commit_bytes));
 
-        // Start with 1 ack for the coordinator itself (implicit local commit).
+        // The coordinator drove the protocol, so it is an implicit ack for both
+        // Commit and Apply; `self_is_replica` is also consumed by the local-apply
+        // below.
         let self_is_replica = self.replica_ids.contains(&self_id) && self_id != uuid::Uuid::nil();
-        let mut commit_acks = if self_is_replica { 1usize } else { 0usize };
 
-        let remote_commit_futs: Vec<_> = self
-            .replica_ids
-            .iter()
-            .filter(|&&id| id != self_id)
-            .map(|&peer_id| {
-                let peers = Arc::clone(&self.peers);
-                let msg = commit_msg.clone();
-                async move { peers.send(peer_id, msg, Lane::Data).await }
-            })
-            .collect();
-        let commit_responses = futures::future::join_all(remote_commit_futs).await;
-
-        for result in &commit_responses {
-            match result {
-                Ok(_) => commit_acks += 1,
-                Err(e) => tracing::warn!(
-                    txn_id = ?txn_id,
-                    error = %e,
-                    "accord: Commit RPC failed"
-                ),
-            }
-        }
-        if commit_acks < sq {
+        // Per-shard quorum: every shard the write-set touches must independently
+        // reach its slow quorum. A single global counter would let one shard
+        // commit while another is a minority — the cross-shard non-atomicity
+        // Accord exists to prevent. (`single_shard_participant` is the
+        // behavior-preserving default for single-key / one replica set; per-key
+        // `ring.replicas` fan-out is a follow-up.)
+        let participant = self.single_shard_participant();
+        if !self
+            .quorum_broadcast(commit_msg, &participant, |r| r.is_ok())
+            .await
+        {
             return Err(AccordDriverError::QuorumUnavailable);
         }
 
@@ -1322,48 +1311,23 @@ impl AccordCoordinatorDriver {
             }
         }
 
-        // Coordinator itself counts as 1 implicit apply ack.
-        let mut apply_acks = if self_is_replica { 1usize } else { 0usize };
-
-        let remote_apply_futs: Vec<_> = self
-            .replica_ids
-            .iter()
-            .filter(|&&id| id != self_id)
-            .map(|&peer_id| {
-                let peers = Arc::clone(&self.peers);
-                let msg = apply_msg.clone();
-                async move { peers.send(peer_id, msg, Lane::Data).await }
+        // Apply quorum: the SAME per-shard rule as Commit (reusing the
+        // `participant` built above). An Apply ack is an `AccordApplyOK` for this
+        // txn — an empty body, or a payload whose `txn_id` matches.
+        let apply_txn = txn_id;
+        let apply_ok = self
+            .quorum_broadcast(apply_msg, &participant, move |r| {
+                matches!(r, Ok(Message::AccordApplyOK(b))
+                    if b.is_empty()
+                        || bincode::deserialize::<ApplyOkPayload>(b)
+                            .map(|ok| ok.txn_id == apply_txn)
+                            .unwrap_or(false))
             })
-            .collect();
-        let apply_responses = futures::future::join_all(remote_apply_futs).await;
-
-        for result in &apply_responses {
-            match result {
-                Ok(Message::AccordApplyOK(b)) => {
-                    if b.is_empty() {
-                        apply_acks += 1;
-                    } else if let Ok(ok) = bincode::deserialize::<ApplyOkPayload>(b) {
-                        if ok.txn_id == txn_id {
-                            apply_acks += 1;
-                        }
-                    }
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        txn_id = ?txn_id,
-                        error = %e,
-                        "accord: Apply RPC failed"
-                    );
-                }
-            }
-        }
-
-        if apply_acks < sq {
+            .await;
+        if !apply_ok {
             tracing::error!(
                 txn_id = ?txn_id,
-                apply_acks,
-                sq,
+                unmet = ?participant.shards.len(),
                 "accord: Apply quorum not reached — LWT result may not be durable"
             );
             return Err(AccordDriverError::ApplyQuorumUnavailable);
@@ -1371,11 +1335,60 @@ impl AccordCoordinatorDriver {
 
         tracing::info!(
             txn_id = ?txn_id,
-            apply_acks,
             "accord: Apply phase complete — [applied]=true"
         );
 
         Ok((commit_t, commit_deps))
+    }
+
+    /// Build the single-shard participant set for the current write-set: every
+    /// key maps to the full `replica_ids`, i.e. one shard. This is the
+    /// behavior-preserving default (per-shard quorum over one shard ==
+    /// `slow_quorum_size(rf)`); the per-key `ring.replicas(token, rf)` fan-out
+    /// that produces multiple shards is a follow-up increment.
+    fn single_shard_participant(&self) -> crate::accord::shard_quorum::ParticipantSet {
+        let keys: Vec<Vec<u8>> = self.write_set.iter().map(|e| e.key.clone()).collect();
+        let replica_ids = self.replica_ids.clone();
+        crate::accord::shard_quorum::ParticipantSet::build(&keys, |_| replica_ids.clone())
+    }
+
+    /// Fan `msg` out to the replica set and decide success by **per-shard** slow
+    /// quorum: every shard in `participant` must independently reach
+    /// `slow_quorum_size(shard_rf)`. The coordinator's own replica is an implicit
+    /// ack (it drove the protocol and its self-send is unreachable). `is_ack`
+    /// decides whether a peer's response counts. Returns true iff every shard
+    /// reached quorum.
+    pub(crate) async fn quorum_broadcast(
+        &self,
+        msg: Message,
+        participant: &crate::accord::shard_quorum::ParticipantSet,
+        is_ack: impl Fn(&ferrosa_net::error::Result<Message>) -> bool,
+    ) -> bool {
+        let self_id = self.self_id;
+        let mut quorum = participant.quorum();
+        if self.replica_ids.contains(&self_id) && self_id != uuid::Uuid::nil() {
+            quorum.record_node_ack(self_id);
+        }
+
+        let futs: Vec<_> = self
+            .replica_ids
+            .iter()
+            .filter(|&&id| id != self_id)
+            .map(|&peer_id| {
+                let peers = Arc::clone(&self.peers);
+                let msg = msg.clone();
+                async move { (peer_id, peers.send(peer_id, msg, Lane::Data).await) }
+            })
+            .collect();
+
+        for (peer_id, result) in futures::future::join_all(futs).await {
+            if is_ack(&result) {
+                quorum.record_node_ack(peer_id);
+            } else if let Err(e) = &result {
+                tracing::warn!(error = %e, peer = %peer_id, "accord: quorum broadcast RPC failed");
+            }
+        }
+        quorum.all_reached()
     }
 
     /// The transaction ID assigned to this coordinator's transaction.
@@ -2317,5 +2330,130 @@ mod tests {
             0,
             "fail-loud must precede any write — no partial multi-key apply"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2: per-shard quorum, exercised through the real `quorum_broadcast`
+    // + the transport seam with a mock that returns controllable per-node acks.
+    // -----------------------------------------------------------------------
+
+    use crate::accord::shard_quorum::ParticipantSet;
+    use crate::accord::transport::AccordTransport;
+
+    /// A mock transport: each peer either acks (canned `Ok` response) or fails
+    /// (`Err`), per a configured map. Routes nothing — it only decides ack/fail.
+    struct MockTransport {
+        behavior: std::collections::HashMap<uuid::Uuid, bool>,
+        ok: Message,
+    }
+
+    #[async_trait::async_trait]
+    impl AccordTransport for MockTransport {
+        async fn send(
+            &self,
+            host_id: uuid::Uuid,
+            _msg: Message,
+            _lane: ferrosa_net::codec::Lane,
+        ) -> ferrosa_net::error::Result<Message> {
+            if *self.behavior.get(&host_id).unwrap_or(&false) {
+                Ok(self.ok.clone())
+            } else {
+                Err(ferrosa_net::error::NetError::Timeout(
+                    "mock node down".into(),
+                ))
+            }
+        }
+    }
+
+    /// Driver whose coordinator is NOT one of the replicas (node_id 999 matches
+    /// no `from_u128(small)` replica), so the quorum is decided purely by the
+    /// mock's per-node responses — no implicit self-ack to muddy the assertion.
+    fn driver_with(
+        transport: Arc<dyn AccordTransport>,
+        replica_ids: Vec<uuid::Uuid>,
+    ) -> AccordCoordinatorDriver {
+        let clock = HybridLogicalClock::new(999, 0);
+        AccordCoordinatorDriver::new_multi_with_transport(
+            999,
+            replica_ids,
+            transport,
+            false,
+            &clock,
+            vec![(b"k".to_vec(), b"m".to_vec())],
+        )
+    }
+
+    /// Two RF=3 shards: A = n[0..3], B = n[3..6].
+    fn two_shards(n: &[uuid::Uuid]) -> ParticipantSet {
+        ParticipantSet::build(&[b"ka".to_vec(), b"kb".to_vec()], |k| {
+            if k == b"ka" {
+                vec![n[0], n[1], n[2]]
+            } else {
+                vec![n[3], n[4], n[5]]
+            }
+        })
+    }
+
+    fn six_nodes() -> Vec<uuid::Uuid> {
+        (1u128..=6).map(uuid::Uuid::from_u128).collect()
+    }
+
+    #[tokio::test]
+    async fn quorum_broadcast_blocks_when_one_shard_is_a_minority() {
+        let n = six_nodes();
+        // Shard A all ack; shard B: only n[3] acks (1/3 < quorum 2).
+        let behavior = [
+            (n[0], true),
+            (n[1], true),
+            (n[2], true),
+            (n[3], true),
+            (n[4], false),
+            (n[5], false),
+        ]
+        .into_iter()
+        .collect();
+        let mock = Arc::new(MockTransport {
+            behavior,
+            ok: Message::AccordApplyOK(Bytes::new()),
+        });
+        let driver = driver_with(mock, n.clone());
+
+        let reached = driver
+            .quorum_broadcast(Message::AccordCommit(Bytes::new()), &two_shards(&n), |r| {
+                r.is_ok()
+            })
+            .await;
+        assert!(
+            !reached,
+            "shard B is a minority (1/3) — a global counter (4/6 acks) would wrongly pass"
+        );
+    }
+
+    #[tokio::test]
+    async fn quorum_broadcast_succeeds_when_every_shard_has_quorum() {
+        let n = six_nodes();
+        // Each shard at 2/3 → quorum in both.
+        let behavior = [
+            (n[0], true),
+            (n[1], true),
+            (n[2], false),
+            (n[3], true),
+            (n[4], true),
+            (n[5], false),
+        ]
+        .into_iter()
+        .collect();
+        let mock = Arc::new(MockTransport {
+            behavior,
+            ok: Message::AccordApplyOK(Bytes::new()),
+        });
+        let driver = driver_with(mock, n.clone());
+
+        let reached = driver
+            .quorum_broadcast(Message::AccordCommit(Bytes::new()), &two_shards(&n), |r| {
+                r.is_ok()
+            })
+            .await;
+        assert!(reached, "both shards at 2/3 → quorum in each");
     }
 }

--- a/ferrosa-cluster/src/accord/mod.rs
+++ b/ferrosa-cluster/src/accord/mod.rs
@@ -32,6 +32,7 @@ pub mod reorder_buffer;
 pub mod shard_quorum;
 pub mod state_machine;
 pub mod test_cluster;
+pub mod transport;
 pub mod two_phase_ddl;
 pub mod uda_integration;
 pub(crate) mod wire;

--- a/ferrosa-cluster/src/accord/mod.rs
+++ b/ferrosa-cluster/src/accord/mod.rs
@@ -29,6 +29,7 @@ pub mod proptests;
 pub mod recovery;
 pub mod recovery_scenarios;
 pub mod reorder_buffer;
+pub mod shard_quorum;
 pub mod state_machine;
 pub mod test_cluster;
 pub mod two_phase_ddl;

--- a/ferrosa-cluster/src/accord/shard_quorum.rs
+++ b/ferrosa-cluster/src/accord/shard_quorum.rs
@@ -1,0 +1,232 @@
+//! Per-shard quorum tracking for multi-key Accord transactions (Phase 2).
+//!
+//! A multi-key transaction's write-set spans one or more **shards** — each a
+//! token-range replica group (`ring.replicas(token, rf)`). Commit and Apply are
+//! durable only when a slow quorum is reached **within every shard
+//! independently**. A single global ack counter (the single-key path's
+//! `commit_acks`/`apply_acks`) is *wrong* for multi-key: a transaction that
+//! collected a full quorum from shard A and a single ack from shard B has NOT
+//! committed shard B, even though the *total* ack count may exceed a global
+//! quorum threshold. That would let one leg of a cross-shard transfer persist
+//! while the other is lost — the exact non-atomicity Accord exists to prevent.
+//!
+//! [`ShardQuorum`] records acks per shard (deduplicated by node) and reports
+//! success only when **each** shard has independently reached
+//! `slow_quorum_size(shard_rf)`.
+
+use std::collections::{HashMap, HashSet};
+
+use uuid::Uuid;
+
+use super::coordinator::slow_quorum_size;
+use super::ShardId;
+
+/// Acks collected for one shard's replica group.
+#[derive(Debug, Clone)]
+struct ShardAcks {
+    /// The shard's replica node ids (its replication factor is `replicas.len()`).
+    replicas: HashSet<Uuid>,
+    /// Distinct replica nodes that have acked so far.
+    acked: HashSet<Uuid>,
+}
+
+/// Tracks per-shard commit/apply acknowledgements for a multi-key transaction.
+#[derive(Debug, Clone)]
+pub struct ShardQuorum {
+    shards: HashMap<ShardId, ShardAcks>,
+}
+
+impl ShardQuorum {
+    /// Build a tracker from the participant set: `shard_id -> replica node ids`.
+    ///
+    /// # Panics
+    /// Panics if `participants` is empty or any shard has no replicas — a
+    /// transaction with no shards/replicas can never reach quorum and signals a
+    /// caller bug rather than a runtime condition.
+    pub fn new(participants: &HashMap<ShardId, Vec<Uuid>>) -> Self {
+        assert!(
+            !participants.is_empty(),
+            "ShardQuorum requires at least one shard"
+        );
+        let shards = participants
+            .iter()
+            .map(|(&shard, replicas)| {
+                assert!(
+                    !replicas.is_empty(),
+                    "shard {shard} must have at least one replica"
+                );
+                (
+                    shard,
+                    ShardAcks {
+                        replicas: replicas.iter().copied().collect(),
+                        acked: HashSet::new(),
+                    },
+                )
+            })
+            .collect();
+        Self { shards }
+    }
+
+    /// Record an ack from `node`. The ack counts toward **every** shard whose
+    /// replica group contains `node` (a node may replicate multiple shards).
+    /// Idempotent per (shard, node): re-acking is a no-op.
+    pub fn record_node_ack(&mut self, node: Uuid) {
+        for acks in self.shards.values_mut() {
+            if acks.replicas.contains(&node) {
+                acks.acked.insert(node);
+            }
+        }
+    }
+
+    /// True iff **every** shard has independently reached its slow quorum
+    /// (`slow_quorum_size(shard_rf)`).
+    pub fn all_reached(&self) -> bool {
+        self.shards.values().all(|acks| {
+            let rf = acks.replicas.len();
+            acks.acked.len() >= slow_quorum_size(rf)
+        })
+    }
+
+    /// The shards that have **not** yet reached quorum (for fail-loud
+    /// diagnostics). Empty iff [`Self::all_reached`] is true.
+    pub fn unmet(&self) -> Vec<ShardId> {
+        let mut out: Vec<ShardId> = self
+            .shards
+            .iter()
+            .filter(|(_, acks)| acks.acked.len() < slow_quorum_size(acks.replicas.len()))
+            .map(|(&sid, _)| sid)
+            .collect();
+        out.sort_unstable();
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    fn participants(entries: &[(ShardId, &[u128])]) -> HashMap<ShardId, Vec<Uuid>> {
+        entries
+            .iter()
+            .map(|(sid, nodes)| (*sid, nodes.iter().map(|&n| node(n)).collect()))
+            .collect()
+    }
+
+    #[test]
+    fn single_shard_needs_slow_quorum() {
+        // One shard, RF=3 → slow quorum = 2.
+        let mut q = ShardQuorum::new(&participants(&[(0, &[1, 2, 3])]));
+        assert!(!q.all_reached(), "0 acks < quorum");
+        q.record_node_ack(node(1));
+        assert!(!q.all_reached(), "1 ack < quorum(3)=2");
+        q.record_node_ack(node(2));
+        assert!(q.all_reached(), "2 acks reach quorum(3)=2");
+    }
+
+    #[test]
+    fn record_is_idempotent_per_node() {
+        let mut q = ShardQuorum::new(&participants(&[(0, &[1, 2, 3])]));
+        q.record_node_ack(node(1));
+        q.record_node_ack(node(1)); // duplicate must not count twice
+        assert!(!q.all_reached(), "one distinct ack is still below quorum");
+    }
+
+    #[test]
+    fn ack_from_non_replica_is_ignored() {
+        let mut q = ShardQuorum::new(&participants(&[(0, &[1, 2, 3])]));
+        q.record_node_ack(node(99)); // not a replica of shard 0
+        q.record_node_ack(node(1));
+        assert!(!q.all_reached(), "the stray ack must not count");
+    }
+
+    /// THE per-shard invariant: a full quorum in shard A plus a single ack in
+    /// shard B must NOT count as committed — shard B is a minority. A global
+    /// counter (4 distinct acks ≥ slow_quorum_size(6)=4) would wrongly report
+    /// success; per-shard correctly blocks on shard B.
+    #[test]
+    fn minority_in_one_shard_blocks_the_whole_txn() {
+        let mut q = ShardQuorum::new(&participants(&[
+            (0, &[1, 2, 3]), // shard A
+            (1, &[4, 5, 6]), // shard B
+        ]));
+        // Shard A: full quorum (all three).
+        q.record_node_ack(node(1));
+        q.record_node_ack(node(2));
+        q.record_node_ack(node(3));
+        // Shard B: a single ack (minority of RF=3).
+        q.record_node_ack(node(4));
+
+        assert!(
+            !q.all_reached(),
+            "shard B has only 1/3 acks (< quorum 2) — txn must NOT be committed"
+        );
+        assert_eq!(q.unmet(), vec![1], "shard B (id 1) is the unmet shard");
+    }
+
+    #[test]
+    fn both_shards_reaching_quorum_commits() {
+        let mut q = ShardQuorum::new(&participants(&[(0, &[1, 2, 3]), (1, &[4, 5, 6])]));
+        for n in [1, 2, 4, 5] {
+            q.record_node_ack(node(n));
+        }
+        assert!(q.all_reached(), "both shards at 2/3 → quorum each");
+        assert!(q.unmet().is_empty());
+    }
+
+    #[test]
+    fn overlapping_replica_counts_for_every_shard_it_owns() {
+        // Node 3 replicates BOTH shards (e.g. ring wrap-around). Its ack counts
+        // toward each shard's quorum independently.
+        let mut q = ShardQuorum::new(&participants(&[(0, &[1, 2, 3]), (1, &[3, 4, 5])]));
+        q.record_node_ack(node(3)); // counts for shard 0 AND shard 1
+        q.record_node_ack(node(1)); // shard 0 → now 2/3
+        q.record_node_ack(node(4)); // shard 1 → now 2/3
+        assert!(
+            q.all_reached(),
+            "the shared node satisfied both shards' quorums"
+        );
+    }
+
+    use proptest::prelude::*;
+    use std::collections::BTreeSet;
+
+    proptest! {
+        /// Fuzz shard-count × per-shard RF × overlapping replicas × ack pattern
+        /// against an independent oracle: `all_reached()` is true iff EVERY
+        /// shard independently has ≥ `slow_quorum_size(rf)` of its DISTINCT
+        /// replicas acked.
+        #[test]
+        fn all_reached_matches_per_shard_oracle(
+            shards in prop::collection::vec(prop::collection::vec(1u128..10, 1..6), 1..5),
+            ack_bits in any::<u64>(),
+        ) {
+            let participants: HashMap<ShardId, Vec<Uuid>> = shards
+                .iter()
+                .enumerate()
+                .map(|(i, nodes)| (i as ShardId, nodes.iter().map(|&n| node(n)).collect()))
+                .collect();
+            let mut q = ShardQuorum::new(&participants);
+
+            // Ack a deterministic subset of the distinct nodes (one bit each).
+            let all_nodes: BTreeSet<u128> = shards.iter().flatten().copied().collect();
+            let mut acked: HashSet<u128> = HashSet::new();
+            for (i, &n) in all_nodes.iter().enumerate() {
+                if (ack_bits >> (i % 64)) & 1 == 1 {
+                    q.record_node_ack(node(n));
+                    acked.insert(n);
+                }
+            }
+
+            let expected = shards.iter().all(|nodes| {
+                let distinct: BTreeSet<u128> = nodes.iter().copied().collect();
+                let got = distinct.iter().filter(|n| acked.contains(n)).count();
+                got >= slow_quorum_size(distinct.len())
+            });
+            prop_assert_eq!(q.all_reached(), expected);
+        }
+    }
+}

--- a/ferrosa-cluster/src/accord/shard_quorum.rs
+++ b/ferrosa-cluster/src/accord/shard_quorum.rs
@@ -101,6 +101,79 @@ impl ShardQuorum {
     }
 }
 
+/// The per-shard participant set for a multi-key transaction.
+///
+/// Built by grouping the write-set's keys by their token-range replica set
+/// (`ring.replicas(token, rf)`): keys whose replica sets are identical share a
+/// shard, and each distinct replica set is one shard. The driver uses `shards`
+/// to seed a [`ShardQuorum`] and to fan out each shard's keys to its replicas,
+/// and `key_shard` to route each write-set entry to the shard that owns it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParticipantSet {
+    /// `shard_id -> the shard's replica host ids` (sorted, deduplicated).
+    pub shards: HashMap<ShardId, Vec<Uuid>>,
+    /// For each input key (by position): the `ShardId` that owns it.
+    pub key_shard: Vec<ShardId>,
+}
+
+impl ParticipantSet {
+    /// Build the participant set from a write-set's keys. `replicas_of(key)`
+    /// returns the replica host ids for that key's token range (the driver wires
+    /// this to `ring.replicas(partitioner.token(key), rf)` mapped to host ids).
+    ///
+    /// Keys with identical replica sets collapse to one shard. `ShardId`s are
+    /// assigned deterministically (by the sorted distinct replica sets), so the
+    /// same write-set always yields the same shard layout.
+    ///
+    /// # Panics
+    /// Panics if `keys` is empty or any key resolves to zero replicas — both
+    /// signal a caller bug (a transaction must write at least one key, and every
+    /// key must have a replica set).
+    pub fn build(keys: &[Vec<u8>], replicas_of: impl Fn(&[u8]) -> Vec<Uuid>) -> Self {
+        assert!(!keys.is_empty(), "write-set must have at least one key");
+
+        // Each key's canonical (sorted, deduped) replica set.
+        let per_key: Vec<Vec<Uuid>> = keys
+            .iter()
+            .map(|k| {
+                let mut r = replicas_of(k);
+                r.sort_unstable();
+                r.dedup();
+                assert!(!r.is_empty(), "key resolved to zero replicas");
+                r
+            })
+            .collect();
+
+        // Distinct replica sets, sorted → stable ShardId = position.
+        let mut distinct: Vec<Vec<Uuid>> = per_key.clone();
+        distinct.sort();
+        distinct.dedup();
+
+        let shards: HashMap<ShardId, Vec<Uuid>> = distinct
+            .iter()
+            .enumerate()
+            .map(|(i, set)| (i as ShardId, set.clone()))
+            .collect();
+        let key_shard: Vec<ShardId> = per_key
+            .iter()
+            .map(|set| {
+                distinct
+                    .iter()
+                    .position(|s| s == set)
+                    .expect("every key's replica set is in the distinct list")
+                    as ShardId
+            })
+            .collect();
+
+        Self { shards, key_shard }
+    }
+
+    /// Seed a [`ShardQuorum`] from this participant set.
+    pub fn quorum(&self) -> ShardQuorum {
+        ShardQuorum::new(&self.shards)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,6 +262,56 @@ mod tests {
             q.all_reached(),
             "the shared node satisfied both shards' quorums"
         );
+    }
+
+    #[test]
+    fn participant_set_collapses_keys_with_identical_replicas_to_one_shard() {
+        let ps = ParticipantSet::build(&[b"a".to_vec(), b"b".to_vec()], |_k| {
+            vec![node(1), node(2), node(3)]
+        });
+        assert_eq!(ps.shards.len(), 1, "shared replica set → one shard");
+        assert_eq!(ps.key_shard, vec![0, 0]);
+    }
+
+    #[test]
+    fn participant_set_distinct_replica_sets_become_distinct_shards() {
+        let ps = ParticipantSet::build(&[b"a".to_vec(), b"b".to_vec()], |k| {
+            if k == b"a" {
+                vec![node(1), node(2), node(3)]
+            } else {
+                vec![node(4), node(5), node(6)]
+            }
+        });
+        assert_eq!(ps.shards.len(), 2);
+        assert_ne!(
+            ps.key_shard[0], ps.key_shard[1],
+            "a and b in different shards"
+        );
+
+        // Quorum in only ONE shard must not satisfy the whole txn.
+        let mut q = ps.quorum();
+        for r in &ps.shards[&ps.key_shard[0]] {
+            q.record_node_ack(*r);
+        }
+        assert!(!q.all_reached(), "the other shard is still unmet");
+    }
+
+    #[test]
+    fn participant_set_overlapping_but_unequal_sets_are_distinct_shards() {
+        let ps = ParticipantSet::build(&[b"a".to_vec(), b"b".to_vec()], |k| {
+            if k == b"a" {
+                vec![node(1), node(2), node(3)]
+            } else {
+                vec![node(3), node(4), node(5)] // shares node 3, not identical
+            }
+        });
+        assert_eq!(ps.shards.len(), 2, "overlap ≠ identical → 2 shards");
+    }
+
+    #[test]
+    fn participant_set_dedups_replicas_within_a_key() {
+        let ps = ParticipantSet::build(&[b"a".to_vec()], |_k| vec![node(1), node(1), node(2)]);
+        assert_eq!(ps.shards[&0].len(), 2, "duplicate replica deduped → rf=2");
     }
 
     use proptest::prelude::*;

--- a/ferrosa-cluster/src/accord/transport.rs
+++ b/ferrosa-cluster/src/accord/transport.rs
@@ -1,0 +1,38 @@
+//! Transport seam for the Accord coordinator driver (Phase 2).
+//!
+//! The driver's only network dependency is "send a [`Message`] to a peer
+//! `host_id` on a [`Lane`] and await the response message". Abstracting that
+//! behind [`AccordTransport`] lets tests inject a mock that returns controllable
+//! per-node responses, so the multi-node Commit/Apply per-shard quorum logic can
+//! be exercised deterministically without a real network. [`PeerManager`] is the
+//! production implementation — a thin forward to its inherent `send`.
+
+use async_trait::async_trait;
+use ferrosa_net::codec::Lane;
+use ferrosa_net::message::Message;
+use ferrosa_net::peer::PeerManager;
+
+/// Request/response transport used by the Accord coordinator driver.
+#[async_trait]
+pub trait AccordTransport: Send + Sync {
+    /// Send `msg` to `host_id` on `lane`, awaiting the peer's response message.
+    async fn send(
+        &self,
+        host_id: uuid::Uuid,
+        msg: Message,
+        lane: Lane,
+    ) -> ferrosa_net::error::Result<Message>;
+}
+
+#[async_trait]
+impl AccordTransport for PeerManager {
+    async fn send(
+        &self,
+        host_id: uuid::Uuid,
+        msg: Message,
+        lane: Lane,
+    ) -> ferrosa_net::error::Result<Message> {
+        // Forward to the inherent method (this trait impl only adds the dyn seam).
+        PeerManager::send(self, host_id, msg, lane).await
+    }
+}

--- a/ferrosa-cluster/src/coordinator/mod.rs
+++ b/ferrosa-cluster/src/coordinator/mod.rs
@@ -159,6 +159,21 @@ impl ClusterCoordinator {
             .map(|info| info.data_center.clone())
     }
 
+    /// Resolve the replica **host ids** that own `token` under the keyspace
+    /// `strategy` from the current ring snapshot. This is the cluster-mode source
+    /// for an Accord transaction's participant set (ADR-021): the coordinator
+    /// owns the ring, so replica placement stays here instead of leaking into the
+    /// CQL/Postgres front-ends.
+    pub fn replica_host_ids_for(
+        &self,
+        token: crate::raft::Token,
+        strategy: &crate::ring::strategy::ReplicationStrategy,
+    ) -> Vec<uuid::Uuid> {
+        self.ring
+            .load()
+            .replica_host_ids_for_strategy(token, strategy)
+    }
+
     /// Attach a Raft state snapshot for index-aware replica selection.
     pub fn with_raft_state(mut self, state: Arc<ArcSwap<RaftState>>) -> Self {
         self.raft_state = Some(state);

--- a/ferrosa-cluster/src/ring/mod.rs
+++ b/ferrosa-cluster/src/ring/mod.rs
@@ -178,6 +178,23 @@ impl TokenRing {
         }
     }
 
+    /// The replica **host ids** (not internal node ids) that own `token` under
+    /// `strategy`. Convenience over [`Self::replicas_for_strategy`] for callers
+    /// that address replicas by `host_id` — e.g. the Accord coordinator driver,
+    /// whose per-shard quorum (`ShardQuorum`/`ParticipantSet`) is keyed by host
+    /// id. A node missing a registry entry is skipped (it cannot be a usable
+    /// replica target). Order follows `replicas_for_strategy`.
+    pub fn replica_host_ids_for_strategy(
+        &self,
+        token: Token,
+        strategy: &strategy::ReplicationStrategy,
+    ) -> Vec<uuid::Uuid> {
+        self.replicas_for_strategy(token, strategy)
+            .into_iter()
+            .filter_map(|id| self.get_node(id).map(|n| n.host_id))
+            .collect()
+    }
+
     /// Find replicas for a token using NetworkTopologyStrategy.
     ///
     /// Walks clockwise from `token`, filling per-DC quotas from `dc_rf`
@@ -747,6 +764,38 @@ mod tests {
         };
         let replicas = ring.replicas_for_strategy(0, &strategy);
         assert_eq!(replicas.len(), 2);
+    }
+
+    #[test]
+    fn replica_host_ids_for_strategy_maps_node_ids_to_host_ids() {
+        let mut ring = TokenRing::new();
+        ring.add_node(1, make_node("10.0.0.1:7000"));
+        ring.add_node(2, make_node("10.0.0.2:7000"));
+        ring.assign_tokens(1, &[100]);
+        ring.assign_tokens(2, &[200]);
+        let strategy = ReplicationStrategy::Simple {
+            replication_factor: 2,
+        };
+
+        // The host-id variant must return exactly the host ids of the node-id
+        // replicas, in the same order (this is what the Accord participant set
+        // consumes — replicas addressed by host_id).
+        let node_ids = ring.replicas_for_strategy(0, &strategy);
+        let expected: Vec<uuid::Uuid> = node_ids
+            .iter()
+            .map(|&id| {
+                ring.get_node(id)
+                    .expect("replica must be in the ring")
+                    .host_id
+            })
+            .collect();
+        let host_ids = ring.replica_host_ids_for_strategy(0, &strategy);
+
+        assert_eq!(host_ids.len(), 2, "RF=2 → two replica host ids");
+        assert_eq!(
+            host_ids, expected,
+            "host-id variant must mirror the node-id replicas"
+        );
     }
 
     #[test]

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -796,6 +796,25 @@ impl WritePath {
         }
     }
 
+    /// Resolve a partition `token`'s replica **host ids** under the keyspace
+    /// `strategy`, for an Accord transaction's participant set (ADR-021).
+    ///
+    /// `Some(..)` only in **cluster** mode — replica placement is the ring's
+    /// concern and lives behind this boundary so the CQL/Postgres front-ends
+    /// never touch the ring/partitioner. Returns `None` in standalone/pair/
+    /// degraded modes, where the caller uses the local node (Accord transactions
+    /// are a cluster feature; a single-node deployment is one trivial replica).
+    pub fn replicas_for_key(
+        &self,
+        token: crate::raft::Token,
+        strategy: &crate::ring::strategy::ReplicationStrategy,
+    ) -> Option<Vec<uuid::Uuid>> {
+        match self {
+            Self::Cluster(coordinator) => Some(coordinator.replica_host_ids_for(token, strategy)),
+            Self::Direct(_) | Self::Pair(_) | Self::Unavailable => None,
+        }
+    }
+
     /// Truncate a table. In standalone/pair mode this truncates local storage.
     /// In cluster mode the coordinator fans out to all nodes.
     pub async fn truncate(&self, table_id: &TableId) -> ferrosa_common::Result<()> {
@@ -991,6 +1010,20 @@ mod tests {
         // Verify data was written
         let result = storage.read(&table_id, &key).unwrap();
         assert!(result.is_some(), "DirectWritePath should write to storage");
+    }
+
+    #[test]
+    fn replicas_for_key_is_none_outside_cluster_mode() {
+        // Standalone/pair/degraded modes have no ring, so the caller falls back
+        // to the local node. Cluster-mode resolution is covered by the ring's
+        // `replica_host_ids_for_strategy` test.
+        let strategy = ReplicationStrategy::Simple {
+            replication_factor: 3,
+        };
+        assert_eq!(
+            WritePath::unavailable().replicas_for_key(0, &strategy),
+            None
+        );
     }
 
     #[test]

--- a/specs/decisions/021-write-path-accord-replica-boundary.md
+++ b/specs/decisions/021-write-path-accord-replica-boundary.md
@@ -1,0 +1,96 @@
+# ADR-021: `write_path` as the Accord transaction / replica-resolution boundary
+
+> Date: 2026-06-22
+> Status: Proposed
+> Scope: `ferrosa-cluster::write_path::WritePath` (new Accord-commit entry),
+> `ferrosa-cql::router::route_lwt_via_accord` (becomes a thin submit), and the
+> multi-key `BEGIN/COMMIT` route (Phase 5). Touches replica resolution and
+> `AccordCoordinatorDriver` construction.
+> Non-goal: changing the per-shard quorum core (`ShardQuorum`, `ParticipantSet`,
+> `AccordTransport` — already ring-free, see PR #182); the Accord wire protocol.
+
+## Context
+
+The per-shard quorum foundation (PR #182) is deliberately topology-free:
+`ParticipantSet::build(keys, replicas_of)` takes a **closure**, and
+`AccordTransport` abstracts the network. Neither references `Ring`, `Token`, or
+the partitioner. Activating *multi-shard* execution needs one thing: each
+write-set key resolved to its token-range replicas
+(`ring.replicas(token(key), rf)`).
+
+Today that resolution can't happen where the driver is built:
+
+- `ferrosa-cql::router::route_lwt_via_accord` **constructs
+  `AccordCoordinatorDriver` directly and hand-builds `replica_ids` from
+  `peers.live_peer_ids()`** — every live peer, not the token's replicas. This is
+  both a latent correctness bug ("uses all live peers") and a layering leak:
+  replica placement is a *cluster* concern living in the *query* crate.
+- `ferrosa-cql::SharedState` carries **no ring snapshot**. The naive fix —
+  thread a concrete `Ring` into `ferrosa-cql` — would couple the query layer to
+  cluster-topology internals (`Ring`, `NodeState`, `node_id`↔`host_id`, the
+  Murmur3 partitioner), and duplicate knowledge that already lives one layer
+  down.
+
+The CQL layer **already** reaches the cluster through
+`state.write_path` (`ferrosa_cluster::write_path::WritePath`), whose `Cluster`
+variant is the coordinator and **already owns the ring** (it is what
+`coordinate_read` / the FTS scatter-gather use). The boundary already exists; we
+are currently reaching *around* it.
+
+## Decision
+
+Make `WritePath` the **single boundary** for Accord transaction execution and
+replica resolution. Add an entry point (shape, not final name):
+
+```text
+WritePath::accord_commit(write_set, read_predicate, options) -> AccordResult
+```
+
+- `Cluster(coordinator)` — resolves `ring.replicas(token(key), rf)` per key
+  (mapping `node_id` → `host_id`), builds the `ParticipantSet`, constructs and
+  drives the `AccordCoordinatorDriver`, and returns the result.
+- `Direct`/`Pair` — the standalone / two-node degenerate case (one shard = the
+  local node(s)), preserving today's single-node behavior.
+
+`ferrosa-cql` submits **intent only** — the write-set plus the IF-predicate — and
+never touches `Ring`, `Token`, `replica_ids`, or the driver. `route_lwt_via_accord`
+collapses to: build the write-set + predicate, call `write_path.accord_commit`,
+map the result to a `RouteResult`.
+
+This mirrors the codebase's established dependency-inversion idiom — `Arc<dyn
+DataStore>`, `Arc<dyn StorageApplier>`, the new `AccordTransport`, and the planned
+`TransactionCommitter` (Phase 6 / ADR pending) — so it is consistent, not novel.
+
+## Consequences
+
+**Positive**
+
+- Removes the CQL → cluster-topology coupling; the query crate stops knowing
+  about rings, tokens, partitioners, or replica sets.
+- **Fixes the "all live peers" bug at its root** — the cluster resolves the
+  correct token replicas instead of every live peer.
+- One place owns replica placement + per-shard participant construction (where
+  the ring already lives), so the multi-key `BEGIN/COMMIT` route (Phase 5) and
+  the single-key LWT route share it.
+- The per-shard quorum core (PR #182) is unchanged — it was built on the right
+  side of this line.
+
+**Negative / cost**
+
+- A new method on `WritePath` and its variants; the `Direct`/`Pair` arms must
+  handle the local degenerate case explicitly (fail-loud, never silently
+  single-node a multi-shard txn).
+- Moves the `local_applier`/`local_reader`/`condition_gate` wiring that the CQL
+  router does today into the cluster layer.
+
+## Alternatives considered
+
+1. **Thread a `Ring` into `ferrosa-cql::SharedState`.** Rejected: couples the
+   query layer to cluster topology internals and duplicates placement logic that
+   `WritePath` already encapsulates.
+2. **A narrow `ReplicaResolver` trait injected into the CQL router.** Better than
+   (1), but still leaves CQL constructing and driving the `AccordCoordinatorDriver`
+   — the deeper smell. `WritePath` *is* already the seam; adding a second one is
+   redundant.
+3. **Status quo (`live_peer_ids()`).** Rejected: it is the active bug, and the
+   coupling only grows once multi-key transactions need per-key replicas.

--- a/specs/decisions/021-write-path-accord-replica-boundary.md
+++ b/specs/decisions/021-write-path-accord-replica-boundary.md
@@ -39,27 +39,76 @@ are currently reaching *around* it.
 
 ## Decision
 
-Make `WritePath` the **single boundary** for Accord transaction execution and
-replica resolution. Add an entry point (shape, not final name):
+Make `WritePath` the boundary for **replica resolution** (the topology concern),
+while keeping `AccordCoordinatorDriver` construction in the CQL layer for the
+single-key LWT path — because the LWT **condition gate** is irreducibly
+CQL-specific: it decodes CQL schema (`decode_agreed_row_to_map`) and evaluates
+the `IF` predicate (`eval_lwt_for_statement`) inside a closure the driver runs
+during the read-vote phase. The cluster layer cannot build that closure, so
+relocating the whole driver there would just push a CQL closure back across the
+boundary — no real decoupling.
+
+Two-part decision:
+
+1. **Replica resolution moves behind `WritePath`** (the only topology leak today):
+   ```text
+   WritePath::replicas_for_key(table_id, key) -> Vec<Uuid>   // host ids
+   ```
+   - `Cluster(coordinator)` — `ring.replicas(token(key), rf)` mapped `node_id` →
+     `host_id`, with `rf` from the keyspace replication.
+   - `Direct`/`Pair` — the local node(s) (standalone / two-node degenerate case).
+
+   `route_lwt_via_accord` sources `replica_ids` from this instead of
+   `peers.live_peer_ids()`. CQL stops touching `Ring`/`Token`/the partitioner;
+   the "all live peers" bug is fixed at the root. CQL still constructs the driver
+   and injects the applier/reader/gate (its own + engine concerns).
+
+2. **The gateless multi-key path (Phase 5 `BEGIN/COMMIT`) gets the fuller
+   `WritePath::accord_commit(write_set, ...)`** — no condition gate there, so the
+   cluster layer can own the whole drive + per-key `ParticipantSet` build. This
+   is added with Phase 5, not now.
+
+Both mirror the codebase's dependency-inversion idiom — `Arc<dyn DataStore>`,
+`Arc<dyn StorageApplier>`, the new `AccordTransport`, the planned
+`TransactionCommitter` (Phase 6) — so they are consistent, not novel.
+
+## Relation to exposing Accord transactions over SQL (Postgres + CQL)
+
+The goal these increments serve is **multi-key Accord transactions exposed over
+SQL** — `BEGIN/COMMIT` on both the Postgres and CQL front-ends. That makes the
+*front-end-facing* seam, not the cluster-internal one, the load-bearing
+boundary, and it must be **front-end-agnostic** because `ferrosa-postgres` does
+**not** (and should not) depend on `ferrosa-cluster`.
+
+Layering:
 
 ```text
-WritePath::accord_commit(write_set, read_predicate, options) -> AccordResult
+ferrosa-postgres ─┐
+                  ├─→  Arc<dyn TransactionCommitter>      (trait in ferrosa-storage — the shared dep)
+ferrosa-cql ──────┘              │   commit_write_set(writes, predicate) -> result
+                                 ▼
+        ferrosa-cluster: the Accord commit impl
+          1. resolve replicas per key  ← THIS ADR (ring.replicas, write.rs:278)
+          2. per-shard quorum          ← ShardQuorum / ParticipantSet (PR #182)
+          3. drive AccordCoordinatorDriver
 ```
 
-- `Cluster(coordinator)` — resolves `ring.replicas(token(key), rf)` per key
-  (mapping `node_id` → `host_id`), builds the `ParticipantSet`, constructs and
-  drives the `AccordCoordinatorDriver`, and returns the result.
-- `Direct`/`Pair` — the standalone / two-node degenerate case (one shard = the
-  local node(s)), preserving today's single-node behavior.
+So:
 
-`ferrosa-cql` submits **intent only** — the write-set plus the IF-predicate — and
-never touches `Ring`, `Token`, `replica_ids`, or the driver. `route_lwt_via_accord`
-collapses to: build the write-set + predicate, call `write_path.accord_commit`,
-map the result to a `RouteResult`.
+- **`TransactionCommitter`** (defined in `ferrosa-storage`, the crate both
+  front-ends already share — Phase 6) is the SQL-exposure boundary. Postgres and
+  CQL `BEGIN/COMMIT` both buffer DML into a write-set and call it on COMMIT;
+  ROLLBACK drops the buffer.
+- This ADR's `WritePath` replica resolution + PR #182's per-shard quorum are the
+  **implementation** behind that trait, in `ferrosa-cluster`, wired into the impl
+  in the binary (mirroring how `Arc<dyn StorageApplier>` is injected).
+- The single-key LWT path keeps its CQL-specific condition gate (above) and uses
+  the same `WritePath` replica resolution; it does not go through
+  `TransactionCommitter` (no buffered write-set).
 
-This mirrors the codebase's established dependency-inversion idiom — `Arc<dyn
-DataStore>`, `Arc<dyn StorageApplier>`, the new `AccordTransport`, and the planned
-`TransactionCommitter` (Phase 6 / ADR pending) — so it is consistent, not novel.
+Net: replica resolution moves behind `WritePath` now (this ADR, unblocks the LWT
+bug fix); the `TransactionCommitter` front-end seam lands with the multi-key
+`BEGIN/COMMIT` work (Phase 5 CQL + Phase 6 Postgres) and reuses both.
 
 ## Consequences
 


### PR DESCRIPTION
## What

Phase 2 of multi-key Accord transactions: the **per-shard quorum** foundation. A multi-key transaction's write-set spans multiple shards (token-range replica groups), and Commit/Apply must reach a slow quorum **within every shard independently** — a single global ack counter would let one leg of a cross-shard transfer persist while the other is a minority (the exact non-atomicity Accord prevents).

## Increments (each TDD, red-first)

1. **`ShardQuorum`** (`accord/shard_quorum.rs`) — records acks per shard (deduped by node; an overlapping replica counts for every shard it owns); `all_reached()` iff every shard hits `slow_quorum_size(shard_rf)`. *Red proven:* the per-shard tests fail against a global counter and pass per-shard; plus a proptest (shard-count × RF × overlap × ack-pattern vs an independent oracle).
2. **`ParticipantSet`** — groups a write-set's keys by replica set into shards; `.quorum()` seeds a `ShardQuorum`.
3. **Transport seam** (`accord/transport.rs`) — `trait AccordTransport` (PeerManager is the prod impl); driver field becomes `Arc<dyn AccordTransport>`, `new`/`new_multi` unchanged (coerced internally), `new_multi_with_transport` lets tests inject a mock. No behavior change.
4. **Wired into Commit/Apply** — both phases now use `quorum_broadcast(msg, participant, is_ack)` (per-shard decision) instead of the global `commit_acks`/`apply_acks`. `single_shard_participant()` is the behavior-preserving default for the current single-key path; per-key `ring.replicas()` fan-out is the follow-up.

## Tests

Driver-level, through the real `quorum_broadcast` + a `MockTransport` with controllable per-node acks: a 2-shard broadcast where one shard has only **1/3** acks does **not** reach quorum — even though a global **4/6** counter would wrongly pass — and both shards at 2/3 do. **244 accord tests green**, fmt + clippy clean.

## Safe to merge

Production is unchanged: the executable path is single-key → one shard → `slow_quorum_size(rf)`, identical to before. The multi-shard machinery is tested and ready for the next increment (thread ring + Murmur3 into the driver to build a real per-key participant set, remove the `MultiKeyNotYetExecutable` guard, add the cross-shard bank-transfer atomicity test vs the `CrossShardCoordinator` oracle). Full plan on task t_a444999f.