### PR TITLE
feat(accord): token-aware per-key replica resolution in the live LWT path

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -60,6 +60,14 @@ strict-serializable multi-key / cross-shard transactions and LWT.
 ### Coordination (`coordinator/`, `consistency.rs`, `write_path.rs`)
 - `ConsistencyLevel` — full CQL CL set incl. `Serial`/`LocalSerial`; `block_for` /
   `block_for_dc` quorum math, wire + string codecs.
+- `write_path.rs` — the front-end-facing replica-placement boundary (ADR-021):
+  `replicas_for_key(token, strategy)` and `accord_replicas_for_key(key,
+  replication)` resolve a key's RF replica host ids from the ring in cluster
+  mode (`None` outside it, so the caller keeps its local/all-peers fallback;
+  `Err` on an unparseable strategy). The CQL/Postgres LWT/Accord paths pass raw
+  key bytes + keyspace replication and never touch the partitioner or ring — the
+  CQL LWT path (`route_lwt_via_accord`) uses this for token-aware, RF-correct
+  participant sets instead of replicating every key to every connected peer.
 - `coordinator/write.rs` — replica fan-out with `cl.block_for(rf)` ack threshold,
   NTS / `LOCAL_QUORUM` / `EACH_QUORUM` per-DC variants, hinted handoff for failed
   replicas, post-quorum hint drain, lazy mutation encoding.

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -815,6 +815,28 @@ impl WritePath {
         }
     }
 
+    /// Resolve the Accord participant replica **host ids** that own a partition
+    /// `key` under the keyspace `replication`, computing the key's token and
+    /// parsing the strategy here so the CQL/Postgres front-ends pass raw key
+    /// bytes + keyspace metadata and never touch the partitioner or ring
+    /// (ADR-021).
+    ///
+    /// - `Ok(Some(replicas))` in **cluster** mode — the RF replicas owning the
+    ///   key's token (a proper subset of the cluster when RF < node count).
+    /// - `Ok(None)` outside cluster mode (no ring) — the caller falls back to
+    ///   its local/all-live-peers participant set.
+    /// - `Err(_)` if `replication` cannot be parsed into a strategy — fail loud
+    ///   rather than silently resolving to an empty/default set.
+    pub fn accord_replicas_for_key(
+        &self,
+        key: &[u8],
+        replication: &ferrosa_schema::metadata::keyspace::ReplicationParams,
+    ) -> Result<Option<Vec<uuid::Uuid>>, crate::ring::strategy::StrategyParseError> {
+        let strategy = crate::ring::strategy::ReplicationStrategy::try_from(replication)?;
+        let token = ferrosa_common::Token::from_key(key).0;
+        Ok(self.replicas_for_key(token, &strategy))
+    }
+
     /// Truncate a table. In standalone/pair mode this truncates local storage.
     /// In cluster mode the coordinator fans out to all nodes.
     pub async fn truncate(&self, table_id: &TableId) -> ferrosa_common::Result<()> {
@@ -1167,6 +1189,120 @@ mod tests {
             projected_body.contains("local_projected_range_stream")
                 && projected_body.contains("coordinate_range_read_projected_stream_all_with"),
             "projected scans must expose a stream and fail clearly when cluster semantics would under-read"
+        );
+    }
+
+    // ── Accord per-key replica resolution (ADR-021) ───────────────────────────
+    // The write path owns replica placement; the CQL/PG front-ends ask it for a
+    // key's Accord participant set rather than resolving the ring themselves.
+
+    fn simple_replication(rf: usize) -> ferrosa_schema::metadata::keyspace::ReplicationParams {
+        ferrosa_schema::metadata::keyspace::ReplicationParams {
+            strategy: "SimpleStrategy".to_string(),
+            options: std::collections::HashMap::from([(
+                "replication_factor".to_string(),
+                rf.to_string(),
+            )]),
+        }
+    }
+
+    fn ring_node(addr: &str) -> crate::raft::NodeInfo {
+        crate::raft::NodeInfo {
+            host_id: uuid::Uuid::new_v4(),
+            addr: addr.to_string(),
+            data_center: "dc1".to_string(),
+            rack: "rack1".to_string(),
+            state: crate::raft::NodeState::Normal,
+            cql_broadcast: None,
+        }
+    }
+
+    #[test]
+    fn accord_replicas_for_key_is_none_outside_cluster_mode() {
+        // Standalone/pair/degraded modes have no ring, so the resolver yields
+        // None and the caller falls back to its local/all-live-peers set rather
+        // than guessing a placement.
+        let params = simple_replication(3);
+        assert_eq!(
+            WritePath::unavailable()
+                .accord_replicas_for_key(b"some-partition-key", &params)
+                .expect("a valid strategy parses"),
+            None
+        );
+    }
+
+    #[test]
+    fn accord_replicas_for_key_fails_loud_on_bad_strategy() {
+        // An unparseable replication strategy must surface an error, never
+        // silently resolve to an empty/default replica set (fail loud).
+        let params = ferrosa_schema::metadata::keyspace::ReplicationParams {
+            strategy: "NoSuchStrategy".to_string(),
+            options: std::collections::HashMap::new(),
+        };
+        assert!(
+            WritePath::unavailable()
+                .accord_replicas_for_key(b"k", &params)
+                .is_err(),
+            "unknown replication strategy must fail loud"
+        );
+    }
+
+    #[test]
+    fn accord_replicas_for_key_resolves_rf_subset_in_cluster_mode() {
+        // Token-aware: over a 3-node ring with RF=2, a key resolves to exactly
+        // its two owning replicas — a proper subset of the cluster, not "all
+        // live peers". This is what makes the live Accord path RF-correct.
+        use ferrosa_net::peer::{PeerEventListener, PeerManager};
+        use ferrosa_net::rpc::handler::PeerId;
+
+        struct NoopListener;
+        impl PeerEventListener for NoopListener {
+            fn on_peer_connected(&self, _: PeerId) {}
+            fn on_peer_disconnected(&self, _: PeerId) {}
+            fn on_peer_suspected(&self, _: PeerId) {}
+            fn on_peer_recovered(&self, _: uuid::Uuid) {}
+            fn on_peer_failed(&self, _: uuid::Uuid) {}
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+
+        let mut ring = crate::ring::TokenRing::new();
+        let n1 = ring_node("10.0.0.1:7000");
+        let n2 = ring_node("10.0.0.2:7000");
+        let n3 = ring_node("10.0.0.3:7000");
+        let members = [n1.host_id, n2.host_id, n3.host_id];
+        ring.add_node(1, n1);
+        ring.add_node(2, n2);
+        ring.add_node(3, n3);
+        ring.assign_tokens(1, &[-3_000_000_000_000_000_000]);
+        ring.assign_tokens(2, &[0]);
+        ring.assign_tokens(3, &[3_000_000_000_000_000_000]);
+
+        let coordinator = ClusterCoordinator::new(
+            std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(ring)),
+            std::sync::Arc::new(PeerManager::new(
+                std::sync::Arc::new(ferrosa_net::config::NetConfig::default()),
+                uuid::Uuid::new_v4(),
+                std::sync::Arc::new(NoopListener),
+            )),
+            1,
+            storage,
+            2,
+            ConsistencyLevel::One,
+        );
+        let write_path = WritePath::cluster(std::sync::Arc::new(coordinator));
+
+        let params = simple_replication(2);
+        let replicas = write_path
+            .accord_replicas_for_key(b"some-partition-key", &params)
+            .expect("a valid strategy parses")
+            .expect("cluster mode resolves a concrete replica set");
+
+        assert_eq!(replicas.len(), 2, "RF=2 → exactly two owning replicas");
+        assert!(
+            replicas.iter().all(|r| members.contains(r)),
+            "every resolved replica must be a ring member"
         );
     }
 }

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1190,17 +1190,20 @@ async fn route_lwt_via_accord(
 ) -> Result<RouteResult, CqlError> {
     use ferrosa_cluster::accord::AccordCoordinatorDriver;
 
-    // Build the replica set from the live peer map plus this node itself.
-    // Ordering is deterministic: local node first, then peers sorted by UUID.
+    // Fallback replica set: the live peer map plus this node itself. Used when
+    // the write path has no ring (standalone/pair/degraded) and as the basis for
+    // the "no peers at all" guard below. Cluster mode replaces this with the
+    // key's token-aware RF replicas (see `select_accord_replicas` after the
+    // keyspace is resolved). Ordering is deterministic: sorted by UUID.
     let host_id = state.node_config.host_id;
-    let mut replica_ids: Vec<uuid::Uuid> = peers.live_peer_ids();
+    let mut fallback_replicas: Vec<uuid::Uuid> = peers.live_peer_ids();
     // Include local node if not already in the list.
-    if !replica_ids.contains(&host_id) {
-        replica_ids.push(host_id);
+    if !fallback_replicas.contains(&host_id) {
+        fallback_replicas.push(host_id);
     }
-    replica_ids.sort_unstable();
+    fallback_replicas.sort_unstable();
 
-    if replica_ids.is_empty() {
+    if fallback_replicas.is_empty() {
         return Err(CqlError::ServerError(
             "Accord replica set is empty — no peers connected for LWT consensus".into(),
         ));
@@ -1220,6 +1223,25 @@ async fn route_lwt_via_accord(
     // Resolve the target keyspace/table for the generic-IF read-vote so replicas
     // (and the coordinator's own local reader) can target the read-at-`t`.
     let (ks, table) = lwt_keyspace_table(ctx, stmt)?;
+
+    // Token-aware participant resolution (ADR-021): in cluster mode the write
+    // path maps the key to its RF replicas from the ring (a proper subset of the
+    // cluster); otherwise we keep the live-peer fallback. This makes the live
+    // Accord LWT path RF-correct rather than replicating every key to every
+    // connected peer. Placement stays behind `WritePath` — the CQL front-end
+    // only passes raw key bytes + keyspace replication.
+    let replication = state
+        .schema
+        .snapshot()
+        .keyspaces
+        .get(&ks)
+        .map(|k| k.replication.clone());
+    let replica_ids = select_accord_replicas(
+        &state.write_path.load(),
+        replication.as_ref(),
+        &key,
+        fallback_replicas,
+    )?;
 
     // Classify the IF predicate. `NotExists` uses the replica existence path;
     // `Generic` reads the row at `t` so the coordinator evaluates `IF col=val`.
@@ -1310,6 +1332,35 @@ async fn route_lwt_via_accord(
     }
 
     finish_lwt_via_accord(state, &ks, &table, driver, None).await
+}
+
+/// Select the Accord participant replicas for a single-key LWT.
+///
+/// In cluster mode the write path resolves the key's owning replicas from the
+/// ring (token-aware, RF-correct — a proper subset of the cluster). Outside
+/// cluster mode (or when the keyspace replication is unknown) we keep the
+/// caller's `fallback` set (the live peer map), since Accord placement is a
+/// cluster concern. An unparseable strategy or an empty cluster-mode resolution
+/// fails loud rather than silently writing to the wrong/empty replica set.
+fn select_accord_replicas(
+    write_path: &ferrosa_cluster::WritePath,
+    replication: Option<&ReplicationParams>,
+    key: &[u8],
+    fallback: Vec<uuid::Uuid>,
+) -> Result<Vec<uuid::Uuid>, CqlError> {
+    let Some(replication) = replication else {
+        return Ok(fallback);
+    };
+    match write_path.accord_replicas_for_key(key, replication) {
+        Ok(Some(resolved)) if !resolved.is_empty() => Ok(resolved),
+        Ok(Some(_)) => Err(CqlError::ServerError(
+            "Accord cluster-mode replica resolution returned no replicas for the LWT key".into(),
+        )),
+        Ok(None) => Ok(fallback),
+        Err(e) => Err(CqlError::ServerError(format!(
+            "LWT replica resolution: {e}"
+        ))),
+    }
 }
 
 /// Drive the Accord transaction to completion and map its result to a CQL LWT
@@ -11357,6 +11408,60 @@ mod tests {
     use arc_swap::ArcSwap;
     use ferrosa_cluster::WritePath;
     use ferrosa_schema::NodeConfig;
+
+    // ── select_accord_replicas: live-path replica selection ───────────────────
+
+    fn simple_replication_params(rf: usize) -> ReplicationParams {
+        ReplicationParams {
+            strategy: "SimpleStrategy".to_string(),
+            options: std::collections::HashMap::from([(
+                "replication_factor".to_string(),
+                rf.to_string(),
+            )]),
+        }
+    }
+
+    #[test]
+    fn select_accord_replicas_falls_back_outside_cluster_mode() {
+        // No ring (standalone/degraded WritePath) → keep the caller's all-live-
+        // peers fallback rather than failing the LWT.
+        let fallback = vec![uuid::Uuid::from_u128(1), uuid::Uuid::from_u128(2)];
+        let params = simple_replication_params(3);
+        let got = select_accord_replicas(
+            &WritePath::unavailable(),
+            Some(&params),
+            b"pk",
+            fallback.clone(),
+        )
+        .expect("fallback path must not error");
+        assert_eq!(got, fallback);
+    }
+
+    #[test]
+    fn select_accord_replicas_falls_back_when_replication_absent() {
+        // No keyspace replication metadata → fall back rather than guess.
+        let fallback = vec![uuid::Uuid::from_u128(7)];
+        let got = select_accord_replicas(&WritePath::unavailable(), None, b"pk", fallback.clone())
+            .expect("absent replication must fall back, not error");
+        assert_eq!(got, fallback);
+    }
+
+    #[test]
+    fn select_accord_replicas_fails_loud_on_bad_strategy() {
+        // An unparseable strategy must surface an error, never silently fall back
+        // to a placement the operator did not configure.
+        let bad = ReplicationParams {
+            strategy: "NoSuchStrategy".to_string(),
+            options: std::collections::HashMap::new(),
+        };
+        let err = select_accord_replicas(
+            &WritePath::unavailable(),
+            Some(&bad),
+            b"pk",
+            vec![uuid::Uuid::from_u128(1)],
+        );
+        assert!(err.is_err(), "unparseable strategy must fail loud");
+    }
     use ferrosa_schema::{
         AuthMethod, DeploymentMode, EnvSecretsProvider, PasswordHasher, PasswordPolicy,
         RateLimitConfig, SchemaConfig, TestAuditSink,


### PR DESCRIPTION
## Summary

Follow-up to #183 (now merged). The live CQL LWT/Accord path resolved its participant set as **"all live peers" + self** — ignoring the ring, RF, and token ownership. So #183's multi-key machinery, when reached by real clients, would replicate every key to every connected node instead of its RF replicas.

Per **ADR-021** (replica placement stays in the write path, not the front-ends):

- **`WritePath::accord_replicas_for_key(key, replication)`** — computes the key's Murmur3 token and parses the keyspace strategy, then delegates to the ring via `replicas_for_key`. Returns `Some(rf_replicas)` in cluster mode, `None` outside it (caller falls back), `Err` on an unparseable strategy.
- **`route_lwt_via_accord`** now selects participants via `select_accord_replicas`: token-aware RF replicas in cluster mode, the live-peer fallback otherwise, **fail-loud** on a bad strategy or an empty cluster-mode resolution (never a silent wrong/empty placement).

LWT is single-key, so resolving `replica_ids` from the key's token gives a correct single-shard participant; the multi-key `with_per_key_replicas` fan-out lands with the multi-statement transaction path (separate task).

## Tests (TDD: red→green)

- 3 `WritePath` tests — fallback-outside-cluster / fail-loud-on-bad-strategy / **cluster-mode RF-subset** (RF=2 over a 3-node ring → exactly 2 owning replicas).
- 3 router tests — fallback / absent-replication / fail-loud.

ferrosa-cluster **1025 pass**, ferrosa-cql **946 pass**, `cargo fmt --check` ✅, clippy clean. Crate docs updated (ferrosa-cluster README, ADR-021 boundary).

Closes the live-wiring follow-up tracked as `t_94880d` / `t_666f07` / `t_5b6532`.