### PR TITLE
feat(storage): TransactionCommitter seam for multi-key SQL transactions

### DIFF
--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -58,7 +58,11 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
   instead of crashing; the self-heal controller detects corrupt SSTables and
   quarantines them under a safety rail.
 - **Accord** (`accord/`) — per-shard conflict index + protocol log for
-  strict-serializable transactions.
+  strict-serializable transactions. Also defines `TransactionCommitter` (ADR-021):
+  the front-end-facing seam CQL/Postgres `BEGIN`/`COMMIT` call to commit a
+  buffered multi-key write-set; the ferrosa-cluster Accord impl resolves replicas
+  and drives the multi-key transaction. `MockTransactionCommitter` backs
+  front-end unit tests without a cluster.
 - **Time-series** (`timeseries/`) — ring-buffer aggregation, late-data handling,
   WASM aggregate execution, materialization queues.
 - **Virtual tables / observability** (`virtual_tables.rs`, `metrics.rs`) —

--- a/ferrosa-storage/src/accord/mod.rs
+++ b/ferrosa-storage/src/accord/mod.rs
@@ -27,9 +27,6 @@ pub mod transaction_committer;
 pub mod write_gate;
 
 pub use conflict_index::{ConflictIndex, ConflictIndexFull, InFlightWrite, TokenRange, TxnStatus};
-pub use transaction_committer::{
-    CommitError, CommitOutcome, MockTransactionCommitter, TransactionCommitter, TransactionWrite,
-};
 pub use crash_recovery::{
     CrashRecoveryReplay, ReplayedConflictEntry, ReplayedPhase, ReplayedTxnState,
 };
@@ -40,4 +37,7 @@ pub use read_2i::{
 };
 pub use sidecar::{AccordSidecar, SidecarUploadManifest, SIDECAR_EXTENSION};
 pub use sync_writer::{FileSyncWriter, MockSyncWriter, SyncWriteResult, SyncWriter};
+pub use transaction_committer::{
+    CommitError, CommitOutcome, MockTransactionCommitter, TransactionCommitter, TransactionWrite,
+};
 pub use write_gate::{check_write_gate, check_write_gate_range, WriteGateDecision};

--- a/ferrosa-storage/src/accord/mod.rs
+++ b/ferrosa-storage/src/accord/mod.rs
@@ -23,9 +23,13 @@ pub mod protocol_log;
 pub mod read_2i;
 pub mod sidecar;
 pub mod sync_writer;
+pub mod transaction_committer;
 pub mod write_gate;
 
 pub use conflict_index::{ConflictIndex, ConflictIndexFull, InFlightWrite, TokenRange, TxnStatus};
+pub use transaction_committer::{
+    CommitError, CommitOutcome, MockTransactionCommitter, TransactionCommitter, TransactionWrite,
+};
 pub use crash_recovery::{
     CrashRecoveryReplay, ReplayedConflictEntry, ReplayedPhase, ReplayedTxnState,
 };

--- a/ferrosa-storage/src/accord/transaction_committer.rs
+++ b/ferrosa-storage/src/accord/transaction_committer.rs
@@ -1,0 +1,172 @@
+//! Transaction commit seam (ADR-021) — the front-end-facing boundary for
+//! multi-key SQL transactions.
+//!
+//! CQL and Postgres `BEGIN`/`COMMIT` buffer their DML into a write-set and call
+//! [`TransactionCommitter::commit`] on `COMMIT`; `ROLLBACK` drops the buffer
+//! without calling it. The `ferrosa-cluster` implementation resolves each key's
+//! replicas (this ADR's `WritePath`) and drives a multi-key Accord transaction
+//! (per-shard quorum, atomic apply). The trait lives here, in the crate both
+//! front-ends already share, so neither front-end has to depend on the cluster
+//! layer — mirroring how `StorageApplier` is injected.
+
+use async_trait::async_trait;
+
+/// One buffered write in a transaction: the partition key, its encoded
+/// commit-log mutation, and the keyspace whose replication settings determine
+/// the key's replica placement (resolved by the cluster implementation).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransactionWrite {
+    /// Keyspace the write targets — selects the replication strategy.
+    pub keyspace: String,
+    /// Raw partition-key bytes (Accord conflict-ordering + routing key).
+    pub key: Vec<u8>,
+    /// Encoded self-describing commit-log mutation to apply for this key.
+    pub mutation: Vec<u8>,
+}
+
+/// Outcome of committing a buffered transaction write-set.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CommitOutcome {
+    /// Every write in the set committed atomically.
+    Committed,
+    /// The transaction aborted cleanly; no write was applied.
+    Aborted { reason: String },
+}
+
+/// The commit path could not reach a decision (e.g. quorum unavailable). This is
+/// distinct from a clean [`CommitOutcome::Aborted`]: the caller must surface it
+/// and MUST NOT report success — never ack a transaction we did not commit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommitError {
+    pub reason: String,
+}
+
+impl std::fmt::Display for CommitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "transaction commit failed: {}", self.reason)
+    }
+}
+
+impl std::error::Error for CommitError {}
+
+/// Front-end-facing seam for committing a multi-key SQL transaction.
+///
+/// Implementations MUST be fail-loud: return `Err(CommitError)` (or
+/// `Ok(Aborted)`) rather than reporting success for a transaction that did not
+/// durably commit. An empty write-set (`BEGIN; COMMIT;` with no DML) is a no-op
+/// that commits cleanly.
+#[async_trait]
+pub trait TransactionCommitter: Send + Sync {
+    /// Commit `writes` as one atomic multi-key transaction.
+    async fn commit(&self, writes: Vec<TransactionWrite>) -> Result<CommitOutcome, CommitError>;
+}
+
+/// In-memory [`TransactionCommitter`] for tests: records every committed
+/// write-set and returns a configurable outcome, so a front-end can unit-test
+/// `BEGIN`/`COMMIT`/`ROLLBACK` buffering without a live cluster.
+pub struct MockTransactionCommitter {
+    committed: std::sync::Mutex<Vec<Vec<TransactionWrite>>>,
+    result: Result<CommitOutcome, CommitError>,
+}
+
+impl MockTransactionCommitter {
+    /// A committer that always reports `Committed`.
+    pub fn new() -> Self {
+        Self {
+            committed: std::sync::Mutex::new(Vec::new()),
+            result: Ok(CommitOutcome::Committed),
+        }
+    }
+
+    /// A committer that always returns `result` (an outcome or a `CommitError`).
+    pub fn with_result(result: Result<CommitOutcome, CommitError>) -> Self {
+        Self {
+            committed: std::sync::Mutex::new(Vec::new()),
+            result,
+        }
+    }
+
+    /// Every write-set passed to [`commit`](TransactionCommitter::commit), in
+    /// call order.
+    pub fn committed(&self) -> Vec<Vec<TransactionWrite>> {
+        self.committed.lock().expect("committer mutex").clone()
+    }
+}
+
+impl Default for MockTransactionCommitter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransactionCommitter for MockTransactionCommitter {
+    async fn commit(&self, writes: Vec<TransactionWrite>) -> Result<CommitOutcome, CommitError> {
+        self.committed.lock().expect("committer mutex").push(writes);
+        self.result.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(ks: &str, key: &[u8]) -> TransactionWrite {
+        TransactionWrite {
+            keyspace: ks.to_string(),
+            key: key.to_vec(),
+            mutation: b"row".to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_records_committed_write_set() {
+        let committer = MockTransactionCommitter::new();
+        let writes = vec![write("ks", b"a"), write("ks", b"b")];
+
+        let outcome = committer.commit(writes.clone()).await.expect("commit");
+
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert_eq!(
+            committer.committed(),
+            vec![writes],
+            "the committer must record the exact write-set it was handed"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_write_set_commits_cleanly() {
+        // BEGIN; COMMIT; with no DML is a no-op that commits.
+        let committer = MockTransactionCommitter::new();
+        let outcome = committer.commit(Vec::new()).await.expect("commit");
+        assert_eq!(outcome, CommitOutcome::Committed);
+    }
+
+    #[tokio::test]
+    async fn configured_abort_outcome_is_surfaced() {
+        let committer = MockTransactionCommitter::with_result(Ok(CommitOutcome::Aborted {
+            reason: "condition not met".to_string(),
+        }));
+        let outcome = committer.commit(vec![write("ks", b"a")]).await.expect("ok");
+        assert_eq!(
+            outcome,
+            CommitOutcome::Aborted {
+                reason: "condition not met".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_commit_error_is_surfaced() {
+        // A commit that cannot reach a decision must propagate as Err — the
+        // front-end must never report success for it.
+        let committer = MockTransactionCommitter::with_result(Err(CommitError {
+            reason: "quorum unavailable".to_string(),
+        }));
+        let err = committer
+            .commit(vec![write("ks", b"a")])
+            .await
+            .expect_err("must surface the commit error");
+        assert_eq!(err.reason, "quorum unavailable");
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for **BEGIN/COMMIT-over-Accord** (`t_82d71e`; unblocks `t_bd3684`/`t_b98434`/`t_0f96cb`/`t_df2035`). Per **ADR-021**, the front-end-facing transaction-commit boundary lives in `ferrosa-storage` — the crate both CQL and Postgres front-ends already share — so neither has to depend on `ferrosa-cluster` (mirroring how `StorageApplier` is injected).

- **`TransactionCommitter`** — `commit(writes) -> Result<CommitOutcome, CommitError>`. Front-ends buffer DML between `BEGIN` and `COMMIT` into a `Vec<TransactionWrite>` (keyspace + key + encoded mutation) and call it on `COMMIT`; `ROLLBACK` drops the buffer. **Fail-loud**: clean abort → `Ok(Aborted)`, undecided → `Err(CommitError)` — never report success for a txn that didn't commit.
- **`MockTransactionCommitter`** — records committed write-sets + returns a configurable outcome, so front-ends can unit-test buffering without a live cluster.

## Tests (TDD)
4 tests: records-write-set / empty-commits-cleanly / abort-surfaced / error-surfaced. ferrosa-storage green, clippy clean.

## Next increments (the epic)
1. **This PR** — the seam + mock (ferrosa-storage).
2. `AccordTransactionCommitter` impl in ferrosa-cluster — resolve replicas per key (WritePath, #185) + drive `AccordCoordinatorDriver::new_multi` (#186/#187 verified the path).
3. CQL `BEGIN/COMMIT` buffering + router wiring (`t_bd3684`).
4. Postgres `BEGIN/COMMIT/ROLLBACK` (`t_b98434`).