### PR TITLE
fix(jepsen): readiness timeout 300s + fail loud on 0 combos / invariant failures

### DIFF
--- a/ferrosa-jepsen/src/docker_provision.rs
+++ b/ferrosa-jepsen/src/docker_provision.rs
@@ -308,8 +308,14 @@ pub async fn provision_docker_cluster(topology: Topology) -> Result<ClusterInfo>
 /// that surfaced under slow podman + from-source image builds).
 ///
 /// Polls every 500 ms for up to `CLUSTER_READY_TIMEOUT`.
+///
+/// A **from-source** image build + cold node bootstrap on a CI runner can take
+/// well over two minutes: an observed run had all three nodes join the cluster at
+/// ~118s, just missing a 120s deadline (0 combos ran, false-green). 300s gives
+/// comfortable margin; the smoke workload itself is only seconds, so a longer
+/// one-time readiness wait costs nothing.
 async fn wait_for_cluster_ready(cluster: &ClusterInfo) -> Result<()> {
-    const CLUSTER_READY_TIMEOUT: Duration = Duration::from_secs(120);
+    const CLUSTER_READY_TIMEOUT: Duration = Duration::from_secs(300);
     const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
     let deadline = tokio::time::Instant::now() + CLUSTER_READY_TIMEOUT;

--- a/ferrosa-jepsen/src/main.rs
+++ b/ferrosa-jepsen/src/main.rs
@@ -167,6 +167,26 @@ async fn main() -> Result<()> {
                 }
             }
 
+            // FAIL LOUD (t_5fdf25f0): the process exit code must reflect the run.
+            // Previously this returned Ok(()) unconditionally, so a run that
+            // executed ZERO combinations (e.g. cluster provisioning failed and the
+            // only topology was skipped) — or even one with failing invariants —
+            // exited 0 and showed green in CI, masking a broken harness.
+            if report.total == 0 {
+                anyhow::bail!(
+                    "jepsen run executed 0 combinations — nothing was verified \
+                     (cluster provisioning likely failed / every topology skipped). \
+                     Refusing to report a false green."
+                );
+            }
+            if !report.all_passed() {
+                anyhow::bail!(
+                    "jepsen run failed: {} of {} combination(s) violated an invariant",
+                    report.failed,
+                    report.total
+                );
+            }
+
             Ok(())
         }
         Commands::Report { action } => {


### PR DESCRIPTION
Two fixes surfaced by the on-main smoke-chaos verification run (after the varchar fix landed).

## 1. Readiness timeout 120s → 300s
The varchar fix (#197) worked — the driver now **discovers all 3 nodes** (`Node added to cluster: …172.18.0.5:49042` etc.), the "Missing UDT" metadata break is gone. But a **from-source image build + cold node bootstrap** on a CI runner had the nodes join at **~118s**, just missing the 120s readiness deadline → topology skipped → 0 combos. 300s gives margin; the smoke workload is only seconds, so a longer one-time readiness wait is free.

## 2. Fail loud on 0 combos / invariant failures (t_5fdf25f0)
The `run` command returned `Ok(())` **unconditionally** — so a run that executed **zero** combinations (every topology skipped) *or even one with failing invariants* exited 0 and went **green** in CI. That's how the 0-combo runs looked "successful" and masked the broken harness. Now it `bail!`s (non-zero exit) when `total == 0` or any combination failed.

This is the same class of issue as the merge-protection gap — a check that verified nothing must not read as a pass.

ferrosa-jepsen builds, clippy + fmt clean.