### PR TITLE
release: bump to 0.17.0 — Cargo + site version, main-sync on promote (docs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,7 +2113,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrosa"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "axum 0.8.9",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cdc"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-sstable",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cluster"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-common"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "num-bigint",
  "proptest",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cql"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-ctl"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-flight"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-graph"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-index"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "crc32fast",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-index-builder"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-jepsen"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-loadgen"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-net"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-postgres"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-row-bridge"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-schema",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-schema"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "argon2 0.6.0-rc.8",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-session"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "ferrosa-cluster",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sim"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sparql"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sql"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "num-bigint",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sstable"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "crc32fast",
  "ferrosa-common",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-storage"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-udf"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-view"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "ferrosa-schema",
  "indexmap 2.14.0",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-worker"
-version = "0.13.0"
+version = "0.17.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-index",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ split-debuginfo = "off"
 strip = "none"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.17.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ferrosadb/ferrosa"

--- a/docs/database/index.html
+++ b/docs/database/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ferrosa Database — AI Native Database</title>
-  <meta name="description" content="Ferrosa Database is a Rust-native distributed database with CQL, graph, SPARQL, vector search, transactions, CDC, and S3-backed storage. Version 0.16.0 developer preview.">
+  <meta name="description" content="Ferrosa Database is a Rust-native distributed database with CQL, graph, SPARQL, vector search, transactions, CDC, and S3-backed storage. Version 0.17.0 developer preview.">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <style>
     :root {
@@ -822,14 +822,14 @@
 </nav>
 
 <div class="beta-banner">
-  <span class="beta-tag">BETA</span> Ferrosa Database is version 0.16.0 and in active development.
+  <span class="beta-tag">BETA</span> Ferrosa Database is version 0.17.0 and in active development.
 </div>
 
 <!-- ═══════════════════ Hero ═══════════════════ -->
 <section class="hero">
   <div class="hero-badge">
     <span class="dot"></span>
-    v0.16.0 — active development
+    v0.17.0 — active development
   </div>
   <h1>
     One database. <span class="gradient">Many workloads.</span><br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -850,7 +850,7 @@
 </nav>
 
 <div class="beta-banner">
-  <span class="beta-tag">Developer Preview</span> Ferrosa Suite is version 0.16.0 and moving toward a public release.
+  <span class="beta-tag">Developer Preview</span> Ferrosa Suite is version 0.17.0 and moving toward a public release.
 </div>
 <section class="hero">
   <div class="hero-badge"><span class="dot"></span> Ferrosa Memory · Developer Preview</div>
@@ -961,7 +961,7 @@ curl -fsSL https://ferrosadb.com/install.sh | bash</code></pre></div>
 </section>
 <footer>
   <div style="max-width: 1200px; margin: 0 auto; padding: 3rem 2rem; border-top: 1px solid var(--border); display:flex; justify-content:space-between; gap:2rem; flex-wrap:wrap; color:var(--text-muted);">
-    <div>Ferrosa Suite <span style="color:var(--accent);">0.16.0</span> · Developer preview</div>
+    <div>Ferrosa Suite <span style="color:var(--accent);">0.17.0</span> · Developer preview</div>
     <div style="display:flex; gap:1rem; flex-wrap:wrap;">
       <a href="/ferrosa-memory/" style="color:var(--text-secondary); text-decoration:none;">Memory</a>
       <a href="/ferrosa-memory/getting-started.html" style="color:var(--text-secondary); text-decoration:none;">Memory Setup</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,12 @@
 
 Public developer-preview documentation for Ferrosa Database and Ferrosa Memory. These pages describe install and getting-started flows; engineering plans and verification notes are tracked separately from the public site.
 
-Latest stable releases: Ferrosa Database `v0.16.0`; Ferrosa Memory `v0.22.0`.
+Latest stable releases: Ferrosa Database `v0.17.0`; Ferrosa Memory `v0.23.0`.
 
 ## Products
 
-- [Ferrosa Database](database/) — developer-preview database docs, examples, CQL/Cypher/SPARQL notes, and migration guidance for the latest stable `v0.16.0` release.
-- [Ferrosa Memory](ferrosa-memory/) — developer-preview long-context linked memory for agents, including document/chunk retrieval, task-aware query decomposition, feedback-aware reranking, query-intent fusion, and Codex/Claude/Hermes hook onboarding for the latest stable `v0.22.0` release.
+- [Ferrosa Database](database/) — developer-preview database docs, examples, CQL/Cypher/SPARQL notes, and migration guidance for the latest stable `v0.17.0` release.
+- [Ferrosa Memory](ferrosa-memory/) — developer-preview long-context linked memory for agents, including document/chunk retrieval, task-aware query decomposition, feedback-aware reranking, query-intent fusion, and Codex/Claude/Hermes hook onboarding for the latest stable `v0.23.0` release.
 - [Ferrosa Memory Getting Started](ferrosa-memory/getting-started.html) — run the local stack, connect MCP clients, and try memory examples.
 
 ## Database Docs

--- a/specs/reference/release-process.md
+++ b/specs/reference/release-process.md
@@ -26,9 +26,21 @@ consumes them.
   - The CalVer/SemVer split makes the channel obvious in the releases list.
     `next-release-version.sh` only treats 3-segment `vX.Y.Z` tags as the stable
     base, so CalVer nightlies never pollute the version math.
-- **Releases are tag-only.** The version-bump commit lives on the tag, never on
-  `main`. `main`'s `Cargo.toml` version is therefore decorative between
-  releases; the released artifact always carries the correct version.
+- **Releases are tag-only.** The version-bump commit lives on the tag, never
+  directly on `main` (the `main` ruleset forbids direct pushes — see below). The
+  released artifact always carries the correct version.
+- **`main` is kept in step via a PR.** On a **stable promote**, `promote-release.yml`
+  opens a `chore(release): sync main version to vX.Y.Z` **pull request** that bumps
+  `main`'s `[workspace.package] version` to the promoted tag. This is cosmetic (the
+  release version is still derived from tags), but it stops `main` drifting behind
+  the latest release. Merge it at convenience; do **not** hand-edit the version in
+  an unrelated PR.
+- **`docs/LATEST` + the marketing-site version are release steps.** `docs/LATEST`
+  (the plain-text tag the install scripts fetch from `ferrosadb.com/LATEST`) and the
+  *descriptive* version strings on the site (`docs/index.html`, `docs/database/index.html`,
+  `docs/index.md`) are updated when a release is promoted. **`docs/LATEST` must only be
+  bumped once the release tarball exists** — pointing it at a tag with no built artifact
+  breaks `install.sh`. (Not yet automated; tracked separately.)
 - **Current promoted stable releases:** Ferrosa Database `v0.16.0`; Ferrosa
   Memory `v0.22.0`. Use GitHub's latest-release endpoint as the source of truth
   for installers and docs that need the current stable tag.


### PR DESCRIPTION
Release-prep for **0.17.0** (the minor bump the automation computes from this cycle's `feat:` commits). Companion to the docs-content PR #216.

## Changes
- **`[workspace.package] version` 0.13.0 → 0.17.0** (+ `Cargo.lock` synced). Per request, `main` no longer trails the released tag. Safe: the release automation derives the real version from **tags**, not main's `Cargo.toml`, so this never conflicts with the version math.
- **Descriptive site version → 0.17.0** (`index.html`, `database/index.html`, `index.md`); **Ferrosa Memory → v0.23.0** on `index.md`.
- **`docs/LATEST` intentionally left at `v0.16.0`** — it's the install pointer `install.sh` fetches; it must only flip once the `0.17.0` tarball exists, or installs break.
- **`release-process.md`** documents the new behavior: `main` is kept in step via a promote-time sync PR, and `docs/LATEST` + site version are release steps (`LATEST` follows the tarball build).

## Note — the workflow step needs your hands
The `promote-release.yml` change (the step that opens the main-sync PR) is **not in this PR**: pushing workflow files requires the `workflow` permission scope my credentials don't have. I've kept that change ready — I'll paste it for you to commit, or you can apply it directly.

ferrosa-memory's `0.16.0 → 0.23.0` Cargo bump is a separate PR in that repo.