### PR TITLE
fix(sec): wire the full production deployment gate (t_27bf4674 + extends t_87a50318)

### DIFF
--- a/ferrosa-schema/src/startup.rs
+++ b/ferrosa-schema/src/startup.rs
@@ -115,6 +115,8 @@ pub struct ProductionCheckConfig {
     pub s3_allow_http: bool,
     /// Whether client/admin authentication is enabled.
     pub auth_enabled: bool,
+    /// Whether CQL client connections require TLS (`[cql].require_tls`).
+    pub cql_require_tls: bool,
 }
 
 /// Validate that the configuration meets production requirements.
@@ -150,9 +152,26 @@ pub fn validate_production_requirements(
     {
         violations.push(ProductionViolation::PasswordPolicyBelowMinimum);
     }
-    // CQL TLS and internode TLS checks are stubs (added when those crates land)
+    if !config.cql_require_tls {
+        violations.push(ProductionViolation::CqlTlsNotConfigured);
+    }
+    // Internode TLS check remains a stub (added when that config is plumbed).
 
     violations
+}
+
+impl ProductionViolation {
+    /// Whether this violation must BLOCK startup (it is operator-fixable today)
+    /// versus only warn. Some violations describe weaknesses whose underlying
+    /// config is not operator-configurable yet (the schema's password policy and
+    /// secrets provider are currently hardcoded) — blocking on those would leave
+    /// no recourse, so they only warn until that config is plumbed.
+    pub fn blocks_startup(&self) -> bool {
+        !matches!(
+            self,
+            Self::EnvSecretsInProduction | Self::PasswordPolicyBelowMinimum
+        )
+    }
 }
 
 #[cfg(test)]
@@ -168,6 +187,7 @@ mod tests {
             secrets_provider_type: "aws-secrets-manager".into(), // pragma: allowlist secret
             s3_allow_http: false,
             auth_enabled: true,
+            cql_require_tls: true,
         }
     }
 
@@ -193,6 +213,36 @@ mod tests {
             validate_production_requirements(&config).is_empty(),
             "development mode must not enforce auth"
         );
+    }
+
+    #[test]
+    fn production_without_cql_tls_is_a_blocking_violation() {
+        let mut config = passing_production_config();
+        config.cql_require_tls = false;
+        let violations = validate_production_requirements(&config);
+        let tls = violations
+            .iter()
+            .find(|v| matches!(v, ProductionViolation::CqlTlsNotConfigured));
+        assert!(
+            tls.is_some(),
+            "production without require_tls must report CqlTlsNotConfigured; got {violations:?}"
+        );
+        assert!(
+            tls.unwrap().blocks_startup(),
+            "missing CQL TLS must block startup"
+        );
+    }
+
+    #[test]
+    fn hardcoded_weaknesses_warn_but_do_not_block() {
+        // Secrets provider + password policy are not operator-configurable yet,
+        // so they must WARN (not block) until that config is plumbed.
+        assert!(!ProductionViolation::EnvSecretsInProduction.blocks_startup());
+        assert!(!ProductionViolation::PasswordPolicyBelowMinimum.blocks_startup());
+        // The operator-fixable security requirements block startup.
+        assert!(ProductionViolation::AuthDisabled.blocks_startup());
+        assert!(ProductionViolation::CqlTlsNotConfigured.blocks_startup());
+        assert!(ProductionViolation::DefaultSuperuserPassword.blocks_startup());
     }
 
     #[test]
@@ -226,6 +276,7 @@ mod tests {
             secrets_provider_type: "env".into(), // pragma: allowlist secret
             s3_allow_http: true,
             auth_enabled: true,
+            cql_require_tls: true,
         };
         let violations = validate_production_requirements(&config);
         assert!(

--- a/ferrosa-schema/tests/auth_integration.rs
+++ b/ferrosa-schema/tests/auth_integration.rs
@@ -86,6 +86,7 @@ fn production_mode_rejects_default_password() {
         secrets_provider_type: "aws-sm".into(), // pragma: allowlist secret
         s3_allow_http: false,
         auth_enabled: true,
+        cql_require_tls: true,
     };
     let violations = validate_production_requirements(&config);
     assert!(violations
@@ -102,6 +103,7 @@ fn production_mode_rejects_weak_password_policy() {
         secrets_provider_type: "aws-sm".into(), // pragma: allowlist secret
         s3_allow_http: false,
         auth_enabled: true,
+        cql_require_tls: true,
     };
     let violations = validate_production_requirements(&config);
     assert!(violations
@@ -118,6 +120,7 @@ fn development_mode_allows_permissive_policy() {
         secrets_provider_type: "env".into(), // pragma: allowlist secret
         s3_allow_http: true,
         auth_enabled: true,
+        cql_require_tls: true,
     };
     let violations = validate_production_requirements(&config);
     assert!(

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -181,6 +181,58 @@ where
 /// `Some(true|false)` when the operator made an explicit choice in
 /// either place, `None` when they did not (so downstream resolution can
 /// fall back to the storage default).
+/// Production deployment gate (FMEA epic). In production mode (`FERROSA_MODE=
+/// production`), refuses startup when an operator-fixable security requirement
+/// is unmet — authentication disabled (`t_87a50318`), CQL TLS not required
+/// (`t_27bf4674`), or the default superuser password. Weaknesses whose config is
+/// not operator-configurable yet (the hardcoded permissive password policy and
+/// env secrets provider) only WARN — see `ProductionViolation::blocks_startup`.
+/// No-op in development mode. Calls `exit(1)` rather than returning so the gate
+/// cannot be accidentally bypassed by a `?` further up.
+fn enforce_production_requirements(
+    auth_enabled: bool,
+    cql_require_tls: bool,
+    has_superuser_password: bool,
+) {
+    use ferrosa_schema::startup::{
+        validate_production_requirements, DeploymentMode, ProductionCheckConfig,
+    };
+    let violations = validate_production_requirements(&ProductionCheckConfig {
+        mode: DeploymentMode::from_env(),
+        auth_enabled,
+        cql_require_tls,
+        has_superuser_password,
+        // The schema is hardcoded to a permissive policy + env secrets (see the
+        // SchemaConfig in main); report them truthfully so the WARN fires, but
+        // they don't block startup until that config is operator-configurable.
+        password_policy: ferrosa_schema::PasswordPolicy::permissive(),
+        secrets_provider_type: "env".to_string(),
+        s3_allow_http: false, // S3 endpoint scheme isn't surfaced here yet.
+    });
+    let (blocking, warnings): (Vec<_>, Vec<_>) =
+        violations.iter().partition(|v| v.blocks_startup());
+    for w in &warnings {
+        tracing::warn!("production config weakness (not yet enforceable): {w}");
+    }
+    if !blocking.is_empty() {
+        eprintln!("FATAL: refusing to start — production deployment requirements not met:");
+        for b in &blocking {
+            eprintln!("  - {b}");
+        }
+        eprintln!(
+            "Remediate the above (e.g. [cql] auth_enabled = true, [cql] require_tls = true, \
+             change the default superuser password), or run a development node (unset \
+             FERROSA_MODE=production)."
+        );
+        std::process::exit(1);
+    }
+}
+
+/// BUG-006: `[cql] auth_enabled = true` in TOML was silently ignored;
+/// only `FERROSA_AUTH_ENABLED=true` activated the authenticator. Returns
+/// `Some(true|false)` when the operator made an explicit choice in
+/// either place, `None` when they did not (so downstream resolution can
+/// fall back to the storage default).
 fn resolve_auth_enabled_toml<F>(file_config: &toml::Value, env: F) -> Option<bool>
 where
     F: Fn(&str) -> Option<String>,
@@ -729,23 +781,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ferrosa_storage::engine::log_cql_auth_state(storage_auth_enabled, auth_source);
     ferrosa_storage::engine::log_auth_warn_state(storage_auth_enabled, storage_auth_warn);
 
-    // SEC (t_87a50318, FMEA FE-3): refuse to start a PRODUCTION node with auth
-    // disabled. A default node has auth_enabled=false, which leaves both the CQL
-    // listener and the web /admin/* cluster-control API (snapshot/restore/promote)
-    // unauthenticated — an open admin surface. Development mode stays permissive
-    // (auth-off is an explicit dev choice); production must opt IN to security.
-    if ferrosa_schema::startup::DeploymentMode::from_env()
-        == ferrosa_schema::startup::DeploymentMode::Production
-        && !storage_auth_enabled
-    {
-        eprintln!(
-            "FATAL: refusing to start — {}. Production requires authentication: set \
-             [cql] auth_enabled = true (or FERROSA_AUTH_ENABLED=true), or run in \
-             development mode (unset FERROSA_MODE=production).",
-            ferrosa_schema::startup::ProductionViolation::AuthDisabled
-        );
-        std::process::exit(1);
-    }
+    // SEC (FMEA epic): the production deployment gate (auth, CQL TLS, default
+    // superuser password, …) runs as `enforce_production_requirements` once the
+    // CQL TLS config is resolved below — it needs `cql_require_tls` and `schema`.
 
     let storage_upload_threads = std::env::var("FERROSA_STORAGE_UPLOAD_THREADS")
         .ok()
@@ -1212,6 +1250,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "cql",
         "require_tls",
         "false",
+    );
+
+    // SEC (FMEA epic: t_87a50318 auth + t_27bf4674 TLS): refuse to start a
+    // production node that fails an operator-fixable security requirement. Runs
+    // before any listener binds. No-op in development mode.
+    enforce_production_requirements(
+        storage_auth_enabled,
+        cql_require_tls == "true" || cql_require_tls == "1",
+        !ferrosa_schema::auth::bootstrap::admin_password_is_default(&schema),
     );
     let cql_max_connections: usize = config_val(
         "FERROSA_CQL_MAX_CONNECTIONS",


### PR DESCRIPTION
Third fix in the security FMEA epic (`t_540ab67f`). **Stacked on #203** — retarget to main once #203 merges.

## What was wrong
`validate_production_requirements` (TLS / S3 / password / secrets) **was never called from `main.rs`** — dead code. #203 enforced only auth, inline. And the CQL-TLS check was a **stub** (`t_27bf4674`).

## Fix
- **`enforce_production_requirements()`** runs at startup before any listener binds (no-op in dev). Refuses to start (exit 1, itemized `FATAL:`) on any blocking violation. Replaces #203's inline auth check with the real gate.
- **CQL-TLS check implemented** (`t_27bf4674`): production + `!require_tls` → `CqlTlsNotConfigured`.
- **Honest blocking/warn split** (`ProductionViolation::blocks_startup`): **auth, CQL TLS, default-superuser-password BLOCK** (operator-fixable today); **env-secrets + password-policy only WARN** — the schema hardcodes a permissive policy + env secrets, so *blocking* on them would leave operators no recourse. They're surfaced loudly until that config is plumbed.

## Tests
production-without-TLS blocks; blocking/warn split; existing auth/superuser/secrets/password cases. ferrosa-schema **14 startup + 6 integration pass**; ferrosa builds; clippy + fmt clean.

## Follow-ups (noted in commit)
- Make `password_policy` + secrets provider operator-configurable, then flip them to blocking.
- Internode-TLS check still a stub.