### PR TITLE
fix(nightly): keep smoke .deb in build context and harden Fly race-stress provisioning

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -227,7 +227,10 @@ jobs:
           set -euo pipefail
           cp "${{ steps.nightly_deb.outputs.deb_path }}" tests/ferrosa.deb
           docker build -f tests/Dockerfile.nightly-deb -t ferrosa-smoke:latest tests/
-          rm -f tests/ferrosa.deb
+          # Keep ferrosa.deb in place: docker-smoke.sh runs `docker compose up --build`
+          # against docker-compose.yml, which uses tests/Dockerfile.smoke and needs
+          # the .deb file as a build context. Deleting it here causes a cache miss and
+          # "ferrosa.deb: not found" during the compose build.
 
       - name: Set up sccache (only when the musl fallback compiles)
         if: steps.nightly_deb.outputs.deb_path == ''
@@ -243,7 +246,7 @@ jobs:
           cp target/x86_64-unknown-linux-musl/release/ferrosa tests/ferrosa
           strip tests/ferrosa
           docker build -f tests/Dockerfile.nightly-bin -t ferrosa-smoke:latest tests/
-          rm -f tests/ferrosa
+          # Keep the static binary in place for the same reason we keep the .deb.
 
       - name: Run Docker smoke test
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 .pytest_cache/
+
+# CI/local smoke build artifacts
+tests/ferrosa.deb
+tests/ferrosa
 target-linux/

--- a/ci/race-stress-fly.sh
+++ b/ci/race-stress-fly.sh
@@ -66,19 +66,32 @@ echo "$M rc=${PIPESTATUS[0]} elapsed=${SECONDS}s"'
 
 echo ":: launching $VM in $REGION (starved baseline is the fuzzer)"
 # Run detached so we can poll for completion instead of blocking on the VM.
-# Capture machine id and provisioning output for diagnostics.
-machine_info=$(fly machine run ubuntu:24.04 \
+# In CI the fly CLI occasionally stalls even with --detach; cap provisioning
+# and discover the machine from the app if the CLI doesn't return its id.
+provision_log=$(mktemp)
+if timeout 180s fly machine run ubuntu:24.04 \
   --app "$APP" --vm-size "$VM" --vm-memory "$VM_MEMORY" --region "$REGION" --restart no \
   --file-local "/usr/local/bin/ferrosa-race-stress=$BINARY" \
-  --env GH_TOKEN="$GH_TOKEN" \
   --detach \
-  -- bash -c "$REMOTE" 2>&1)
-echo "$machine_info"
-machine_id=$(printf '%s' "$machine_info" | awk '/^id/{print $2; exit}' | tr -d '\r')
-if [ -z "$machine_id" ]; then
-  echo "::error::could not extract fly machine id from provisioning output"
+  -- bash -c "$REMOTE" >"$provision_log" 2>&1; then
+  echo ":: machine provisioning returned"
+  cat "$provision_log"
+  machine_id=$(awk '/^id/{print $2; exit}' "$provision_log" | tr -d '\r')
+else
+  echo "::warning::fly machine run --detach timed out or failed; discovering machine via list"
+  cat "$provision_log" || true
+fi
+
+if [ -z "${machine_id:-}" ]; then
+  # fly machine list output is JSON; extract the first machine id for this app.
+  machine_id=$(fly machine list -a "$APP" --json 2>/dev/null | grep -aoE '"id":"[^"]+"' | head -1 | cut -d'"' -f4 || true)
+fi
+
+if [ -z "${machine_id:-}" ]; then
+  echo "::error::could not create or discover a fly machine for app $APP"
   exit 1
 fi
+echo ":: machine id $machine_id"
 
 echo ":: waiting for completion (RS_RESULT marker)…"
 LOG="$(mktemp)"


### PR DESCRIPTION
Fixes the two remaining nightly failures observed in run 28080238733.

- Docker smoke: keep `tests/ferrosa.deb` in place through `docker-smoke.sh` because `docker-compose.yml` rebuilds from `tests/Dockerfile.smoke`.
- Fly race-stress: cap `fly machine run --detach` at 180s and discover the machine via `fly machine list` if the CLI stalls.

Refs run https://github.com/ferrosadb/ferrosa/actions/runs/28080238733