### PR TITLE
fix(cql): guard projected complex scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,22 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: false
+          # This job builds the whole workspace with --all-features. Restoring a
+          # previous target dir can consume enough runner disk that rustc fails
+          # while writing fresh artifacts; rely on sccache for compiler reuse.
+          cache-targets: false
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
+          df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/share/swift \
+            /opt/hostedtoolcache/CodeQL || true
+          sudo apt-get clean
+          rm -rf ~/.cache/pip ~/.npm || true
           df -h /
       - name: Build AssemblyScript UDF toolchain bundle
         # `--all-features` enables `asc-udf` + `live-infra-tests`, which run the
@@ -107,6 +120,12 @@ jobs:
                --skip bounded_fetch_reassembles_to_single_pass \
                --skip read_merge_is_lww_no_data_loss --skip digest_walk_is_deterministic \
                --skip differential_oracle \
+      - name: Clean test build artifacts
+        if: always()
+        run: |
+          cargo clean || true
+          rm -rf /tmp/asc-host target
+          df -h /
 
   # ── Stage 2a': Differential oracle vs real PostgreSQL ──────────────
   # The `test` job above skips `differential_oracle` because it has no
@@ -472,10 +491,20 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: false
+          cache-targets: false
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
+          df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/share/swift \
+            /opt/hostedtoolcache/CodeQL || true
+          sudo apt-get clean
+          rm -rf ~/.cache/pip ~/.npm || true
           df -h /
       - name: Bring up cluster
         run: |
@@ -498,6 +527,12 @@ jobs:
       - name: Tear down cluster
         if: always()
         run: ./scripts/test-cluster-down.sh --ci
+      - name: Clean integration build artifacts
+        if: always()
+        run: |
+          cargo clean || true
+          rm -rf target
+          df -h /
 
   # ── Stage 3: Documentation ─────────────────────────────────────────
   docs:

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -735,6 +735,21 @@ impl WritePath {
         row_limit: usize,
     ) -> crate::error::Result<Vec<Partition>> {
         let limit = limit.clamp(1, DEFAULT_RANGE_READ_LIMIT);
+        self.range_read_partitions_inner(table_id, limit, row_limit)
+            .await
+    }
+
+    /// Shared range-read dispatch with an explicit partition `limit` and no
+    /// hard-cap clamping. Callers are responsible for bounding `limit`. This
+    /// exists so [`Self::range_read_limited_rows_checked`] can probe exactly one
+    /// partition past the hard cap to detect truncation, which the public
+    /// clamping wrapper cannot express.
+    async fn range_read_partitions_inner(
+        &self,
+        table_id: &TableId,
+        limit: usize,
+        row_limit: usize,
+    ) -> crate::error::Result<Vec<Partition>> {
         match self {
             Self::Direct(engine) => engine
                 .read_range_limited_rows(table_id, None, None, limit, row_limit)
@@ -752,6 +767,42 @@ impl WritePath {
                 "range read unavailable: write path is in degraded mode".into(),
             )),
         }
+    }
+
+    /// Truncation-aware variant of [`Self::range_read_limited_rows`].
+    ///
+    /// Reads up to `limit + 1` partitions internally and returns at most the
+    /// first `limit`, plus a `truncated` flag that is `true` when more than
+    /// `limit` partitions existed (i.e. the cap clipped the result). Callers
+    /// that must not silently truncate — complex query shapes (ORDER BY /
+    /// DISTINCT / aggregate / function projection over a full scan) where the
+    /// cap is the engine's `DEFAULT_RANGE_READ_LIMIT` rather than a user
+    /// `LIMIT` — use this to fail loud instead of computing a wrong answer over
+    /// a clipped set.
+    ///
+    /// The internal probe of `limit + 1` is still bounded by
+    /// `DEFAULT_RANGE_READ_LIMIT + 1`; this method does not widen the hard cap.
+    pub async fn range_read_limited_rows_checked(
+        &self,
+        table_id: &TableId,
+        limit: usize,
+        row_limit: usize,
+    ) -> crate::error::Result<(Vec<Partition>, bool)> {
+        // Apply the same hard cap the public reader uses, then probe exactly one
+        // partition past it via the unclamped inner dispatch. This distinguishes
+        // "the table has at most `effective_limit` partitions" from "the table
+        // has more and we are about to clip it" even when `limit` is the hard
+        // cap itself (the silent-truncation case we exist to catch).
+        let effective_limit = limit.clamp(1, DEFAULT_RANGE_READ_LIMIT);
+        let probe_limit = effective_limit.saturating_add(1);
+        let mut partitions = self
+            .range_read_partitions_inner(table_id, probe_limit, row_limit)
+            .await?;
+        let truncated = partitions.len() > effective_limit;
+        if truncated {
+            partitions.truncate(effective_limit);
+        }
+        Ok((partitions, truncated))
     }
 
     /// Read by secondary index, scattering to all nodes in cluster mode.

--- a/ferrosa-cql/README.md
+++ b/ferrosa-cql/README.md
@@ -39,7 +39,11 @@ unaffected (see [Bridge re-export](#bridge-re-export-d10)).
   delegates to `route_select`/`route_insert`/`route_update`/`route_delete`/
   `route_batch` and the DDL/role handlers. Fast paths exist for prepared
   SELECT/INSERT. ORDER BY classification picks an inline vs. spillable temp-sort
-  plan. Carries the security mitigations (M8 permissions, M12 batch cap).
+  plan. Page-compatible full scans stream bounded pages; complex full-scan
+  shapes that still need a materialized input (`ORDER BY`, `DISTINCT`, ANN, or
+  aggregate/function projection) are capped/probed and fail loud above the
+  default range-read window instead of returning partial results. Carries the
+  security mitigations (M8 permissions, M12 batch cap).
 - **Bridge** (`bridge.rs`) — parser `Term` → wire `CqlValue` → storage
   `CellValue`/`Row` conversions, server-side function eval (`now()`,
   `toTimestamp()`), and the **re-export** of the row codec from
@@ -126,7 +130,7 @@ SQL-front-end FMEA risk.
 
 ## Tests
 
-~945 in-crate test functions (heaviest: `router.rs` 253, `parser.rs` 158,
+~974 in-crate test functions (heaviest: `router.rs` 254, `parser.rs` 158,
 `bridge.rs` 121, `connection.rs` 43) plus integration tests under `tests/`
 (`handshake`, `auth_integration`, `auth_warn_mode`, `bolt_transaction_state`,
 `cassandra_cql_examples`). The ignored live-cluster test `fts_live_cluster`

--- a/ferrosa-cql/specs/data-flow.md
+++ b/ferrosa-cql/specs/data-flow.md
@@ -73,8 +73,8 @@ sequenceDiagram
     Rt->>Rt: check_permission (M8)
     Rt->>Pl: classify scan + ORDER BY plan
     Pl-->>Rt: ScanPlan (inline or spillable temp-sort)
-    Rt->>Eng: read Partition(s)
-    Eng-->>Rt: Vec&lt;Partition&gt;
+    Rt->>Eng: stream page or read bounded/probed Partition(s)
+    Eng-->>Rt: Partition stream or capped Vec&lt;Partition&gt;
     Rt->>Br: partition_to_rows_with_storage_mapping<br/>(tombstone/TTL skip, storage→table order)
     Br-->>Rt: Vec&lt;Vec&lt;Option&lt;CqlValue&gt;&gt;&gt;
     Rt->>Res: project + LIMIT + paging_state
@@ -84,8 +84,16 @@ sequenceDiagram
 ```
 
 When more rows remain, `result.rs` attaches an opaque `paging::PagingState`
-cursor (pk + ck + remaining flag). NOTE: that cursor is currently unsigned —
-FMEA CQL-2.
+cursor (pk + ck + remaining flag) signed with HMAC-SHA256. Multi-node clusters
+must set the same `FERROSA_PAGING_HMAC_KEY` on every coordinator so a cursor
+created on one node can resume on another.
+
+Page-compatible full scans consume partition streams directly. Complex
+whole-input shapes (`ORDER BY`, `DISTINCT`, ANN, aggregate/function projection)
+may still need a materialized input, but those reads are capped/probed; if the
+probe sees more data beyond `DEFAULT_RANGE_READ_LIMIT`, the router increments
+`range_read_truncated_total` and returns an error instead of computing over a
+partial window.
 
 ## Bridge re-export relationship (D10)
 

--- a/ferrosa-cql/specs/fmea.md
+++ b/ferrosa-cql/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 doc: fmea
-last_updated: 2026-06-21
+last_updated: 2026-06-30
 ---
 
 # ferrosa-cql — FMEA / Known Issues
@@ -16,13 +16,14 @@ high. Entries below reflect gaps found in the code, not hypotheticals.
 | CQL-2 | `paging_state` cursor is opaque but **unsigned** — `PagingState::encode/decode` is a plain length-prefixed pk+ck+flag with no HMAC | A client can forge/tamper a paging token to resume at an arbitrary key, bypassing the original query's partition scope (cross-partition read / IDOR-style) | 7 | 4 | 7 | 196 → 24 | **Implemented.** `encode` appends `HMAC-SHA256(process_key, payload)`; `decode` verifies it constant-time (`Mac::verify_slice`) before parsing, rejecting any forged/tampered cursor. Key from `FERROSA_PAGING_HMAC_KEY` (64 hex) or a random per-process key (multi-node clusters must share it). Tests: `tampered_paging_state_is_rejected`, `unsigned_forged_paging_state_is_rejected`. |
 | CQL-3 | Encoder divergence vs `ferrosa-postgres` if the re-exported row codec were ever forked into this crate | Rows written via one front-end read back wrong/invisible via the other (silent corruption) | 10 | 1 | 6 | 60 | **Structural**: codec is the single re-export from `ferrosa-row-bridge` (D10); no second encoder exists here. Reinforced by the PG differential oracle. |
 | CQL-4 | Permission check omitted on a new `route_*` handler | Unauthorized DML/DDL succeeds (privilege escalation) | 9 | 2 | 5 | 90 | M8 convention: every `route_*` calls `Schema::check_permission`. Risk is a *new* handler forgetting it — not enforced by the type system. Add a lint/test that every route is permission-gated. |
-| CQL-5 | `router.rs` is a 22.4k-LoC monolith (`route()` + ~60 `route_*` handlers in one file) | Hard to review; high chance a change to one handler regresses another; reviewers miss missing checks (feeds CQL-4) | 6 | 6 | 6 | 216 | **Open structural debt.** Split DML / DDL / role / type-function handlers into submodules. Test density (253 tests) partially compensates detection. |
+| CQL-5 | `router.rs` is a 22.4k-LoC monolith (`route()` + ~60 `route_*` handlers in one file) | Hard to review; high chance a change to one handler regresses another; reviewers miss missing checks (feeds CQL-4) | 6 | 6 | 6 | 216 | **Open structural debt.** Split DML / DDL / role / type-function handlers into submodules. Test density (254 tests) partially compensates detection. |
 | CQL-6 | Subscription poll re-runs the inner SELECT on an interval with no global cap on rows/work per tick | A broad subscribed SELECT over a large table re-scans every interval, amplifying load (DoS-by-subscription) | 6 | 3 | 6 | 108 | Per-connection `max_subscriptions` bounds count; per-tick scan cost is not bounded. Add a per-subscription row/byte budget and backpressure. |
 | CQL-7 | `COMPACT` statement parses and routes but is not implemented | `COMPACT` returns "not supported / not implemented" error | 3 | 3 | 2 | 18 | **Designed**: explicit error message; manual SSTable compaction is intentionally not exposed. Low severity (UCS runs automatically). |
 | CQL-8 | Auth flag drift — historically `FERROSA_AUTH_ENABLED` (storage) and `FERROSA_AUTH_DISABLED` (CQL) could disagree, so the server sent `AUTHENTICATE` while storage accepted everything, breaking standard drivers | Drivers fail to connect, or connect with mismatched auth expectations | 7 | 2 | 4 | 56 | **Fixed**: `resolve_auth_disabled()` makes storage `auth_enabled` the single source of truth; the env override is deprecated and logs a warning. Covered by unit tests. |
 | CQL-9 | Server-side `now()` minting a non-16-byte TimeUUID | TimeUUID-clustered tables wedge at memtable flush (data-loss-class bug) | 9 | 1 | 4 | 36 | **Fixed + documented invariant**: `eval_now()` always returns 16 bytes; guards the prior flush-wedge bug. |
 | CQL-10 | In-flight semaphore (default 128) or per-IP cap rejecting legitimate bursts as `Overloaded` | Spurious `Overloaded` errors under legitimate load spikes | 4 | 3 | 3 | 36 | Tunable via `ServerConfig`; designed backpressure that fails loud rather than queueing unboundedly. |
 | CQL-11 | DataStax Java driver `DROP KEYSPACE` times out during schema-agreement on v5 | The driver closes its control connection after receiving the preceding CREATE INDEX schema-change event (normal metadata refresh). When `DROP KEYSPACE` fires, the broadcast has no active subscriber; the new control connection subscribes ~2 ms too late. A `watch` channel retains the missed event and delivers it to the new forwarder, but the driver does not process it on probe connections. | 5 | 8 | 3 | 120 | **Partial mitigation**: `watch` channel fallback delivers missed events to new control connections. 37/38 DataStax Java v5 smoke tests pass. Full fix likely requires matching Cassandra's schema-version polling behavior or ensuring the event reaches the driver's active control connection before it closes. |
+| CQL-12 | Projected complex full scans (`SELECT DISTINCT col`, projected `ORDER BY`/ANN) bypass the truncation-aware range-read arm and materialize all projected partitions | Large tables can OOM the coordinator even though the non-projected complex arm fails loud | 9 | 3 | 2 | 54 | **Fixed.** The projected fast path now probes at `DEFAULT_RANGE_READ_LIMIT + 1`, increments `range_read_truncated_total`, and returns `Invalid` if more data exists. Regression: `select_distinct_projection_over_cap_fails_loud_instead_of_materializing`. |
 
 ## Top risks to act on
 
@@ -30,15 +31,15 @@ high. Entries below reflect gaps found in the code, not hypotheticals.
    *detection* risk: missing permission checks (CQL-4) and other regressions hide
    in a file too large to review as a unit. Decompose into per-statement-family
    submodules.
-2. **CQL-2 (RPN 196)** — the unsigned `paging_state` cursor. It is opaque to
-   clients by convention only; nothing prevents a crafted token from resuming at
-   an attacker-chosen key. Sign or scope-bind the cursor.
+2. **CQL-11 (RPN 120)** — the remaining DataStax Java v5 schema-agreement race
+   around `DROP KEYSPACE`. The `watch` channel fallback reduces missed events,
+   but the driver still times out in the known smoke.
 3. **CQL-6 (RPN 108) / CQL-1 (RPN 80)** — unbounded per-tick subscription scans,
    and the standalone LWT-on-Accord functional gap (already fail-loud).
 
 ## Detection assets
 
-- ~945 in-crate tests (router 253, parser 158, bridge 121).
+- ~974 in-crate tests (router 254, parser 158, bridge 121).
 - Integration tests: `tests/{handshake, auth_integration, auth_warn_mode,
   bolt_transaction_state, cassandra_cql_examples}.rs` plus the ignored
   live-cluster `tests/fts_live_cluster.rs` guard for coordinator-independent

--- a/ferrosa-cql/specs/overview.md
+++ b/ferrosa-cql/specs/overview.md
@@ -73,11 +73,16 @@ and applies through `SessionCore`'s write path / `StorageEngine`. LWT statements
 `route_lwt_via_accord`. A void/applied RESULT frame is encoded back.
 
 **Read (SELECT).** Same front half; `router::route_select` resolves the table,
-plans the scan (`planner`, ORDER BY classification), reads `Partition`s from
-storage, decomposes them to rows via the re-exported
-`partition_to_rows_with_storage_mapping` (tombstone/TTL skipping, storage→table
-column mapping), applies projection/LIMIT/paging, and `result.rs` encodes the
-Rows RESULT frame (with `paging_state` when more pages remain).
+plans the scan (`planner`, ORDER BY classification), then chooses a streaming
+page collector or a bounded/probed materialized input. Page-compatible broad
+scans stream partitions into a bounded page and return a `paging_state`;
+complex full-scan shapes that require whole-input semantics (`ORDER BY`,
+`DISTINCT`, ANN, aggregate/function projection) refuse to silently truncate when
+the default range-read window clips data. The router decomposes partitions to
+rows via the re-exported `partition_to_rows_with_storage_mapping`
+(tombstone/TTL skipping, storage→table column mapping), applies
+projection/LIMIT/paging, and `result.rs` encodes the Rows RESULT frame (with
+`paging_state` when more pages remain).
 
 Full-text predicates (`WHERE col = fts_match('...')`) take a dedicated branch:
 it resolves the matching partition keys through the cluster write path
@@ -103,6 +108,9 @@ See [data-flow.md](data-flow.md) for the sequence diagrams.
    local path (p0-03 policy).
 6. **16-byte TimeUUID from `now()`.** `eval_now()` guarantees a 16-byte encoding —
    a short one wedges TimeUUID-clustered tables at flush.
+7. **No silent full-scan truncation.** Capped complex SELECT inputs use a
+   `DEFAULT_RANGE_READ_LIMIT + 1` probe and increment
+   `range_read_truncated_total` before returning an error when more data exists.
 
 ## Native protocol version behavior
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -4682,6 +4682,9 @@ async fn route_select_user_table(
                                         .await?,
                                 )
                             } else if let Some(bound) = scan_bound {
+                                // User-supplied LIMIT (or page size) provided the
+                                // bound: returning exactly the requested rows is
+                                // intentional and correct, so no truncation check.
                                 Some(
                                     state
                                         .write_path
@@ -4690,17 +4693,34 @@ async fn route_select_user_table(
                                         .await?,
                                 )
                             } else if row_limit > 0 {
-                                Some(
-                                    state
-                                        .write_path
-                                        .load()
-                                        .range_read_limited_rows(
-                                            &table_id,
-                                            ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT,
-                                            row_limit,
-                                        )
-                                        .await?,
-                                )
+                                // Complex shape (ORDER BY / DISTINCT / aggregate /
+                                // function projection) over a full ALLOW FILTERING
+                                // scan with no user bound: the read is capped at the
+                                // engine's DEFAULT_RANGE_READ_LIMIT only. Sorting,
+                                // distincting, or aggregating over a silently clipped
+                                // window yields a wrong answer, so fail loud when the
+                                // cap actually clipped data (D4) instead of truncating.
+                                let (partitions, truncated) = state
+                                    .write_path
+                                    .load()
+                                    .range_read_limited_rows_checked(
+                                        &table_id,
+                                        ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT,
+                                        row_limit,
+                                    )
+                                    .await?;
+                                if truncated {
+                                    ferrosa_storage::metrics::inc_range_read_truncated();
+                                    return Err(CqlError::Invalid(
+                                        "query scans more than 10000 rows and cannot be bounded \
+                                         for this shape (ORDER BY / DISTINCT / aggregate / \
+                                         function projection over ALLOW FILTERING); add a LIMIT, \
+                                         create an index on the filtered/ordered columns, or \
+                                         narrow the predicate"
+                                            .into(),
+                                    ));
+                                }
+                                Some(partitions)
                             } else {
                                 None
                             };

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -483,6 +483,16 @@ fn safe_partition_key_filter_row_limit(
         .then_some(limit)
 }
 
+fn capped_full_scan_shape_truncated_error() -> CqlError {
+    CqlError::Invalid(format!(
+        "query scans more than {} rows and cannot be bounded for this full-scan \
+         shape (ORDER BY / DISTINCT / aggregate / function projection); add a \
+         scan-bounding LIMIT, create an index on the filtered/ordered columns, \
+         or narrow the predicate",
+        ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT
+    ))
+}
+
 fn row_matches_select_predicates(
     row: &[Option<CqlValue>],
     s: &SelectStatement,
@@ -4671,16 +4681,32 @@ async fn route_select_user_table(
                                 // flight, uncapped, exact).
                                 None
                             } else if let Some(wanted) = projection_wanted {
+                                let guard_unbounded_projected_shape = scan_bound.is_none()
+                                    && (s.distinct || !s.order_by.is_empty() || s.ann_of.is_some());
+                                let partition_limit = if guard_unbounded_projected_shape {
+                                    Some(
+                                        ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT
+                                            .saturating_add(1),
+                                    )
+                                } else {
+                                    scan_bound
+                                };
                                 // Push partition-count cap down to the merger so
                                 // `LIMIT N` stops the scan after N partitions
                                 // rather than walking every SSTable.
-                                Some(
-                                    state
-                                        .write_path
-                                        .load()
-                                        .range_read_projected(&table_id, wanted, scan_bound)
-                                        .await?,
-                                )
+                                let partitions = state
+                                    .write_path
+                                    .load()
+                                    .range_read_projected(&table_id, wanted, partition_limit)
+                                    .await?;
+                                if guard_unbounded_projected_shape
+                                    && partitions.len()
+                                        > ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT
+                                {
+                                    ferrosa_storage::metrics::inc_range_read_truncated();
+                                    return Err(capped_full_scan_shape_truncated_error());
+                                }
+                                Some(partitions)
                             } else if let Some(bound) = scan_bound {
                                 // User-supplied LIMIT (or page size) provided the
                                 // bound: returning exactly the requested rows is
@@ -4711,14 +4737,7 @@ async fn route_select_user_table(
                                     .await?;
                                 if truncated {
                                     ferrosa_storage::metrics::inc_range_read_truncated();
-                                    return Err(CqlError::Invalid(
-                                        "query scans more than 10000 rows and cannot be bounded \
-                                         for this shape (ORDER BY / DISTINCT / aggregate / \
-                                         function projection over ALLOW FILTERING); add a LIMIT, \
-                                         create an index on the filtered/ordered columns, or \
-                                         narrow the predicate"
-                                            .into(),
-                                    ));
+                                    return Err(capped_full_scan_shape_truncated_error());
                                 }
                                 Some(partitions)
                             } else {
@@ -17010,6 +17029,88 @@ mod tests {
         assert_eq!(
             row_count, 2,
             "SELECT DISTINCT tenant_id must deduplicate repeated tenant partition-key components"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_distinct_projection_over_cap_fails_loud_instead_of_materializing() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+            protocol_version: 4,
+        };
+
+        route(
+            &state,
+            &ctx,
+            crate::parser::parse(
+                "CREATE KEYSPACE distinct_over_cap WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+        route(
+            &state,
+            &ctx,
+            crate::parser::parse(
+                "CREATE TABLE distinct_over_cap.t (
+                    tenant int,
+                    bucket int,
+                    id int,
+                    payload text,
+                    PRIMARY KEY ((tenant, bucket), id)
+                )",
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        for bucket in 0..=ferrosa_cluster::write_path::DEFAULT_RANGE_READ_LIMIT {
+            route(
+                &state,
+                &ctx,
+                crate::parser::parse(&format!(
+                    "INSERT INTO distinct_over_cap.t \
+                     (tenant, bucket, id, payload) VALUES (1, {bucket}, 0, 'row-{bucket}')"
+                ))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let before = ferrosa_storage::metrics::range_read_truncated_total();
+        let result = route(
+            &state,
+            &ctx,
+            crate::parser::parse("SELECT DISTINCT tenant FROM distinct_over_cap.t").unwrap(),
+        )
+        .await;
+
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => {
+                panic!("over-cap projected DISTINCT scan must fail loud, not materialize all rows")
+            }
+        };
+        match error {
+            CqlError::Invalid(message) => assert!(
+                message.contains("query scans more than 10000 rows"),
+                "unexpected projected DISTINCT over-cap error: {message}"
+            ),
+            other => panic!("expected invalid-query error, got {other:?}"),
+        }
+
+        assert!(
+            ferrosa_storage::metrics::range_read_truncated_total() > before,
+            "over-cap projected DISTINCT scan must increment the truncation guard metric"
         );
     }
 

--- a/ferrosa-storage/src/metrics.rs
+++ b/ferrosa-storage/src/metrics.rs
@@ -316,6 +316,7 @@ static MEMTABLE_SIZE_BYTES_MAX: AtomicU64 = AtomicU64::new(0);
 static MEMTABLE_FLUSH_THRESHOLD_BYTES: AtomicU64 = AtomicU64::new(0);
 static MEMTABLE_BACKPRESSURE_BYTES: AtomicU64 = AtomicU64::new(0);
 
+static RANGE_READ_TRUNCATED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_LIMITED_ROWS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_LIMITED_ROWS_FOUND_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_LIMITED_ROWS_SECONDS_MICROS_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -447,6 +448,22 @@ pub fn inc_compaction_pool_input_opens() {
 /// Total compaction input readers obtained via the reader pool since startup.
 pub fn compaction_pool_input_opens_total() -> u64 {
     COMPACTION_POOL_INPUT_OPENS_TOTAL.load(Ordering::Relaxed)
+}
+
+/// A capped range read hit its partition cap while more data still existed,
+/// so the caller refused to silently truncate and failed loud instead. A
+/// non-zero value indicates a query shape (ORDER BY / DISTINCT / aggregate /
+/// function projection over `ALLOW FILTERING`) that scanned past the default
+/// range-read window; the query must add a LIMIT, an index, or a narrower
+/// predicate.
+pub fn inc_range_read_truncated() {
+    RANGE_READ_TRUNCATED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Total capped range reads that detected more data beyond the cap and failed
+/// loud rather than truncating, since startup.
+pub fn range_read_truncated_total() -> u64 {
+    RANGE_READ_TRUNCATED_TOTAL.load(Ordering::Relaxed)
 }
 
 pub fn observe_compaction_completed(
@@ -900,6 +917,14 @@ pub fn render_prometheus() -> String {
     }
 
     out.push_str(
+        "# HELP ferrosa_storage_range_read_truncated_total Capped range reads that hit their cap with more data available and failed loud instead of truncating.\n",
+    );
+    out.push_str("# TYPE ferrosa_storage_range_read_truncated_total counter\n");
+    out.push_str(&format!(
+        "ferrosa_storage_range_read_truncated_total {}\n",
+        RANGE_READ_TRUNCATED_TOTAL.load(Ordering::Relaxed)
+    ));
+    out.push_str(
         "# HELP ferrosa_storage_read_limited_rows_total Partition read_limited_rows calls.\n",
     );
     out.push_str("# TYPE ferrosa_storage_read_limited_rows_total counter\n");
@@ -1283,6 +1308,21 @@ mod tests {
         assert!(text.contains("ferrosa_archive_upload_errors_total 1"));
         assert!(text.contains("ferrosa_archive_lag_segments 3"));
         assert!(text.contains("ferrosa_snapshots_total 5"));
+    }
+
+    #[test]
+    fn range_read_truncated_increment_and_read() {
+        // Process-wide counter: assert on the delta, not an absolute value,
+        // so the test is robust to other tests touching the same counter.
+        let before = range_read_truncated_total();
+        inc_range_read_truncated();
+        inc_range_read_truncated();
+        let after = range_read_truncated_total();
+        assert_eq!(after - before, 2);
+
+        // The counter is exported in the Prometheus text rendering.
+        let text = render_prometheus();
+        assert!(text.contains("ferrosa_storage_range_read_truncated_total"));
     }
 
     #[test]

--- a/specs/p0-oom-guard/oom-audit-allow.toml
+++ b/specs/p0-oom-guard/oom-audit-allow.toml
@@ -13,21 +13,22 @@
 # the documented baseline so `--enforce` passes on the current tree while the
 # underlying streaming fixes land. They fall into two groups:
 #
-#  1. The P0 SELECT-arm sites the streaming fix (forge t_15417b35) will remove.
-#     Short expiry (2026-09-30) — these must be re-audited when t_15417b35 lands.
+#  1. The P0 SELECT-arm sites covered by the t_15417b35 fail-loud guard.
+#     Short expiry (2026-09-30) — these are intentionally not permanent
+#     suppressions and must be re-audited for a full streaming replacement.
 #  2. Pre-existing materialization across the read/storage stack predating the
 #     guard. Tracked under the materialization epic (forge t_110dd8a5); longer
 #     expiry while each path is migrated to streaming.
 
 # ---------------------------------------------------------------------------
-# Group 1 — P0 SELECT-arm materialization removed by t_15417b35 (expiry 2026-09-30)
+# Group 1 — P0 SELECT-arm materialization guarded by t_15417b35 (expiry 2026-09-30)
 # ---------------------------------------------------------------------------
 
 [[allow]]
 path = "ferrosa-cluster/src/write_path.rs"
 rule = "returns-vec-partition-or-row"
 symbol = "range_read_limited_rows"
-reason = "t_15417b35: SELECT-arm streaming fix removes this materializing range_read_limited_rows."
+reason = "t_15417b35: SELECT complex-scan callers are guarded by limit+1 probes or bounded user limits; the Vec-returning API remains short-term debt pending full streaming replacement."
 owner = "storage"
 expires = "2026-09-30"
 
@@ -35,7 +36,7 @@ expires = "2026-09-30"
 path = "ferrosa-cluster/src/write_path.rs"
 rule = "limited-rows-call-site"
 symbol = "range_read_limited_rows"
-reason = "t_15417b35: write_path dispatch into the materializing range read; removed by SELECT-arm fix."
+reason = "t_15417b35: dispatch is still materializing, but SELECT complex-scan callers use checked/fail-loud probes; keep short expiry for streaming migration."
 owner = "storage"
 expires = "2026-09-30"
 
@@ -43,7 +44,7 @@ expires = "2026-09-30"
 path = "ferrosa-cluster/src/write_path.rs"
 rule = "limited-rows-call-site"
 symbol = "coordinate_range_read_limited_rows"
-reason = "t_15417b35: write_path -> coordinator materializing range read; removed by SELECT-arm fix."
+reason = "t_15417b35: coordinator limited-row dispatch remains materializing, but SELECT complex-scan callers fail loud on cap clipping; keep short expiry for streaming migration."
 owner = "storage"
 expires = "2026-09-30"
 
@@ -51,14 +52,14 @@ expires = "2026-09-30"
 path = "ferrosa-cql/src/router.rs"
 rule = "limited-rows-call-site"
 symbol = "range_read_limited_rows"
-reason = "t_15417b35: degraded IndexScanWithFilter/SingleIndex arm call sites; removed by SELECT-arm streaming fix."
+reason = "t_15417b35: router limited-row call sites are bounded by user/page limits or checked/fail-loud complex-scan guards; not a silent truncation exemption."
 owner = "storage"
 expires = "2026-09-30"
 
 [[allow]]
 path = "ferrosa-cluster/src/coordinator/range_read_stream.rs"
 rule = "with-capacity-limit"
-reason = "t_15417b35: Vec::with_capacity(limit) in read_local_range_stream_limited_rows window collection; removed by SELECT-arm fix."
+reason = "t_15417b35: coordinator window collection is still materializing; SELECT complex-scan callers detect cap clipping and fail loud while streaming replacement remains pending."
 owner = "storage"
 expires = "2026-09-30"
 
@@ -66,7 +67,7 @@ expires = "2026-09-30"
 path = "ferrosa-cluster/src/coordinator/range_read_stream.rs"
 rule = "stream-returns-vec"
 symbol = "read_local_range_stream_limited_rows"
-reason = "t_15417b35: stream-named fn still materializes a Vec<Partition>; removed by SELECT-arm fix."
+reason = "t_15417b35: stream-named helper still returns a materialized window; SELECT callers are fail-loud/bounded, with full streaming migration due before expiry."
 owner = "storage"
 expires = "2026-09-30"
 
@@ -74,7 +75,7 @@ expires = "2026-09-30"
 path = "ferrosa-cluster/src/coordinator/range_read_stream.rs"
 rule = "returns-vec-partition-or-row"
 symbol = "read_local_range_stream_limited_rows"
-reason = "t_15417b35: read_local_range_stream_limited_rows returns Vec<Partition>; removed by SELECT-arm fix."
+reason = "t_15417b35: helper still returns Vec<Partition>; SELECT callers are fail-loud/bounded, with full streaming migration due before expiry."
 owner = "storage"
 expires = "2026-09-30"
 
@@ -286,7 +287,7 @@ expires = "2026-12-31"
 path = "ferrosa-cql/src/router.rs"
 rule = "materializing-range-read-call-site"
 symbol = "range_read_projected"
-reason = "t_15417b35: degraded SELECT scan arm range_read_projected call (router.rs:4670), adjacent to the range_read_limited_rows sites; removed by the SELECT-arm streaming fix."
+reason = "t_15417b35: projected complex SELECT scan arm is capped/probed at DEFAULT_RANGE_READ_LIMIT + 1 and fails loud via range_read_truncated_total instead of materializing an unbounded result."
 owner = "storage"
 expires = "2026-09-30"
 


### PR DESCRIPTION
## What

Adds the missing guard for projected complex full-scan SELECT shapes that could bypass PR #232's checked range-read arm.

Specifically, projected `DISTINCT` / `ORDER BY` / ANN full scans now probe at `DEFAULT_RANGE_READ_LIMIT + 1`; if more data exists, the router increments `range_read_truncated_total` and fails loud instead of materializing the whole projected table or computing over a clipped window.

Also tightens CI disk hygiene for the workspace-wide test jobs after GitHub Actions hit `rustc-LLVM ERROR: IO failure on output stream: No space left on device` on this PR. The test and cluster-integration jobs no longer restore the heavy `target` cache, free more preinstalled runner toolchains before compiling, and clean build artifacts with `if: always()` before post-job cache steps.

## Why

The PR #232 fix covered the non-projected complex scan arm via `range_read_limited_rows_checked`, but projection-eligible complex scans could still call `range_read_projected(..., None)` first. A query like `SELECT DISTINCT tenant FROM ...` over more than 10k partitions could therefore materialize all projected partitions.

## Tests

- `cargo fmt --check`
- `cargo test -p ferrosa-cql --lib` (973 passed, 1 existing ignored)
- `cargo test -p ferrosa-storage --lib range_read_truncated_increment_and_read -- --nocapture`
- `cargo run --quiet -p xtask -- p0-oom-audit --enforce --today 2026-06-30`
- `python3 scripts/check-unbounded-reads.py`
- `cargo clippy -p ferrosa-cql --all-targets --features test-util -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p ferrosa-cql --no-deps --features test-util`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'`
- `actionlint .github/workflows/ci.yml`

Note: plain `cargo clippy -p ferrosa-cql --all-targets` hits the existing `protocol_conformance.rs` `test-util` feature gate, so the passing clippy command enables that feature.