### PR TITLE
feat(server): all user-facing endpoints on by default, explicit opt-out preserved (t_acc3c7fd)

### DIFF
--- a/config/ferrosa.example.toml
+++ b/config/ferrosa.example.toml
@@ -76,6 +76,13 @@ bind      = "127.0.0.1:7474"      # HTTP / Cypher REST + graph visualizer (/viz)
 bolt_port = 7687                  # Bolt v5 (Neo4j drivers)
 
 # ---------------------------------------------------------------------------
+# SPARQL 1.1 endpoint (RDF). Enabled by default. Set `enabled = false` here OR
+# FERROSA_SPARQL_ENABLED=false to disable it and reduce the attack surface.
+# ---------------------------------------------------------------------------
+[sparql]
+enabled = true                    # SPARQL HTTP endpoint (8080)
+
+# ---------------------------------------------------------------------------
 # Web admin console — also serves Prometheus metrics at /metrics.
 # Bind to localhost only; if you need remote access, front this with a reverse
 # proxy that handles TLS and auth.

--- a/ferrosa/ferrosa.example.toml
+++ b/ferrosa/ferrosa.example.toml
@@ -35,9 +35,18 @@ memtable_num_shards = 64
 # region = "us-east-1"
 # allow_http = false
 
+# ── User-facing endpoints ────────────────────────────────────────────────────
+# All standard endpoints are ON by default so a fresh install exposes the full
+# feature set. To REDUCE THE ATTACK SURFACE, explicitly disable the ones you
+# don't need by setting `enabled = false` below (absence = enabled).
+#   Always-on (no toggle): CQL 9042 · Postgres 5432 · web/observability 9090
+
 [graph]
-enabled = false
+enabled = true                    # graph HTTP (7474) + Bolt (7687); set false to disable
 bind = "0.0.0.0:7474"
+
+[sparql]
+enabled = true                    # SPARQL 1.1 endpoint (8080); set false to disable
 
 [web]
 bind = "0.0.0.0:9090"

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -157,9 +157,11 @@ fn apply_internode_toml_overrides<F>(
 
 /// Resolve the graph-enabled flag honouring TOML when the env var is unset.
 ///
-/// Previously the binary only read `FERROSA_GRAPH_ENABLED`, so a user
-/// who set `[graph] enabled = true` in TOML saw the graph engine stay
-/// silently off — BUG-006.
+/// Defaults to ON (t_acc3c7fd): a fresh install should expose the full
+/// user-facing feature set, so the graph HTTP (7474) + Bolt (7687) endpoints
+/// come up by default. Opt out explicitly with `FERROSA_GRAPH_ENABLED=false`
+/// or `[graph] enabled = false`. (Env wins over TOML — historically the binary
+/// only read the env var, so a TOML-only `enabled` was silently ignored, BUG-006.)
 fn resolve_graph_enabled<F>(file_config: &toml::Value, env: F) -> bool
 where
     F: Fn(&str) -> Option<String>,
@@ -171,7 +173,26 @@ where
         .get("graph")
         .and_then(|s| s.get("enabled"))
         .and_then(|v| v.as_bool())
-        .unwrap_or(false)
+        .unwrap_or(true)
+}
+
+/// Resolve the SPARQL-enabled flag honouring TOML when the env var is unset.
+///
+/// Defaults to ON (t_acc3c7fd) so a fresh install exposes the SPARQL 1.1
+/// endpoint (8080). Opt out with `FERROSA_SPARQL_ENABLED=false` or
+/// `[sparql] enabled = false`.
+fn resolve_sparql_enabled<F>(file_config: &toml::Value, env: F) -> bool
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if let Some(v) = env("FERROSA_SPARQL_ENABLED") {
+        return v == "true" || v == "1";
+    }
+    file_config
+        .get("sparql")
+        .and_then(|s| s.get("enabled"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
 }
 
 /// Resolve the auth-enabled flag honouring TOML when the env var is unset.
@@ -1821,10 +1842,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
-    // 11. SPARQL endpoint (check FERROSA_SPARQL_ENABLED)
-    let sparql_enabled = std::env::var("FERROSA_SPARQL_ENABLED")
-        .map(|v| v == "true" || v == "1")
-        .unwrap_or(false);
+    // 11. SPARQL endpoint — on by default (t_acc3c7fd); env wins over TOML.
+    let sparql_enabled = resolve_sparql_enabled(&file_config, |k| std::env::var(k).ok());
 
     if sparql_enabled {
         let sparql_bind: std::net::SocketAddr = std::env::var("FERROSA_SPARQL_BIND")
@@ -2549,9 +2568,33 @@ mod tests {
     }
 
     #[test]
-    fn resolve_graph_enabled_defaults_false_when_unset_everywhere() {
+    fn resolve_graph_enabled_defaults_on_when_unset_everywhere() {
+        // t_acc3c7fd: a fresh install (no env, no TOML) exposes the graph engine.
         let toml = empty_config();
+        assert!(resolve_graph_enabled(&toml, |_| None));
+    }
+
+    #[test]
+    fn resolve_graph_enabled_explicit_opt_out_is_honored() {
+        let toml: toml::Value = toml::from_str("[graph]\nenabled = false\n").unwrap();
         assert!(!resolve_graph_enabled(&toml, |_| None));
+        // env opt-out wins too.
+        let toml = empty_config();
+        assert!(!resolve_graph_enabled(&toml, |k| (k
+            == "FERROSA_GRAPH_ENABLED")
+            .then(|| "false".into())));
+    }
+
+    #[test]
+    fn resolve_sparql_enabled_defaults_on_with_explicit_opt_out() {
+        let toml = empty_config();
+        assert!(resolve_sparql_enabled(&toml, |_| None));
+        let toml: toml::Value = toml::from_str("[sparql]\nenabled = false\n").unwrap();
+        assert!(!resolve_sparql_enabled(&toml, |_| None));
+        let toml = empty_config();
+        assert!(!resolve_sparql_enabled(&toml, |k| (k
+            == "FERROSA_SPARQL_ENABLED")
+            .then(|| "false".into())));
     }
 
     /// Auth enabled via TOML.


### PR DESCRIPTION
A fresh install should expose the full user-facing feature set. Previously the **graph** engine (HTTP 7474 + Bolt 7687) and **SPARQL** (8080) shipped **OFF** and never started — so ferrosa-memory's `create_edge` surfaced a misleading `no table with graph.label` instead of working (same Linux-setup report behind #212).

## Change
- `resolve_graph_enabled` now **defaults ON** (was `false`); env still wins over TOML.
- Added `resolve_sparql_enabled` (mirrors graph: env → TOML → default **ON**), replacing the env-only check that defaulted off.
- **The default lives in the server config**, not `install.sh` (which writes no endpoint config) — so script and non-script installs match (the task's stated preference).
- Already always-on (unchanged): CQL 9042, Postgres 5432, web/viz/Prometheus 9090.
- **Auth + telemetry stay opt-IN by design** — security and privacy, not "features."

## Explicit opt-out preserved (reduce attack surface)
Per the ask, disabling is **explicit only** — absence = ON, only an explicit `false` turns something off:
- `FERROSA_GRAPH_ENABLED=false` / `[graph] enabled = false`
- `FERROSA_SPARQL_ENABLED=false` / `[sparql] enabled = false`

Both example tomls updated: stale `[graph] enabled=false` → `true`, a documented `[sparql]` section, and an "all-on; set `false` to reduce attack surface" note.

## Tests — build + clippy + fmt clean
`resolve_graph_enabled_defaults_on_when_unset_everywhere`, `resolve_graph_enabled_explicit_opt_out_is_honored`, `resolve_sparql_enabled_defaults_on_with_explicit_opt_out`. Both example tomls validated as parseable.