### PR TITLE
feat(storage): durable local file:// object_store backend (single-node DMG durability)

### DIFF
--- a/ferrosa-loadgen/src/main.rs
+++ b/ferrosa-loadgen/src/main.rs
@@ -187,6 +187,7 @@ fn main() {
     std::fs::create_dir_all(&args.data_dir).expect("create data dir");
 
     let object_store = args.s3_endpoint.map(|endpoint| ObjectStoreConfig {
+        local_path: None,
         endpoint,
         bucket: args.s3_bucket,
         region: "us-east-1".into(),

--- a/ferrosa-loadgen/tests/ucs_load_s3_test.rs
+++ b/ferrosa-loadgen/tests/ucs_load_s3_test.rs
@@ -27,6 +27,7 @@ fn s3_config(dir: &Path, profile: &LoadProfile) -> StorageEngineConfig {
         .unwrap_or_else(|_| "http://127.0.0.1:29000".into());
 
     let object_store = ObjectStoreConfig {
+        local_path: None,
         endpoint: s3_endpoint,
         bucket: "ferrosa-compaction-test".into(),
         region: "us-east-1".into(),

--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -39,8 +39,20 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
 - **S3 write-behind** (`upload/`) — `UploadManager` tokio task + bounded mpsc;
   SHA-256 integrity metadata; pending-upload log + replay for crash safety;
   separate flush vs. compaction upload managers. **Wired into the flush path.**
+- **Object-store backend** (`upload/config.rs`) — `ObjectStoreConfig` selects
+  the durable backend. Default is S3-compatible (`AmazonS3Builder`, ETag CAS).
+  Set `FERROSA_LOCAL_STORE_PATH` (or `[s3].local_path` in `ferrosa.toml`) to use
+  a durable **local `file://` backend** (`object_store::LocalFileSystem`) for
+  single-node durability without S3 — the previous "no object store" mode lost
+  flushed SSTables silently. The local backend does **not** support conditional
+  PUT (CAS); the startup probe (`probe_conditional_put_support`) detects this and
+  manifest saves fall back to unconditional PUT. Last-writer-wins is correct
+  because a single node is the only manifest writer.
 - **Local cache** (`cache.rs`) — LRU eviction with manifest-pinned entries that
-  are never evicted.
+  are never evicted. With the local `file://` backend the cache is constructed
+  durable (`new_with_durability`): the local disk *is* the store of record, so
+  `evict_if_needed` is a no-op — evicting a flushed SSTable would drop its only
+  durable copy.
 - **NVMe pinning** (`pin_config.rs`) — `PinMode::NvMe` keeps a table local and
   skips S3 upload; pin/unpin transitions reconcile the S3 lifecycle.
 - **Secondary-index pipeline** (`index/`, `memtable/eager_index.rs`) —

--- a/ferrosa-storage/specs/overview.md
+++ b/ferrosa-storage/specs/overview.md
@@ -74,6 +74,12 @@ for the mermaid diagrams.
 
 1. **S3 is authoritative; local disk is a write-behind cache.** Cache eviction
    must never delete the only copy — manifest-pinned entries are never evicted.
+   **Exception — local `file://` backend** (`FERROSA_LOCAL_STORE_PATH` /
+   `[s3].local_path`): the local disk *is* the authoritative durable store, so
+   `ObjectStoreConfig::is_local()` is threaded into `LocalCache` as `durable` and
+   eviction is disabled entirely (`evict_if_needed` is a no-op). The local
+   backend has no conditional-PUT (CAS) support, so manifest saves use the
+   unconditional path; this is safe because a single node is the sole writer.
 2. **Reads are wait-free; flush never blocks reads/writes.** All view
    transitions go through `ArcSwap`; only flushes contend, on a per-table `Mutex`.
 3. **Cell-level last-write-wins everywhere.** Memtable merge-on-write, read-path

--- a/ferrosa-storage/src/cache.rs
+++ b/ferrosa-storage/src/cache.rs
@@ -6,6 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use parking_lot::Mutex;
@@ -22,20 +23,47 @@ struct CacheEntry {
 /// Thread-safe via interior mutex. Call `register()` when a file is
 /// downloaded, `touch()` on read hits, and `evict_if_needed()` periodically
 /// or after registering new files.
+///
+/// When constructed with `durable = true` (the local `file://` backend), the
+/// local disk *is* the durable store of record, so eviction is disabled
+/// entirely: [`evict_if_needed`](Self::evict_if_needed) is a no-op. Evicting a
+/// flushed SSTable would otherwise drop the only durable copy.
 pub struct LocalCache {
     base_dir: PathBuf,
     max_bytes: u64,
+    /// When true, disk is the durable store — never evict.
+    durable: bool,
     entries: Mutex<HashMap<String, CacheEntry>>,
+    /// Guards the one-shot "eviction disabled" log line.
+    eviction_disabled_logged: AtomicBool,
 }
 
 impl LocalCache {
     /// Creates a new cache rooted at `base_dir` with the given size limit.
+    ///
+    /// Eviction is enabled (the cache is a write-behind cache over a remote
+    /// durable store such as S3).
     pub fn new(base_dir: PathBuf, max_bytes: u64) -> Self {
+        Self::new_with_durability(base_dir, max_bytes, false)
+    }
+
+    /// Creates a new cache, specifying whether the local disk is durable.
+    ///
+    /// When `durable` is true (local `file://` backend), eviction is disabled
+    /// so flushed SSTables are never removed from their only durable home.
+    pub fn new_with_durability(base_dir: PathBuf, max_bytes: u64, durable: bool) -> Self {
         Self {
             base_dir,
             max_bytes,
+            durable,
             entries: Mutex::new(HashMap::new()),
+            eviction_disabled_logged: AtomicBool::new(false),
         }
+    }
+
+    /// Whether the local disk is treated as the durable store (no eviction).
+    pub fn is_durable(&self) -> bool {
+        self.durable
     }
 
     /// Returns the base directory for cached files.
@@ -82,6 +110,18 @@ impl LocalCache {
     /// Entries whose IDs appear in `pinned` are never evicted.
     /// Returns the file paths that were removed (caller should delete them).
     pub fn evict_if_needed(&self, pinned: &HashSet<String>) -> Vec<PathBuf> {
+        // Durable local backend: disk is the source of truth. Evicting a
+        // flushed SSTable would drop its only durable copy, so never evict.
+        if self.durable {
+            if !self.eviction_disabled_logged.swap(true, Ordering::Relaxed) {
+                tracing::info!(
+                    "local file:// backend is durable — SSTable cache eviction \
+                     disabled (local disk is the durable store of record)"
+                );
+            }
+            return Vec::new();
+        }
+
         let mut entries = self.entries.lock();
         let total: u64 = entries.values().map(|e| e.size).sum();
         if total <= self.max_bytes {
@@ -207,6 +247,29 @@ mod tests {
         assert_eq!(removed.len(), 1);
         assert_eq!(removed[0], PathBuf::from("/tmp/u"));
         assert!(cache.contains("pinned1"));
+    }
+
+    #[test]
+    fn eviction_disabled_when_backend_is_local() {
+        // Durable local backend: even though the cache is well over its byte
+        // limit, eviction must remove nothing — disk is the durable store.
+        let cache = LocalCache::new_with_durability(PathBuf::from("/tmp"), 100, true);
+        assert!(cache.is_durable());
+
+        cache.register("flushed1", PathBuf::from("/tmp/flushed1"), 100);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        cache.register("flushed2", PathBuf::from("/tmp/flushed2"), 100);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        cache.register("flushed3", PathBuf::from("/tmp/flushed3"), 100);
+
+        // 300 bytes registered against a 100-byte limit; a non-durable cache
+        // would evict two entries. The durable cache evicts none.
+        let removed = cache.evict_if_needed(&HashSet::new());
+        assert!(removed.is_empty(), "durable backend must not evict");
+        assert_eq!(cache.total_size(), 300);
+        assert!(cache.contains("flushed1"));
+        assert!(cache.contains("flushed2"));
+        assert!(cache.contains("flushed3"));
     }
 
     #[test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -1808,8 +1808,23 @@ impl StorageEngine {
             object_store.as_ref(),
         );
 
-        let local_cache =
-            LocalCache::new(config.data_dir.join("cache"), config.local_cache_max_bytes);
+        // Durable local file:// backend → disk is the store of record, so the
+        // SSTable cache must never evict (would drop the only durable copy).
+        let durable_local = config
+            .object_store
+            .as_ref()
+            .is_some_and(crate::upload::ObjectStoreConfig::is_local);
+        if durable_local {
+            tracing::info!(
+                "object store backend is local file:// — treating local disk as durable; \
+                 SSTable cache eviction disabled"
+            );
+        }
+        let local_cache = LocalCache::new_with_durability(
+            config.data_dir.join("cache"),
+            config.local_cache_max_bytes,
+            durable_local,
+        );
 
         let (index_scheduler, index_tracker) = build_index_scheduler(&config);
 
@@ -1931,8 +1946,23 @@ impl StorageEngine {
             object_store.as_ref(),
         );
 
-        let local_cache =
-            LocalCache::new(config.data_dir.join("cache"), config.local_cache_max_bytes);
+        // Durable local file:// backend → disk is the store of record, so the
+        // SSTable cache must never evict (would drop the only durable copy).
+        let durable_local = config
+            .object_store
+            .as_ref()
+            .is_some_and(crate::upload::ObjectStoreConfig::is_local);
+        if durable_local {
+            tracing::info!(
+                "object store backend is local file:// — treating local disk as durable; \
+                 SSTable cache eviction disabled"
+            );
+        }
+        let local_cache = LocalCache::new_with_durability(
+            config.data_dir.join("cache"),
+            config.local_cache_max_bytes,
+            durable_local,
+        );
 
         // Set up archiver if enabled.
         let archiver_handle = match (&config.commit_log.archive, archive_store, runtime) {
@@ -2059,8 +2089,23 @@ impl StorageEngine {
             object_store.as_ref(),
         );
 
-        let local_cache =
-            LocalCache::new(config.data_dir.join("cache"), config.local_cache_max_bytes);
+        // Durable local file:// backend → disk is the store of record, so the
+        // SSTable cache must never evict (would drop the only durable copy).
+        let durable_local = config
+            .object_store
+            .as_ref()
+            .is_some_and(crate::upload::ObjectStoreConfig::is_local);
+        if durable_local {
+            tracing::info!(
+                "object store backend is local file:// — treating local disk as durable; \
+                 SSTable cache eviction disabled"
+            );
+        }
+        let local_cache = LocalCache::new_with_durability(
+            config.data_dir.join("cache"),
+            config.local_cache_max_bytes,
+            durable_local,
+        );
 
         let (index_scheduler, index_tracker) = build_index_scheduler(&config);
 
@@ -8227,8 +8272,23 @@ impl StorageEngine {
             runtime,
         ));
 
-        let local_cache =
-            LocalCache::new(config.data_dir.join("cache"), config.local_cache_max_bytes);
+        // Durable local file:// backend → disk is the store of record, so the
+        // SSTable cache must never evict (would drop the only durable copy).
+        let durable_local = config
+            .object_store
+            .as_ref()
+            .is_some_and(crate::upload::ObjectStoreConfig::is_local);
+        if durable_local {
+            tracing::info!(
+                "object store backend is local file:// — treating local disk as durable; \
+                 SSTable cache eviction disabled"
+            );
+        }
+        let local_cache = LocalCache::new_with_durability(
+            config.data_dir.join("cache"),
+            config.local_cache_max_bytes,
+            durable_local,
+        );
 
         let (index_scheduler, index_tracker) = build_index_scheduler(&config);
 

--- a/ferrosa-storage/src/manifest.rs
+++ b/ferrosa-storage/src/manifest.rs
@@ -438,6 +438,34 @@ mod tests {
         });
     }
 
+    /// Local `file://` backend: CAS is unsupported, so the engine must fall
+    /// back to the no-CAS manifest path. Single-node = exactly one writer, so
+    /// last-writer-wins is correct. Proves the no-CAS save/load round-trips on
+    /// a real `LocalFileSystem`.
+    #[tokio::test]
+    async fn local_store_cas_probe_is_false_and_manifest_saves_without_cas() {
+        use object_store::local::LocalFileSystem;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalFileSystem::new_with_prefix(dir.path()).unwrap();
+
+        assert!(
+            !probe_conditional_put_support(&store).await,
+            "LocalFileSystem must not advertise conditional-PUT (CAS) support"
+        );
+
+        let mut manifest = Manifest::new();
+        manifest.add_sstable("ks.table", sample_entry("sst-local"));
+        manifest
+            .save_without_cas(&store, "test")
+            .await
+            .expect("no-CAS save must succeed on local backend");
+
+        let (loaded, _) = Manifest::load(&store, "test").await.unwrap();
+        assert_eq!(loaded.sstables["ks.table"].len(), 1);
+        assert_eq!(loaded.sstables["ks.table"][0].id, "sst-local");
+    }
+
     #[test]
     fn remove_sstables() {
         let mut manifest = Manifest::new();

--- a/ferrosa-storage/src/upload/config.rs
+++ b/ferrosa-storage/src/upload/config.rs
@@ -1,14 +1,29 @@
 //! Object store configuration from environment variables.
 
 use object_store::aws::{AmazonS3Builder, S3ConditionalPut};
+use object_store::local::LocalFileSystem;
 use object_store::ObjectStore;
 
-/// S3-compatible object store configuration.
+/// Object store configuration.
 ///
-/// All settings are read from `FERROSA_S3_*` environment variables,
-/// following 12-factor app principles.
+/// By default this describes an S3-compatible backend whose settings are read
+/// from `FERROSA_S3_*` environment variables, following 12-factor app
+/// principles. When [`local_path`](Self::local_path) is `Some`, the engine
+/// instead builds a durable local `file://` backend
+/// ([`object_store::local::LocalFileSystem`]) rooted at that path — intended
+/// for single-node deployments that want durable storage without S3. The S3
+/// fields are ignored in that mode.
 #[derive(Debug, Clone)]
 pub struct ObjectStoreConfig {
+    /// When set, use a local `file://` backend rooted at this directory instead
+    /// of S3. Single-node durability: flushed SSTables get a durable copy on
+    /// local disk and eviction is disabled (disk is the durable store).
+    ///
+    /// The local backend does **not** support conditional PUT (CAS); the
+    /// startup CAS probe detects this and manifest saves fall back to
+    /// unconditional PUT. This is safe because a single node is the only
+    /// manifest writer.
+    pub local_path: Option<std::path::PathBuf>,
     /// S3-compatible endpoint URL (e.g., `https://s3.amazonaws.com`).
     pub endpoint: String,
     /// Bucket name.
@@ -36,11 +51,49 @@ pub struct ObjectStoreConfig {
 }
 
 impl ObjectStoreConfig {
-    /// Reads configuration from `FERROSA_S3_*` environment variables.
+    /// Reads configuration from environment variables.
     ///
-    /// Required: `FERROSA_S3_ENDPOINT`, `FERROSA_S3_BUCKET`.
-    /// Optional with defaults: region, allow_http, prefix, queue_depth.
+    /// If `FERROSA_LOCAL_STORE_PATH` is set, returns a **local `file://`
+    /// backend** configuration rooted at that path; the `FERROSA_S3_*`
+    /// variables are ignored. Otherwise reads the S3 configuration, where
+    /// `FERROSA_S3_ENDPOINT` and `FERROSA_S3_BUCKET` are required and the rest
+    /// have defaults (region, allow_http, prefix, queue/worker counts).
     pub fn from_env() -> ferrosa_common::Result<Self> {
+        // Shared worker/queue tuning is honored in both backends.
+        let prefix = std::env::var("FERROSA_S3_PREFIX").unwrap_or_default();
+        let upload_queue_depth = Self::queue_depth_from_env();
+        let upload_workers = Self::workers_from_env("FERROSA_S3_UPLOAD_WORKERS", 8);
+        let compaction_upload_workers =
+            Self::workers_from_env("FERROSA_S3_COMPACTION_UPLOAD_WORKERS", 4);
+        let compaction_upload_queue_depth =
+            std::env::var("FERROSA_S3_COMPACTION_UPLOAD_QUEUE_DEPTH")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|&v| v > 0)
+                .unwrap_or(upload_queue_depth);
+        let delete_workers = Self::workers_from_env("FERROSA_S3_DELETE_WORKERS", 2);
+
+        // Local file:// backend takes precedence when its path is set.
+        if let Ok(local_path) = std::env::var("FERROSA_LOCAL_STORE_PATH") {
+            if !local_path.trim().is_empty() {
+                return Ok(Self {
+                    local_path: Some(std::path::PathBuf::from(local_path)),
+                    endpoint: String::new(),
+                    bucket: String::new(),
+                    region: String::new(),
+                    access_key_id: None,
+                    secret_access_key: None,
+                    allow_http: false,
+                    prefix,
+                    upload_queue_depth,
+                    upload_workers,
+                    compaction_upload_workers,
+                    compaction_upload_queue_depth,
+                    delete_workers,
+                });
+            }
+        }
+
         let endpoint = std::env::var("FERROSA_S3_ENDPOINT").map_err(|_| {
             ferrosa_common::Error::InvalidFormat(
                 "FERROSA_S3_ENDPOINT environment variable is required".into(),
@@ -63,39 +116,8 @@ impl ObjectStoreConfig {
             .and_then(|v| v.parse().ok())
             .unwrap_or(false);
 
-        let prefix = std::env::var("FERROSA_S3_PREFIX").unwrap_or_default();
-
-        let upload_queue_depth = std::env::var("FERROSA_S3_UPLOAD_QUEUE_DEPTH")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(16);
-
-        let upload_workers = std::env::var("FERROSA_S3_UPLOAD_WORKERS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .filter(|&v| v > 0)
-            .unwrap_or(8);
-
-        let compaction_upload_workers = std::env::var("FERROSA_S3_COMPACTION_UPLOAD_WORKERS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .filter(|&v| v > 0)
-            .unwrap_or(4);
-
-        let compaction_upload_queue_depth =
-            std::env::var("FERROSA_S3_COMPACTION_UPLOAD_QUEUE_DEPTH")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .filter(|&v| v > 0)
-                .unwrap_or(upload_queue_depth);
-
-        let delete_workers = std::env::var("FERROSA_S3_DELETE_WORKERS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .filter(|&v| v > 0)
-            .unwrap_or(2);
-
         Ok(Self {
+            local_path: None,
             endpoint,
             bucket,
             region,
@@ -111,8 +133,48 @@ impl ObjectStoreConfig {
         })
     }
 
+    /// Whether this configuration targets the local `file://` backend.
+    pub fn is_local(&self) -> bool {
+        self.local_path.is_some()
+    }
+
+    fn queue_depth_from_env() -> usize {
+        std::env::var("FERROSA_S3_UPLOAD_QUEUE_DEPTH")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(16)
+    }
+
+    fn workers_from_env(var: &str, default: usize) -> usize {
+        std::env::var(var)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(default)
+    }
+
     /// Builds an `ObjectStore` instance from this configuration.
+    ///
+    /// When [`local_path`](Self::local_path) is set, builds a durable local
+    /// `file://` backend rooted there (creating the directory if missing).
+    /// Otherwise builds the S3-compatible client.
     pub fn build_object_store(&self) -> ferrosa_common::Result<Box<dyn ObjectStore>> {
+        if let Some(ref path) = self.local_path {
+            std::fs::create_dir_all(path).map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to create local object store dir {}: {e}",
+                    path.display()
+                ))
+            })?;
+            let store = LocalFileSystem::new_with_prefix(path).map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to build local file:// object store at {}: {e}",
+                    path.display()
+                ))
+            })?;
+            return Ok(Box::new(store));
+        }
+
         let mut builder = AmazonS3Builder::new()
             .with_endpoint(&self.endpoint)
             .with_bucket_name(&self.bucket)
@@ -138,6 +200,7 @@ impl ObjectStoreConfig {
     #[cfg(test)]
     pub fn test_config() -> Self {
         Self {
+            local_path: None,
             endpoint: "http://localhost:9000".into(),
             bucket: "test-bucket".into(),
             region: "us-east-1".into(),
@@ -204,5 +267,33 @@ mod tests {
         let store = object_store::memory::InMemory::new();
         let warnings = validate_s3_bucket(&store).await.unwrap();
         assert!(warnings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn local_object_store_round_trips() {
+        use object_store::path::Path as ObjectPath;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store_root = dir.path().join("does-not-exist-yet");
+        let config = ObjectStoreConfig {
+            local_path: Some(store_root.clone()),
+            ..ObjectStoreConfig::test_config()
+        };
+        assert!(config.is_local());
+
+        // build_object_store creates the missing directory and returns a
+        // LocalFileSystem rooted there.
+        let store = config.build_object_store().unwrap();
+        assert!(store_root.is_dir(), "build must create the store dir");
+
+        let path = ObjectPath::from("sub/dir/blob.bin");
+        let payload = bytes::Bytes::from_static(b"durable-local-bytes");
+        store.put(&path, payload.clone().into()).await.unwrap();
+
+        let got = store.get(&path).await.unwrap().bytes().await.unwrap();
+        assert_eq!(got, payload);
+
+        // The blob is a real file on disk under the store root.
+        assert!(store_root.join("sub/dir/blob.bin").is_file());
     }
 }

--- a/ferrosa-storage/src/upload/manager.rs
+++ b/ferrosa-storage/src/upload/manager.rs
@@ -958,6 +958,112 @@ mod tests {
         });
     }
 
+    /// Durability guarantee for the local `file://` backend: a flushed SSTable
+    /// uploaded through the normal upload pipeline lands as a real file under
+    /// the local store directory and survives reopening the store (i.e. a
+    /// process restart). This is the fix for silent data loss when no object
+    /// store was configured.
+    #[test]
+    fn flushed_sstable_is_durable_on_local_backend() {
+        let rt = make_runtime();
+        rt.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let store_dir = dir.path().join("objstore");
+            let component_path = dir.path().join("abc123-Data.db");
+            std::fs::write(&component_path, b"flushed sstable bytes").unwrap();
+
+            // Build the durable local backend via ObjectStoreConfig.
+            let config = crate::upload::ObjectStoreConfig {
+                local_path: Some(store_dir.clone()),
+                ..crate::upload::ObjectStoreConfig::test_config()
+            };
+            assert!(config.is_local());
+            let store: Arc<dyn ObjectStore> = Arc::from(config.build_object_store().unwrap());
+
+            let manager = UploadManager::new(
+                Arc::clone(&store),
+                "test".into(),
+                16,
+                &tokio::runtime::Handle::current(),
+            );
+            manager
+                .submit(UploadTask::SSTable {
+                    table_id: "ks.table".into(),
+                    sstable_id: "abc123".into(),
+                    files: vec![SstableComponentFile::new("abc123-Data.db", component_path)],
+                    on_complete: None,
+                })
+                .await
+                .unwrap();
+            manager.shutdown().await;
+
+            let hex = hex_prefix_for("abc123");
+            let path = sstable_object_key("test", &hex, "ks.table", "abc123", "Data.db");
+
+            // Present via the live store handle.
+            let bytes = store.get(&path).await.unwrap().bytes().await.unwrap();
+            assert_eq!(bytes.as_ref(), b"flushed sstable bytes");
+
+            // Durable: a freshly opened store over the same dir still has it
+            // (simulates a restart reattaching to the local store).
+            let reopened =
+                object_store::local::LocalFileSystem::new_with_prefix(&store_dir).unwrap();
+            let durable = reopened.get(&path).await.unwrap().bytes().await.unwrap();
+            assert_eq!(durable.as_ref(), b"flushed sstable bytes");
+        });
+    }
+
+    /// A multipart-sized upload (> the 8 MiB part threshold) lands durably on
+    /// the local backend. `put_multipart` sets no attributes, so the
+    /// LocalFileSystem multipart path is exercised without the NotImplemented
+    /// attributes special-case — no fallback needed.
+    #[test]
+    fn multipart_sized_upload_is_durable_on_local_backend() {
+        let rt = make_runtime();
+        rt.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let store_dir = dir.path().join("objstore");
+            let component_path = dir.path().join("big-Data.db");
+
+            // Larger than one part so the upload routes through put_multipart.
+            let total_len = S3_UPLOAD_PART_BYTES + 4096;
+            let data: Vec<u8> = (0..total_len).map(|i| (i % 251) as u8).collect();
+            std::fs::write(&component_path, &data).unwrap();
+
+            let config = crate::upload::ObjectStoreConfig {
+                local_path: Some(store_dir.clone()),
+                ..crate::upload::ObjectStoreConfig::test_config()
+            };
+            let store: Arc<dyn ObjectStore> = Arc::from(config.build_object_store().unwrap());
+
+            let manager = UploadManager::new(
+                Arc::clone(&store),
+                "test".into(),
+                16,
+                &tokio::runtime::Handle::current(),
+            );
+            manager
+                .submit(UploadTask::SSTable {
+                    table_id: "ks.table".into(),
+                    sstable_id: "big".into(),
+                    files: vec![SstableComponentFile::new("big-Data.db", component_path)],
+                    on_complete: None,
+                })
+                .await
+                .unwrap();
+            manager.shutdown().await;
+
+            let hex = hex_prefix_for("big");
+            let path = sstable_object_key("test", &hex, "ks.table", "big", "Data.db");
+
+            let reopened =
+                object_store::local::LocalFileSystem::new_with_prefix(&store_dir).unwrap();
+            let durable = reopened.get(&path).await.unwrap().bytes().await.unwrap();
+            assert_eq!(durable.len(), total_len);
+            assert_eq!(durable.as_ref(), data.as_slice());
+        });
+    }
+
     #[test]
     fn upload_sstable_bytes_round_trip() {
         let rt = make_runtime();

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -730,6 +730,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // else reads `FERROSA_DATA_DIR`.)
     std::env::set_var("FERROSA_DATA_DIR", &data_dir);
 
+    // Durable local `file://` object-store backend (single-node durability
+    // without S3). Resolve from `FERROSA_LOCAL_STORE_PATH` env or `[s3].local_path`
+    // TOML, expand a leading `~`, and pin it back into the env so the engine's
+    // `ObjectStoreConfig::from_env()` selects the local backend. When set, the
+    // `FERROSA_S3_*` settings are ignored. Absent → existing S3/no-store
+    // behavior is unchanged.
+    if let Some(local_store_path) =
+        config_val_opt("FERROSA_LOCAL_STORE_PATH", &file_config, "s3", "local_path")
+            .map(expand_tilde)
+            .filter(|p| !p.trim().is_empty())
+    {
+        tracing::info!(
+            path = %local_store_path,
+            "using durable local file:// object-store backend (S3 settings ignored; \
+             disk is the durable store, SSTable eviction disabled)"
+        );
+        std::env::set_var("FERROSA_LOCAL_STORE_PATH", &local_store_path);
+    }
+
     // 3. Create StorageEngine — use open() on restart to replay commit log
     let mut storage_config = ferrosa_storage::StorageEngineConfig::from_env()?;
     // Allow TOML to override the memtable shard count. `from_env`


### PR DESCRIPTION
Critical path for the macOS DMG MVP (`t_e667239d`, parent `t_f1725b54`). Lets a single-node, no-cloud install have a **durable** object store.

## Problem
With `object_store = None`, flushed SSTables had no durable destination beyond local disk, and the upload/compaction path skips silently — compaction could drop source SSTables believing they were uploaded. No durable corpus without S3.

## Fix
- `ObjectStoreConfig` gains `local_path: Option<PathBuf>` (additive — no enum rewrite). `build_object_store()` builds `LocalFileSystem::new_with_prefix` when set (fail-loud on dir/store errors), else the existing S3 path. `from_env` honors `FERROSA_LOCAL_STORE_PATH`; `main.rs` resolves env-or-`[s3].local_path` (with `~` expansion).
- **No object_store feature flag needed** — `LocalFileSystem` is unconditional in 0.11 (the task's premise was off).
- **CAS**: local returns `NotImplemented` for `PutMode::Update`, but the engine already probes CAS support and every manifest save branches to `save_without_cas` when unsupported. Single-node = one writer, so no-CAS is correct. **No CAS-logic change.**
- **Multipart** works on local (the upload path sets no attributes — verified + tested with a >8 MiB upload).
- `LocalCache` durability gate: `evict_if_needed` is a no-op when the backend is local (disk = durable source of truth).

## Tests — 5 new, ferrosa-storage 907 lib pass; clippy + fmt clean; crate docs updated
local round-trip, CAS-probe-false + no-CAS manifest round-trip, flushed-SSTable-durable-on-local, multipart-durable-on-local, eviction-disabled-when-local.

## Honest finding (surfaced, pre-existing, out of scope)
`LocalCache::evict_if_needed` has **zero non-test callers** — LRU eviction isn't wired into any production worker. So the eviction gate is **future-proofing**; the actual durability fix is the backend giving flushed SSTables a real upload destination. The S3 write-behind cache likewise has no active runtime size enforcement today — worth a separate task.

Implemented via subagent to a pre-verified design (I checked object_store 0.11.2 source for the CAS/feature/multipart facts first), then verified independently: build, clippy, all 5 tests, dead-code claim, and a read of the `build_object_store` seam.