### PR TITLE
fix(cql): fail loud on complex-shape ALLOW FILTERING scan truncation (no silent data loss)

### DIFF
--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -735,6 +735,21 @@ impl WritePath {
         row_limit: usize,
     ) -> crate::error::Result<Vec<Partition>> {
         let limit = limit.clamp(1, DEFAULT_RANGE_READ_LIMIT);
+        self.range_read_partitions_inner(table_id, limit, row_limit)
+            .await
+    }
+
+    /// Shared range-read dispatch with an explicit partition `limit` and no
+    /// hard-cap clamping. Callers are responsible for bounding `limit`. This
+    /// exists so [`Self::range_read_limited_rows_checked`] can probe exactly one
+    /// partition past the hard cap to detect truncation, which the public
+    /// clamping wrapper cannot express.
+    async fn range_read_partitions_inner(
+        &self,
+        table_id: &TableId,
+        limit: usize,
+        row_limit: usize,
+    ) -> crate::error::Result<Vec<Partition>> {
         match self {
             Self::Direct(engine) => engine
                 .read_range_limited_rows(table_id, None, None, limit, row_limit)
@@ -752,6 +767,42 @@ impl WritePath {
                 "range read unavailable: write path is in degraded mode".into(),
             )),
         }
+    }
+
+    /// Truncation-aware variant of [`Self::range_read_limited_rows`].
+    ///
+    /// Reads up to `limit + 1` partitions internally and returns at most the
+    /// first `limit`, plus a `truncated` flag that is `true` when more than
+    /// `limit` partitions existed (i.e. the cap clipped the result). Callers
+    /// that must not silently truncate — complex query shapes (ORDER BY /
+    /// DISTINCT / aggregate / function projection over a full scan) where the
+    /// cap is the engine's `DEFAULT_RANGE_READ_LIMIT` rather than a user
+    /// `LIMIT` — use this to fail loud instead of computing a wrong answer over
+    /// a clipped set.
+    ///
+    /// The internal probe of `limit + 1` is still bounded by
+    /// `DEFAULT_RANGE_READ_LIMIT + 1`; this method does not widen the hard cap.
+    pub async fn range_read_limited_rows_checked(
+        &self,
+        table_id: &TableId,
+        limit: usize,
+        row_limit: usize,
+    ) -> crate::error::Result<(Vec<Partition>, bool)> {
+        // Apply the same hard cap the public reader uses, then probe exactly one
+        // partition past it via the unclamped inner dispatch. This distinguishes
+        // "the table has at most `effective_limit` partitions" from "the table
+        // has more and we are about to clip it" even when `limit` is the hard
+        // cap itself (the silent-truncation case we exist to catch).
+        let effective_limit = limit.clamp(1, DEFAULT_RANGE_READ_LIMIT);
+        let probe_limit = effective_limit.saturating_add(1);
+        let mut partitions = self
+            .range_read_partitions_inner(table_id, probe_limit, row_limit)
+            .await?;
+        let truncated = partitions.len() > effective_limit;
+        if truncated {
+            partitions.truncate(effective_limit);
+        }
+        Ok((partitions, truncated))
     }
 
     /// Read by secondary index, scattering to all nodes in cluster mode.

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -4682,6 +4682,9 @@ async fn route_select_user_table(
                                         .await?,
                                 )
                             } else if let Some(bound) = scan_bound {
+                                // User-supplied LIMIT (or page size) provided the
+                                // bound: returning exactly the requested rows is
+                                // intentional and correct, so no truncation check.
                                 Some(
                                     state
                                         .write_path
@@ -4690,17 +4693,34 @@ async fn route_select_user_table(
                                         .await?,
                                 )
                             } else if row_limit > 0 {
-                                Some(
-                                    state
-                                        .write_path
-                                        .load()
-                                        .range_read_limited_rows(
-                                            &table_id,
-                                            ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT,
-                                            row_limit,
-                                        )
-                                        .await?,
-                                )
+                                // Complex shape (ORDER BY / DISTINCT / aggregate /
+                                // function projection) over a full ALLOW FILTERING
+                                // scan with no user bound: the read is capped at the
+                                // engine's DEFAULT_RANGE_READ_LIMIT only. Sorting,
+                                // distincting, or aggregating over a silently clipped
+                                // window yields a wrong answer, so fail loud when the
+                                // cap actually clipped data (D4) instead of truncating.
+                                let (partitions, truncated) = state
+                                    .write_path
+                                    .load()
+                                    .range_read_limited_rows_checked(
+                                        &table_id,
+                                        ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT,
+                                        row_limit,
+                                    )
+                                    .await?;
+                                if truncated {
+                                    ferrosa_storage::metrics::inc_range_read_truncated();
+                                    return Err(CqlError::Invalid(
+                                        "query scans more than 10000 rows and cannot be bounded \
+                                         for this shape (ORDER BY / DISTINCT / aggregate / \
+                                         function projection over ALLOW FILTERING); add a LIMIT, \
+                                         create an index on the filtered/ordered columns, or \
+                                         narrow the predicate"
+                                            .into(),
+                                    ));
+                                }
+                                Some(partitions)
                             } else {
                                 None
                             };

--- a/ferrosa-storage/src/metrics.rs
+++ b/ferrosa-storage/src/metrics.rs
@@ -316,6 +316,7 @@ static MEMTABLE_SIZE_BYTES_MAX: AtomicU64 = AtomicU64::new(0);
 static MEMTABLE_FLUSH_THRESHOLD_BYTES: AtomicU64 = AtomicU64::new(0);
 static MEMTABLE_BACKPRESSURE_BYTES: AtomicU64 = AtomicU64::new(0);
 
+static RANGE_READ_TRUNCATED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_LIMITED_ROWS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_LIMITED_ROWS_FOUND_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_LIMITED_ROWS_SECONDS_MICROS_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -447,6 +448,22 @@ pub fn inc_compaction_pool_input_opens() {
 /// Total compaction input readers obtained via the reader pool since startup.
 pub fn compaction_pool_input_opens_total() -> u64 {
     COMPACTION_POOL_INPUT_OPENS_TOTAL.load(Ordering::Relaxed)
+}
+
+/// A capped range read hit its partition cap while more data still existed,
+/// so the caller refused to silently truncate and failed loud instead. A
+/// non-zero value indicates a query shape (ORDER BY / DISTINCT / aggregate /
+/// function projection over `ALLOW FILTERING`) that scanned past the default
+/// range-read window; the query must add a LIMIT, an index, or a narrower
+/// predicate.
+pub fn inc_range_read_truncated() {
+    RANGE_READ_TRUNCATED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Total capped range reads that detected more data beyond the cap and failed
+/// loud rather than truncating, since startup.
+pub fn range_read_truncated_total() -> u64 {
+    RANGE_READ_TRUNCATED_TOTAL.load(Ordering::Relaxed)
 }
 
 pub fn observe_compaction_completed(
@@ -900,6 +917,14 @@ pub fn render_prometheus() -> String {
     }
 
     out.push_str(
+        "# HELP ferrosa_storage_range_read_truncated_total Capped range reads that hit their cap with more data available and failed loud instead of truncating.\n",
+    );
+    out.push_str("# TYPE ferrosa_storage_range_read_truncated_total counter\n");
+    out.push_str(&format!(
+        "ferrosa_storage_range_read_truncated_total {}\n",
+        RANGE_READ_TRUNCATED_TOTAL.load(Ordering::Relaxed)
+    ));
+    out.push_str(
         "# HELP ferrosa_storage_read_limited_rows_total Partition read_limited_rows calls.\n",
     );
     out.push_str("# TYPE ferrosa_storage_read_limited_rows_total counter\n");
@@ -1283,6 +1308,21 @@ mod tests {
         assert!(text.contains("ferrosa_archive_upload_errors_total 1"));
         assert!(text.contains("ferrosa_archive_lag_segments 3"));
         assert!(text.contains("ferrosa_snapshots_total 5"));
+    }
+
+    #[test]
+    fn range_read_truncated_increment_and_read() {
+        // Process-wide counter: assert on the delta, not an absolute value,
+        // so the test is robust to other tests touching the same counter.
+        let before = range_read_truncated_total();
+        inc_range_read_truncated();
+        inc_range_read_truncated();
+        let after = range_read_truncated_total();
+        assert_eq!(after - before, 2);
+
+        // The counter is exported in the Prometheus text rendering.
+        let text = render_prometheus();
+        assert!(text.contains("ferrosa_storage_range_read_truncated_total"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes the ALLOW FILTERING OOM/data-loss work after #230 (which fixed COUNT). Complex full-scan shapes — `ORDER BY` / `DISTINCT` / aggregate / function-projection over `ALLOW FILTERING` — reach the materializing scan arm, which reads at most `DEFAULT_RANGE_READ_LIMIT` (10,000) partitions and then sorts/distincts/aggregates over that truncated set. On a table with >10k rows this **silently returned wrong results** (a correctness/data-loss bug).

Simple `WHERE … ALLOW FILTERING` SELECTs already stream/page and are unaffected; COUNT was fixed in #230. This is the last silent-truncation path.

## Fix (blueprint D4: fail loud, never silently truncate)

- `ferrosa-storage/src/metrics.rs`: `range_read_truncated_total` counter.
- `ferrosa-cluster/src/write_path.rs`: `range_read_limited_rows_checked` — probes `limit + 1` and returns `(rows, truncated)`. Existing `range_read_limited_rows` delegates to a shared inner; `DEFAULT_RANGE_READ_LIMIT` unchanged.
- `ferrosa-cql/src/router.rs`: the complex-shape arm (`row_limit > 0`, `scan_bound = None`) uses the checked read; on truncation it increments the metric and returns a clear `CqlError::Invalid` (add a LIMIT / create an index / narrow the predicate). **User-`LIMIT` and streaming paths are untouched** (separate arms).

## Verification

- `cargo test -p ferrosa-cql --lib`: **972 passed, 0 failed** (regression gate).
- New metric unit-tested; clippy clean; fmt clean.
- Surgical: only the `row_limit > 0` complex-shape arm changed.

## Follow-up
- Behavioral over-cap regression test (P2) added against the live cluster.
- This lets the p0-oom-audit (#231) drop its SELECT-arm allowlist entries (the migrated sites).

forge t_15417b35; epic t_110dd8a5.