### PR TITLE
feat(cql): BEGIN/COMMIT over Accord — buffer + connection wiring (t_bd3684)

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -124,11 +124,15 @@ strict-serializable multi-key / cross-shard transactions and LWT.
 
 ### Accord transactions (`accord/`)
 - `coordinator.rs` / `state_machine.rs` — PreAccept → {fast path | Accept} →
-  Commit → Apply, fast/slow quorum math, HLC timestamps + `TxnId`. The replica
-  apply path is **dep-ordered**: `handle_apply` routes every real write through
-  `apply.rs`'s `DepWaitApplier`, so a mutation persists only once all of its
-  dependencies have applied locally (otherwise it parks and the cascade applies
-  it in order).
+  Commit → [read-vote] → Apply, fast/slow quorum math, HLC timestamps + `TxnId`.
+  The read-vote phase is the LWT `IF`-condition gate (`ReadPredicate::NotExists`
+  for `INSERT IF NOT EXISTS`, `ReadRow` for generic `IF`); a general multi-key
+  SQL transaction uses `ReadPredicate::Always`, which **skips the read-vote
+  entirely** and always applies after commit (there is no `IF` to evaluate). The
+  replica apply path is **dep-ordered**: `handle_apply` routes every real write
+  through `apply.rs`'s `DepWaitApplier`, so a mutation persists only once all of
+  its dependencies have applied locally (otherwise it parks and the cascade
+  applies it in order).
 - `recovery.rs` — Paxos-style recovery selecting by highest `accepted_ballot`.
 - `apply.rs` — `DepWaitApplier` (dep-wait + `StorageApplier` seam) +
   `EngineStorageApplier`/`EngineStorageReader` (real persistence and linearizable

--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -134,6 +134,13 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   its dependencies have applied locally (otherwise it parks and the cascade
   applies it in order).
 - `recovery.rs` — Paxos-style recovery selecting by highest `accepted_ballot`.
+- `transaction_commit.rs` — `AccordTransactionCommitter`: the cluster-side
+  implementation of `ferrosa_storage`'s `TransactionCommitter` seam (ADR-021). CQL/
+  Postgres `BEGIN`/`COMMIT` buffer DML and call it; it resolves replicas per key
+  (injected resolver wrapping `WritePath::accord_replicas_for_key` + schema in prod),
+  then drives ONE unconditional (`ReadPredicate::Always`) multi-key Accord
+  transaction via `new_multi`, mapping the outcome to `Committed`/`Aborted`/`Err`
+  (fail-loud — never acks an uncommitted txn).
 - `apply.rs` — `DepWaitApplier` (dep-wait + `StorageApplier` seam) +
   `EngineStorageApplier`/`EngineStorageReader` (real persistence and linearizable
   read-at-`t`). **Multi-key (Phase 2/3):** `DepWaitApplier::try_apply_writeset`

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -1152,200 +1152,209 @@ impl AccordCoordinatorDriver {
         // a fresh INSERT IF NOT EXISTS).
         // ------------------------------------------------------------------
 
-        let read_payload = ReadVotePayload {
-            txn_id,
-            t: commit_t,
-            key: key.clone(),
-            predicate: self.read_predicate.clone(),
-        };
-        let read_bytes = bincode::serialize(&read_payload)
-            .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
-        let read_msg = Message::AccordRead(Bytes::from(read_bytes));
-
-        let mut votes_false = 0usize;
-        let mut dissenting_row: Vec<u8> = Vec::new();
-        // For the generic ReadRow predicate: collect each replica's row-at-`t`
-        // bytes so we can require F+1 *agreement* on the row state before the
-        // coordinator evaluates the IF predicate. Disagreement is a correctness
-        // failure (non-linearizable read) and must abort, never silently pick one.
-        let mut read_rows: Vec<Vec<u8>> = Vec::new();
-        let is_generic = matches!(
+        // The read-vote phase is the LWT IF-condition gate. An unconditional
+        // transaction (`ReadPredicate::Always`) has no IF, so skip the whole
+        // phase and apply directly — otherwise the existence/row read-vote would
+        // wrongly gate an UPDATE to an existing row.
+        if !matches!(
             self.read_predicate,
-            crate::accord::wire::ReadPredicate::ReadRow { .. }
-        );
+            crate::accord::wire::ReadPredicate::Always
+        ) {
+            let read_payload = ReadVotePayload {
+                txn_id,
+                t: commit_t,
+                key: key.clone(),
+                predicate: self.read_predicate.clone(),
+            };
+            let read_bytes = bincode::serialize(&read_payload)
+                .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
+            let read_msg = Message::AccordRead(Bytes::from(read_bytes));
 
-        // The coordinator's own replica is not reachable over the network
-        // (self-send fails). For the generic path it must contribute its local
-        // read-at-`t` so that, with RF=2 (sq=2), F+1 agreement is achievable and
-        // the result is deterministic across all replicas. The applier already
-        // persisted earlier conflicting txns locally before this read (dep-wait).
-        if is_generic {
-            if let crate::accord::wire::ReadPredicate::ReadRow { keyspace, table } =
-                &self.read_predicate
-            {
-                // Prefer the local state machine when wired: it performs the SAME
-                // dep-wait the remote handler does (block until every conflicting
-                // `t0 < t` has Applied locally) before reading at `t`. This is what
-                // serializes a genuinely concurrent contender's write ahead of this
-                // read — without it the coordinator's own replica could read the key
-                // as absent while a smaller-`t` contender is mid-apply (the
-                // concurrent INSERT IF NOT EXISTS double-apply). On dep-wait timeout
-                // we ABSTAIN (push no row) so F+1 agreement fails loud rather than
-                // reading stale.
-                if let Some(local_sm) = &self.local_accord_state {
-                    if crate::accord::handlers::await_conflicting_deps_applied(
-                        local_sm, &key, commit_t,
-                    )
-                    .await
-                    {
-                        let row = local_sm
-                            .lock()
-                            .read_row_bytes_at(keyspace, table, &key, commit_t);
-                        read_rows.push(row.unwrap_or_default());
-                    } else {
-                        tracing::error!(
-                            txn_id = ?txn_id,
-                            "accord: coordinator local read-vote dep-wait timed out — abstaining"
-                        );
-                        // Abstain: contribute no local read. F+1 agreement then
-                        // fails loud below rather than treating a stale read as truth.
-                    }
-                } else if let Some(reader) = &self.local_reader {
-                    match reader.read_row_at(keyspace, table, &key, commit_t) {
-                        Ok(bytes) => read_rows.push(bytes.unwrap_or_default()),
-                        Err(e) => {
-                            return Err(AccordDriverError::Network(format!(
-                                "coordinator local read-at-t failed: {e}"
-                            )));
+            let mut votes_false = 0usize;
+            let mut dissenting_row: Vec<u8> = Vec::new();
+            // For the generic ReadRow predicate: collect each replica's row-at-`t`
+            // bytes so we can require F+1 *agreement* on the row state before the
+            // coordinator evaluates the IF predicate. Disagreement is a correctness
+            // failure (non-linearizable read) and must abort, never silently pick one.
+            let mut read_rows: Vec<Vec<u8>> = Vec::new();
+            let is_generic = matches!(
+                self.read_predicate,
+                crate::accord::wire::ReadPredicate::ReadRow { .. }
+            );
+
+            // The coordinator's own replica is not reachable over the network
+            // (self-send fails). For the generic path it must contribute its local
+            // read-at-`t` so that, with RF=2 (sq=2), F+1 agreement is achievable and
+            // the result is deterministic across all replicas. The applier already
+            // persisted earlier conflicting txns locally before this read (dep-wait).
+            if is_generic {
+                if let crate::accord::wire::ReadPredicate::ReadRow { keyspace, table } =
+                    &self.read_predicate
+                {
+                    // Prefer the local state machine when wired: it performs the SAME
+                    // dep-wait the remote handler does (block until every conflicting
+                    // `t0 < t` has Applied locally) before reading at `t`. This is what
+                    // serializes a genuinely concurrent contender's write ahead of this
+                    // read — without it the coordinator's own replica could read the key
+                    // as absent while a smaller-`t` contender is mid-apply (the
+                    // concurrent INSERT IF NOT EXISTS double-apply). On dep-wait timeout
+                    // we ABSTAIN (push no row) so F+1 agreement fails loud rather than
+                    // reading stale.
+                    if let Some(local_sm) = &self.local_accord_state {
+                        if crate::accord::handlers::await_conflicting_deps_applied(
+                            local_sm, &key, commit_t,
+                        )
+                        .await
+                        {
+                            let row = local_sm
+                                .lock()
+                                .read_row_bytes_at(keyspace, table, &key, commit_t);
+                            read_rows.push(row.unwrap_or_default());
+                        } else {
+                            tracing::error!(
+                                txn_id = ?txn_id,
+                                "accord: coordinator local read-vote dep-wait timed out — abstaining"
+                            );
+                            // Abstain: contribute no local read. F+1 agreement then
+                            // fails loud below rather than treating a stale read as truth.
                         }
-                    }
-                }
-            }
-        }
-
-        let remote_read_futs: Vec<_> = self
-            .replica_ids
-            .iter()
-            .filter(|&&id| id != self_id)
-            .map(|&peer_id| {
-                let peers = Arc::clone(&self.peers);
-                let msg = read_msg.clone();
-                async move { peers.send(peer_id, msg, Lane::Data).await }
-            })
-            .collect();
-        let read_responses = futures::future::join_all(remote_read_futs).await;
-
-        for result in &read_responses {
-            match result {
-                Ok(Message::AccordReadOK(b)) if !b.is_empty() => {
-                    match bincode::deserialize::<ReadVoteOkPayload>(b) {
-                        Ok(vote) => {
-                            if is_generic {
-                                // Generic IF: replica returns the row bytes at `t`
-                                // (condition_holds is a neutral true). Collect for
-                                // F+1 agreement; the coordinator evaluates the
-                                // predicate authoritatively below.
-                                read_rows.push(vote.current_row.clone());
-                            } else if !vote.condition_holds {
-                                // INSERT IF NOT EXISTS existence path.
-                                votes_false += 1;
-                                if dissenting_row.is_empty() {
-                                    dissenting_row = vote.current_row.clone();
-                                }
+                    } else if let Some(reader) = &self.local_reader {
+                        match reader.read_row_at(keyspace, table, &key, commit_t) {
+                            Ok(bytes) => read_rows.push(bytes.unwrap_or_default()),
+                            Err(e) => {
+                                return Err(AccordDriverError::Network(format!(
+                                    "coordinator local read-at-t failed: {e}"
+                                )));
                             }
                         }
-                        Err(_) => {
-                            // pre-Gap-4 replica or parse error: treat as
-                            // condition_holds=true (forward-compatible default).
-                        }
-                    }
-                }
-                Ok(_) | Err(_) => {
-                    // No response or network error — skip (don't count as false vote).
-                    // Log network errors at warn level.
-                    if let Err(e) = result {
-                        tracing::warn!(
-                            txn_id = ?txn_id,
-                            error = %e,
-                            "accord: ReadVote RPC failed (non-fatal)"
-                        );
                     }
                 }
             }
-        }
 
-        if is_generic {
-            // Require F+1 replicas to agree on the SAME row bytes at `t`. This is
-            // the linearizable read: a divergent read is non-linearizable and must
-            // abort (fail loud) rather than have the coordinator guess.
-            let agreed = agreed_row(&read_rows, sq);
-            let agreed_row_bytes = match agreed {
-                Some(row) => {
-                    self.last_read_row = if row.is_empty() {
+            let remote_read_futs: Vec<_> = self
+                .replica_ids
+                .iter()
+                .filter(|&&id| id != self_id)
+                .map(|&peer_id| {
+                    let peers = Arc::clone(&self.peers);
+                    let msg = read_msg.clone();
+                    async move { peers.send(peer_id, msg, Lane::Data).await }
+                })
+                .collect();
+            let read_responses = futures::future::join_all(remote_read_futs).await;
+
+            for result in &read_responses {
+                match result {
+                    Ok(Message::AccordReadOK(b)) if !b.is_empty() => {
+                        match bincode::deserialize::<ReadVoteOkPayload>(b) {
+                            Ok(vote) => {
+                                if is_generic {
+                                    // Generic IF: replica returns the row bytes at `t`
+                                    // (condition_holds is a neutral true). Collect for
+                                    // F+1 agreement; the coordinator evaluates the
+                                    // predicate authoritatively below.
+                                    read_rows.push(vote.current_row.clone());
+                                } else if !vote.condition_holds {
+                                    // INSERT IF NOT EXISTS existence path.
+                                    votes_false += 1;
+                                    if dissenting_row.is_empty() {
+                                        dissenting_row = vote.current_row.clone();
+                                    }
+                                }
+                            }
+                            Err(_) => {
+                                // pre-Gap-4 replica or parse error: treat as
+                                // condition_holds=true (forward-compatible default).
+                            }
+                        }
+                    }
+                    Ok(_) | Err(_) => {
+                        // No response or network error — skip (don't count as false vote).
+                        // Log network errors at warn level.
+                        if let Err(e) = result {
+                            tracing::warn!(
+                                txn_id = ?txn_id,
+                                error = %e,
+                                "accord: ReadVote RPC failed (non-fatal)"
+                            );
+                        }
+                    }
+                }
+            }
+
+            if is_generic {
+                // Require F+1 replicas to agree on the SAME row bytes at `t`. This is
+                // the linearizable read: a divergent read is non-linearizable and must
+                // abort (fail loud) rather than have the coordinator guess.
+                let agreed = agreed_row(&read_rows, sq);
+                let agreed_row_bytes = match agreed {
+                    Some(row) => {
+                        self.last_read_row = if row.is_empty() {
+                            None
+                        } else {
+                            Some(row.clone())
+                        };
+                        row
+                    }
+                    None => {
+                        return Err(AccordDriverError::Network(format!(
+                            "generic IF read-vote lacked F+1 ({sq}) agreement on the row at t \
+                         (got {} reads) — refusing a non-linearizable LWT",
+                            read_rows.len()
+                        )));
+                    }
+                };
+
+                // GATE THE WRITE on the IF condition. The coordinator owns the table
+                // schema (via the injected gate, which wraps the canonical
+                // eval_if_conditions); it evaluates the predicate against the
+                // F+1-agreed, linearizable row-at-`t` and ABORTS before the Apply
+                // phase when the condition does not hold. Without this the generic
+                // path would persist its mutation unconditionally and still report
+                // [applied]=false — a lost-update / wrong-[applied] data-loss bug.
+                //
+                // Determinism: every replica sees the same `t` and the same agreed
+                // row bytes, so the gate's verdict is identical everywhere.
+                if let Some(gate) = &self.condition_gate {
+                    let row_arg: Option<&[u8]> = if agreed_row_bytes.is_empty() {
                         None
                     } else {
-                        Some(row.clone())
+                        Some(agreed_row_bytes.as_slice())
                     };
-                    row
+                    if !gate(row_arg) {
+                        tracing::info!(
+                            txn_id = ?txn_id,
+                            "accord: generic IF condition not met — [applied]=false, no Apply"
+                        );
+                        // Finalize this committed-but-not-applied txn as a no-write
+                        // across replicas so it does not linger as a phantom dep that
+                        // would stall later reads' dep-wait on this key.
+                        self.finalize_no_write().await;
+                        return Err(AccordDriverError::ConditionNotMet {
+                            current_row: agreed_row_bytes,
+                        });
+                    }
                 }
-                None => {
-                    return Err(AccordDriverError::Network(format!(
-                        "generic IF read-vote lacked F+1 ({sq}) agreement on the row at t \
-                         (got {} reads) — refusing a non-linearizable LWT",
-                        read_rows.len()
-                    )));
-                }
-            };
-
-            // GATE THE WRITE on the IF condition. The coordinator owns the table
-            // schema (via the injected gate, which wraps the canonical
-            // eval_if_conditions); it evaluates the predicate against the
-            // F+1-agreed, linearizable row-at-`t` and ABORTS before the Apply
-            // phase when the condition does not hold. Without this the generic
-            // path would persist its mutation unconditionally and still report
-            // [applied]=false — a lost-update / wrong-[applied] data-loss bug.
-            //
-            // Determinism: every replica sees the same `t` and the same agreed
-            // row bytes, so the gate's verdict is identical everywhere.
-            if let Some(gate) = &self.condition_gate {
-                let row_arg: Option<&[u8]> = if agreed_row_bytes.is_empty() {
-                    None
-                } else {
-                    Some(agreed_row_bytes.as_slice())
-                };
-                if !gate(row_arg) {
+            } else {
+                // F+1 matching votes decide the outcome.
+                // Only return ConditionNotMet if F+1 replicas explicitly voted false.
+                if votes_false >= sq {
                     tracing::info!(
                         txn_id = ?txn_id,
-                        "accord: generic IF condition not met — [applied]=false, no Apply"
+                        votes_false,
+                        sq,
+                        "accord: IF condition not met — [applied]=false"
                     );
                     // Finalize this committed-but-not-applied txn as a no-write
                     // across replicas so it does not linger as a phantom dep that
                     // would stall later reads' dep-wait on this key.
                     self.finalize_no_write().await;
                     return Err(AccordDriverError::ConditionNotMet {
-                        current_row: agreed_row_bytes,
+                        current_row: dissenting_row,
                     });
                 }
             }
-        } else {
-            // F+1 matching votes decide the outcome.
-            // Only return ConditionNotMet if F+1 replicas explicitly voted false.
-            if votes_false >= sq {
-                tracing::info!(
-                    txn_id = ?txn_id,
-                    votes_false,
-                    sq,
-                    "accord: IF condition not met — [applied]=false"
-                );
-                // Finalize this committed-but-not-applied txn as a no-write
-                // across replicas so it does not linger as a phantom dep that
-                // would stall later reads' dep-wait on this key.
-                self.finalize_no_write().await;
-                return Err(AccordDriverError::ConditionNotMet {
-                    current_row: dissenting_row,
-                });
-            }
-        }
+        } // end read-vote phase (skipped for ReadPredicate::Always)
 
         // ------------------------------------------------------------------
         // Phase 5: Apply broadcast (Gap 5 — dep-wait + storage write)

--- a/ferrosa-cluster/src/accord/driver_cross_shard_e2e.rs
+++ b/ferrosa-cluster/src/accord/driver_cross_shard_e2e.rs
@@ -17,10 +17,13 @@
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
     use uuid::Uuid;
+
+    use crate::accord::wire::ReadPredicate;
 
     use ferrosa_common::accord::{HybridLogicalClock, TxnId};
     use ferrosa_net::codec::Lane;
@@ -94,6 +97,9 @@ mod tests {
     struct RoutingTransport {
         nodes: HashMap<Uuid, Arc<AccordHandler>>,
         down: HashSet<Uuid>,
+        /// Number of `AccordRead` (read-vote) messages routed — lets a test prove
+        /// the read-vote phase ran (or, for an unconditional txn, was skipped).
+        read_votes: Arc<AtomicUsize>,
     }
     #[async_trait]
     impl AccordTransport for RoutingTransport {
@@ -103,6 +109,9 @@ mod tests {
             msg: Message,
             _lane: Lane,
         ) -> ferrosa_net::error::Result<Message> {
+            if matches!(msg, Message::AccordRead(_)) {
+                self.read_votes.fetch_add(1, Ordering::Relaxed);
+            }
             if self.down.contains(&host_id) {
                 return Err(NetError::Timeout("node down".into()));
             }
@@ -121,16 +130,19 @@ mod tests {
     /// Build a 2-shard cluster (one RF=1 node per shard) + an external coordinator
     /// driver for a 2-key cross-shard transaction. `down` names host ids whose
     /// node drops all messages. Returns (driver, nodeA, nodeB).
+    #[allow(clippy::too_many_arguments)]
     fn cross_shard_transfer(
         key_a: &[u8],
         mut_a: &[u8],
         key_b: &[u8],
         mut_b: &[u8],
         down: HashSet<Uuid>,
+        predicate: ReadPredicate,
     ) -> (
         AccordCoordinatorDriver,
         Arc<RecordingApplier>,
         Arc<RecordingApplier>,
+        Arc<AtomicUsize>,
     ) {
         let node_a = make_node(0xA);
         let node_b = make_node(0xB);
@@ -139,7 +151,12 @@ mod tests {
         let mut nodes = HashMap::new();
         nodes.insert(node_a.host_id, node_a.handler.clone());
         nodes.insert(node_b.host_id, node_b.handler.clone());
-        let transport: Arc<dyn AccordTransport> = Arc::new(RoutingTransport { nodes, down });
+        let read_votes = Arc::new(AtomicUsize::new(0));
+        let transport: Arc<dyn AccordTransport> = Arc::new(RoutingTransport {
+            nodes,
+            down,
+            read_votes: read_votes.clone(),
+        });
 
         // External coordinator (its id matches no replica → no self-loopback; every
         // message goes over the routing transport to a real handler).
@@ -169,9 +186,10 @@ mod tests {
             &clock,
             write_set,
         )
-        .with_per_key_replicas(Arc::new(resolver));
+        .with_per_key_replicas(Arc::new(resolver))
+        .with_read_predicate(predicate);
 
-        (driver, node_a.applier, node_b.applier)
+        (driver, node_a.applier, node_b.applier, read_votes)
     }
 
     /// Happy path: a 2-key transaction across two shards commits, and BOTH shards
@@ -180,8 +198,14 @@ mod tests {
     /// across genuinely distinct shards.
     #[tokio::test]
     async fn cross_shard_txn_commits_and_applies_on_both_shards() {
-        let (mut driver, applier_a, applier_b) =
-            cross_shard_transfer(b"acct_a", b"row_a", b"acct_b", b"row_b", HashSet::new());
+        let (mut driver, applier_a, applier_b, _reads) = cross_shard_transfer(
+            b"acct_a",
+            b"row_a",
+            b"acct_b",
+            b"row_b",
+            HashSet::new(),
+            ReadPredicate::NotExists,
+        );
 
         let result = driver.run_transaction().await;
         assert!(
@@ -201,6 +225,36 @@ mod tests {
         );
     }
 
+    /// Unconditional transaction (`ReadPredicate::Always`): a plain `BEGIN/COMMIT`
+    /// has no `IF` to evaluate, so the driver must SKIP the read-vote phase
+    /// entirely and apply on every shard. This is the unlock for general
+    /// multi-key SQL transactions (2a), which `NotExists`/`ReadRow` cannot serve.
+    #[tokio::test]
+    async fn unconditional_txn_skips_read_vote_and_applies_on_both_shards() {
+        let (mut driver, applier_a, applier_b, read_votes) = cross_shard_transfer(
+            b"acct_a",
+            b"row_a",
+            b"acct_b",
+            b"row_b",
+            HashSet::new(),
+            ReadPredicate::Always,
+        );
+
+        let result = driver.run_transaction().await;
+        assert!(
+            result.is_ok(),
+            "unconditional cross-shard txn must commit: {result:?}"
+        );
+        assert_eq!(
+            read_votes.load(Ordering::Relaxed),
+            0,
+            "an unconditional (Always) txn must send NO AccordRead — the read-vote \
+             phase is skipped"
+        );
+        assert_eq!(applier_a.applied_data(), vec![b"row_a".to_vec()]);
+        assert_eq!(applier_b.applied_data(), vec![b"row_b".to_vec()]);
+    }
+
     /// Abort-all: when one shard's only replica is down, the transaction cannot
     /// reach that shard's quorum and aborts — NEITHER shard applies (no partial
     /// cross-shard write).
@@ -208,8 +262,14 @@ mod tests {
     async fn cross_shard_txn_with_one_shard_down_applies_nothing() {
         let node_b_host = Uuid::from_u128(0xB);
         let down = HashSet::from([node_b_host]);
-        let (mut driver, applier_a, applier_b) =
-            cross_shard_transfer(b"acct_a", b"row_a", b"acct_b", b"row_b", down);
+        let (mut driver, applier_a, applier_b, _reads) = cross_shard_transfer(
+            b"acct_a",
+            b"row_a",
+            b"acct_b",
+            b"row_b",
+            down,
+            ReadPredicate::NotExists,
+        );
 
         let result = driver.run_transaction().await;
         assert!(

--- a/ferrosa-cluster/src/accord/handlers.rs
+++ b/ferrosa-cluster/src/accord/handlers.rs
@@ -332,6 +332,10 @@ impl RpcHandler for AccordHandler {
                             sm.read_condition_holds_at(&vote_req.key, &vote_req.t),
                             vec![],
                         ),
+                        // Unconditional transaction: no IF to evaluate, always
+                        // holds. Defensive — the coordinator skips the read-vote
+                        // for `Always`, so this arm is not normally reached.
+                        ReadPredicate::Always => (true, vec![]),
                         // Generic IF col=val: the replica does the read-at-`t`
                         // and returns the row bytes; the coordinator (which owns
                         // the table schema) evaluates the predicate via the

--- a/ferrosa-cluster/src/accord/mod.rs
+++ b/ferrosa-cluster/src/accord/mod.rs
@@ -72,5 +72,6 @@ pub use recovery::{
 pub use reorder_buffer::ReorderBuffer;
 pub use state_machine::{AccordStateMachine, SmResponse};
 pub use test_cluster::{TestCluster, TestMessage, TestMessagePayload, TestReplica};
+pub use transaction_commit::{AccordTransactionCommitter, ReplicaResolver};
 pub use two_phase_ddl::{DdlMarker, DdlOperation, DdlPhase, TwoPhaseDdlError, TwoPhaseDdlManager};
 pub use wire::ReadPredicate;

--- a/ferrosa-cluster/src/accord/mod.rs
+++ b/ferrosa-cluster/src/accord/mod.rs
@@ -34,6 +34,7 @@ pub mod reorder_buffer;
 pub mod shard_quorum;
 pub mod state_machine;
 pub mod test_cluster;
+pub mod transaction_commit;
 pub mod transport;
 pub mod two_phase_ddl;
 pub mod uda_integration;

--- a/ferrosa-cluster/src/accord/transaction_commit.rs
+++ b/ferrosa-cluster/src/accord/transaction_commit.rs
@@ -1,0 +1,345 @@
+//! `AccordTransactionCommitter` — the cluster-side implementation of the
+//! [`TransactionCommitter`](ferrosa_storage::accord::TransactionCommitter) seam
+//! (ADR-021, increment 2b).
+//!
+//! CQL/Postgres `BEGIN`/`COMMIT` buffer DML into a write-set and call
+//! [`commit`](TransactionCommitter::commit); this routes the whole write-set
+//! through one multi-key Accord transaction:
+//!
+//! 1. **resolve replicas per key** — via the injected `resolve` closure, which in
+//!    production wraps `WritePath::accord_replicas_for_key` (token-aware, RF-correct,
+//!    #185) keyed by each write's keyspace replication;
+//! 2. **per-shard quorum** — `AccordCoordinatorDriver::new_multi` builds a per-key
+//!    `ParticipantSet` and drives PreAccept(V2)/Commit/Apply under per-shard quorum;
+//! 3. **unconditional apply** — a general transaction has no `IF`, so it runs in
+//!    [`ReadPredicate::Always`] mode (no read-vote; #190).
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use ferrosa_common::accord::HybridLogicalClock;
+use ferrosa_storage::accord::{CommitError, CommitOutcome, TransactionCommitter, TransactionWrite};
+
+use crate::accord::apply::StorageApplier;
+use crate::accord::coordinator::{AccordCoordinatorDriver, AccordDriverError};
+use crate::accord::transport::AccordTransport;
+use crate::accord::wire::ReadPredicate;
+
+/// Resolves the replica host ids that own `key` in `keyspace`. `None` means the
+/// key cannot be placed (e.g. not in cluster mode, or unknown keyspace) — the
+/// commit fails loud rather than guessing.
+pub type ReplicaResolver = Arc<dyn Fn(&str, &[u8]) -> Option<Vec<Uuid>> + Send + Sync>;
+
+/// Cluster-side [`TransactionCommitter`]: commits a buffered multi-key write-set
+/// as one unconditional Accord transaction.
+pub struct AccordTransactionCommitter {
+    /// This (coordinator) node's id — derived from its host UUID like the driver.
+    node_id: u64,
+    clock: Arc<HybridLogicalClock>,
+    /// Internode transport (a `PeerManager` in production).
+    transport: Arc<dyn AccordTransport>,
+    /// Applier for the coordinator's own replica (its self-send is unreachable).
+    applier: Arc<dyn StorageApplier>,
+    /// Per-key replica resolution (wraps `WritePath` + schema in production).
+    resolve: ReplicaResolver,
+}
+
+impl AccordTransactionCommitter {
+    pub fn new(
+        node_id: u64,
+        clock: Arc<HybridLogicalClock>,
+        transport: Arc<dyn AccordTransport>,
+        applier: Arc<dyn StorageApplier>,
+        resolve: ReplicaResolver,
+    ) -> Self {
+        Self {
+            node_id,
+            clock,
+            transport,
+            applier,
+            resolve,
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionCommitter for AccordTransactionCommitter {
+    async fn commit(&self, writes: Vec<TransactionWrite>) -> Result<CommitOutcome, CommitError> {
+        // BEGIN; COMMIT; with no DML is a no-op — never drive Accord for nothing.
+        if writes.is_empty() {
+            return Ok(CommitOutcome::Committed);
+        }
+
+        // 1. Resolve each key's replicas; fail loud on an unplaceable key (never
+        //    commit a write to a guessed/empty replica set).
+        let mut replica_union: BTreeSet<Uuid> = BTreeSet::new();
+        let mut per_key: HashMap<Vec<u8>, Vec<Uuid>> = HashMap::new();
+        for w in &writes {
+            let replicas = (self.resolve)(&w.keyspace, &w.key).ok_or_else(|| CommitError {
+                reason: format!(
+                    "no replicas resolved for a key in keyspace '{}' (cluster mode required)",
+                    w.keyspace
+                ),
+            })?;
+            if replicas.is_empty() {
+                return Err(CommitError {
+                    reason: format!("empty replica set for a key in keyspace '{}'", w.keyspace),
+                });
+            }
+            for r in &replicas {
+                replica_union.insert(*r);
+            }
+            per_key.insert(w.key.clone(), replicas);
+        }
+        let replica_ids: Vec<Uuid> = replica_union.into_iter().collect();
+
+        // 2. Build the write-set + the per-key participant resolver for the driver.
+        let write_set: Vec<(Vec<u8>, Vec<u8>)> =
+            writes.into_iter().map(|w| (w.key, w.mutation)).collect();
+        let per_key = Arc::new(per_key);
+        let pk = per_key.clone();
+        let participant_resolver =
+            move |k: &[u8]| -> Vec<Uuid> { pk.get(k).cloned().unwrap_or_default() };
+
+        // 3. Drive one unconditional multi-key Accord transaction.
+        let mut driver = AccordCoordinatorDriver::new_multi_with_transport(
+            self.node_id,
+            replica_ids,
+            self.transport.clone(),
+            false,
+            &self.clock,
+            write_set,
+        )
+        .with_per_key_replicas(Arc::new(participant_resolver))
+        .with_local_applier(self.applier.clone())
+        .with_read_predicate(ReadPredicate::Always);
+
+        match driver.run_transaction().await {
+            Ok(_) => Ok(CommitOutcome::Committed),
+            // A general transaction is unconditional (Always mode), so a condition
+            // abort should not arise — map it cleanly if it ever does.
+            Err(AccordDriverError::ConditionNotMet { .. }) => Ok(CommitOutcome::Aborted {
+                reason: "transaction condition not met".to_string(),
+            }),
+            // Quorum/network/codec failures: the commit did not reach a decision —
+            // surface as Err so the front-end never acks an uncommitted transaction.
+            Err(e) => Err(CommitError {
+                reason: e.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    use ferrosa_net::error::NetError;
+    use ferrosa_net::message::Message;
+
+    use crate::accord::apply::{ApplyError, ApplyMutation};
+
+    /// Records every applied mutation's data, so a test can assert which keys' writes landed.
+    struct RecordingApplier {
+        applied: Mutex<Vec<Vec<u8>>>,
+    }
+    impl RecordingApplier {
+        fn new() -> Self {
+            Self {
+                applied: Mutex::new(Vec::new()),
+            }
+        }
+        fn applied_data(&self) -> Vec<Vec<u8>> {
+            self.applied.lock().expect("applier mutex").clone()
+        }
+    }
+    impl StorageApplier for RecordingApplier {
+        fn apply(
+            &self,
+            _txn_id: ferrosa_common::accord::TxnId,
+            mutation: ApplyMutation,
+        ) -> Result<(), ApplyError> {
+            self.applied
+                .lock()
+                .expect("applier mutex")
+                .push(mutation.data);
+            Ok(())
+        }
+    }
+
+    /// Transport with no reachable peers — used when the coordinator is the sole
+    /// replica (every send is a self-send the driver never makes).
+    struct NoPeersTransport;
+    #[async_trait]
+    impl AccordTransport for NoPeersTransport {
+        async fn send(
+            &self,
+            _host: Uuid,
+            _msg: Message,
+            _lane: ferrosa_net::codec::Lane,
+        ) -> ferrosa_net::error::Result<Message> {
+            Err(NetError::Timeout("no peers".into()))
+        }
+    }
+
+    fn write(ks: &str, key: &[u8], mutation: &[u8]) -> TransactionWrite {
+        TransactionWrite {
+            keyspace: ks.to_string(),
+            key: key.to_vec(),
+            mutation: mutation.to_vec(),
+        }
+    }
+
+    fn committer_with(host: Uuid, applier: Arc<RecordingApplier>) -> AccordTransactionCommitter {
+        let node_id = u64::from_be_bytes(host.as_bytes()[..8].try_into().expect("uuid 16 bytes"));
+        let clock = Arc::new(HybridLogicalClock::new(node_id, 0));
+        // Sole replica = the coordinator itself, for every key.
+        let resolve: ReplicaResolver = Arc::new(move |_ks: &str, _key: &[u8]| Some(vec![host]));
+        AccordTransactionCommitter::new(
+            node_id,
+            clock,
+            Arc::new(NoPeersTransport),
+            applier,
+            resolve,
+        )
+    }
+
+    #[tokio::test]
+    async fn empty_write_set_commits_without_driving_accord() {
+        let applier = Arc::new(RecordingApplier::new());
+        let committer = committer_with(Uuid::from_u128(1), applier.clone());
+
+        let outcome = committer.commit(Vec::new()).await.expect("empty commit");
+
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert!(
+            applier.applied_data().is_empty(),
+            "an empty transaction must not apply anything"
+        );
+    }
+
+    fn node_id_of(u: Uuid) -> u64 {
+        u64::from_be_bytes(u.as_bytes()[..8].try_into().expect("uuid 16 bytes"))
+    }
+
+    /// One real cluster node: its state-machine handler + recording applier.
+    fn make_node(
+        seed: u128,
+    ) -> (
+        Uuid,
+        Arc<crate::accord::handlers::AccordHandler>,
+        Arc<RecordingApplier>,
+    ) {
+        use crate::accord::handlers::{AccordHandler, AccordState};
+        use crate::accord::state_machine::AccordStateMachine;
+        use ferrosa_storage::accord::sync_writer::MockSyncWriter;
+        let host_id = Uuid::from_u128(seed);
+        let nid = node_id_of(host_id);
+        let applier = Arc::new(RecordingApplier::new());
+        let sm =
+            AccordStateMachine::with_applier(nid, Arc::new(MockSyncWriter::new()), applier.clone());
+        let state: AccordState = Arc::new(parking_lot::Mutex::new(sm));
+        (host_id, Arc::new(AccordHandler::new(state, nid)), applier)
+    }
+
+    /// Routes each Accord message to the addressed node's real handler.
+    struct RoutingTransport {
+        nodes: HashMap<Uuid, Arc<crate::accord::handlers::AccordHandler>>,
+    }
+    #[async_trait]
+    impl AccordTransport for RoutingTransport {
+        async fn send(
+            &self,
+            host: Uuid,
+            msg: Message,
+            _lane: ferrosa_net::codec::Lane,
+        ) -> ferrosa_net::error::Result<Message> {
+            use ferrosa_net::rpc::handler::{PeerId, RpcHandler};
+            let handler = self
+                .nodes
+                .get(&host)
+                .ok_or_else(|| NetError::Timeout("unknown peer".into()))?;
+            let peer: PeerId = (host, "127.0.0.1:0".parse().expect("addr"));
+            handler
+                .handle(peer, msg)
+                .await
+                .ok_or_else(|| NetError::Timeout("no response".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn commits_multi_key_write_set_across_shards_and_applies_every_key() {
+        // Two shards (one RF=1 node each), external coordinator. The committer
+        // resolves key_a → shard A, key_b → shard B and drives ONE unconditional
+        // Accord transaction; each shard must apply its own key — the committer
+        // turns a buffered write-set into a real cross-shard commit end to end.
+        let (ha, handler_a, applier_a) = make_node(0xA);
+        let (hb, handler_b, applier_b) = make_node(0xB);
+        let mut nodes = HashMap::new();
+        nodes.insert(ha, handler_a);
+        nodes.insert(hb, handler_b);
+        let transport: Arc<dyn AccordTransport> = Arc::new(RoutingTransport { nodes });
+
+        let coord_id = 999_999u64; // external coordinator (matches no replica)
+        let clock = Arc::new(HybridLogicalClock::new(coord_id, 0));
+        let resolve: ReplicaResolver = Arc::new(move |_ks: &str, key: &[u8]| {
+            if key == b"acct_a" {
+                Some(vec![ha])
+            } else {
+                Some(vec![hb])
+            }
+        });
+        let committer = AccordTransactionCommitter::new(
+            coord_id,
+            clock,
+            transport,
+            Arc::new(RecordingApplier::new()), // coordinator is not a replica
+            resolve,
+        );
+
+        let writes = vec![
+            write("ks", b"acct_a", b"row_a"),
+            write("ks", b"acct_b", b"row_b"),
+        ];
+        let outcome = committer.commit(writes).await.expect("commit");
+
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert_eq!(
+            applier_a.applied_data(),
+            vec![b"row_a".to_vec()],
+            "shard A must apply its key"
+        );
+        assert_eq!(
+            applier_b.applied_data(),
+            vec![b"row_b".to_vec()],
+            "shard B must apply its key"
+        );
+    }
+
+    #[tokio::test]
+    async fn unplaceable_key_fails_loud() {
+        // A key the resolver cannot place must abort the commit with an error —
+        // never silently commit to a guessed/empty replica set.
+        let applier = Arc::new(RecordingApplier::new());
+        let node_id = 7u64;
+        let clock = Arc::new(HybridLogicalClock::new(node_id, 0));
+        let resolve: ReplicaResolver = Arc::new(|_ks: &str, _key: &[u8]| None);
+        let committer = AccordTransactionCommitter::new(
+            node_id,
+            clock,
+            Arc::new(NoPeersTransport),
+            applier,
+            resolve,
+        );
+
+        let err = committer
+            .commit(vec![write("ks", b"k", b"v")])
+            .await
+            .expect_err("unplaceable key must fail loud");
+        assert!(err.reason.contains("no replicas"), "got: {}", err.reason);
+    }
+}

--- a/ferrosa-cluster/src/accord/transaction_commit.rs
+++ b/ferrosa-cluster/src/accord/transaction_commit.rs
@@ -1,6 +1,7 @@
 //! `AccordTransactionCommitter` — the cluster-side implementation of the
-//! [`TransactionCommitter`](ferrosa_storage::accord::TransactionCommitter) seam
-//! (ADR-021, increment 2b).
+//! [`TransactionCommitter`] seam (ADR-021, increment 2b).
+//!
+//! [`TransactionCommitter`]: ferrosa_storage::accord::TransactionCommitter
 //!
 //! CQL/Postgres `BEGIN`/`COMMIT` buffer DML into a write-set and call
 //! [`commit`](TransactionCommitter::commit); this routes the whole write-set

--- a/ferrosa-cluster/src/accord/wire.rs
+++ b/ferrosa-cluster/src/accord/wire.rs
@@ -184,6 +184,11 @@ pub enum ReadPredicate {
         /// Target table name.
         table: String,
     },
+    /// Unconditional commit: there is no `IF` to evaluate, so the transaction
+    /// always applies after commit. The coordinator SKIPS the read-vote phase
+    /// entirely (no `AccordRead` fan-out). This is the path for a general
+    /// multi-key SQL transaction (`BEGIN`/`COMMIT`), which has no LWT condition.
+    Always,
 }
 
 /// Read-vote response from a replica.

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -260,6 +260,11 @@ pub(crate) async fn handle_connection<S>(
     let mut auth_context: Option<AuthContext> = None;
     let mut current_keyspace: Option<String> = None;
     let mut subscription_state = SubscriptionState::new(8);
+    // Per-connection BEGIN/COMMIT transaction buffer (shared across this
+    // connection's concurrent in-flight requests; transactions are serialized).
+    let conn_txn = std::sync::Arc::new(tokio::sync::Mutex::new(
+        crate::session::CqlTransaction::new(),
+    ));
     let mut pending_compression: Option<Compression> = None;
     let mut client_protocol_version: u8 = 4; // default; updated from STARTUP frame
     let mut client_use_beta: bool = false; // USE_BETA flag (0x10) in STARTUP
@@ -443,6 +448,7 @@ pub(crate) async fn handle_connection<S>(
                     let mut ks_for_handler = ks_at_spawn.clone();
                     let peer_addr = peer;
                     let request_task_pool = task_pool.clone();
+                    let conn_txn_for_handler = conn_txn.clone();
                     request_task_pool.spawn(async move {
                         let request_span = cql_request_span(opcode, peer_addr);
                         let result = (async {
@@ -455,6 +461,7 @@ pub(crate) async fn handle_connection<S>(
                                         &body,
                                         peer_addr,
                                         proto_version,
+                                        &conn_txn_for_handler,
                                     )
                                     .await
                                 }
@@ -538,6 +545,7 @@ pub(crate) async fn handle_connection<S>(
                         &mut pending_compression,
                         peer,
                         task_pool.clone(),
+                        &conn_txn,
                     )
                     .await
                 })
@@ -1047,6 +1055,7 @@ async fn handle_frame(
     pending_compression: &mut Option<Compression>,
     peer: SocketAddr,
     task_pool: TaskPool,
+    conn_txn: &tokio::sync::Mutex<crate::session::CqlTransaction>,
 ) -> HandleResult {
     match phase {
         ConnectionPhase::AwaitingStartup => match frame.header.opcode {
@@ -1087,6 +1096,7 @@ async fn handle_frame(
                     &frame.body,
                     peer,
                     frame.header.version,
+                    conn_txn,
                 )
                 .await
             }
@@ -1374,6 +1384,7 @@ async fn handle_query(
     body: &Bytes,
     peer: SocketAddr,
     protocol_version: u8,
+    conn_txn: &tokio::sync::Mutex<crate::session::CqlTransaction>,
 ) -> HandleResult {
     // Parse the query string: [int length][bytes query][short consistency][byte flags]...
     if body.len() < 4 {
@@ -1442,6 +1453,22 @@ async fn handle_query(
 
     // Build an auth context for routing (use a default if auth was disabled).
     let ctx = build_request_context(auth_context, current_keyspace, cl, peer);
+
+    // Transaction control + in-transaction DML buffering (BEGIN/COMMIT over
+    // Accord). The per-connection buffer is locked only for the duration of the
+    // check/commit (transactions on a connection are inherently serial), then
+    // released before normal routing; `None` falls through.
+    let txn_result = {
+        let mut txn = conn_txn.lock().await;
+        crate::router::route_transactional(state, &ctx, &stmt, &mut txn).await
+    };
+    if let Some(result) = txn_result {
+        return match result {
+            Ok(RouteResult::Result(body)) => HandleResult::Reply(Opcode::Result, body),
+            Ok(_) => HandleResult::Reply(Opcode::Result, crate::result::encode_void()),
+            Err(e) => HandleResult::Reply(Opcode::Error, e.encode_body()),
+        };
+    }
 
     match crate::router::route(state, &ctx, stmt).await {
         Ok(RouteResult::Result(body)) => HandleResult::Reply(Opcode::Result, body),

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1100,8 +1100,8 @@ fn build_transaction_write(
 ///
 /// In an open transaction, `INSERT`/`UPDATE`/`DELETE` are **buffered** (not
 /// executed); `COMMIT` commits the whole buffered write-set as one multi-key
-/// Accord transaction via the [`SessionCore`](ferrosa_session::SessionCore)
-/// committer; `ROLLBACK` drops the buffer.
+/// Accord transaction via the `SessionCore` committer
+/// (`accord_transaction_committer`); `ROLLBACK` drops the buffer.
 pub async fn route_transactional(
     state: &SharedState,
     ctx: &RequestContext<'_>,

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1046,6 +1046,116 @@ fn build_lwt_mutation(
     Ok((key_bytes, mutation_bytes))
 }
 
+/// Encode a DML statement as a buffered [`TransactionWrite`] for a CQL
+/// `BEGIN`/`COMMIT` transaction — the same key + commit-log mutation encoding as
+/// [`build_lwt_mutation`], plus the keyspace so the committer can resolve the
+/// key's replicas from that keyspace's replication.
+fn build_transaction_write(
+    state: &SharedState,
+    ctx: &RequestContext<'_>,
+    stmt: &Statement,
+) -> Result<ferrosa_storage::accord::TransactionWrite, CqlError> {
+    use ferrosa_storage::Mutation;
+
+    let now_micros = || -> Result<i64, CqlError> {
+        Ok(std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| CqlError::ServerError(format!("system clock error: {e}")))?
+            .as_micros() as i64)
+    };
+
+    let (table_id, key, row, ts) = match stmt {
+        Statement::Insert(s) => materialize_insert(state, ctx, s, now_micros()?)?,
+        Statement::Update(s) => materialize_update(state, ctx, s, now_micros()?)?,
+        Statement::Delete(s) => materialize_delete(state, ctx, s, now_micros()?)?,
+        _ => {
+            return Err(CqlError::Invalid(
+                "only INSERT/UPDATE/DELETE may be buffered in a transaction".into(),
+            ));
+        }
+    };
+
+    let keyspace = table_id.keyspace.clone();
+    let key_bytes = key.key.as_bytes().to_vec();
+    let mutation = Mutation::new(
+        table_id.keyspace.clone(),
+        table_id.table.clone(),
+        key,
+        vec![row],
+        ts,
+    );
+    let mut mutation_bytes = vec![0u8; mutation.serialized_size()];
+    mutation.serialize_into(&mut mutation_bytes);
+
+    Ok(ferrosa_storage::accord::TransactionWrite {
+        keyspace,
+        key: key_bytes,
+        mutation: mutation_bytes,
+    })
+}
+
+/// Intercept transaction control (`BEGIN`/`COMMIT`/`ROLLBACK`) and in-transaction
+/// DML for a CQL session. Returns `Some(result)` if the statement was handled as
+/// a transaction operation; `None` if it should be routed normally.
+///
+/// In an open transaction, `INSERT`/`UPDATE`/`DELETE` are **buffered** (not
+/// executed); `COMMIT` commits the whole buffered write-set as one multi-key
+/// Accord transaction via the [`SessionCore`](ferrosa_session::SessionCore)
+/// committer; `ROLLBACK` drops the buffer.
+pub async fn route_transactional(
+    state: &SharedState,
+    ctx: &RequestContext<'_>,
+    stmt: &Statement,
+    txn: &mut crate::session::CqlTransaction,
+) -> Option<Result<RouteResult, CqlError>> {
+    match stmt {
+        Statement::BeginTransaction => Some(
+            txn.begin()
+                .map(|()| RouteResult::Result(crate::result::encode_void())),
+        ),
+        Statement::Rollback => Some(
+            txn.rollback()
+                .map(|()| RouteResult::Result(crate::result::encode_void())),
+        ),
+        Statement::Commit => Some(commit_cql_transaction(state, txn).await),
+        // Buffer DML only while a transaction is open; otherwise route normally.
+        Statement::Insert(_) | Statement::Update(_) | Statement::Delete(_) if txn.is_open() => {
+            Some(
+                build_transaction_write(state, ctx, stmt)
+                    .and_then(|w| txn.stage(w))
+                    .map(|()| RouteResult::Result(crate::result::encode_void())),
+            )
+        }
+        _ => None,
+    }
+}
+
+/// Commit the buffered write-set through the Accord committer. Fails loud (and
+/// closes the transaction) when not in cluster mode or when the commit cannot be
+/// driven — the client never gets a success it did not earn.
+async fn commit_cql_transaction(
+    state: &SharedState,
+    txn: &mut crate::session::CqlTransaction,
+) -> Result<RouteResult, CqlError> {
+    use ferrosa_storage::accord::CommitOutcome;
+    let committer = match state.accord_transaction_committer() {
+        Some(c) => c,
+        None => {
+            let _ = txn.rollback();
+            return Err(CqlError::Invalid(
+                "multi-statement transactions require cluster mode (Accord)".into(),
+            ));
+        }
+    };
+    match txn.commit(committer.as_ref()).await {
+        Ok(CommitOutcome::Committed) => Ok(RouteResult::Result(crate::result::encode_void())),
+        Ok(CommitOutcome::Aborted { reason }) => {
+            Err(CqlError::Invalid(format!("transaction aborted: {reason}")))
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Decode the agreed row-at-`t` bytes (a serialized single-partition
 /// [`Mutation`](ferrosa_storage::Mutation)) into a `column -> value` map for IF
 /// evaluation, using the SAME positional decode the local read path uses
@@ -11821,6 +11931,49 @@ mod tests {
     fn keyspace_rf_returns_1_when_keyspace_not_found() {
         let (state, _dir) = setup();
         assert_eq!(keyspace_rf(&state.schema, "nonexistent"), 1);
+    }
+
+    #[tokio::test]
+    async fn route_transactional_handles_begin_rollback_and_fails_commit_in_standalone() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        let mut txn = crate::session::CqlTransaction::new();
+
+        // A non-transactional statement is NOT intercepted (routes normally).
+        let select = crate::parser::parse("SELECT * FROM system.local").unwrap();
+        assert!(
+            route_transactional(&state, &ctx, &select, &mut txn)
+                .await
+                .is_none(),
+            "SELECT must fall through to normal routing"
+        );
+
+        // BEGIN opens the transaction; ROLLBACK closes it.
+        assert!(matches!(
+            route_transactional(&state, &ctx, &Statement::BeginTransaction, &mut txn).await,
+            Some(Ok(_))
+        ));
+        assert!(txn.is_open());
+        assert!(matches!(
+            route_transactional(&state, &ctx, &Statement::Rollback, &mut txn).await,
+            Some(Ok(_))
+        ));
+        assert!(!txn.is_open());
+
+        // COMMIT in standalone mode (no Accord committer) must fail loud.
+        txn.begin().unwrap();
+        let committed = route_transactional(&state, &ctx, &Statement::Commit, &mut txn).await;
+        assert!(
+            matches!(committed, Some(Err(_))),
+            "COMMIT without a cluster committer must fail loud, not fake success"
+        );
     }
 
     #[tokio::test]

--- a/ferrosa-cql/src/session.rs
+++ b/ferrosa-cql/src/session.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 
 use crate::ast::Statement;
 use crate::error::CqlError;
+use ferrosa_storage::accord::{CommitOutcome, TransactionCommitter, TransactionWrite};
 use ferrosa_storage::{BatchOp, StorageEngine};
 
 /// Transaction state for a CQL session.
@@ -275,10 +276,180 @@ impl ConnTxn {
     }
 }
 
+/// Per-connection buffer for a **cluster-wide** CQL `BEGIN`/`COMMIT` transaction.
+///
+/// Distinct from [`ConnTxn`] (which commits a *local* atomic batch on the single
+/// engine for Bolt): this buffers DML between `BEGIN` and `COMMIT` and, on
+/// `COMMIT`, commits the WHOLE write-set as one multi-key Accord transaction via
+/// the injected [`TransactionCommitter`] (ADR-021). `ROLLBACK` drops the buffer.
+///
+/// FAIL-LOUD (URS-QEC-X01): a failed commit returns `Err` and the transaction is
+/// closed — the server never acks a transaction it did not commit.
+#[derive(Default)]
+pub struct CqlTransaction {
+    open: bool,
+    buffer: Vec<TransactionWrite>,
+}
+
+impl CqlTransaction {
+    /// A fresh connection with no open transaction.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `true` while a transaction is open.
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Number of DML writes buffered so far.
+    pub fn staged_len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// `BEGIN`: open a transaction. FAILS LOUD on a nested `BEGIN`.
+    pub fn begin(&mut self) -> Result<(), CqlError> {
+        if self.open {
+            return Err(CqlError::Invalid(
+                "nested transactions are not supported".to_string(),
+            ));
+        }
+        self.open = true;
+        self.buffer.clear();
+        Ok(())
+    }
+
+    /// Buffer one DML write. FAILS LOUD if no transaction is open.
+    pub fn stage(&mut self, write: TransactionWrite) -> Result<(), CqlError> {
+        if !self.open {
+            return Err(CqlError::Invalid(
+                "DML staged outside of a transaction".to_string(),
+            ));
+        }
+        self.buffer.push(write);
+        Ok(())
+    }
+
+    /// `COMMIT`: commit the buffered write-set via `committer`, then close the
+    /// transaction. FAILS LOUD if no transaction is open. The buffer is drained
+    /// and the transaction closed regardless of outcome — a failed commit is
+    /// surfaced as `Err` (never silently retried or acked), a clean abort as the
+    /// returned [`CommitOutcome`].
+    pub async fn commit(
+        &mut self,
+        committer: &dyn TransactionCommitter,
+    ) -> Result<CommitOutcome, CqlError> {
+        if !self.open {
+            return Err(CqlError::Invalid(
+                "COMMIT outside of a transaction".to_string(),
+            ));
+        }
+        let writes = std::mem::take(&mut self.buffer);
+        self.open = false;
+        committer
+            .commit(writes)
+            .await
+            .map_err(|e| CqlError::ServerError(format!("transaction commit failed: {}", e.reason)))
+    }
+
+    /// `ROLLBACK`: discard the buffer and close. FAILS LOUD if not open.
+    pub fn rollback(&mut self) -> Result<(), CqlError> {
+        if !self.open {
+            return Err(CqlError::Invalid(
+                "ROLLBACK outside of a transaction".to_string(),
+            ));
+        }
+        self.buffer.clear();
+        self.open = false;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ast::*;
+
+    fn tw(ks: &str, key: &[u8]) -> TransactionWrite {
+        TransactionWrite {
+            keyspace: ks.to_string(),
+            key: key.to_vec(),
+            mutation: b"m".to_vec(),
+        }
+    }
+
+    #[test]
+    fn cql_txn_begin_stage_rollback() {
+        let mut tx = CqlTransaction::new();
+        assert!(!tx.is_open());
+        tx.begin().unwrap();
+        assert!(tx.is_open());
+        assert!(tx.begin().is_err(), "nested BEGIN must fail loud");
+        tx.stage(tw("ks", b"a")).unwrap();
+        tx.stage(tw("ks", b"b")).unwrap();
+        assert_eq!(tx.staged_len(), 2);
+        tx.rollback().unwrap();
+        assert!(!tx.is_open());
+        assert_eq!(tx.staged_len(), 0, "ROLLBACK drops the buffer");
+    }
+
+    #[test]
+    fn cql_txn_stage_and_rollback_outside_fail() {
+        let mut tx = CqlTransaction::new();
+        assert!(tx.stage(tw("ks", b"a")).is_err());
+        assert!(tx.rollback().is_err());
+    }
+
+    #[tokio::test]
+    async fn cql_txn_commit_sends_buffer_to_committer_and_closes() {
+        use ferrosa_storage::accord::MockTransactionCommitter;
+        let committer = MockTransactionCommitter::new();
+        let mut tx = CqlTransaction::new();
+        tx.begin().unwrap();
+        tx.stage(tw("ks", b"a")).unwrap();
+        tx.stage(tw("ks", b"b")).unwrap();
+
+        let outcome = tx.commit(&committer).await.unwrap();
+
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert!(!tx.is_open(), "COMMIT closes the transaction");
+        assert_eq!(tx.staged_len(), 0, "buffer is drained on commit");
+        assert_eq!(
+            committer.committed(),
+            vec![vec![tw("ks", b"a"), tw("ks", b"b")]],
+            "the exact buffered write-set reaches the committer, in order"
+        );
+    }
+
+    #[tokio::test]
+    async fn cql_txn_commit_outside_fails() {
+        use ferrosa_storage::accord::MockTransactionCommitter;
+        let committer = MockTransactionCommitter::new();
+        let mut tx = CqlTransaction::new();
+        assert!(tx.commit(&committer).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cql_txn_commit_failure_surfaced_and_closes() {
+        use ferrosa_storage::accord::{CommitError, MockTransactionCommitter};
+        let committer = MockTransactionCommitter::with_result(Err(CommitError {
+            reason: "quorum unavailable".to_string(),
+        }));
+        let mut tx = CqlTransaction::new();
+        tx.begin().unwrap();
+        tx.stage(tw("ks", b"a")).unwrap();
+
+        let result = tx.commit(&committer).await;
+
+        assert!(
+            result.is_err(),
+            "a failed commit must surface as Err — never ack an uncommitted transaction"
+        );
+        assert!(
+            !tx.is_open(),
+            "the transaction closes even when commit fails"
+        );
+    }
 
     #[test]
     fn transition_begin_commit() {

--- a/ferrosa-jepsen/src/cql_session.rs
+++ b/ferrosa-jepsen/src/cql_session.rs
@@ -1,7 +1,12 @@
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
+use scylla::client::PoolSize;
+use scylla::policies::host_filter::AllowListHostFilter;
 use scylla::value::{CqlValue, Row};
 
 use crate::workload::CqlSession;
@@ -16,13 +21,33 @@ pub struct ScyllaCqlSession {
 
 impl ScyllaCqlSession {
     /// Connect to the cluster at the given contact points (e.g. `["127.0.0.1:9042"]`).
+    ///
+    /// The session is **pinned to a single node + a single connection**. A
+    /// `BEGIN…COMMIT` transaction buffers on one server connection, so every
+    /// statement in it must share one TCP connection — the pinned node forwards
+    /// writes as the Accord coordinator (cross-shard fan-out still happens).
+    /// Without pinning, the driver routes each statement by token to a different
+    /// node, and the transaction's buffered DML never reaches the `BEGIN`'s
+    /// connection.
+    ///
+    /// Caveat: the pinned node is a single point of failure for this client, so
+    /// a nemesis that kills it fails the client's ops (never *partial* writes —
+    /// the atomicity invariant still holds). Per-transaction reconnect / failover
+    /// to another node is a follow-up.
     pub async fn connect(contact_points: &[String]) -> Result<Self> {
         assert!(
             !contact_points.is_empty(),
             "contact_points must not be empty"
         );
+        let pinned = contact_points[0].clone();
+        let filter = AllowListHostFilter::new([pinned.clone()])
+            .context("building single-node host filter")?;
         let session = SessionBuilder::new()
-            .known_nodes(contact_points)
+            .known_node(&pinned)
+            .host_filter(Arc::new(filter))
+            .pool_size(PoolSize::PerHost(
+                NonZeroUsize::new(1).expect("1 is nonzero"),
+            ))
             .build()
             .await
             .context("failed to connect to CQL cluster")?;

--- a/ferrosa-jepsen/src/workload/bank.rs
+++ b/ferrosa-jepsen/src/workload/bank.rs
@@ -14,11 +14,26 @@ const INITIAL_BALANCE: i64 = 1000;
 /// Expected total across all accounts.
 const EXPECTED_TOTAL: i64 = NUM_ACCOUNTS * INITIAL_BALANCE;
 
+/// Read one account's balance, `None` if the row is absent/unparseable.
+async fn read_balance(session: &dyn CqlSession, id: i64) -> Result<Option<i64>> {
+    let rows = session
+        .execute(&format!(
+            "SELECT balance FROM jepsen.accounts WHERE id = {id}"
+        ))
+        .await?;
+    Ok(rows
+        .first()
+        .and_then(|r| r.first())
+        .and_then(|(_, v)| v.parse::<i64>().ok()))
+}
+
 /// Multi-account bank transfer workload.
 ///
 /// Setup: 10 accounts each with balance 1000.
-/// Operations: transfers between random pairs (via LWT), reads of all balances.
-/// Invariant: total balance is conserved (sum == 10000).
+/// Operations: **atomic** transfers between random pairs (one multi-key Accord
+/// `BEGIN…COMMIT` transaction — both writes or neither), reads of all balances.
+/// Invariant: total balance is conserved (sum == 10000); a partial transfer
+/// (e.g. from a node failure mid-commit) would break it.
 pub struct BankWorkload;
 
 #[async_trait]
@@ -80,83 +95,69 @@ impl Workload for BankWorkload {
                 }
                 let amount = (rand::random::<u64>() % 100 + 1) as i64;
 
-                // Read source balance first.
+                // Read both balances (outside the transaction). This is an
+                // ATOMICITY test: the two writes commit together or not at all
+                // (one multi-key Accord transaction), so a PARTIAL transfer —
+                // debit without credit, e.g. a node failure mid-COMMIT — breaks
+                // total conservation and the checker flags it. Full lost-update
+                // serializability (conditional commit) is deferred (t_6edfea95).
                 recorder.invoke(Op::Read {
                     key: format!("account-{from}"),
                 });
-                let balance = match session
-                    .execute(&format!(
-                        "SELECT balance FROM jepsen.accounts WHERE id = {from}"
-                    ))
-                    .await
-                {
-                    Ok(rows) => {
-                        let val = rows
-                            .first()
-                            .and_then(|r| r.first())
-                            .and_then(|(_, v)| v.parse::<i64>().ok());
-                        recorder.complete(OpResult::Value(val));
-                        val
+                let from_balance = match read_balance(session, from).await {
+                    Ok(v) => {
+                        recorder.complete(OpResult::Value(v));
+                        v
                     }
                     Err(e) => {
                         recorder.complete(OpResult::Err(e.to_string()));
                         continue;
                     }
                 };
-
-                let Some(balance) = balance else {
+                let Some(from_balance) = from_balance else {
                     continue;
                 };
-
-                if balance < amount {
+                if from_balance < amount {
                     continue;
                 }
 
-                // CAS debit from source.
-                let new_balance = balance - amount;
-                recorder.invoke(Op::Cas {
-                    key: format!("account-{from}"),
-                    expected: balance,
-                    value: new_balance,
+                recorder.invoke(Op::Read {
+                    key: format!("account-{to}"),
                 });
-                let debit_ok = match session
-                    .execute(&format!(
-                        "UPDATE jepsen.accounts SET balance = {new_balance} \
-                         WHERE id = {from} IF balance = {balance}"
-                    ))
-                    .await
-                {
-                    Ok(rows) => {
-                        let applied = rows
-                            .first()
-                            .map(|r| r.iter().any(|(k, v)| k == "[applied]" && v == "true"))
-                            .unwrap_or(false);
-                        recorder.complete(OpResult::Applied(applied));
-                        applied
+                let to_balance = match read_balance(session, to).await {
+                    Ok(v) => {
+                        recorder.complete(OpResult::Value(v));
+                        v
                     }
                     Err(e) => {
                         recorder.complete(OpResult::Err(e.to_string()));
-                        false
+                        continue;
                     }
                 };
-
-                if !debit_ok {
+                let Some(to_balance) = to_balance else {
                     continue;
-                }
+                };
 
-                // Credit destination (unconditional, transfer is committed).
+                // Atomic cross-shard transfer: BEGIN; debit; credit; COMMIT — one
+                // multi-key Accord transaction. Both writes land, or neither.
+                let new_from = from_balance - amount;
+                let new_to = to_balance + amount;
                 recorder.invoke(Op::Write {
                     key: format!("account-{to}"),
                     value: amount,
                 });
                 match session
-                    .execute(&format!(
-                        "UPDATE jepsen.accounts SET balance = balance + {amount} \
-                         WHERE id = {to}"
-                    ))
+                    .transaction(&[
+                        "BEGIN TRANSACTION".to_string(),
+                        format!(
+                            "UPDATE jepsen.accounts SET balance = {new_from} WHERE id = {from}"
+                        ),
+                        format!("UPDATE jepsen.accounts SET balance = {new_to} WHERE id = {to}"),
+                        "COMMIT".to_string(),
+                    ])
                     .await
                 {
-                    Ok(_) => recorder.complete(OpResult::Ok),
+                    Ok(()) => recorder.complete(OpResult::Ok),
                     Err(e) => recorder.complete(OpResult::Err(e.to_string())),
                 }
             } else {

--- a/ferrosa-jepsen/src/workload/mod.rs
+++ b/ferrosa-jepsen/src/workload/mod.rs
@@ -17,6 +17,20 @@ use crate::history::{History, HistoryRecorder};
 #[async_trait]
 pub trait CqlSession: Send + Sync {
     async fn execute(&self, query: &str) -> Result<Vec<Vec<(String, String)>>>;
+
+    /// Execute `statements` as one **connection-affine** unit — used for a
+    /// `BEGIN TRANSACTION; …; COMMIT` block, whose buffer lives on a single
+    /// server connection. The default runs them sequentially via [`execute`],
+    /// which is correct for a single-connection session (see `ScyllaCqlSession`,
+    /// pinned to one node so the whole block shares one TCP connection).
+    ///
+    /// [`execute`]: CqlSession::execute
+    async fn transaction(&self, statements: &[String]) -> Result<()> {
+        for stmt in statements {
+            self.execute(stmt).await?;
+        }
+        Ok(())
+    }
 }
 
 /// A workload that generates operations and checks invariants.

--- a/ferrosa-session/src/lib.rs
+++ b/ferrosa-session/src/lib.rs
@@ -66,4 +66,45 @@ impl SessionCore {
     pub fn accord_enabled(&self) -> bool {
         self.peer_manager.is_some() && self.accord_clock.is_some()
     }
+
+    /// Build the Accord transaction committer for cluster-wide `BEGIN`/`COMMIT`
+    /// (ADR-021 / D11), or `None` in standalone mode. Built on demand from the
+    /// current write path + schema — cheap (Arc clones + a closure) — so no
+    /// committer is stored in or threaded through `SharedState`, and every
+    /// front-end (CQL and Postgres) gets it the same way.
+    ///
+    /// The per-key replica resolver wraps `WritePath::accord_replicas_for_key`
+    /// keyed by each write's keyspace replication; replica placement stays in the
+    /// cluster layer, never the front-ends.
+    pub fn accord_transaction_committer(
+        &self,
+    ) -> Option<Arc<dyn ferrosa_storage::accord::TransactionCommitter>> {
+        let peers = self.peer_manager.clone()?;
+        let clock = self.accord_clock.clone()?;
+        let node_id = u64::from_be_bytes(
+            self.node_config.host_id.as_bytes()[..8]
+                .try_into()
+                .expect("uuid is 16 bytes"),
+        );
+        let write_path = self.write_path.clone();
+        let schema = self.schema.clone();
+        let resolve: ferrosa_cluster::accord::ReplicaResolver =
+            Arc::new(move |ks: &str, key: &[u8]| {
+                let snap = schema.snapshot();
+                let replication = &snap.keyspaces.get(ks)?.replication;
+                write_path
+                    .load()
+                    .accord_replicas_for_key(key, replication)
+                    .ok()
+                    .flatten()
+            });
+        let applier = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
+            self.engine.clone(),
+        ));
+        Some(Arc::new(
+            ferrosa_cluster::accord::AccordTransactionCommitter::new(
+                node_id, clock, peers, applier, resolve,
+            ),
+        ))
+    }
 }


### PR DESCRIPTION
## Summary

**Increment 3 (complete: 3a + 3b)** of BEGIN/COMMIT-over-Accord (`t_bd3684`). A CQL client doing `BEGIN; INSERT…; INSERT…; COMMIT;` now buffers the DML and commits the whole write-set as **one multi-key Accord transaction**.

**3a — `CqlTransaction` buffer** (ferrosa-cql/session): begin/stage/commit/rollback; fail-loud (a failed commit is `Err`, never acks an uncommitted txn). Unit-tested with `MockTransactionCommitter`.

**3b — wiring**:
- `SessionCore::accord_transaction_committer()` (ferrosa-session) builds `AccordTransactionCommitter` (#191) **on demand** from existing fields (write_path, schema, peer_manager, clock, engine) in cluster mode — no stored field, no `main.rs` change, and **Postgres (increment 4) reuses it for free**. Per-key resolver wraps `WritePath::accord_replicas_for_key` keyed by keyspace replication (ADR-021).
- `route_transactional` + `build_transaction_write` (router): control + in-txn DML buffering; COMMIT drives the committer, fail-loud outside cluster mode.
- `connection.rs`: per-connection `Arc<Mutex<CqlTransaction>>` threaded through both request paths (pipelined spawn + `handle_frame`), intercepting before normal routing.

## Tests
`route_transactional` (begin/rollback handled, non-txn falls through, COMMIT-in-standalone fails loud) + 3a's 5 `CqlTransaction` tests. ferrosa-cql **952 pass**, clippy + workspace-fmt clean, binary builds.

## ⚠️ Stacked on #190
Based on #190 (2a+2b). Retarget to `main` once #190 merges.

## Epic
1 (#188 ✅) → 2a/2b (#190) → **3 (this) ✅** → 4 Postgres (`t_b98434`, reuses `SessionCore::accord_transaction_committer`).