### PR TITLE
fix(release): .dockerignore excluded dist/ arch dirs needed by Dockerfile.release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,9 @@ docs/
 specs/
 *.md
 .claude/
+# Ignore dist/ generally, but keep the per-arch binaries that Dockerfile.release
+# COPYs from (dist/${TARGETARCH}/ferrosa, ferrosa-ctl). Without these exceptions
+# the GHCR container build fails: "/dist/arm64/ferrosa-ctl: not found".
 dist/
+!dist/amd64
+!dist/arm64


### PR DESCRIPTION
The Release workflow's GHCR container job fails on every run: Dockerfile.release COPYs `dist/${TARGETARCH}/ferrosa` and `ferrosa-ctl`, but `.dockerignore` excluded all of `dist/` → buildx `/dist/arm64/ferrosa-ctl: not found`. Binary tarballs + GitHub Release are unaffected; only the container image fails. This re-includes `dist/amd64` and `dist/arm64`. Found via DMG e2e (run 28272516066).