### PR TITLE
feat(postgres): real BEGIN/COMMIT/ROLLBACK atomicity via Accord (PG-1)

### DIFF
--- a/ferrosa-postgres/README.md
+++ b/ferrosa-postgres/README.md
@@ -19,8 +19,9 @@ byte-identically over CQL — without `ferrosa-postgres` ever depending on the
 ~54k-LOC `ferrosa-cql` crate.
 
 This is a **developer preview**. See [specs/fmea.md](specs/fmea.md) for the exact
-supported-vs-not surface (key gaps: `$N` params in DML, `RETURNING`, `ON
-CONFLICT`, and real transaction atomicity via Accord are all still in progress).
+supported-vs-not surface (key gaps: `$N` params in DML, `RETURNING`, and `ON
+CONFLICT` are still in progress; transaction atomicity via Accord is now wired —
+see below).
 
 ## What's implemented
 
@@ -40,15 +41,25 @@ CONFLICT`, and real transaction atomicity via Accord are all still in progress).
   parameter type inference (`ParameterDescription`), text + binary parameter and
   result encodings, and Postgres error-skip-until-`Sync` semantics. **Only
   `SELECT`** (and no-`FROM` expression selects) can be prepared.
-- **Transaction protocol state** — `BEGIN`/`COMMIT`/`ROLLBACK` drive the
-  `ReadyForQuery` status byte `I`/`T`/`E`; an error inside a block aborts it
-  (`T → E`) and only `COMMIT`/`ROLLBACK` are then accepted (`25P02`). **Atomicity
-  is not yet real** — the front-end commit seam is wired but writes are not yet
-  routed through Accord (blueprint D11).
+- **Transaction atomicity via Accord** (FMEA PG-1) — `BEGIN`/`COMMIT`/`ROLLBACK`
+  drive the `ReadyForQuery` status byte `I`/`T`/`E`, and DML inside an open `T`
+  block is **buffered** as a `ferrosa_storage::accord::TransactionWrite` instead
+  of applied (`apply_or_buffer` in `query.rs`). `COMMIT` drives the whole
+  write-set through the injected `TransactionCommitter` as one atomic multi-key
+  Accord transaction (`commit_txn` in `server.rs`); `ROLLBACK` discards the
+  buffer so the writes are **never applied**. Fail-loud: a statement that errors
+  inside a block poisons it (`T → E`, only `COMMIT`/`ROLLBACK` accepted, `25P02`);
+  in standalone mode (no committer) a `COMMIT` carrying buffered DML fails loud
+  (`0A000`, cluster mode required) rather than faking atomicity; an empty
+  write-set commits cleanly. The buffer is capped at `MAX_TXN_WRITES` (10 000).
+  This mirrors the CQL `CqlTransaction` path. *Not yet:* read-your-writes inside
+  the open block (buffered writes are not visible to in-transaction reads).
 - **DML execution** — INSERT/UPDATE/DELETE build storage rows through the shared
-  `ferrosa-row-bridge` encoder and `engine.write_atomic_batch`. UPDATE/DELETE are
-  Cassandra-style blind upserts/tombstones keyed by a full-primary-key equality
-  `WHERE` (reported as `UPDATE 1` / `DELETE 1`).
+  `ferrosa-row-bridge` encoder. **Autocommit** (no open transaction) applies
+  immediately via `engine.write_atomic_batch`; **inside a transaction** the write
+  is buffered (see above). UPDATE/DELETE are Cassandra-style blind
+  upserts/tombstones keyed by a full-primary-key equality `WHERE` (reported as
+  `UPDATE 1` / `DELETE 1`).
 - **`pg_catalog` projection** — `catalog` projects `pg_namespace`/`pg_class`/
   `pg_attribute`/`pg_type` from live schema metadata with deterministic OIDs.
 - **TCP server** — `serve` / `QueryContext`: one spawned task per connection over
@@ -66,7 +77,10 @@ shared `ferrosa_row_bridge::partition_to_rows_with_storage_mapping`) into an
 **Write (`INSERT`/`UPDATE`/`DELETE`):** parse → resolve each value to a
 `CqlValue` by the column's CQL type (`value_to_cql`) → `build_decorated_key` +
 `build_row`/`build_delete_row` (the SAME `ferrosa-row-bridge` encoder CQL uses) →
-`engine.write_atomic_batch` → `CommandComplete`.
+build a `Mutation` → `apply_or_buffer`: **autocommit** →
+`engine.write_atomic_batch` and `CommandComplete`; **in a transaction** →
+serialize the `Mutation` into a buffered `TransactionWrite` (applied later by the
+committer on `COMMIT`) and `CommandComplete`.
 
 See [specs/data-flow.md](specs/data-flow.md) for the sequence diagrams.
 

--- a/ferrosa-postgres/specs/data-flow.md
+++ b/ferrosa-postgres/specs/data-flow.md
@@ -91,7 +91,10 @@ Notes:
   `WHERE` identifies the row; `UPDATE` writes regular/static cells (blind
   upsert), `DELETE` writes a row-level tombstone (`build_delete_row`). Both
   report `1` because the Cassandra-style write has no match count.
-- Inside a `BEGIN`/`COMMIT` block the write currently applies immediately — the
-  Accord commit seam exists but is not yet wired (see [fmea.md](fmea.md) PG-1).
+- Autocommit (no open transaction) applies immediately via `write_atomic_batch`,
+  as drawn above. Inside a `BEGIN`/`COMMIT` block the write is instead BUFFERED
+  as a `TransactionWrite` (`apply_or_buffer`) and the whole write-set is applied
+  atomically through the Accord `TransactionCommitter` on `COMMIT` (`commit_txn`);
+  `ROLLBACK` discards the buffer (never applied). See [fmea.md](fmea.md) PG-1.
 - The encoder is the single canonical `ferrosa-row-bridge` codec, so the row is
   byte-identical whether written via Postgres or CQL (no second encoder, D10).

--- a/ferrosa-postgres/specs/fmea.md
+++ b/ferrosa-postgres/specs/fmea.md
@@ -45,7 +45,7 @@ actual code (`src/query.rs`, `src/server.rs`, `src/storage_provider.rs`,
 
 | ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
 |----|--------------|--------|---|---|---|-----|---------------------|
-| PG-1 | **Transaction atomicity is not real** — `BEGIN`/`COMMIT` move the `I`/`T`/`E` status but the commit seam has an empty write-set; DML inside a block applies immediately and is not rolled back by `ROLLBACK` | A driver in a transaction sees PG-shaped status bytes but writes are NOT atomic/isolated — partial visibility / no rollback (silent correctness gap if a client relies on it) | 9 | 5 | 7 | 315 | **Open, top gap.** Accord commit seam is wired (`execute_simple`, blueprint D11) but writes are not yet accumulated/committed through Accord. Simple `SELECT 1` txn path is exercised; DML-in-txn atomicity is NOT. Document loudly as preview. |
+| PG-1 | **Transaction atomicity is not real** — `BEGIN`/`COMMIT` move the `I`/`T`/`E` status but the commit seam has an empty write-set; DML inside a block applies immediately and is not rolled back by `ROLLBACK` | A driver in a transaction sees PG-shaped status bytes but writes are NOT atomic/isolated — partial visibility / no rollback (silent correctness gap if a client relies on it) | 9 | 2 | 2 | 36 | **Implemented.** DML inside an open `T` block now BUFFERS as a `ferrosa_storage::accord::TransactionWrite` (`apply_or_buffer` in `query.rs`); `COMMIT` drives the whole write-set through the injected `TransactionCommitter` atomically (`commit_txn` in `server.rs`), `ROLLBACK`/`end_txn` discards the buffer (never applied). No committer (standalone) ⇒ COMMIT of a non-empty buffer fails loud (`0A000`); empty buffer commits cleanly. Write-set capped at `MAX_TXN_WRITES`. Autocommit unchanged. Mirrors the CQL `CqlTransaction` path. Tests: `server::txn_atomicity_tests`, `query::txn_buffer_tests`. |
 | PG-2 | **`$N` params unsupported in DML** — `INSERT`/`UPDATE`/`DELETE` with a `ScalarValue::Param` fail loud `0A000` | Every parameterized write from a real driver (the common path) is rejected; only literal DML works | 7 | 8 | 2 | 112 | Fail-loud `0A000` (no silent wrong write). `SELECT` params DO work via the extended path; extending inference to DML is roadmap Now. |
 | PG-3 | **No `RETURNING` / `ON CONFLICT`** — parser/executor do not accept them | ORMs/`INSERT ... RETURNING id` patterns fail | 6 | 7 | 2 | 84 | Fail-loud at parse (`42601`) — never a wrong row. Roadmap Next. |
 | PG-4 | **Lossy CQL→Value: `Duration`/collections read as NULL** | A `SELECT` over a table with a duration/list/map column silently shows NULL for that column | 6 | 4 | 6 | 144 | Documented in `storage_provider::cql_to_value` (code comment, never a panic). Detectable only by inspection — no error is raised. Widen `Value` (roadmap Later). |
@@ -58,10 +58,11 @@ actual code (`src/query.rs`, `src/server.rs`, `src/storage_provider.rs`,
 
 ## Top risks to act on
 
-1. **PG-1 (RPN 315)** — transaction atomicity is the single most consequential
-   gap: the protocol *looks* transactional but writes are not yet Accord-backed.
-   Either wire the Accord commit seam or document the preview limitation
-   prominently so no client relies on rollback/isolation.
+1. ~~**PG-1 (RPN 315)** — transaction atomicity~~ **RESOLVED.** DML in a `T`
+   block now buffers and commits atomically through Accord (`commit_txn`);
+   `ROLLBACK` discards the buffer; no-committer COMMIT of a non-empty buffer
+   fails loud. Re-scored to RPN 36 (residual: real isolation/MVCC semantics
+   beyond atomic multi-key apply are still future work).
 2. **PG-4 (RPN 144)** — lossy-NULL for `Duration`/collections is undetectable at
    runtime (no error). Make these fail loud where queried, or widen `Value`.
 3. **PG-2 (RPN 112)** — `$N` params in DML block the most common write path from

--- a/ferrosa-postgres/specs/overview.md
+++ b/ferrosa-postgres/specs/overview.md
@@ -8,9 +8,11 @@ executive_summary: >
   and lowers SQL onto the bespoke ferrosa-sql relational engine over live
   ferrosa storage. SELECT (incl. one JOIN) and single-row INSERT/UPDATE/DELETE
   are supported; it shares the storage row codec with CQL via ferrosa-row-bridge
-  (D10) and is differential-tested against real PostgreSQL 16. Developer preview:
-  $N params in DML, RETURNING, ON CONFLICT, and Accord-backed transaction
-  atomicity are still in progress.
+  (D10) and is differential-tested against real PostgreSQL 16. DML in a
+  BEGIN/COMMIT block buffers and commits atomically through Accord (FMEA PG-1);
+  ROLLBACK discards the buffer. Developer preview: $N params in DML, RETURNING,
+  and ON CONFLICT are still in progress, as is read-your-writes inside an open
+  transaction.
 ---
 
 # ferrosa-postgres — Architecture Overview

--- a/ferrosa-postgres/specs/roadmap.md
+++ b/ferrosa-postgres/specs/roadmap.md
@@ -13,10 +13,14 @@ Sourced from in-code fail-loud `0A000`/preview gaps, the FMEA
 
 ## Now (highest value)
 
-- **Accord-backed transaction atomicity** (FMEA PG-1). Accumulate a `T`-block's
-  writes and commit them through Accord at `COMMIT` (the seam in
-  `execute_simple` / blueprint D11), with real `ROLLBACK`. Until then, document
-  the preview limitation prominently so no client relies on isolation/rollback.
+- ~~**Accord-backed transaction atomicity** (FMEA PG-1)~~ **DONE.** DML in a
+  `T` block buffers as a `TransactionWrite` (`apply_or_buffer`) and `COMMIT`
+  drives the write-set through the injected `TransactionCommitter` atomically
+  (`commit_txn`); `ROLLBACK` discards the buffer (never applied). No committer
+  (standalone) ⇒ COMMIT of a non-empty buffer fails loud; empty buffer commits
+  cleanly. Mirrors the CQL `CqlTransaction` path. *Residual (future):* true
+  snapshot isolation / read-your-writes inside the open block — buffered writes
+  are not visible to reads in the same transaction yet.
 - **`$N` parameters in DML** (FMEA PG-2). Extend the extended-protocol path so
   `INSERT`/`UPDATE`/`DELETE` accept bound parameters (today literal-only,
   `0A000`). Reuse `decode_param` + the existing `$N` inference.

--- a/ferrosa-postgres/src/extended.rs
+++ b/ferrosa-postgres/src/extended.rs
@@ -71,6 +71,11 @@ pub struct Session {
     /// (`I`/`T`/`E`). Entering a `T` block is the trigger to route the
     /// transaction's writes through Accord once DML lands (blueprint D11).
     txn: TransactionStatus,
+    /// Buffered DML write-set for the open `BEGIN`/`COMMIT` block. DML inside a
+    /// transaction is BUFFERED here instead of applied; `COMMIT` drives the whole
+    /// set through the Accord committer atomically; `ROLLBACK`/`end_txn` clears it
+    /// so a discarded transaction never touches storage (FMEA PG-1).
+    txn_writes: Vec<ferrosa_storage::accord::TransactionWrite>,
 }
 
 /// The format code (0 text / 1 binary) for parameter `i` under the Bind fan-out
@@ -136,17 +141,34 @@ impl Session {
         matches!(self.txn, TransactionStatus::Failed)
     }
 
-    /// `BEGIN`: enter a transaction block. A `BEGIN` while already in one keeps
-    /// the session in-transaction (PG warns but stays `T`).
+    /// `BEGIN`: enter a transaction block and start a fresh empty write-set. A
+    /// `BEGIN` while already in one keeps the session in-transaction (PG warns
+    /// but stays `T`) and clears any buffered writes.
     pub fn begin_txn(&mut self) {
+        self.txn_writes.clear();
         if matches!(self.txn, TransactionStatus::Idle) {
             self.txn = TransactionStatus::InTransaction;
         }
     }
 
-    /// `COMMIT`/`ROLLBACK`: leave the transaction block, back to idle.
+    /// `COMMIT`/`ROLLBACK`: leave the transaction block, back to idle, and drop
+    /// the buffered write-set. After `end_txn` no buffered write survives, so a
+    /// rolled-back (or committed) transaction never re-applies on the next one.
     pub fn end_txn(&mut self) {
         self.txn = TransactionStatus::Idle;
+        self.txn_writes.clear();
+    }
+
+    /// Mutable handle to the open transaction's buffered write-set, for the DML
+    /// path to push a `TransactionWrite` into while in a `T` block.
+    pub fn txn_writes_mut(&mut self) -> &mut Vec<ferrosa_storage::accord::TransactionWrite> {
+        &mut self.txn_writes
+    }
+
+    /// Drain the buffered write-set, leaving it empty. Used by `COMMIT` to hand
+    /// the whole set to the Accord committer.
+    pub fn take_txn_writes(&mut self) -> Vec<ferrosa_storage::accord::TransactionWrite> {
+        std::mem::take(&mut self.txn_writes)
     }
 
     /// An error while executing a statement inside a transaction aborts it

--- a/ferrosa-postgres/src/query.rs
+++ b/ferrosa-postgres/src/query.rs
@@ -685,6 +685,7 @@ pub async fn execute_query(
     schema: &Schema,
     sql: &str,
     default_schema: &str,
+    txn: Option<&mut Vec<ferrosa_storage::accord::TransactionWrite>>,
 ) -> Vec<BackendMessage> {
     // 1. Parse the top-level statement.
     let stmt = match parse_statement(sql) {
@@ -722,10 +723,65 @@ pub async fn execute_query(
             "0A000",
             "SET/RESET session statements are not yet implemented",
         )],
-        // DML: single-row INSERT / UPDATE / DELETE write through the engine.
-        Statement::Insert(ins) => execute_insert(engine, schema, &ins, default_schema),
-        Statement::Update(upd) => execute_update(engine, schema, &upd, default_schema),
-        Statement::Delete(del) => execute_delete(engine, schema, &del, default_schema),
+        // DML: single-row INSERT / UPDATE / DELETE. With `txn = Some(buffer)`
+        // (an open transaction) the write is BUFFERED as a `TransactionWrite`
+        // and committed atomically via Accord on COMMIT; with `txn = None`
+        // (autocommit) it applies immediately via `write_atomic_batch`.
+        Statement::Insert(ins) => execute_insert(engine, schema, &ins, default_schema, txn),
+        Statement::Update(upd) => execute_update(engine, schema, &upd, default_schema, txn),
+        Statement::Delete(del) => execute_delete(engine, schema, &del, default_schema, txn),
+    }
+}
+
+/// Max DML writes buffered in one Postgres transaction before it is rejected.
+/// A client must not be able to OOM the server with an unbounded open `BEGIN`
+/// (Power-of-10 Rule 3: every server-side dynamic collection has a hard cap).
+/// Mirrors `ferrosa_cql::session::MAX_TXN_WRITES`.
+const MAX_TXN_WRITES: usize = 10_000;
+
+/// Buffer a built `Mutation` as a [`TransactionWrite`] into the open
+/// transaction's write-set, or apply it immediately via `write_atomic_batch`
+/// when there is no open transaction (autocommit).
+///
+/// FAIL LOUD: when buffering, exceeding [`MAX_TXN_WRITES`] returns an error
+/// response (and the server poisons the transaction) rather than growing the
+/// buffer without bound; a buffered write is NEVER applied to storage here —
+/// only the Accord committer applies it on COMMIT.
+fn apply_or_buffer(
+    engine: &StorageEngine,
+    txn: Option<&mut Vec<ferrosa_storage::accord::TransactionWrite>>,
+    key: &ferrosa_common::DecoratedKey,
+    mutation: Mutation,
+    ok_tag: &str,
+) -> Vec<BackendMessage> {
+    match txn {
+        Some(buffer) => {
+            if buffer.len() >= MAX_TXN_WRITES {
+                return vec![error_response(
+                    "53400",
+                    &format!(
+                        "transaction write-set exceeds the {MAX_TXN_WRITES}-write limit; \
+                         ROLLBACK required"
+                    ),
+                )];
+            }
+            let mut mutation_bytes = vec![0u8; mutation.serialized_size()];
+            mutation.serialize_into(&mut mutation_bytes);
+            buffer.push(ferrosa_storage::accord::TransactionWrite {
+                keyspace: mutation.keyspace.clone(),
+                key: key.key.as_bytes().to_vec(),
+                mutation: mutation_bytes,
+            });
+            vec![BackendMessage::CommandComplete {
+                tag: ok_tag.to_string(),
+            }]
+        }
+        None => match engine.write_atomic_batch(vec![mutation]) {
+            Ok(()) => vec![BackendMessage::CommandComplete {
+                tag: ok_tag.to_string(),
+            }],
+            Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
+        },
     }
 }
 
@@ -791,6 +847,7 @@ fn execute_insert(
     schema: &Schema,
     ins: &InsertStmt,
     default_schema: &str,
+    txn: Option<&mut Vec<ferrosa_storage::accord::TransactionWrite>>,
 ) -> Vec<BackendMessage> {
     use std::collections::HashMap;
 
@@ -893,16 +950,11 @@ fn execute_insert(
     let mutation = Mutation::new(
         ks.to_string(),
         ins.table.table.clone(),
-        key,
+        key.clone(),
         vec![row],
         timestamp,
     );
-    match engine.write_atomic_batch(vec![mutation]) {
-        Ok(()) => vec![BackendMessage::CommandComplete {
-            tag: "INSERT 0 1".to_string(),
-        }],
-        Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
-    }
+    apply_or_buffer(engine, txn, &key, mutation, "INSERT 0 1")
 }
 
 /// Resolve a `(column, value)` pair from a DML statement to its `CqlValue`,
@@ -954,6 +1006,7 @@ fn execute_update(
     schema: &Schema,
     upd: &UpdateStmt,
     default_schema: &str,
+    txn: Option<&mut Vec<ferrosa_storage::accord::TransactionWrite>>,
 ) -> Vec<BackendMessage> {
     use std::collections::HashMap;
 
@@ -1047,13 +1100,14 @@ fn execute_update(
         Err(e) => return vec![error_response("22000", &e.to_string())],
     };
     let row = ferrosa_row_bridge::build_row(&regular_cells, &ck_values, timestamp, None);
-    let mutation = Mutation::new(ks.to_string(), table.to_string(), key, vec![row], timestamp);
-    match engine.write_atomic_batch(vec![mutation]) {
-        Ok(()) => vec![BackendMessage::CommandComplete {
-            tag: "UPDATE 1".to_string(),
-        }],
-        Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
-    }
+    let mutation = Mutation::new(
+        ks.to_string(),
+        table.to_string(),
+        key.clone(),
+        vec![row],
+        timestamp,
+    );
+    apply_or_buffer(engine, txn, &key, mutation, "UPDATE 1")
 }
 
 /// Execute a single-row `DELETE`: a row-level tombstone. The equality `WHERE`
@@ -1065,6 +1119,7 @@ fn execute_delete(
     schema: &Schema,
     del: &DeleteStmt,
     default_schema: &str,
+    txn: Option<&mut Vec<ferrosa_storage::accord::TransactionWrite>>,
 ) -> Vec<BackendMessage> {
     use std::collections::HashMap;
 
@@ -1134,13 +1189,14 @@ fn execute_delete(
     };
     // Empty delete-columns => row-level tombstone.
     let row = ferrosa_row_bridge::build_delete_row(&[], &ck_values, timestamp);
-    let mutation = Mutation::new(ks.to_string(), table.to_string(), key, vec![row], timestamp);
-    match engine.write_atomic_batch(vec![mutation]) {
-        Ok(()) => vec![BackendMessage::CommandComplete {
-            tag: "DELETE 1".to_string(),
-        }],
-        Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
-    }
+    let mutation = Mutation::new(
+        ks.to_string(),
+        table.to_string(),
+        key.clone(),
+        vec![row],
+        timestamp,
+    );
+    apply_or_buffer(engine, txn, &key, mutation, "DELETE 1")
 }
 
 /// Evaluate a no-`FROM` expression SELECT (`SELECT 1`, `SELECT version()`,
@@ -1923,5 +1979,316 @@ mod tests {
             alias: None,
         }];
         assert!(execute_scalar_select(&items, "ks").is_err());
+    }
+}
+
+/// Transaction-buffer correctness (FMEA PG-1): DML in a `BEGIN`/`COMMIT` block
+/// must BUFFER as an Accord `TransactionWrite` instead of applying to storage;
+/// only the committer applies it. These run a real local `StorageEngine` (temp
+/// dir, no S3/Docker/cluster) and read back via the same `execute_query` path.
+#[cfg(test)]
+mod txn_buffer_tests {
+    use super::*;
+    use ferrosa_schema::{
+        AuthContext, AuthMethod, ClusteringOrder, ColumnKind, ColumnMetadata, DeploymentMode,
+        EnvSecretsProvider, KeyspaceMetadata, PasswordHasher, PasswordPolicy, RateLimitConfig,
+        ReplicationParams, Schema, SchemaConfig, TableMetadata, TableParams, TestAuditSink,
+    };
+    use ferrosa_storage::{
+        CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+    };
+    use indexmap::IndexMap;
+    use std::collections::{HashMap, HashSet};
+    use std::path::Path;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    fn schema_config() -> SchemaConfig {
+        SchemaConfig {
+            hasher: PasswordHasher::Bcrypt { cost: 4 },
+            password_policy: PasswordPolicy::permissive(),
+            auth_method: AuthMethod::Password,
+            rate_limit: RateLimitConfig::default(),
+            audit_sink: Box::new(TestAuditSink::new()),
+            secrets: Box::new(EnvSecretsProvider),
+            mode: DeploymentMode::Development,
+        }
+    }
+
+    fn superuser() -> AuthContext {
+        AuthContext {
+            role: "cassandra".to_string(),
+            is_superuser: true,
+            must_change_password: false,
+        }
+    }
+
+    fn column(name: &str, kind: ColumnKind, ty: &str) -> ColumnMetadata {
+        ColumnMetadata {
+            name: name.to_string(),
+            kind,
+            position: 0,
+            column_type: ty.to_string(),
+            clustering_order: ClusteringOrder::None,
+            mask: None,
+        }
+    }
+
+    /// Schema with keyspace `public` and table `kv(k text PK, v text)`.
+    fn schema_with_kv() -> Schema {
+        let schema = Schema::new(schema_config()).expect("schema bootstraps");
+        let auth = superuser();
+        schema
+            .create_keyspace(
+                KeyspaceMetadata {
+                    name: "public".to_string(),
+                    durable_writes: true,
+                    replication: ReplicationParams {
+                        strategy: "SimpleStrategy".to_string(),
+                        options: {
+                            let mut o = HashMap::new();
+                            o.insert("replication_factor".to_string(), "1".to_string());
+                            o
+                        },
+                    },
+                },
+                &auth,
+            )
+            .expect("create keyspace public");
+        let mut cols = IndexMap::new();
+        cols.insert(
+            "k".to_string(),
+            column("k", ColumnKind::PartitionKey, "text"),
+        );
+        cols.insert("v".to_string(), column("v", ColumnKind::Regular, "text"));
+        schema
+            .create_table(
+                TableMetadata {
+                    keyspace: "public".to_string(),
+                    name: "kv".to_string(),
+                    id: Uuid::new_v4(),
+                    columns: cols,
+                    partition_key: vec!["k".to_string()],
+                    clustering_key: vec![],
+                    params: TableParams::default(),
+                    flags: HashSet::new(),
+                    extensions: HashMap::new(),
+                    is_system: false,
+                },
+                &auth,
+            )
+            .expect("create table kv");
+        schema
+    }
+
+    fn engine_config(dir: &Path) -> StorageEngineConfig {
+        StorageEngineConfig {
+            commit_log: CommitLogConfig {
+                segment_size: 256 * 1024,
+                max_segment_age: Duration::from_secs(60),
+                sync_strategy: SyncStrategyConfig::Batch,
+                batch: Default::default(),
+                log_dir: dir.join("commitlog"),
+                checkpoint_dir: dir.join("commitlog"),
+                archive: None,
+            },
+            compaction: CompactionConfig::from_env(dir.join("compaction")),
+            object_store: None,
+            local_cache_max_bytes: 1024 * 1024,
+            local_disk_free_reserve_bytes: 0,
+            flush_threshold_bytes: 4096,
+            memtable_backpressure_bytes: u64::MAX,
+            flush_max_age_secs: 5,
+            data_dir: dir.to_path_buf(),
+            index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+            auth_enabled: false,
+            auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
+            memtable_num_shards: 64,
+            write_verify: false,
+        }
+    }
+
+    fn kv_storage_schema() -> ferrosa_common::schema::TableSchema {
+        use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+        TableSchema {
+            keyspace: "public".to_string(),
+            table: "kv".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "v".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: Default::default(),
+        }
+    }
+
+    /// How many `kv` rows whose `k` equals `key` are visible in storage, read
+    /// back through the SAME `execute_query` SELECT path the front-end serves.
+    async fn row_count(engine: &StorageEngine, schema: &Schema, key: &str) -> usize {
+        let msgs = execute_query(
+            engine,
+            schema,
+            &format!("SELECT k FROM kv WHERE k = '{key}'"),
+            "public",
+            None,
+        )
+        .await;
+        assert!(
+            !msgs
+                .iter()
+                .any(|m| matches!(m, BackendMessage::ErrorResponse { .. })),
+            "read-back SELECT failed: {msgs:?}"
+        );
+        msgs.iter()
+            .filter(|m| matches!(m, BackendMessage::DataRow { .. }))
+            .count()
+    }
+
+    async fn new_engine_and_schema() -> (tempfile::TempDir, StorageEngine, Schema) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = StorageEngine::new(engine_config(dir.path()), None).unwrap();
+        engine.register_table(kv_storage_schema()).unwrap();
+        let schema = schema_with_kv();
+        (dir, engine, schema)
+    }
+
+    #[tokio::test]
+    async fn buffered_insert_is_not_applied_until_committer() {
+        // An INSERT with `txn = Some(buffer)` is BUFFERED, never written to
+        // storage. Contrast: an autocommit INSERT (`txn = None`) IS written.
+        let (_dir, engine, schema) = new_engine_and_schema().await;
+
+        // Buffered: must NOT touch storage.
+        let mut buffer: Vec<ferrosa_storage::accord::TransactionWrite> = Vec::new();
+        let msgs = execute_query(
+            &engine,
+            &schema,
+            "INSERT INTO kv (k, v) VALUES ('a', 'buffered')",
+            "public",
+            Some(&mut buffer),
+        )
+        .await;
+        assert!(
+            matches!(&msgs[..], [BackendMessage::CommandComplete { tag }] if tag == "INSERT 0 1"),
+            "buffered INSERT still acks INSERT 0 1: {msgs:?}"
+        );
+        assert_eq!(
+            buffer.len(),
+            1,
+            "the write was buffered as a TransactionWrite"
+        );
+        assert_eq!(buffer[0].keyspace, "public");
+        assert!(
+            !buffer[0].mutation.is_empty() && !buffer[0].key.is_empty(),
+            "the buffered write carries encoded key + mutation bytes"
+        );
+        assert_eq!(
+            row_count(&engine, &schema, "a").await,
+            0,
+            "a BUFFERED write must NOT be visible in storage (FMEA PG-1)"
+        );
+
+        // Autocommit: IS applied immediately.
+        let msgs = execute_query(
+            &engine,
+            &schema,
+            "INSERT INTO kv (k, v) VALUES ('b', 'autocommit')",
+            "public",
+            None,
+        )
+        .await;
+        assert!(
+            matches!(&msgs[..], [BackendMessage::CommandComplete { tag }] if tag == "INSERT 0 1"),
+            "autocommit INSERT acks: {msgs:?}"
+        );
+        assert_eq!(
+            row_count(&engine, &schema, "b").await,
+            1,
+            "an autocommit write IS applied immediately"
+        );
+
+        engine.shutdown().unwrap();
+    }
+
+    #[tokio::test]
+    async fn applying_a_buffered_write_set_makes_it_visible() {
+        // The committer's job: apply the buffered mutation. Here we apply the
+        // buffered TransactionWrite's mutation bytes through the engine exactly
+        // as the cluster committer's apply path does, proving the buffered bytes
+        // are a faithful, applyable mutation (not a fake ack).
+        let (_dir, engine, schema) = new_engine_and_schema().await;
+
+        let mut buffer: Vec<ferrosa_storage::accord::TransactionWrite> = Vec::new();
+        execute_query(
+            &engine,
+            &schema,
+            "INSERT INTO kv (k, v) VALUES ('c', 'committed')",
+            "public",
+            Some(&mut buffer),
+        )
+        .await;
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(
+            row_count(&engine, &schema, "c").await,
+            0,
+            "buffered, not yet applied"
+        );
+
+        // Apply the buffered mutation (what the committer does on COMMIT).
+        let mutation = Mutation::deserialize_from(&buffer[0].mutation).expect("decode mutation");
+        engine.write_atomic_batch(vec![mutation]).expect("apply");
+        assert_eq!(
+            row_count(&engine, &schema, "c").await,
+            1,
+            "after the committer applies the buffered write-set the row is visible"
+        );
+
+        engine.shutdown().unwrap();
+    }
+
+    #[tokio::test]
+    async fn buffer_respects_write_cap() {
+        // Staging past MAX_TXN_WRITES fails loud (53400) rather than growing the
+        // buffer without bound; nothing is applied to storage.
+        let (_dir, engine, schema) = new_engine_and_schema().await;
+        let mut buffer: Vec<ferrosa_storage::accord::TransactionWrite> =
+            Vec::with_capacity(MAX_TXN_WRITES);
+        // Pre-fill to the cap with dummy writes so the next stage trips it.
+        for _ in 0..MAX_TXN_WRITES {
+            buffer.push(ferrosa_storage::accord::TransactionWrite {
+                keyspace: "public".to_string(),
+                key: b"x".to_vec(),
+                mutation: b"x".to_vec(),
+            });
+        }
+        let msgs = execute_query(
+            &engine,
+            &schema,
+            "INSERT INTO kv (k, v) VALUES ('over', 'cap')",
+            "public",
+            Some(&mut buffer),
+        )
+        .await;
+        match &msgs[..] {
+            [BackendMessage::ErrorResponse { fields }] => {
+                assert_eq!(fields[1], (b'C', "53400".to_string()));
+            }
+            other => panic!("expected a fail-loud cap ErrorResponse, got {other:?}"),
+        }
+        assert_eq!(
+            buffer.len(),
+            MAX_TXN_WRITES,
+            "the over-cap write was NOT buffered"
+        );
+        assert_eq!(
+            row_count(&engine, &schema, "over").await,
+            0,
+            "an over-cap write is never applied to storage"
+        );
+
+        engine.shutdown().unwrap();
     }
 }

--- a/ferrosa-postgres/src/server.rs
+++ b/ferrosa-postgres/src/server.rs
@@ -31,6 +31,11 @@ pub struct QueryContext {
     pub engine: Arc<StorageEngine>,
     pub schema: Arc<Schema>,
     pub default_schema: String,
+    /// The Accord committer that drives a buffered `BEGIN`/`COMMIT` write-set to
+    /// an atomic multi-key transaction. `None` in standalone mode — a `COMMIT`
+    /// with buffered DML then fails loud (cluster mode required) rather than
+    /// faking atomicity (FMEA PG-1).
+    pub accord_committer: Option<Arc<dyn ferrosa_storage::accord::TransactionCommitter>>,
 }
 
 /// An unpredictable, printable SCRAM server nonce (base64, so no comma — the one
@@ -279,33 +284,110 @@ async fn execute_simple(
                 tag: "BEGIN".to_string(),
             }]
         }
-        ferrosa_sql::Statement::Commit => {
-            // Accord commit seam: read-only front-end ⇒ empty write-set today.
-            session.end_txn();
-            vec![BackendMessage::CommandComplete {
-                tag: "COMMIT".to_string(),
-            }]
-        }
+        ferrosa_sql::Statement::Commit => commit_txn(ctx, session).await,
         ferrosa_sql::Statement::Rollback => {
+            // ROLLBACK discards the buffered write-set — those writes were never
+            // applied — and leaves the transaction block.
             session.end_txn();
             vec![BackendMessage::CommandComplete {
                 tag: "ROLLBACK".to_string(),
             }]
         }
         // Data + session statements: delegate to the stateless executor. (It
-        // re-parses; cheap, and keeps the executor self-contained.)
+        // re-parses; cheap, and keeps the executor self-contained.) In an open
+        // transaction, DML is BUFFERED into the session write-set instead of
+        // applied; autocommit (no open txn) applies immediately.
         _ => {
-            let msgs =
-                query::execute_query(&ctx.engine, &ctx.schema, sql, &ctx.default_schema).await;
+            let msgs = if session.in_txn() {
+                query::execute_query(
+                    &ctx.engine,
+                    &ctx.schema,
+                    sql,
+                    &ctx.default_schema,
+                    Some(session.txn_writes_mut()),
+                )
+                .await
+            } else {
+                query::execute_query(&ctx.engine, &ctx.schema, sql, &ctx.default_schema, None).await
+            };
             if session.in_txn()
                 && msgs
                     .iter()
                     .any(|m| matches!(m, BackendMessage::ErrorResponse { .. }))
             {
+                // A statement that fails inside a transaction POISONS it (`T` →
+                // `E`): the next COMMIT is rejected (PG `25P02`) rather than
+                // committing a partial buffered write-set.
                 session.mark_txn_failed();
             }
             msgs
         }
+    }
+}
+
+/// Drive the buffered `BEGIN`/`COMMIT` write-set through the Accord committer,
+/// then leave the transaction block. FAILS LOUD and never applies a buffered
+/// write outside the committer:
+///
+/// * standalone mode (no committer) → ErrorResponse (cluster mode required);
+/// * a clean Accord abort → ErrorResponse (`40001`/`25000`);
+/// * a commit that cannot reach a decision → ErrorResponse (`58000`).
+///
+/// In every case the transaction is ended and the buffer dropped, so the server
+/// never acks a transaction it did not commit.
+async fn commit_txn(ctx: &QueryContext, session: &mut Session) -> Vec<BackendMessage> {
+    use ferrosa_storage::accord::CommitOutcome;
+
+    // A COMMIT on an aborted (poisoned) transaction never commits the partial
+    // buffer — Postgres treats it as a ROLLBACK. Drop the buffer and report
+    // ROLLBACK rather than committing an incomplete write-set.
+    if session.in_failed_txn() {
+        session.end_txn();
+        return vec![BackendMessage::CommandComplete {
+            tag: "ROLLBACK".to_string(),
+        }];
+    }
+
+    let writes = session.take_txn_writes();
+
+    // An empty write-set (`BEGIN; COMMIT;` with no DML, or only reads) is a
+    // no-op that commits cleanly — there is nothing to apply, so no atomicity to
+    // honor and no committer required (matches the `TransactionCommitter`
+    // contract). This is NOT a fake success: zero writes means zero state change.
+    if writes.is_empty() {
+        session.end_txn();
+        return vec![BackendMessage::CommandComplete {
+            tag: "COMMIT".to_string(),
+        }];
+    }
+
+    let committer = match &ctx.accord_committer {
+        Some(c) => c.clone(),
+        None => {
+            session.end_txn();
+            // Buffered writes were never applied; fail loud rather than fake a
+            // COMMIT we cannot honor atomically.
+            return vec![query::error_response(
+                "0A000",
+                "multi-statement transactions require cluster mode (Accord)",
+            )];
+        }
+    };
+
+    let outcome = committer.commit(writes).await;
+    session.end_txn();
+    match outcome {
+        Ok(CommitOutcome::Committed) => vec![BackendMessage::CommandComplete {
+            tag: "COMMIT".to_string(),
+        }],
+        Ok(CommitOutcome::Aborted { reason }) => vec![query::error_response(
+            "40001",
+            &format!("transaction aborted: {reason}"),
+        )],
+        Err(e) => vec![query::error_response(
+            "58000",
+            &format!("transaction commit failed: {}", e.reason),
+        )],
     }
 }
 
@@ -536,5 +618,371 @@ where
         tokio::spawn(async move {
             let _ = handle_connection(stream, store, ctx).await;
         });
+    }
+}
+
+/// Transaction atomicity (FMEA PG-1): a `BEGIN`/`COMMIT` block buffers its DML
+/// and only the Accord committer applies it. ROLLBACK discards the buffer (the
+/// writes were never applied); COMMIT with no committer fails loud instead of
+/// faking atomicity. Runs a real local `StorageEngine` (temp dir, no S3/Docker).
+#[cfg(test)]
+mod txn_atomicity_tests {
+    use super::*;
+    use crate::extended::Session;
+    use ferrosa_schema::{
+        AuthContext, AuthMethod, ClusteringOrder, ColumnKind, ColumnMetadata, DeploymentMode,
+        EnvSecretsProvider, KeyspaceMetadata, PasswordHasher, PasswordPolicy, RateLimitConfig,
+        ReplicationParams, SchemaConfig, TableMetadata, TableParams, TestAuditSink,
+    };
+    use ferrosa_storage::accord::MockTransactionCommitter;
+    use ferrosa_storage::{
+        CommitLogConfig, CompactionConfig, StorageEngineConfig, SyncStrategyConfig,
+    };
+    use indexmap::IndexMap;
+    use std::collections::{HashMap, HashSet};
+    use std::path::Path;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    fn schema_config() -> SchemaConfig {
+        SchemaConfig {
+            hasher: PasswordHasher::Bcrypt { cost: 4 },
+            password_policy: PasswordPolicy::permissive(),
+            auth_method: AuthMethod::Password,
+            rate_limit: RateLimitConfig::default(),
+            audit_sink: Box::new(TestAuditSink::new()),
+            secrets: Box::new(EnvSecretsProvider),
+            mode: DeploymentMode::Development,
+        }
+    }
+
+    fn superuser() -> AuthContext {
+        AuthContext {
+            role: "cassandra".to_string(),
+            is_superuser: true,
+            must_change_password: false,
+        }
+    }
+
+    fn column(name: &str, kind: ColumnKind, ty: &str) -> ColumnMetadata {
+        ColumnMetadata {
+            name: name.to_string(),
+            kind,
+            position: 0,
+            column_type: ty.to_string(),
+            clustering_order: ClusteringOrder::None,
+            mask: None,
+        }
+    }
+
+    fn schema_with_kv() -> Schema {
+        let schema = Schema::new(schema_config()).expect("schema bootstraps");
+        let auth = superuser();
+        schema
+            .create_keyspace(
+                KeyspaceMetadata {
+                    name: "public".to_string(),
+                    durable_writes: true,
+                    replication: ReplicationParams {
+                        strategy: "SimpleStrategy".to_string(),
+                        options: {
+                            let mut o = HashMap::new();
+                            o.insert("replication_factor".to_string(), "1".to_string());
+                            o
+                        },
+                    },
+                },
+                &auth,
+            )
+            .expect("create keyspace public");
+        let mut cols = IndexMap::new();
+        cols.insert(
+            "k".to_string(),
+            column("k", ColumnKind::PartitionKey, "text"),
+        );
+        cols.insert("v".to_string(), column("v", ColumnKind::Regular, "text"));
+        schema
+            .create_table(
+                TableMetadata {
+                    keyspace: "public".to_string(),
+                    name: "kv".to_string(),
+                    id: Uuid::new_v4(),
+                    columns: cols,
+                    partition_key: vec!["k".to_string()],
+                    clustering_key: vec![],
+                    params: TableParams::default(),
+                    flags: HashSet::new(),
+                    extensions: HashMap::new(),
+                    is_system: false,
+                },
+                &auth,
+            )
+            .expect("create table kv");
+        schema
+    }
+
+    fn engine_config(dir: &Path) -> StorageEngineConfig {
+        StorageEngineConfig {
+            commit_log: CommitLogConfig {
+                segment_size: 256 * 1024,
+                max_segment_age: Duration::from_secs(60),
+                sync_strategy: SyncStrategyConfig::Batch,
+                batch: Default::default(),
+                log_dir: dir.join("commitlog"),
+                checkpoint_dir: dir.join("commitlog"),
+                archive: None,
+            },
+            compaction: CompactionConfig::from_env(dir.join("compaction")),
+            object_store: None,
+            local_cache_max_bytes: 1024 * 1024,
+            local_disk_free_reserve_bytes: 0,
+            flush_threshold_bytes: 4096,
+            memtable_backpressure_bytes: u64::MAX,
+            flush_max_age_secs: 5,
+            data_dir: dir.to_path_buf(),
+            index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+            auth_enabled: false,
+            auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
+            memtable_num_shards: 64,
+            write_verify: false,
+        }
+    }
+
+    fn kv_storage_schema() -> ferrosa_common::schema::TableSchema {
+        use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+        TableSchema {
+            keyspace: "public".to_string(),
+            table: "kv".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "v".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: Default::default(),
+        }
+    }
+
+    fn ctx_with(engine: Arc<StorageEngine>, schema: Arc<Schema>, committer: bool) -> QueryContext {
+        QueryContext {
+            engine,
+            schema,
+            default_schema: "public".to_string(),
+            accord_committer: if committer {
+                Some(Arc::new(MockTransactionCommitter::new()))
+            } else {
+                None
+            },
+        }
+    }
+
+    async fn make_ctx(committer: bool) -> (tempfile::TempDir, QueryContext) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = StorageEngine::new(engine_config(dir.path()), None).unwrap();
+        engine.register_table(kv_storage_schema()).unwrap();
+        let ctx = ctx_with(Arc::new(engine), Arc::new(schema_with_kv()), committer);
+        (dir, ctx)
+    }
+
+    /// Rows visible for key `k`, read back through the `execute_query` SELECT
+    /// path with no transaction buffer.
+    async fn row_count(ctx: &QueryContext, key: &str) -> usize {
+        let msgs = query::execute_query(
+            &ctx.engine,
+            &ctx.schema,
+            &format!("SELECT k FROM kv WHERE k = '{key}'"),
+            &ctx.default_schema,
+            None,
+        )
+        .await;
+        assert!(
+            !msgs
+                .iter()
+                .any(|m| matches!(m, BackendMessage::ErrorResponse { .. })),
+            "read-back SELECT failed: {msgs:?}"
+        );
+        msgs.iter()
+            .filter(|m| matches!(m, BackendMessage::DataRow { .. }))
+            .count()
+    }
+
+    fn is_error(msgs: &[BackendMessage], code: &str) -> bool {
+        msgs.iter().any(|m| {
+            matches!(m, BackendMessage::ErrorResponse { fields }
+                if fields.iter().any(|f| *f == (b'C', code.to_string())))
+        })
+    }
+
+    #[tokio::test]
+    async fn rollback_discards_buffered_writes() {
+        // BEGIN; INSERT (buffered); ROLLBACK ⇒ the row was never applied.
+        // Contrast: an autocommit INSERT IS applied.
+        let (_dir, ctx) = make_ctx(true).await;
+        let mut session = Session::new();
+
+        let m = execute_simple(&ctx, &mut session, "BEGIN").await;
+        assert!(matches!(&m[..], [BackendMessage::CommandComplete { tag }] if tag == "BEGIN"));
+        assert!(session.in_txn());
+
+        let m = execute_simple(
+            &ctx,
+            &mut session,
+            "INSERT INTO kv (k, v) VALUES ('r', 'rolledback')",
+        )
+        .await;
+        assert!(
+            matches!(&m[..], [BackendMessage::CommandComplete { tag }] if tag == "INSERT 0 1"),
+            "buffered INSERT still acks: {m:?}"
+        );
+        assert_eq!(
+            row_count(&ctx, "r").await,
+            0,
+            "a write buffered inside a txn is NOT yet in storage"
+        );
+
+        let m = execute_simple(&ctx, &mut session, "ROLLBACK").await;
+        assert!(matches!(&m[..], [BackendMessage::CommandComplete { tag }] if tag == "ROLLBACK"));
+        assert!(!session.in_txn());
+        assert_eq!(
+            row_count(&ctx, "r").await,
+            0,
+            "ROLLBACK discards the buffer — the write is NEVER applied (FMEA PG-1)"
+        );
+
+        // Autocommit contrast: this DML applies immediately.
+        let m = execute_simple(
+            &ctx,
+            &mut session,
+            "INSERT INTO kv (k, v) VALUES ('a', 'auto')",
+        )
+        .await;
+        assert!(matches!(&m[..], [BackendMessage::CommandComplete { tag }] if tag == "INSERT 0 1"));
+        assert_eq!(
+            row_count(&ctx, "a").await,
+            1,
+            "an autocommit INSERT IS applied immediately"
+        );
+
+        ctx.engine.shutdown().unwrap();
+    }
+
+    #[tokio::test]
+    async fn commit_without_committer_fails_loud() {
+        // No committer (standalone mode): BEGIN; INSERT; COMMIT must FAIL LOUD
+        // (cluster mode required) and the buffered row must NOT be in storage.
+        let (_dir, ctx) = make_ctx(false).await;
+        let mut session = Session::new();
+
+        execute_simple(&ctx, &mut session, "BEGIN").await;
+        execute_simple(
+            &ctx,
+            &mut session,
+            "INSERT INTO kv (k, v) VALUES ('x', 'never')",
+        )
+        .await;
+        assert_eq!(row_count(&ctx, "x").await, 0, "still buffered, not applied");
+
+        let m = execute_simple(&ctx, &mut session, "COMMIT").await;
+        assert!(
+            is_error(&m, "0A000"),
+            "COMMIT with no committer must fail loud (0A000), got {m:?}"
+        );
+        assert!(
+            m.iter()
+                .any(|msg| matches!(msg, BackendMessage::ErrorResponse { fields }
+                if fields.iter().any(|f| f.0 == b'M' && f.1.contains("cluster mode")))),
+            "the error must mention cluster mode: {m:?}"
+        );
+        assert!(
+            !session.in_txn(),
+            "the transaction is ended even on failure"
+        );
+        assert_eq!(
+            row_count(&ctx, "x").await,
+            0,
+            "a COMMIT that cannot be honored NEVER applies the buffered write"
+        );
+
+        ctx.engine.shutdown().unwrap();
+    }
+
+    #[tokio::test]
+    async fn commit_with_committer_acks_and_records_write_set() {
+        // With a committer, COMMIT drives the buffered write-set through it and
+        // acks COMMIT. (The mock records the set; it does not itself apply.)
+        let (_dir, ctx) = make_ctx(true).await;
+        let mut session = Session::new();
+
+        execute_simple(&ctx, &mut session, "BEGIN").await;
+        execute_simple(
+            &ctx,
+            &mut session,
+            "INSERT INTO kv (k, v) VALUES ('y', 'committed')",
+        )
+        .await;
+        let m = execute_simple(&ctx, &mut session, "COMMIT").await;
+        assert!(
+            matches!(&m[..], [BackendMessage::CommandComplete { tag }] if tag == "COMMIT"),
+            "COMMIT acks via the committer: {m:?}"
+        );
+        assert!(!session.in_txn());
+
+        ctx.engine.shutdown().unwrap();
+    }
+
+    #[tokio::test]
+    async fn failed_txn_commit_does_not_apply() {
+        // A statement that errors inside a txn poisons it; subsequent DML hits
+        // 25P02; COMMIT is treated as ROLLBACK and nothing is applied.
+        let (_dir, ctx) = make_ctx(true).await;
+        let mut session = Session::new();
+
+        execute_simple(&ctx, &mut session, "BEGIN").await;
+        // A bad INSERT (missing PK column) errors and poisons the txn.
+        let m = execute_simple(&ctx, &mut session, "INSERT INTO kv (v) VALUES ('no-pk')").await;
+        assert!(
+            m.iter()
+                .any(|x| matches!(x, BackendMessage::ErrorResponse { .. })),
+            "the bad INSERT fails loud: {m:?}"
+        );
+        assert!(session.in_failed_txn(), "the txn is now poisoned (T → E)");
+
+        // Further DML is rejected with 25P02 until the block ends.
+        let m = execute_simple(
+            &ctx,
+            &mut session,
+            "INSERT INTO kv (k, v) VALUES ('z', 'x')",
+        )
+        .await;
+        assert!(is_error(&m, "25P02"), "aborted txn rejects DML: {m:?}");
+
+        // COMMIT on a poisoned txn behaves like ROLLBACK; nothing applied.
+        let m = execute_simple(&ctx, &mut session, "COMMIT").await;
+        assert!(
+            matches!(&m[..], [BackendMessage::CommandComplete { tag }] if tag == "ROLLBACK"),
+            "COMMIT on an aborted txn reports ROLLBACK: {m:?}"
+        );
+        assert!(!session.in_txn() && !session.in_failed_txn());
+        assert_eq!(row_count(&ctx, "z").await, 0);
+
+        ctx.engine.shutdown().unwrap();
+    }
+
+    #[tokio::test]
+    async fn select_inside_txn_still_works() {
+        // A read inside a transaction is served normally (it does not buffer).
+        let (_dir, ctx) = make_ctx(true).await;
+        let mut session = Session::new();
+        execute_simple(&ctx, &mut session, "BEGIN").await;
+        let m = execute_simple(&ctx, &mut session, "SELECT 1").await;
+        assert!(
+            m.iter()
+                .any(|x| matches!(x, BackendMessage::DataRow { .. })),
+            "SELECT 1 inside a txn returns a row: {m:?}"
+        );
+        assert!(!is_error(&m, "0A000"));
+        ctx.engine.shutdown().unwrap();
     }
 }

--- a/ferrosa-postgres/tests/differential_oracle.rs
+++ b/ferrosa-postgres/tests/differential_oracle.rs
@@ -1044,6 +1044,7 @@ async fn start_ferrosa() -> (tokio_postgres::Client, tempfile::TempDir) {
         engine: Arc::new(engine),
         schema: Arc::new(schema),
         default_schema: "public".into(),
+        accord_committer: None,
     });
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/ferrosa-postgres/tests/m1_join_live.rs
+++ b/ferrosa-postgres/tests/m1_join_live.rs
@@ -311,6 +311,7 @@ async fn m1_join_returns_rows_to_a_real_driver() {
         engine: Arc::new(engine),
         schema: Arc::new(schema),
         default_schema: "public".into(),
+        accord_committer: None,
     });
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -395,6 +396,7 @@ async fn extended_query_error_recovers_after_sync() {
         engine: Arc::new(engine),
         schema: Arc::new(schema),
         default_schema: "public".into(),
+        accord_committer: None,
     });
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -436,6 +438,7 @@ async fn extended_parameterized_join_over_a_real_driver() {
         engine: Arc::new(engine),
         schema: Arc::new(schema),
         default_schema: "public".into(),
+        accord_committer: None,
     });
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -485,6 +488,7 @@ async fn group_by_order_by_limit_over_a_real_driver() {
         engine: Arc::new(engine),
         schema: Arc::new(schema),
         default_schema: "public".into(),
+        accord_committer: None,
     });
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -544,6 +548,7 @@ async fn where_having_distinct_over_a_real_driver() {
         engine: Arc::new(engine),
         schema: Arc::new(schema),
         default_schema: "public".into(),
+        accord_committer: None,
     });
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/ferrosa-postgres/tests/scram_live.rs
+++ b/ferrosa-postgres/tests/scram_live.rs
@@ -90,6 +90,7 @@ fn minimal_ctx() -> (Arc<QueryContext>, tempfile::TempDir) {
         engine: Arc::new(engine),
         schema: Arc::new(schema),
         default_schema: "public".into(),
+        accord_committer: None,
     });
     (ctx, dir)
 }

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -1473,6 +1473,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Clone write_path and ddl_path before shared_state is moved into the CQL server.
     let cluster_write_path = shared_state.write_path.clone();
     let cluster_ddl_path = shared_state.ddl_path.clone();
+    // Capture the Accord transaction committer for the Postgres front-end before
+    // shared_state is moved into the CQL server. `None` in standalone mode — a
+    // Postgres BEGIN/COMMIT with buffered DML then fails loud (FMEA PG-1).
+    let pg_accord_committer = shared_state.core.accord_transaction_committer();
     // Clone the shared execution state for the Flight endpoint before it is
     // moved into the CQL server (feature-gated so it is not an unused clone).
     #[cfg(feature = "flight")]
@@ -1794,6 +1798,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             engine: storage.clone(),
             schema: schema.clone(),
             default_schema: "public".into(),
+            accord_committer: pg_accord_committer,
         });
         runtimes.background.spawn(async move {
             match tokio::net::TcpListener::bind(pg_bind).await {


### PR DESCRIPTION
Closes the Postgres frontend's top correctness gap, **FMEA PG-1 (RPN 315)**.

## Before
DML inside a Postgres `BEGIN`/`COMMIT` block **applied immediately**, and `ROLLBACK` did **not** undo it. A driver in a transaction saw PG-shaped `I`/`T`/`E` status bytes but writes were neither atomic nor isolated — silent partial visibility if a client relied on transactions.

## After (mirrors the CQL `CqlTransaction` path)
- In a txn, DML **buffers** as `TransactionWrite` instead of applying.
- `COMMIT` drives the buffered write-set through the Accord `TransactionCommitter` **atomically**.
- `ROLLBACK` discards the buffer — the writes were never applied.
- **Autocommit** (DML outside a txn) is unchanged: direct `write_atomic_batch`.

## Fail-loud `commit_txn` (reviewed line-by-line)
- poisoned txn → ROLLBACK (never commits a partial buffer)
- empty write-set → clean COMMIT (read-only txn; no committer needed — not a fake success, zero writes = zero state change)
- non-empty + **no committer (standalone)** → error `0A000` "requires cluster mode (Accord)", **writes never applied**
- `Aborted` → `40001`; commit error → `58000`. Never acks a commit it didn't earn.
- 10 000-write cap (`53400`) mirrors CQL's `MAX_TXN_WRITES`.

## Tests — 8 new, **119 pass**, clippy clean
`rollback_discards_buffered_writes`, `commit_without_committer_fails_loud` (+ asserts nothing applied), `buffer_respects_write_cap`, `commit_with_committer_acks_and_records_write_set`, `failed_txn_commit_does_not_apply`, `select_inside_txn_still_works`, and two query-level buffer tests. Crate docs updated (PG-1 → implemented, re-scored 315→36).

## Known limitation (documented; follow-up filed)
**No read-your-writes** — buffered writes aren't visible to reads in the same open transaction. Fine for insert/update/delete-then-commit (Ecto's common path); a txn that reads its own writes would see stale data. Not a silent corruption (data isn't wrong, just not-yet-visible); tracked as follow-up.

Implemented via subagent to a precise spec, then verified independently: builds (default + live-infra-tests + binary), full suite, clippy, and a manual review of the COMMIT seam.