### PR TITLE
fix: full-text search returns empty after restart (replay indexes into schema registry + re-register FullText)

### DIFF
--- a/ferrosa-cluster/src/system_table_loader.rs
+++ b/ferrosa-cluster/src/system_table_loader.rs
@@ -199,6 +199,62 @@ impl SystemTableLoader {
         }
         Ok(restored)
     }
+
+    /// Replay persisted `system_schema.indexes` rows into the live schema
+    /// Registry's index set.
+    ///
+    /// `load_local_schema` (schema.json) restores table schemas with NO
+    /// indexes, and the storage-side `reload_indexes_from_system_schema` only
+    /// repopulates the *engine*. The CQL router resolves an `fts_match` column
+    /// to its index via `SchemaSnapshot.indexes` (`resolve_fulltext_index_name`),
+    /// so without this replay that lookup falls back to the bare column name
+    /// after a restart and full-text search silently returns nothing. Returns
+    /// the number of indexes (re-)registered.
+    ///
+    /// Filtered (partial) indexes are skipped here: their predicate lives in
+    /// the persisted options and would need faithful decoding to register
+    /// soundly; they already route via the engine, and only full-text routing
+    /// depends on the schema registry.
+    pub fn replay_indexes_into_schema(&self, schema: &Schema) -> ferrosa_common::Result<usize> {
+        use ferrosa_schema::metadata::index::IndexMetadata;
+        let rows = self.engine.read_persisted_indexes()?;
+        let mut restored = 0usize;
+        for row in rows {
+            let Some(index_type) =
+                ferrosa_schema::system::persistence::index_type_from_kind(&row.kind)
+            else {
+                tracing::warn!(
+                    keyspace = %row.keyspace_name,
+                    index = %row.index_name,
+                    kind = %row.kind,
+                    "skipping system_schema.indexes replay: unknown index kind"
+                );
+                continue;
+            };
+            if matches!(index_type, ferrosa_index::IndexType::Filtered) {
+                continue;
+            }
+            let meta = IndexMetadata {
+                keyspace: row.keyspace_name.clone(),
+                table: row.table_name.clone(),
+                name: row.index_name.clone(),
+                index_type,
+                target_columns: row.target.split(", ").map(|s| s.to_string()).collect(),
+                filter_predicate: None,
+                options: serde_json::from_str(&row.options).unwrap_or_default(),
+            };
+            match schema.create_index_internal(meta) {
+                Ok(()) => restored += 1,
+                Err(e) => tracing::warn!(
+                    keyspace = %row.keyspace_name,
+                    index = %row.index_name,
+                    %e,
+                    "skipping system_schema.indexes replay row"
+                ),
+            }
+        }
+        Ok(restored)
+    }
 }
 
 fn decode_permission(name: &str) -> ferrosa_common::Result<Permission> {

--- a/ferrosa-cluster/src/system_table_loader.rs
+++ b/ferrosa-cluster/src/system_table_loader.rs
@@ -566,6 +566,59 @@ mod tests {
     }
 
     #[test]
+    fn replay_indexes_restores_fulltext_index_for_router_resolution() {
+        use ferrosa_index::IndexType;
+        use ferrosa_schema::metadata::index::IndexMetadata;
+
+        let dir = tempfile::tempdir().unwrap();
+        let engine = test_engine(dir.path());
+        engine.register_system_tables().unwrap();
+
+        // Persist a CREATE INDEX (FullText) through the dogfooded writer.
+        let idx = IndexMetadata {
+            keyspace: "app".to_string(),
+            table: "docs".to_string(),
+            name: "idx_body_fts".to_string(),
+            index_type: IndexType::FullText,
+            target_columns: vec!["body".to_string()],
+            filter_predicate: None,
+            options: std::collections::HashMap::new(),
+        };
+        SystemTableWriter::new(Arc::clone(&engine))
+            .apply(
+                ferrosa_schema::system::persistence::SystemTableMutation::IndexCreated(idx.clone()),
+            )
+            .unwrap();
+
+        // Cold restart: a fresh registry has NO indexes (the bug — the router's
+        // fts_match resolution would fall back to the bare column name).
+        let schema = test_schema();
+        assert!(
+            schema.snapshot().indexes.is_empty(),
+            "fresh schema must start with no indexes"
+        );
+
+        let count = SystemTableLoader::new(engine)
+            .replay_indexes_into_schema(&schema)
+            .unwrap();
+        assert_eq!(count, 1, "exactly one persisted index should be replayed");
+
+        // After replay the FullText index is resolvable, so the router maps
+        // fts_match(body) -> idx_body_fts instead of the bare column.
+        let snap = schema.snapshot();
+        let meta = snap
+            .indexes
+            .get(&(
+                "app".to_string(),
+                "docs".to_string(),
+                "idx_body_fts".to_string(),
+            ))
+            .expect("FullText index must be live in the registry after replay");
+        assert_eq!(meta.index_type, IndexType::FullText);
+        assert_eq!(meta.target_columns, vec!["body".to_string()]);
+    }
+
+    #[test]
     fn replay_role_permissions_restores_write_permission() {
         let dir = tempfile::tempdir().unwrap();
         let engine = test_engine(dir.path());

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -3154,19 +3154,19 @@ impl StorageEngine {
             return Ok(false);
         };
 
-        // Generic add_index covers BTree/Hash/Composite/Phonetic/Filtered.
-        // FullText and Vector use dedicated sidecar build paths and are
-        // reconstructed elsewhere; skip them loudly here so the gap is visible.
-        if matches!(
-            index_type,
-            ferrosa_index::IndexType::FullText | ferrosa_index::IndexType::Vector
-        ) {
+        // Vector indexes need their dimension + HNSW params to rebuild and use
+        // a dedicated path; skip them here. FullText is re-registered after
+        // column resolution below (and its sidecars rebuilt) — leaving it
+        // skipped made fts_match return EMPTY after a restart even though the
+        // on-disk FTI sidecars were intact, because the engine's
+        // fulltext_indexes map (column position) was never repopulated.
+        if matches!(index_type, ferrosa_index::IndexType::Vector) {
             tracing::warn!(
                 keyspace,
                 table,
                 index_name,
                 kind,
-                "skipping reload of fulltext/vector index — needs dedicated rebuild path"
+                "skipping reload of vector index — needs dedicated rebuild path"
             );
             return Ok(false);
         }
@@ -3209,6 +3209,46 @@ impl StorageEngine {
         } else {
             None
         };
+
+        // FullText: repopulate the engine's fulltext_indexes map (so fts_match
+        // can resolve the column and read the on-disk FTI sidecars / scan
+        // sidecar-less SSTables), then submit rebuild jobs so any SSTable that
+        // predates the index gets its FTI sidecar reindexed. This is the
+        // restart reindex path whose absence silently broke lexical search.
+        if matches!(index_type, ferrosa_index::IndexType::FullText) {
+            self.add_fulltext_index(&table_id, &index_name, column_position)?;
+            if let Some(ref scheduler) = self.index_scheduler {
+                let tables = self.tables.read();
+                if let Some(state) = tables.get(&table_id) {
+                    for sstable_id in state.store.sstable_generation_ids() {
+                        let job = crate::index::IndexBuildJob {
+                            sstable_id,
+                            index_name: index_name.clone(),
+                            index_type,
+                            table: (
+                                table_id.keyspace().to_string(),
+                                table_id.table().to_string(),
+                            ),
+                            priority: crate::index::BuildPriority::Initial,
+                            enqueued_at: std::time::Instant::now(),
+                            column_position,
+                            filter_predicate: None,
+                        };
+                        if let Err(e) = scheduler.submit(job) {
+                            tracing::error!(%e, index_name, "reload: failed to submit fulltext reindex");
+                        }
+                    }
+                }
+            }
+            tracing::info!(
+                keyspace,
+                table,
+                index_name,
+                kind,
+                "re-registered + reindexed full-text index after restart"
+            );
+            return Ok(true);
+        }
 
         self.add_index_with_predicate(
             &table_id,

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -936,6 +936,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(e) => tracing::warn!(%e, "failed to reload secondary indexes from system_schema"),
     }
 
+    // 4b'½. Replay persisted indexes into the SCHEMA REGISTRY too (the reload
+    // above only repopulates the storage engine). schema.json carries no
+    // indexes, so the CQL router's `resolve_fulltext_index_name` — which reads
+    // SchemaSnapshot.indexes — would fall back to the bare column name after a
+    // restart, silently breaking full-text search even though the FTI sidecars
+    // are intact on disk. This restores the index set the router resolves
+    // against.
+    {
+        let loader =
+            ferrosa_cluster::system_table_loader::SystemTableLoader::new(Arc::clone(&storage));
+        match loader.replay_indexes_into_schema(&schema) {
+            Ok(count) if count > 0 => {
+                tracing::info!(
+                    count,
+                    "replayed persisted indexes into schema registry after restart"
+                )
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(%e, "failed to replay indexes into schema registry from system_schema")
+            }
+        }
+    }
+
     // 4b''. Reconstruct user-defined types from the persisted
     // `system_schema.types` table. `schema.json` does not carry UDTs, so without
     // this every CREATE TYPE is silently lost on restart. Runs after system


### PR DESCRIPTION
## Problem

After a cluster/node restart, `fts_match` (full-text search) returns **empty for every table** even though the `-FTI-` sidecars are intact on disk — silently breaking all lexical/BM25 search. Vector/ANN is unaffected. Reproduced by restarting a populated cluster.

## Root cause (two layers)

1. **Schema registry**: `schema.json` restores tables with **no** indexes, and the boot sequence replays *types* and *functions* into the schema registry but **never indexes** (`reload_indexes_from_system_schema` only repopulates the storage *engine*). The CQL router resolves an `fts_match` column to its index via `SchemaSnapshot.indexes` (`resolve_fulltext_index_name`) → after restart that's empty → falls back to the **bare column name** → looks for `-FTI-<column>.db` instead of `-FTI-<index_name>.db` → empty.
2. **Storage engine**: `reload_one_index` early-returned for FullText, so the engine's `fulltext_indexes` map (column position) was never repopulated — so flush wouldn't build new sidecars and the sidecar-less-SSTable scan couldn't run.

## Fix

- **`SystemTableLoader::replay_indexes_into_schema`** (new) — reads `system_schema.indexes` and re-registers each via `schema.create_index_internal`, mirroring the existing `replay_types/functions`. Wired into the boot sequence right after the storage-side reload. Filtered indexes are skipped (predicate decode deferred; they route via the engine, only full-text routing needs the schema registry). **This is what restores `fts_match`.**
- **`reload_one_index`** — stop skipping FullText: re-register via `add_fulltext_index` + submit `IndexBuildJob`s so SSTables missing a sidecar are reindexed (skip only Vector, which needs its dimension/HNSW params via a separate path).

## Test
`replay_indexes_restores_fulltext_index_for_router_resolution` — persist a FullText index, replay into a fresh registry, assert it's resolvable. Compiles clean.

Live end-to-end validation (rebuild a real cluster on this branch, confirm `fts_match` returns rows post-restart) is in progress and will be noted here.
