### PR TITLE
feat(accord): per-key PreAcceptV2 dependency union for multi-shard conflict ordering

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -138,8 +138,9 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   per-shard participant (`ParticipantSet::from_per_key` via the
   `with_per_key_replicas` resolver) and fans a per-replica `AccordApplyV2`
   (scoped to each replica's owned keys) out under per-shard quorum. Conflict
-  ordering still uses the representative first key (full per-key `PreAcceptV2` dep
-  union is a documented follow-up).
+  ordering unions dependencies across ALL keys: PreAccept fans `AccordPreAcceptV2`
+  (every key) so each replica registers the txn under all its keys and returns the
+  dep union, serializing transactions that overlap on a non-first key (t_276e12).
 - `dep_wait.rs` — waits-for graph with deterministic cycle-breaking.
 - `cross_shard.rs` / `cross_dc_adapter.rs` — multi-shard atomicity, cross-DC glue.
 - `electorate.rs` / `epoch.rs` — JoinElectorate membership gates, epoch tracking.

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -560,9 +560,10 @@ impl AccordCoordinatorDriver {
     /// Build a driver for a multi-key (multi-partition) transaction.
     ///
     /// `write_set` is one `(partition_key, encoded_mutation)` per key the
-    /// transaction writes; it must be non-empty. The first key drives Accord
-    /// conflict ordering for now (representative-key); the full per-key
-    /// `PreAcceptV2` dependency union is a follow-up. The Apply phase builds a
+    /// transaction writes; it must be non-empty. Conflict ordering unions
+    /// dependencies across ALL keys via `AccordPreAcceptV2` (t_276e12); the first
+    /// key is kept only as the representative for the single-key ReadVote and the
+    /// v1 wire path. The Apply phase builds a
     /// per-shard participant ([`Self::with_per_key_replicas`]) and fans a
     /// per-replica `AccordApplyV2` (scoped to each replica's owned keys) out under
     /// per-shard quorum; the coordinator applies the keys it owns locally as one
@@ -923,15 +924,15 @@ impl AccordCoordinatorDriver {
     ) -> Result<(Timestamp, HashSet<TxnId>), AccordDriverError> {
         use crate::accord::wire::{
             AcceptOkPayload, AcceptPayload, ApplyOkPayload, CommitPayload, PreAcceptOkPayload,
-            PreAcceptPayload, ReadVoteOkPayload, ReadVotePayload,
+            PreAcceptPayload, PreAcceptV2Payload, ReadVoteOkPayload, ReadVotePayload,
         };
 
-        // Multi-key execution is wired: the Apply phase fans a per-replica
-        // `AccordApplyV2` (scoped to each replica's owned keys) out under a
-        // per-shard participant, and each replica applies its whole write-set
-        // atomically. Conflict ordering (PreAccept/Accept) still uses the
-        // representative first key — full per-key `PreAcceptV2` dep union is a
-        // documented follow-up (see specs/in-process/multikey-accord-apply-rekeying.md).
+        // Multi-key execution is wired end to end: PreAccept fans `AccordPreAcceptV2`
+        // (all keys) so each replica unions dependencies across the whole write-set
+        // (t_276e12), and the Apply phase fans a per-replica `AccordApplyV2` (scoped
+        // to each replica's owned keys) under a per-shard participant, each replica
+        // applying its whole write-set atomically. The representative `key` below is
+        // used only for the single-key ReadVote (LWT IF-read) and v1 wire paths.
         let txn_id = self.coordinator.txn_id;
         let t0 = self.coordinator.t0;
         let key = self.coordinator.key.clone();
@@ -941,16 +942,34 @@ impl AccordCoordinatorDriver {
         // Phase 1: PreAccept fanout
         // ------------------------------------------------------------------
 
-        let pa_payload = PreAcceptPayload {
-            txn_id,
-            t0,
-            key: key.clone(),
-            ballot: BallotNumber(0),
-            epoch: 0,
+        // Single-key keeps the v1 `AccordPreAccept` wire (byte-identical). Multi-key
+        // sends `AccordPreAcceptV2` carrying every key, so each replica registers
+        // the txn under all of them and returns the UNION of dependencies across
+        // keys — serializing transactions that overlap on a non-first key (t_276e12).
+        let pa_msg = if self.write_set.len() == 1 {
+            let pa_payload = PreAcceptPayload {
+                txn_id,
+                t0,
+                key: key.clone(),
+                ballot: BallotNumber(0),
+                epoch: 0,
+            };
+            let pa_bytes = bincode::serialize(&pa_payload)
+                .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
+            Message::AccordPreAccept(Bytes::from(pa_bytes))
+        } else {
+            let keys: Vec<Vec<u8>> = self.write_set.iter().map(|w| w.key.clone()).collect();
+            let pa_payload = PreAcceptV2Payload {
+                txn_id,
+                t0,
+                keys,
+                ballot: BallotNumber(0),
+                epoch: 0,
+            };
+            let pa_bytes = bincode::serialize(&pa_payload)
+                .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
+            Message::AccordPreAcceptV2(Bytes::from(pa_bytes))
         };
-        let pa_bytes =
-            bincode::serialize(&pa_payload).map_err(|e| AccordDriverError::Codec(e.to_string()))?;
-        let pa_msg = Message::AccordPreAccept(Bytes::from(pa_bytes));
 
         // Fanout to all replicas in parallel.
         let futs: Vec<_> = self

--- a/ferrosa-cluster/src/accord/handlers.rs
+++ b/ferrosa-cluster/src/accord/handlers.rs
@@ -19,7 +19,8 @@ use ferrosa_net::rpc::handler::{PeerId, RpcHandler};
 use super::state_machine::{AccordStateMachine, SmResponse};
 use super::wire::{
     AcceptOkPayload, AcceptPayload, ApplyOkPayload, ApplyPayload, ApplyV2Payload, CommitPayload,
-    PreAcceptOkPayload, PreAcceptPayload, ReadVoteOkPayload, ReadVotePayload, RecoverPayload,
+    PreAcceptOkPayload, PreAcceptPayload, PreAcceptV2Payload, ReadVoteOkPayload, ReadVotePayload,
+    RecoverPayload,
 };
 
 /// Shared mutable access to the Accord state machine.
@@ -144,6 +145,39 @@ impl RpcHandler for AccordHandler {
                         // Return empty PreAcceptOK to signal rejection.
                         Some(Message::AccordPreAcceptOK(Bytes::new()))
                     }
+                    _ => Some(Message::AccordPreAcceptOK(Bytes::new())),
+                }
+            }
+
+            Message::AccordPreAcceptV2(b) => {
+                // Multi-key PreAccept: register the txn under EVERY key it writes
+                // and return the UNION of dependencies across all keys, so a txn
+                // overlapping on a non-first key is serialized (t_276e12). The
+                // single-key AccordPreAccept arm above is the degenerate case.
+                let payload: PreAcceptV2Payload = bincode::deserialize(&b)
+                    .map_err(|e| tracing::error!("AccordPreAcceptV2: deserialize failed: {e}"))
+                    .ok()?;
+                let key_refs: Vec<&[u8]> = payload.keys.iter().map(|k| k.as_slice()).collect();
+                let mut sm = self.state.lock();
+                let resp = sm.handle_preaccept_multi(
+                    payload.txn_id,
+                    payload.t0,
+                    &key_refs,
+                    payload.ballot,
+                    payload.epoch,
+                );
+                drop(sm);
+                match resp {
+                    SmResponse::PreAcceptOK { t, deps, .. } => {
+                        let ok = PreAcceptOkPayload {
+                            from: self.local_node_id,
+                            t,
+                            deps,
+                        };
+                        let bytes = bincode::serialize(&ok).ok()?;
+                        Some(Message::AccordPreAcceptOK(Bytes::from(bytes)))
+                    }
+                    SmResponse::Nack { .. } => Some(Message::AccordPreAcceptOK(Bytes::new())),
                     _ => Some(Message::AccordPreAcceptOK(Bytes::new())),
                 }
             }
@@ -406,5 +440,53 @@ mod tests {
             TxnPhase::Applied,
             "the multi-key txn must reach Applied after AccordApplyV2"
         );
+    }
+
+    /// AccordPreAcceptV2 must union dependencies across ALL the transaction's
+    /// keys — a conflict registered on a non-first key must appear in the deps
+    /// the replica returns (t_276e12).
+    #[tokio::test]
+    async fn accord_preaccept_v2_unions_deps_across_keys_over_the_wire() {
+        let writer = std::sync::Arc::new(MockSyncWriter::new());
+        let sm = AccordStateMachine::new(1, writer);
+        let state: AccordState = std::sync::Arc::new(parking_lot::Mutex::new(sm));
+        let handler = AccordHandler::new(state.clone(), 1);
+
+        // A pre-existing txn registered (via normal PreAccept) only on key k2.
+        let conflict = TxnId::new(2, ts(500));
+        {
+            let mut sm = state.lock();
+            sm.handle_preaccept(conflict, ts(500), b"k2", BallotNumber(0), 0);
+        }
+
+        // New multi-key txn preaccepts {k1, k2} at t0=1000 over AccordPreAcceptV2.
+        let txn_id = TxnId::new(1, ts(1000));
+        let payload = PreAcceptV2Payload {
+            txn_id,
+            t0: ts(1000),
+            keys: vec![b"k1".to_vec(), b"k2".to_vec()],
+            ballot: BallotNumber(0),
+            epoch: 0,
+        };
+        let bytes = bincode::serialize(&payload).unwrap();
+        let peer: PeerId = (
+            uuid::Uuid::from_u128(3),
+            "127.0.0.1:0".parse().expect("valid socket addr"),
+        );
+        let resp = handler
+            .handle(peer, Message::AccordPreAcceptV2(Bytes::from(bytes)))
+            .await;
+
+        match resp {
+            Some(Message::AccordPreAcceptOK(b)) => {
+                let ok: PreAcceptOkPayload = bincode::deserialize(&b).expect("PreAcceptOk decodes");
+                assert!(
+                    ok.deps.contains(&conflict),
+                    "V2 PreAccept must union deps across all keys — the conflict on the \
+                     non-first key k2 must appear in the returned deps"
+                );
+            }
+            other => panic!("expected AccordPreAcceptOK, got {:?}", other),
+        }
     }
 }

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -341,6 +341,24 @@ impl AccordStateMachine {
         t0: Timestamp,
         key: &[u8],
         ballot: BallotNumber,
+        epoch: u64,
+    ) -> SmResponse {
+        // Single-key PreAccept is the degenerate one-entry write-set; the wire
+        // path for a single-partition LWT stays byte-identical.
+        self.handle_preaccept_multi(txn_id, t0, &[key], ballot, epoch)
+    }
+
+    /// PreAccept for a multi-key write-set: register the txn under EVERY key it
+    /// writes and return the UNION of dependencies across all keys, bumping `t`
+    /// past the max conflicting timestamp on any key. This serializes two
+    /// transactions that overlap on a non-representative key (t_276e12) — the
+    /// representative-first-key PreAccept would miss the conflict.
+    pub fn handle_preaccept_multi(
+        &mut self,
+        txn_id: TxnId,
+        t0: Timestamp,
+        keys: &[&[u8]],
+        ballot: BallotNumber,
         _epoch: u64,
     ) -> SmResponse {
         // Check if we've already promised a higher ballot for this txn.
@@ -370,27 +388,37 @@ impl AccordStateMachine {
             }
         }
 
-        // Query ConflictIndex for deps using t0 (not t).
-        let deps = self.conflict_index.deps_before_t0(key, &t0);
+        // Query ConflictIndex for deps using t0 (not t), UNIONED across every
+        // key the transaction writes — a conflict on any key is a dependency.
+        let mut deps = HashSet::new();
+        for key in keys {
+            deps.extend(self.conflict_index.deps_before_t0(key, &t0));
+        }
 
-        // Check for timestamp conflict: if any conflicting t0 >= our t0,
-        // we need to bump our timestamp past it.
-        let max_conflict = self.conflict_index.max_conflicting_timestamp(key);
+        // Bump our timestamp past the max conflicting t0 on ANY key, not just
+        // the representative first key.
+        let max_conflict = keys
+            .iter()
+            .filter_map(|key| self.conflict_index.max_conflicting_timestamp(key))
+            .max();
         let t = match max_conflict {
             Some(ct) if ct >= t0 => t0.bump_past(&ct, self.node_id),
             _ => t0,
         };
 
-        // Register in ConflictIndex.
-        let entry = InFlightWrite {
-            txn_id,
-            t0,
-            accord_ts: None,
-            status: TxnStatus::PreAccepted,
-        };
-        // Don't fail the protocol message on capacity errors, but log them.
-        if let Err(e) = self.conflict_index.register(key, entry) {
-            tracing::error!(%e, "accord: conflict_index register failed");
+        // Register the txn under EVERY key it writes, so a later conflicting
+        // txn on any of them sees it as a dependency.
+        for key in keys {
+            let entry = InFlightWrite {
+                txn_id,
+                t0,
+                accord_ts: None,
+                status: TxnStatus::PreAccepted,
+            };
+            // Don't fail the protocol message on capacity errors, but log them.
+            if let Err(e) = self.conflict_index.register(key, entry) {
+                tracing::error!(%e, "accord: conflict_index register failed");
+            }
         }
 
         // Track whether THIS call created the TxnState, so a persist failure can
@@ -1472,6 +1500,113 @@ mod tests {
                     "should NOT include t0=1200 > t0=1000"
                 );
             }
+            other => panic!("expected PreAcceptOK, got {:?}", other),
+        }
+    }
+
+    /// Multi-key PreAccept registers the txn under EVERY key it writes, so a
+    /// later txn conflicting on any one of those keys sees it as a dependency —
+    /// not just on the representative first key (t_276e12).
+    #[test]
+    fn sm_preaccept_multi_key_registers_all_keys_for_conflict() {
+        let (mut sm, _writer) = make_sm(1);
+        let k1: &[u8] = b"key_one";
+        let k2: &[u8] = b"key_two";
+
+        // Txn A preaccepts BOTH keys at t0=500.
+        let a = txn(2, 500);
+        sm.handle_preaccept_multi(a, ts(500), &[k1, k2], BallotNumber(0), 0);
+
+        // Txn B preaccepts ONLY k2 at t0=1000 (> 500). It must depend on A
+        // because A registered itself under k2, not just its first key k1.
+        let b = txn(1, 1000);
+        let resp = sm.handle_preaccept(b, ts(1000), k2, BallotNumber(0), 0);
+        match resp {
+            SmResponse::PreAcceptOK { deps, .. } => assert!(
+                deps.contains(&a),
+                "B on k2 must depend on A — A must register under all its keys"
+            ),
+            other => panic!("expected PreAcceptOK, got {:?}", other),
+        }
+    }
+
+    /// Multi-key PreAccept returns the UNION of dependencies across all of the
+    /// transaction's keys, not just the first.
+    #[test]
+    fn sm_preaccept_multi_key_unions_deps_across_keys() {
+        let (mut sm, _writer) = make_sm(1);
+        let k1: &[u8] = b"k1";
+        let k2: &[u8] = b"k2";
+
+        // A pre-existing conflicting txn on each key, both with t0 < 1000.
+        let on_k1 = txn(2, 400);
+        let on_k2 = txn(3, 600);
+        let _ = sm.conflict_index_mut().register(
+            k1,
+            InFlightWrite {
+                txn_id: on_k1,
+                t0: ts(400),
+                accord_ts: None,
+                status: TxnStatus::PreAccepted,
+            },
+        );
+        let _ = sm.conflict_index_mut().register(
+            k2,
+            InFlightWrite {
+                txn_id: on_k2,
+                t0: ts(600),
+                accord_ts: None,
+                status: TxnStatus::PreAccepted,
+            },
+        );
+
+        // Txn C preaccepts {k1, k2} at t0=1000 → deps = union {on_k1, on_k2}.
+        let c = txn(1, 1000);
+        let resp = sm.handle_preaccept_multi(c, ts(1000), &[k1, k2], BallotNumber(0), 0);
+        match resp {
+            SmResponse::PreAcceptOK { deps, .. } => {
+                assert!(
+                    deps.contains(&on_k1),
+                    "deps must include the conflict on k1"
+                );
+                assert!(
+                    deps.contains(&on_k2),
+                    "deps must include the conflict on k2"
+                );
+            }
+            other => panic!("expected PreAcceptOK, got {:?}", other),
+        }
+    }
+
+    /// Multi-key PreAccept bumps `t` past the max conflicting timestamp across
+    /// ALL keys — a conflict on a non-first key must still push the timestamp.
+    #[test]
+    fn sm_preaccept_multi_key_t_bumps_past_conflict_on_any_key() {
+        let (mut sm, _writer) = make_sm(1);
+        let k1: &[u8] = b"quiet_key";
+        let k2: &[u8] = b"busy_key";
+
+        // A conflict on k2 (not k1) with t0=1500 >= our t0=1000.
+        let hot = txn(2, 1500);
+        let _ = sm.conflict_index_mut().register(
+            k2,
+            InFlightWrite {
+                txn_id: hot,
+                t0: ts(1500),
+                accord_ts: None,
+                status: TxnStatus::PreAccepted,
+            },
+        );
+
+        // Txn C preaccepts {k1, k2} at t0=1000. Because k2 has a conflict at
+        // 1500 >= 1000, C's final `t` must be bumped past 1500.
+        let c = txn(1, 1000);
+        let resp = sm.handle_preaccept_multi(c, ts(1000), &[k1, k2], BallotNumber(0), 0);
+        match resp {
+            SmResponse::PreAcceptOK { t, .. } => assert!(
+                t > ts(1500),
+                "t must bump past the conflict on k2 (got {t:?}), not stay at t0"
+            ),
             other => panic!("expected PreAcceptOK, got {:?}", other),
         }
     }

--- a/ferrosa-cluster/src/accord/wire.rs
+++ b/ferrosa-cluster/src/accord/wire.rs
@@ -97,6 +97,22 @@ pub(crate) struct ApplyV2Payload {
     pub(crate) writes: Vec<WriteSetEntry>,
 }
 
+/// PreAccept request for a multi-key transaction.
+///
+/// Carries every partition key the transaction writes so the replica registers
+/// the txn under all of them and returns the UNION of dependencies across keys
+/// (t_276e12). The single-key [`PreAcceptPayload`] is the degenerate one-key
+/// case, kept byte-identical for single-partition LWT.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct PreAcceptV2Payload {
+    pub(crate) txn_id: TxnId,
+    pub(crate) t0: Timestamp,
+    /// All partition keys the transaction writes (conflict-ordering keys).
+    pub(crate) keys: Vec<Vec<u8>>,
+    pub(crate) ballot: BallotNumber,
+    pub(crate) epoch: u64,
+}
+
 // ---------------------------------------------------------------------------
 // Replica → Coordinator
 // ---------------------------------------------------------------------------

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -1150,6 +1150,8 @@ impl ModeController {
             self.registry
                 .register(MsgType::AccordPreAccept, accord_handler.clone());
             self.registry
+                .register(MsgType::AccordPreAcceptV2, accord_handler.clone());
+            self.registry
                 .register(MsgType::AccordAccept, accord_handler.clone());
             self.registry
                 .register(MsgType::AccordCommit, accord_handler.clone());

--- a/specs/implemented/multikey-accord-apply-rekeying.md
+++ b/specs/implemented/multikey-accord-apply-rekeying.md
@@ -110,8 +110,13 @@ ring/strategy into `AccordHandler`. Per-key replica resolution is an injected se
 driver is not yet constructed in the live CQL path, so production wiring of the ring
 resolver into the driver is the broader Phase-2 follow-up the CI e2e covers.
 
-**Conflict-ordering limitation (unchanged from spec).** PreAccept/Accept still order
-on the representative first key; full per-key `PreAcceptV2` dep union is a follow-up.
+**Conflict ordering — per-key dependency union (RESOLVED, t_276e12).** PreAccept now
+fans `AccordPreAcceptV2` carrying every key; each replica registers the txn under all
+its keys and returns the UNION of dependencies across them (`handle_preaccept_multi`),
+bumping `t` past the max conflict on any key. This serializes transactions that overlap
+on a non-representative key. Single-key LWT keeps the v1 `AccordPreAccept` wire path
+byte-identical. The representative first key is retained only for the single-key
+ReadVote (LWT IF-read).
 
 **Removed:** `AccordDriverError::MultiKeyNotYetExecutable` (the fail-loud guard) and
 its references in `accord_nemesis.rs`.


### PR DESCRIPTION
## Summary

Follow-up to #183 (closes `t_276e12`). Multi-key Accord conflict ordering used the **representative first key** only, so two transactions overlapping on a non-first key — A writes `{k1,k2}`, B writes `{k2,k3}` — could fail to see each other as dependencies, a multi-shard serialization gap.

This unions dependencies across **all** keys, end to end:

1. **State machine** (`handle_preaccept_multi`) — registers the txn under every key it writes, returns the **union** of deps across all keys, bumps `t` past the max conflict on any key. `handle_preaccept(key)` delegates with a one-element slice (single-key wire path byte-identical).
2. **Wire** — `PreAcceptV2Payload` carries all keys; `AccordHandler` handles `Message::AccordPreAcceptV2` → `handle_preaccept_multi`, registered for dispatch in `controller/cluster.rs`. The wire code (`0x7B`) already existed in ferrosa-net (round-trip tested).
3. **Coordinator** — sends `AccordPreAcceptV2` (all keys) for a multi-key write-set; single-key keeps v1 `AccordPreAccept`.

Deps unioned at PreAccept propagate through Accept/Commit unchanged. The representative first key is retained only for the single-key ReadVote (LWT `IF`-read).

## Tests (TDD: red→green)

- 3 state-machine tests — registers-all-keys-for-conflict / unions-deps-across-keys / t-bumps-past-conflict-on-any-key.
- 1 handler test — deps unioned across keys through the `AccordPreAcceptV2` wire path.

ferrosa-cluster **1026 pass**, `cargo fmt --check` ✅, clippy clean. Docs updated (README, coordinator comments; spec marks the conflict-ordering limitation **RESOLVED**).

## Follow-up

The cross-shard bank-transfer e2e (`t_afa3ee`) on the live 5-node cluster validates this end-to-end — next, now that the cluster bring-up (#184) is fixed.