### PR TITLE
release: prep 0.17.0 — public docs, version bump, site version, main-sync on promote

### DIFF
--- a/docs/database/getting-started.html
+++ b/docs/database/getting-started.html
@@ -273,17 +273,18 @@
   <h2 id="run">Run Ferrosa</h2>
 
   <h3>Minimal startup</h3>
-  <pre><span class="cm"># Start with defaults — CQL on :9042, operations console on :9090</span>
+  <pre><span class="cm"># Start with defaults — all user-facing endpoints come up:</span>
+<span class="cm"># CQL :9042 · Postgres :5432 · graph HTTP :7474 + Bolt :7687 · SPARQL :8080 · console :9090</span>
 <span class="kw">ferrosa</span></pre>
 
-  <h3>With graph engine enabled</h3>
-  <pre><span class="kw">FERROSA_GRAPH_ENABLED</span>=true ferrosa</pre>
+  <h3>Disable endpoints you don't need (reduce attack surface)</h3>
+  <pre><span class="cm"># Everything is on by default; opt out explicitly.</span>
+<span class="kw">FERROSA_GRAPH_ENABLED</span>=false <span class="kw">FERROSA_SPARQL_ENABLED</span>=false ferrosa</pre>
 
   <h3>Custom ports and auth disabled (development)</h3>
   <pre><span class="kw">FERROSA_CQL_BIND</span>=127.0.0.1:9042 \
 <span class="kw">FERROSA_WEB_BIND</span>=127.0.0.1:9090 \
 <span class="kw">FERROSA_AUTH_DISABLED</span>=true \
-<span class="kw">FERROSA_GRAPH_ENABLED</span>=true \
 ferrosa</pre>
 
   <div class="note">
@@ -305,8 +306,11 @@ ferrosa</pre>
     </thead>
     <tbody>
       <tr><td>CQL Server</td><td><code>9042</code></td><td>CQL native protocol (v4)</td></tr>
+      <tr><td>Postgres</td><td><code>5432</code></td><td>PostgreSQL v3 wire protocol (SCRAM-SHA-256)</td></tr>
       <tr><td>Web Console</td><td><code>9090</code></td><td>HTTP (REST API + static UI + WebSocket)</td></tr>
       <tr><td>Graph HTTP</td><td><code>7474</code></td><td>HTTP/JSON (Cypher queries)</td></tr>
+      <tr><td>Graph Bolt</td><td><code>7687</code></td><td>Bolt v5 (Neo4j drivers)</td></tr>
+      <tr><td>SPARQL</td><td><code>8080</code></td><td>SPARQL 1.1 protocol over HTTP</td></tr>
       <tr><td>Prometheus Metrics</td><td><code>9090/metrics</code></td><td>HTTP (text exposition)</td></tr>
       <tr><td>Internode (cluster)</td><td><code>17000</code></td><td>Custom binary protocol (changed from :7000 in v0.11.0 to avoid macOS ControlCenter conflict)</td></tr>
     </tbody>
@@ -438,13 +442,21 @@ session.execute(<span class="str">"""
       <tr><td><code>FERROSA_AUTH_WARN</code></td><td><code>false</code></td><td>Soak mode: log auth failures as warnings while still allowing requests</td></tr>
       <tr><td><code>FERROSA_AUTH_DISABLED</code></td><td><code>false</code></td><td>Development escape hatch that skips the CQL SASL handshake entirely</td></tr>
       <tr><td><code>FERROSA_SUPERUSER_PASSWORD</code></td><td>—</td><td>Optional override for the seeded <code>ferrosa_admin</code> password during bootstrap</td></tr>
-      <tr><td><code>FERROSA_GRAPH_ENABLED</code></td><td><code>false</code></td><td>Enable graph engine + HTTP endpoint</td></tr>
-      <tr><td><code>FERROSA_BOLT_PORT</code></td><td><code>7687</code></td><td>Bolt listener port when the graph engine is enabled</td></tr>
-      <tr><td><code>FERROSA_SPARQL_ENABLED</code></td><td><code>false</code></td><td>Enable the SPARQL HTTP endpoint</td></tr>
+      <tr><td><code>FERROSA_GRAPH_ENABLED</code></td><td><code>true</code></td><td>Graph engine (HTTP 7474 + Bolt 7687) — on by default; set <code>false</code> to disable</td></tr>
+      <tr><td><code>FERROSA_BOLT_PORT</code></td><td><code>7687</code></td><td>Bolt listener port</td></tr>
+      <tr><td><code>FERROSA_SPARQL_ENABLED</code></td><td><code>true</code></td><td>SPARQL HTTP endpoint (8080) — on by default; set <code>false</code> to disable</td></tr>
       <tr><td><code>FERROSA_SPARQL_BIND</code></td><td><code>0.0.0.0:8080</code></td><td>SPARQL HTTP listen address</td></tr>
       <tr><td><code>RUST_LOG</code></td><td><code>info</code></td><td>Tracing filter (e.g. <code>debug</code>, <code>ferrosa_cql=trace</code>)</td></tr>
     </tbody>
   </table>
+
+  <div class="note">
+    <strong>Production safety gate.</strong> With <code>FERROSA_MODE=production</code>, Ferrosa
+    <em>refuses to start</em> if it would expose an unauthenticated or unencrypted surface —
+    notably authentication disabled or CQL TLS not required. This prevents accidentally
+    running an open admin surface in production; development mode stays permissive.
+    Client paging cursors are HMAC-signed so a forged cursor can't read another partition.
+  </div>
 
   <h3>Cluster, Internode, and Consensus</h3>
   <table>
@@ -657,6 +669,15 @@ session.execute(<span class="str">"""
 
   <!-- ── Operational Notes ── -->
   <h2 id="operational-notes">Operational Notes</h2>
+
+  <h3>Durable storage without S3 (single node)</h3>
+  <p>A single-node install no longer requires S3 to be durable. Point Ferrosa at a
+    local directory and it uses a durable local <code>file://</code> object-store backend —
+    flushed SSTables are persisted to that directory and treated as the source of truth
+    (eviction is disabled), so the corpus survives restarts on local disk alone:</p>
+  <pre><span class="kw">FERROSA_LOCAL_STORE_PATH</span>=~/.ferrosa/objectstore ferrosa</pre>
+  <p>This is ideal for laptops, single-VM, and air-gapped deployments. S3 remains the
+    recommended durable backend for multi-node clusters and off-host recovery.</p>
 
   <h3>S3 Storage Resilience</h3>
   <p>When S3 is configured as the durable backend, Ferrosa writes asynchronously to S3 via an

--- a/docs/database/postgres.html
+++ b/docs/database/postgres.html
@@ -266,13 +266,14 @@ psql "host=127.0.0.1 port=5432 user=ferrosa_user dbname=ferrosa"
     <li>Values are converted per the target column type; out-of-range or type-mismatched values are rejected with a SQLSTATE error rather than coerced.</li>
     <li><code>NULL</code> deletes the cell (it reads back as SQL <code>NULL</code>, not <code>""</code> / <code>0</code>).</li>
     <li>Following Cassandra-storage semantics, <code>UPDATE</code> of a non-existent key is an upsert. The <code>WHERE</code> clause must specify the full primary key.</li>
+    <li><strong>Parameterized DML over the extended protocol:</strong> <code>INSERT</code>/<code>UPDATE</code>/<code>DELETE</code> accept <code>$N</code> bind parameters, and <code>INSERT … RETURNING</code> returns the written row — so ORMs that prepare statements (e.g. Ecto/Postgrex) drive inserts/updates/deletes the way they expect.</li>
   </ul>
 
   <!-- ── Transactions ── -->
   <h2 id="transactions">Transactions</h2>
   <p><code>BEGIN</code> / <code>COMMIT</code> / <code>ROLLBACK</code> are honored at the protocol level: the connection moves through idle → in-transaction → (on error) failed, and a failed transaction rejects further statements with SQLSTATE <code>25P02</code> until <code>ROLLBACK</code>.</p>
   <div class="note">
-    <strong>In progress:</strong> multi-statement atomicity routes through Accord (Ferrosa's strict-serializable transaction engine). The protocol-state machine is complete; the atomic commit path is being wired up.
+    <strong>Atomic transactions:</strong> multi-statement transactions commit through Accord, Ferrosa's strict-serializable transaction engine. Writes inside <code>BEGIN</code>…<code>COMMIT</code> are buffered and applied <em>atomically</em> at <code>COMMIT</code>; <code>ROLLBACK</code> discards them, so nothing is ever partially applied. Atomic multi-statement <em>write</em> transactions require Accord (cluster mode); a standalone single node fails <code>COMMIT</code> loudly rather than apply non-atomically. Read-your-writes inside an open transaction is not yet supported.
   </div>
 
   <!-- ── Testing ── -->
@@ -289,8 +290,7 @@ psql "host=127.0.0.1 port=5432 user=ferrosa_user dbname=ferrosa"
   <table>
     <thead><tr><th>Feature</th><th>Status</th></tr></thead>
     <tbody>
-      <tr><td><code>$N</code> params in DML</td><td><span class="partial">in progress</span> — extended-protocol bind for writes</td></tr>
-      <tr><td><code>RETURNING</code> / <code>ON CONFLICT</code></td><td><span class="cross">planned</span></td></tr>
+      <tr><td><code>ON CONFLICT</code>, <code>UPDATE/DELETE … RETURNING</code>, <code>= ANY($N)</code></td><td><span class="cross">planned</span></td></tr>
       <tr><td><code>IS [NOT] NULL</code></td><td><span class="cross">planned</span></td></tr>
       <tr><td>Subqueries, <code>WITH</code>, <code>UNION</code>, window functions</td><td><span class="cross">not supported</span></td></tr>
       <tr><td>Non-<code>C</code> collations</td><td><span class="cross">v1 is <code>COLLATE "C"</code> only</span></td></tr>

--- a/docs/database/sparql.html
+++ b/docs/database/sparql.html
@@ -284,9 +284,18 @@
 
   <table>
     <tr><th>Environment Variable</th><th>Default</th><th>Description</th></tr>
-    <tr><td><code>FERROSA_SPARQL_ENABLED</code></td><td><code>false</code></td><td>Enable SPARQL endpoint</td></tr>
+    <tr><td><code>FERROSA_SPARQL_ENABLED</code></td><td><code>true</code></td><td>SPARQL endpoint (8080) — on by default; set <code>false</code> to disable</td></tr>
     <tr><td><code>FERROSA_SPARQL_BIND</code></td><td><code>0.0.0.0:8080</code></td><td>SPARQL HTTP listen address</td></tr>
   </table>
+
+  <div class="note" style="margin-top:1.5rem">
+    <strong>Authentication &amp; authorization.</strong> The <code>/sparql</code> and <code>/sparql/update</code>
+    endpoints authenticate via HTTP Basic auth against Ferrosa roles and enforce
+    <em>per-keyspace</em> authorization — read (<code>SELECT</code>) for queries, write
+    (<code>MODIFY</code>) for updates. Requests without valid credentials are rejected.
+    Grant access with <code>GRANT&nbsp;SELECT/MODIFY&nbsp;ON&nbsp;KEYSPACE&nbsp;… TO&nbsp;role</code>.
+    When auth is disabled (development), the endpoint serves as superuser.
+  </div>
 
   <p style="margin-top: 4rem; color: var(--text-muted); font-size: 0.8rem;">
     Ferrosa SPARQL is currently in beta. Feature availability reflects the current release.


### PR DESCRIPTION
Updates the public ferrosadb.com docs (`ferrosa/docs/`) to match what shipped this cycle (PRs #202–#214). Driven by a staleness audit of the site against the merged features.

## Corrected (were factually wrong)
- **postgres.html** — transactions were labeled *"in progress / atomic commit being wired up"*; they're now **real atomicity via Accord** (#206). Parameterized DML (`$N`) + `INSERT … RETURNING` were in the *"not yet supported"* table; now **documented as supported** (#207). Kept `ON CONFLICT` / `UPDATE/DELETE RETURNING` / `= ANY($N)` as planned. Honest caveats retained (atomic *writes* need cluster mode; no read-your-writes in an open txn).
- **getting-started.html** — graph + SPARQL were documented as **OFF by default**; they now **default ON** (#214). Flipped the env-default table and the run examples (now show opt-*out*), and completed the default-ports table (added Postgres 5432, Bolt 7687, SPARQL 8080).
- **sparql.html** — documented that `/sparql` now **authenticates + authorizes per-keyspace** (#204); default enabled.

## Added (now-shipped capabilities the docs omitted)
- **Durable storage without S3** for single-node via `FERROSA_LOCAL_STORE_PATH` (#210).
- **Production safety gate** — refuses to start unauthenticated/unencrypted in `FERROSA_MODE=production` (#203/#205); **HMAC-signed paging cursors** (#211).

All edits are tag-balanced and use the site's existing `.note`/table styling.

## Scope
Public marketing site only. **Still to do** (you selected these too): top-level READMEs, a CHANGELOG/release notes file, and the ferrosa-memory docs — happy to take those next or file them.