### PR TITLE
fix: P0 GRANT persistence across restart + actionable graph-label error

### DIFF
--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -8473,7 +8473,21 @@ async fn route_grant(
     let ddl = &**ddl_guard;
     match ddl {
         DdlPath::Direct { .. } => {
-            state.schema.grant(&s.role, &resource, perms, ctx.auth)?;
+            // In-memory apply (also emits the audit event). Then run the same
+            // persisted DDL path the Pair/Cluster arms use so the grant is
+            // written to system_auth.role_permissions and survives a restart —
+            // standalone mode otherwise only updated memory, silently losing
+            // grants on restart (t_fb280b30). grant_internal is idempotent.
+            state
+                .schema
+                .grant(&s.role, &resource, perms.clone(), ctx.auth)?;
+            ddl.execute(DdlOperation::Grant(GrantEntry {
+                role: s.role.clone(),
+                resource,
+                permissions: perms,
+            }))
+            .await
+            .map_err(CqlError::from)?;
         }
         DdlPath::Pair(coordinator) => {
             let op = DdlOperation::Grant(GrantEntry {
@@ -8520,7 +8534,21 @@ async fn route_revoke(
     let ddl = &**ddl_guard;
     match ddl {
         DdlPath::Direct { .. } => {
-            state.schema.revoke(&s.role, &resource, perms, ctx.auth)?;
+            // In-memory apply (+ audit), then persist each revoke to
+            // system_auth.role_permissions so it survives a restart — else the
+            // revoked permission silently reappears after restart (t_fb280b30).
+            state
+                .schema
+                .revoke(&s.role, &resource, perms.clone(), ctx.auth)?;
+            for perm in perms {
+                ddl.execute(DdlOperation::Revoke {
+                    role: s.role.clone(),
+                    resource: resource.clone(),
+                    permission: perm,
+                })
+                .await
+                .map_err(CqlError::from)?;
+            }
         }
         DdlPath::Pair(coordinator) => {
             // DdlOperation::Revoke carries one permission at a time; emit one
@@ -8602,11 +8630,11 @@ async fn route_grant_role(
     let ddl = &**ddl_guard;
     match ddl {
         DdlPath::Direct { .. } => {
-            if grant {
-                state.schema.grant_role_internal(&member, &role)?;
-            } else {
-                state.schema.revoke_role_internal(&member, &role)?;
-            }
+            // Route through the persisted DDL path (apply_direct) so the
+            // membership change is written to system_auth.role_members and
+            // survives a restart — Direct mode previously only updated memory,
+            // silently losing role grants on restart (t_fb280b30).
+            ddl.execute(op).await.map_err(CqlError::from)?;
         }
         DdlPath::Pair(coordinator) => {
             coordinator.coordinate_ddl(op).await?;
@@ -11637,6 +11665,10 @@ mod tests {
             memtable_num_shards: 64,
         };
         let engine = Arc::new(StorageEngine::new(engine_config, None).unwrap());
+        // Real startup registers the system tables unconditionally (main.rs:802);
+        // mirror that so the harness reflects standalone mode (system_auth.* must
+        // exist for grant persistence — t_fb280b30).
+        engine.register_system_tables().unwrap();
 
         let schema = Arc::new(
             Schema::new(SchemaConfig {
@@ -20908,6 +20940,49 @@ mod tests {
             result.is_ok(),
             "GRANT SELECT ON TABLE should succeed: {:?}",
             result.err()
+        );
+    }
+
+    /// t_fb280b30: in standalone (Direct) mode a GRANT must be written to
+    /// `system_auth.role_permissions` so it survives a restart — the startup
+    /// replay (`SystemTableLoader::replay_role_permissions_into_schema`) reads
+    /// that table. Previously Direct mode only updated in-memory state, so grants
+    /// silently vanished on restart.
+    #[tokio::test]
+    async fn grant_persists_to_storage_to_survive_restart() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+        };
+        for cql in [
+            "CREATE KEYSPACE pgks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE pgks.t (k int PRIMARY KEY, v text)",
+            "CREATE ROLE pg_user WITH PASSWORD = 'pass' AND LOGIN = true",
+            "GRANT SELECT ON pgks.t TO pg_user",
+        ] {
+            let stmt = crate::parser::parse(cql).unwrap();
+            route(&state, &ctx, stmt)
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        // Simulate a restart: flush the auth table, then read grants straight
+        // from storage via the same loader startup uses.
+        let _ = state.engine.flush(&ferrosa_storage::TableId::new(
+            "system_auth",
+            "role_permissions",
+        ));
+        let loader =
+            ferrosa_cluster::system_table_loader::SystemTableLoader::new(state.engine.clone());
+        let grants = loader.load_role_permissions().unwrap();
+        assert!(
+            grants.iter().any(|g| g.role == "pg_user"),
+            "GRANT must persist to system_auth.role_permissions to survive restart; got {grants:?}"
         );
     }
 

--- a/ferrosa-graph/src/planner/logical.rs
+++ b/ferrosa-graph/src/planner/logical.rs
@@ -87,8 +87,15 @@ pub fn resolve_label(snap: &SchemaSnapshot, keyspace: &str, label: &str) -> Resu
         }
     }
 
+    // Actionable remediation (t_2dd438d2): the bare "no table" message read like
+    // missing DDL and hid the two real causes — (a) the graph engine is disabled,
+    // or (b) the labelled table was never created.
     Err(GraphError::Validation(format!(
-        "no table with graph.label '{label}' found in keyspace '{keyspace}'"
+        "no table with graph.label '{label}' found in keyspace '{keyspace}' — \
+         create it with CREATE TABLE {keyspace}.<name> (...) WITH extensions = \
+         {{'graph.type': 'vertex' or 'edge', 'graph.label': '{label}'}}; if you \
+         intended to use graph features, also ensure the graph engine is enabled \
+         ([graph] enabled = true)"
     )))
 }
 
@@ -365,6 +372,15 @@ mod tests {
             GraphError::Validation(msg) => {
                 assert!(msg.contains("Person"));
                 assert!(msg.contains("social"));
+                // t_2dd438d2: the error must be actionable, not a bare "no table".
+                assert!(
+                    msg.contains("graph.label") && msg.contains("extensions"),
+                    "error should explain how to create the labelled table: {msg}"
+                );
+                assert!(
+                    msg.contains("enabled = true"),
+                    "error should point at the disabled-engine cause: {msg}"
+                );
             }
             other => panic!("expected Validation error, got: {other:?}"),
         }


### PR DESCRIPTION
Two P0s from the Linux setup bug reports.

## 1. `t_fb280b30` (P91) — role GRANTs lost on restart (COMPLETE)
In `DdlPath::Direct` (standalone — the default dev setup with ferrosa-memory), `route_grant`/`route_revoke`/`route_grant_role` only updated the **in-memory** schema and never wrote to `system_auth.role_permissions`/`role_members`. The Pair/Cluster paths persist via `DdlOperation`; standalone didn't — so the startup replay read an empty table and **every grant silently vanished on restart** (ferrosa-memory then reported ingest success while reads missed data).

**Fix:** the Direct arms now run the persisted DDL path (`ddl.execute(op)` → `apply_direct` → `SystemTableWriter`), mirroring Pair/Cluster. `route_grant` keeps `schema.grant()` for the in-memory + audit emit and *adds* the persist. Test harness `setup()` now registers system tables (mirrors `main.rs:802`, which does so unconditionally). Repro/regression test `grant_persists_to_storage_to_survive_restart`. **ferrosa-cql 955 tests pass.**

*Repair for existing dev clusters: re-issue any GRANTs made before this fix.*

## 2. `t_2dd438d2` (P89) — graph-label error was opaque (PARTIAL — actionable-error done)
`no table with graph.label 'X'` read like missing DDL and hid the real causes. Now the message explains how to create the labelled table **and** to set `[graph] enabled=true`. Keeps the prefix so `engine.rs:730`'s empty-match special-case still works.

**Deliberately NOT in this PR** (needs a design decision, scoped on the task): the *disabled-engine* case — when `[graph] enabled=false` the endpoints don't start, so a client gets connection-refused rather than a clear "graph engine disabled". Fixing that requires always-starting a thin endpoint that enforces `GraphConfig.enabled` (currently vestigial) + an install-time graph-enable config. I didn't rush that part.

clippy + fmt clean on both crates.