### PR TITLE
feat(accord): unconditional commit mode for general multi-key transactions

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -124,11 +124,15 @@ strict-serializable multi-key / cross-shard transactions and LWT.
 
 ### Accord transactions (`accord/`)
 - `coordinator.rs` / `state_machine.rs` — PreAccept → {fast path | Accept} →
-  Commit → Apply, fast/slow quorum math, HLC timestamps + `TxnId`. The replica
-  apply path is **dep-ordered**: `handle_apply` routes every real write through
-  `apply.rs`'s `DepWaitApplier`, so a mutation persists only once all of its
-  dependencies have applied locally (otherwise it parks and the cascade applies
-  it in order).
+  Commit → [read-vote] → Apply, fast/slow quorum math, HLC timestamps + `TxnId`.
+  The read-vote phase is the LWT `IF`-condition gate (`ReadPredicate::NotExists`
+  for `INSERT IF NOT EXISTS`, `ReadRow` for generic `IF`); a general multi-key
+  SQL transaction uses `ReadPredicate::Always`, which **skips the read-vote
+  entirely** and always applies after commit (there is no `IF` to evaluate). The
+  replica apply path is **dep-ordered**: `handle_apply` routes every real write
+  through `apply.rs`'s `DepWaitApplier`, so a mutation persists only once all of
+  its dependencies have applied locally (otherwise it parks and the cascade
+  applies it in order).
 - `recovery.rs` — Paxos-style recovery selecting by highest `accepted_ballot`.
 - `apply.rs` — `DepWaitApplier` (dep-wait + `StorageApplier` seam) +
   `EngineStorageApplier`/`EngineStorageReader` (real persistence and linearizable

--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -134,6 +134,13 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   its dependencies have applied locally (otherwise it parks and the cascade
   applies it in order).
 - `recovery.rs` — Paxos-style recovery selecting by highest `accepted_ballot`.
+- `transaction_commit.rs` — `AccordTransactionCommitter`: the cluster-side
+  implementation of `ferrosa_storage`'s `TransactionCommitter` seam (ADR-021). CQL/
+  Postgres `BEGIN`/`COMMIT` buffer DML and call it; it resolves replicas per key
+  (injected resolver wrapping `WritePath::accord_replicas_for_key` + schema in prod),
+  then drives ONE unconditional (`ReadPredicate::Always`) multi-key Accord
+  transaction via `new_multi`, mapping the outcome to `Committed`/`Aborted`/`Err`
+  (fail-loud — never acks an uncommitted txn).
 - `apply.rs` — `DepWaitApplier` (dep-wait + `StorageApplier` seam) +
   `EngineStorageApplier`/`EngineStorageReader` (real persistence and linearizable
   read-at-`t`). **Multi-key (Phase 2/3):** `DepWaitApplier::try_apply_writeset`

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -1152,200 +1152,209 @@ impl AccordCoordinatorDriver {
         // a fresh INSERT IF NOT EXISTS).
         // ------------------------------------------------------------------
 
-        let read_payload = ReadVotePayload {
-            txn_id,
-            t: commit_t,
-            key: key.clone(),
-            predicate: self.read_predicate.clone(),
-        };
-        let read_bytes = bincode::serialize(&read_payload)
-            .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
-        let read_msg = Message::AccordRead(Bytes::from(read_bytes));
-
-        let mut votes_false = 0usize;
-        let mut dissenting_row: Vec<u8> = Vec::new();
-        // For the generic ReadRow predicate: collect each replica's row-at-`t`
-        // bytes so we can require F+1 *agreement* on the row state before the
-        // coordinator evaluates the IF predicate. Disagreement is a correctness
-        // failure (non-linearizable read) and must abort, never silently pick one.
-        let mut read_rows: Vec<Vec<u8>> = Vec::new();
-        let is_generic = matches!(
+        // The read-vote phase is the LWT IF-condition gate. An unconditional
+        // transaction (`ReadPredicate::Always`) has no IF, so skip the whole
+        // phase and apply directly — otherwise the existence/row read-vote would
+        // wrongly gate an UPDATE to an existing row.
+        if !matches!(
             self.read_predicate,
-            crate::accord::wire::ReadPredicate::ReadRow { .. }
-        );
+            crate::accord::wire::ReadPredicate::Always
+        ) {
+            let read_payload = ReadVotePayload {
+                txn_id,
+                t: commit_t,
+                key: key.clone(),
+                predicate: self.read_predicate.clone(),
+            };
+            let read_bytes = bincode::serialize(&read_payload)
+                .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
+            let read_msg = Message::AccordRead(Bytes::from(read_bytes));
 
-        // The coordinator's own replica is not reachable over the network
-        // (self-send fails). For the generic path it must contribute its local
-        // read-at-`t` so that, with RF=2 (sq=2), F+1 agreement is achievable and
-        // the result is deterministic across all replicas. The applier already
-        // persisted earlier conflicting txns locally before this read (dep-wait).
-        if is_generic {
-            if let crate::accord::wire::ReadPredicate::ReadRow { keyspace, table } =
-                &self.read_predicate
-            {
-                // Prefer the local state machine when wired: it performs the SAME
-                // dep-wait the remote handler does (block until every conflicting
-                // `t0 < t` has Applied locally) before reading at `t`. This is what
-                // serializes a genuinely concurrent contender's write ahead of this
-                // read — without it the coordinator's own replica could read the key
-                // as absent while a smaller-`t` contender is mid-apply (the
-                // concurrent INSERT IF NOT EXISTS double-apply). On dep-wait timeout
-                // we ABSTAIN (push no row) so F+1 agreement fails loud rather than
-                // reading stale.
-                if let Some(local_sm) = &self.local_accord_state {
-                    if crate::accord::handlers::await_conflicting_deps_applied(
-                        local_sm, &key, commit_t,
-                    )
-                    .await
-                    {
-                        let row = local_sm
-                            .lock()
-                            .read_row_bytes_at(keyspace, table, &key, commit_t);
-                        read_rows.push(row.unwrap_or_default());
-                    } else {
-                        tracing::error!(
-                            txn_id = ?txn_id,
-                            "accord: coordinator local read-vote dep-wait timed out — abstaining"
-                        );
-                        // Abstain: contribute no local read. F+1 agreement then
-                        // fails loud below rather than treating a stale read as truth.
-                    }
-                } else if let Some(reader) = &self.local_reader {
-                    match reader.read_row_at(keyspace, table, &key, commit_t) {
-                        Ok(bytes) => read_rows.push(bytes.unwrap_or_default()),
-                        Err(e) => {
-                            return Err(AccordDriverError::Network(format!(
-                                "coordinator local read-at-t failed: {e}"
-                            )));
+            let mut votes_false = 0usize;
+            let mut dissenting_row: Vec<u8> = Vec::new();
+            // For the generic ReadRow predicate: collect each replica's row-at-`t`
+            // bytes so we can require F+1 *agreement* on the row state before the
+            // coordinator evaluates the IF predicate. Disagreement is a correctness
+            // failure (non-linearizable read) and must abort, never silently pick one.
+            let mut read_rows: Vec<Vec<u8>> = Vec::new();
+            let is_generic = matches!(
+                self.read_predicate,
+                crate::accord::wire::ReadPredicate::ReadRow { .. }
+            );
+
+            // The coordinator's own replica is not reachable over the network
+            // (self-send fails). For the generic path it must contribute its local
+            // read-at-`t` so that, with RF=2 (sq=2), F+1 agreement is achievable and
+            // the result is deterministic across all replicas. The applier already
+            // persisted earlier conflicting txns locally before this read (dep-wait).
+            if is_generic {
+                if let crate::accord::wire::ReadPredicate::ReadRow { keyspace, table } =
+                    &self.read_predicate
+                {
+                    // Prefer the local state machine when wired: it performs the SAME
+                    // dep-wait the remote handler does (block until every conflicting
+                    // `t0 < t` has Applied locally) before reading at `t`. This is what
+                    // serializes a genuinely concurrent contender's write ahead of this
+                    // read — without it the coordinator's own replica could read the key
+                    // as absent while a smaller-`t` contender is mid-apply (the
+                    // concurrent INSERT IF NOT EXISTS double-apply). On dep-wait timeout
+                    // we ABSTAIN (push no row) so F+1 agreement fails loud rather than
+                    // reading stale.
+                    if let Some(local_sm) = &self.local_accord_state {
+                        if crate::accord::handlers::await_conflicting_deps_applied(
+                            local_sm, &key, commit_t,
+                        )
+                        .await
+                        {
+                            let row = local_sm
+                                .lock()
+                                .read_row_bytes_at(keyspace, table, &key, commit_t);
+                            read_rows.push(row.unwrap_or_default());
+                        } else {
+                            tracing::error!(
+                                txn_id = ?txn_id,
+                                "accord: coordinator local read-vote dep-wait timed out — abstaining"
+                            );
+                            // Abstain: contribute no local read. F+1 agreement then
+                            // fails loud below rather than treating a stale read as truth.
                         }
-                    }
-                }
-            }
-        }
-
-        let remote_read_futs: Vec<_> = self
-            .replica_ids
-            .iter()
-            .filter(|&&id| id != self_id)
-            .map(|&peer_id| {
-                let peers = Arc::clone(&self.peers);
-                let msg = read_msg.clone();
-                async move { peers.send(peer_id, msg, Lane::Data).await }
-            })
-            .collect();
-        let read_responses = futures::future::join_all(remote_read_futs).await;
-
-        for result in &read_responses {
-            match result {
-                Ok(Message::AccordReadOK(b)) if !b.is_empty() => {
-                    match bincode::deserialize::<ReadVoteOkPayload>(b) {
-                        Ok(vote) => {
-                            if is_generic {
-                                // Generic IF: replica returns the row bytes at `t`
-                                // (condition_holds is a neutral true). Collect for
-                                // F+1 agreement; the coordinator evaluates the
-                                // predicate authoritatively below.
-                                read_rows.push(vote.current_row.clone());
-                            } else if !vote.condition_holds {
-                                // INSERT IF NOT EXISTS existence path.
-                                votes_false += 1;
-                                if dissenting_row.is_empty() {
-                                    dissenting_row = vote.current_row.clone();
-                                }
+                    } else if let Some(reader) = &self.local_reader {
+                        match reader.read_row_at(keyspace, table, &key, commit_t) {
+                            Ok(bytes) => read_rows.push(bytes.unwrap_or_default()),
+                            Err(e) => {
+                                return Err(AccordDriverError::Network(format!(
+                                    "coordinator local read-at-t failed: {e}"
+                                )));
                             }
                         }
-                        Err(_) => {
-                            // pre-Gap-4 replica or parse error: treat as
-                            // condition_holds=true (forward-compatible default).
-                        }
-                    }
-                }
-                Ok(_) | Err(_) => {
-                    // No response or network error — skip (don't count as false vote).
-                    // Log network errors at warn level.
-                    if let Err(e) = result {
-                        tracing::warn!(
-                            txn_id = ?txn_id,
-                            error = %e,
-                            "accord: ReadVote RPC failed (non-fatal)"
-                        );
                     }
                 }
             }
-        }
 
-        if is_generic {
-            // Require F+1 replicas to agree on the SAME row bytes at `t`. This is
-            // the linearizable read: a divergent read is non-linearizable and must
-            // abort (fail loud) rather than have the coordinator guess.
-            let agreed = agreed_row(&read_rows, sq);
-            let agreed_row_bytes = match agreed {
-                Some(row) => {
-                    self.last_read_row = if row.is_empty() {
+            let remote_read_futs: Vec<_> = self
+                .replica_ids
+                .iter()
+                .filter(|&&id| id != self_id)
+                .map(|&peer_id| {
+                    let peers = Arc::clone(&self.peers);
+                    let msg = read_msg.clone();
+                    async move { peers.send(peer_id, msg, Lane::Data).await }
+                })
+                .collect();
+            let read_responses = futures::future::join_all(remote_read_futs).await;
+
+            for result in &read_responses {
+                match result {
+                    Ok(Message::AccordReadOK(b)) if !b.is_empty() => {
+                        match bincode::deserialize::<ReadVoteOkPayload>(b) {
+                            Ok(vote) => {
+                                if is_generic {
+                                    // Generic IF: replica returns the row bytes at `t`
+                                    // (condition_holds is a neutral true). Collect for
+                                    // F+1 agreement; the coordinator evaluates the
+                                    // predicate authoritatively below.
+                                    read_rows.push(vote.current_row.clone());
+                                } else if !vote.condition_holds {
+                                    // INSERT IF NOT EXISTS existence path.
+                                    votes_false += 1;
+                                    if dissenting_row.is_empty() {
+                                        dissenting_row = vote.current_row.clone();
+                                    }
+                                }
+                            }
+                            Err(_) => {
+                                // pre-Gap-4 replica or parse error: treat as
+                                // condition_holds=true (forward-compatible default).
+                            }
+                        }
+                    }
+                    Ok(_) | Err(_) => {
+                        // No response or network error — skip (don't count as false vote).
+                        // Log network errors at warn level.
+                        if let Err(e) = result {
+                            tracing::warn!(
+                                txn_id = ?txn_id,
+                                error = %e,
+                                "accord: ReadVote RPC failed (non-fatal)"
+                            );
+                        }
+                    }
+                }
+            }
+
+            if is_generic {
+                // Require F+1 replicas to agree on the SAME row bytes at `t`. This is
+                // the linearizable read: a divergent read is non-linearizable and must
+                // abort (fail loud) rather than have the coordinator guess.
+                let agreed = agreed_row(&read_rows, sq);
+                let agreed_row_bytes = match agreed {
+                    Some(row) => {
+                        self.last_read_row = if row.is_empty() {
+                            None
+                        } else {
+                            Some(row.clone())
+                        };
+                        row
+                    }
+                    None => {
+                        return Err(AccordDriverError::Network(format!(
+                            "generic IF read-vote lacked F+1 ({sq}) agreement on the row at t \
+                         (got {} reads) — refusing a non-linearizable LWT",
+                            read_rows.len()
+                        )));
+                    }
+                };
+
+                // GATE THE WRITE on the IF condition. The coordinator owns the table
+                // schema (via the injected gate, which wraps the canonical
+                // eval_if_conditions); it evaluates the predicate against the
+                // F+1-agreed, linearizable row-at-`t` and ABORTS before the Apply
+                // phase when the condition does not hold. Without this the generic
+                // path would persist its mutation unconditionally and still report
+                // [applied]=false — a lost-update / wrong-[applied] data-loss bug.
+                //
+                // Determinism: every replica sees the same `t` and the same agreed
+                // row bytes, so the gate's verdict is identical everywhere.
+                if let Some(gate) = &self.condition_gate {
+                    let row_arg: Option<&[u8]> = if agreed_row_bytes.is_empty() {
                         None
                     } else {
-                        Some(row.clone())
+                        Some(agreed_row_bytes.as_slice())
                     };
-                    row
+                    if !gate(row_arg) {
+                        tracing::info!(
+                            txn_id = ?txn_id,
+                            "accord: generic IF condition not met — [applied]=false, no Apply"
+                        );
+                        // Finalize this committed-but-not-applied txn as a no-write
+                        // across replicas so it does not linger as a phantom dep that
+                        // would stall later reads' dep-wait on this key.
+                        self.finalize_no_write().await;
+                        return Err(AccordDriverError::ConditionNotMet {
+                            current_row: agreed_row_bytes,
+                        });
+                    }
                 }
-                None => {
-                    return Err(AccordDriverError::Network(format!(
-                        "generic IF read-vote lacked F+1 ({sq}) agreement on the row at t \
-                         (got {} reads) — refusing a non-linearizable LWT",
-                        read_rows.len()
-                    )));
-                }
-            };
-
-            // GATE THE WRITE on the IF condition. The coordinator owns the table
-            // schema (via the injected gate, which wraps the canonical
-            // eval_if_conditions); it evaluates the predicate against the
-            // F+1-agreed, linearizable row-at-`t` and ABORTS before the Apply
-            // phase when the condition does not hold. Without this the generic
-            // path would persist its mutation unconditionally and still report
-            // [applied]=false — a lost-update / wrong-[applied] data-loss bug.
-            //
-            // Determinism: every replica sees the same `t` and the same agreed
-            // row bytes, so the gate's verdict is identical everywhere.
-            if let Some(gate) = &self.condition_gate {
-                let row_arg: Option<&[u8]> = if agreed_row_bytes.is_empty() {
-                    None
-                } else {
-                    Some(agreed_row_bytes.as_slice())
-                };
-                if !gate(row_arg) {
+            } else {
+                // F+1 matching votes decide the outcome.
+                // Only return ConditionNotMet if F+1 replicas explicitly voted false.
+                if votes_false >= sq {
                     tracing::info!(
                         txn_id = ?txn_id,
-                        "accord: generic IF condition not met — [applied]=false, no Apply"
+                        votes_false,
+                        sq,
+                        "accord: IF condition not met — [applied]=false"
                     );
                     // Finalize this committed-but-not-applied txn as a no-write
                     // across replicas so it does not linger as a phantom dep that
                     // would stall later reads' dep-wait on this key.
                     self.finalize_no_write().await;
                     return Err(AccordDriverError::ConditionNotMet {
-                        current_row: agreed_row_bytes,
+                        current_row: dissenting_row,
                     });
                 }
             }
-        } else {
-            // F+1 matching votes decide the outcome.
-            // Only return ConditionNotMet if F+1 replicas explicitly voted false.
-            if votes_false >= sq {
-                tracing::info!(
-                    txn_id = ?txn_id,
-                    votes_false,
-                    sq,
-                    "accord: IF condition not met — [applied]=false"
-                );
-                // Finalize this committed-but-not-applied txn as a no-write
-                // across replicas so it does not linger as a phantom dep that
-                // would stall later reads' dep-wait on this key.
-                self.finalize_no_write().await;
-                return Err(AccordDriverError::ConditionNotMet {
-                    current_row: dissenting_row,
-                });
-            }
-        }
+        } // end read-vote phase (skipped for ReadPredicate::Always)
 
         // ------------------------------------------------------------------
         // Phase 5: Apply broadcast (Gap 5 — dep-wait + storage write)

--- a/ferrosa-cluster/src/accord/driver_cross_shard_e2e.rs
+++ b/ferrosa-cluster/src/accord/driver_cross_shard_e2e.rs
@@ -17,10 +17,13 @@
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
     use uuid::Uuid;
+
+    use crate::accord::wire::ReadPredicate;
 
     use ferrosa_common::accord::{HybridLogicalClock, TxnId};
     use ferrosa_net::codec::Lane;
@@ -94,6 +97,9 @@ mod tests {
     struct RoutingTransport {
         nodes: HashMap<Uuid, Arc<AccordHandler>>,
         down: HashSet<Uuid>,
+        /// Number of `AccordRead` (read-vote) messages routed — lets a test prove
+        /// the read-vote phase ran (or, for an unconditional txn, was skipped).
+        read_votes: Arc<AtomicUsize>,
     }
     #[async_trait]
     impl AccordTransport for RoutingTransport {
@@ -103,6 +109,9 @@ mod tests {
             msg: Message,
             _lane: Lane,
         ) -> ferrosa_net::error::Result<Message> {
+            if matches!(msg, Message::AccordRead(_)) {
+                self.read_votes.fetch_add(1, Ordering::Relaxed);
+            }
             if self.down.contains(&host_id) {
                 return Err(NetError::Timeout("node down".into()));
             }
@@ -121,16 +130,19 @@ mod tests {
     /// Build a 2-shard cluster (one RF=1 node per shard) + an external coordinator
     /// driver for a 2-key cross-shard transaction. `down` names host ids whose
     /// node drops all messages. Returns (driver, nodeA, nodeB).
+    #[allow(clippy::too_many_arguments)]
     fn cross_shard_transfer(
         key_a: &[u8],
         mut_a: &[u8],
         key_b: &[u8],
         mut_b: &[u8],
         down: HashSet<Uuid>,
+        predicate: ReadPredicate,
     ) -> (
         AccordCoordinatorDriver,
         Arc<RecordingApplier>,
         Arc<RecordingApplier>,
+        Arc<AtomicUsize>,
     ) {
         let node_a = make_node(0xA);
         let node_b = make_node(0xB);
@@ -139,7 +151,12 @@ mod tests {
         let mut nodes = HashMap::new();
         nodes.insert(node_a.host_id, node_a.handler.clone());
         nodes.insert(node_b.host_id, node_b.handler.clone());
-        let transport: Arc<dyn AccordTransport> = Arc::new(RoutingTransport { nodes, down });
+        let read_votes = Arc::new(AtomicUsize::new(0));
+        let transport: Arc<dyn AccordTransport> = Arc::new(RoutingTransport {
+            nodes,
+            down,
+            read_votes: read_votes.clone(),
+        });
 
         // External coordinator (its id matches no replica → no self-loopback; every
         // message goes over the routing transport to a real handler).
@@ -169,9 +186,10 @@ mod tests {
             &clock,
             write_set,
         )
-        .with_per_key_replicas(Arc::new(resolver));
+        .with_per_key_replicas(Arc::new(resolver))
+        .with_read_predicate(predicate);
 
-        (driver, node_a.applier, node_b.applier)
+        (driver, node_a.applier, node_b.applier, read_votes)
     }
 
     /// Happy path: a 2-key transaction across two shards commits, and BOTH shards
@@ -180,8 +198,14 @@ mod tests {
     /// across genuinely distinct shards.
     #[tokio::test]
     async fn cross_shard_txn_commits_and_applies_on_both_shards() {
-        let (mut driver, applier_a, applier_b) =
-            cross_shard_transfer(b"acct_a", b"row_a", b"acct_b", b"row_b", HashSet::new());
+        let (mut driver, applier_a, applier_b, _reads) = cross_shard_transfer(
+            b"acct_a",
+            b"row_a",
+            b"acct_b",
+            b"row_b",
+            HashSet::new(),
+            ReadPredicate::NotExists,
+        );
 
         let result = driver.run_transaction().await;
         assert!(
@@ -201,6 +225,36 @@ mod tests {
         );
     }
 
+    /// Unconditional transaction (`ReadPredicate::Always`): a plain `BEGIN/COMMIT`
+    /// has no `IF` to evaluate, so the driver must SKIP the read-vote phase
+    /// entirely and apply on every shard. This is the unlock for general
+    /// multi-key SQL transactions (2a), which `NotExists`/`ReadRow` cannot serve.
+    #[tokio::test]
+    async fn unconditional_txn_skips_read_vote_and_applies_on_both_shards() {
+        let (mut driver, applier_a, applier_b, read_votes) = cross_shard_transfer(
+            b"acct_a",
+            b"row_a",
+            b"acct_b",
+            b"row_b",
+            HashSet::new(),
+            ReadPredicate::Always,
+        );
+
+        let result = driver.run_transaction().await;
+        assert!(
+            result.is_ok(),
+            "unconditional cross-shard txn must commit: {result:?}"
+        );
+        assert_eq!(
+            read_votes.load(Ordering::Relaxed),
+            0,
+            "an unconditional (Always) txn must send NO AccordRead — the read-vote \
+             phase is skipped"
+        );
+        assert_eq!(applier_a.applied_data(), vec![b"row_a".to_vec()]);
+        assert_eq!(applier_b.applied_data(), vec![b"row_b".to_vec()]);
+    }
+
     /// Abort-all: when one shard's only replica is down, the transaction cannot
     /// reach that shard's quorum and aborts — NEITHER shard applies (no partial
     /// cross-shard write).
@@ -208,8 +262,14 @@ mod tests {
     async fn cross_shard_txn_with_one_shard_down_applies_nothing() {
         let node_b_host = Uuid::from_u128(0xB);
         let down = HashSet::from([node_b_host]);
-        let (mut driver, applier_a, applier_b) =
-            cross_shard_transfer(b"acct_a", b"row_a", b"acct_b", b"row_b", down);
+        let (mut driver, applier_a, applier_b, _reads) = cross_shard_transfer(
+            b"acct_a",
+            b"row_a",
+            b"acct_b",
+            b"row_b",
+            down,
+            ReadPredicate::NotExists,
+        );
 
         let result = driver.run_transaction().await;
         assert!(

--- a/ferrosa-cluster/src/accord/handlers.rs
+++ b/ferrosa-cluster/src/accord/handlers.rs
@@ -332,6 +332,10 @@ impl RpcHandler for AccordHandler {
                             sm.read_condition_holds_at(&vote_req.key, &vote_req.t),
                             vec![],
                         ),
+                        // Unconditional transaction: no IF to evaluate, always
+                        // holds. Defensive — the coordinator skips the read-vote
+                        // for `Always`, so this arm is not normally reached.
+                        ReadPredicate::Always => (true, vec![]),
                         // Generic IF col=val: the replica does the read-at-`t`
                         // and returns the row bytes; the coordinator (which owns
                         // the table schema) evaluates the predicate via the

--- a/ferrosa-cluster/src/accord/mod.rs
+++ b/ferrosa-cluster/src/accord/mod.rs
@@ -34,6 +34,7 @@ pub mod reorder_buffer;
 pub mod shard_quorum;
 pub mod state_machine;
 pub mod test_cluster;
+pub mod transaction_commit;
 pub mod transport;
 pub mod two_phase_ddl;
 pub mod uda_integration;

--- a/ferrosa-cluster/src/accord/transaction_commit.rs
+++ b/ferrosa-cluster/src/accord/transaction_commit.rs
@@ -1,0 +1,345 @@
+//! `AccordTransactionCommitter` — the cluster-side implementation of the
+//! [`TransactionCommitter`](ferrosa_storage::accord::TransactionCommitter) seam
+//! (ADR-021, increment 2b).
+//!
+//! CQL/Postgres `BEGIN`/`COMMIT` buffer DML into a write-set and call
+//! [`commit`](TransactionCommitter::commit); this routes the whole write-set
+//! through one multi-key Accord transaction:
+//!
+//! 1. **resolve replicas per key** — via the injected `resolve` closure, which in
+//!    production wraps `WritePath::accord_replicas_for_key` (token-aware, RF-correct,
+//!    #185) keyed by each write's keyspace replication;
+//! 2. **per-shard quorum** — `AccordCoordinatorDriver::new_multi` builds a per-key
+//!    `ParticipantSet` and drives PreAccept(V2)/Commit/Apply under per-shard quorum;
+//! 3. **unconditional apply** — a general transaction has no `IF`, so it runs in
+//!    [`ReadPredicate::Always`] mode (no read-vote; #190).
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use ferrosa_common::accord::HybridLogicalClock;
+use ferrosa_storage::accord::{CommitError, CommitOutcome, TransactionCommitter, TransactionWrite};
+
+use crate::accord::apply::StorageApplier;
+use crate::accord::coordinator::{AccordCoordinatorDriver, AccordDriverError};
+use crate::accord::transport::AccordTransport;
+use crate::accord::wire::ReadPredicate;
+
+/// Resolves the replica host ids that own `key` in `keyspace`. `None` means the
+/// key cannot be placed (e.g. not in cluster mode, or unknown keyspace) — the
+/// commit fails loud rather than guessing.
+pub type ReplicaResolver = Arc<dyn Fn(&str, &[u8]) -> Option<Vec<Uuid>> + Send + Sync>;
+
+/// Cluster-side [`TransactionCommitter`]: commits a buffered multi-key write-set
+/// as one unconditional Accord transaction.
+pub struct AccordTransactionCommitter {
+    /// This (coordinator) node's id — derived from its host UUID like the driver.
+    node_id: u64,
+    clock: Arc<HybridLogicalClock>,
+    /// Internode transport (a `PeerManager` in production).
+    transport: Arc<dyn AccordTransport>,
+    /// Applier for the coordinator's own replica (its self-send is unreachable).
+    applier: Arc<dyn StorageApplier>,
+    /// Per-key replica resolution (wraps `WritePath` + schema in production).
+    resolve: ReplicaResolver,
+}
+
+impl AccordTransactionCommitter {
+    pub fn new(
+        node_id: u64,
+        clock: Arc<HybridLogicalClock>,
+        transport: Arc<dyn AccordTransport>,
+        applier: Arc<dyn StorageApplier>,
+        resolve: ReplicaResolver,
+    ) -> Self {
+        Self {
+            node_id,
+            clock,
+            transport,
+            applier,
+            resolve,
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionCommitter for AccordTransactionCommitter {
+    async fn commit(&self, writes: Vec<TransactionWrite>) -> Result<CommitOutcome, CommitError> {
+        // BEGIN; COMMIT; with no DML is a no-op — never drive Accord for nothing.
+        if writes.is_empty() {
+            return Ok(CommitOutcome::Committed);
+        }
+
+        // 1. Resolve each key's replicas; fail loud on an unplaceable key (never
+        //    commit a write to a guessed/empty replica set).
+        let mut replica_union: BTreeSet<Uuid> = BTreeSet::new();
+        let mut per_key: HashMap<Vec<u8>, Vec<Uuid>> = HashMap::new();
+        for w in &writes {
+            let replicas = (self.resolve)(&w.keyspace, &w.key).ok_or_else(|| CommitError {
+                reason: format!(
+                    "no replicas resolved for a key in keyspace '{}' (cluster mode required)",
+                    w.keyspace
+                ),
+            })?;
+            if replicas.is_empty() {
+                return Err(CommitError {
+                    reason: format!("empty replica set for a key in keyspace '{}'", w.keyspace),
+                });
+            }
+            for r in &replicas {
+                replica_union.insert(*r);
+            }
+            per_key.insert(w.key.clone(), replicas);
+        }
+        let replica_ids: Vec<Uuid> = replica_union.into_iter().collect();
+
+        // 2. Build the write-set + the per-key participant resolver for the driver.
+        let write_set: Vec<(Vec<u8>, Vec<u8>)> =
+            writes.into_iter().map(|w| (w.key, w.mutation)).collect();
+        let per_key = Arc::new(per_key);
+        let pk = per_key.clone();
+        let participant_resolver =
+            move |k: &[u8]| -> Vec<Uuid> { pk.get(k).cloned().unwrap_or_default() };
+
+        // 3. Drive one unconditional multi-key Accord transaction.
+        let mut driver = AccordCoordinatorDriver::new_multi_with_transport(
+            self.node_id,
+            replica_ids,
+            self.transport.clone(),
+            false,
+            &self.clock,
+            write_set,
+        )
+        .with_per_key_replicas(Arc::new(participant_resolver))
+        .with_local_applier(self.applier.clone())
+        .with_read_predicate(ReadPredicate::Always);
+
+        match driver.run_transaction().await {
+            Ok(_) => Ok(CommitOutcome::Committed),
+            // A general transaction is unconditional (Always mode), so a condition
+            // abort should not arise — map it cleanly if it ever does.
+            Err(AccordDriverError::ConditionNotMet { .. }) => Ok(CommitOutcome::Aborted {
+                reason: "transaction condition not met".to_string(),
+            }),
+            // Quorum/network/codec failures: the commit did not reach a decision —
+            // surface as Err so the front-end never acks an uncommitted transaction.
+            Err(e) => Err(CommitError {
+                reason: e.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    use ferrosa_net::error::NetError;
+    use ferrosa_net::message::Message;
+
+    use crate::accord::apply::{ApplyError, ApplyMutation};
+
+    /// Records every applied mutation's data, so a test can assert which keys' writes landed.
+    struct RecordingApplier {
+        applied: Mutex<Vec<Vec<u8>>>,
+    }
+    impl RecordingApplier {
+        fn new() -> Self {
+            Self {
+                applied: Mutex::new(Vec::new()),
+            }
+        }
+        fn applied_data(&self) -> Vec<Vec<u8>> {
+            self.applied.lock().expect("applier mutex").clone()
+        }
+    }
+    impl StorageApplier for RecordingApplier {
+        fn apply(
+            &self,
+            _txn_id: ferrosa_common::accord::TxnId,
+            mutation: ApplyMutation,
+        ) -> Result<(), ApplyError> {
+            self.applied
+                .lock()
+                .expect("applier mutex")
+                .push(mutation.data);
+            Ok(())
+        }
+    }
+
+    /// Transport with no reachable peers — used when the coordinator is the sole
+    /// replica (every send is a self-send the driver never makes).
+    struct NoPeersTransport;
+    #[async_trait]
+    impl AccordTransport for NoPeersTransport {
+        async fn send(
+            &self,
+            _host: Uuid,
+            _msg: Message,
+            _lane: ferrosa_net::codec::Lane,
+        ) -> ferrosa_net::error::Result<Message> {
+            Err(NetError::Timeout("no peers".into()))
+        }
+    }
+
+    fn write(ks: &str, key: &[u8], mutation: &[u8]) -> TransactionWrite {
+        TransactionWrite {
+            keyspace: ks.to_string(),
+            key: key.to_vec(),
+            mutation: mutation.to_vec(),
+        }
+    }
+
+    fn committer_with(host: Uuid, applier: Arc<RecordingApplier>) -> AccordTransactionCommitter {
+        let node_id = u64::from_be_bytes(host.as_bytes()[..8].try_into().expect("uuid 16 bytes"));
+        let clock = Arc::new(HybridLogicalClock::new(node_id, 0));
+        // Sole replica = the coordinator itself, for every key.
+        let resolve: ReplicaResolver = Arc::new(move |_ks: &str, _key: &[u8]| Some(vec![host]));
+        AccordTransactionCommitter::new(
+            node_id,
+            clock,
+            Arc::new(NoPeersTransport),
+            applier,
+            resolve,
+        )
+    }
+
+    #[tokio::test]
+    async fn empty_write_set_commits_without_driving_accord() {
+        let applier = Arc::new(RecordingApplier::new());
+        let committer = committer_with(Uuid::from_u128(1), applier.clone());
+
+        let outcome = committer.commit(Vec::new()).await.expect("empty commit");
+
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert!(
+            applier.applied_data().is_empty(),
+            "an empty transaction must not apply anything"
+        );
+    }
+
+    fn node_id_of(u: Uuid) -> u64 {
+        u64::from_be_bytes(u.as_bytes()[..8].try_into().expect("uuid 16 bytes"))
+    }
+
+    /// One real cluster node: its state-machine handler + recording applier.
+    fn make_node(
+        seed: u128,
+    ) -> (
+        Uuid,
+        Arc<crate::accord::handlers::AccordHandler>,
+        Arc<RecordingApplier>,
+    ) {
+        use crate::accord::handlers::{AccordHandler, AccordState};
+        use crate::accord::state_machine::AccordStateMachine;
+        use ferrosa_storage::accord::sync_writer::MockSyncWriter;
+        let host_id = Uuid::from_u128(seed);
+        let nid = node_id_of(host_id);
+        let applier = Arc::new(RecordingApplier::new());
+        let sm =
+            AccordStateMachine::with_applier(nid, Arc::new(MockSyncWriter::new()), applier.clone());
+        let state: AccordState = Arc::new(parking_lot::Mutex::new(sm));
+        (host_id, Arc::new(AccordHandler::new(state, nid)), applier)
+    }
+
+    /// Routes each Accord message to the addressed node's real handler.
+    struct RoutingTransport {
+        nodes: HashMap<Uuid, Arc<crate::accord::handlers::AccordHandler>>,
+    }
+    #[async_trait]
+    impl AccordTransport for RoutingTransport {
+        async fn send(
+            &self,
+            host: Uuid,
+            msg: Message,
+            _lane: ferrosa_net::codec::Lane,
+        ) -> ferrosa_net::error::Result<Message> {
+            use ferrosa_net::rpc::handler::{PeerId, RpcHandler};
+            let handler = self
+                .nodes
+                .get(&host)
+                .ok_or_else(|| NetError::Timeout("unknown peer".into()))?;
+            let peer: PeerId = (host, "127.0.0.1:0".parse().expect("addr"));
+            handler
+                .handle(peer, msg)
+                .await
+                .ok_or_else(|| NetError::Timeout("no response".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn commits_multi_key_write_set_across_shards_and_applies_every_key() {
+        // Two shards (one RF=1 node each), external coordinator. The committer
+        // resolves key_a → shard A, key_b → shard B and drives ONE unconditional
+        // Accord transaction; each shard must apply its own key — the committer
+        // turns a buffered write-set into a real cross-shard commit end to end.
+        let (ha, handler_a, applier_a) = make_node(0xA);
+        let (hb, handler_b, applier_b) = make_node(0xB);
+        let mut nodes = HashMap::new();
+        nodes.insert(ha, handler_a);
+        nodes.insert(hb, handler_b);
+        let transport: Arc<dyn AccordTransport> = Arc::new(RoutingTransport { nodes });
+
+        let coord_id = 999_999u64; // external coordinator (matches no replica)
+        let clock = Arc::new(HybridLogicalClock::new(coord_id, 0));
+        let resolve: ReplicaResolver = Arc::new(move |_ks: &str, key: &[u8]| {
+            if key == b"acct_a" {
+                Some(vec![ha])
+            } else {
+                Some(vec![hb])
+            }
+        });
+        let committer = AccordTransactionCommitter::new(
+            coord_id,
+            clock,
+            transport,
+            Arc::new(RecordingApplier::new()), // coordinator is not a replica
+            resolve,
+        );
+
+        let writes = vec![
+            write("ks", b"acct_a", b"row_a"),
+            write("ks", b"acct_b", b"row_b"),
+        ];
+        let outcome = committer.commit(writes).await.expect("commit");
+
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert_eq!(
+            applier_a.applied_data(),
+            vec![b"row_a".to_vec()],
+            "shard A must apply its key"
+        );
+        assert_eq!(
+            applier_b.applied_data(),
+            vec![b"row_b".to_vec()],
+            "shard B must apply its key"
+        );
+    }
+
+    #[tokio::test]
+    async fn unplaceable_key_fails_loud() {
+        // A key the resolver cannot place must abort the commit with an error —
+        // never silently commit to a guessed/empty replica set.
+        let applier = Arc::new(RecordingApplier::new());
+        let node_id = 7u64;
+        let clock = Arc::new(HybridLogicalClock::new(node_id, 0));
+        let resolve: ReplicaResolver = Arc::new(|_ks: &str, _key: &[u8]| None);
+        let committer = AccordTransactionCommitter::new(
+            node_id,
+            clock,
+            Arc::new(NoPeersTransport),
+            applier,
+            resolve,
+        );
+
+        let err = committer
+            .commit(vec![write("ks", b"k", b"v")])
+            .await
+            .expect_err("unplaceable key must fail loud");
+        assert!(err.reason.contains("no replicas"), "got: {}", err.reason);
+    }
+}

--- a/ferrosa-cluster/src/accord/transaction_commit.rs
+++ b/ferrosa-cluster/src/accord/transaction_commit.rs
@@ -1,6 +1,7 @@
 //! `AccordTransactionCommitter` — the cluster-side implementation of the
-//! [`TransactionCommitter`](ferrosa_storage::accord::TransactionCommitter) seam
-//! (ADR-021, increment 2b).
+//! [`TransactionCommitter`] seam (ADR-021, increment 2b).
+//!
+//! [`TransactionCommitter`]: ferrosa_storage::accord::TransactionCommitter
 //!
 //! CQL/Postgres `BEGIN`/`COMMIT` buffer DML into a write-set and call
 //! [`commit`](TransactionCommitter::commit); this routes the whole write-set

--- a/ferrosa-cluster/src/accord/wire.rs
+++ b/ferrosa-cluster/src/accord/wire.rs
@@ -184,6 +184,11 @@ pub enum ReadPredicate {
         /// Target table name.
         table: String,
     },
+    /// Unconditional commit: there is no `IF` to evaluate, so the transaction
+    /// always applies after commit. The coordinator SKIPS the read-vote phase
+    /// entirely (no `AccordRead` fan-out). This is the path for a general
+    /// multi-key SQL transaction (`BEGIN`/`COMMIT`), which has no LWT condition.
+    Always,
 }
 
 /// Read-vote response from a replica.


### PR DESCRIPTION
## Summary

Increment **2a** of BEGIN/COMMIT-over-Accord (follows #188). The Accord driver was **LWT-shaped**: `run_transaction` always ran a read-vote phase that gates Apply on an IF condition (`NotExists` → applies only for *fresh* keys; `ReadRow` → generic `IF`). A general `BEGIN/COMMIT` transaction is **unconditional** — it UPDATEs existing rows — so it needs an apply path with no IF gate.

Adds **`ReadPredicate::Always`**: the coordinator **skips the read-vote phase entirely** (no `AccordRead` fan-out) and applies after commit. The existing `NotExists`/`ReadRow` gating paths are unchanged; a defensive handler arm covers a stray `Always` read-vote (always holds), though the coordinator never sends one.

This is the unlock the `AccordTransactionCommitter` (2b) needs to commit a general write-set through Accord.

## Test (TDD: red→green)

`unconditional_txn_skips_read_vote_and_applies_on_both_shards` — a cross-shard `Always` transaction sends **0 `AccordRead`** and applies on **both** shards, via an `AccordRead` counter added to the step-4 (#187) routing harness.

ferrosa-cluster **1032 pass**, clippy clean, fmt green.

## Epic position
2a (this) → **2b** `AccordTransactionCommitter` impl → **3** CQL `BEGIN/COMMIT` (`t_bd3684`) → **4** Postgres (`t_b98434`).