### PR TITLE
test(fts): regression guards for FTS-after-restart (follow-up to #193)

### DIFF
--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -17612,6 +17612,68 @@ mod tests {
         }
     }
 
+    /// TDD repro for the live memory FTS failure: every ferrosa-memory query is
+    /// `... WHERE <pk preds> AND <col> = fts_match('...') ... ALLOW FILTERING`.
+    /// The end-to-end test above uses fts_match with NO partition-key predicate;
+    /// this exercises the PK-predicate + fts_match combination (entity_store
+    /// shape: partition key + clustering key + fts on a regular column).
+    // KNOWN BUG (unfixed): with PK predicates present, fts_match is matched at
+    // PARTITION granularity and the post-filter skips re-applying it per-row
+    // (evaluate_where_predicates_skips_fts_match_clauses), so a matched
+    // partition leaks rows that don't contain the term. Reproduced here;
+    // ignored until the per-row fts re-evaluation / row-granular FTI lands.
+    #[ignore = "known bug: fts_match dropped to partition granularity when PK predicates present"]
+    #[tokio::test]
+    async fn fts_match_with_pk_predicates_returns_matches() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        for cql in [
+            "CREATE KEYSPACE fpk WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE fpk.docs (tenant int, sid int, id int, body text, PRIMARY KEY (tenant, sid, id))",
+            "CREATE INDEX docs_body_fts ON fpk.docs (body) USING 'fulltext'",
+            "INSERT INTO fpk.docs (tenant, sid, id, body) VALUES (1, 1, 1, 'rust distributed database')",
+            "INSERT INTO fpk.docs (tenant, sid, id, body) VALUES (1, 1, 2, 'cassandra storage engine')",
+            "INSERT INTO fpk.docs (tenant, sid, id, body) VALUES (2, 9, 3, 'rust other tenant')",
+        ] {
+            let stmt = crate::parser::parse(cql).unwrap();
+            route(&state, &ctx, stmt)
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+        state
+            .engine
+            .flush(&ferrosa_storage::TableId::new("fpk", "docs"))
+            .unwrap();
+
+        let stmt = crate::parser::parse(
+            "SELECT id FROM fpk.docs WHERE tenant = 1 AND sid = 1 AND body = fts_match('rust') ALLOW FILTERING",
+        )
+        .unwrap();
+        let result = route(&state, &ctx, stmt).await;
+        assert!(
+            result.is_ok(),
+            "fts_match+pk query errored: {:?}",
+            result.err()
+        );
+        match result.unwrap() {
+            RouteResult::Result(b) => {
+                let count = extract_row_count(&b);
+                assert_eq!(
+                    count, 1,
+                    "only (tenant=1,sid=1,id=1) matches 'rust' AND the PK filter; got {count}"
+                );
+            }
+            _ => panic!("expected Result"),
+        }
+    }
+
     #[tokio::test]
     async fn fulltext_index_fts_match_reads_unflushed_memtable_row() {
         let (state, _dir) = setup();

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -18232,6 +18232,68 @@ mod tests {
         assert!(!hits.is_empty(), "search for 'rust' must return results");
     }
 
+    /// TDD repro for the post-restart fts_match-empty bug: flush an FTI sidecar,
+    /// persist the index, CLOSE the engine, reopen + reload, and require
+    /// fulltext_search to still return the row.
+    #[test]
+    fn fts_match_works_after_engine_reopen() {
+        use ferrosa_index::IndexType;
+        use ferrosa_schema::system::persistence;
+
+        let dir = tempfile::tempdir().unwrap();
+        let tid = table_id();
+        let indexes_tid = TableId::new("system_schema", "indexes");
+        let idx_meta = ferrosa_schema::metadata::index::IndexMetadata {
+            keyspace: tid.keyspace().to_string(),
+            table: tid.table().to_string(),
+            name: "idx_body".to_string(),
+            index_type: IndexType::FullText,
+            target_columns: vec!["val".to_string()],
+            filter_predicate: None,
+            options: std::collections::HashMap::new(),
+        };
+
+        {
+            let config = StorageEngineConfig::test_config(dir.path());
+            let engine = StorageEngine::new(config, None).unwrap();
+            engine.register_table(test_schema()).unwrap();
+            engine.register_system_tables().unwrap();
+            engine.add_fulltext_index(&tid, "idx_body", 0).unwrap();
+            engine
+                .write(
+                    &tid,
+                    &make_key("r1"),
+                    make_row(b"rust distributed database", 1000),
+                    1000,
+                )
+                .unwrap();
+            engine.flush(&tid).unwrap();
+
+            let row = persistence::index_to_rows(&idx_meta);
+            engine
+                .write(&indexes_tid, &row.key, row.row, now_micros_for_test())
+                .unwrap();
+            engine.flush(&indexes_tid).unwrap();
+
+            // Sanity: fts_match works before the restart.
+            let hits = engine.fulltext_search(&tid, "idx_body", "rust").unwrap();
+            assert!(!hits.is_empty(), "fts_match must work before reopen");
+        }
+
+        // Reopen, replicating the boot sequence's index reload.
+        let config = StorageEngineConfig::test_config(dir.path());
+        let (engine, _pending) = StorageEngine::open(config, None).unwrap();
+        engine.register_system_tables().unwrap();
+        engine.reload_indexes_from_system_schema().unwrap();
+
+        // The bug: fts_match must still return the row after restart.
+        let hits = engine.fulltext_search(&tid, "idx_body", "rust").unwrap();
+        assert!(
+            !hits.is_empty(),
+            "fts_match must return the indexed row after an engine reopen"
+        );
+    }
+
     // ── FT-019: FTS end-to-end insert → flush → query ──────────────────────
 
     #[test]


### PR DESCRIPTION
Follow-up to #193 (merged), which fixed `fts_match` returning empty after a cluster restart. These are the two TDD artifacts that came out of validating that fix on a live cluster — test-only, no production changes.

## What's here
- **`fts_match_works_after_engine_reopen`** (ferrosa-storage) — a real regression guard: builds an FTI sidecar, closes the engine, reopens via `StorageEngine::open` + `reload_indexes_from_system_schema()`, and asserts `fulltext_search` returns the indexed row. This is the engine-level proof that the reload path (re-register FullText on restart) works. **Passes.**
- **`fts_match_with_pk_predicates_returns_matches`** (ferrosa-cql, `#[ignore]`) — documents a *separate* correctness bug discovered while validating: when PK predicates are present alongside `fts_match`, the match is applied at **partition granularity** and the post-filter skips re-applying `fts_match` per-row, so a partition matched by any row leaks all PK-matching rows. Ignored until the per-row fts re-evaluation lands; kept as an executable repro.

## Validation
On the live 3-node cluster (running the merged #193 fix), FTS is confirmed working: `fts_match` returns thousands of rows for real indexed terms across `context_segments`, `document_chunks`, and `entity_store`. The earlier "FTS still broken" signal was a bad-test-term artifact (stopwords like `the`, and distinctive terms tested against the wrong column).

No production code changes — both crates' test suites compile and the storage guard passes against current `main`.