### PR TITLE
ci: run Cluster integration tests in the merge queue (gate merges on it)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,11 @@ jobs:
     name: Cluster integration tests
     runs-on: ubuntu-latest
     needs: build-node-image
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    # Run on PRs, on main, AND in the merge queue (`merge_group`). Without the
+    # merge_group arm this job is skipped in the queue, so a red integration run
+    # could never gate the merge — which is exactly how a red PR slipped through.
+    # It must also be added to the ruleset's required status checks.
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.ref == 'refs/heads/main'
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Why

#198 merged **while its Cluster integration test was red**. Two compounding gaps:
1. `Cluster integration tests` is **not** a required status check, so it never gated the PR.
2. Its `if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'` **skips it on `merge_group`** — so it doesn't run in the merge queue and can't block a merge there either.

## This PR
Adds the `merge_group` arm to the `if:` so the integration job runs in the queue (like every other gating job).

## Required follow-up (repo settings — I'll do this once this merges)
Add to the ruleset's **required status checks**: `Cluster integration tests`, `Jepsen Smoke Tier`, `Driver Smoke (ubuntu-latest)`, `Example CQL Scripts`, `Install smoke (ubuntu-latest)`. Ordering matters — requiring `Cluster integration tests` *before* this merges would deadlock the queue (the check would be skipped-but-required on `merge_group`), so the settings change must come **after**.

Net: a non-passing test will then block merge, as it should have for #198.