### PR TITLE
fix(fts): row-granular full-text index (MATCH + clustering predicates no longer leak)

### DIFF
--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -2182,12 +2182,23 @@ mod tests {
             .write(&table_id, &test_key(), test_row(1000), 1000)
             .unwrap();
 
+        // The local FTI now returns a full ROW-GRANULAR doc key (partition +
+        // clustering), not a bare partition key. Capture the actual local key so
+        // the remote returns the SAME bytes — exercising real dedup — instead of a
+        // hand-rolled partition key that would no longer match.
+        let local_keys = storage
+            .fulltext_search(&table_id, "val_fti", "hello")
+            .unwrap();
+        assert_eq!(local_keys.len(), 1, "local node should have one FTI hit");
+        let shared_key = local_keys[0].clone();
+        let remote_only = vec![9u8, 9, 9];
+
         // Remote node: returns the SAME local key (must dedup) plus a
-        // remote-only key [9,9,9].
+        // remote-only key.
         let (server, addr, remote_host_id) = start_rpc_server(
             MsgType::FulltextSearchRequest,
             Arc::new(StaticFulltextSearchHandler {
-                keys: vec![vec![1, 2, 3], vec![9, 9, 9]],
+                keys: vec![shared_key.clone(), remote_only.clone()],
             }),
         )
         .await;
@@ -2224,9 +2235,10 @@ mod tests {
             .unwrap();
         keys.sort();
 
+        let mut expected = vec![shared_key, remote_only];
+        expected.sort();
         assert_eq!(
-            keys,
-            vec![vec![1u8, 2, 3], vec![9, 9, 9]],
+            keys, expected,
             "fan-out must union local + remote FTI hits and de-duplicate the shared key"
         );
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -3568,20 +3568,38 @@ async fn route_select_user_table(
             .await
             .map_err(|e| CqlError::Invalid(format!("fts_match search failed: {e}")))?;
 
-        // Fetch each matching partition and apply post-filter.
-        // The raw_pk bytes are the PartitionKey bytes as stored in the FTI.
-        // Reconstruct a DecoratedKey by wrapping them in PartitionKey directly.
+        // `matching_pks` are full-key document ids (partition + clustering), one
+        // per matching ROW. Read each distinct partition once, keep ONLY the rows
+        // whose full key actually matched — so non-matching clustering rows in a
+        // matched partition don't leak (t_da51e20c) — then post-filter.
+        let matched: std::collections::HashSet<Vec<u8>> = matching_pks.into_iter().collect();
+        let mut seen_partitions = std::collections::HashSet::new();
         let mut fts_rows = Vec::new();
-        for raw_pk in matching_pks {
+        for doc_key in &matched {
+            let Some(pk) = ferrosa_index::fulltext::keys::doc_key_partition(doc_key) else {
+                // Legacy/malformed id (e.g. a sidecar built before row-granular
+                // keys, pending rebuild) — skip rather than misread.
+                continue;
+            };
+            if !seen_partitions.insert(pk.to_vec()) {
+                continue; // partition already read
+            }
             let decorated =
-                ferrosa_common::DecoratedKey::new(ferrosa_common::PartitionKey::new(raw_pk));
-            if let Some(partition) = state
+                ferrosa_common::DecoratedKey::new(ferrosa_common::PartitionKey::new(pk.to_vec()));
+            if let Some(mut partition) = state
                 .write_path
                 .load()
                 .read(&table_id, &decorated)
                 .await
                 .map_err(|e| CqlError::ServerError(format!("{e}")))?
             {
+                // Keep only the rows whose full key is in the FTS match set.
+                partition.rows.retain(|row| {
+                    matched.contains(&ferrosa_index::fulltext::keys::encode_doc_key(
+                        pk,
+                        &row.clustering,
+                    ))
+                });
                 let mut prows = bridge::partition_to_rows_with_storage_mapping(
                     &partition,
                     &all_col_names,

--- a/ferrosa-index/src/fulltext/keys.rs
+++ b/ferrosa-index/src/fulltext/keys.rs
@@ -1,0 +1,85 @@
+//! Row-granular FTI document-key codec.
+//!
+//! Historically the FTI keyed each document by **partition key** and (worse)
+//! concatenated every row's text in a partition into one document, so a hit
+//! identified only the partition — leaking non-matching clustering rows on
+//! `WHERE … AND col = fts_match(…)` against clustered tables (t_da51e20c).
+//!
+//! The index now keys each document by the **full primary key** so a hit
+//! identifies an exact row. This codec serializes that key as
+//! `[tag][pk_len: u32 BE][partition_key][clustering]` and parses the partition
+//! portion back out (the router reads partitions by partition key, then keeps
+//! only the rows whose full key actually matched).
+//!
+//! The leading [`ROW_KEY_TAG`] byte distinguishes a row-granular key from a
+//! legacy bare-partition-key id, so a stale sidecar (pre-rebuild) is detected
+//! rather than silently misparsed.
+
+/// Format tag marking a row-granular full-key document id.
+const ROW_KEY_TAG: u8 = 0x01;
+
+/// Encode a row's document key as `[tag][pk_len: u32 BE][partition_key][clustering]`.
+pub fn encode_doc_key(partition_key: &[u8], clustering: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + 4 + partition_key.len() + clustering.len());
+    out.push(ROW_KEY_TAG);
+    out.extend_from_slice(&(partition_key.len() as u32).to_be_bytes());
+    out.extend_from_slice(partition_key);
+    out.extend_from_slice(clustering);
+    out
+}
+
+/// Extract the partition-key portion of a row-granular doc key, or `None` if the
+/// bytes are not in the row-granular format (e.g. a legacy partition-key-only id
+/// from a sidecar built before this change — such a sidecar must be rebuilt).
+pub fn doc_key_partition(doc_key: &[u8]) -> Option<&[u8]> {
+    if doc_key.first() != Some(&ROW_KEY_TAG) || doc_key.len() < 5 {
+        return None;
+    }
+    let pk_len = u32::from_be_bytes(doc_key[1..5].try_into().ok()?) as usize;
+    let start = 5usize;
+    let end = start.checked_add(pk_len)?;
+    if end > doc_key.len() {
+        return None;
+    }
+    Some(&doc_key[start..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_extracts_partition_key() {
+        let pk = b"tenant=1".to_vec();
+        let ck = b"sid=1,id=1".to_vec();
+        let key = encode_doc_key(&pk, &ck);
+        assert_eq!(doc_key_partition(&key), Some(pk.as_slice()));
+    }
+
+    #[test]
+    fn distinct_clustering_yields_distinct_keys_same_partition() {
+        let pk = b"tenant=1".to_vec();
+        let a = encode_doc_key(&pk, b"id=1");
+        let b = encode_doc_key(&pk, b"id=2");
+        assert_ne!(
+            a, b,
+            "rows in the same partition must have distinct doc keys"
+        );
+        assert_eq!(doc_key_partition(&a), doc_key_partition(&b));
+    }
+
+    #[test]
+    fn empty_clustering_is_supported() {
+        // Tables with no clustering columns: full key == partition key.
+        let pk = b"pk".to_vec();
+        let key = encode_doc_key(&pk, b"");
+        assert_eq!(doc_key_partition(&key), Some(pk.as_slice()));
+    }
+
+    #[test]
+    fn legacy_partition_key_id_is_rejected() {
+        // A bare partition key (no tag) from a stale sidecar must not misparse.
+        assert_eq!(doc_key_partition(b"raw-partition-key"), None);
+        assert_eq!(doc_key_partition(&[]), None);
+    }
+}

--- a/ferrosa-index/src/fulltext/keys.rs
+++ b/ferrosa-index/src/fulltext/keys.rs
@@ -11,7 +11,7 @@
 //! portion back out (the router reads partitions by partition key, then keeps
 //! only the rows whose full key actually matched).
 //!
-//! The leading [`ROW_KEY_TAG`] byte distinguishes a row-granular key from a
+//! The leading `ROW_KEY_TAG` byte distinguishes a row-granular key from a
 //! legacy bare-partition-key id, so a stale sidecar (pre-rebuild) is detected
 //! rather than silently misparsed.
 

--- a/ferrosa-index/src/fulltext/mod.rs
+++ b/ferrosa-index/src/fulltext/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod analyzer;
 pub mod builder;
+pub mod keys;
 pub mod merge;
 pub mod query;
 pub mod reader;

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -18328,7 +18328,12 @@ mod tests {
             .unwrap();
         let result_keys: Vec<String> = results
             .iter()
-            .map(|pk| String::from_utf8_lossy(pk).to_string())
+            .filter_map(|dk| {
+                // fulltext_search returns full row-granular doc keys now; decode
+                // the partition-key portion for these partition-level assertions.
+                ferrosa_index::fulltext::keys::doc_key_partition(dk)
+                    .map(|pk| String::from_utf8_lossy(pk).to_string())
+            })
             .collect();
 
         assert!(result_keys.contains(&"r1".to_string()), "r1 has both terms");
@@ -18363,7 +18368,12 @@ mod tests {
             .unwrap();
         let result_keys: Vec<String> = results
             .iter()
-            .map(|pk| String::from_utf8_lossy(pk).to_string())
+            .filter_map(|dk| {
+                // fulltext_search returns full row-granular doc keys now; decode
+                // the partition-key portion for these partition-level assertions.
+                ferrosa_index::fulltext::keys::doc_key_partition(dk)
+                    .map(|pk| String::from_utf8_lossy(pk).to_string())
+            })
             .collect();
 
         assert_eq!(
@@ -18485,7 +18495,12 @@ mod tests {
         let after = engine.fulltext_search(&tid, "idx_body", PROBE).unwrap();
         let keys: Vec<String> = after
             .iter()
-            .map(|pk| String::from_utf8_lossy(pk).to_string())
+            .filter_map(|dk| {
+                // fulltext_search returns full row-granular doc keys now; decode
+                // the partition-key portion for these partition-level assertions.
+                ferrosa_index::fulltext::keys::doc_key_partition(dk)
+                    .map(|pk| String::from_utf8_lossy(pk).to_string())
+            })
             .collect();
         assert_eq!(
             keys,
@@ -18558,7 +18573,12 @@ mod tests {
         let hits = engine.fulltext_search(&tid, "idx_body", PROBE).unwrap();
         let keys: Vec<String> = hits
             .iter()
-            .map(|pk| String::from_utf8_lossy(pk).to_string())
+            .filter_map(|dk| {
+                // fulltext_search returns full row-granular doc keys now; decode
+                // the partition-key portion for these partition-level assertions.
+                ferrosa_index::fulltext::keys::doc_key_partition(dk)
+                    .map(|pk| String::from_utf8_lossy(pk).to_string())
+            })
             .collect();
         assert_eq!(
             keys,

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -2237,10 +2237,13 @@ impl<F: FlushTarget> TableStore<F> {
         for (index_name, col_pos) in &self.fulltext_indexes {
             let mut fti_builder = ferrosa_index::fulltext::builder::FullTextIndexBuilder::new();
             for partition in &partitions {
-                let pk_bytes = partition.key.key.as_bytes().to_vec();
-                // Extract the text value from the target column.
-                let mut text = String::new();
+                let pk_bytes = partition.key.key.as_bytes();
+                // Index ONE document PER ROW, keyed by the full primary key
+                // (partition + clustering). Indexing per-partition with the text
+                // of all rows concatenated made a hit identify only the partition,
+                // leaking non-matching clustering rows (t_da51e20c).
                 for row in &partition.rows {
+                    let mut text = String::new();
                     for (col_idx, cell) in &row.cells {
                         if *col_idx as usize == *col_pos {
                             if let Some(ref val) = cell.value {
@@ -2251,9 +2254,13 @@ impl<F: FlushTarget> TableStore<F> {
                             }
                         }
                     }
-                }
-                if !text.is_empty() {
-                    fti_builder.add_document(pk_bytes, text.trim());
+                    if !text.is_empty() {
+                        let doc_key = ferrosa_index::fulltext::keys::encode_doc_key(
+                            pk_bytes,
+                            &row.clustering,
+                        );
+                        fti_builder.add_document(doc_key, text.trim());
+                    }
                 }
             }
             match fti_builder.finish() {
@@ -4433,9 +4440,10 @@ impl<F: FlushTarget> TableStore<F> {
         let mut builder = FullTextIndexBuilder::new();
         let mut add_partitions = |partitions: Vec<Partition>| {
             for partition in partitions {
-                let pk_bytes = partition.key.key.as_bytes().to_vec();
-                let mut text = String::new();
+                let pk_bytes = partition.key.key.as_bytes();
+                // Per-row document keyed by the full primary key (t_da51e20c).
                 for row in &partition.rows {
+                    let mut text = String::new();
                     for (col_idx, cell) in &row.cells {
                         if *col_idx as usize == *col_pos {
                             if let Some(ref val) = cell.value {
@@ -4446,9 +4454,13 @@ impl<F: FlushTarget> TableStore<F> {
                             }
                         }
                     }
-                }
-                if !text.is_empty() {
-                    builder.add_document(pk_bytes, text.trim());
+                    if !text.is_empty() {
+                        let doc_key = ferrosa_index::fulltext::keys::encode_doc_key(
+                            pk_bytes,
+                            &row.clustering,
+                        );
+                        builder.add_document(doc_key, text.trim());
+                    }
                 }
             }
         };
@@ -4542,9 +4554,10 @@ impl<F: FlushTarget> TableStore<F> {
                 match iter.next_partition() {
                     Ok(Some(mut p)) => {
                         mapping.remap_partition(&mut p);
-                        let pk_bytes = p.key.key.as_bytes().to_vec();
-                        let mut text = String::new();
+                        let pk_bytes = p.key.key.as_bytes();
+                        // Per-row document keyed by the full primary key (t_da51e20c).
                         for row in &p.rows {
+                            let mut text = String::new();
                             for (col_idx, cell) in &row.cells {
                                 if *col_idx as usize == col_pos {
                                     if let Some(ref val) = cell.value {
@@ -4555,10 +4568,14 @@ impl<F: FlushTarget> TableStore<F> {
                                     }
                                 }
                             }
-                        }
-                        if !text.is_empty() {
-                            builder.add_document(pk_bytes, text.trim());
-                            any_docs = true;
+                            if !text.is_empty() {
+                                let doc_key = ferrosa_index::fulltext::keys::encode_doc_key(
+                                    pk_bytes,
+                                    &row.clustering,
+                                );
+                                builder.add_document(doc_key, text.trim());
+                                any_docs = true;
+                            }
                         }
                     }
                     Ok(None) => break,


### PR DESCRIPTION
Fixes **t_da51e20c** — and clears the red `Cluster integration tests` that #198 merged onto main (which is currently failing on **every** PR, including #199/#200).

## The bug
The FTI keyed each document by **partition key** and concatenated **every row's text** in a partition into one document. So `SELECT … WHERE tenant=1 AND sid=1 AND body = fts_match('rust')` on `PRIMARY KEY (tenant, sid, id)` returned **all** rows of partition `tenant=1` that matched the PK predicates — including `(1,1,2,'cassandra…')`, which doesn't match `'rust'` — because a hit only identified the partition and the post-filter (correctly) skips `fts_match`. Got 2, expected 1.

## The fix (option 2 — row-granular, correct by construction)
- **`ferrosa-index/fulltext/keys.rs`** — `encode_doc_key([tag][pk_len][pk][clustering])` + `doc_key_partition()`; self-describing so a legacy bare-partition-key id is detected and skipped (pending sidecar rebuild), not misparsed.
- **`ferrosa-storage/store.rs`** (3 index-build sites) — index **one document per row**, keyed by the full primary key, with that row's text only.
- **`ferrosa-cql/router.rs`** — `fulltext_search` returns full doc keys; read each distinct partition once and **keep only the rows whose full key matched**, then post-filter.
- Engine FTS tests decode the partition portion for their partition-level assertions.

## Tests
The previously-failing guard `fts_match_with_pk_predicates_returns_matches` now passes; ferrosa-index **252**, ferrosa-storage **902**, ferrosa-cql **954** (+ `--ignored` fts) all pass; clippy + fmt clean. Codec has roundtrip/legacy-rejection unit tests.

Note: existing FTI sidecars (partition-key format) are rebuilt on the next flush/compaction; until then their hits are skipped (no leak, no crash).