### PR TITLE
feat(postgres): parameterized DML + INSERT RETURNING over the extended protocol

### DIFF
--- a/ferrosa-postgres/README.md
+++ b/ferrosa-postgres/README.md
@@ -19,9 +19,10 @@ byte-identically over CQL — without `ferrosa-postgres` ever depending on the
 ~54k-LOC `ferrosa-cql` crate.
 
 This is a **developer preview**. See [specs/fmea.md](specs/fmea.md) for the exact
-supported-vs-not surface (key gaps: `$N` params in DML, `RETURNING`, and `ON
-CONFLICT` are still in progress; transaction atomicity via Accord is now wired —
-see below).
+supported-vs-not surface. Now wired: transaction atomicity via Accord,
+parameterized DML, and `INSERT … RETURNING`. Key remaining gaps: `ON CONFLICT`,
+`UPDATE`/`DELETE … RETURNING`, `= ANY($N)` / IN-lists, and read-your-writes
+inside an open transaction block.
 
 ## What's implemented
 
@@ -39,21 +40,35 @@ see below).
 - **Extended query protocol** — `Parse`/`Bind`/`Describe`/`Execute`/`Sync`/`Close`
   with a per-connection [`Session`] (prepared statements + portals), `$N`
   parameter type inference (`ParameterDescription`), text + binary parameter and
-  result encodings, and Postgres error-skip-until-`Sync` semantics. **Only
-  `SELECT`** (and no-`FROM` expression selects) can be prepared.
+  result encodings, and Postgres error-skip-until-`Sync` semantics. `SELECT`,
+  no-`FROM` expression selects, AND parameterized `INSERT` / `UPDATE` / `DELETE`
+  can be prepared. This is the path `Ecto.Repo.insert/update/delete/all` drives.
+- **Parameterized DML + `INSERT … RETURNING`** — `$N` placeholders in `INSERT`
+  VALUES, `UPDATE` SET/WHERE, and `DELETE` WHERE are bound at `Bind` and
+  substituted at `Execute` (fail-loud `08P01` if a `$N` has no bound value).
+  Param OIDs in `Describe` are inferred from each placeholder's target column
+  (so a driver that does not pre-declare OIDs gets a concrete type). `INSERT …
+  RETURNING col,…` / `RETURNING *` echoes the just-written values as a `DataRow`
+  (built in-memory — no storage read-back), exactly what Ecto needs to recover a
+  generated/echoed key. RETURNING rows honor the portal's result formats (binary
+  works). `UPDATE`/`DELETE … RETURNING`, `ON CONFLICT`, and `= ANY($N)` are
+  **not yet supported** and fail loud (`0A000`/parse error), never silently.
 - **Transaction atomicity via Accord** (FMEA PG-1) — `BEGIN`/`COMMIT`/`ROLLBACK`
   drive the `ReadyForQuery` status byte `I`/`T`/`E`, and DML inside an open `T`
   block is **buffered** as a `ferrosa_storage::accord::TransactionWrite` instead
-  of applied (`apply_or_buffer` in `query.rs`). `COMMIT` drives the whole
-  write-set through the injected `TransactionCommitter` as one atomic multi-key
-  Accord transaction (`commit_txn` in `server.rs`); `ROLLBACK` discards the
-  buffer so the writes are **never applied**. Fail-loud: a statement that errors
-  inside a block poisons it (`T → E`, only `COMMIT`/`ROLLBACK` accepted, `25P02`);
-  in standalone mode (no committer) a `COMMIT` carrying buffered DML fails loud
-  (`0A000`, cluster mode required) rather than faking atomicity; an empty
-  write-set commits cleanly. The buffer is capped at `MAX_TXN_WRITES` (10 000).
-  This mirrors the CQL `CqlTransaction` path. *Not yet:* read-your-writes inside
-  the open block (buffered writes are not visible to in-transaction reads).
+  of applied (`apply_or_buffer` in `query.rs`) — over BOTH the simple and the
+  extended (parameterized) protocols. `COMMIT` drives the whole write-set through
+  the injected `TransactionCommitter` as one atomic multi-key Accord transaction
+  (`commit_txn` in `server.rs`); `ROLLBACK` discards the buffer so the writes are
+  **never applied**. `INSERT … RETURNING` inside a `T` block returns its rows now
+  (built from the in-memory values) while the write commits at COMMIT. Fail-loud:
+  a statement that errors inside a block poisons it (`T → E`, only
+  `COMMIT`/`ROLLBACK` accepted, `25P02`); in standalone mode (no committer) a
+  `COMMIT` carrying buffered DML fails loud (`0A000`, cluster mode required)
+  rather than faking atomicity; an empty write-set commits cleanly. The buffer is
+  capped at `MAX_TXN_WRITES` (10 000). This mirrors the CQL `CqlTransaction` path.
+  *Not yet:* read-your-writes inside the open block (buffered writes are not
+  visible to in-transaction reads).
 - **DML execution** — INSERT/UPDATE/DELETE build storage rows through the shared
   `ferrosa-row-bridge` encoder. **Autocommit** (no open transaction) applies
   immediately via `engine.write_atomic_batch`; **inside a transaction** the write
@@ -124,13 +139,18 @@ See [specs/data-flow.md](specs/data-flow.md) for the sequence diagrams.
 
 ## Tests
 
-~111 in-crate unit tests (codec/messages/scram/handshake/connection/extended/
-query/storage_provider/catalog/store) run with no infrastructure, plus
-integration tests:
+~119 in-crate unit tests (codec/messages/scram/handshake/connection/extended/
+query/storage_provider/catalog/store + `txn_atomicity_tests`) run with no
+infrastructure, plus integration tests:
 
-- `tests/m1_join_live.rs` (5) — full stack over a real `tokio-postgres` driver
+- `tests/m1_join_live.rs` (15) — full stack over a real `tokio-postgres` driver
   in-process: SCRAM → JOIN, parameterized extended query, GROUP BY/ORDER
-  BY/LIMIT, error-recovery-after-`Sync`. Local temp engine, no Docker.
+  BY/LIMIT, error-recovery-after-`Sync`, AND the parameterized DML path
+  (`INSERT`/`UPDATE`/`DELETE` via `$N`, `INSERT … RETURNING id`/`*`,
+  `UPDATE`/`DELETE … RETURNING` fail-loud, and extended-protocol DML inside a
+  transaction: BEGIN/INSERT RETURNING/ROLLBACK discards, BEGIN/INSERT/COMMIT
+  via a mock committer, and standalone-COMMIT fail-loud). Local temp engine, no
+  Docker.
 - `tests/scram_live.rs` (3) — real-driver SCRAM + `SELECT 1`, extended
   expression select, wrong-password rejection. In-process loopback.
 - `tests/differential_oracle.rs` (3, `#[cfg(feature = "live-infra-tests")]`) —

--- a/ferrosa-postgres/specs/fmea.md
+++ b/ferrosa-postgres/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-postgres
 doc: fmea
-last_updated: 2026-06-19
+last_updated: 2026-06-25
 ---
 
 # ferrosa-postgres — FMEA / Known Issues
@@ -19,22 +19,29 @@ actual code (`src/query.rs`, `src/server.rs`, `src/storage_provider.rs`,
   `UPDATE` / `DELETE` (key-equality `WHERE`, Cassandra-style blind
   upsert/tombstone).
 - **Protocols:** simple (`Q`) and extended (`Parse`/`Bind`/`Describe`/`Execute`/
-  `Sync`/`Close`); `SELECT`-only prepared statements; text + binary param/result
-  formats; `$N` type inference for `SELECT`.
+  `Sync`/`Close`); prepared `SELECT` **and parameterized `INSERT`/`UPDATE`/
+  `DELETE`**; text + binary param/result formats; `$N` type inference for
+  `SELECT` (from comparison columns) and DML (from each placeholder's target
+  column).
+- **Parameterized DML + `INSERT … RETURNING`:** `$N` bound at `Bind`, substituted
+  at `Execute`; `INSERT … RETURNING col,…`/`*` echoes the just-written values.
+  This is the `Ecto.Repo.insert/update/delete/all` path.
 - **Auth:** SCRAM-SHA-256 against the live schema role store.
 - **Catalog:** `pg_catalog` namespace/class/attribute/type projection.
 
 ## Not yet supported (fail-loud gaps)
 
-- `$N` parameters in `INSERT`/`UPDATE`/`DELETE` (DML is literal-only) → `0A000`.
-- `RETURNING`, `ON CONFLICT` (upsert), multi-row `INSERT ... VALUES (...),(...)`.
+- `UPDATE`/`DELETE … RETURNING` → `0A000` (only `INSERT … RETURNING` is wired).
+- `ON CONFLICT` (upsert) → parse error; multi-row `INSERT … VALUES (…),(…)`.
+- `= ANY($N)` / IN-list parameter expansion.
 - `UPDATE`/`DELETE` with a non-key or range `WHERE` (only full-PK equality).
-- Real transaction **atomicity** — `BEGIN`/`COMMIT`/`ROLLBACK` drive protocol
-  state but writes are not yet routed through Accord.
+- **Read-your-writes inside an open transaction block** — buffered writes are not
+  visible to in-transaction reads (the buffer is applied only at `COMMIT`).
+  Transactional DML itself IS supported now (buffered + committed via Accord; see
+  PG-1) over both the simple and extended protocols.
 - `SET`/`RESET` session GUCs (simple-query path returns `0A000`).
 - Function calls in DML `VALUES`; most scalar functions beyond
   `version()`/`current_database()`/`current_schema()`.
-- Preparing non-`SELECT` statements via the extended protocol.
 - TLS (`SSLRequest` is declined with `N`); query cancellation (`BackendKeyData`
   is a `(0,0)` placeholder).
 - Binary `numeric` result/param (falls back to text).
@@ -45,9 +52,9 @@ actual code (`src/query.rs`, `src/server.rs`, `src/storage_provider.rs`,
 
 | ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
 |----|--------------|--------|---|---|---|-----|---------------------|
-| PG-1 | **Transaction atomicity is not real** — `BEGIN`/`COMMIT` move the `I`/`T`/`E` status but the commit seam has an empty write-set; DML inside a block applies immediately and is not rolled back by `ROLLBACK` | A driver in a transaction sees PG-shaped status bytes but writes are NOT atomic/isolated — partial visibility / no rollback (silent correctness gap if a client relies on it) | 9 | 2 | 2 | 36 | **Implemented.** DML inside an open `T` block now BUFFERS as a `ferrosa_storage::accord::TransactionWrite` (`apply_or_buffer` in `query.rs`); `COMMIT` drives the whole write-set through the injected `TransactionCommitter` atomically (`commit_txn` in `server.rs`), `ROLLBACK`/`end_txn` discards the buffer (never applied). No committer (standalone) ⇒ COMMIT of a non-empty buffer fails loud (`0A000`); empty buffer commits cleanly. Write-set capped at `MAX_TXN_WRITES`. Autocommit unchanged. Mirrors the CQL `CqlTransaction` path. Tests: `server::txn_atomicity_tests`, `query::txn_buffer_tests`. |
-| PG-2 | **`$N` params unsupported in DML** — `INSERT`/`UPDATE`/`DELETE` with a `ScalarValue::Param` fail loud `0A000` | Every parameterized write from a real driver (the common path) is rejected; only literal DML works | 7 | 8 | 2 | 112 | Fail-loud `0A000` (no silent wrong write). `SELECT` params DO work via the extended path; extending inference to DML is roadmap Now. |
-| PG-3 | **No `RETURNING` / `ON CONFLICT`** — parser/executor do not accept them | ORMs/`INSERT ... RETURNING id` patterns fail | 6 | 7 | 2 | 84 | Fail-loud at parse (`42601`) — never a wrong row. Roadmap Next. |
+| PG-1 | **Transaction atomicity** — `BEGIN`/`COMMIT`/`ROLLBACK` over an Accord-committed buffered write-set | A driver in a transaction gets real atomic multi-key commit, or fail-loud — never partial/faked | 9 | 2 | 2 | 36 | **Implemented.** DML inside an open `T` block BUFFERS as a `ferrosa_storage::accord::TransactionWrite` (`apply_or_buffer` in `query.rs`), over BOTH the simple and extended protocols; `COMMIT` drives the whole write-set through the injected `TransactionCommitter` atomically (`commit_txn` in `server.rs`), `ROLLBACK`/`end_txn` discards the buffer (never applied). No committer (standalone) ⇒ COMMIT of a non-empty buffer fails loud (`0A000`); empty buffer commits cleanly. Write-set capped at `MAX_TXN_WRITES`. Autocommit unchanged. Mirrors the CQL `CqlTransaction` path. Tests: `server::txn_atomicity_tests`, `m1_join_live` extended-DML-in-txn. Residual: read-your-writes / MVCC isolation. |
+| PG-2 | **(resolved) `$N` params in DML** — parameterized `INSERT`/`UPDATE`/`DELETE` are now bound at `Bind` and substituted at `Execute` | — | 2 | 1 | 1 | 2 | **Done.** `substitute_param` fails loud `08P01` if a `$N` has no bound value; param OIDs inferred from each placeholder's target column. Covered by the `extended_parameterized_*` live tests. |
+| PG-3 | **`INSERT … RETURNING` only; `UPDATE`/`DELETE … RETURNING` + `ON CONFLICT` unsupported** | `UPDATE`/`DELETE … RETURNING` and upsert ORM patterns fail | 5 | 5 | 2 | 50 | `INSERT … RETURNING` done (in-memory row, no read-back). `UPDATE`/`DELETE … RETURNING` fail loud `0A000`; `ON CONFLICT` fails at parse. Never a wrong row. Roadmap Next. |
 | PG-4 | **Lossy CQL→Value: `Duration`/collections read as NULL** | A `SELECT` over a table with a duration/list/map column silently shows NULL for that column | 6 | 4 | 6 | 144 | Documented in `storage_provider::cql_to_value` (code comment, never a panic). Detectable only by inspection — no error is raised. Widen `Value` (roadmap Later). |
 | PG-5 | **Row-codec divergence from CQL/engine** — a write encodes differently than the canonical codec | Postgres-written rows read back wrong/invisible over CQL or the engine (silent corruption) | 10 | 1 | 4 | 40 | **Structural (D10):** INSERT/UPDATE/DELETE use `ferrosa-row-bridge` `build_row`/`build_delete_row`/`build_decorated_key` — the SAME code CQL uses. Reinforced by the differential oracle (PG vs real PG) + the M1 live tests. |
 | PG-6 | **Missing table served as empty relation** | A typo'd table silently returns zero rows instead of erroring | 8 | 1 | 3 | 24 | **R15 guard:** `load_table` checks schema metadata first → `NoSuchTable` (`42P01`), distinct from an existing empty table. Covered by `load_table_missing_table_is_no_such_table`. |
@@ -58,21 +65,27 @@ actual code (`src/query.rs`, `src/server.rs`, `src/storage_provider.rs`,
 
 ## Top risks to act on
 
-1. ~~**PG-1 (RPN 315)** — transaction atomicity~~ **RESOLVED.** DML in a `T`
-   block now buffers and commits atomically through Accord (`commit_txn`);
-   `ROLLBACK` discards the buffer; no-committer COMMIT of a non-empty buffer
-   fails loud. Re-scored to RPN 36 (residual: real isolation/MVCC semantics
-   beyond atomic multi-key apply are still future work).
-2. **PG-4 (RPN 144)** — lossy-NULL for `Duration`/collections is undetectable at
+1. **PG-4 (RPN 144)** — lossy-NULL for `Duration`/collections is undetectable at
    runtime (no error). Make these fail loud where queried, or widen `Value`.
-3. **PG-2 (RPN 112)** — `$N` params in DML block the most common write path from
-   real drivers; extend the extended-protocol inference to DML.
+2. **PG-10 (RPN 100)** — UPDATE/DELETE report `1` row unconditionally (Cassandra
+   blind upsert/tombstone); differs from PG's real match count.
+3. ~~**PG-1**~~ **RESOLVED** — transactional DML now buffers and commits
+   atomically through Accord (`commit_txn`); `ROLLBACK` discards the buffer;
+   no-committer COMMIT of a non-empty buffer fails loud. Re-scored to RPN 36
+   (residual: read-your-writes / real isolation-MVCC semantics beyond atomic
+   multi-key apply are still future work).
 
 ## Detection assets
 
 - `tests/differential_oracle.rs` — corpus + DML vs real PostgreSQL 16 (gated on
   `live-infra-tests` + `FERROSA_TEST_CONTAINERS=1`).
-- `tests/m1_join_live.rs`, `tests/scram_live.rs` — full-stack over `tokio-postgres`,
-  no external infra.
-- ~111 in-crate unit tests for codecs, SQLSTATE mapping, SCRAM vectors, the R15
+- `tests/m1_join_live.rs`, `tests/scram_live.rs` — full-stack over
+  `tokio-postgres`, no external infra. The DML subset covers parameterized
+  `INSERT`/`UPDATE`/`DELETE`, `INSERT … RETURNING id`/`*`, `UPDATE`/`DELETE …
+  RETURNING` fail-loud, and extended-protocol DML inside a transaction
+  (BEGIN/INSERT RETURNING/ROLLBACK discards; BEGIN/INSERT/COMMIT applies via a
+  mock committer).
+- `server::txn_atomicity_tests` — simple-protocol BEGIN/COMMIT/ROLLBACK
+  atomicity over a real local engine + `MockTransactionCommitter`.
+- in-crate unit tests for codecs, SQLSTATE mapping, SCRAM vectors, the R15
   guard, and the transaction state machine.

--- a/ferrosa-postgres/specs/roadmap.md
+++ b/ferrosa-postgres/specs/roadmap.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-postgres
 doc: roadmap
-last_updated: 2026-06-19
+last_updated: 2026-06-25
 ---
 
 # ferrosa-postgres — Roadmap
@@ -11,23 +11,37 @@ Sourced from in-code fail-loud `0A000`/preview gaps, the FMEA
 `FIXME` markers in the source — the open work is encoded as fail-loud
 `feature_not_supported` paths and documented lossy fallbacks instead.
 
+## Done (recent)
+
+- **Accord-backed transaction atomicity** (FMEA PG-1, #206). DML in a `T` block
+  buffers as a `TransactionWrite` (`apply_or_buffer`) — over BOTH the simple and
+  extended protocols — and `COMMIT` drives the write-set through the injected
+  `TransactionCommitter` atomically (`commit_txn`); `ROLLBACK` discards the buffer
+  (never applied). No committer (standalone) ⇒ COMMIT of a non-empty buffer fails
+  loud; empty buffer commits cleanly. Mirrors the CQL `CqlTransaction` path.
+- **Parameterized DML** (was FMEA PG-2, `feat/pg-extended-crud`).
+  `INSERT`/`UPDATE`/`DELETE` accept bound `$N` parameters over the extended
+  protocol: prepared as `PreparedKind::{Insert,Update,Delete}`, substituted at
+  `Execute` via `substitute_param` (fail-loud `08P01` on an unbound `$N`), with
+  param OIDs inferred from each placeholder's target column. Transactional
+  parameterized DML buffers into the same session write-set.
+- **`INSERT … RETURNING col,…`/`*`** (part of FMEA PG-3, `feat/pg-extended-crud`).
+  Echoes the just-written values as a `DataRow` (built in-memory, no storage
+  read-back) — the `Ecto.Repo.insert` generated-key path; works inside a
+  transaction (rows returned now, write commits at COMMIT).
+
 ## Now (highest value)
 
-- ~~**Accord-backed transaction atomicity** (FMEA PG-1)~~ **DONE.** DML in a
-  `T` block buffers as a `TransactionWrite` (`apply_or_buffer`) and `COMMIT`
-  drives the write-set through the injected `TransactionCommitter` atomically
-  (`commit_txn`); `ROLLBACK` discards the buffer (never applied). No committer
-  (standalone) ⇒ COMMIT of a non-empty buffer fails loud; empty buffer commits
-  cleanly. Mirrors the CQL `CqlTransaction` path. *Residual (future):* true
-  snapshot isolation / read-your-writes inside the open block — buffered writes
-  are not visible to reads in the same transaction yet.
-- **`$N` parameters in DML** (FMEA PG-2). Extend the extended-protocol path so
-  `INSERT`/`UPDATE`/`DELETE` accept bound parameters (today literal-only,
-  `0A000`). Reuse `decode_param` + the existing `$N` inference.
+- **Read-your-writes inside an open transaction** (FMEA PG-1 residual). Buffered
+  writes are not yet visible to reads in the same transaction; wire the buffer
+  into the in-transaction read path (or document the snapshot-isolation gap).
 
 ## Next
 
-- **`RETURNING` and `ON CONFLICT`** (FMEA PG-3) — the common ORM insert idioms.
+- **`UPDATE`/`DELETE … RETURNING`** (FMEA PG-3) — today fail loud `0A000`; only
+  `INSERT … RETURNING` is wired.
+- **`ON CONFLICT` (upsert)** — today a parse error; the common ORM upsert idiom.
+- **`= ANY($N)` / IN-list parameter expansion** — Ecto `where: x in ^ids`.
 - **Multi-row `INSERT ... VALUES`** and richer `UPDATE`/`DELETE` `WHERE`
   (range/non-key predicates), which today are restricted to single-row, full-PK
   equality.

--- a/ferrosa-postgres/src/extended.rs
+++ b/ferrosa-postgres/src/extended.rs
@@ -26,20 +26,26 @@
 use std::collections::HashMap;
 
 use ferrosa_sql::{
-    parse_statement, ScalarItem, ScalarValue, SelectStmt, Statement, Value as SqlValue,
+    parse_statement, DeleteStmt, InsertStmt, ScalarItem, ScalarValue, SelectStmt, Statement,
+    UpdateStmt, Value as SqlValue,
 };
 
 use crate::messages::{BackendMessage, TransactionStatus};
 use crate::query::{decode_param, error_response, exec_error_response, row_description_fields};
 
-/// What a prepared statement parses to: a table query, or a no-`FROM`
-/// expression query (`SELECT version()`, `SELECT 1`). Transaction-control and
-/// session statements are handled on the simple-query path, not prepared here.
-/// `Select` is boxed — `SelectStmt` is far larger than the other variant.
+/// What a prepared statement parses to: a table query, a no-`FROM` expression
+/// query (`SELECT version()`, `SELECT 1`), or parameterized DML (`INSERT` /
+/// `UPDATE` / `DELETE`). Transaction-control and session statements are handled
+/// on the simple-query path, not prepared here. The statement variants are boxed
+/// — `SelectStmt` (and, for size parity, the DML statements) are far larger than
+/// the `Exprs` variant.
 #[derive(Debug, Clone)]
 pub enum PreparedKind {
     Select(Box<SelectStmt>),
     Exprs(Vec<ScalarItem>),
+    Insert(Box<InsertStmt>),
+    Update(Box<UpdateStmt>),
+    Delete(Box<DeleteStmt>),
 }
 
 /// A prepared statement: the parsed query plus the client-declared parameter
@@ -207,12 +213,21 @@ impl Session {
                 }
                 PreparedKind::Exprs(items)
             }
+            // Parameterized DML: prepare the statement as-is. Bound `$N` values
+            // are substituted at Execute (the declared `param_types` OIDs drive
+            // the Bind-time decode; an unspecified OID decodes leniently). No
+            // column-from-comparison inference like SELECT — Ecto declares the
+            // param OIDs in Parse, which we honor.
+            Ok(Statement::Insert(ins)) => PreparedKind::Insert(ins),
+            Ok(Statement::Update(upd)) => PreparedKind::Update(upd),
+            Ok(Statement::Delete(del)) => PreparedKind::Delete(del),
             Ok(_) => {
                 // BEGIN/COMMIT/ROLLBACK/SET reach the backend via simple Query.
                 self.error_pending = true;
                 return error_response(
                     "0A000",
-                    "only SELECT statements can be prepared via the extended-query protocol",
+                    "only SELECT and INSERT/UPDATE/DELETE statements can be prepared via the \
+                     extended-query protocol",
                 );
             }
             Err(e) => {

--- a/ferrosa-postgres/src/query.rs
+++ b/ferrosa-postgres/src/query.rs
@@ -36,7 +36,7 @@ use ferrosa_common::{CqlType, CqlValue};
 use ferrosa_schema::{ColumnKind, Schema};
 use ferrosa_sql::{
     execute, parse_statement, Column, ColumnType, DeleteStmt, ExecError, InsertStmt, MapCatalog,
-    QueryResult, Row, ScalarItem, ScalarValue, Statement, UpdateStmt, Value as SqlValue,
+    QueryResult, Returning, Row, ScalarItem, ScalarValue, Statement, UpdateStmt, Value as SqlValue,
 };
 use ferrosa_storage::{Mutation, StorageEngine};
 
@@ -723,13 +723,24 @@ pub async fn execute_query(
             "0A000",
             "SET/RESET session statements are not yet implemented",
         )],
-        // DML: single-row INSERT / UPDATE / DELETE. With `txn = Some(buffer)`
-        // (an open transaction) the write is BUFFERED as a `TransactionWrite`
-        // and committed atomically via Accord on COMMIT; with `txn = None`
-        // (autocommit) it applies immediately via `write_atomic_batch`.
-        Statement::Insert(ins) => execute_insert(engine, schema, &ins, default_schema, txn),
-        Statement::Update(upd) => execute_update(engine, schema, &upd, default_schema, txn),
-        Statement::Delete(del) => execute_delete(engine, schema, &del, default_schema, txn),
+        // DML: single-row INSERT / UPDATE / DELETE. The simple-query path has no
+        // bound parameters (`&[]`); a `$N` in simple SQL is therefore a fail-loud
+        // error (no value to bind). With `txn = Some(buffer)` (an open
+        // transaction) the write is BUFFERED as a `TransactionWrite` and
+        // committed atomically via Accord on COMMIT; with `txn = None`
+        // (autocommit) it applies immediately via `write_atomic_batch`. An INSERT
+        // RETURNING leads with a RowDescription on this (simple) path.
+        Statement::Insert(ins) => execute_insert(
+            engine,
+            schema,
+            &ins,
+            default_schema,
+            &[],
+            ReturningOpts::simple(),
+            txn,
+        ),
+        Statement::Update(upd) => execute_update(engine, schema, &upd, default_schema, &[], txn),
+        Statement::Delete(del) => execute_delete(engine, schema, &del, default_schema, &[], txn),
     }
 }
 
@@ -782,6 +793,31 @@ fn apply_or_buffer(
             }],
             Err(e) => vec![error_response("58000", &format!("write failed: {e}"))],
         },
+    }
+}
+
+/// Resolve a DML scalar to a concrete [`SqlValue`], substituting bound
+/// parameters from `params` (1-based, the Postgres `$N` numbering). A literal
+/// passes through; a `$N` indexes `params`. FAILS LOUD (`08P01`,
+/// protocol_violation) when `$N` has no bound value — never a silent default, so
+/// a parameter the client failed to bind can never become NULL. Function calls
+/// in DML values are unsupported (`0A000`).
+fn substitute_param(sv: &ScalarValue, params: &[SqlValue]) -> Result<SqlValue, BackendMessage> {
+    match sv {
+        ScalarValue::Literal(v) => Ok(v.clone()),
+        ScalarValue::Param(n) => {
+            // `$N` is 1-based; `params` is 0-based.
+            params.get(n.wrapping_sub(1)).cloned().ok_or_else(|| {
+                error_response(
+                    "08P01",
+                    &format!("bind parameter ${n} has no value (out of range)"),
+                )
+            })
+        }
+        ScalarValue::Func(_) => Err(error_response(
+            "0A000",
+            "function calls in DML values are not supported",
+        )),
     }
 }
 
@@ -838,18 +874,56 @@ fn value_to_cql(value: &SqlValue, ty: &CqlType) -> Result<CqlValue, BackendMessa
     Ok(out)
 }
 
+/// How an `INSERT ... RETURNING` result is rendered, bundled so `execute_insert`
+/// stays within the argument limit. `with_row_description` controls whether the
+/// result leads with a `RowDescription` (simple path: `true`; extended Execute:
+/// `false`, the client already learned columns from `Describe`); `result_formats`
+/// are the portal's per-column format codes (empty ⇒ all text).
+#[derive(Clone, Copy)]
+pub(crate) struct ReturningOpts<'a> {
+    pub with_row_description: bool,
+    pub result_formats: &'a [i16],
+}
+
+impl ReturningOpts<'_> {
+    /// The simple-query default: lead with a `RowDescription`, all text format.
+    pub(crate) fn simple() -> Self {
+        Self {
+            with_row_description: true,
+            result_formats: &[],
+        }
+    }
+}
+
 /// Execute a single-row `INSERT`: materialize the row from the table schema and
 /// write it through the engine. Returns `CommandComplete "INSERT 0 1"` (Postgres
 /// reports oid 0 + a 1-row count). The row encoder is the shared
 /// `ferrosa-row-bridge` one — the SAME bytes the engine + CQL reads decode.
-fn execute_insert(
+///
+/// `params` supplies bound `$N` values (the extended-query path); the simple
+/// path passes `&[]`. `returning_opts` controls RETURNING rendering (see
+/// [`ReturningOpts`]). `txn = Some(buffer)` BUFFERS the write as a
+/// `TransactionWrite` (committed atomically on COMMIT); `None` is autocommit.
+///
+/// `RETURNING` echoes the values just written (built in-memory from the supplied
+/// column values — storage is NOT read back): exactly what Ecto needs to recover
+/// a generated/echoed key after an insert. A buffered write still returns its
+/// RETURNING rows now; the write commits at COMMIT.
+pub(crate) fn execute_insert(
     engine: &StorageEngine,
     schema: &Schema,
     ins: &InsertStmt,
     default_schema: &str,
+    params: &[SqlValue],
+    returning_opts: ReturningOpts<'_>,
     txn: Option<&mut Vec<ferrosa_storage::accord::TransactionWrite>>,
 ) -> Vec<BackendMessage> {
     use std::collections::HashMap;
+
+    let ReturningOpts {
+        with_row_description,
+        result_formats,
+    } = returning_opts;
 
     let ks = ins.table.schema.as_deref().unwrap_or(default_schema);
     let snap = schema.snapshot();
@@ -863,46 +937,24 @@ fn execute_insert(
         }
     };
 
-    // Convert each named column's value (per its CQL type); collect regular/
-    // static cells by storage index, and all values by name for key ordering.
+    // Resolve each named column's value (per its CQL type), substituting bound
+    // params; collect regular/static cells by storage index, the CQL values by
+    // name for key ordering, and the SQL values by name for RETURNING.
     let mut col_values: HashMap<String, CqlValue> = HashMap::new();
+    let mut sql_values: HashMap<String, SqlValue> = HashMap::new();
     let mut regular_cells: Vec<(u16, CqlValue)> = Vec::new();
     for (i, col_name) in ins.columns.iter().enumerate() {
-        let col_meta = match meta.columns.get(col_name) {
-            Some(c) => c,
-            None => {
-                return vec![error_response(
-                    "42703",
-                    &format!(
-                        "column \"{col_name}\" of relation \"{}\" does not exist",
-                        ins.table.table
-                    ),
-                )]
-            }
-        };
-        let cql_type =
-            match ferrosa_row_bridge::parse_cql_type_in_keyspace(&col_meta.column_type, ks, schema)
-            {
-                Ok(t) => t,
-                Err(e) => return vec![error_response("42704", &e.to_string())],
-            };
-        let value = match &ins.values[i] {
-            ScalarValue::Literal(v) => match value_to_cql(v, &cql_type) {
-                Ok(cv) => cv,
-                Err(msg) => return vec![msg],
-            },
-            ScalarValue::Param(_) => {
-                return vec![error_response(
-                "0A000",
-                "$N parameters in INSERT require the extended-query protocol (not yet supported)",
-            )]
-            }
-            ScalarValue::Func(_) => {
-                return vec![error_response(
-                    "0A000",
-                    "function calls in INSERT VALUES are not supported",
-                )]
-            }
+        let (col_meta, sql_value, value) = match resolve_dml_value(
+            meta,
+            schema,
+            ks,
+            &ins.table.table,
+            col_name,
+            &ins.values[i],
+            params,
+        ) {
+            Ok(r) => r,
+            Err(msg) => return vec![msg],
         };
         if matches!(col_meta.kind, ColumnKind::Regular | ColumnKind::Static) {
             if let Some(idx) = meta.storage_column_index(col_name) {
@@ -910,6 +962,7 @@ fn execute_insert(
             }
         }
         col_values.insert(col_name.clone(), value);
+        sql_values.insert(col_name.clone(), sql_value);
     }
 
     // Partition-key and clustering values in key order — all required for INSERT.
@@ -938,6 +991,17 @@ fn execute_insert(
         }
     }
 
+    // Build the RETURNING result BEFORE the write, from the in-memory values, so
+    // a missing RETURNING column fails loud without a half-applied side effect.
+    let returning = match ins.returning.as_ref() {
+        Some(r) => match build_insert_returning(meta, schema, ks, &ins.table.table, r, &sql_values)
+        {
+            Ok(rows) => Some(rows),
+            Err(msg) => return vec![msg],
+        },
+        None => None,
+    };
+
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_micros() as i64)
@@ -954,13 +1018,365 @@ fn execute_insert(
         vec![row],
         timestamp,
     );
-    apply_or_buffer(engine, txn, &key, mutation, "INSERT 0 1")
+    // Write (or buffer into the open transaction) via the shared seam. On any
+    // error — including the write-set cap — `apply_or_buffer` returns an
+    // `ErrorResponse`; propagate it untouched (the RETURNING rows are never
+    // emitted for a failed write). On success it returns `CommandComplete
+    // "INSERT 0 1"`; when RETURNING is present we replace that with the
+    // RETURNING DataRow(s) + the same CommandComplete tag, built from the
+    // in-memory values resolved above (no storage read-back). A buffered write
+    // still returns its RETURNING rows now and commits at COMMIT.
+    let write_result = apply_or_buffer(engine, txn, &key, mutation, "INSERT 0 1");
+    let errored = write_result
+        .iter()
+        .any(|m| matches!(m, BackendMessage::ErrorResponse { .. }));
+    match returning {
+        Some(result) if !errored => render_dml_returning(
+            result,
+            with_row_description,
+            result_formats,
+            "INSERT 0 1".to_string(),
+        ),
+        _ => write_result,
+    }
+}
+
+/// Resolve a `RETURNING` clause for an `INSERT` into the output column set + the
+/// single returned row, from the values just written (no storage read-back).
+/// `RETURNING *` expands to every table column in schema order; a named column
+/// not present in the statement's value list is reported as NULL (it was not
+/// supplied — Cassandra has no row to read a default from). A `RETURNING` of a
+/// column that does not exist in the table fails loud (`42703`).
+fn build_insert_returning(
+    meta: &ferrosa_schema::TableMetadata,
+    schema: &Schema,
+    ks: &str,
+    table: &str,
+    returning: &Returning,
+    sql_values: &std::collections::HashMap<String, SqlValue>,
+) -> Result<QueryResult, BackendMessage> {
+    let names: Vec<String> = match returning {
+        Returning::Star => meta.columns.keys().cloned().collect(),
+        Returning::Columns(cols) => cols.clone(),
+    };
+    let mut columns = Vec::with_capacity(names.len());
+    let mut row = Vec::with_capacity(names.len());
+    for name in &names {
+        let col_meta = meta.columns.get(name).ok_or_else(|| {
+            error_response(
+                "42703",
+                &format!("column \"{name}\" of relation \"{table}\" does not exist in RETURNING"),
+            )
+        })?;
+        let cql_type =
+            ferrosa_row_bridge::parse_cql_type_in_keyspace(&col_meta.column_type, ks, schema)
+                .map_err(|e| error_response("42704", &e.to_string()))?;
+        columns.push(Column::new(
+            name.clone(),
+            cql_type_to_column_type(&cql_type),
+        ));
+        row.push(sql_values.get(name).cloned().unwrap_or(SqlValue::Null));
+    }
+    Ok(QueryResult {
+        columns,
+        rows: vec![Row(row)],
+    })
+}
+
+/// The parameter type OIDs to advertise for a parameterized DML statement in
+/// `ParameterDescription`. The COUNT is the number of distinct `$N` placeholders
+/// (driven by the highest index `N` referenced), so a driver like tokio-postgres
+/// — which does NOT pre-declare OIDs in `Parse` and learns the count from this
+/// reply — binds the right number of parameters. Each OID is the client-declared
+/// type where given (non-zero), else `0` (unspecified ⇒ decode leniently at
+/// Bind). No column-from-comparison inference is attempted for DML.
+///
+/// Fails loud (`08P01`) on a non-contiguous placeholder set (e.g. `$1, $3` with
+/// no `$2`): Postgres requires `$1..$N` dense, and a gap would silently bind the
+/// wrong value.
+pub(crate) fn dml_param_oids(
+    placeholders: &[usize],
+    declared: &[i32],
+) -> Result<Vec<i32>, BackendMessage> {
+    let max = placeholders.iter().copied().max().unwrap_or(0);
+    if max == 0 {
+        return Ok(Vec::new());
+    }
+    // Every index 1..=max must be present (Postgres requires dense $1..$N).
+    for n in 1..=max {
+        if !placeholders.contains(&n) {
+            return Err(error_response(
+                "08P01",
+                &format!("parameter ${n} is referenced out of order or missing in $1..${max}"),
+            ));
+        }
+    }
+    Ok((1..=max)
+        .map(|n| match declared.get(n - 1).copied() {
+            Some(oid) if oid != 0 => oid,
+            _ => 0,
+        })
+        .collect())
+}
+
+/// Collect the `$N` placeholder indices referenced by an `INSERT`'s VALUES.
+pub(crate) fn insert_placeholders(ins: &InsertStmt) -> Vec<usize> {
+    ins.values.iter().filter_map(scalar_param_index).collect()
+}
+
+/// Collect the `$N` placeholder indices referenced by an `UPDATE` (SET + WHERE).
+pub(crate) fn update_placeholders(upd: &UpdateStmt) -> Vec<usize> {
+    upd.assignments
+        .iter()
+        .chain(upd.where_eq.iter())
+        .filter_map(|(_, sv)| scalar_param_index(sv))
+        .collect()
+}
+
+/// Collect the `$N` placeholder indices referenced by a `DELETE`'s WHERE.
+pub(crate) fn delete_placeholders(del: &DeleteStmt) -> Vec<usize> {
+    del.where_eq
+        .iter()
+        .filter_map(|(_, sv)| scalar_param_index(sv))
+        .collect()
+}
+
+/// The 1-based `$N` index of a scalar, if it is a parameter placeholder.
+fn scalar_param_index(sv: &ScalarValue) -> Option<usize> {
+    match sv {
+        ScalarValue::Param(n) => Some(*n),
+        _ => None,
+    }
+}
+
+/// `(placeholder index, target column name)` pairs for an `INSERT`: each `$N` in
+/// VALUES is bound to the column at the same position in the column list.
+fn insert_param_targets(ins: &InsertStmt) -> Vec<(usize, &str)> {
+    ins.columns
+        .iter()
+        .zip(ins.values.iter())
+        .filter_map(|(col, sv)| scalar_param_index(sv).map(|n| (n, col.as_str())))
+        .collect()
+}
+
+/// `(placeholder index, target column name)` pairs for an `UPDATE`: SET and
+/// WHERE `$N`s are bound to the column on the left of each `=`.
+fn update_param_targets(upd: &UpdateStmt) -> Vec<(usize, &str)> {
+    upd.assignments
+        .iter()
+        .chain(upd.where_eq.iter())
+        .filter_map(|(col, sv)| scalar_param_index(sv).map(|n| (n, col.as_str())))
+        .collect()
+}
+
+/// `(placeholder index, target column name)` pairs for a `DELETE` WHERE.
+fn delete_param_targets(del: &DeleteStmt) -> Vec<(usize, &str)> {
+    del.where_eq
+        .iter()
+        .filter_map(|(col, sv)| scalar_param_index(sv).map(|n| (n, col.as_str())))
+        .collect()
+}
+
+/// Infer the parameter type OIDs for a parameterized DML statement by resolving
+/// each `$N` against its TARGET COLUMN's type in the table schema. This lets a
+/// driver (tokio-postgres) serialize bound values with a concrete type instead
+/// of probing the catalog for an unspecified (`0`) OID. The client-declared OID
+/// wins where it is non-zero; otherwise the column's type drives it; a target we
+/// cannot resolve falls back to `0` (lenient). FAILS LOUD on a non-dense `$1..$N`
+/// placeholder set (via [`dml_param_oids`]).
+///
+/// `targets` maps each present placeholder to its column name; `meta` is the
+/// table metadata; `declared` the client-declared OIDs from Parse.
+fn infer_dml_param_oids(
+    targets: &[(usize, &str)],
+    meta: &ferrosa_schema::TableMetadata,
+    schema: &Schema,
+    ks: &str,
+    declared: &[i32],
+) -> Result<Vec<i32>, BackendMessage> {
+    let placeholders: Vec<usize> = targets.iter().map(|(n, _)| *n).collect();
+    // Validate density + length and seed with declared/0 first.
+    let mut oids = dml_param_oids(&placeholders, declared)?;
+    // Then refine each `0` (unspecified) slot from its target column's type.
+    for (n, col_name) in targets {
+        let idx = n - 1;
+        if oids.get(idx).copied() != Some(0) {
+            continue; // a non-zero client-declared OID already won
+        }
+        if let Some(col_meta) = meta.columns.get(*col_name) {
+            if let Ok(cql_type) =
+                ferrosa_row_bridge::parse_cql_type_in_keyspace(&col_meta.column_type, ks, schema)
+            {
+                oids[idx] = column_type_oid(cql_type_to_column_type(&cql_type));
+            }
+        }
+    }
+    Ok(oids)
+}
+
+/// Resolve a DML statement's table metadata for parameter inference, or a
+/// fail-loud `42P01` if the table does not exist. Returns the OIDs inferred from
+/// each `$N`'s target column.
+pub(crate) fn infer_insert_param_oids(
+    schema: &Schema,
+    ins: &InsertStmt,
+    default_schema: &str,
+    declared: &[i32],
+) -> Result<Vec<i32>, BackendMessage> {
+    let ks = ins.table.schema.as_deref().unwrap_or(default_schema);
+    let snap = schema.snapshot();
+    let Some(meta) = snap.tables.get(&(ks.to_string(), ins.table.table.clone())) else {
+        // Defer the table-existence error to Describe/Execute; here just fall
+        // back to declared/0 OIDs so the count is still correct.
+        return dml_param_oids(&insert_placeholders(ins), declared);
+    };
+    infer_dml_param_oids(&insert_param_targets(ins), meta, schema, ks, declared)
+}
+
+/// As [`infer_insert_param_oids`] for an `UPDATE`.
+pub(crate) fn infer_update_param_oids(
+    schema: &Schema,
+    upd: &UpdateStmt,
+    default_schema: &str,
+    declared: &[i32],
+) -> Result<Vec<i32>, BackendMessage> {
+    let ks = upd.table.schema.as_deref().unwrap_or(default_schema);
+    let snap = schema.snapshot();
+    let Some(meta) = snap.tables.get(&(ks.to_string(), upd.table.table.clone())) else {
+        return dml_param_oids(&update_placeholders(upd), declared);
+    };
+    infer_dml_param_oids(&update_param_targets(upd), meta, schema, ks, declared)
+}
+
+/// As [`infer_insert_param_oids`] for a `DELETE`.
+pub(crate) fn infer_delete_param_oids(
+    schema: &Schema,
+    del: &DeleteStmt,
+    default_schema: &str,
+    declared: &[i32],
+) -> Result<Vec<i32>, BackendMessage> {
+    let ks = del.table.schema.as_deref().unwrap_or(default_schema);
+    let snap = schema.snapshot();
+    let Some(meta) = snap.tables.get(&(ks.to_string(), del.table.table.clone())) else {
+        return dml_param_oids(&delete_placeholders(del), declared);
+    };
+    infer_dml_param_oids(&delete_param_targets(del), meta, schema, ks, declared)
+}
+
+/// Resolve the output columns of an `INSERT ... RETURNING` for the extended
+/// `Describe('S')` reply (a `RowDescription`). Returns `Ok(None)` when the
+/// statement has no `RETURNING` (the caller emits `NoData`), or the resolved
+/// column descriptors. Fails loud on an unknown table (`42P01`) or an unknown
+/// RETURNING column (`42703`) — the same errors Execute would raise, surfaced at
+/// Describe time so the driver learns the shape before binding.
+pub(crate) fn describe_insert_returning(
+    schema: &Schema,
+    ins: &InsertStmt,
+    default_schema: &str,
+) -> Result<Option<Vec<Column>>, BackendMessage> {
+    let Some(returning) = ins.returning.as_ref() else {
+        return Ok(None);
+    };
+    let ks = ins.table.schema.as_deref().unwrap_or(default_schema);
+    let snap = schema.snapshot();
+    let meta = snap
+        .tables
+        .get(&(ks.to_string(), ins.table.table.clone()))
+        .ok_or_else(|| {
+            error_response(
+                "42P01",
+                &format!("relation \"{ks}.{}\" does not exist", ins.table.table),
+            )
+        })?;
+    let names: Vec<String> = match returning {
+        Returning::Star => meta.columns.keys().cloned().collect(),
+        Returning::Columns(cols) => cols.clone(),
+    };
+    let mut columns = Vec::with_capacity(names.len());
+    for name in &names {
+        let col_meta = meta.columns.get(name).ok_or_else(|| {
+            error_response(
+                "42703",
+                &format!(
+                    "column \"{name}\" of relation \"{}\" does not exist in RETURNING",
+                    ins.table.table
+                ),
+            )
+        })?;
+        let cql_type =
+            ferrosa_row_bridge::parse_cql_type_in_keyspace(&col_meta.column_type, ks, schema)
+                .map_err(|e| error_response("42704", &e.to_string()))?;
+        columns.push(Column::new(
+            name.clone(),
+            cql_type_to_column_type(&cql_type),
+        ));
+    }
+    Ok(Some(columns))
+}
+
+/// Map a [`CqlType`] to the relational [`ColumnType`] used for the Postgres
+/// RowDescription OID/size. Mirrors `storage_provider`'s column typing; unmapped
+/// CQL types default to `Text` (their text rendering is always valid).
+fn cql_type_to_column_type(ty: &CqlType) -> ColumnType {
+    match ty {
+        CqlType::Int
+        | CqlType::Smallint
+        | CqlType::Tinyint
+        | CqlType::Bigint
+        | CqlType::Counter => ColumnType::Int,
+        CqlType::Boolean => ColumnType::Bool,
+        CqlType::Float | CqlType::Double => ColumnType::Float,
+        CqlType::Uuid | CqlType::Timeuuid => ColumnType::Uuid,
+        CqlType::Blob => ColumnType::Bytea,
+        CqlType::Timestamp => ColumnType::Timestamp,
+        CqlType::Date => ColumnType::Date,
+        CqlType::Time => ColumnType::Time,
+        CqlType::Inet => ColumnType::Inet,
+        CqlType::Decimal | CqlType::Varint => ColumnType::Numeric,
+        _ => ColumnType::Text,
+    }
+}
+
+/// Render a DML `RETURNING` result into backend messages: an optional leading
+/// `RowDescription` (simple path), the `DataRow`(s) encoded per `result_formats`
+/// (the Postgres fan-out rule — empty ⇒ all text), then `CommandComplete` with
+/// the supplied `tag`. The extended Execute path passes `with_row_description =
+/// false` (the client learned the columns from `Describe`) AND the portal's
+/// chosen result formats, so a driver requesting binary results (tokio-postgres)
+/// decodes the RETURNING row correctly.
+fn render_dml_returning(
+    result: QueryResult,
+    with_row_description: bool,
+    result_formats: &[i16],
+    tag: String,
+) -> Vec<BackendMessage> {
+    let mut out = Vec::with_capacity(result.rows.len() + 2);
+    if with_row_description {
+        out.push(BackendMessage::RowDescription {
+            fields: row_description_fields(&result.columns, result_formats),
+        });
+    }
+    let col_types: Vec<ColumnType> = result.columns.iter().map(|c| c.ty).collect();
+    for row in &result.rows {
+        let columns = row
+            .0
+            .iter()
+            .enumerate()
+            .map(|(i, v)| encode_value(result_format_for(result_formats, i), col_types[i], v))
+            .collect();
+        out.push(BackendMessage::DataRow { columns });
+    }
+    out.push(BackendMessage::CommandComplete { tag });
+    out
 }
 
 /// Resolve a `(column, value)` pair from a DML statement to its `CqlValue`,
-/// looking up the column's CQL type from `meta`. Returns the column metadata
-/// alongside so the caller can classify it (key vs regular). `$N`/function
-/// values fail loud (extended-protocol / unsupported).
+/// substituting any bound `$N` parameter from `params` first (see
+/// [`substitute_param`]), then looking up the column's CQL type from `meta`.
+/// Returns the column metadata alongside so the caller can classify it (key vs
+/// regular), and the resolved [`SqlValue`] so the caller can build a `RETURNING`
+/// row without re-reading storage. A simple-protocol caller passes `&[]`, so a
+/// `$N` there fails loud (no value bound).
 fn resolve_dml_value<'a>(
     meta: &'a ferrosa_schema::TableMetadata,
     schema: &Schema,
@@ -968,7 +1384,8 @@ fn resolve_dml_value<'a>(
     table: &str,
     col_name: &str,
     sv: &ScalarValue,
-) -> Result<(&'a ferrosa_schema::ColumnMetadata, CqlValue), BackendMessage> {
+    params: &[SqlValue],
+) -> Result<(&'a ferrosa_schema::ColumnMetadata, SqlValue, CqlValue), BackendMessage> {
     let col_meta = meta.columns.get(col_name).ok_or_else(|| {
         error_response(
             "42703",
@@ -978,22 +1395,9 @@ fn resolve_dml_value<'a>(
     let cql_type =
         ferrosa_row_bridge::parse_cql_type_in_keyspace(&col_meta.column_type, ks, schema)
             .map_err(|e| error_response("42704", &e.to_string()))?;
-    let value = match sv {
-        ScalarValue::Literal(v) => value_to_cql(v, &cql_type)?,
-        ScalarValue::Param(_) => {
-            return Err(error_response(
-                "0A000",
-                "$N parameters require the extended-query protocol (not yet supported)",
-            ))
-        }
-        ScalarValue::Func(_) => {
-            return Err(error_response(
-                "0A000",
-                "function calls in DML values are not supported",
-            ))
-        }
-    };
-    Ok((col_meta, value))
+    let sql_value = substitute_param(sv, params)?;
+    let value = value_to_cql(&sql_value, &cql_type)?;
+    Ok((col_meta, sql_value, value))
 }
 
 /// Execute a single-row `UPDATE`: a Cassandra-style upsert. The equality `WHERE`
@@ -1001,14 +1405,24 @@ fn resolve_dml_value<'a>(
 /// regular/static cells. Returns `CommandComplete "UPDATE 1"` — the engine write
 /// is a blind upsert, so the affected-row count is reported as 1 when the write
 /// lands (Cassandra has no match count; this is the documented semantic).
-fn execute_update(
+pub(crate) fn execute_update(
     engine: &StorageEngine,
     schema: &Schema,
     upd: &UpdateStmt,
     default_schema: &str,
+    params: &[SqlValue],
     txn: Option<&mut Vec<ferrosa_storage::accord::TransactionWrite>>,
 ) -> Vec<BackendMessage> {
     use std::collections::HashMap;
+
+    // UPDATE ... RETURNING is out of scope for this PR (only INSERT RETURNING is
+    // wired). Fail loud rather than silently dropping the clause.
+    if upd.returning.is_some() {
+        return vec![error_response(
+            "0A000",
+            "UPDATE ... RETURNING is not yet supported",
+        )];
+    }
 
     let ks = upd.table.schema.as_deref().unwrap_or(default_schema);
     let table = upd.table.table.as_str();
@@ -1026,10 +1440,11 @@ fn execute_update(
     // SET assignments -> regular/static cells (by storage index).
     let mut regular_cells: Vec<(u16, CqlValue)> = Vec::new();
     for (col_name, sv) in &upd.assignments {
-        let (col_meta, value) = match resolve_dml_value(meta, schema, ks, table, col_name, sv) {
-            Ok(r) => r,
-            Err(msg) => return vec![msg],
-        };
+        let (col_meta, _sql_value, value) =
+            match resolve_dml_value(meta, schema, ks, table, col_name, sv, params) {
+                Ok(r) => r,
+                Err(msg) => return vec![msg],
+            };
         if !matches!(col_meta.kind, ColumnKind::Regular | ColumnKind::Static) {
             return vec![error_response(
                 "0A000",
@@ -1050,10 +1465,11 @@ fn execute_update(
     // WHERE equality -> key values (must be key columns).
     let mut key_values: HashMap<String, CqlValue> = HashMap::new();
     for (col_name, sv) in &upd.where_eq {
-        let (col_meta, value) = match resolve_dml_value(meta, schema, ks, table, col_name, sv) {
-            Ok(r) => r,
-            Err(msg) => return vec![msg],
-        };
+        let (col_meta, _sql_value, value) =
+            match resolve_dml_value(meta, schema, ks, table, col_name, sv, params) {
+                Ok(r) => r,
+                Err(msg) => return vec![msg],
+            };
         if !matches!(
             col_meta.kind,
             ColumnKind::PartitionKey | ColumnKind::Clustering
@@ -1114,14 +1530,23 @@ fn execute_update(
 /// supplies the full primary key identifying the row. Returns `CommandComplete
 /// "DELETE 1"` — the engine writes a tombstone unconditionally, so the count is
 /// reported as 1 when the write lands (Cassandra has no match count).
-fn execute_delete(
+pub(crate) fn execute_delete(
     engine: &StorageEngine,
     schema: &Schema,
     del: &DeleteStmt,
     default_schema: &str,
+    params: &[SqlValue],
     txn: Option<&mut Vec<ferrosa_storage::accord::TransactionWrite>>,
 ) -> Vec<BackendMessage> {
     use std::collections::HashMap;
+
+    // DELETE ... RETURNING is out of scope for this PR. Fail loud.
+    if del.returning.is_some() {
+        return vec![error_response(
+            "0A000",
+            "DELETE ... RETURNING is not yet supported",
+        )];
+    }
 
     let ks = del.table.schema.as_deref().unwrap_or(default_schema);
     let table = del.table.table.as_str();
@@ -1138,10 +1563,11 @@ fn execute_delete(
 
     let mut key_values: HashMap<String, CqlValue> = HashMap::new();
     for (col_name, sv) in &del.where_eq {
-        let (col_meta, value) = match resolve_dml_value(meta, schema, ks, table, col_name, sv) {
-            Ok(r) => r,
-            Err(msg) => return vec![msg],
-        };
+        let (col_meta, _sql_value, value) =
+            match resolve_dml_value(meta, schema, ks, table, col_name, sv, params) {
+                Ok(r) => r,
+                Err(msg) => return vec![msg],
+            };
         if !matches!(
             col_meta.kind,
             ColumnKind::PartitionKey | ColumnKind::Clustering

--- a/ferrosa-postgres/src/server.rs
+++ b/ferrosa-postgres/src/server.rs
@@ -443,6 +443,68 @@ async fn describe(
                         Err(err) => vec![session.fail(err)],
                     }
                 }
+                // Parameterized DML: advertise one OID per `$N` placeholder so a
+                // driver that does NOT pre-declare OIDs (tokio-postgres) learns
+                // the count. Each OID is the client-declared type where given,
+                // else `0` (unspecified ⇒ lenient Bind decode). We persist these
+                // so the subsequent Bind decodes against the same OIDs. The
+                // result shape is a RowDescription for INSERT RETURNING, else
+                // NoData (UPDATE/DELETE never return rows here).
+                PreparedKind::Insert(ins) => {
+                    let param_oids = match query::infer_insert_param_oids(
+                        &ctx.schema,
+                        &ins,
+                        &ctx.default_schema,
+                        &declared,
+                    ) {
+                        Ok(oids) => oids,
+                        Err(err) => return vec![session.fail(err)],
+                    };
+                    session.set_param_oids(name, param_oids.clone());
+                    match query::describe_insert_returning(&ctx.schema, &ins, &ctx.default_schema) {
+                        Ok(Some(columns)) => vec![
+                            extended::parameter_description(&param_oids),
+                            extended::describe_statement_rows(&columns),
+                        ],
+                        Ok(None) => vec![
+                            extended::parameter_description(&param_oids),
+                            BackendMessage::NoData,
+                        ],
+                        Err(err) => vec![session.fail(err)],
+                    }
+                }
+                PreparedKind::Update(upd) => {
+                    let param_oids = match query::infer_update_param_oids(
+                        &ctx.schema,
+                        &upd,
+                        &ctx.default_schema,
+                        &declared,
+                    ) {
+                        Ok(oids) => oids,
+                        Err(err) => return vec![session.fail(err)],
+                    };
+                    session.set_param_oids(name, param_oids.clone());
+                    vec![
+                        extended::parameter_description(&param_oids),
+                        BackendMessage::NoData,
+                    ]
+                }
+                PreparedKind::Delete(del) => {
+                    let param_oids = match query::infer_delete_param_oids(
+                        &ctx.schema,
+                        &del,
+                        &ctx.default_schema,
+                        &declared,
+                    ) {
+                        Ok(oids) => oids,
+                        Err(err) => return vec![session.fail(err)],
+                    };
+                    session.set_param_oids(name, param_oids.clone());
+                    vec![
+                        extended::parameter_description(&param_oids),
+                        BackendMessage::NoData,
+                    ]
+                }
             }
         }
         b'P' => {
@@ -480,6 +542,20 @@ async fn describe(
                         }
                         Err(err) => vec![session.fail(err)],
                     }
+                }
+                // DML portal: a RowDescription for INSERT RETURNING (under the
+                // portal's result formats), else NoData. UPDATE/DELETE: NoData.
+                PreparedKind::Insert(ins) => {
+                    match query::describe_insert_returning(&ctx.schema, &ins, &ctx.default_schema) {
+                        Ok(Some(columns)) => {
+                            vec![extended::describe_portal_rows(&columns, &result_formats)]
+                        }
+                        Ok(None) => vec![BackendMessage::NoData],
+                        Err(err) => vec![session.fail(err)],
+                    }
+                }
+                PreparedKind::Update(_) | PreparedKind::Delete(_) => {
+                    vec![BackendMessage::NoData]
                 }
             }
         }
@@ -592,7 +668,107 @@ async fn execute_portal(
                 Err(msg) => vec![session.fail(msg)],
             }
         }
+        // Parameterized DML over the extended protocol. The bound params drive
+        // `$N` substitution; the Execute path omits the leading RowDescription
+        // for INSERT RETURNING (the client learned columns from Describe). In an
+        // open transaction the write is BUFFERED into the session write-set
+        // (`Some(txn_writes_mut())`) and committed atomically via Accord at
+        // COMMIT; autocommit (no open txn) applies immediately. A failed DML
+        // poisons the transaction (`execute_dml`).
+        PreparedKind::Insert(ins) => {
+            // Extended Execute: no leading RowDescription for RETURNING (sent at
+            // Describe time); rows honor the portal's result formats.
+            let returning_opts = query::ReturningOpts {
+                with_row_description: false,
+                result_formats: &result_formats,
+            };
+            let in_txn = session.in_txn();
+            let msgs = if in_txn {
+                query::execute_insert(
+                    &ctx.engine,
+                    &ctx.schema,
+                    &ins,
+                    &ctx.default_schema,
+                    &params,
+                    returning_opts,
+                    Some(session.txn_writes_mut()),
+                )
+            } else {
+                query::execute_insert(
+                    &ctx.engine,
+                    &ctx.schema,
+                    &ins,
+                    &ctx.default_schema,
+                    &params,
+                    returning_opts,
+                    None,
+                )
+            };
+            execute_dml(session, msgs)
+        }
+        PreparedKind::Update(upd) => {
+            let in_txn = session.in_txn();
+            let msgs = if in_txn {
+                query::execute_update(
+                    &ctx.engine,
+                    &ctx.schema,
+                    &upd,
+                    &ctx.default_schema,
+                    &params,
+                    Some(session.txn_writes_mut()),
+                )
+            } else {
+                query::execute_update(
+                    &ctx.engine,
+                    &ctx.schema,
+                    &upd,
+                    &ctx.default_schema,
+                    &params,
+                    None,
+                )
+            };
+            execute_dml(session, msgs)
+        }
+        PreparedKind::Delete(del) => {
+            let in_txn = session.in_txn();
+            let msgs = if in_txn {
+                query::execute_delete(
+                    &ctx.engine,
+                    &ctx.schema,
+                    &del,
+                    &ctx.default_schema,
+                    &params,
+                    Some(session.txn_writes_mut()),
+                )
+            } else {
+                query::execute_delete(
+                    &ctx.engine,
+                    &ctx.schema,
+                    &del,
+                    &ctx.default_schema,
+                    &params,
+                    None,
+                )
+            };
+            execute_dml(session, msgs)
+        }
     }
+}
+
+/// Post-process a DML executor's messages for the extended Execute path: if it
+/// produced an `ErrorResponse`, set the skip-until-Sync flag AND poison the
+/// transaction (so a failed statement inside a `BEGIN` block can never be
+/// committed — the same fail-loud rule the simple-query path applies). Returns
+/// the messages unchanged.
+fn execute_dml(session: &mut Session, msgs: Vec<BackendMessage>) -> Vec<BackendMessage> {
+    if msgs
+        .iter()
+        .any(|m| matches!(m, BackendMessage::ErrorResponse { .. }))
+    {
+        session.mark_error();
+        session.mark_txn_failed();
+    }
+    msgs
 }
 
 /// SQLSTATE for a codec-level framing error (always a protocol violation).

--- a/ferrosa-postgres/tests/m1_join_live.rs
+++ b/ferrosa-postgres/tests/m1_join_live.rs
@@ -605,3 +605,284 @@ async fn where_having_distinct_over_a_real_driver() {
     assert_eq!(distinct[0].get(0), Some("1"));
     assert_eq!(distinct[1].get(0), Some("2"));
 }
+
+// ── Extended-protocol DML (parameterized INSERT/UPDATE/DELETE + RETURNING) ──────
+//
+// These exercise the Parse → Bind($N) → Execute path that `Ecto.Repo`'s
+// insert/update/delete/all calls drive: tokio-postgres `execute`/`query` with
+// bound parameters, over the same in-memory engine + `users(id int PK, name
+// text)` fixture. They are the end-to-end evidence for `feat/pg-extended-crud`.
+
+/// Spin up a fresh server over the seeded engine and return a connected driver
+/// client (+ the tempdir to keep storage alive for the test's lifetime). No
+/// Accord committer — autocommit DML applies immediately; a COMMIT carrying
+/// buffered DML would fail loud (cluster mode required).
+async fn dml_client() -> (tokio_postgres::Client, tempfile::TempDir) {
+    dml_client_with_committer(false).await
+}
+
+/// As [`dml_client`], but `with_committer` installs a
+/// [`MockTransactionCommitter`] in the `QueryContext` so a `BEGIN`/`COMMIT`
+/// block commits its buffered write-set (the mock records it and reports
+/// `Committed`) instead of failing loud for missing cluster mode.
+async fn dml_client_with_committer(
+    with_committer: bool,
+) -> (tokio_postgres::Client, tempfile::TempDir) {
+    use ferrosa_storage::accord::MockTransactionCommitter;
+    let dir = tempfile::tempdir().unwrap();
+    let engine = seed_engine(dir.path());
+    let schema = create_schema();
+    let accord_committer: Option<Arc<dyn ferrosa_storage::accord::TransactionCommitter>> =
+        if with_committer {
+            Some(Arc::new(MockTransactionCommitter::new()))
+        } else {
+            None
+        };
+    let ctx = Arc::new(QueryContext {
+        engine: Arc::new(engine),
+        schema: Arc::new(schema),
+        default_schema: "public".into(),
+        accord_committer,
+    });
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(server::serve(listener, dev_store(), ctx));
+    (connect(port).await, dir)
+}
+
+#[tokio::test]
+async fn extended_parameterized_insert_writes_row() {
+    let (client, _dir) = dml_client().await;
+
+    // Parse → Bind($1=42, $2='carol') → Execute. tokio-postgres `execute`
+    // returns the affected-row count parsed from the CommandComplete tag.
+    let n = client
+        .execute(
+            "INSERT INTO users (id, name) VALUES ($1, $2)",
+            &[&42i32, &"carol"],
+        )
+        .await
+        .expect("parameterized INSERT should apply");
+    assert_eq!(n, 1, "INSERT 0 1 ⇒ one affected row");
+
+    // The row is now readable back over the same connection.
+    let rows = client
+        .query("SELECT name FROM users WHERE id = $1", &[&42i32])
+        .await
+        .expect("the inserted row should be readable");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, &str>(0), "carol");
+}
+
+#[tokio::test]
+async fn extended_insert_returning_id_yields_a_data_row() {
+    let (client, _dir) = dml_client().await;
+
+    // INSERT ... RETURNING id: the row Ecto reads back to recover a key. The
+    // returned value is the value just written (no storage read-back).
+    let rows = client
+        .query(
+            "INSERT INTO users (id, name) VALUES ($1, $2) RETURNING id",
+            &[&7i32, &"dave"],
+        )
+        .await
+        .expect("INSERT RETURNING should return the new row");
+    assert_eq!(rows.len(), 1, "RETURNING yields exactly the inserted row");
+    assert_eq!(rows[0].get::<_, i32>(0), 7, "RETURNING id echoes the key");
+}
+
+#[tokio::test]
+async fn extended_insert_returning_star_yields_all_columns() {
+    let (client, _dir) = dml_client().await;
+    let rows = client
+        .query(
+            "INSERT INTO users (id, name) VALUES ($1, $2) RETURNING *",
+            &[&9i32, &"erin"],
+        )
+        .await
+        .expect("INSERT RETURNING * should return all columns");
+    assert_eq!(rows.len(), 1);
+    // Column order follows the table schema: id (PK) then name.
+    assert_eq!(rows[0].get::<_, i32>("id"), 9);
+    assert_eq!(rows[0].get::<_, &str>("name"), "erin");
+}
+
+#[tokio::test]
+async fn extended_parameterized_update_applies() {
+    let (client, _dir) = dml_client().await;
+
+    // alice (id=1) starts as "alice"; UPDATE her name via bound params.
+    let n = client
+        .execute(
+            "UPDATE users SET name = $1 WHERE id = $2",
+            &[&"alice2", &1i32],
+        )
+        .await
+        .expect("parameterized UPDATE should apply");
+    assert_eq!(n, 1, "UPDATE 1 ⇒ one affected row");
+
+    let rows = client
+        .query("SELECT name FROM users WHERE id = $1", &[&1i32])
+        .await
+        .expect("the updated row should be readable");
+    assert_eq!(rows[0].get::<_, &str>(0), "alice2");
+}
+
+#[tokio::test]
+async fn extended_parameterized_delete_applies() {
+    let (client, _dir) = dml_client().await;
+
+    // bob (id=2) exists in the fixture; DELETE him via a bound param.
+    let n = client
+        .execute("DELETE FROM users WHERE id = $1", &[&2i32])
+        .await
+        .expect("parameterized DELETE should apply");
+    assert_eq!(n, 1, "DELETE 1 ⇒ one affected row");
+
+    let rows = client
+        .query("SELECT name FROM users WHERE id = $1", &[&2i32])
+        .await
+        .expect("query after delete should succeed");
+    assert!(rows.is_empty(), "the deleted row is gone");
+}
+
+#[tokio::test]
+async fn extended_update_returning_is_unsupported_fail_loud() {
+    let (client, _dir) = dml_client().await;
+    // UPDATE ... RETURNING is out of scope this PR: a clear 0A000, not a silent
+    // drop of the RETURNING clause.
+    let err = client
+        .query(
+            "UPDATE users SET name = $1 WHERE id = $2 RETURNING id",
+            &[&"x", &1i32],
+        )
+        .await
+        .expect_err("UPDATE RETURNING must fail loud");
+    assert_eq!(
+        err.code().map(|c| c.code()),
+        Some("0A000"),
+        "UPDATE RETURNING should be feature_not_supported, got: {err}"
+    );
+    // The connection survives (its own Sync/ReadyForQuery): a plain read works.
+    let ok = client
+        .query("SELECT name FROM users WHERE id = $1", &[&1i32])
+        .await
+        .expect("session usable after the fail-loud error");
+    assert_eq!(ok.len(), 1);
+}
+
+#[tokio::test]
+async fn extended_delete_returning_is_unsupported_fail_loud() {
+    let (client, _dir) = dml_client().await;
+    let err = client
+        .query("DELETE FROM users WHERE id = $1 RETURNING id", &[&1i32])
+        .await
+        .expect_err("DELETE RETURNING must fail loud");
+    assert_eq!(
+        err.code().map(|c| c.code()),
+        Some("0A000"),
+        "DELETE RETURNING should be feature_not_supported, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn extended_dml_in_transaction_rollback_discards_buffered_write() {
+    // Extended-protocol DML inside a BEGIN block is BUFFERED (not applied), and
+    // ROLLBACK discards the buffer — the write is never applied. The INSERT
+    // RETURNING still returns its row (built from the in-memory values) while
+    // the write would only commit at COMMIT. A committer is installed so the
+    // write buffers cleanly rather than tripping the standalone fail-loud path.
+    let (client, _dir) = dml_client_with_committer(true).await;
+
+    client.batch_execute("BEGIN").await.expect("BEGIN");
+
+    // INSERT ... RETURNING inside the txn returns its row now (buffered write).
+    let rows = client
+        .query(
+            "INSERT INTO users (id, name) VALUES ($1, $2) RETURNING id",
+            &[&100i32, &"frank"],
+        )
+        .await
+        .expect("buffered INSERT RETURNING returns its row");
+    assert_eq!(rows.len(), 1, "RETURNING yields the buffered row");
+    assert_eq!(rows[0].get::<_, i32>(0), 100);
+
+    // ROLLBACK discards the buffer — the write was never applied.
+    client.batch_execute("ROLLBACK").await.expect("ROLLBACK");
+
+    // Nothing was applied: the targeted row never appeared in storage.
+    let after = client
+        .query("SELECT name FROM users WHERE id = $1", &[&100i32])
+        .await
+        .expect("read after rollback should succeed");
+    assert!(
+        after.is_empty(),
+        "the buffered in-txn INSERT was discarded by ROLLBACK, not applied"
+    );
+}
+
+#[tokio::test]
+async fn extended_dml_in_transaction_commit_drives_the_committer() {
+    // Extended-protocol DML inside a BEGIN block buffers; COMMIT drives the
+    // buffered write-set through the Accord committer. With a committer wired,
+    // COMMIT succeeds cleanly (not the standalone `0A000`). The atomic-apply
+    // semantics themselves are unit-tested in `server::txn_atomicity_tests`
+    // against a real engine; here we prove the extended path reaches COMMIT.
+    let (client, _dir) = dml_client_with_committer(true).await;
+
+    client.batch_execute("BEGIN").await.expect("BEGIN");
+    let n = client
+        .execute(
+            "INSERT INTO users (id, name) VALUES ($1, $2)",
+            &[&101i32, &"grace"],
+        )
+        .await
+        .expect("buffered INSERT acks inside the txn");
+    assert_eq!(n, 1, "INSERT 0 1 ⇒ one buffered row");
+
+    // COMMIT drives the write-set through the committer and succeeds.
+    client
+        .batch_execute("COMMIT")
+        .await
+        .expect("COMMIT of a buffered write-set should succeed with a committer");
+}
+
+#[tokio::test]
+async fn extended_dml_in_transaction_without_committer_fails_loud_at_commit() {
+    // Standalone mode (no committer): an extended-protocol DML buffers, but
+    // COMMIT of a non-empty buffer fails loud (`0A000`, cluster mode required)
+    // rather than faking atomicity or applying outside the committer. The buffer
+    // is discarded, so nothing is applied.
+    let (client, _dir) = dml_client().await; // no committer
+
+    client.batch_execute("BEGIN").await.expect("BEGIN");
+    let n = client
+        .execute(
+            "INSERT INTO users (id, name) VALUES ($1, $2)",
+            &[&102i32, &"heidi"],
+        )
+        .await
+        .expect("buffered INSERT acks inside the txn");
+    assert_eq!(n, 1, "the write buffers (acks) inside the txn");
+
+    // COMMIT fails loud: no committer to apply the buffered write-set.
+    let err = client
+        .batch_execute("COMMIT")
+        .await
+        .expect_err("COMMIT without a committer must fail loud");
+    assert_eq!(
+        err.code().map(|c| c.code()),
+        Some("0A000"),
+        "standalone COMMIT of buffered DML is feature_not_supported, got: {err}"
+    );
+
+    // Nothing was applied: the buffered write was dropped, not written.
+    let after = client
+        .query("SELECT name FROM users WHERE id = $1", &[&102i32])
+        .await
+        .expect("read after failed commit should succeed");
+    assert!(
+        after.is_empty(),
+        "the buffered write was never applied outside the committer"
+    );
+}

--- a/ferrosa-sql/src/ast.rs
+++ b/ferrosa-sql/src/ast.rs
@@ -39,31 +39,47 @@ pub enum Statement {
     Delete(Box<DeleteStmt>),
 }
 
-/// `INSERT INTO [schema.]table (col, ...) VALUES (val, ...)`. Single-row, with
-/// literal or `$N` values (one per named column).
+/// `INSERT INTO [schema.]table (col, ...) VALUES (val, ...) [RETURNING ...]`.
+/// Single-row, with literal or `$N` values (one per named column). The optional
+/// `returning` clause names the columns to echo back (see [`Returning`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InsertStmt {
     pub table: TableRef,
     pub columns: Vec<String>,
     pub values: Vec<ScalarValue>,
+    pub returning: Option<Returning>,
 }
 
-/// `UPDATE [schema.]table SET col = val, ... WHERE col = val [AND ...]`. The
-/// `WHERE` is restricted to equality on key columns (Cassandra-style upsert: the
-/// full primary key identifies the row); `assignments` are the SET cells.
+/// `UPDATE [schema.]table SET col = val, ... WHERE col = val [AND ...]
+/// [RETURNING ...]`. The `WHERE` is restricted to equality on key columns
+/// (Cassandra-style upsert: the full primary key identifies the row);
+/// `assignments` are the SET cells.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateStmt {
     pub table: TableRef,
     pub assignments: Vec<(String, ScalarValue)>,
     pub where_eq: Vec<(String, ScalarValue)>,
+    pub returning: Option<Returning>,
 }
 
-/// `DELETE FROM [schema.]table WHERE col = val [AND ...]`. Row-level delete; the
-/// equality `WHERE` supplies the full primary key identifying the row.
+/// `DELETE FROM [schema.]table WHERE col = val [AND ...] [RETURNING ...]`.
+/// Row-level delete; the equality `WHERE` supplies the full primary key
+/// identifying the row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteStmt {
     pub table: TableRef,
     pub where_eq: Vec<(String, ScalarValue)>,
+    pub returning: Option<Returning>,
+}
+
+/// A `RETURNING` clause: either `RETURNING *` (all of the table's columns, in
+/// schema order — resolved at execute time) or an explicit list of column names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Returning {
+    /// `RETURNING *` — every column of the target table.
+    Star,
+    /// `RETURNING col, col, ...` — the named columns, in the order written.
+    Columns(Vec<String>),
 }
 
 /// One projected scalar in a no-`FROM` SELECT, with an optional `AS` alias.

--- a/ferrosa-sql/src/lib.rs
+++ b/ferrosa-sql/src/lib.rs
@@ -17,8 +17,8 @@ pub mod types;
 
 pub use ast::SelectStmt;
 pub use ast::{
-    AggArg, DeleteStmt, Expr, InsertStmt, Operand, OrderItem, Projection, ScalarItem, ScalarValue,
-    SelectItem, Statement, Term, UpdateStmt,
+    AggArg, DeleteStmt, Expr, InsertStmt, Operand, OrderItem, Projection, Returning, ScalarItem,
+    ScalarValue, SelectItem, Statement, Term, UpdateStmt,
 };
 pub use catalog::{Catalog, MapCatalog, SharedTable};
 pub use exec::{

--- a/ferrosa-sql/src/parser.rs
+++ b/ferrosa-sql/src/parser.rs
@@ -4,7 +4,8 @@ use std::fmt;
 
 use crate::ast::{
     AggArg, ColumnRef, DeleteStmt, Expr, InsertStmt, Join, Operand, OrderItem, Projection,
-    ScalarItem, ScalarValue, SelectItem, SelectStmt, Statement, TableRef, Term, UpdateStmt,
+    Returning, ScalarItem, ScalarValue, SelectItem, SelectStmt, Statement, TableRef, Term,
+    UpdateStmt,
 };
 use crate::exec::{AggFunc, CmpOp, SortDir};
 use crate::types::Value;
@@ -598,6 +599,11 @@ impl Parser {
             values.push(self.parse_scalar_value()?);
         }
         self.expect(&Tok::RParen, ")")?;
+
+        // ON CONFLICT is recognized to fail loud (out of scope), never silently
+        // ignored — a client that relies on upsert semantics must learn it.
+        self.reject_on_conflict()?;
+        let returning = self.parse_returning()?;
         self.expect_end()?;
 
         if columns.len() != values.len() {
@@ -610,6 +616,7 @@ impl Parser {
             table,
             columns,
             values,
+            returning,
         })))
     }
 
@@ -633,12 +640,14 @@ impl Parser {
             self.next();
             where_eq.push(self.parse_assignment()?);
         }
+        let returning = self.parse_returning()?;
         self.expect_end()?;
 
         Ok(Statement::Update(Box::new(UpdateStmt {
             table,
             assignments,
             where_eq,
+            returning,
         })))
     }
 
@@ -655,9 +664,52 @@ impl Parser {
             self.next();
             where_eq.push(self.parse_assignment()?);
         }
+        let returning = self.parse_returning()?;
         self.expect_end()?;
 
-        Ok(Statement::Delete(Box::new(DeleteStmt { table, where_eq })))
+        Ok(Statement::Delete(Box::new(DeleteStmt {
+            table,
+            where_eq,
+            returning,
+        })))
+    }
+
+    /// Parse an optional `RETURNING * | col, col, ...` clause. Returns `None`
+    /// when the next token is not the `RETURNING` keyword (it is lexed as a bare
+    /// identifier). `RETURNING *` yields [`Returning::Star`].
+    fn parse_returning(&mut self) -> Result<Option<Returning>, ParseError> {
+        match self.peek() {
+            Some(Tok::Ident(w)) if w.eq_ignore_ascii_case("RETURNING") => {
+                self.next(); // RETURNING
+            }
+            _ => return Ok(None),
+        }
+        if matches!(self.peek(), Some(Tok::Star)) {
+            self.next();
+            return Ok(Some(Returning::Star));
+        }
+        let mut cols = vec![self.ident()?];
+        while matches!(self.peek(), Some(Tok::Comma)) {
+            self.next();
+            cols.push(self.ident()?);
+        }
+        Ok(Some(Returning::Columns(cols)))
+    }
+
+    /// Fail loud on an `ON CONFLICT` clause: upsert/`DO` semantics are out of
+    /// scope, and silently dropping the clause would change the statement's
+    /// meaning. A bare `ON` not followed by `CONFLICT` is left for the caller's
+    /// `expect_end`/`parse_returning` to reject in context.
+    fn reject_on_conflict(&mut self) -> Result<(), ParseError> {
+        if matches!(self.peek(), Some(Tok::On))
+            && matches!(self.toks.get(self.pos + 1), Some(Tok::Ident(w)) if w.eq_ignore_ascii_case("CONFLICT"))
+        {
+            return Err(ParseError::Unexpected {
+                expected: "no ON CONFLICT (not yet supported)",
+                found: "ON CONFLICT".to_string(),
+            });
+        }
+        Ok(())
     }
 
     /// Parse `[schema.]table` with NO trailing alias — for DML targets, where a
@@ -1726,6 +1778,81 @@ mod tests {
             }
             other => panic!("expected Delete, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_statement_insert_returning_columns() {
+        let stmt =
+            parse_statement("INSERT INTO t (id, v) VALUES ($1, $2) RETURNING id, v").unwrap();
+        match stmt {
+            Statement::Insert(ins) => {
+                assert_eq!(
+                    ins.values,
+                    vec![ScalarValue::Param(1), ScalarValue::Param(2)]
+                );
+                assert_eq!(
+                    ins.returning,
+                    Some(Returning::Columns(vec!["id".to_string(), "v".to_string()]))
+                );
+            }
+            other => panic!("expected Insert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_statement_insert_returning_star() {
+        let stmt = parse_statement("INSERT INTO t (id) VALUES (1) RETURNING *").unwrap();
+        match stmt {
+            Statement::Insert(ins) => assert_eq!(ins.returning, Some(Returning::Star)),
+            other => panic!("expected Insert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_statement_insert_no_returning_is_none() {
+        let stmt = parse_statement("INSERT INTO t (id) VALUES (1)").unwrap();
+        match stmt {
+            Statement::Insert(ins) => assert_eq!(ins.returning, None),
+            other => panic!("expected Insert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_statement_update_delete_returning() {
+        let upd = parse_statement("UPDATE t SET v = $1 WHERE id = $2 RETURNING id").unwrap();
+        match upd {
+            Statement::Update(u) => {
+                assert_eq!(
+                    u.assignments,
+                    vec![("v".to_string(), ScalarValue::Param(1))]
+                );
+                assert_eq!(u.where_eq, vec![("id".to_string(), ScalarValue::Param(2))]);
+                assert_eq!(
+                    u.returning,
+                    Some(Returning::Columns(vec!["id".to_string()]))
+                );
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
+        let del = parse_statement("DELETE FROM t WHERE id = $1 RETURNING *").unwrap();
+        match del {
+            Statement::Delete(d) => {
+                assert_eq!(d.where_eq, vec![("id".to_string(), ScalarValue::Param(1))]);
+                assert_eq!(d.returning, Some(Returning::Star));
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_statement_insert_on_conflict_is_clear_error() {
+        let err = parse_statement("INSERT INTO t (id) VALUES (1) ON CONFLICT DO NOTHING")
+            .expect_err("ON CONFLICT must be rejected, not silently ignored");
+        // The error message names ON CONFLICT so the boundary is explicit.
+        assert!(
+            err.to_string().contains("ON CONFLICT"),
+            "error should mention ON CONFLICT, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Continues the Postgres frontend epic `t_12d3c760` (the CRUD half; the transaction-atomicity half landed in #206). Unblocks the `Ecto.Repo.insert/update/delete/all` wire path. **Rebased onto #206** — clean single commit on top.

## What was broken
The extended query protocol (Parse/Bind/Execute — what Ecto uses) had **no DML path**: `PreparedKind` only had `Select`/`Exprs`, and the DML executors *rejected* `$N` params outright. So any parameterized INSERT/UPDATE/DELETE failed.

## What this adds
- `PreparedKind::{Insert,Update,Delete}`; `on_parse` accepts DML.
- **`$N` param binding** in DML (`substitute_param`, fail-loud `08P01` on unbound/out-of-range).
- **`RETURNING`** parsing + `INSERT … RETURNING` returning the just-inserted values in-memory (no storage read-back); `RETURNING *` supported.
- Param-OID inference from each placeholder's target column, so real `tokio-postgres` binds correctly.
- `ON CONFLICT` → clear parse error (not silently ignored).

## Integrated with #206's transaction atomicity
Extended-protocol DML inside a `BEGIN`/`COMMIT` block **buffers** into the same `Session.txn_writes` set (via `apply_or_buffer`) and commits atomically through the Accord committer at COMMIT — identical to the simple-protocol path. A buffered `INSERT … RETURNING` returns its rows immediately while the write commits at COMMIT. The earlier fail-loud-in-txn guard was removed.

## Tests (all pass; build incl. live-infra-tests + clippy clean)
8 extended-DML live driver tests (param INSERT/UPDATE/DELETE, INSERT RETURNING id/`*`, UPDATE/DELETE RETURNING → clear unsupported error) + 5 parser tests, plus the reconciled in-txn trio: `rollback_discards_buffered_write`, `commit_drives_the_committer` (MockTransactionCommitter), `without_committer_fails_loud_at_commit` (nothing applied). #206's `txn_atomicity_tests` still green.

## Out of scope (filed as follow-ups on the epic)
ON CONFLICT execution, UPDATE/DELETE RETURNING, `= ANY($N)`/IN-list.

Implemented + reconciled via subagent to a precise spec; verified independently (full build, live-infra-tests, clippy, manual read of the DML buffer/commit seam).