### PR TITLE
fix(sec): refuse production startup with auth disabled (t_87a50318, FMEA FE-3)

### DIFF
--- a/ferrosa-schema/src/startup.rs
+++ b/ferrosa-schema/src/startup.rs
@@ -49,6 +49,9 @@ pub enum ProductionViolation {
     EnvSecretsInProduction,
     /// The password policy does not meet minimum requirements.
     PasswordPolicyBelowMinimum,
+    /// Authentication is disabled, leaving the CQL listener and the web
+    /// `/admin/*` cluster-control API unauthenticated (FMEA FE-3).
+    AuthDisabled,
 }
 
 impl std::fmt::Display for ProductionViolation {
@@ -84,6 +87,13 @@ impl std::fmt::Display for ProductionViolation {
                     "password policy does not meet minimum production requirements"
                 )
             }
+            Self::AuthDisabled => {
+                write!(
+                    f,
+                    "authentication is disabled — the CQL listener and web /admin/* \
+                     cluster-control API are unauthenticated; set [cql] auth_enabled = true"
+                )
+            }
         }
     }
 }
@@ -103,6 +113,8 @@ pub struct ProductionCheckConfig {
     pub secrets_provider_type: String, // pragma: allowlist secret
     /// Whether the S3 endpoint allows HTTP (non-TLS) connections.
     pub s3_allow_http: bool,
+    /// Whether client/admin authentication is enabled.
+    pub auth_enabled: bool,
 }
 
 /// Validate that the configuration meets production requirements.
@@ -119,6 +131,9 @@ pub fn validate_production_requirements(
         return violations;
     }
 
+    if !config.auth_enabled {
+        violations.push(ProductionViolation::AuthDisabled);
+    }
     if !config.has_superuser_password {
         violations.push(ProductionViolation::DefaultSuperuserPassword);
     }
@@ -152,7 +167,32 @@ mod tests {
             has_superuser_password: true,
             secrets_provider_type: "aws-secrets-manager".into(), // pragma: allowlist secret
             s3_allow_http: false,
+            auth_enabled: true,
         }
+    }
+
+    #[test]
+    fn production_with_auth_disabled_is_a_violation() {
+        let mut config = passing_production_config();
+        config.auth_enabled = false;
+        let violations = validate_production_requirements(&config);
+        assert!(
+            violations
+                .iter()
+                .any(|v| matches!(v, ProductionViolation::AuthDisabled)),
+            "production mode with auth disabled must report AuthDisabled; got {violations:?}"
+        );
+    }
+
+    #[test]
+    fn development_with_auth_disabled_is_allowed() {
+        let mut config = passing_production_config();
+        config.mode = DeploymentMode::Development;
+        config.auth_enabled = false;
+        assert!(
+            validate_production_requirements(&config).is_empty(),
+            "development mode must not enforce auth"
+        );
     }
 
     #[test]
@@ -185,6 +225,7 @@ mod tests {
             has_superuser_password: false,
             secrets_provider_type: "env".into(), // pragma: allowlist secret
             s3_allow_http: true,
+            auth_enabled: true,
         };
         let violations = validate_production_requirements(&config);
         assert!(

--- a/ferrosa-schema/tests/auth_integration.rs
+++ b/ferrosa-schema/tests/auth_integration.rs
@@ -85,6 +85,7 @@ fn production_mode_rejects_default_password() {
         has_superuser_password: false,
         secrets_provider_type: "aws-sm".into(), // pragma: allowlist secret
         s3_allow_http: false,
+        auth_enabled: true,
     };
     let violations = validate_production_requirements(&config);
     assert!(violations
@@ -100,6 +101,7 @@ fn production_mode_rejects_weak_password_policy() {
         has_superuser_password: true,
         secrets_provider_type: "aws-sm".into(), // pragma: allowlist secret
         s3_allow_http: false,
+        auth_enabled: true,
     };
     let violations = validate_production_requirements(&config);
     assert!(violations
@@ -115,6 +117,7 @@ fn development_mode_allows_permissive_policy() {
         has_superuser_password: false,
         secrets_provider_type: "env".into(), // pragma: allowlist secret
         s3_allow_http: true,
+        auth_enabled: true,
     };
     let violations = validate_production_requirements(&config);
     assert!(

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -729,6 +729,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ferrosa_storage::engine::log_cql_auth_state(storage_auth_enabled, auth_source);
     ferrosa_storage::engine::log_auth_warn_state(storage_auth_enabled, storage_auth_warn);
 
+    // SEC (t_87a50318, FMEA FE-3): refuse to start a PRODUCTION node with auth
+    // disabled. A default node has auth_enabled=false, which leaves both the CQL
+    // listener and the web /admin/* cluster-control API (snapshot/restore/promote)
+    // unauthenticated — an open admin surface. Development mode stays permissive
+    // (auth-off is an explicit dev choice); production must opt IN to security.
+    if ferrosa_schema::startup::DeploymentMode::from_env()
+        == ferrosa_schema::startup::DeploymentMode::Production
+        && !storage_auth_enabled
+    {
+        eprintln!(
+            "FATAL: refusing to start — {}. Production requires authentication: set \
+             [cql] auth_enabled = true (or FERROSA_AUTH_ENABLED=true), or run in \
+             development mode (unset FERROSA_MODE=production).",
+            ferrosa_schema::startup::ProductionViolation::AuthDisabled
+        );
+        std::process::exit(1);
+    }
+
     let storage_upload_threads = std::env::var("FERROSA_STORAGE_UPLOAD_THREADS")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())


### PR DESCRIPTION
First fix in the security/correctness FMEA epic (`t_540ab67f`).

## The hole
A **default node has `auth_enabled=false`**, leaving the CQL listener **and** the web `/admin/*` cluster-control API (snapshot/restore/promote) **unauthenticated** — an open admin surface. The reporting/log-accuracy half was fixed in #176; this is the **security-posture** half.

While fixing it I also found the production security gate `validate_production_requirements` (TLS/S3/password/secrets) **had no auth check and was never called from `main.rs`** — it's dead code, never enforced.

## Fix
- Add `ProductionViolation::AuthDisabled` + the check to `validate_production_requirements`.
- `main.rs` now **refuses to start** (exit 1, clear `FATAL:` message) when `FERROSA_MODE=production` and auth is disabled. **Development mode is unchanged** (auth-off is an explicit dev choice) — only production must opt *in* to security, so no dev workflow breaks.
- Tests: `production_with_auth_disabled_is_a_violation`, `development_with_auth_disabled_is_allowed`; full ferrosa-schema startup + auth_integration suites pass; clippy + fmt clean.

## Scoped follow-ups (noted in commit)
- **Wire the full gate** into startup (currently only auth is enforced inline) — plumb real TLS/secrets/S3/password inputs so those production checks go live (part of `t_540ab67f`).
- TLS-gate stub is `t_27bf4674`.