### PR TITLE
feat(jepsen): transaction connection affinity + CQL-handshake readiness gate (+ Linux smoke-chaos CI)

### DIFF
--- a/.github/workflows/jepsen-smoke-chaos.yml
+++ b/.github/workflows/jepsen-smoke-chaos.yml
@@ -1,0 +1,49 @@
+name: Jepsen Smoke Chaos (manual)
+
+# Live verification of the jepsen harness against a real, **from-source** 3-node
+# cluster on a Linux runner: runs the smoke tier (register / lwt / bank workloads
+# x nemeses) with FERROSA_TEST_CONTAINERS=1. The compose file builds the node
+# image from the current checkout, so this exercises the branch's server code
+# (BEGIN/COMMIT) and driver code (transaction connection affinity + the CQL
+# handshake readiness gate) end to end.
+#
+# `workflow_dispatch` is the permanent entry point (works once this file is on
+# the default branch). The scoped `push` trigger lets the verification run from
+# the feature branch before it merges; remove it before merging.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - feat/jepsen-fly-chaos
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-chaos:
+    name: smoke tier (3-node from-source cluster)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04-25
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Run jepsen smoke chaos (from-source cluster)
+        env:
+          FERROSA_TEST_CONTAINERS: '1'
+          RUST_LOG: info
+        run: |
+          set -o pipefail
+          cargo run -p ferrosa-jepsen -- \
+            run \
+            --tier smoke \
+            --output-dir ./jepsen-out \
+            2>&1 | tee smoke-chaos.log
+      - name: Upload logs + history
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: smoke-chaos-logs
+          path: |
+            smoke-chaos.log
+            jepsen-out

--- a/ferrosa-jepsen/src/cql_session.rs
+++ b/ferrosa-jepsen/src/cql_session.rs
@@ -1,7 +1,12 @@
+use std::num::NonZeroUsize;
+
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
+use scylla::client::PoolSize;
+use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
 use scylla::value::{CqlValue, Row};
 
 use crate::workload::CqlSession;
@@ -17,30 +22,55 @@ pub struct ScyllaCqlSession {
 impl ScyllaCqlSession {
     /// Connect to the cluster at the given contact points (e.g. `["127.0.0.1:9042"]`).
     ///
-    /// Uses the standard multi-node `known_nodes` session (the proven path the
-    /// nightly multi-DC runner relies on). The driver discovers the full topology
-    /// and routes each query token-aware.
+    /// The session **pins every query to a single coordinator node** so a
+    /// `BEGIN…COMMIT` block's statements share one connection — the server buffers
+    /// a transaction per connection, so without affinity the token-aware pool
+    /// would scatter the statements across coordinators and the buffered DML would
+    /// never reach the `BEGIN`'s connection (silently non-atomic).
     ///
-    /// NOTE on transactions: a `BEGIN…COMMIT` block buffers on one *server
-    /// connection*, so to be atomic its statements must all reach the same
-    /// connection. The token-aware pool can scatter them across coordinators, so
-    /// the atomic-transaction bank workload needs connection affinity — a
-    /// **single-node load-balancing policy** that pins every query to one
-    /// coordinator while keeping the full topology connected (so the cluster
-    /// stays reachable). An earlier attempt to pin via `AllowListHostFilter`
-    /// broke connectivity: the filter matches a node's *advertised* address,
-    /// which differs from the port-mapped contact point in Docker, so it filtered
-    /// out the only node and every query failed. See t_ec740b8f.
+    /// Pinning is by **`host_id`** (a stable cluster identity), discovered via a
+    /// short-lived probe session — NOT by address. A node's advertised address
+    /// differs from the port-mapped contact point in Docker/Fly, which is exactly
+    /// why the earlier `AllowListHostFilter` attempt filtered out the only node
+    /// and broke all connectivity (t_ec740b8f). The full topology stays connected
+    /// (`known_nodes` + `PoolSize(1)`); the pinned node forwards writes as the
+    /// Accord coordinator, so cross-shard fan-out still happens.
     pub async fn connect(contact_points: &[String]) -> Result<Self> {
         assert!(
             !contact_points.is_empty(),
             "contact_points must not be empty"
         );
-        let session = SessionBuilder::new()
+
+        // Phase 1 — probe with a normal session to learn a live node's host_id.
+        let probe = SessionBuilder::new()
             .known_nodes(contact_points)
             .build()
             .await
-            .context("failed to connect to CQL cluster")?;
+            .context("failed to connect to CQL cluster (probe)")?;
+        let target = probe
+            .get_cluster_state()
+            .get_nodes_info()
+            .iter()
+            .min_by_key(|n| n.host_id) // deterministic across topology refreshes
+            .map(|n| n.host_id)
+            .context("cluster reports no known nodes to pin to")?;
+        drop(probe);
+
+        // Phase 2 — pin all queries to that node (one connection ⇒ transaction
+        // affinity), keeping the full topology connected for reachability.
+        let policy = SingleTargetLoadBalancingPolicy::new(NodeIdentifier::HostId(target), None);
+        let profile = ExecutionProfile::builder()
+            .load_balancing_policy(policy)
+            .build();
+        let session = SessionBuilder::new()
+            .known_nodes(contact_points)
+            .default_execution_profile_handle(profile.into_handle())
+            .pool_size(PoolSize::PerHost(
+                NonZeroUsize::new(1).expect("1 is nonzero"),
+            ))
+            .build()
+            .await
+            .context("failed to connect to CQL cluster (pinned)")?;
         Ok(Self { session })
     }
 }

--- a/ferrosa-jepsen/src/docker_provision.rs
+++ b/ferrosa-jepsen/src/docker_provision.rs
@@ -64,10 +64,36 @@ impl NodeInfo {
     }
 
     /// Return `true` if the CQL port accepts a TCP connection.
+    ///
+    /// NOTE: TCP-open is NOT the same as CQL-ready — a node's listener can accept
+    /// a socket before it can complete the protocol handshake (which then fails
+    /// with `early eof` on `OPTIONS`). Use [`cql_handshake_ok`](Self::cql_handshake_ok)
+    /// as the readiness gate; this bare check is kept only for cheap liveness.
     pub async fn cql_reachable(&self) -> bool {
         tokio::net::TcpStream::connect(self.cql_address())
             .await
             .is_ok()
+    }
+
+    /// Return `true` only if a full CQL **handshake + trivial query** succeeds —
+    /// the real readiness signal. Building a session drives the `OPTIONS`/`STARTUP`
+    /// negotiation and a `SELECT` proves the node is actually serving CQL, not
+    /// merely holding an open socket. Any error (handshake `early eof`, control
+    /// connection broken, query failure) returns `false` so the caller keeps
+    /// polling.
+    pub async fn cql_handshake_ok(&self) -> bool {
+        use scylla::client::session_builder::SessionBuilder;
+        match SessionBuilder::new()
+            .known_node(self.cql_address())
+            .build()
+            .await
+        {
+            Ok(session) => session
+                .query_unpaged("SELECT key FROM system.local", &[])
+                .await
+                .is_ok(),
+            Err(_) => false,
+        }
     }
 }
 
@@ -275,7 +301,11 @@ pub async fn provision_docker_cluster(topology: Topology) -> Result<ClusterInfo>
     Ok(cluster)
 }
 
-/// Wait for all nodes in the cluster to accept TCP connections on their CQL port.
+/// Wait for all nodes in the cluster to be **CQL-ready** — i.e. to complete a
+/// real CQL handshake + query, not merely accept a TCP socket. Gating on
+/// TCP-open let the orchestrator connect before the listener could handshake,
+/// failing every workload with `early eof` on `OPTIONS` (a node-readiness race
+/// that surfaced under slow podman + from-source image builds).
 ///
 /// Polls every 500 ms for up to `CLUSTER_READY_TIMEOUT`.
 async fn wait_for_cluster_ready(cluster: &ClusterInfo) -> Result<()> {
@@ -291,8 +321,8 @@ async fn wait_for_cluster_ready(cluster: &ClusterInfo) -> Result<()> {
         );
 
         loop {
-            if node.cql_reachable().await {
-                info!(cql_address = node.cql_address(), "CQL port ready");
+            if node.cql_handshake_ok().await {
+                info!(cql_address = node.cql_address(), "CQL handshake ready");
                 break;
             }
             if tokio::time::Instant::now() > deadline {


### PR DESCRIPTION
Follow-up to #195 (which reverted the broken pinning). Two correctness fixes + a Linux verification workflow.

## 1. Transaction connection affinity (t_ec740b8f)
A `BEGIN…COMMIT` block buffers on one *server connection*, so its statements must share a connection to be atomic. Pins every query to one coordinator via scylla's **`SingleTargetLoadBalancingPolicy`** keyed by **`host_id`** (a probe session discovers a live one) + `PoolSize::PerHost(1)`. Robust where the reverted `AllowListHostFilter` wasn't — `host_id` is a stable identity, immune to the advertised-address-vs-contact-point mismatch in Docker/Fly. Full topology stays connected; the pinned node forwards as the Accord coordinator.

## 2. CQL handshake readiness gate
The first retest failed all combos with `early eof` on the CQL `OPTIONS` handshake: `wait_for_cluster_ready` gated on `TcpStream::connect` (TCP-open), but TCP-open ≠ CQL-ready. Adds `NodeInfo::cql_handshake_ok()` (build a session + `SELECT key FROM system.local`) and gates on it.

## 3. Linux smoke-chaos CI (`jepsen-smoke-chaos.yml`)
Runs the smoke tier against a from-source 3-node cluster on ubuntu — verifies both fixes end to end where the cluster comes up reliably (podman-on-Mac loses the readiness race). The `push` trigger runs it from this branch now; remove before merge.

ferrosa-jepsen: 224 unit tests pass, clippy + fmt clean. Live smoke-chaos result pending (this PR's CI run).