### PR TITLE
fix(storage,cql): bound SSTable recovery and prevent corrupt publication (P0)

### DIFF
--- a/ferrosa-cluster/src/controller/membership.rs
+++ b/ferrosa-cluster/src/controller/membership.rs
@@ -667,8 +667,9 @@ mod streaming_contract_tests {
             .split("#[cfg(test)]")
             .next()
             .expect("production membership source must be present");
+        let unbounded_range_read = concat!("read_range", "(&table_id, None, None, usize::MAX)");
         assert!(
-            !source.contains("read_range(&table_id, None, None, usize::MAX)"),
+            !source.contains(unbounded_range_read),
             "decommission must stream partitions instead of materializing every partition with usize::MAX"
         );
     }

--- a/ferrosa-cluster/src/repair/trigger.rs
+++ b/ferrosa-cluster/src/repair/trigger.rs
@@ -25,8 +25,9 @@
 //! periodic repair cycle is the backstop (design Q3 / FMEA #10). Corruption is
 //! therefore never silently dropped from observability.
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use ferrosa_net::task_pool::TaskPool;
 use ferrosa_storage::self_heal::{RepairTrigger, TableKey};
@@ -114,6 +115,25 @@ pub struct ClusterRepairTrigger {
     topology: Arc<dyn ClusterTopology>,
     probe: Arc<dyn RepairProbe>,
     executor: Arc<dyn ExecutorProvider>,
+    in_flight: Arc<Mutex<HashSet<RefillKey>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RefillKey {
+    table: TableId,
+    range: (i64, i64),
+    peer_ring_id: u64,
+}
+
+struct RefillInFlightGuard {
+    in_flight: Arc<Mutex<HashSet<RefillKey>>>,
+    key: RefillKey,
+}
+
+impl Drop for RefillInFlightGuard {
+    fn drop(&mut self) {
+        self.in_flight.lock().unwrap().remove(&self.key);
+    }
 }
 
 impl ClusterRepairTrigger {
@@ -127,6 +147,7 @@ impl ClusterRepairTrigger {
             topology,
             probe,
             executor,
+            in_flight: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -155,11 +176,36 @@ impl ClusterRepairTrigger {
     /// (which may touch the ring snapshot) never runs on the controller tick. A
     /// `None` executor (node not ring-ready) is logged loudly — the periodic
     /// cycle is the backstop (FMEA #10).
-    fn schedule_session(&self, table: &TableId, range: (i64, i64), peer_ring_id: u64) {
+    fn schedule_session(&self, table: &TableId, range: (i64, i64), peer_ring_id: u64) -> bool {
+        let key = RefillKey {
+            table: table.clone(),
+            range,
+            peer_ring_id,
+        };
+        {
+            let mut in_flight = self.in_flight.lock().unwrap();
+            if !in_flight.insert(key.clone()) {
+                tracing::debug!(
+                    keyspace = table.keyspace(),
+                    table = table.table(),
+                    range_start = range.0,
+                    range_end = range.1,
+                    peer = peer_ring_id,
+                    "anti-entropy refill: duplicate targeted refill already in flight; coalescing request"
+                );
+                return false;
+            }
+        }
+
         let provider = self.executor.clone();
         let table = table.clone();
         let (start, end) = range;
+        let guard = RefillInFlightGuard {
+            in_flight: self.in_flight.clone(),
+            key,
+        };
         TaskPool::current("anti-entropy-refill").spawn(async move {
+            let _guard = guard;
             let Some(executor) = provider.current_executor() else {
                 tracing::warn!(
                     keyspace = table.keyspace(),
@@ -198,6 +244,7 @@ impl ClusterRepairTrigger {
                 }
             }
         });
+        true
     }
 }
 
@@ -206,17 +253,18 @@ impl RepairTrigger for ClusterRepairTrigger {
         for &range in ranges {
             match self.healthy_peer_for(table, range) {
                 Some((ring_id, host_id)) => {
-                    REFILLS_SCHEDULED.fetch_add(1, Ordering::Relaxed);
-                    tracing::info!(
-                        keyspace = table.keyspace(),
-                        table = table.table(),
-                        range_start = range.0,
-                        range_end = range.1,
-                        peer = ring_id,
-                        %host_id,
-                        "anti-entropy refill: verified healthy replica; scheduling targeted refill"
-                    );
-                    self.schedule_session(table, range, ring_id);
+                    if self.schedule_session(table, range, ring_id) {
+                        REFILLS_SCHEDULED.fetch_add(1, Ordering::Relaxed);
+                        tracing::info!(
+                            keyspace = table.keyspace(),
+                            table = table.table(),
+                            range_start = range.0,
+                            range_end = range.1,
+                            peer = ring_id,
+                            %host_id,
+                            "anti-entropy refill: verified healthy replica; scheduling targeted refill"
+                        );
+                    }
                 }
                 None => {
                     REFILLS_NO_SOURCE.fetch_add(1, Ordering::Relaxed);
@@ -239,6 +287,7 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use std::collections::HashMap;
+    use std::sync::atomic::AtomicUsize;
     use std::sync::Mutex;
 
     use super::super::cluster_view::{ClusterTopology, RepairProbe};
@@ -308,10 +357,38 @@ mod tests {
         }
     }
 
+    /// Executor that blocks sessions until the test releases them, so duplicate
+    /// refill requests can be made while the first session is definitely still
+    /// in flight.
+    #[derive(Default)]
+    struct BlockingExecutor {
+        calls: AtomicUsize,
+        release: tokio::sync::Notify,
+    }
+    #[async_trait]
+    impl SessionExecutor for BlockingExecutor {
+        async fn run_session(
+            &self,
+            _table: &TableId,
+            _range_start: i64,
+            _range_end: i64,
+            _peer: u64,
+        ) -> Result<SessionStats, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.release.notified().await;
+            Ok(SessionStats::default())
+        }
+    }
+
     /// Build an [`ExecutorProvider`] that always resolves to `exec` — the
     /// healthy, ring-ready case the production closure hits once the node is
     /// placed in the ring.
     fn provider_for(exec: &Arc<RecordingExecutor>) -> Arc<dyn ExecutorProvider> {
+        let exec = exec.clone();
+        Arc::new(move || Some(exec.clone() as Arc<dyn SessionExecutor>))
+    }
+
+    fn blocking_provider_for(exec: &Arc<BlockingExecutor>) -> Arc<dyn ExecutorProvider> {
         let exec = exec.clone();
         Arc::new(move || Some(exec.clone() as Arc<dyn SessionExecutor>))
     }
@@ -330,6 +407,27 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
         exec.calls.lock().unwrap().clone()
+    }
+
+    async fn wait_for_blocking_calls(exec: &Arc<BlockingExecutor>, n: usize) -> usize {
+        for _ in 0..200 {
+            let calls = exec.calls.load(Ordering::Relaxed);
+            if calls >= n {
+                return calls;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        exec.calls.load(Ordering::Relaxed)
+    }
+
+    async fn wait_for_no_refills_in_flight(trigger: &ClusterRepairTrigger) {
+        for _ in 0..200 {
+            if trigger.in_flight.lock().unwrap().is_empty() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        panic!("refill in-flight set did not drain");
     }
 
     /// RED: a quarantine refill request must enqueue exactly one targeted repair
@@ -373,6 +471,47 @@ mod tests {
             anti_entropy_refills_scheduled_total() > before,
             "the scheduled-refill metric must increment (corruption self-heal is observable)"
         );
+    }
+
+    #[tokio::test]
+    async fn duplicate_refill_requests_for_same_table_range_are_coalesced_while_in_flight() {
+        let healthy_peer = (3u64, uuid::Uuid::from_u128(0xBBBB));
+        let topology = Arc::new(MockTopology {
+            peers: vec![healthy_peer],
+        });
+        let probe = Arc::new(MockProbe::new(vec![(
+            healthy_peer.1,
+            ProbeOutcome::HealthyNonEmpty,
+        )]));
+        let exec = Arc::new(BlockingExecutor::default());
+        let trigger = ClusterRepairTrigger::new(topology, probe, blocking_provider_for(&exec));
+
+        let table = TableId::new("ks", "t");
+        let range = (100i64, 200i64);
+
+        trigger.request_refill(&table, &[range]);
+        assert_eq!(wait_for_blocking_calls(&exec, 1).await, 1);
+
+        for _ in 0..100 {
+            trigger.request_refill(&table, &[range]);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            exec.calls.load(Ordering::Relaxed),
+            1,
+            "duplicate refill requests for the same table/range/peer must coalesce while in flight"
+        );
+
+        exec.release.notify_waiters();
+        wait_for_no_refills_in_flight(&trigger).await;
+
+        trigger.request_refill(&table, &[range]);
+        assert_eq!(
+            wait_for_blocking_calls(&exec, 2).await,
+            2,
+            "a later refill after the first completed must be schedulable"
+        );
+        exec.release.notify_waiters();
     }
 
     /// WIRING (FMEA #10): when a verified-healthy replica IS found but the

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -803,6 +803,90 @@ async fn collect_page_from_partition_stream(
     })
 }
 
+async fn collect_filtered_page_from_partition_stream(
+    mut stream: ferrosa_cluster::write_path::PartitionResultStream,
+    page_size: usize,
+    resume: Option<StreamResumeCursor>,
+    row_context: PartitionRowContext<'_>,
+    predicate_context: SelectPredicateContext<'_>,
+) -> Result<StreamedPage, CqlError> {
+    debug_assert!(page_size > 0, "page_size must be positive");
+
+    let mut rows: Vec<Vec<Option<CqlValue>>> = Vec::with_capacity(page_size);
+    let mut last_pk: Vec<u8> = Vec::new();
+    let mut last_ck: Vec<u8> = Vec::new();
+    let mut more_rows_remain = false;
+    let mut processed_partitions = 0usize;
+
+    'outer: while let Some(partition) = stream.next().await {
+        let partition = partition?;
+        let pk_bytes = partition.key.key.as_bytes().to_vec();
+        let paired = bridge::partition_to_rows_with_clustering(
+            &partition,
+            row_context.all_col_names,
+            row_context.all_col_types,
+            row_context.pk_indices,
+            row_context.ck_indices,
+            row_context.storage_to_table,
+        );
+
+        for (clustering, output_row) in paired {
+            if let Some(ref cur) = resume {
+                if pk_bytes == cur.partition_key && clustering <= cur.clustering_key {
+                    continue;
+                }
+            }
+
+            if !row_matches_select_predicates(
+                &output_row,
+                predicate_context.statement,
+                row_context.all_col_names,
+                row_context.all_col_types,
+                predicate_context.table_meta,
+                predicate_context.keyspace,
+                predicate_context.state,
+            )? {
+                continue;
+            }
+
+            if rows.len() == page_size {
+                more_rows_remain = true;
+                break 'outer;
+            }
+
+            rows.push(output_row);
+            last_pk = pk_bytes.clone();
+            last_ck = clustering;
+        }
+
+        processed_partitions += 1;
+        if should_yield_during_partition_scan(
+            processed_partitions,
+            cooperative_scan_yield_every_partitions(),
+        ) {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    let next_paging_state = if more_rows_remain {
+        Some(
+            crate::paging::PagingState {
+                partition_key: last_pk,
+                clustering_key: last_ck,
+                remaining_in_partition: false,
+            }
+            .encode(),
+        )
+    } else {
+        None
+    };
+
+    Ok(StreamedPage {
+        rows,
+        next_paging_state,
+    })
+}
+
 fn storage_to_table_indices(table_meta: &TableMetadata) -> Vec<usize> {
     let mut pairs: Vec<(u16, usize)> = table_meta
         .columns
@@ -4415,151 +4499,257 @@ async fn route_select_user_table(
                         // table and apply LIMIT/page semantics after filtering.
                         // Ordered and aggregate queries still materialize their scan
                         // window before sorting/counting.
-                        let scan_bound = if s.order_by.is_empty()
+                        let has_post_filter = s.allow_filtering && !non_token_clauses.is_empty();
+                        let has_function_projection = s
+                            .columns
+                            .iter()
+                            .any(|c| matches!(c, SelectColumn::FunctionCall { .. }));
+                        let stream_filtered_page_shape = has_post_filter
+                            && s.order_by.is_empty()
                             && s.ann_of.is_none()
+                            && !s.distinct
+                            && s.limit.is_none()
                             && !count_only_select
-                        {
-                            let has_post_filter =
-                                s.allow_filtering && !non_token_clauses.is_empty();
-                            if has_post_filter {
-                                None
-                            } else {
-                                let page_size = ctx
-                                    .paging
-                                    .page_size
-                                    .and_then(|ps| (ps > 0).then_some(ps as usize));
-                                let limit_size = s
-                                    .limit
-                                    .as_ref()
-                                    .and_then(|l| l.as_literal())
-                                    .map(|n| n as usize);
-                                let base = match (page_size, limit_size) {
-                                    (Some(ps), Some(lim)) => Some(std::cmp::min(ps, lim)),
-                                    (Some(ps), None) => Some(ps),
-                                    (None, Some(lim)) => Some(lim),
-                                    (None, None) => None,
-                                };
-                                let start = ctx
-                                    .paging
-                                    .paging_state
-                                    .as_deref()
-                                    .and_then(|bytes| {
-                                        crate::paging::PagingState::decode(bytes).ok()
-                                    })
-                                    .and_then(|state| {
-                                        (state.partition_key.len() == 8).then(|| {
-                                            u64::from_be_bytes(
-                                                state.partition_key.as_slice().try_into().unwrap(),
-                                            ) as usize
+                            && !has_function_projection;
+
+                        if stream_filtered_page_shape {
+                            let page_size = ctx
+                                .paging
+                                .page_size
+                                .and_then(|ps| (ps > 0).then_some(ps as usize))
+                                .unwrap_or_else(crate::paging::default_scan_page_size);
+                            let resume = StreamResumeCursor::from_paging_state(
+                                ctx.paging.paging_state.as_deref(),
+                            )?;
+                            let start_key = resume.as_ref().map(|cur| {
+                                ferrosa_common::key::DecoratedKey::new(
+                                    ferrosa_common::key::PartitionKey::from(
+                                        cur.partition_key.as_slice(),
+                                    ),
+                                )
+                            });
+                            let stream = state
+                                .write_path
+                                .load()
+                                .range_read_stream_all_from(
+                                    &table_id,
+                                    start_key.as_ref(),
+                                    ctx.consistency,
+                                    &table_strategy,
+                                )
+                                .await?;
+                            let page = collect_filtered_page_from_partition_stream(
+                                stream,
+                                page_size,
+                                resume,
+                                PartitionRowContext {
+                                    all_col_names: &all_col_names,
+                                    all_col_types: &all_col_types,
+                                    pk_indices: &pk_indices,
+                                    ck_indices: &ck_indices,
+                                    storage_to_table: &storage_to_table,
+                                },
+                                SelectPredicateContext {
+                                    statement: s,
+                                    table_meta,
+                                    keyspace: ks,
+                                    state,
+                                },
+                            )
+                            .await?;
+                            streamed_paging_state = Some(page.next_paging_state);
+                            page.rows
+                        } else {
+                            let scan_bound = if s.order_by.is_empty()
+                                && s.ann_of.is_none()
+                                && !count_only_select
+                            {
+                                if has_post_filter {
+                                    None
+                                } else {
+                                    let page_size = ctx
+                                        .paging
+                                        .page_size
+                                        .and_then(|ps| (ps > 0).then_some(ps as usize));
+                                    let limit_size = s
+                                        .limit
+                                        .as_ref()
+                                        .and_then(|l| l.as_literal())
+                                        .map(|n| n as usize);
+                                    let base = match (page_size, limit_size) {
+                                        (Some(ps), Some(lim)) => Some(std::cmp::min(ps, lim)),
+                                        (Some(ps), None) => Some(ps),
+                                        (None, Some(lim)) => Some(lim),
+                                        (None, None) => None,
+                                    };
+                                    let start = ctx
+                                        .paging
+                                        .paging_state
+                                        .as_deref()
+                                        .and_then(|bytes| {
+                                            crate::paging::PagingState::decode(bytes).ok()
                                         })
-                                    })
-                                    .unwrap_or(0);
-                                base.map(|n| start.saturating_add(n).max(1))
+                                        .and_then(|state| {
+                                            (state.partition_key.len() == 8).then(|| {
+                                                u64::from_be_bytes(
+                                                    state
+                                                        .partition_key
+                                                        .as_slice()
+                                                        .try_into()
+                                                        .unwrap(),
+                                                )
+                                                    as usize
+                                            })
+                                        })
+                                        .unwrap_or(0);
+                                    base.map(|n| start.saturating_add(n).max(1))
+                                }
+                            } else {
+                                None
+                            };
+                            let row_limit = safe_partition_key_filter_row_limit(
+                                s,
+                                table_meta,
+                                count_only_select,
+                            )
+                            .unwrap_or(0);
+                            // ADR-020 projection fast path. Route through
+                            // range_read_projected whenever the query only needs a subset
+                            // of regular cells, so the SSTable layer byte-skips bulky
+                            // unneeded payloads. Big win on wide tables with bulky cells
+                            // (e.g. entity_store's entity_embedding column).
+                            //
+                            // Non-count SELECT requires no WHERE because predicates over
+                            // unprojected regular columns would evaluate against NULL.
+                            let projection_wanted =
+                                if !count_only_select && s.where_clauses.is_empty() {
+                                    projection_storage_ordinals_for_select_scan(s, table_meta)
+                                } else {
+                                    None
+                                };
+                            // Count-only filtered scans project predicate columns only and
+                            // fold over a partition stream, so COUNT(*) avoids decoding
+                            // unrelated cells without first collecting partitions in a Vec.
+                            let count_projection_wanted = if count_only_select {
+                                projection_storage_ordinals_for_count_predicates(
+                                    &s.where_clauses,
+                                    table_meta,
+                                )
+                            } else {
+                                None
+                            };
+                            let partitions = if let Some(wanted) = projection_wanted {
+                                // Push partition-count cap down to the merger so
+                                // `LIMIT N` stops the scan after N partitions
+                                // rather than walking every SSTable.
+                                Some(
+                                    state
+                                        .write_path
+                                        .load()
+                                        .range_read_projected(&table_id, wanted, scan_bound)
+                                        .await?,
+                                )
+                            } else if let Some(bound) = scan_bound {
+                                Some(
+                                    state
+                                        .write_path
+                                        .load()
+                                        .range_read_limited_rows(&table_id, bound, row_limit)
+                                        .await?,
+                                )
+                            } else if row_limit > 0 {
+                                Some(
+                                    state
+                                        .write_path
+                                        .load()
+                                        .range_read_limited_rows(
+                                            &table_id,
+                                            ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT,
+                                            row_limit,
+                                        )
+                                        .await?,
+                                )
+                            } else {
+                                None
+                            };
+                            if count_only_select {
+                                let row_context = PartitionRowContext {
+                                    all_col_names: &all_col_names,
+                                    all_col_types: &all_col_types,
+                                    pk_indices: &pk_indices,
+                                    ck_indices: &ck_indices,
+                                    storage_to_table: &storage_to_table,
+                                };
+                                let predicate_context = SelectPredicateContext {
+                                    statement: s,
+                                    table_meta,
+                                    keyspace: ks,
+                                    state,
+                                };
+                                let count = if let Some(partitions) = partitions.as_ref() {
+                                    count_rows_from_partitions(
+                                        partitions,
+                                        row_context,
+                                        predicate_context,
+                                    )
+                                    .await?
+                                } else if let Some(wanted) = count_projection_wanted {
+                                    let stream = state
+                                        .write_path
+                                        .load()
+                                        .range_read_projected_stream_all_with(
+                                            &table_id,
+                                            wanted,
+                                            scan_bound,
+                                            ctx.consistency,
+                                            &table_strategy,
+                                        )
+                                        .await?;
+                                    count_rows_from_partition_stream(
+                                        stream,
+                                        row_context,
+                                        predicate_context,
+                                    )
+                                    .await?
+                                } else {
+                                    let stream = state
+                                        .write_path
+                                        .load()
+                                        .range_read_stream_all_with(
+                                            &table_id,
+                                            row_limit,
+                                            ctx.consistency,
+                                            &table_strategy,
+                                        )
+                                        .await?;
+                                    count_rows_from_partition_stream(
+                                        stream,
+                                        row_context,
+                                        predicate_context,
+                                    )
+                                    .await?
+                                };
+                                return Ok(SelectRawResult {
+                                    column_names: col_names.to_vec(),
+                                    column_types: col_types.to_vec(),
+                                    rows: vec![vec![Some(CqlValue::Bigint(count))]],
+                                    keyspace: ks.to_string(),
+                                    table: s.table.clone(),
+                                    paging_state: None,
+                                });
                             }
-                        } else {
-                            None
-                        };
-                        let row_limit =
-                            safe_partition_key_filter_row_limit(s, table_meta, count_only_select)
-                                .unwrap_or(0);
-                        // ADR-020 projection fast path. Route through
-                        // range_read_projected whenever the query only needs a subset
-                        // of regular cells, so the SSTable layer byte-skips bulky
-                        // unneeded payloads. Big win on wide tables with bulky cells
-                        // (e.g. entity_store's entity_embedding column).
-                        //
-                        // Non-count SELECT requires no WHERE because predicates over
-                        // unprojected regular columns would evaluate against NULL.
-                        let projection_wanted = if !count_only_select && s.where_clauses.is_empty()
-                        {
-                            projection_storage_ordinals_for_select_scan(s, table_meta)
-                        } else {
-                            None
-                        };
-                        // Count-only filtered scans project predicate columns only and
-                        // fold over a partition stream, so COUNT(*) avoids decoding
-                        // unrelated cells without first collecting partitions in a Vec.
-                        let count_projection_wanted = if count_only_select {
-                            projection_storage_ordinals_for_count_predicates(
-                                &s.where_clauses,
-                                table_meta,
-                            )
-                        } else {
-                            None
-                        };
-                        let partitions = if let Some(wanted) = projection_wanted {
-                            // Push partition-count cap down to the merger so
-                            // `LIMIT N` stops the scan after N partitions
-                            // rather than walking every SSTable.
-                            Some(
-                                state
-                                    .write_path
-                                    .load()
-                                    .range_read_projected(&table_id, wanted, scan_bound)
-                                    .await?,
-                            )
-                        } else if let Some(bound) = scan_bound {
-                            Some(
-                                state
-                                    .write_path
-                                    .load()
-                                    .range_read_limited_rows(&table_id, bound, row_limit)
-                                    .await?,
-                            )
-                        } else if row_limit > 0 {
-                            Some(
-                                state
-                                    .write_path
-                                    .load()
-                                    .range_read_limited_rows(
-                                        &table_id,
-                                        ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT,
-                                        row_limit,
-                                    )
-                                    .await?,
-                            )
-                        } else {
-                            None
-                        };
-                        if count_only_select {
-                            let row_context = PartitionRowContext {
-                                all_col_names: &all_col_names,
-                                all_col_types: &all_col_types,
-                                pk_indices: &pk_indices,
-                                ck_indices: &ck_indices,
-                                storage_to_table: &storage_to_table,
-                            };
-                            let predicate_context = SelectPredicateContext {
-                                statement: s,
-                                table_meta,
-                                keyspace: ks,
-                                state,
-                            };
-                            let count = if let Some(partitions) = partitions.as_ref() {
-                                count_rows_from_partitions(
+                            let mut all_rows = Vec::new();
+                            if let Some(partitions) = partitions.as_ref() {
+                                extend_rows_from_partitions(
                                     partitions,
-                                    row_context,
-                                    predicate_context,
+                                    &mut all_rows,
+                                    &all_col_names,
+                                    &all_col_types,
+                                    &pk_indices,
+                                    &ck_indices,
+                                    &storage_to_table,
                                 )
-                                .await?
-                            } else if let Some(wanted) = count_projection_wanted {
-                                let stream = state
-                                    .write_path
-                                    .load()
-                                    .range_read_projected_stream_all_with(
-                                        &table_id,
-                                        wanted,
-                                        scan_bound,
-                                        ctx.consistency,
-                                        &table_strategy,
-                                    )
-                                    .await?;
-                                count_rows_from_partition_stream(
-                                    stream,
-                                    row_context,
-                                    predicate_context,
-                                )
-                                .await?
+                                .await;
                             } else {
                                 let stream = state
                                     .write_path
@@ -4571,66 +4761,28 @@ async fn route_select_user_table(
                                         &table_strategy,
                                     )
                                     .await?;
-                                count_rows_from_partition_stream(
+                                extend_rows_from_partition_stream(
                                     stream,
-                                    row_context,
-                                    predicate_context,
-                                )
-                                .await?
-                            };
-                            return Ok(SelectRawResult {
-                                column_names: col_names.to_vec(),
-                                column_types: col_types.to_vec(),
-                                rows: vec![vec![Some(CqlValue::Bigint(count))]],
-                                keyspace: ks.to_string(),
-                                table: s.table.clone(),
-                                paging_state: None,
-                            });
-                        }
-                        let mut all_rows = Vec::new();
-                        if let Some(partitions) = partitions.as_ref() {
-                            extend_rows_from_partitions(
-                                partitions,
-                                &mut all_rows,
-                                &all_col_names,
-                                &all_col_types,
-                                &pk_indices,
-                                &ck_indices,
-                                &storage_to_table,
-                            )
-                            .await;
-                        } else {
-                            let stream = state
-                                .write_path
-                                .load()
-                                .range_read_stream_all_with(
-                                    &table_id,
-                                    row_limit,
-                                    ctx.consistency,
-                                    &table_strategy,
+                                    &mut all_rows,
+                                    &all_col_names,
+                                    &all_col_types,
+                                    &pk_indices,
+                                    &ck_indices,
+                                    &storage_to_table,
                                 )
                                 .await?;
-                            extend_rows_from_partition_stream(
-                                stream,
+                            }
+                            filter_rows_by_select_predicates(
                                 &mut all_rows,
+                                s,
                                 &all_col_names,
                                 &all_col_types,
-                                &pk_indices,
-                                &ck_indices,
-                                &storage_to_table,
-                            )
-                            .await?;
+                                table_meta,
+                                ks,
+                                state,
+                            )?;
+                            all_rows
                         }
-                        filter_rows_by_select_predicates(
-                            &mut all_rows,
-                            s,
-                            &all_col_names,
-                            &all_col_types,
-                            table_meta,
-                            ks,
-                            state,
-                        )?;
-                        all_rows
                     }
                 }
             }
@@ -12237,8 +12389,9 @@ mod tests {
     #[tokio::test]
     async fn route_transactional_handles_begin_rollback_and_fails_commit_in_standalone() {
         let (state, _dir) = setup();
+        let auth = dev_auth();
         let ctx = RequestContext {
-            auth: &dev_auth(),
+            auth: &auth,
             current_keyspace: &None,
             consistency: ConsistencyLevel::One,
             serial_consistency: None,
@@ -16621,8 +16774,9 @@ mod tests {
     #[tokio::test]
     async fn allow_filtering_partial_composite_partition_key_scans_all_matching_partitions() {
         let (state, _dir) = setup();
+        let auth = dev_auth();
         let ctx = RequestContext {
-            auth: &dev_auth(),
+            auth: &auth,
             current_keyspace: &None,
             consistency: ConsistencyLevel::One,
             serial_consistency: None,
@@ -16696,18 +16850,32 @@ mod tests {
         .await
         .unwrap();
 
-        let stmt = crate::parser::parse(&format!(
+        let select_cql = format!(
             "SELECT src_id, edge_type, dst_id FROM edge_scan.typed_edges \
              WHERE tenant_id = {tenant_a} ALLOW FILTERING"
-        ))
-        .unwrap();
-        let result = route(&state, &ctx, stmt).await.unwrap();
-        let row_count = match &result {
-            RouteResult::Result(b) => extract_row_count(b),
-            _ => panic!("expected Result"),
+        );
+        let select = match crate::parser::parse(&select_cql).unwrap() {
+            Statement::Select(s) => s,
+            other => panic!("expected select, got {other:?}"),
         };
+
+        let first_page = route_select_raw(&state, &ctx, &select).await.unwrap();
+        let default_page = crate::paging::default_scan_page_size();
         assert_eq!(
-            row_count, matching_rows as i32,
+            first_page.rows.len(),
+            default_page,
+            "unpaged ALLOW FILTERING scan must return a bounded default page, not the whole table"
+        );
+        assert!(
+            first_page.paging_state.is_some(),
+            "matching rows exceed the default page, so a continuation is required"
+        );
+
+        let (all_rows, pages) = collect_all_pages(&state, &auth, &None, &select_cql, None).await;
+        assert!(pages > 1, "fixture should require multiple bounded pages");
+        assert_eq!(
+            all_rows.len(),
+            matching_rows,
             "ALLOW FILTERING on the first component of a composite partition key must scan every matching tenant/session partition"
         );
     }
@@ -22920,6 +23088,29 @@ mod tests {
                 && broad_scan.contains("ctx.consistency")
                 && broad_scan.contains("&table_strategy"),
             "broad SELECT streams must propagate the request consistency and keyspace replication strategy"
+        );
+    }
+
+    #[test]
+    fn allow_filtering_post_filter_full_scans_must_stream_bounded_pages() {
+        let source = include_str!("router.rs");
+        let full_scan_block = source
+            .split("ScanPlan::FullScan =>")
+            .nth(1)
+            .and_then(|rest| rest.split("let mut all_rows = Vec::new();").next())
+            .expect("full-scan branch before materialization must be present");
+
+        assert!(
+            full_scan_block.contains("stream_filtered_page_shape"),
+            "ALLOW FILTERING full scans must classify the unbounded post-filter shape"
+        );
+        assert!(
+            full_scan_block.contains("collect_filtered_page_from_partition_stream"),
+            "ALLOW FILTERING post-filter full scans must stream into a bounded page before any all_rows materialization"
+        );
+        assert!(
+            full_scan_block.contains("range_read_stream_all_from"),
+            "ALLOW FILTERING post-filter full scans must resume from stream paging state instead of restarting from table start"
         );
     }
 

--- a/ferrosa-sstable/src/bin/ferrosa-sstable-dump.rs
+++ b/ferrosa-sstable/src/bin/ferrosa-sstable-dump.rs
@@ -51,32 +51,53 @@ fn main() {
         }
     };
 
-    match reader.read_all_partitions() {
-        Ok(partitions) => {
-            println!("SSTable: {}/{gen}", dir.display());
-            println!("Partitions: {}", partitions.len());
-            let total_rows: usize = partitions.iter().map(|p| p.rows.len()).sum();
-            println!("Total rows: {total_rows}");
-            println!("---");
-            for (i, partition) in partitions.iter().enumerate() {
-                let key_str = String::from_utf8_lossy(partition.key.key.as_bytes());
-                println!(
-                    "[{i}] key={key_str:?} token={} rows={}",
-                    partition.key.token.0,
-                    partition.rows.len()
-                );
-                for (j, row) in partition.rows.iter().enumerate() {
+    let mut iter = match reader.partitions_iter() {
+        Ok(iter) => iter,
+        Err(e) => {
+            eprintln!("Error opening partition stream: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!("SSTable: {}/{gen}", dir.display());
+    println!("---");
+    let mut partition_count = 0usize;
+    let mut total_rows = 0usize;
+    loop {
+        match iter.next_partition_header_only() {
+            Ok(Some((key, _deletion, static_row))) => {
+                let i = partition_count;
+                partition_count += 1;
+                let key_str = String::from_utf8_lossy(key.key.as_bytes());
+                println!("[{i}] key={key_str:?} token={}", key.token.0);
+                if let Some(row) = static_row {
                     println!(
-                        "  row[{j}] ck_len={} cells={}",
+                        "  static ck_len={} cells={}",
                         row.clustering.len(),
                         row.cells.len()
                     );
                 }
+                if let Err(e) = iter.stream_clustered_rows(|row| {
+                    total_rows += 1;
+                    println!(
+                        "  row ck_len={} cells={}",
+                        row.clustering.len(),
+                        row.cells.len()
+                    );
+                    Ok(())
+                }) {
+                    eprintln!("Error reading partition rows: {e}");
+                    std::process::exit(1);
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error reading partition stream: {e}");
+                std::process::exit(1);
             }
         }
-        Err(e) => {
-            eprintln!("Error reading partitions: {e}");
-            std::process::exit(1);
-        }
     }
+    println!("---");
+    println!("Partitions: {partition_count}");
+    println!("Total rows: {total_rows}");
 }

--- a/ferrosa-sstable/src/bin/ferrosa-sstable-dump.rs
+++ b/ferrosa-sstable/src/bin/ferrosa-sstable-dump.rs
@@ -10,6 +10,20 @@ use std::path::PathBuf;
 use ferrosa_sstable::io::FileReadAt;
 use ferrosa_sstable::reader::{SSTableComponents, SSTableReader};
 
+fn open_required_component(dir: &std::path::Path, gen: &str, component: &str) -> FileReadAt {
+    let path = dir.join(format!("{gen}-{component}"));
+    match FileReadAt::open(&path) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!(
+                "Error: required SSTable component {component} is missing or unreadable at {}: {e}",
+                path.display()
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 3 {
@@ -28,10 +42,9 @@ fn main() {
         std::process::exit(1);
     }
 
-    let data = FileReadAt::open(&data_path).expect("open Data.db");
-    let partitions_file =
-        FileReadAt::open(dir.join(format!("{gen}-Partitions.db"))).expect("open Partitions.db");
-    let rows = FileReadAt::open(dir.join(format!("{gen}-Rows.db"))).expect("open Rows.db");
+    let data = open_required_component(&dir, gen, "Data.db");
+    let partitions_file = open_required_component(&dir, gen, "Partitions.db");
+    let rows = open_required_component(&dir, gen, "Rows.db");
     let filter = std::fs::read(dir.join(format!("{gen}-Filter.db"))).unwrap_or_default();
     let statistics = std::fs::read(dir.join(format!("{gen}-Statistics.db"))).unwrap_or_default();
     let compression_info = std::fs::read(dir.join(format!("{gen}-CompressionInfo.db"))).ok();

--- a/ferrosa-sstable/src/bin/ferrosa-sstable-import.rs
+++ b/ferrosa-sstable/src/bin/ferrosa-sstable-import.rs
@@ -7,6 +7,19 @@
 
 use std::path::PathBuf;
 
+fn temp_import_directory(table_dir: &std::path::Path, gen: &str) -> PathBuf {
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|time| time.as_nanos())
+        .unwrap_or(0);
+    table_dir.join(format!(".import-{gen}-{}-{suffix}", std::process::id()))
+}
+
+fn sync_directory(dir: &std::path::Path) -> std::io::Result<()> {
+    let file = std::fs::File::open(dir)?;
+    file.sync_all()
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 6 {
@@ -26,10 +39,16 @@ fn main() {
     let keyspace = &args[4];
     let table = &args[5];
 
-    let data_path = source_dir.join(format!("{gen}-Data.db"));
-    if !data_path.exists() {
-        eprintln!("Error: Data.db not found: {}", data_path.display());
-        std::process::exit(1);
+    let required_components = ["Data.db", "Partitions.db", "Rows.db"];
+    for component in required_components {
+        let path = source_dir.join(format!("{gen}-{component}"));
+        if !path.exists() {
+            eprintln!(
+                "Error: required SSTable component {component} not found: {}",
+                path.display()
+            );
+            std::process::exit(1);
+        }
     }
 
     let table_dir = target_dir
@@ -37,6 +56,19 @@ fn main() {
         .join(format!("{keyspace}.{table}"));
     if let Err(e) = std::fs::create_dir_all(&table_dir) {
         eprintln!("Error creating target dir: {e}");
+        std::process::exit(1);
+    }
+    let final_dir = table_dir.join(gen);
+    if final_dir.exists() {
+        eprintln!(
+            "Error: target generation directory already exists: {}",
+            final_dir.display()
+        );
+        std::process::exit(1);
+    }
+    let staging_dir = temp_import_directory(&table_dir, gen);
+    if let Err(e) = std::fs::create_dir(&staging_dir) {
+        eprintln!("Error creating import staging dir: {e}");
         std::process::exit(1);
     }
 
@@ -54,7 +86,7 @@ fn main() {
     for ext in &extensions {
         let src = source_dir.join(format!("{gen}-{ext}"));
         if src.exists() {
-            let dst = table_dir.join(format!("{gen}-{ext}"));
+            let dst = staging_dir.join(format!("{gen}-{ext}"));
             match std::fs::copy(&src, &dst) {
                 Ok(bytes) => {
                     println!("  {gen}-{ext} ({bytes} bytes)");
@@ -62,11 +94,28 @@ fn main() {
                 }
                 Err(e) => {
                     eprintln!("  Error copying {gen}-{ext}: {e}");
+                    let _ = std::fs::remove_dir_all(&staging_dir);
+                    std::process::exit(1);
                 }
             }
         }
     }
 
-    println!("Imported {copied} files to {}/", table_dir.display());
+    if let Err(e) = sync_directory(&staging_dir) {
+        eprintln!("Error syncing import staging dir: {e}");
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        std::process::exit(1);
+    }
+    if let Err(e) = std::fs::rename(&staging_dir, &final_dir) {
+        eprintln!("Error promoting import into {}: {e}", final_dir.display());
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        std::process::exit(1);
+    }
+    if let Err(e) = sync_directory(&table_dir) {
+        eprintln!("Error syncing target table dir: {e}");
+        std::process::exit(1);
+    }
+
+    println!("Imported {copied} files to {}/", final_dir.display());
     println!("Restart ferrosa to load the imported SSTable.");
 }

--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -664,19 +664,6 @@ impl<R: ReadAt> SSTableReader<R> {
         self.partition_index.largest_key()
     }
 
-    /// Read all partitions from this SSTable in storage order.
-    ///
-    /// Scans the Data.db file sequentially from position 0, reading each
-    /// partition until EOF. **Materializes the entire SSTable into memory.**
-    ///
-    /// Prefer [`Self::partitions_iter`] for compaction and other large-scan
-    /// callers — full materialization here was OOM-ing the compaction
-    /// executor on tombstone-heavy workloads (`cql_timeseries2`, IoT TTL
-    /// patterns).  See `specs/in-process/streaming-compaction.md`.
-    pub fn read_all_partitions(&self) -> Result<Vec<crate::types::Partition>> {
-        self.read_partitions_limited(usize::MAX)
-    }
-
     /// Stream partitions from this SSTable in storage (token) order, one at
     /// a time, without materializing the whole file into memory.
     ///
@@ -686,16 +673,17 @@ impl<R: ReadAt> SSTableReader<R> {
     /// uncompressed). Each call to [`PartitionIter::next_partition`] yields
     /// at most one partition; the iterator returns `Ok(None)` at EOF.
     ///
-    /// Memory: `O(decompressed_data_size)` for compressed SSTables (single
-    /// pre-decompressed buffer held for the iterator's lifetime), `O(1)`
-    /// for uncompressed.  Independent of partition count.
+    /// Memory: `O(decompressed_chunk_cache_entries * chunk_length)` for
+    /// compressed SSTables via the bounded chunk LRU, `O(1)` for uncompressed.
+    /// Independent of partition count.
     pub fn partitions_iter(&self) -> Result<PartitionIter<'_, R>> {
         PartitionIter::new(self)
     }
 
     /// Scan partitions sequentially, stopping once `limit` partitions have
-    /// been decoded. This bounds range-read materialization while preserving
-    /// the existing all-partitions API for compaction callers.
+    /// been decoded. Production full-table callers should use
+    /// [`Self::partitions_iter`] instead of passing an effectively unbounded
+    /// limit.
     pub fn read_partitions_limited(&self, limit: usize) -> Result<Vec<crate::types::Partition>> {
         self.read_partitions_limited_rows(limit, 0)
     }
@@ -2170,11 +2158,10 @@ mod tests {
         assert!(reader.compression_info().is_none());
     }
 
-    /// Parity: streaming `partitions_iter()` yields the same sequence as
-    /// the materializing `read_all_partitions()`.  This is the regression
-    /// guard for the streaming-compaction refactor.
+    /// Parity: streaming `partitions_iter()` yields the same sequence as a
+    /// small, explicitly bounded partition read.
     #[test]
-    fn partitions_iter_matches_read_all_partitions() {
+    fn partitions_iter_matches_bounded_partition_read() {
         let header = test_header();
         let dks: Vec<_> = (0..7u32)
             .map(|i| DecoratedKey::new(PartitionKey::from(format!("pk{i:02}").as_bytes())))
@@ -2201,7 +2188,9 @@ mod tests {
         };
         let reader = SSTableReader::open(components).unwrap();
 
-        let materialized = reader.read_all_partitions().expect("read_all");
+        let materialized = reader
+            .read_partitions_limited(dks.len())
+            .expect("bounded partition read");
         let mut streamed = Vec::new();
         let mut iter = reader.partitions_iter().expect("partitions_iter");
         while let Some(p) = iter.next_partition().expect("next") {

--- a/ferrosa-sstable/src/writer.rs
+++ b/ferrosa-sstable/src/writer.rs
@@ -3045,7 +3045,7 @@ mod tests {
         writer.add_partition(&partition).unwrap();
         let output = writer.finish().unwrap();
 
-        // Read back via sequential DataReader (same path as read_all_partitions)
+        // Read back via sequential DataReader.
         let mut reader = DataReader::new(&output.data, &header, 0);
         let read_back = reader
             .read_partition()

--- a/ferrosa-sstable/tests/data_only_cli.rs
+++ b/ferrosa-sstable/tests/data_only_cli.rs
@@ -1,0 +1,68 @@
+use std::process::Command;
+
+fn write_data_only_sstable(dir: &std::path::Path, gen: &str) {
+    std::fs::write(dir.join(format!("{gen}-Data.db")), b"nonzero data").unwrap();
+}
+
+#[test]
+fn dump_reports_missing_required_components_without_panicking() {
+    let dir = tempfile::tempdir().unwrap();
+    write_data_only_sstable(dir.path(), "1");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ferrosa-sstable-dump"))
+        .arg(dir.path())
+        .arg("1")
+        .output()
+        .expect("run ferrosa-sstable-dump");
+
+    assert!(
+        !output.status.success(),
+        "Data-only SSTable dump must fail closed"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Partitions.db"),
+        "error should identify the missing required component, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "dump must return a controlled error, not a Rust panic: {stderr}"
+    );
+}
+
+#[test]
+fn import_rejects_data_only_source_without_publishing_live_data_file() {
+    let source = tempfile::tempdir().unwrap();
+    let target = tempfile::tempdir().unwrap();
+    write_data_only_sstable(source.path(), "7");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ferrosa-sstable-import"))
+        .arg(source.path())
+        .arg("7")
+        .arg(target.path())
+        .arg("ks")
+        .arg("tbl")
+        .output()
+        .expect("run ferrosa-sstable-import");
+
+    assert!(
+        !output.status.success(),
+        "Data-only import must fail closed instead of publishing an orphan"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Partitions.db"),
+        "error should identify the missing required component, got: {stderr}"
+    );
+
+    let published = target
+        .path()
+        .join("sstables")
+        .join("ks.tbl")
+        .join("7-Data.db");
+    assert!(
+        !published.exists(),
+        "import must not publish live Data-only SSTable component at {}",
+        published.display()
+    );
+}

--- a/ferrosa-sstable/tests/p0_production_disk_replay.rs
+++ b/ferrosa-sstable/tests/p0_production_disk_replay.rs
@@ -37,14 +37,28 @@ fn open_fixture(dir: &Path) -> SSTableReader<Vec<u8>> {
     SSTableReader::open(components).expect("open SSTable fixture")
 }
 
+fn collect_fixture_partitions(
+    reader: &SSTableReader<Vec<u8>>,
+) -> Vec<ferrosa_sstable::types::Partition> {
+    let mut partitions = Vec::new();
+    let mut iter = reader
+        .partitions_iter()
+        .expect("reader replay must open a streaming iterator");
+    while let Some(partition) = iter
+        .next_partition()
+        .expect("reader replay must decode streamed partition")
+    {
+        partitions.push(partition);
+    }
+    partitions
+}
+
 #[test]
 fn replay_entity_store_fixture_sstable_end_to_end() {
     let dir = fixture_dir("multi_partition");
     let reader = open_fixture(&dir);
 
-    let partitions = reader
-        .read_all_partitions()
-        .expect("reader replay must decode all partitions");
+    let partitions = collect_fixture_partitions(&reader);
     assert_eq!(partitions.len() as u64, reader.key_count());
     assert!(!partitions.is_empty());
 }
@@ -54,9 +68,7 @@ fn replay_typed_edges_fixture_sstable_end_to_end() {
     let dir = fixture_dir("wide_partition");
     let reader = open_fixture(&dir);
 
-    let partitions = reader
-        .read_all_partitions()
-        .expect("reader replay must decode all partitions");
+    let partitions = collect_fixture_partitions(&reader);
     assert_eq!(partitions.len() as u64, reader.key_count());
     assert!(!partitions.is_empty());
 }

--- a/ferrosa-storage/src/compaction/executor.rs
+++ b/ferrosa-storage/src/compaction/executor.rs
@@ -713,6 +713,8 @@ impl CompactionExecutor {
         }
 
         let mut heap: BinaryHeap<HeapEntry> = BinaryHeap::with_capacity(iters.len());
+        let mut last_input_keys: Vec<Option<ferrosa_common::DecoratedKey>> =
+            vec![None; iters.len()];
         for (idx, it) in iters.iter_mut().enumerate() {
             let read_start = Instant::now();
             let next = it.next_partition().map_err(|e| format!("iter init: {e}"))?;
@@ -721,6 +723,12 @@ impl CompactionExecutor {
                 read_start.elapsed(),
             );
             if let Some(mut partition) = next {
+                validate_compaction_input_key_order(
+                    &task.inputs[idx].id,
+                    &last_input_keys[idx],
+                    &partition.key,
+                )?;
+                last_input_keys[idx] = Some(partition.key.clone());
                 mappings[idx].remap_partition(&mut partition);
                 heap.push(HeapEntry {
                     partition,
@@ -762,6 +770,12 @@ impl CompactionExecutor {
             );
             if let Some(next) = next {
                 let mut next = next;
+                validate_compaction_input_key_order(
+                    &task.inputs[first_idx].id,
+                    &last_input_keys[first_idx],
+                    &next.key,
+                )?;
+                last_input_keys[first_idx] = Some(next.key.clone());
                 mappings[first_idx].remap_partition(&mut next);
                 heap.push(HeapEntry {
                     partition: next,
@@ -786,6 +800,12 @@ impl CompactionExecutor {
                 );
                 if let Some(next) = next {
                     let mut next = next;
+                    validate_compaction_input_key_order(
+                        &task.inputs[reader_idx].id,
+                        &last_input_keys[reader_idx],
+                        &next.key,
+                    )?;
+                    last_input_keys[reader_idx] = Some(next.key.clone());
                     mappings[reader_idx].remap_partition(&mut next);
                     heap.push(HeapEntry {
                         partition: next,
@@ -1049,6 +1069,26 @@ fn validate_partition_writable(
     Ok(())
 }
 
+fn validate_compaction_input_key_order(
+    gen: &str,
+    previous: &Option<ferrosa_common::DecoratedKey>,
+    next: &ferrosa_common::DecoratedKey,
+) -> std::result::Result<(), String> {
+    if let Some(previous) = previous {
+        if next <= previous {
+            return Err(format!(
+                "aborting compaction: SSTable {gen} corrupt: Data.db partitions out of token order: \
+                 key {:?} token {} <= previous key {:?} token {}",
+                next.key.as_bytes(),
+                next.token.0,
+                previous.key.as_bytes(),
+                previous.token.0
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn validate_row_writable(
     row: &ferrosa_sstable::types::Row,
     is_static: bool,
@@ -1133,6 +1173,17 @@ mod tests {
 
     fn test_table_id() -> crate::TableId {
         crate::TableId::new("test_ks", "test_table")
+    }
+
+    fn collect_reader_partitions<R: ferrosa_sstable::io::ReadAt>(
+        reader: &ferrosa_sstable::reader::SSTableReader<R>,
+    ) -> Vec<ferrosa_sstable::types::Partition> {
+        let mut partitions = Vec::new();
+        let mut iter = reader.partitions_iter().expect("stream partitions");
+        while let Some(partition) = iter.next_partition().expect("read streamed partition") {
+            partitions.push(partition);
+        }
+        partitions
     }
 
     #[test]
@@ -1239,6 +1290,27 @@ mod tests {
             max_timestamp: 2000,
             partition_count: partitions.len() as u64,
         }
+    }
+
+    fn data_bytes_for_single_partition(
+        schema: &ferrosa_common::schema::TableSchema,
+        header_partitions: &[ferrosa_sstable::types::Partition],
+        partition: &ferrosa_sstable::types::Partition,
+    ) -> Vec<u8> {
+        use crate::flush;
+        use ferrosa_sstable::writer::SSTableWriter;
+        use ferrosa_sstable::WriteOptions;
+
+        let header = flush::build_serialization_header(schema, header_partitions);
+        let mut writer = SSTableWriter::new(
+            WriteOptions {
+                compression: None,
+                ..WriteOptions::default()
+            },
+            header,
+        );
+        writer.add_partition(partition).unwrap();
+        writer.finish().unwrap().data
     }
 
     fn make_test_partition(
@@ -1488,7 +1560,7 @@ mod tests {
         )
         .unwrap();
 
-        let output_partitions = reader.read_all_partitions().unwrap();
+        let output_partitions = collect_reader_partitions(&reader);
         assert_eq!(
             output_partitions.len(),
             10,
@@ -1542,6 +1614,53 @@ mod tests {
             max_group_width,
             inputs.len(),
             "streaming compaction may hold at most one partition per input for a key"
+        );
+    }
+
+    #[test]
+    fn compaction_rejects_input_with_out_of_order_data_stream() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema = test_schema_with_columns();
+        let dir = tmp.path().join("sstable");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let first = make_test_partition("decision", "first", 1000);
+        let second = make_test_partition("org", "second", 1000);
+        assert!(
+            first.key > second.key,
+            "test keys must be descending by decorated token"
+        );
+
+        let meta = write_sstable_to_dir(&dir, &[first.clone(), second.clone()], &schema);
+        let data_path = dir.join(format!("{}-Data.db", meta.id));
+        let header_partitions = vec![second.clone(), first.clone()];
+        let mut unsorted_data =
+            data_bytes_for_single_partition(&schema, &header_partitions, &first);
+        unsorted_data.extend(data_bytes_for_single_partition(
+            &schema,
+            &header_partitions,
+            &second,
+        ));
+        std::fs::write(data_path, unsorted_data).unwrap();
+
+        let output_dir = tmp.path().join("output");
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let task = CompactionTask {
+            inputs: vec![meta],
+            output_dir,
+            schema,
+            table_id: test_table_id(),
+        };
+
+        let err = CompactionExecutor::execute_task(&task)
+            .expect_err("compaction must reject an input whose Data.db stream is not token-sorted");
+        assert!(
+            err.contains("partitions out of token order"),
+            "error must classify the input as corrupt, got: {err}"
+        );
+        assert!(
+            !err.contains("keys must be added in sorted order"),
+            "executor should reject the corrupt input before surfacing writer internals: {err}"
         );
     }
 
@@ -1623,7 +1742,7 @@ mod tests {
             statistics: std::fs::read(output_dir.join(format!("{gen}-Statistics.db"))).unwrap(),
         })
         .unwrap();
-        let partitions = reader.read_all_partitions().unwrap();
+        let partitions = collect_reader_partitions(&reader);
         assert_eq!(partitions.len(), 1);
         let cells = &partitions[0].rows[0].cells;
         assert_eq!(cells[0].0, 0);

--- a/ferrosa-storage/src/compaction/validator/driver.rs
+++ b/ferrosa-storage/src/compaction/validator/driver.rs
@@ -103,11 +103,19 @@ pub fn open_reader(dir: &Path, generation: &str) -> SSTableReader<FileReadAt> {
     .expect("open output reader")
 }
 
+fn collect_partitions_streaming(reader: &SSTableReader<FileReadAt>) -> Vec<Partition> {
+    let mut partitions = Vec::new();
+    let mut iter = reader.partitions_iter().expect("stream output partitions");
+    while let Some(partition) = iter.next_partition().expect("read streamed partition") {
+        partitions.push(partition);
+    }
+    partitions
+}
+
 /// Read every partition from a compaction output SSTable `generation` in `dir`.
 pub fn read_sstable(dir: &Path, generation: &str) -> Vec<Partition> {
-    open_reader(dir, generation)
-        .read_all_partitions()
-        .expect("read output partitions")
+    let reader = open_reader(dir, generation);
+    collect_partitions_streaming(&reader)
 }
 
 /// Verify the reader's index-driven point reads agree with a full scan for
@@ -115,7 +123,7 @@ pub fn read_sstable(dir: &Path, generation: &str) -> Vec<Partition> {
 /// off-by-one seeking bugs hide. Returns the list of mismatches.
 pub fn audit_point_reads(dir: &Path, generation: &str) -> Vec<String> {
     let reader = open_reader(dir, generation);
-    let scanned = reader.read_all_partitions().expect("scan partitions");
+    let scanned = collect_partitions_streaming(&reader);
     let mut violations = Vec::new();
     for partition in &scanned {
         match reader.get_partition(&partition.key) {
@@ -450,7 +458,7 @@ mod tests {
 
         // Explicit first/last boundary point reads.
         let reader = open_reader(&dir, &meta.id);
-        let scanned = reader.read_all_partitions().unwrap();
+        let scanned = collect_partitions_streaming(&reader);
         for boundary in [scanned.first().unwrap(), scanned.last().unwrap()] {
             assert!(
                 reader.get_partition(&boundary.key).unwrap().is_some(),

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -3685,25 +3685,53 @@ impl StorageEngine {
         // Note: the Data.db-truncation extent check (validate_data_extent) runs
         // mode-independently in the caller's load loop, BEFORE this smoke test,
         // so a truncated SSTable is already excluded by the time we get here.
-        let partitions = reader.read_all_partitions()?;
-        for partition in &partitions {
-            if let Some(static_row) = &partition.static_row {
+        //
+        // Keep this pass streaming. Self-heal runs the same smoke test on
+        // every unverified generation; materializing a whole SSTable here can
+        // turn corruption detection itself into an OOM vector.
+        let mut iter = reader.partitions_iter()?;
+        let mut previous_key: Option<DecoratedKey> = None;
+        let mut saw_real_cell_timestamp = false;
+        while let Some((key, _deletion, static_row)) = iter.next_partition_header_only()? {
+            if let Some(previous) = &previous_key {
+                if key <= *previous {
+                    return Err(ferrosa_common::Error::InvalidFormat(format!(
+                        "startup smoke test found Data.db partition order violation: \
+                         key {:?} token {} <= previous key {:?} token {}",
+                        key.key.as_bytes(),
+                        key.token.0,
+                        previous.key.as_bytes(),
+                        previous.token.0
+                    )));
+                }
+            }
+
+            if let Some(static_row) = &static_row {
                 Self::validate_startup_row_timestamps(static_row, true)?;
-            }
-            for row in &partition.rows {
-                Self::validate_startup_row_timestamps(row, false)?;
-            }
-        }
-        if reader.header().min_timestamp == NO_TIMESTAMP
-            && partitions.iter().any(|partition| {
-                partition
-                    .static_row
+                if static_row
+                    .cells
                     .iter()
-                    .chain(partition.rows.iter())
-                    .flat_map(|row| row.cells.iter())
                     .any(|(_, cell)| cell.timestamp != NO_TIMESTAMP)
-            })
-        {
+                {
+                    saw_real_cell_timestamp = true;
+                }
+            }
+
+            iter.stream_clustered_rows(|row| {
+                Self::validate_startup_row_timestamps(row, false)?;
+                if row
+                    .cells
+                    .iter()
+                    .any(|(_, cell)| cell.timestamp != NO_TIMESTAMP)
+                {
+                    saw_real_cell_timestamp = true;
+                }
+                Ok(())
+            })?;
+
+            previous_key = Some(key);
+        }
+        if reader.header().min_timestamp == NO_TIMESTAMP && saw_real_cell_timestamp {
             return Err(ferrosa_common::Error::InvalidFormat(
                 "startup smoke test found real cell timestamps with NO_TIMESTAMP serialization header".to_string(),
             ));
@@ -11535,9 +11563,10 @@ mod tests {
         let mut total = 0usize;
         let mut cursor = i64::MIN;
         let mut chunks = 0;
+        let large_byte_budget = 1_000_000usize;
         loop {
             let (chunk, next) = engine
-                .read_token_range_bounded(&tid, cursor, i64::MAX, 5, usize::MAX)
+                .read_token_range_bounded(&tid, cursor, i64::MAX, 5, large_byte_budget)
                 .unwrap();
             if chunk.is_empty() {
                 break;

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -7830,14 +7830,13 @@ impl StorageEngine {
         })?;
 
         let mut downloaded = 0;
-        // Data.db is the only required component; the rest are optional.
-        // Missing optional components produce a warning but do not fail the
-        // download.  Missing Data.db is a hard error — the SSTable cannot be
-        // read without it.
-        let required_components = ["Data.db"];
+        // Match `open_sstable_from_dir`: a generation is not readable unless
+        // all three required components are present. Restore into a staging
+        // directory and publish that directory only after every required
+        // component has streamed to disk, so a crash or partial object-store
+        // entry cannot expose a live Data-only orphan.
+        let required_components = ["Data.db", "Partitions.db", "Rows.db"];
         let optional_components = [
-            "Partitions.db",
-            "Rows.db",
             "Filter.db",
             "Statistics.db",
             "TOC.txt",
@@ -7846,7 +7845,25 @@ impl StorageEngine {
 
         'entry_loop: for entry in entries {
             let hex = crate::upload::manager::hex_prefix_for(&entry.id);
-            let mut wrote_any = false;
+            let local_complete = required_components.iter().all(|component| {
+                Self::generation_component_path(&table_dir, &entry.id, component).is_some()
+            });
+            if local_complete {
+                downloaded += 1;
+                continue;
+            }
+
+            let local_incomplete = required_components.iter().any(|component| {
+                Self::generation_component_path(&table_dir, &entry.id, component).is_some()
+            });
+            let staging_dir = Self::temp_download_directory(&table_dir, &entry.id);
+            let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+            tokio::fs::create_dir_all(&staging_dir).await.map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to create SSTable download staging dir {}: {e}",
+                    staging_dir.display()
+                ))
+            })?;
 
             // Required components: skip stale manifest entries whose required
             // data is neither local nor in object storage, but keep restoring
@@ -7859,46 +7876,27 @@ impl StorageEngine {
                     &entry.id,
                     component,
                 );
-                let local_path = table_dir.join(format!("{}-{component}", entry.id));
+                let local_path = staging_dir.join(format!("{}-{component}", entry.id));
 
-                if local_path.exists() {
-                    wrote_any = true;
-                    continue;
-                }
-
-                match store.get(&s3_path).await {
-                    Ok(result) => {
-                        let data = result.bytes().await.map_err(|e| {
-                            ferrosa_common::Error::InvalidFormat(format!(
-                                "failed to read {s3_path}: {e}"
-                            ))
-                        })?;
-                        std::fs::write(&local_path, &data).map_err(|e| {
-                            ferrosa_common::Error::InvalidFormat(format!(
-                                "failed to write {}: {e}",
-                                local_path.display()
-                            ))
-                        })?;
-                        wrote_any = true;
+                if Self::download_sstable_component_to_path(store.as_ref(), &s3_path, &local_path)
+                    .await?
+                    .is_none()
+                {
+                    let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+                    if local_incomplete {
+                        Self::quarantine_incomplete_generation(&table_dir, &entry.id);
                     }
-                    Err(object_store::Error::NotFound { .. }) => {
-                        tracing::warn!(
-                            sstable = entry.id,
-                            component,
-                            path = %s3_path,
-                            "required SSTable component absent in S3 and local disk — skipping stale manifest entry"
-                        );
-                        continue 'entry_loop;
-                    }
-                    Err(e) => {
-                        return Err(ferrosa_common::Error::InvalidFormat(format!(
-                            "S3 download failed for {s3_path}: {e}"
-                        )));
-                    }
+                    tracing::warn!(
+                        sstable = entry.id,
+                        component,
+                        path = %s3_path,
+                        "required SSTable component absent in S3 and local disk — skipping stale manifest entry"
+                    );
+                    continue 'entry_loop;
                 }
             }
 
-            // Optional components: log a warning on NotFound, continue.
+            // Optional components: stream when present, skip on NotFound.
             for component in &optional_components {
                 let s3_path = crate::upload::manager::sstable_object_key(
                     &prefix,
@@ -7907,47 +7905,54 @@ impl StorageEngine {
                     &entry.id,
                     component,
                 );
-                let local_path = table_dir.join(format!("{}-{component}", entry.id));
+                let local_path = staging_dir.join(format!("{}-{component}", entry.id));
 
-                if local_path.exists() {
-                    continue;
-                }
-
-                match store.get(&s3_path).await {
-                    Ok(result) => {
-                        let data = result.bytes().await.map_err(|e| {
-                            ferrosa_common::Error::InvalidFormat(format!(
-                                "failed to read {s3_path}: {e}"
-                            ))
-                        })?;
-                        std::fs::write(&local_path, &data).map_err(|e| {
-                            ferrosa_common::Error::InvalidFormat(format!(
-                                "failed to write {}: {e}",
-                                local_path.display()
-                            ))
-                        })?;
-                    }
-                    Err(object_store::Error::NotFound { .. }) => {
-                        tracing::debug!(
-                            sstable = entry.id,
-                            component,
-                            "optional SSTable component absent in S3 — skipping"
-                        );
-                    }
-                    Err(e) => {
-                        return Err(ferrosa_common::Error::InvalidFormat(format!(
-                            "S3 download failed for {s3_path}: {e}"
-                        )));
-                    }
+                if Self::download_sstable_component_to_path(store.as_ref(), &s3_path, &local_path)
+                    .await?
+                    .is_none()
+                {
+                    tracing::debug!(
+                        sstable = entry.id,
+                        component,
+                        "optional SSTable component absent in S3 — skipping"
+                    );
                 }
             }
 
-            // Only count this SSTable as downloaded after at least one file
-            // landed on disk.  This ensures `downloaded_total` reflects
-            // bytes-on-disk reality rather than manifest-entry count.
-            if wrote_any {
-                downloaded += 1;
+            Self::sync_directory(&staging_dir).map_err(|e| {
+                let _ = std::fs::remove_dir_all(&staging_dir);
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to sync SSTable download staging dir {}: {e}",
+                    staging_dir.display()
+                ))
+            })?;
+
+            if local_incomplete {
+                Self::quarantine_incomplete_generation(&table_dir, &entry.id);
             }
+
+            let final_dir = table_dir.join(&entry.id);
+            if final_dir.exists() {
+                let _ = std::fs::remove_dir_all(&final_dir);
+            }
+            tokio::fs::rename(&staging_dir, &final_dir)
+                .await
+                .map_err(|e| {
+                    let _ = std::fs::remove_dir_all(&staging_dir);
+                    ferrosa_common::Error::InvalidFormat(format!(
+                        "failed to atomically promote SSTable download {} to {}: {e}",
+                        staging_dir.display(),
+                        final_dir.display()
+                    ))
+                })?;
+            Self::sync_directory(&table_dir).map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to sync SSTable table dir {} after download promotion: {e}",
+                    table_dir.display()
+                ))
+            })?;
+
+            downloaded += 1;
         }
 
         if downloaded == 0 && !entries.is_empty() {
@@ -7957,6 +7962,95 @@ impl StorageEngine {
         }
 
         Ok(downloaded)
+    }
+
+    fn temp_download_directory(
+        target_dir: &std::path::Path,
+        sstable_id: &str,
+    ) -> std::path::PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|time| time.as_nanos())
+            .unwrap_or(0);
+        target_dir.join(format!(
+            ".download-{sstable_id}-{}-{suffix}",
+            std::process::id()
+        ))
+    }
+
+    async fn download_sstable_component_to_path(
+        store: &dyn object_store::ObjectStore,
+        s3_path: &object_store::path::Path,
+        local_path: &std::path::Path,
+    ) -> ferrosa_common::Result<Option<u64>> {
+        let result = match store.get(s3_path).await {
+            Ok(result) => result,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(e) => {
+                return Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "S3 download failed for {s3_path}: {e}"
+                )));
+            }
+        };
+
+        let mut stream = result.into_stream();
+        let mut file = tokio::fs::File::create(local_path).await.map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to create SSTable download temp file {}: {e}",
+                local_path.display()
+            ))
+        })?;
+        use tokio::io::AsyncWriteExt;
+        let mut bytes = 0u64;
+        while let Some(chunk) = stream.try_next().await.map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to stream SSTable component {s3_path}: {e}"
+            ))
+        })? {
+            bytes = bytes.saturating_add(chunk.len() as u64);
+            file.write_all(&chunk).await.map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to write SSTable download temp file {}: {e}",
+                    local_path.display()
+                ))
+            })?;
+        }
+        file.sync_data().await.map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to sync SSTable download temp file {}: {e}",
+                local_path.display()
+            ))
+        })?;
+        Ok(Some(bytes))
+    }
+
+    fn sync_directory(dir: &std::path::Path) -> std::io::Result<()> {
+        let file = std::fs::File::open(dir)?;
+        file.sync_all()
+    }
+
+    fn quarantine_incomplete_generation(table_dir: &std::path::Path, sstable_id: &str) {
+        let Ok(gen) = sstable_id.parse::<u64>() else {
+            return;
+        };
+        let quarantine_dir = table_dir.join("quarantine");
+        if let Err(e) = std::fs::create_dir_all(&quarantine_dir) {
+            tracing::warn!(
+                %e,
+                sstable = sstable_id,
+                dir = %table_dir.display(),
+                "failed to create quarantine dir for incomplete SSTable download"
+            );
+            return;
+        }
+        if let Err(e) = Self::quarantine_generation(table_dir, gen, &quarantine_dir) {
+            tracing::warn!(
+                %e,
+                sstable = sstable_id,
+                dir = %table_dir.display(),
+                "failed to quarantine incomplete SSTable download"
+            );
+        }
     }
 
     /// Scan a table directory for SSTable generation numbers.
@@ -18841,6 +18935,78 @@ mod tests {
             // compaction/upload cleanup. Bootstrap should restore the usable
             // SSTable instead of failing the whole table on the stale entry.
             let hex = crate::upload::manager::hex_prefix_for("1");
+            for (component, bytes) in [
+                ("Data.db", b"data".as_slice()),
+                ("Partitions.db", b"partitions".as_slice()),
+                ("Rows.db", b"rows".as_slice()),
+            ] {
+                let path = crate::upload::manager::sstable_object_key(
+                    &prefix,
+                    &hex,
+                    &table_id_str,
+                    "1",
+                    component,
+                );
+                store
+                    .put(
+                        &path,
+                        object_store::PutPayload::from(bytes::Bytes::copy_from_slice(bytes)),
+                    )
+                    .await
+                    .unwrap();
+            }
+
+            let downloaded = engine
+                .download_sstables_from_s3(&tid, &manifest)
+                .await
+                .expect("stale missing SSTable entries must not fail partial restore");
+
+            assert_eq!(downloaded, 1);
+            let table_dir = dir.path().join("sstables").join(&table_id_str);
+            assert!(StorageEngine::generation_component_path(&table_dir, "1", "Data.db").is_some());
+            assert!(StorageEngine::generation_component_path(&table_dir, "2", "Data.db").is_none());
+
+            engine.shutdown().unwrap();
+        });
+    }
+
+    #[test]
+    fn download_sstables_from_s3_rejects_data_only_orphans_without_publishing_live_file() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let store: Arc<dyn object_store::ObjectStore> =
+                Arc::new(object_store::memory::InMemory::new());
+            let prefix = "test-data-only-restore".to_string();
+            let tid = table_id();
+            let table_id_str = tid.to_string();
+
+            let engine = StorageEngine::new_with_upload_store(
+                StorageEngineConfig::test_config(dir.path()),
+                Arc::clone(&store),
+                prefix.clone(),
+                &tokio::runtime::Handle::current(),
+            )
+            .unwrap();
+
+            let mut manifest = crate::manifest::Manifest::new();
+            manifest.add_sstable(
+                &table_id_str,
+                crate::manifest::ManifestEntry {
+                    id: "1".to_string(),
+                    size: 4,
+                    min_token: 0,
+                    max_token: 0,
+                    min_timestamp: 0,
+                    max_timestamp: 0,
+                },
+            );
+
+            let hex = crate::upload::manager::hex_prefix_for("1");
             let path = crate::upload::manager::sstable_object_key(
                 &prefix,
                 &hex,
@@ -18856,24 +19022,23 @@ mod tests {
                 .await
                 .unwrap();
 
-            let downloaded = engine
-                .download_sstables_from_s3(&tid, &manifest)
-                .await
-                .expect("stale missing SSTable entries must not fail partial restore");
+            let result = engine.download_sstables_from_s3(&tid, &manifest).await;
+            assert!(
+                result.is_err(),
+                "a manifest entry with only Data.db must fail closed, not restore a corrupt SSTable"
+            );
 
-            assert_eq!(downloaded, 1);
-            assert!(dir
-                .path()
-                .join("sstables")
-                .join(&table_id_str)
-                .join("1-Data.db")
-                .exists());
-            assert!(!dir
-                .path()
-                .join("sstables")
-                .join(&table_id_str)
-                .join("2-Data.db")
-                .exists());
+            let table_dir = dir.path().join("sstables").join(&table_id_str);
+            assert!(
+                !table_dir.join("1-Data.db").exists(),
+                "download must not publish a live Data-only orphan in flat layout"
+            );
+            assert!(
+                !table_dir.join("1").join("1-Data.db").exists(),
+                "download must not publish a live Data-only orphan in generation-dir layout"
+            );
+
+            engine.shutdown().unwrap();
         });
     }
 
@@ -19004,7 +19169,9 @@ mod tests {
 
             // ── Verify files are on disk ──────────────────────────────────────
             for entry in &sstable_entries {
-                let data_file = table_dir.join(format!("{}-Data.db", entry.id));
+                let data_file =
+                    StorageEngine::generation_component_path(&table_dir, &entry.id, "Data.db")
+                        .unwrap_or_else(|| table_dir.join(format!("{}-Data.db", entry.id)));
                 assert!(
                     data_file.exists(),
                     "Data.db for SSTable '{}' must exist on disk after download: {}",

--- a/ferrosa-storage/src/flush.rs
+++ b/ferrosa-storage/src/flush.rs
@@ -592,6 +592,7 @@ pub(crate) mod fsync_probe {
     static EXCLUSIVE: Mutex<()> = Mutex::new(());
     static SYNCED_FILES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
     static SYNCED_DIRS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+    static RENAMED_FILES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
     pub(crate) struct ExclusiveGuard {
         _guard: MutexGuard<'static, ()>,
@@ -614,6 +615,7 @@ pub(crate) mod fsync_probe {
     fn reset() {
         SYNCED_FILES.lock().expect("fsync probe poisoned").clear();
         SYNCED_DIRS.lock().expect("fsync probe poisoned").clear();
+        RENAMED_FILES.lock().expect("fsync probe poisoned").clear();
     }
 
     pub(crate) fn note_file(path: &Path) {
@@ -625,6 +627,13 @@ pub(crate) mod fsync_probe {
 
     pub(crate) fn note_dir(path: &Path) {
         SYNCED_DIRS
+            .lock()
+            .expect("fsync probe poisoned")
+            .push(path.to_path_buf());
+    }
+
+    pub(crate) fn note_rename(path: &Path) {
+        RENAMED_FILES
             .lock()
             .expect("fsync probe poisoned")
             .push(path.to_path_buf());
@@ -646,6 +655,10 @@ pub(crate) mod fsync_probe {
             .iter()
             .cloned()
             .collect()
+    }
+
+    pub(crate) fn renamed_files() -> Vec<PathBuf> {
+        RENAMED_FILES.lock().expect("fsync probe poisoned").clone()
     }
 }
 
@@ -776,6 +789,34 @@ impl FileFlushTarget {
             Some("txt") => path.with_extension("txt.tmp"),
             _ => path.with_extension("db.tmp"),
         }
+    }
+
+    fn rename_path(source: impl AsRef<Path>, target: impl AsRef<Path>) -> std::io::Result<()> {
+        std::fs::rename(source.as_ref(), target.as_ref())?;
+        #[cfg(test)]
+        fsync_probe::note_rename(target.as_ref());
+        Ok(())
+    }
+
+    fn promote_tmp_components(
+        paths: &FileComponentPaths,
+        has_compression_info: bool,
+    ) -> Result<()> {
+        let tmp = Self::tmp_component_path;
+
+        // `Data.db` is the discovery marker for a live generation. Promote it
+        // last so a crash between renames can leave side components without
+        // Data.db, but never a discoverable Data-only orphan.
+        Self::rename_path(tmp(&paths.partitions), &paths.partitions)?;
+        Self::rename_path(tmp(&paths.rows), &paths.rows)?;
+        Self::rename_path(tmp(&paths.filter), &paths.filter)?;
+        Self::rename_path(tmp(&paths.statistics), &paths.statistics)?;
+        Self::rename_path(tmp(&paths.toc), &paths.toc)?;
+        if has_compression_info {
+            Self::rename_path(tmp(&paths.compression_info), &paths.compression_info)?;
+        }
+        Self::rename_path(tmp(&paths.data), &paths.data)?;
+        Ok(())
     }
 
     /// fsync a single file so its bytes are durable on the underlying device.
@@ -1126,16 +1167,9 @@ impl FlushTarget for FileFlushTarget {
         }
 
         // All tmp files written successfully — atomically rename to final names.
-        // rename() is atomic on POSIX (same filesystem).
-        std::fs::rename(tmp(&paths.data), &paths.data)?;
-        std::fs::rename(tmp(&paths.partitions), &paths.partitions)?;
-        std::fs::rename(tmp(&paths.rows), &paths.rows)?;
-        std::fs::rename(tmp(&paths.filter), &paths.filter)?;
-        std::fs::rename(tmp(&paths.statistics), &paths.statistics)?;
-        std::fs::rename(&toc_tmp, &paths.toc)?;
-        if has_compression_info {
-            std::fs::rename(tmp(&paths.compression_info), &paths.compression_info)?;
-        }
+        // rename() is atomic on POSIX (same filesystem). Data.db is promoted
+        // last because it is the generation discovery marker.
+        Self::promote_tmp_components(&paths, has_compression_info)?;
 
         // Verify the renamed Data.db file is the correct size.
         // If it differs from the tmp file we just checked, something else
@@ -1203,15 +1237,7 @@ impl FlushTarget for FileFlushTarget {
             )));
         }
 
-        std::fs::rename(tmp(&paths.data), &paths.data)?;
-        std::fs::rename(tmp(&paths.partitions), &paths.partitions)?;
-        std::fs::rename(tmp(&paths.rows), &paths.rows)?;
-        std::fs::rename(tmp(&paths.filter), &paths.filter)?;
-        std::fs::rename(tmp(&paths.statistics), &paths.statistics)?;
-        std::fs::rename(tmp(&paths.toc), &paths.toc)?;
-        if has_compression_info {
-            std::fs::rename(tmp(&paths.compression_info), &paths.compression_info)?;
-        }
+        Self::promote_tmp_components(&paths, has_compression_info)?;
 
         // Durability barrier: fsync every promoted component, then fsync the
         // directory once, BEFORE cleaning up staging or returning. This path is
@@ -1380,6 +1406,33 @@ mod tests {
                 deletion: DeletionTime::LIVE,
                 primary_key_liveness: LivenessInfo::with_timestamp(ts),
             }],
+        }
+    }
+
+    fn assert_data_db_promoted_last(base_dir: &Path, gen: u64) {
+        let renamed = fsync_probe::renamed_files();
+        let expected_data = base_dir.join(format!("{gen}-Data.db"));
+        let data_pos = renamed
+            .iter()
+            .position(|path| path == &expected_data)
+            .unwrap_or_else(|| panic!("Data.db was not promoted; renamed={renamed:?}"));
+
+        assert_eq!(
+            data_pos,
+            renamed.len() - 1,
+            "Data.db must be the last final component promoted; renamed={renamed:?}"
+        );
+
+        for suffix in ["Partitions.db", "Rows.db"] {
+            let path = base_dir.join(format!("{gen}-{suffix}"));
+            let pos = renamed
+                .iter()
+                .position(|renamed_path| renamed_path == &path)
+                .unwrap_or_else(|| panic!("{suffix} was not promoted; renamed={renamed:?}"));
+            assert!(
+                pos < data_pos,
+                "{suffix} must be promoted before Data.db; renamed={renamed:?}"
+            );
         }
     }
 
@@ -1762,6 +1815,65 @@ mod tests {
             tmp_files.is_empty(),
             "no .tmp files should remain after successful flush, found: {tmp_files:?}"
         );
+    }
+
+    #[test]
+    fn flush_promotes_data_db_after_required_components() {
+        let _fsync_probe = fsync_probe::exclusive();
+
+        let dir = tempfile::tempdir().unwrap();
+        let schema = test_schema();
+        let mut partitions = vec![make_partition("k1", b"v1", 5000)];
+        partitions.sort_by(|a, b| a.key.cmp(&b.key));
+
+        let header = build_serialization_header(&schema, &partitions);
+        let options = WriteOptions {
+            compression: None,
+            ..WriteOptions::default()
+        };
+        let mut writer = SSTableWriter::new(options, header);
+        for p in &partitions {
+            writer.add_partition(p).unwrap();
+        }
+        let output = writer.finish().unwrap();
+
+        let target = FileFlushTarget::new(dir.path().to_path_buf()).unwrap();
+        let _reader = target.flush(output).unwrap();
+        let gen = target.generation();
+
+        assert_data_db_promoted_last(dir.path(), gen);
+    }
+
+    #[test]
+    fn flush_files_promotes_data_db_after_required_components() {
+        let _fsync_probe = fsync_probe::exclusive();
+
+        let dir = tempfile::tempdir().unwrap();
+        let schema = test_schema();
+        let mut partitions = vec![
+            make_partition("k1", b"v1", 5000),
+            make_partition("k2", b"v2", 3000),
+        ];
+        partitions.sort_by(|a, b| a.key.cmp(&b.key));
+
+        let target = FileFlushTarget::new(dir.path().to_path_buf()).unwrap();
+        let staging_dir = target
+            .file_output_staging_dir()
+            .unwrap()
+            .expect("file target staging dir");
+        let header = build_serialization_header(&schema, &partitions);
+        let options = WriteOptions::default();
+        let mut writer =
+            SSTableWriter::new_file_backed(options, header, staging_dir.join("Data.raw")).unwrap();
+        for p in &partitions {
+            writer.add_partition(p).unwrap();
+        }
+        let output = writer.finish_to_directory(&staging_dir).unwrap();
+
+        let _reader = target.flush_files(output).unwrap();
+        let gen = target.generation();
+
+        assert_data_db_promoted_last(dir.path(), gen);
     }
 
     #[test]

--- a/ferrosa-storage/src/index/scheduler.rs
+++ b/ferrosa-storage/src/index/scheduler.rs
@@ -236,7 +236,7 @@ impl IndexBuildBackend for LocalBackend {
         .map_err(|e| format!("open sstable: {e}"))?;
 
         // Stream partitions one at a time rather than materializing the whole
-        // SSTable. `read_all_partitions()` would hold every decoded partition —
+        // SSTable. A full partition Vec would hold every decoded partition —
         // all cell values of all columns — in memory at once; on a large
         // SSTable that is an OOM hazard. `partitions_iter()` keeps a single
         // partition live plus the (much smaller) extracted index entries:

--- a/ferrosa-storage/src/restore/manager.rs
+++ b/ferrosa-storage/src/restore/manager.rs
@@ -10,9 +10,11 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use futures::TryStreamExt;
 use object_store::path::Path as ObjectPath;
 use object_store::ObjectStore;
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
 
 use crate::manifest::Manifest;
 use crate::snapshot::metadata::SnapshotMetadata;
@@ -24,6 +26,23 @@ pub struct RestoreManager {
 }
 
 impl RestoreManager {
+    const REQUIRED_SSTABLE_COMPONENTS: [&'static str; 3] = ["Data.db", "Partitions.db", "Rows.db"];
+    const OPTIONAL_SSTABLE_COMPONENTS: [&'static str; 4] = [
+        "Filter.db",
+        "Statistics.db",
+        "TOC.txt",
+        "CompressionInfo.db",
+    ];
+    const ALL_SSTABLE_COMPONENTS: [&'static str; 7] = [
+        "Data.db",
+        "Partitions.db",
+        "Rows.db",
+        "Filter.db",
+        "Statistics.db",
+        "TOC.txt",
+        "CompressionInfo.db",
+    ];
+
     /// Creates a new manager backed by `store` with the given key prefix.
     pub fn new(store: Arc<dyn ObjectStore>, prefix: impl Into<String>) -> Self {
         Self {
@@ -91,16 +110,6 @@ impl RestoreManager {
         manifest: &Manifest,
         dest_dir: &Path,
     ) -> ferrosa_common::Result<usize> {
-        let components = [
-            "Data.db",
-            "Partitions.db",
-            "Rows.db",
-            "Filter.db",
-            "Statistics.db",
-            "TOC.txt",
-            "CompressionInfo.db",
-        ];
-
         let mut total = 0usize;
 
         for (table_id_str, entries) in &manifest.sstables {
@@ -114,11 +123,25 @@ impl RestoreManager {
 
             for entry in entries {
                 let hex = crate::upload::manager::hex_prefix_for(&entry.id);
+                let local_complete = Self::REQUIRED_SSTABLE_COMPONENTS.iter().all(|component| {
+                    Self::generation_component_path(&table_dir, &entry.id, component).is_some()
+                });
+                if local_complete {
+                    total += 1;
+                    continue;
+                }
 
-                for component in &components {
-                    // Use the shared key constructor — guarantees upload and
-                    // download always agree on the path format.  The key
-                    // format is: {prefix}/{hex}/{table}/{sstable}/{sstable}-{component}
+                let local_incomplete = Self::generation_exists(&table_dir, &entry.id);
+                let staging_dir = Self::temp_download_directory(&table_dir, &entry.id);
+                let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+                tokio::fs::create_dir_all(&staging_dir).await.map_err(|e| {
+                    ferrosa_common::Error::InvalidFormat(format!(
+                        "failed to create SSTable restore staging dir {}: {e}",
+                        staging_dir.display()
+                    ))
+                })?;
+
+                for component in &Self::REQUIRED_SSTABLE_COMPONENTS {
                     let s3_path = crate::upload::manager::sstable_object_key(
                         &self.prefix,
                         &hex,
@@ -126,36 +149,79 @@ impl RestoreManager {
                         &entry.id,
                         component,
                     );
-                    let local_path = table_dir.join(format!("{}-{component}", entry.id));
+                    let local_path = staging_dir.join(format!("{}-{component}", entry.id));
 
-                    // Skip if already present.
-                    if local_path.exists() {
-                        continue;
-                    }
-
-                    match self.store.get(&s3_path).await {
-                        Ok(result) => {
-                            let data = result.bytes().await.map_err(|e| {
-                                ferrosa_common::Error::InvalidFormat(format!(
-                                    "failed to read bytes from {s3_path}: {e}"
-                                ))
-                            })?;
-                            std::fs::write(&local_path, &data).map_err(|e| {
-                                ferrosa_common::Error::InvalidFormat(format!(
-                                    "failed to write {}: {e}",
-                                    local_path.display()
-                                ))
-                            })?;
+                    if Self::download_component_to_path(self.store.as_ref(), &s3_path, &local_path)
+                        .await?
+                        .is_none()
+                    {
+                        let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+                        if local_incomplete {
+                            Self::quarantine_incomplete_generation(&table_dir, &entry.id);
                         }
-                        // Optional components (e.g., CompressionInfo.db) may be absent.
-                        Err(object_store::Error::NotFound { .. }) => continue,
-                        Err(e) => {
-                            return Err(ferrosa_common::Error::InvalidFormat(format!(
-                                "S3 download failed for {s3_path}: {e}"
-                            )));
-                        }
+                        return Err(ferrosa_common::Error::InvalidFormat(format!(
+                            "snapshot SSTable {} for table {table_id_str} is missing required \
+                             component {component} at {s3_path}; refusing to publish partial restore",
+                            entry.id
+                        )));
                     }
                 }
+
+                for component in &Self::OPTIONAL_SSTABLE_COMPONENTS {
+                    let s3_path = crate::upload::manager::sstable_object_key(
+                        &self.prefix,
+                        &hex,
+                        table_id_str,
+                        &entry.id,
+                        component,
+                    );
+                    let local_path = staging_dir.join(format!("{}-{component}", entry.id));
+
+                    if Self::download_component_to_path(self.store.as_ref(), &s3_path, &local_path)
+                        .await?
+                        .is_none()
+                    {
+                        tracing::debug!(
+                            table = table_id_str,
+                            sstable = entry.id,
+                            component,
+                            "optional snapshot SSTable component absent in object store"
+                        );
+                    }
+                }
+
+                Self::sync_directory(&staging_dir).map_err(|e| {
+                    let _ = std::fs::remove_dir_all(&staging_dir);
+                    ferrosa_common::Error::InvalidFormat(format!(
+                        "failed to sync SSTable restore staging dir {}: {e}",
+                        staging_dir.display()
+                    ))
+                })?;
+
+                if local_incomplete {
+                    Self::quarantine_incomplete_generation(&table_dir, &entry.id);
+                }
+
+                let final_dir = table_dir.join(&entry.id);
+                if final_dir.exists() {
+                    Self::quarantine_incomplete_generation(&table_dir, &entry.id);
+                }
+                tokio::fs::rename(&staging_dir, &final_dir)
+                    .await
+                    .map_err(|e| {
+                        let _ = std::fs::remove_dir_all(&staging_dir);
+                        ferrosa_common::Error::InvalidFormat(format!(
+                            "failed to atomically promote SSTable restore {} to {}: {e}",
+                            staging_dir.display(),
+                            final_dir.display()
+                        ))
+                    })?;
+                Self::sync_directory(&table_dir).map_err(|e| {
+                    ferrosa_common::Error::InvalidFormat(format!(
+                        "failed to sync table dir {} after SSTable restore promotion: {e}",
+                        table_dir.display()
+                    ))
+                })?;
                 total += 1;
             }
         }
@@ -214,6 +280,138 @@ impl RestoreManager {
     }
 
     // ── Private helpers ──────────────────────────────────────────────────────
+
+    fn generation_component_path(
+        table_dir: &Path,
+        sstable_id: &str,
+        component: &str,
+    ) -> Option<std::path::PathBuf> {
+        let generation_dir_path = table_dir
+            .join(sstable_id)
+            .join(format!("{sstable_id}-{component}"));
+        if generation_dir_path.exists() {
+            return Some(generation_dir_path);
+        }
+
+        let flat_path = table_dir.join(format!("{sstable_id}-{component}"));
+        flat_path.exists().then_some(flat_path)
+    }
+
+    fn generation_exists(table_dir: &Path, sstable_id: &str) -> bool {
+        table_dir.join(sstable_id).exists()
+            || Self::ALL_SSTABLE_COMPONENTS
+                .iter()
+                .any(|component| table_dir.join(format!("{sstable_id}-{component}")).exists())
+    }
+
+    fn temp_download_directory(table_dir: &Path, sstable_id: &str) -> std::path::PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|time| time.as_nanos())
+            .unwrap_or(0);
+        table_dir.join(format!(
+            ".download-{sstable_id}-{}-{suffix}",
+            std::process::id()
+        ))
+    }
+
+    async fn download_component_to_path(
+        store: &dyn ObjectStore,
+        s3_path: &ObjectPath,
+        local_path: &Path,
+    ) -> ferrosa_common::Result<Option<u64>> {
+        let result = match store.get(s3_path).await {
+            Ok(result) => result,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(e) => {
+                return Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "S3 download failed for {s3_path}: {e}"
+                )));
+            }
+        };
+
+        let mut stream = result.into_stream();
+        let mut file = tokio::fs::File::create(local_path).await.map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to create SSTable restore temp file {}: {e}",
+                local_path.display()
+            ))
+        })?;
+        let mut bytes = 0u64;
+        while let Some(chunk) = stream.try_next().await.map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to stream SSTable component {s3_path}: {e}"
+            ))
+        })? {
+            bytes = bytes.saturating_add(chunk.len() as u64);
+            file.write_all(&chunk).await.map_err(|e| {
+                ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to write SSTable restore temp file {}: {e}",
+                    local_path.display()
+                ))
+            })?;
+        }
+        file.sync_data().await.map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to sync SSTable restore temp file {}: {e}",
+                local_path.display()
+            ))
+        })?;
+        Ok(Some(bytes))
+    }
+
+    fn sync_directory(dir: &Path) -> std::io::Result<()> {
+        let file = std::fs::File::open(dir)?;
+        file.sync_all()
+    }
+
+    fn quarantine_incomplete_generation(table_dir: &Path, sstable_id: &str) {
+        let quarantine_dir = table_dir.join("quarantine");
+        if let Err(e) = std::fs::create_dir_all(&quarantine_dir) {
+            tracing::warn!(
+                %e,
+                sstable = sstable_id,
+                dir = %table_dir.display(),
+                "failed to create quarantine dir for incomplete SSTable restore"
+            );
+            return;
+        }
+
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|time| time.as_nanos())
+            .unwrap_or(0);
+        let generation_dir = table_dir.join(sstable_id);
+        if generation_dir.exists() {
+            let dst = quarantine_dir.join(format!("{sstable_id}-{suffix}"));
+            if let Err(e) = std::fs::rename(&generation_dir, &dst) {
+                tracing::warn!(
+                    %e,
+                    sstable = sstable_id,
+                    src = %generation_dir.display(),
+                    dst = %dst.display(),
+                    "failed to quarantine incomplete generation directory"
+                );
+            }
+        }
+
+        for component in &Self::ALL_SSTABLE_COMPONENTS {
+            let src = table_dir.join(format!("{sstable_id}-{component}"));
+            if !src.exists() {
+                continue;
+            }
+            let dst = quarantine_dir.join(format!("{sstable_id}-{suffix}-{component}"));
+            if let Err(e) = std::fs::rename(&src, &dst) {
+                tracing::warn!(
+                    %e,
+                    sstable = sstable_id,
+                    src = %src.display(),
+                    dst = %dst.display(),
+                    "failed to quarantine incomplete flat component"
+                );
+            }
+        }
+    }
 
     async fn get_bytes(&self, path: &ObjectPath) -> ferrosa_common::Result<bytes::Bytes> {
         let result = self.store.get(path).await.map_err(|e| {
@@ -276,6 +474,24 @@ mod tests {
             .create_snapshot(name, &manifest, b"{}", pos, node_id, None, false)
             .await
             .unwrap()
+    }
+
+    async fn put_sstable_component(
+        store: &Arc<dyn ObjectStore>,
+        prefix: &str,
+        table_id: &str,
+        sstable_id: &str,
+        component: &str,
+        bytes: &'static [u8],
+    ) {
+        let hex = crate::upload::manager::hex_prefix_for(sstable_id);
+        let s3_path = crate::upload::manager::sstable_object_key(
+            prefix, &hex, table_id, sstable_id, component,
+        );
+        store
+            .put(&s3_path, PutPayload::from(bytes::Bytes::from_static(bytes)))
+            .await
+            .unwrap();
     }
 
     // ── Test 1: load_and_validate_snapshot ────────────────────────────────
@@ -360,19 +576,19 @@ mod tests {
         // Place a fake SSTable file in S3 at the canonical path.
         let table_id = "ks.users";
         let sstable_id = "0001";
-        let hex = crate::upload::manager::hex_prefix_for(sstable_id);
-        // Use sstable_object_key so this test always stays in sync with the
-        // upload path.  The file must be at {prefix}/{hex}/{table}/{id}/{id}-Data.db.
-        let s3_path = crate::upload::manager::sstable_object_key(
-            prefix, &hex, table_id, sstable_id, "Data.db",
-        );
-        store
-            .put(
-                &s3_path,
-                PutPayload::from(bytes::Bytes::from_static(b"data")),
-            )
-            .await
-            .unwrap();
+        // Use sstable_object_key via the helper so this test always stays in
+        // sync with the upload path.
+        put_sstable_component(&store, prefix, table_id, sstable_id, "Data.db", b"data").await;
+        put_sstable_component(
+            &store,
+            prefix,
+            table_id,
+            sstable_id,
+            "Partitions.db",
+            b"partitions",
+        )
+        .await;
+        put_sstable_component(&store, prefix, table_id, sstable_id, "Rows.db", b"rows").await;
 
         let mut manifest = Manifest::new();
         manifest.add_sstable(
@@ -394,10 +610,56 @@ mod tests {
         assert_eq!(count, 1);
 
         // The file should exist on local disk.
-        let local = dir
-            .path()
-            .join(table_id)
-            .join(format!("{sstable_id}-Data.db"));
+        let local = RestoreManager::generation_component_path(
+            &dir.path().join(table_id),
+            sstable_id,
+            "Data.db",
+        )
+        .expect("Data.db should be present on disk");
         assert!(local.exists(), "Data.db should be present on disk");
+    }
+
+    #[tokio::test]
+    async fn download_sstables_rejects_data_only_without_publishing_live_file() {
+        let store = make_store();
+        let prefix = "test-data-only";
+        let dir = tempfile::tempdir().unwrap();
+        let table_id = "ks.users";
+        let sstable_id = "0007";
+
+        put_sstable_component(&store, prefix, table_id, sstable_id, "Data.db", b"data").await;
+
+        let mut manifest = Manifest::new();
+        manifest.add_sstable(
+            table_id,
+            ManifestEntry {
+                id: sstable_id.to_string(),
+                size: 4,
+                min_token: 0,
+                max_token: 0,
+                min_timestamp: 0,
+                max_timestamp: 0,
+            },
+        );
+
+        let mgr = RestoreManager::new(Arc::clone(&store), prefix);
+        let result = mgr.download_sstables(&manifest, dir.path()).await;
+
+        assert!(
+            result.is_err(),
+            "Data-only snapshot restore must fail closed instead of publishing an orphan"
+        );
+        let table_dir = dir.path().join(table_id);
+        assert!(
+            !table_dir.join(format!("{sstable_id}-Data.db")).exists(),
+            "restore must not publish a flat Data-only component"
+        );
+        assert!(
+            !table_dir
+                .join(sstable_id)
+                .join(format!("{sstable_id}-Data.db"))
+                .exists(),
+            "restore must not publish a generation-dir Data-only component"
+        );
     }
 }

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -7886,6 +7886,89 @@ mod tests {
         );
     }
 
+    #[test]
+    fn startup_smoke_test_rejects_out_of_order_data_stream() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = file_backed_test_store(tmp.path());
+        let schema = test_schema();
+
+        let first = make_partition("decision", b"first", 1000);
+        let second = make_partition("org", b"second", 1000);
+        assert!(
+            first.key > second.key,
+            "test keys must be descending by decorated token"
+        );
+
+        store.write(&first.key, first.rows[0].clone()).unwrap();
+        store.write(&second.key, second.rows[0].clone()).unwrap();
+        store.flush().unwrap();
+
+        let gen = store.last_flush_generation();
+        let data_path = tmp.path().join(format!("{gen}-Data.db"));
+        let header_partitions = vec![second.clone(), first.clone()];
+        let mut unsorted_data =
+            data_bytes_for_single_partition(&schema, &header_partitions, &first);
+        unsorted_data.extend(data_bytes_for_single_partition(
+            &schema,
+            &header_partitions,
+            &second,
+        ));
+        std::fs::write(&data_path, unsorted_data).unwrap();
+
+        let err = crate::engine::StorageEngine::smoke_test_generation(tmp.path(), gen)
+            .expect_err("startup/self-heal smoke test must detect Data.db token-order corruption");
+        assert!(
+            err.to_string().contains("partition order violation"),
+            "error must name the token-order corruption, got: {err}"
+        );
+    }
+
+    #[test]
+    fn production_table_read_paths_must_not_materialize_unbounded_sstables() {
+        let production_sources = [
+            ("engine.rs", include_str!("engine.rs")),
+            ("store.rs", include_str!("store.rs")),
+            (
+                "ferrosa-sstable/reader.rs",
+                include_str!("../../ferrosa-sstable/src/reader.rs"),
+            ),
+            (
+                "compaction/executor.rs",
+                include_str!("compaction/executor.rs"),
+            ),
+            (
+                "compaction/validator/driver.rs",
+                include_str!("compaction/validator/driver.rs"),
+            ),
+            (
+                "ferrosa-cql/router.rs",
+                include_str!("../../ferrosa-cql/src/router.rs"),
+            ),
+            (
+                "ferrosa-cluster/repair/trigger.rs",
+                include_str!("../../ferrosa-cluster/src/repair/trigger.rs"),
+            ),
+            (
+                "ferrosa-sstable-dump.rs",
+                include_str!("../../ferrosa-sstable/src/bin/ferrosa-sstable-dump.rs"),
+            ),
+        ];
+
+        let unbounded_read_all = concat!(".read_all", "_partitions(");
+        let unbounded_partition_limit = concat!("read_partitions_limited", "(usize::MAX");
+        for (name, source) in production_sources {
+            let production = source.split("#[cfg(test)]").next().unwrap_or(source);
+            assert!(
+                !production.contains(unbounded_read_all),
+                "{name} production code must stream SSTables; whole-table partition reads materialize an unbounded Vec"
+            );
+            assert!(
+                !production.contains(unbounded_partition_limit),
+                "{name} production code must not request an effectively unbounded materialized SSTable read"
+            );
+        }
+    }
+
     // -------------------------------------------------------------------------
     // WP-003: sstable_metadata reports correct max_timestamp
     // -------------------------------------------------------------------------
@@ -8679,7 +8762,7 @@ mod tests {
         // `n_sstables` readers open at once — impossible under a pool capped at
         // `fanin`, forcing a soft-cap breach.
         let merged = store
-            .read_token_range(i64::MIN, i64::MAX, usize::MAX)
+            .read_token_range(i64::MIN, i64::MAX, distinct_keys)
             .unwrap();
         assert_eq!(
             merged.len(),
@@ -8892,8 +8975,11 @@ mod tests {
             (i64::MIN + 1, i64::MAX - 1),
         ];
 
+        let fixture_partition_limit = 5;
         for (start, end) in windows {
-            let rtr = store.read_token_range(start, end, usize::MAX).unwrap();
+            let rtr = store
+                .read_token_range(start, end, fixture_partition_limit)
+                .unwrap();
             let mut walk: Vec<Partition> = Vec::new();
             store
                 .walk_token_range(start, end, |p| {
@@ -8935,9 +9021,7 @@ mod tests {
             })
             .unwrap();
 
-        let rtr = store
-            .read_token_range(i64::MIN, i64::MAX, usize::MAX)
-            .unwrap();
+        let rtr = store.read_token_range(i64::MIN, i64::MAX, 4).unwrap();
         assert_eq!(
             digest, rtr,
             "streaming digest walk partitions must match single-pass read_token_range"
@@ -8999,7 +9083,7 @@ mod tests {
 
         // Sanity: a single-pass read sees all distinct keys (the merged result).
         let merged = store
-            .read_token_range(i64::MIN, i64::MAX, usize::MAX)
+            .read_token_range(i64::MIN, i64::MAX, distinct_keys)
             .unwrap();
         assert_eq!(
             merged.len(),
@@ -9063,22 +9147,22 @@ mod tests {
         // the cell-merge / dedup / tombstone-preservation paths are exercised.
         let store = file_store_with_many_sstables(dir.path(), 1024, 64, 12);
 
-        // Reference: single-pass, unbounded.
-        let reference = store
-            .read_token_range(i64::MIN, i64::MAX, usize::MAX)
-            .unwrap();
+        // Reference: single-pass with a fixture-sized finite limit.
+        let reference = store.read_token_range(i64::MIN, i64::MAX, 12).unwrap();
         assert!(!reference.is_empty(), "fixture must produce partitions");
 
         // Loop the bounded fetch over the full window under a spread of
         // (max_partitions, max_bytes) budgets; the result must reassemble to the
         // single-pass reference regardless of how the chunk boundaries fall.
+        let all_partitions = reference.len().max(1);
+        let large_byte_budget = 1_000_000usize;
         let cases: &[(usize, usize)] = &[
-            (usize::MAX, usize::MAX), // single chunk
-            (3, usize::MAX),          // count budget
-            (usize::MAX, 64),         // byte budget
-            (2, usize::MAX),          // tight count budget
-            (1, usize::MAX),          // one partition per chunk
-            (usize::MAX, 48),         // tight byte budget
+            (all_partitions, large_byte_budget), // single chunk
+            (3, large_byte_budget),              // count budget
+            (all_partitions, 64),                // byte budget
+            (2, large_byte_budget),              // tight count budget
+            (1, large_byte_budget),              // one partition per chunk
+            (all_partitions, 48),                // tight byte budget
         ];
 
         for &(max_partitions, max_bytes) in cases {
@@ -9093,7 +9177,7 @@ mod tests {
                     .unwrap();
                 if !chunk.is_empty() {
                     assert!(
-                        max_partitions == usize::MAX || chunk.len() <= max_partitions,
+                        chunk.len() <= max_partitions,
                         "chunk len {} exceeded count budget {max_partitions}",
                         chunk.len()
                     );
@@ -9135,9 +9219,10 @@ mod tests {
         inflight::reset();
         let mut total = 0usize;
         let mut cursor = i64::MIN;
+        let large_byte_budget = 1_000_000usize;
         loop {
             let (chunk, next) = store
-                .read_token_range_bounded(cursor, i64::MAX, 2, usize::MAX)
+                .read_token_range_bounded(cursor, i64::MAX, 2, large_byte_budget)
                 .unwrap();
             total += chunk.len();
             match next {

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -2138,6 +2138,28 @@ impl<F: FlushTarget> TableStore<F> {
             );
         }
 
+        if partitions.is_empty() {
+            tracing::warn!(
+                keyspace = %schema.keyspace,
+                table = %schema.table,
+                quarantined_rows = total_quarantined,
+                "flush: all rows were quarantined; skipping empty SSTable publish"
+            );
+            let live = self.view.load();
+            let new_view = StoreView {
+                active: Arc::clone(&live.active),
+                flushing: None,
+                sstables: Arc::clone(&live.sstables),
+                sstable_ids: Arc::clone(&live.sstable_ids),
+                indexes: Arc::clone(&live.indexes),
+                sidecar_indexes: Arc::clone(&live.sidecar_indexes),
+                vector_indexes: Arc::clone(&live.vector_indexes),
+            };
+            new_view.check_invariants("flush:clear_all_quarantined");
+            self.view.store(Arc::new(new_view));
+            return Ok(());
+        }
+
         let header = flush::build_serialization_header(&schema, &partitions);
         let staged_output = self.flush_target.file_output_staging_dir()?;
         let mut writer = if let Some(staging_dir) = staged_output.as_ref() {
@@ -5454,6 +5476,104 @@ mod tests {
                 ..WriteOptions::default()
             },
         )
+    }
+
+    struct SnapshotMemtable {
+        partitions: Vec<Partition>,
+    }
+
+    impl Memtable for SnapshotMemtable {
+        fn put(&self, _key: &DecoratedKey, _row: Row, _schema: &TableSchema) -> Result<()> {
+            panic!("SnapshotMemtable is read-only and only used as a legacy flush snapshot")
+        }
+
+        fn get(&self, key: &DecoratedKey) -> Result<Option<Arc<Partition>>> {
+            Ok(self
+                .partitions
+                .iter()
+                .find(|partition| &partition.key == key)
+                .cloned()
+                .map(Arc::new))
+        }
+
+        fn snapshot(&self) -> Vec<Partition> {
+            self.partitions.clone()
+        }
+
+        fn size_bytes(&self) -> usize {
+            0
+        }
+
+        fn partition_count(&self) -> usize {
+            self.partitions.len()
+        }
+    }
+
+    fn install_snapshot_memtable<F: FlushTarget>(
+        store: &TableStore<F>,
+        partitions: Vec<Partition>,
+    ) {
+        let current = store.view.load();
+        let replacement = StoreView {
+            active: Arc::new(SnapshotMemtable { partitions }),
+            flushing: None,
+            sstables: Arc::clone(&current.sstables),
+            sstable_ids: Arc::clone(&current.sstable_ids),
+            indexes: Arc::clone(&current.indexes),
+            sidecar_indexes: Arc::clone(&current.sidecar_indexes),
+            vector_indexes: Arc::clone(&current.vector_indexes),
+        };
+        replacement.check_invariants("test:install_snapshot_memtable");
+        store.view.store(Arc::new(replacement));
+    }
+
+    #[test]
+    fn flush_all_quarantined_rows_does_not_publish_zero_byte_sstable() {
+        crate::quarantine::_reset_flush_quarantined_rows_total_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let store = file_backed_test_store(dir.path());
+        let bad_row = Row {
+            // Int32 clustering must be exactly 4 bytes. This simulates a legacy
+            // malformed memtable row that predates the write-path validator.
+            clustering: vec![0; 8],
+            cells: vec![(0, CellValue::live(b"bad".to_vec(), 1000))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(1000),
+        };
+        install_snapshot_memtable(
+            &store,
+            vec![Partition {
+                key: make_key("pk_bad"),
+                deletion: DeletionTime::LIVE,
+                static_row: None,
+                rows: vec![bad_row],
+            }],
+        );
+
+        store.flush().unwrap();
+
+        assert_eq!(
+            crate::quarantine::flush_quarantined_rows_total(),
+            1,
+            "the malformed legacy row must be preserved in row quarantine"
+        );
+        let data_files: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with("-Data.db"))
+            })
+            .collect();
+        assert!(
+            data_files.is_empty(),
+            "an entirely quarantined flush must not publish zero-byte Data.db files: {data_files:?}"
+        );
+        let view = store.view.load();
+        assert_eq!(view.sstables.len(), 0);
+        assert_eq!(view.sstable_ids.len(), 0);
     }
 
     fn two_column_schema(first: &str, second: &str) -> TableSchema {

--- a/ferrosa-storage/tests/recovery_oom_memory_bound.rs
+++ b/ferrosa-storage/tests/recovery_oom_memory_bound.rs
@@ -164,7 +164,9 @@ fn open_vec_reader(table_dir: &Path, gen_str: &str) -> SSTableReader<Vec<u8>> {
 
 fn big_row(seed: usize, ts: i64) -> Row {
     // Vary the bytes per partition so the payload is not trivially deduplicated.
-    let value: Vec<u8> = (0..VALUE_BYTES).map(|j| (seed.wrapping_add(j)) as u8).collect();
+    let value: Vec<u8> = (0..VALUE_BYTES)
+        .map(|j| (seed.wrapping_add(j)) as u8)
+        .collect();
     Row {
         clustering: vec![],
         cells: vec![(0, CellValue::live(value, ts))],
@@ -226,7 +228,8 @@ fn measure_recovery_peaks(n: usize) -> Peaks {
     drop(materialized);
 
     // The actual recovery entry point (also run by the periodic self-heal scan).
-    let (smoke_result, smoke) = measure_peak(|| StorageEngine::smoke_test_generation(&table_dir, gen));
+    let (smoke_result, smoke) =
+        measure_peak(|| StorageEngine::smoke_test_generation(&table_dir, gen));
     smoke_result.expect("a healthy SSTable must pass the startup smoke test");
 
     Peaks { materialize, smoke }

--- a/ferrosa-storage/tests/recovery_oom_memory_bound.rs
+++ b/ferrosa-storage/tests/recovery_oom_memory_bound.rs
@@ -1,0 +1,281 @@
+//! P0 regression guard: startup/self-heal SSTable validation must stream.
+//!
+//! The startup smoke test (`StorageEngine::smoke_test_generation`, also run by
+//! the periodic self-heal corruption scan) validates every unverified SSTable
+//! generation. It once materialized each whole SSTable into a `Vec<Partition>`
+//! (`read_all_partitions`). On a large or corrupt SSTable that materialization
+//! could exhaust the node's 2 GiB cgroup cap, get OOM-killed, restart, re-read
+//! the SAME SSTable, and OOM again — an unrecoverable crash loop. This was
+//! observed in the dev cluster: `fmem-dev-node1` `OOMKilled=true`,
+//! `RestartCount=5`, which took the cluster's CQL endpoint (and the forge task
+//! board on :19042) down until the restart budget was exhausted.
+//!
+//! The fix streams validation one partition at a time. This test locks that in:
+//! peak heap during `smoke_test_generation` must stay far below the cost of
+//! materializing the whole SSTable. If recovery ever materializes again, peak
+//! memory scales with partition count and this test fails loudly — long before
+//! it can OOM a real node.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::time::Duration;
+
+use ferrosa_common::cell::CellValue;
+use ferrosa_common::key::{DecoratedKey, PartitionKey};
+use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+use ferrosa_sstable::{SSTableComponents, SSTableReader};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+    TableId,
+};
+
+// --- peak-allocation tracker (scoped to this integration-test binary only) ---
+//
+// Each integration test file is its own binary, so this `#[global_allocator]`
+// affects nothing else in the workspace. `alloc`/`dealloc` touch only atomics
+// and `System`, never the heap, so there is no reentrancy. Tracking is gated by
+// `ARMED` and this file deliberately contains a single test, so no other thread
+// flips the flag concurrently. `LIVE` is `i64` and may dip below zero when
+// allocations made before arming are freed during the window — that is fine,
+// `PEAK` only ever grows on allocation and captures the peak *additional* bytes
+// held at once during the measured call.
+
+struct TrackingAlloc;
+static ARMED: AtomicBool = AtomicBool::new(false);
+static LIVE: AtomicI64 = AtomicI64::new(0);
+static PEAK: AtomicI64 = AtomicI64::new(0);
+
+unsafe impl GlobalAlloc for TrackingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() && ARMED.load(Ordering::Relaxed) {
+            let live =
+                LIVE.fetch_add(layout.size() as i64, Ordering::Relaxed) + layout.size() as i64;
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if ARMED.load(Ordering::Relaxed) {
+            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+        }
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: TrackingAlloc = TrackingAlloc;
+
+/// Run `f` with peak-allocation tracking armed; return its result and the peak
+/// number of additional live bytes observed during the call.
+fn measure_peak<T>(f: impl FnOnce() -> T) -> (T, i64) {
+    LIVE.store(0, Ordering::Relaxed);
+    PEAK.store(0, Ordering::Relaxed);
+    ARMED.store(true, Ordering::Relaxed);
+    let out = f();
+    ARMED.store(false, Ordering::Relaxed);
+    (out, PEAK.load(Ordering::Relaxed))
+}
+
+const VALUE_BYTES: usize = 16 * 1024; // payload per partition
+const SMALL_PARTITIONS: usize = 64; // ~1 MiB SSTable
+const LARGE_PARTITIONS: usize = 1024; // 16x larger SSTable, same per-partition size
+
+fn mem_test_config(dir: &Path) -> StorageEngineConfig {
+    StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 8 * 1024 * 1024,
+            max_segment_age: Duration::from_secs(3600),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.join("commitlog"),
+            checkpoint_dir: dir.join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        // No auto-flush: keep all partitions in the memtable so a single manual
+        // flush produces exactly one generation holding all N partitions.
+        flush_threshold_bytes: 256 * 1024 * 1024,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 3600,
+        data_dir: dir.to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+        write_verify: false,
+    }
+}
+
+fn single_column_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "ks".to_string(),
+        table: "big".to_string(),
+        key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        clustering_columns: vec![],
+        static_columns: vec![],
+        regular_columns: vec![ColumnDefinition {
+            name: "v".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        }],
+        extensions: Default::default(),
+    }
+}
+
+/// Read SSTable component `{gen}-{comp}` for the single generation, searching
+/// the table dir recursively (the engine may nest the generation in a subdir).
+fn read_component(table_dir: &Path, gen_str: &str, comp: &str) -> Option<Vec<u8>> {
+    let target = format!("{gen_str}-{comp}");
+    let mut stack = vec![table_dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in std::fs::read_dir(&d).into_iter().flatten().flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if entry.file_name().to_string_lossy() == target {
+                return Some(std::fs::read(&path).expect("read SSTable component"));
+            }
+        }
+    }
+    None
+}
+
+/// Open a `Vec`-backed reader for the generation. Component bytes are read into
+/// memory *before* the caller arms the tracker, so the backing buffers count as
+/// baseline rather than as per-call allocation.
+fn open_vec_reader(table_dir: &Path, gen_str: &str) -> SSTableReader<Vec<u8>> {
+    let components = SSTableComponents {
+        data: read_component(table_dir, gen_str, "Data.db").expect("Data.db"),
+        partitions: read_component(table_dir, gen_str, "Partitions.db").expect("Partitions.db"),
+        rows: read_component(table_dir, gen_str, "Rows.db").unwrap_or_default(),
+        filter: read_component(table_dir, gen_str, "Filter.db").expect("Filter.db"),
+        compression_info: read_component(table_dir, gen_str, "CompressionInfo.db"),
+        statistics: read_component(table_dir, gen_str, "Statistics.db").expect("Statistics.db"),
+    };
+    SSTableReader::open(components).expect("open reconstructed SSTable reader")
+}
+
+fn big_row(seed: usize, ts: i64) -> Row {
+    // Vary the bytes per partition so the payload is not trivially deduplicated.
+    let value: Vec<u8> = (0..VALUE_BYTES).map(|j| (seed.wrapping_add(j)) as u8).collect();
+    Row {
+        clustering: vec![],
+        cells: vec![(0, CellValue::live(value, ts))],
+        deletion: DeletionTime::LIVE,
+        primary_key_liveness: LivenessInfo::with_timestamp(ts),
+    }
+}
+
+/// Peaks observed for one SSTable size: materializing every partition vs.
+/// running the real recovery smoke test.
+struct Peaks {
+    materialize: i64,
+    smoke: i64,
+}
+
+/// Build a single-generation SSTable with `n` partitions, then measure the peak
+/// heap of (a) materializing all partitions and (b) the recovery smoke test.
+fn measure_recovery_peaks(n: usize) -> Peaks {
+    let dir = tempfile::tempdir().unwrap();
+    let tid = TableId::new("ks", "big");
+
+    {
+        let engine = StorageEngine::new(mem_test_config(dir.path()), None).unwrap();
+        engine.register_table(single_column_schema()).unwrap();
+        for i in 0..n {
+            let key = DecoratedKey::new(PartitionKey::new(format!("pk{i:06}").into_bytes()));
+            let ts = 1_000 + i as i64;
+            engine.write(&tid, &key, big_row(i, ts), ts).unwrap();
+        }
+        engine.flush(&tid).unwrap();
+    }
+
+    let table_dir = dir.path().join("sstables").join(tid.to_string());
+    let gens = StorageEngine::list_generations_in_dir(&table_dir);
+    assert_eq!(
+        gens.len(),
+        1,
+        "a single manual flush must produce exactly one generation, got {gens:?}"
+    );
+    let gen = gens[0];
+    let gen_str = gen.to_string();
+
+    // Open once, before arming, so the reader's fixed structures (and the
+    // backing Data buffer) are baseline and excluded from the per-call peak.
+    let reader = open_vec_reader(&table_dir, &gen_str);
+
+    // Baseline: materialize every partition — the OLD recovery behavior
+    // (`read_all_partitions`) whose peak scales with partition count.
+    let (materialized, materialize) = measure_peak(|| {
+        reader
+            .read_partitions_limited(usize::MAX)
+            .expect("materialize all partitions")
+    });
+    assert_eq!(
+        materialized.len(),
+        n,
+        "the fixture must hold every partition in one generation"
+    );
+    drop(materialized);
+
+    // The actual recovery entry point (also run by the periodic self-heal scan).
+    let (smoke_result, smoke) = measure_peak(|| StorageEngine::smoke_test_generation(&table_dir, gen));
+    smoke_result.expect("a healthy SSTable must pass the startup smoke test");
+
+    Peaks { materialize, smoke }
+}
+
+/// Recovery validation must cost roughly the same memory whether the SSTable
+/// holds 64 partitions or 512. Materialization cost grows with partition count;
+/// streaming cost is bounded by the decompression chunk cache (independent of
+/// partition count). If recovery ever materializes again, its peak will scale
+/// with SSTable size like the materialization baseline — and OOM a real node.
+#[test]
+fn recovery_smoke_test_memory_is_independent_of_sstable_size() {
+    let small = measure_recovery_peaks(SMALL_PARTITIONS);
+    let large = measure_recovery_peaks(LARGE_PARTITIONS);
+
+    // Sanity: the materialization baseline must actually scale with the 16x
+    // larger partition count, otherwise the comparison proves nothing.
+    assert!(
+        large.materialize > small.materialize * 4,
+        "sanity: materializing {LARGE_PARTITIONS} partitions ({} B) should cost far more than \
+         {SMALL_PARTITIONS} ({} B); fixture sizes are too close to be meaningful",
+        large.materialize,
+        small.materialize,
+    );
+
+    // Primary guard: on the large SSTable, recovery must hold only a small
+    // fraction of what materializing the whole table would. If recovery
+    // materializes, its peak ~= the materialization peak and this fails.
+    assert!(
+        large.smoke * 4 < large.materialize,
+        "recovery smoke-test peak {} B is not far below materialization peak {} B on a \
+         {LARGE_PARTITIONS}-partition SSTable — REGRESSION: startup validation is materializing \
+         whole SSTables again, the OOM-crash-loop vector that took node1 down (OOMKilled, \
+         RestartCount=5)",
+        large.smoke,
+        large.materialize,
+    );
+
+    // Shape guard: recovery cost stays ~flat as the SSTable grows 16x, while
+    // materialization grew with it. A materializing recovery would scale like
+    // the baseline (well past 3x), not stay bounded by the chunk cache.
+    assert!(
+        large.smoke < small.smoke * 3,
+        "recovery smoke-test peak scaled with SSTable size ({} B for {SMALL_PARTITIONS} parts -> \
+         {} B for {LARGE_PARTITIONS} parts) while materialization went {} B -> {} B — REGRESSION: \
+         recovery memory now tracks SSTable size instead of staying bounded",
+        small.smoke,
+        large.smoke,
+        small.materialize,
+        large.materialize,
+    );
+}


### PR DESCRIPTION
## Executive Summary
This PR fixes the P0 SSTable recovery OOM loop and closes the corrupt SSTable publication paths found while investigating ferrosa-memory quarantines.

It now covers both observed corruption shapes:
- zero-byte `Data.db` generations from all-row quarantine during flush
- nonzero `Data.db`-only generations where required side components were absent

## Root Causes
The startup/self-heal smoke test validated each SSTable by materializing it whole into memory. Large or corrupt SSTables could OOM a 2 GiB node during recovery, causing an unrecoverable restart loop.

A flush salvage path introduced on June 13 could quarantine every malformed legacy row in a snapshot, then continue into `SSTableWriter` with zero surviving partitions. That manufactured full component sets with zero-byte `Data.db`, matching the June 19, June 20, and June 28 quarantine artifacts found in ferrosa-memory data.

The nonzero Data-only shape had concrete producer paths too: object-store restore accepted `Data.db` as the only required component and wrote directly into the live table directory; snapshot restore had the same unbounded/direct-publish pattern; `ferrosa-sstable-import` also copied whatever components existed after checking only `Data.db`. Separately, flush promotion renamed `Data.db` before required side components, leaving a crash window where `Data.db` could become the discoverable generation marker first.

## Changes
- Stream whole-SSTable recovery, CQL scan, and compaction paths instead of materializing full tables.
- Add bounded reader-pool and range-read guardrails for recovery and compaction pressure.
- Reject out-of-order/truncated SSTable streams during startup/compaction validation.
- Skip SSTable publication when flush-time quarantine removes every row; preserve the row-quarantine JSONL and clear the flushing memtable.
- Require `Data.db`, `Partitions.db`, and `Rows.db` for object-store restore and snapshot restore.
- Stream SSTable restore bodies into hidden staging directories, fsync them, then publish complete generation directories atomically.
- Quarantine local incomplete generations before replacing them with complete restored copies.
- Promote flush/compaction `Data.db` last so the discovery marker is not visible before required side components.
- Make `ferrosa-sstable-dump` fail loud instead of panicking on Data-only input.
- Make `ferrosa-sstable-import` reject Data-only sources and stage complete imports before publication.

## Test Plan
- [x] `pre-commit run --files ferrosa-storage/src/store.rs ferrosa-storage/tests/recovery_oom_memory_bound.rs`
- [x] `cargo test -p ferrosa-storage flush_all_quarantined_rows_does_not_publish_zero_byte_sstable -- --nocapture`
- [x] `cargo test -p ferrosa-storage quarantine -- --nocapture`
- [x] `cargo test -p ferrosa-storage zero_byte -- --nocapture`
- [x] `cargo test -p ferrosa-storage`
- [x] `CARGO_TARGET_DIR=target-codex-p0-nonzero cargo test -p ferrosa-storage download_sstables_from_s3 -- --nocapture`
- [x] `CARGO_TARGET_DIR=target-codex-p0-nonzero cargo test -p ferrosa-storage restore::manager::tests::download_sstables -- --nocapture`
- [x] `CARGO_TARGET_DIR=target-codex-p0-nonzero cargo test -p ferrosa-storage promotes_data_db_after_required_components -- --nocapture`
- [x] `CARGO_TARGET_DIR=target-codex-p0-nonzero cargo test -p ferrosa-storage p0_13_sstable_upload_download_round_trip -- --nocapture`
- [x] `CARGO_TARGET_DIR=target-codex-p0-nonzero cargo test -p ferrosa-sstable --test data_only_cli -- --nocapture`
- [x] `pre-commit run --files ferrosa-storage/src/engine.rs ferrosa-storage/src/flush.rs ferrosa-storage/src/restore/manager.rs ferrosa-sstable/src/bin/ferrosa-sstable-dump.rs ferrosa-sstable/src/bin/ferrosa-sstable-import.rs ferrosa-sstable/tests/data_only_cli.rs`
- [x] `frg materialization-scan ferrosa-storage/src/engine.rs ferrosa-storage/src/restore/manager.rs ferrosa-storage/src/flush.rs ferrosa-sstable/src/bin/ferrosa-sstable-dump.rs ferrosa-sstable/src/bin/ferrosa-sstable-import.rs ferrosa-sstable/tests/data_only_cli.rs`

## Follow-ups
- Rebuild/restart live dev-cluster node images after merge; pre-fix binaries can still OOM until redeployed.
- Triage remaining materialization-scan findings outside the SSTable restore/publication P0, especially FTI/schema/commitlog metadata paths that are not fixed in this PR.