### PR TITLE
fix(jepsen): revert connectivity-breaking session pinning + Fly-IP foundation

### DIFF
--- a/ferrosa-jepsen/src/cql_session.rs
+++ b/ferrosa-jepsen/src/cql_session.rs
@@ -1,12 +1,7 @@
-use std::num::NonZeroUsize;
-use std::sync::Arc;
-
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
-use scylla::client::PoolSize;
-use scylla::policies::host_filter::AllowListHostFilter;
 use scylla::value::{CqlValue, Row};
 
 use crate::workload::CqlSession;
@@ -22,32 +17,27 @@ pub struct ScyllaCqlSession {
 impl ScyllaCqlSession {
     /// Connect to the cluster at the given contact points (e.g. `["127.0.0.1:9042"]`).
     ///
-    /// The session is **pinned to a single node + a single connection**. A
-    /// `BEGIN…COMMIT` transaction buffers on one server connection, so every
-    /// statement in it must share one TCP connection — the pinned node forwards
-    /// writes as the Accord coordinator (cross-shard fan-out still happens).
-    /// Without pinning, the driver routes each statement by token to a different
-    /// node, and the transaction's buffered DML never reaches the `BEGIN`'s
-    /// connection.
+    /// Uses the standard multi-node `known_nodes` session (the proven path the
+    /// nightly multi-DC runner relies on). The driver discovers the full topology
+    /// and routes each query token-aware.
     ///
-    /// Caveat: the pinned node is a single point of failure for this client, so
-    /// a nemesis that kills it fails the client's ops (never *partial* writes —
-    /// the atomicity invariant still holds). Per-transaction reconnect / failover
-    /// to another node is a follow-up.
+    /// NOTE on transactions: a `BEGIN…COMMIT` block buffers on one *server
+    /// connection*, so to be atomic its statements must all reach the same
+    /// connection. The token-aware pool can scatter them across coordinators, so
+    /// the atomic-transaction bank workload needs connection affinity — a
+    /// **single-node load-balancing policy** that pins every query to one
+    /// coordinator while keeping the full topology connected (so the cluster
+    /// stays reachable). An earlier attempt to pin via `AllowListHostFilter`
+    /// broke connectivity: the filter matches a node's *advertised* address,
+    /// which differs from the port-mapped contact point in Docker, so it filtered
+    /// out the only node and every query failed. See t_ec740b8f.
     pub async fn connect(contact_points: &[String]) -> Result<Self> {
         assert!(
             !contact_points.is_empty(),
             "contact_points must not be empty"
         );
-        let pinned = contact_points[0].clone();
-        let filter = AllowListHostFilter::new([pinned.clone()])
-            .context("building single-node host filter")?;
         let session = SessionBuilder::new()
-            .known_node(&pinned)
-            .host_filter(Arc::new(filter))
-            .pool_size(PoolSize::PerHost(
-                NonZeroUsize::new(1).expect("1 is nonzero"),
-            ))
+            .known_nodes(contact_points)
             .build()
             .await
             .context("failed to connect to CQL cluster")?;
@@ -90,11 +80,15 @@ fn hex_encode(bytes: &[u8]) -> String {
 impl CqlSession for ScyllaCqlSession {
     async fn execute(&self, query: &str) -> Result<Vec<Vec<(String, String)>>> {
         assert!(!query.is_empty(), "query must not be empty");
+        // Flatten the driver error into the message (not just an anyhow context)
+        // so the workload's `e.to_string()` surfaces the ROOT cause — a bare
+        // "executing query: …" with the real failure hidden is a fail-loud gap
+        // that masked a connectivity regression once already.
         let result = self
             .session
             .query_unpaged(query, &[])
             .await
-            .with_context(|| format!("executing query: {query}"))?;
+            .map_err(|e| anyhow::anyhow!("executing query `{query}`: {e}"))?;
 
         // Non-SELECT statements (CREATE, INSERT, UPDATE, DELETE) produce no rows.
         let rows_result = match result.into_rows_result() {

--- a/ferrosa-jepsen/src/docker_provision.rs
+++ b/ferrosa-jepsen/src/docker_provision.rs
@@ -49,8 +49,10 @@ pub fn container_runtime() -> &'static str {
 /// Information about a single provisioned node.
 #[derive(Debug, Clone)]
 pub struct NodeInfo {
-    /// Hostname used to reach this node from the test runner.
-    pub host: &'static str,
+    /// Hostname or IP used to reach this node from the test runner. Owned so it
+    /// can hold a dynamic address (e.g. a Fly machine's private IP), not just a
+    /// static `"localhost"`.
+    pub host: String,
     /// CQL port on the test runner host.
     pub cql_port: u16,
 }
@@ -256,7 +258,7 @@ pub async fn provision_docker_cluster(topology: Topology) -> Result<ClusterInfo>
     let nodes: Vec<NodeInfo> = NODE_CQL_PORTS[..node_count]
         .iter()
         .map(|&port| NodeInfo {
-            host: "localhost",
+            host: "localhost".to_string(),
             cql_port: port,
         })
         .collect();
@@ -335,7 +337,7 @@ mod tests {
     #[test]
     fn node_info_cql_address() {
         let node = NodeInfo {
-            host: "localhost",
+            host: "localhost".to_string(),
             cql_port: 49042,
         };
         assert_eq!(node.cql_address(), "localhost:49042");
@@ -346,15 +348,15 @@ mod tests {
         let cluster = ClusterInfo {
             nodes: vec![
                 NodeInfo {
-                    host: "localhost",
+                    host: "localhost".to_string(),
                     cql_port: 49042,
                 },
                 NodeInfo {
-                    host: "localhost",
+                    host: "localhost".to_string(),
                     cql_port: 49043,
                 },
                 NodeInfo {
-                    host: "localhost",
+                    host: "localhost".to_string(),
                     cql_port: 49044,
                 },
             ],

--- a/ferrosa-jepsen/src/orchestrator.rs
+++ b/ferrosa-jepsen/src/orchestrator.rs
@@ -346,15 +346,15 @@ mod tests {
         let cluster = ClusterInfo {
             nodes: vec![
                 JepsenNodeInfo {
-                    host: "localhost",
+                    host: "localhost".to_string(),
                     cql_port: 49042,
                 },
                 JepsenNodeInfo {
-                    host: "localhost",
+                    host: "localhost".to_string(),
                     cql_port: 49043,
                 },
                 JepsenNodeInfo {
-                    host: "localhost",
+                    host: "localhost".to_string(),
                     cql_port: 49044,
                 },
             ],


### PR DESCRIPTION
## Regression fix (urgent)

The `ScyllaCqlSession` single-node pinning shipped via #192 (`AllowListHostFilter` + `known_node` + `PoolSize::PerHost(1)`) **broke the live jepsen harness**. The host filter matches a node's *advertised* address, which differs from the **port-mapped contact point** in Docker (and Fly), so it filtered out the only node → empty connection pool → **every query failed at `CREATE KEYSPACE`** across *all* workloads (register/lwt/bank), not just transactional ones.

Found by a local smoke chaos run against a #192-image cluster: identical setup failure on every workload×nemesis combo.

- **Revert to `known_nodes`** — the proven path the nightly multi-DC runner relies on. Connectivity restored.
- **Surface root errors** — `execute()` now flattens the driver error into the message so the workload's `e.to_string()` shows the *root* cause; the bare anyhow context had masked this very failure (fail-loud).

## Fly-chaos foundation (B1)

- `docker_provision::NodeInfo.host: &'static str → String` so a node address can be a **dynamic Fly machine IP**, not just static `"localhost"`. No behavior change for Docker.

## Follow-ups captured
- **t_ec740b8f** (P70) — the *real* need behind the reverted pinning: transaction **connection affinity** via a single-node `LoadBalancingPolicy` (pin to one coordinator, keep topology connected) — not an address-fragile host filter. Until then, the bank workload's transactions aren't truly atomic over the pooled driver.
- **t_1aa35437** — wire `flyio.rs` into the orchestrator + nemesis (B2–B4): `provision_fly_cluster`, 6PN-DNS cluster formation, `MachineProvisioner` trait seam.

ferrosa-jepsen: 224 tests pass, clippy + fmt clean. Nemesis logic separately verified (41 chaos:: tests pass).