### PR TITLE
fix(cql): decode page_size + paging_state from the QUERY/EXECUTE wire — cluster paged scans page correctly (t_a0f922a3)

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -127,6 +127,22 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   nobody; the producer-side handler is registered for the Cancel MsgType.
   Harness: `tests/range_scan_multi_replica_paging.rs` (real 3-node loopback,
   RF=3/CL=ALL, counter-asserted).
+  **Flow control (t_a0f922a3):** internode range streams are WINDOWED — each
+  `RangeReadStreamRequest` carries `max_chunks` (`STREAM_WINDOW_CHUNKS = 16`,
+  provably < the 32-slot route buffer); the producer stops at the window and
+  reports a `(partition_key, clustering)` resume position in its Done, and the
+  coordinator's `WindowedReplicaForwarder` fires the continuation only after
+  the consumer drains the window. Without this, any scan larger than the
+  buffer overflowed the route (`ChannelFull` → fail-loud close → retryable
+  ReadTimeout that drivers retry forever — the live 15k-partition paged-scan
+  "stall"). Heartbeats route lossily (`StreamRouter::route_lossy`) so a
+  keep-alive can never close a healthy mid-window route. Paged scans resume
+  WITHIN a partition end-to-end: `write_path::ScanResume { key, clustering }`
+  ships the cursor's clustering position to every producer
+  (`start_clustering` on the wire; `resume_filtered_stream` locally), so a
+  wide partition spanning pages never re-streams its delivered prefix.
+  **Wire note:** the request/Done payload field additions are a bincode wire
+  change — upgrade all nodes together (mixed versions fail decode loudly).
 - **Write backpressure**: `WRITE_CONCURRENCY_LIMIT = 128` semaphore prevents bulk
   CQL inserts from starving Raft heartbeats on the tokio runtime.
 

--- a/ferrosa-cluster/specs/roadmap.md
+++ b/ferrosa-cluster/specs/roadmap.md
@@ -11,6 +11,23 @@ reference/decision specs, and the dependency/usage review. Ordered by value.
 
 ## Recently addressed
 
+- **Paged-scan fail-loud completion contract (t_a0f922a3 bug #2).** The N-way
+  merge concludes a scan complete once every source stream ends; that inference
+  ("channel closed ⇒ replica exhausted") is only sound when the per-replica
+  `WindowedReplicaForwarder` closed cleanly. Added a `clean_end` flag set only at
+  genuine exhaustion (`Completed { resume: None }`) or a deliberate consumer
+  abandon, and wrapped every source stream in `clean_end_guarded_stream`: a close
+  WITHOUT that flag now emits one loud, retryable `Internal` error instead of a
+  silent `None`, so an unexpected forwarder end (panic / future refactor) fails
+  the scan loudly rather than returning a silent partial with `has_more = false`.
+  Observability: `forwarder_diag::{error_send_dropped, continuations_fired}`.
+  Tests: `range_read_stream` unit guard tests +
+  `range_scan_multi_replica_paging` disjoint-data / many-windows-per-page
+  harness. **Note:** the exact live 21160-of-50807 truncation did NOT reproduce
+  in-process (fresh-data scans page complete); the guard closes the
+  silent-complete class structurally. Live RF=3 re-validation on the real
+  `typed_edges` shape is the remaining confirmation step.
+
 - **Paged multi-replica stream lifecycle (t_dc729b1d / t_3fc6be3c, CL-14).**
   Fixed the phantom `expected_seq=0 observed_seq=5` gap-close on every abandoned
   page (seq-state creation now gated on route liveness; no-state+no-route is a

--- a/ferrosa-cluster/src/coordinator/range_read_stream.rs
+++ b/ferrosa-cluster/src/coordinator/range_read_stream.rs
@@ -15,6 +15,7 @@
 //! consume.
 
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -33,7 +34,9 @@ use crate::error::ClusterError;
 use crate::raft::handlers::{
     partition_from_wire, RangeReadStreamCancelPayload, RangeReadStreamChunkPayload,
     RangeReadStreamDonePayload, RangeReadStreamHeartbeatPayload, RangeReadStreamRequestPayload,
+    StreamResumePositionWire,
 };
+use crate::write_path::ScanResume;
 
 /// Idle deadline on the streaming receiver. Reset on every chunk OR
 /// heartbeat. A producer that stops sending entirely for longer
@@ -57,6 +60,29 @@ const STREAM_RECEIVER_BUFFER: usize = 32;
 /// still amortizing the per-message frame overhead. Tunable later
 /// via NetConfig.
 pub const STREAMING_CHUNK_PARTITIONS: usize = 64;
+
+/// Producer flow-control window: chunk frames per stream request
+/// (t_a0f922a3 mode 2). The remote producer fires chunks with no per-frame
+/// acknowledgement, so everything it emits beyond what the consumer has
+/// drained sits in the coordinator's bounded route buffer
+/// ([`STREAM_RECEIVER_BUFFER`]). Without a window, any scan larger than the
+/// buffer overflows it the moment the consumer is slower than the wire —
+/// `StreamRouter::route` then FAIL-LOUD-closes the route and the query dies
+/// with a retryable ReadTimeout that drivers retry forever (the live
+/// `SELECT id FROM vfix.nums` paged scan blocked >14 min).
+///
+/// The producer stops after this many chunks and reports a resume position
+/// in its Done; the coordinator's per-replica forwarder fires a continuation
+/// request only after the consumer has drained the window. Un-drained frames
+/// per stream are therefore ≤ `STREAM_WINDOW_CHUNKS` + 1 (Done) + a few
+/// heartbeats (which are lossy on a full buffer), comfortably under
+/// [`STREAM_RECEIVER_BUFFER`].
+const STREAM_WINDOW_CHUNKS: u32 = 16;
+
+const _: () = assert!(
+    (STREAM_WINDOW_CHUNKS as usize) + 1 < STREAM_RECEIVER_BUFFER,
+    "a full producer window plus its Done must fit in the route buffer"
+);
 
 pub type ClusterPartitionStream =
     Pin<Box<dyn Stream<Item = crate::error::Result<Partition>> + Send>>;
@@ -282,16 +308,21 @@ fn next_remote_error(err: StreamConsumeError) -> crate::error::Result<Partition>
     Err(cluster_err)
 }
 
-/// How a per-replica forwarder task ended. Anything other than `Completed`
-/// means the REMOTE producer may still be streaming — the coordinator must
-/// fire a `RangeReadStreamCancel` so the replica stops between batches instead
+/// How a per-replica forwarder task ended. `Abandoned`/`Failed` mean the
+/// REMOTE producer may still be streaming — the coordinator must fire a
+/// `RangeReadStreamCancel` so the replica stops between batches instead
 /// of scanning the whole table into `Lane::Bulk` for nobody (t_3fc6be3c: the
 /// uncancelled `pages × replicas` producers starved live streams into
 /// heartbeat-defunct connections and OOM-killed replicas).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ForwardOutcome {
     /// The stream terminated normally (every expected `Done` delivered).
-    Completed,
+    /// `resume` is `Some` when the producer stopped at its flow-control
+    /// window with more data remaining — the caller continues the logical
+    /// stream by firing a fresh request from that position.
+    Completed {
+        resume: Option<StreamResumePositionWire>,
+    },
     /// The consumer dropped the merged stream mid-flight (a paged read fills
     /// its page and abandons the rest — every page but the last does this).
     Abandoned,
@@ -323,10 +354,11 @@ async fn forward_remote_range_stream_inner(
 ) -> Result<ForwardOutcome, StreamConsumeError> {
     let mut watchdog = IdleTimeoutWatchdog::new(receiver, STREAMING_IDLE_TIMEOUT);
     let mut delivered_done = 0usize;
+    let mut resume: Option<StreamResumePositionWire> = None;
 
     loop {
         if delivered_done >= expected_done {
-            return Ok(ForwardOutcome::Completed);
+            return Ok(ForwardOutcome::Completed { resume });
         }
 
         // Notice consumer abandonment PROMPTLY — even when the producer is
@@ -393,6 +425,7 @@ async fn forward_remote_range_stream_inner(
                     );
                     return Err(StreamConsumeError::TruncatedReplica { request_id });
                 }
+                resume = done.resume;
                 delivered_done += 1;
             }
             other => {
@@ -409,7 +442,7 @@ async fn merge_local_and_single_remote_stream(
     table_id: TableId,
     row_limit: usize,
     projected_regular_ordinals: Option<Vec<u16>>,
-    remote_rx: mpsc::Receiver<crate::error::Result<Partition>>,
+    remote: ClusterPartitionStream,
     out_tx: mpsc::Sender<crate::error::Result<Partition>>,
 ) {
     // `row_limit > 0` only for `LIMIT N` queries with partition-key
@@ -424,7 +457,7 @@ async fn merge_local_and_single_remote_stream(
             table_id,
             row_limit,
             projected_regular_ordinals,
-            remote_rx,
+            remote,
             out_tx,
         )
         .await;
@@ -434,7 +467,7 @@ async fn merge_local_and_single_remote_stream(
         storage,
         table_id,
         projected_regular_ordinals,
-        remote_rx,
+        remote,
         out_tx,
     )
     .await;
@@ -448,7 +481,7 @@ async fn merge_local_and_single_remote_whole(
     table_id: TableId,
     row_limit: usize,
     projected_regular_ordinals: Option<Vec<u16>>,
-    mut remote_rx: mpsc::Receiver<crate::error::Result<Partition>>,
+    mut remote_stream: ClusterPartitionStream,
     out_tx: mpsc::Sender<crate::error::Result<Partition>>,
 ) {
     let mut local_stream: ClusterPartitionStream = if let Some(wanted) = projected_regular_ordinals
@@ -466,7 +499,7 @@ async fn merge_local_and_single_remote_whole(
         )
     };
     let mut local_next = local_stream.next().await;
-    let mut remote_next = remote_rx.recv().await;
+    let mut remote_next = remote_stream.next().await;
 
     loop {
         match (local_next.take(), remote_next.take()) {
@@ -497,7 +530,7 @@ async fn merge_local_and_single_remote_whole(
                 {
                     return;
                 }
-                remote_next = remote_rx.recv().await;
+                remote_next = remote_stream.next().await;
             }
             (Some(Ok(local)), Some(Ok(remote))) => {
                 let local_token = local.key.token.0;
@@ -521,7 +554,7 @@ async fn merge_local_and_single_remote_whole(
                         return;
                     }
                     local_next = Some(Ok(local));
-                    remote_next = remote_rx.recv().await;
+                    remote_next = remote_stream.next().await;
                 } else {
                     let merged = ferrosa_storage::merge::merge_partitions(vec![local, remote]);
                     if out_tx
@@ -532,7 +565,7 @@ async fn merge_local_and_single_remote_whole(
                         return;
                     }
                     local_next = local_stream.next().await;
-                    remote_next = remote_rx.recv().await;
+                    remote_next = remote_stream.next().await;
                 }
             }
         }
@@ -741,7 +774,7 @@ async fn merge_local_and_single_remote_fragmented(
     storage: std::sync::Arc<ferrosa_storage::StorageEngine>,
     table_id: TableId,
     projected_regular_ordinals: Option<Vec<u16>>,
-    remote_rx: mpsc::Receiver<crate::error::Result<Partition>>,
+    remote_stream: ClusterPartitionStream,
     out_tx: mpsc::Sender<crate::error::Result<Partition>>,
 ) {
     let local_stream: ClusterPartitionStream = if let Some(wanted) = projected_regular_ordinals {
@@ -758,7 +791,7 @@ async fn merge_local_and_single_remote_fragmented(
         )
     };
     let local = FragmentCursor::new(local_stream);
-    let remote = FragmentCursor::new(ReceiverStream { rx: remote_rx });
+    let remote = FragmentCursor::new(remote_stream);
     let k = super::stream_request_handler::stream_chunk_row_cap();
     run_fragment_merge(local, remote, k, out_tx).await;
 }
@@ -987,22 +1020,6 @@ async fn run_fragment_merge<L, R>(
     run_fragment_merge_nway(vec![local.boxed(), remote.boxed()], k, out_tx).await;
 }
 
-/// Adapter so an `mpsc::Receiver` of partition results drives the same
-/// `Stream`-based cursor as the local engine stream.
-struct ReceiverStream {
-    rx: mpsc::Receiver<crate::error::Result<Partition>>,
-}
-
-impl futures::Stream for ReceiverStream {
-    type Item = Result<Partition, ClusterError>;
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        self.rx.poll_recv(cx)
-    }
-}
-
 /// Build one output fragment, draining `out_rows`. The FIRST fragment of a
 /// token carries the merged header (`deletion` + `static_row`); subsequent
 /// fragments carry `LIVE` / `None` so the CQL bridge never double-applies
@@ -1050,75 +1067,216 @@ struct RemoteFanout {
     fire_failures: usize,
 }
 
-impl ClusterCoordinator {
-    async fn fan_out_remote_fragment_streams(
+/// Per-replica windowed continuation forwarder (t_a0f922a3 mode 2).
+///
+/// One logical replica stream is a SEQUENCE of bounded window requests: each
+/// request asks the producer for at most `window_chunks` chunk frames; the
+/// producer's Done carries a resume position when more data remains, and the
+/// next request is fired only after the consumer has drained the previous
+/// window (the forward loop below returns when the window's Done arrives, and
+/// every chunk it forwards goes through the bounded, consumer-paced
+/// `remote_tx`). Un-drained frames at the route can therefore never exceed
+/// one window — the fail-loud `ChannelFull` route close cannot fire on a slow
+/// consumer, no matter how large the scan is. Memory stays bounded and no
+/// server-side result cap is involved.
+struct WindowedReplicaForwarder {
+    router: Arc<ferrosa_net::stream_router::StreamRouter>,
+    peers: Arc<ferrosa_net::peer::PeerManager>,
+    next_request_id: Arc<std::sync::atomic::AtomicU32>,
+    host_id: uuid::Uuid,
+    keyspace: String,
+    table: String,
+    wanted: Option<Vec<u16>>,
+    window_chunks: u32,
+}
+
+impl WindowedReplicaForwarder {
+    fn encode_request(
         &self,
-        table_id: &TableId,
-        remotes: &[(uuid::Uuid, String)],
-        projected_regular_ordinals: Option<&[u16]>,
-        start_key: Option<&ferrosa_common::key::DecoratedKey>,
-    ) -> crate::error::Result<RemoteFanout> {
-        let mut streams: Vec<ClusterPartitionStream> = Vec::with_capacity(remotes.len());
-        let mut fire_failures = 0usize;
-
-        for (host_id, _addr) in remotes {
-            let request_id = self.next_stream_request_id();
-            let receiver = self
-                .stream_router
-                .register(request_id, STREAM_RECEIVER_BUFFER);
-
-            let req_payload = RangeReadStreamRequestPayload {
-                request_id,
-                keyspace: table_id.keyspace.clone(),
-                table: table_id.table.clone(),
-                projected_regular_ordinals: projected_regular_ordinals.map(|w| w.to_vec()),
-                start_key: start_key.map(|k| k.key.as_bytes().to_vec()),
-            };
-            let req_body = Bytes::from(bincode::serialize(&req_payload).map_err(|e| {
+        request_id: u32,
+        start_key: Option<Vec<u8>>,
+        start_clustering: Option<Vec<u8>>,
+    ) -> crate::error::Result<Bytes> {
+        let req_payload = RangeReadStreamRequestPayload {
+            request_id,
+            keyspace: self.keyspace.clone(),
+            table: self.table.clone(),
+            projected_regular_ordinals: self.wanted.clone(),
+            start_key,
+            start_clustering,
+            max_chunks: self.window_chunks,
+        };
+        bincode::serialize(&req_payload)
+            .map(Bytes::from)
+            .map_err(|e| {
                 ClusterError::Internal(format!("streaming range read: encode request: {e}"))
-            })?);
+            })
+    }
 
-            if let Err(e) = self
-                .peer_manager
-                .fire(
-                    *host_id,
-                    Message::RangeReadStreamRequest(req_body),
-                    Lane::Bulk,
-                )
-                .await
-            {
-                tracing::warn!(
-                    request_id,
-                    peer = %host_id,
-                    "streaming range read: failed to fire request: {e}"
-                );
-                self.stream_router.unregister(request_id);
-                fire_failures += 1;
-                continue;
-            }
+    /// Drive the logical stream across window continuations. `request_id` /
+    /// `receiver` belong to the already-fired FIRST window.
+    async fn run(
+        self,
+        mut request_id: u32,
+        mut receiver: mpsc::Receiver<Message>,
+        remote_tx: mpsc::Sender<crate::error::Result<Partition>>,
+    ) {
+        loop {
+            let outcome =
+                forward_remote_range_stream(receiver, request_id, 1, remote_tx.clone()).await;
+            self.router.unregister(request_id);
 
-            let (remote_tx, remote_rx) = mpsc::channel(STREAM_RECEIVER_BUFFER);
-            let router = self.stream_router.clone();
-            let peer_manager = self.peer_manager.clone();
-            let peer_host = *host_id;
-            TaskPool::current("range-read-forward").spawn(async move {
-                let outcome = forward_remote_range_stream(receiver, request_id, 1, remote_tx).await;
-                router.unregister(request_id);
+            let resume = match outcome {
+                ForwardOutcome::Completed { resume: None } => return, // scan complete
+                ForwardOutcome::Completed {
+                    resume: Some(resume),
+                } => resume,
                 // Anything but a clean Done means the remote producer may
                 // still be streaming for nobody — tell it to stop. Fired from
                 // THIS live async task (not a Drop guard: the reverted
                 // 3ec30240 guard never actually sent a cancel on the live
                 // cluster), so the fire is a plain awaited call that either
                 // succeeds or logs loudly.
-                if outcome != ForwardOutcome::Completed {
-                    fire_stream_cancel(&peer_manager, peer_host, request_id, outcome).await;
+                other => {
+                    fire_stream_cancel(&self.peers, self.host_id, request_id, other).await;
+                    return;
                 }
-            });
+            };
 
-            let stream = futures::stream::unfold(remote_rx, |mut rx| async move {
-                rx.recv().await.map(|item| (item, rx))
-            });
-            streams.push(Box::pin(stream));
+            // Window boundary. Don't fire a continuation the consumer will
+            // never read (a paged read abandons the stream between pages).
+            if remote_tx.is_closed() {
+                return;
+            }
+
+            request_id = self
+                .next_request_id
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            receiver = self.router.register(request_id, STREAM_RECEIVER_BUFFER);
+            let body = match self.encode_request(
+                request_id,
+                Some(resume.partition_key),
+                Some(resume.clustering),
+            ) {
+                Ok(body) => body,
+                Err(e) => {
+                    self.router.unregister(request_id);
+                    let _ = remote_tx.send(Err(e)).await;
+                    return;
+                }
+            };
+            if let Err(e) = self
+                .peers
+                .fire(
+                    self.host_id,
+                    Message::RangeReadStreamRequest(body),
+                    Lane::Bulk,
+                )
+                .await
+            {
+                // A continuation fire failure mid-scan is a hard, loud error:
+                // the consumer already holds a prefix, so silently ending the
+                // stream here would return PARTIAL data as success.
+                self.router.unregister(request_id);
+                let _ = remote_tx
+                    .send(Err(ClusterError::Internal(format!(
+                        "streaming range read: window continuation fire to {} failed: {e}",
+                        self.host_id
+                    ))))
+                    .await;
+                return;
+            }
+        }
+    }
+}
+
+impl ClusterCoordinator {
+    /// Fire the first window of one replica's fragment stream and spawn its
+    /// windowed continuation forwarder. Returns the bounded, consumer-paced
+    /// partition stream for that replica, or `Err` when the initial fire
+    /// fails (the caller counts fan-out failures).
+    async fn spawn_replica_fragment_stream(
+        &self,
+        table_id: &TableId,
+        host_id: uuid::Uuid,
+        projected_regular_ordinals: Option<&[u16]>,
+        resume: Option<&ScanResume>,
+        window_chunks: u32,
+    ) -> crate::error::Result<ClusterPartitionStream> {
+        let request_id = self.next_stream_request_id();
+        let receiver = self
+            .stream_router
+            .register(request_id, STREAM_RECEIVER_BUFFER);
+
+        let forwarder = WindowedReplicaForwarder {
+            router: self.stream_router.clone(),
+            peers: self.peer_manager.clone(),
+            next_request_id: self.next_request_id.clone(),
+            host_id,
+            keyspace: table_id.keyspace.clone(),
+            table: table_id.table.clone(),
+            wanted: projected_regular_ordinals.map(|w| w.to_vec()),
+            window_chunks,
+        };
+        let body = forwarder
+            .encode_request(
+                request_id,
+                resume.map(|r| r.key.key.as_bytes().to_vec()),
+                resume.and_then(|r| r.clustering.clone()),
+            )
+            .inspect_err(|_| self.stream_router.unregister(request_id))?;
+        if let Err(e) = self
+            .peer_manager
+            .fire(host_id, Message::RangeReadStreamRequest(body), Lane::Bulk)
+            .await
+        {
+            self.stream_router.unregister(request_id);
+            return Err(ClusterError::Internal(format!(
+                "streaming range read: failed to fire request to {host_id}: {e}"
+            )));
+        }
+
+        let (remote_tx, remote_rx) = mpsc::channel(STREAM_RECEIVER_BUFFER);
+        TaskPool::current("range-read-forward").spawn(async move {
+            forwarder.run(request_id, receiver, remote_tx).await;
+        });
+
+        let stream = futures::stream::unfold(remote_rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+        Ok(Box::pin(stream))
+    }
+
+    async fn fan_out_remote_fragment_streams(
+        &self,
+        table_id: &TableId,
+        remotes: &[(uuid::Uuid, String)],
+        projected_regular_ordinals: Option<&[u16]>,
+        resume: Option<&ScanResume>,
+    ) -> crate::error::Result<RemoteFanout> {
+        let mut streams: Vec<ClusterPartitionStream> = Vec::with_capacity(remotes.len());
+        let mut fire_failures = 0usize;
+
+        for (host_id, _addr) in remotes {
+            match self
+                .spawn_replica_fragment_stream(
+                    table_id,
+                    *host_id,
+                    projected_regular_ordinals,
+                    resume,
+                    STREAM_WINDOW_CHUNKS,
+                )
+                .await
+            {
+                Ok(stream) => streams.push(stream),
+                Err(e) => {
+                    tracing::warn!(
+                        peer = %host_id,
+                        "streaming range read: failed to fire request: {e}"
+                    );
+                    fire_failures += 1;
+                }
+            }
         }
 
         Ok(RemoteFanout {
@@ -1176,18 +1334,20 @@ async fn fire_stream_cancel(
 
 /// Drive a token-aware N-way fragment merge of the LOCAL fragmented stream and
 /// one or more REMOTE replica fragment streams, emitting `<= k`-row fragments
-/// into `out_tx`. The local stream is start-bounded by `start` (the resume
-/// cursor); the remote streams are already start-bounded at their producers.
-/// Resident set is `O(num_sources + k)` — every cursor holds at most one peeked
-/// fragment and the merge buffers at most `k` output rows.
+/// into `out_tx`. The local stream is resume-bounded by `resume` (partition
+/// key + within-partition clustering skip); the remote streams are already
+/// resume-bounded at their producers. Resident set is `O(num_sources + k)` —
+/// every cursor holds at most one peeked fragment and the merge buffers at
+/// most `k` output rows.
 async fn merge_local_and_remotes_fragmented(
     storage: std::sync::Arc<ferrosa_storage::StorageEngine>,
     table_id: TableId,
     projected_regular_ordinals: Option<Vec<u16>>,
-    start: Option<ferrosa_common::key::DecoratedKey>,
+    resume: Option<ScanResume>,
     remote_streams: Vec<ClusterPartitionStream>,
     out_tx: mpsc::Sender<crate::error::Result<Partition>>,
 ) {
+    let start = resume.as_ref().map(|r| r.key.clone());
     let local_stream: ClusterPartitionStream = if let Some(wanted) = projected_regular_ordinals {
         Box::pin(
             storage
@@ -1201,6 +1361,7 @@ async fn merge_local_and_remotes_fragmented(
                 .map(|item| item.map_err(ClusterError::Storage)),
         )
     };
+    let local_stream = crate::write_path::resume_filtered_stream(local_stream, resume.as_ref());
 
     let mut cursors: Vec<FragmentCursor<BoxedFragmentStream>> =
         Vec::with_capacity(1 + remote_streams.len());
@@ -1295,20 +1456,20 @@ impl ClusterCoordinator {
         all_remotes.into_iter().take(cl_remote_count).collect()
     }
 
-    /// Drive the local-start-bounded fragmented stream + the CL-selected remote
-    /// replica fragment streams (each start-bounded at its producer) through the
-    /// token-aware N-way merge, returning the merged partition stream. Shared by
-    /// the paged (`*_stream_from`) variants. `start` is the inclusive resume
-    /// cursor (`None` on the first page).
+    /// Drive the local resume-bounded fragmented stream + the CL-selected
+    /// remote replica fragment streams (each resume-bounded at its producer)
+    /// through the token-aware N-way merge, returning the merged partition
+    /// stream. Shared by the paged (`*_stream_from`) variants. `resume` is the
+    /// page resume position (`None` on the first page).
     async fn paged_multi_replica_stream(
         &self,
         table_id: &TableId,
         wanted: Option<Vec<u16>>,
-        start: Option<&ferrosa_common::key::DecoratedKey>,
+        resume: Option<&ScanResume>,
         remotes: &[(uuid::Uuid, String)],
     ) -> crate::error::Result<ClusterPartitionStream> {
         let fanout = self
-            .fan_out_remote_fragment_streams(table_id, remotes, wanted.as_deref(), start)
+            .fan_out_remote_fragment_streams(table_id, remotes, wanted.as_deref(), resume)
             .await?;
         if fanout.streams.is_empty() {
             return Err(ClusterError::Internal(format!(
@@ -1328,13 +1489,13 @@ impl ClusterCoordinator {
         let (out_tx, out_rx) = mpsc::channel(STREAM_RECEIVER_BUFFER);
         let storage = self.storage.clone();
         let table_id = table_id.clone();
-        let start = start.cloned();
+        let resume = resume.cloned();
         TaskPool::current("range-read-merge-nway-paged").spawn(async move {
             merge_local_and_remotes_fragmented(
                 storage,
                 table_id,
                 wanted,
-                start,
+                resume,
                 fanout.streams,
                 out_tx,
             )
@@ -1346,62 +1507,64 @@ impl ClusterCoordinator {
         Ok(Box::pin(stream))
     }
 
-    /// Resume-capable streaming range scan with an inclusive lower-bound key.
+    /// Resume-capable streaming range scan.
     ///
     /// Backs `WritePath::range_read_stream_all_from` (the coordinator-side
     /// paging cursor). The local-only fan-out shape (CL=ONE with the keyspace RF
     /// spanning the ring) streams the local fragmented iterator directly; a
-    /// multi-replica shape fans out a start-bounded fragment stream to each
+    /// multi-replica shape fans out a resume-bounded fragment stream to each
     /// CL-selected replica and merges them with the local stream through the
     /// token-aware N-way fragment merge (`run_fragment_merge_nway`). The
-    /// resume cursor (`start`) is shipped to every replica so a resumed page
-    /// never re-streams the already-emitted prefix; the CQL paging collector
-    /// applies the exact skip-≤-last semantics on top, so the merged page is
-    /// gap- and duplicate-free even mid-wide-partition.
+    /// resume position is shipped to every replica so a resumed page never
+    /// re-streams the already-emitted prefix (including mid-wide-partition);
+    /// the CQL paging collector applies the exact skip-≤-last semantics on
+    /// top, so the merged page is gap- and duplicate-free.
     pub async fn coordinate_range_read_stream_from(
         &self,
         table_id: &TableId,
-        start: Option<&ferrosa_common::key::DecoratedKey>,
+        resume: Option<&ScanResume>,
         cl: crate::consistency::ConsistencyLevel,
         replication_factor: usize,
     ) -> crate::error::Result<ClusterPartitionStream> {
         let remotes = self.range_read_remotes(cl, replication_factor);
 
         if remotes.is_empty() {
-            return Ok(Box::pin(
+            let stream: ClusterPartitionStream = Box::pin(
                 self.storage
-                    .range_iter_fragmented(table_id, start, None)
+                    .range_iter_fragmented(table_id, resume.map(|r| &r.key), None)
                     .map(|item| item.map_err(ClusterError::Storage)),
-            ));
+            );
+            return Ok(crate::write_path::resume_filtered_stream(stream, resume));
         }
 
-        self.paged_multi_replica_stream(table_id, None, start, &remotes)
+        self.paged_multi_replica_stream(table_id, None, resume, &remotes)
             .await
     }
 
     /// Projection-aware resume-capable streaming range scan. See
     /// [`Self::coordinate_range_read_stream_from`]; serves the multi-replica
-    /// shape via the same start-bounded N-way fragment merge, byte-skipping
+    /// shape via the same resume-bounded N-way fragment merge, byte-skipping
     /// unprojected cells at every replica.
     pub async fn coordinate_range_read_projected_stream_from(
         &self,
         table_id: &TableId,
         wanted: Vec<u16>,
-        start: Option<&ferrosa_common::key::DecoratedKey>,
+        resume: Option<&ScanResume>,
         cl: crate::consistency::ConsistencyLevel,
         replication_factor: usize,
     ) -> crate::error::Result<ClusterPartitionStream> {
         let remotes = self.range_read_remotes(cl, replication_factor);
 
         if remotes.is_empty() {
-            return Ok(Box::pin(
+            let stream: ClusterPartitionStream = Box::pin(
                 self.storage
-                    .range_iter_projected_fragmented(table_id, wanted, start, None)
+                    .range_iter_projected_fragmented(table_id, wanted, resume.map(|r| &r.key), None)
                     .map(|item| item.map_err(ClusterError::Storage)),
-            ));
+            );
+            return Ok(crate::write_path::resume_filtered_stream(stream, resume));
         }
 
-        self.paged_multi_replica_stream(table_id, Some(wanted), start, &remotes)
+        self.paged_multi_replica_stream(table_id, Some(wanted), resume, &remotes)
             .await
     }
 
@@ -1545,46 +1708,33 @@ impl ClusterCoordinator {
             return Ok(stream);
         }
 
-        let request_id = self.next_stream_request_id();
-        let receiver = self
-            .stream_router
-            .register(request_id, STREAM_RECEIVER_BUFFER);
-
-        let req_payload = RangeReadStreamRequestPayload {
-            request_id,
-            keyspace: table_id.keyspace.clone(),
-            table: table_id.table.clone(),
-            projected_regular_ordinals: projected_regular_ordinals.clone(),
-            start_key: None,
-        };
-        let req_body = Bytes::from(bincode::serialize(&req_payload).map_err(|e| {
-            ClusterError::Internal(format!("streaming range read: encode request: {e}"))
-        })?);
-
         let (host_id, _addr) = remotes.first().ok_or_else(|| {
             ClusterError::Internal("streaming range read: missing remote replica".into())
         })?;
-        if let Err(e) = self
-            .peer_manager
-            .fire(
+        // Windowed continuation applies to the unbounded fragment-merged shape
+        // (`row_limit == 0`). The `row_limit > 0` shape targets bounded
+        // specific partitions (LIMIT with partition-key equality), whose
+        // result fits well inside one window — keep it unwindowed so the
+        // whole-partition merge sees the legacy single-request fragmenting.
+        let window_chunks = if row_limit == 0 {
+            STREAM_WINDOW_CHUNKS
+        } else {
+            0
+        };
+        let remote_stream = self
+            .spawn_replica_fragment_stream(
+                table_id,
                 *host_id,
-                Message::RangeReadStreamRequest(req_body),
-                Lane::Bulk,
+                projected_regular_ordinals.as_deref(),
+                None,
+                window_chunks,
             )
             .await
-        {
-            self.stream_router.unregister(request_id);
-            return Err(ClusterError::Internal(format!(
-                "streaming range read: remote replica fire failed ({host_id}): {e}"
-            )));
-        }
-
-        let (remote_tx, remote_rx) = mpsc::channel(STREAM_RECEIVER_BUFFER);
-        let router = self.stream_router.clone();
-        TaskPool::current("range-read-forward").spawn(async move {
-            forward_remote_range_stream(receiver, request_id, 1, remote_tx).await;
-            router.unregister(request_id);
-        });
+            .map_err(|e| {
+                ClusterError::Internal(format!(
+                    "streaming range read: remote replica fire failed ({host_id}): {e}"
+                ))
+            })?;
 
         let (out_tx, out_rx) = mpsc::channel(STREAM_RECEIVER_BUFFER);
         let storage = self.storage.clone();
@@ -1595,7 +1745,7 @@ impl ClusterCoordinator {
                 table_id,
                 row_limit,
                 projected_regular_ordinals,
-                remote_rx,
+                remote_stream,
                 out_tx,
             )
             .await;
@@ -1757,6 +1907,7 @@ mod tests {
             request_id: 42,
             total_chunks: 0,
             truncated: true,
+            resume: None,
         };
         frame_tx
             .send(Message::RangeReadStreamDone(bytes::Bytes::from(

--- a/ferrosa-cluster/src/coordinator/range_read_stream.rs
+++ b/ferrosa-cluster/src/coordinator/range_read_stream.rs
@@ -84,6 +84,44 @@ const _: () = assert!(
     "a full producer window plus its Done must fit in the route buffer"
 );
 
+/// Diagnostic counters for the windowed multi-replica forwarder. A steady-state
+/// non-zero `forwarder_error_send_dropped` or `forwarder_abandoned_with_resume`
+/// on a healthy full-drain scan is the signature of the silent-partial bug
+/// (t_a0f922a3 bug #2): a source dropped out mid-scan and its failure was not
+/// delivered to the consumer, so the scan looked complete while rows remained.
+///
+/// Always compiled (not test-gated) so a live deploy can assert on them via the
+/// same counters an integration harness reads.
+pub mod forwarder_diag {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    pub(super) static ERROR_SEND_DROPPED: AtomicU64 = AtomicU64::new(0);
+    pub(super) static CONTINUATIONS_FIRED: AtomicU64 = AtomicU64::new(0);
+
+    /// Count of times a per-replica forwarder produced a loud error
+    /// (idle timeout / closed-before-Done / decode) but could NOT deliver it to
+    /// the consumer because the merged output was already gone. Each such event
+    /// is a place a scan could silently look complete while a replica had more
+    /// data — it MUST stay 0 on a full-drain scan.
+    pub fn error_send_dropped() -> u64 {
+        ERROR_SEND_DROPPED.load(Ordering::Relaxed)
+    }
+
+    /// Count of window continuations fired across all replica forwarders. Used
+    /// by tests to prove the many-window regime is actually exercised.
+    pub fn continuations_fired() -> u64 {
+        CONTINUATIONS_FIRED.load(Ordering::Relaxed)
+    }
+
+    /// Reset both counters. Test-only entry point (a live deploy reads
+    /// monotonic counters); kept un-gated so integration tests in a separate
+    /// crate can call it.
+    pub fn reset() {
+        ERROR_SEND_DROPPED.store(0, Ordering::Relaxed);
+        CONTINUATIONS_FIRED.store(0, Ordering::Relaxed);
+    }
+}
+
 pub type ClusterPartitionStream =
     Pin<Box<dyn Stream<Item = crate::error::Result<Partition>> + Send>>;
 
@@ -340,7 +378,15 @@ async fn forward_remote_range_stream(
     match forward_remote_range_stream_inner(receiver, request_id, expected_done, tx.clone()).await {
         Ok(outcome) => outcome,
         Err(err) => {
-            let _ = tx.send(next_remote_error(err)).await;
+            if tx.send(next_remote_error(err)).await.is_err() {
+                // The consumer already dropped the merged output, so this loud
+                // error was discarded. If the consumer abandoned deliberately
+                // (paged read filled its page) this is benign; on a full drain
+                // it means a replica's failure vanished — the silent-partial
+                // signature. Counted so tests + live metrics can catch it.
+                forwarder_diag::ERROR_SEND_DROPPED
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
             ForwardOutcome::Failed
         }
     }
@@ -1088,6 +1134,15 @@ struct WindowedReplicaForwarder {
     table: String,
     wanted: Option<Vec<u16>>,
     window_chunks: u32,
+    /// Set true ONLY when this replica's logical stream ends for a reason that
+    /// makes a silent `remote_tx` close SAFE for the merge to read as "this
+    /// source is done": either the producer signalled genuine exhaustion
+    /// (`Completed { resume: None }`) or the consumer deliberately abandoned the
+    /// merged output (a paged read filled its page). Any OTHER termination
+    /// leaves this false, and the source's stream wrapper turns the resulting
+    /// channel close into a LOUD error rather than letting the merge conclude
+    /// the scan is complete while rows may remain (t_a0f922a3 bug #2, fail-loud).
+    clean_end: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl WindowedReplicaForwarder {
@@ -1127,28 +1182,55 @@ impl WindowedReplicaForwarder {
             self.router.unregister(request_id);
 
             let resume = match outcome {
-                ForwardOutcome::Completed { resume: None } => return, // scan complete
+                // The ONLY clean end-of-this-replica signal: the producer's Done
+                // carried no resume position, so this replica's local range is
+                // genuinely exhausted. Mark the clean-end flag so the source's
+                // stream wrapper lets the merge read the coming `remote_tx` close
+                // as "this source is done".
+                ForwardOutcome::Completed { resume: None } => {
+                    self.clean_end
+                        .store(true, std::sync::atomic::Ordering::Release);
+                    return; // scan complete for this replica
+                }
                 ForwardOutcome::Completed {
                     resume: Some(resume),
                 } => resume,
-                // Anything but a clean Done means the remote producer may
-                // still be streaming for nobody — tell it to stop. Fired from
-                // THIS live async task (not a Drop guard: the reverted
-                // 3ec30240 guard never actually sent a cancel on the live
-                // cluster), so the fire is a plain awaited call that either
-                // succeeds or logs loudly.
-                other => {
-                    fire_stream_cancel(&self.peers, self.host_id, request_id, other).await;
+                // Failed: `forward_remote_range_stream` already delivered a loud
+                // error to the consumer (or discarded + counted it because the
+                // consumer had already gone). Either way the consumer saw the
+                // failure or is not waiting; the close is NOT a clean end, so
+                // leave `clean_end` false — the wrapper's fallback error only
+                // fires if no error reached the consumer. Cancel the producer.
+                ForwardOutcome::Failed => {
+                    fire_stream_cancel(&self.peers, self.host_id, request_id, outcome).await;
+                    return;
+                }
+                // Abandoned: the consumer dropped the merged output on purpose (a
+                // paged read filled its page). Completeness of THIS scan is no
+                // longer the source's concern — mark clean-end so the wrapper
+                // does not manufacture a spurious error, then cancel the
+                // producer.
+                ForwardOutcome::Abandoned => {
+                    self.clean_end
+                        .store(true, std::sync::atomic::Ordering::Release);
+                    fire_stream_cancel(&self.peers, self.host_id, request_id, outcome).await;
                     return;
                 }
             };
 
-            // Window boundary. Don't fire a continuation the consumer will
-            // never read (a paged read abandons the stream between pages).
+            // Window boundary with data still remaining (`resume: Some`). If the
+            // consumer has dropped the merged output the continuation would be
+            // read by nobody — deliberate abandon, mark clean-end and return.
+            // Otherwise we MUST fire the continuation: silently ending here would
+            // close `remote_tx` with data remaining, and the merge would read
+            // that as genuine exhaustion — a silent partial (t_a0f922a3 bug #2).
             if remote_tx.is_closed() {
+                self.clean_end
+                    .store(true, std::sync::atomic::Ordering::Release);
                 return;
             }
 
+            forwarder_diag::CONTINUATIONS_FIRED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             request_id = self
                 .next_request_id
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1190,6 +1272,47 @@ impl WindowedReplicaForwarder {
     }
 }
 
+/// Wrap a per-replica forwarder's `remote_rx` so the N-way merge can only read a
+/// stream end as "this source is exhausted" when the forwarder set `clean_end`.
+///
+/// The merge concludes the whole scan is complete once every source's stream
+/// ends. A source stream ends when its `remote_tx` (all clones) drop. The
+/// forwarder sets `clean_end` exactly at the terminations where a silent close
+/// is CORRECT (producer signalled genuine exhaustion, or the consumer
+/// deliberately abandoned the page). Any OTHER close — a panicked forwarder
+/// task, or a future refactor that drops `remote_tx` without either delivering
+/// an error or setting the flag — would otherwise vanish into a silent partial.
+/// Here it becomes ONE final loud, retryable error so the scan FAILS loudly
+/// (t_a0f922a3 bug #2 / fail-loud rule). A forwarder that already delivered its
+/// own error item before dropping `remote_tx` (the `Failed` path) is unaffected:
+/// the merge sees that error first and this fallback never runs.
+fn clean_end_guarded_stream(
+    remote_rx: mpsc::Receiver<crate::error::Result<Partition>>,
+    clean_end: Arc<std::sync::atomic::AtomicBool>,
+    host_id: uuid::Uuid,
+) -> impl Stream<Item = crate::error::Result<Partition>> + Send {
+    futures::stream::unfold(
+        (remote_rx, clean_end, host_id, false),
+        |(mut rx, clean_end, host_id, emitted_error)| async move {
+            if emitted_error {
+                return None;
+            }
+            match rx.recv().await {
+                Some(item) => Some((item, (rx, clean_end, host_id, false))),
+                None if clean_end.load(std::sync::atomic::Ordering::Acquire) => None,
+                None => {
+                    let err = Err(ClusterError::Internal(format!(
+                        "streaming range read: replica {host_id} forwarder ended without a \
+                         clean terminal signal — failing the scan loudly rather than \
+                         returning a silent partial (t_a0f922a3 bug #2)"
+                    )));
+                    Some((err, (rx, clean_end, host_id, true)))
+                }
+            }
+        },
+    )
+}
+
 impl ClusterCoordinator {
     /// Fire the first window of one replica's fragment stream and spawn its
     /// windowed continuation forwarder. Returns the bounded, consumer-paced
@@ -1208,6 +1331,7 @@ impl ClusterCoordinator {
             .stream_router
             .register(request_id, STREAM_RECEIVER_BUFFER);
 
+        let clean_end = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let forwarder = WindowedReplicaForwarder {
             router: self.stream_router.clone(),
             peers: self.peer_manager.clone(),
@@ -1217,6 +1341,7 @@ impl ClusterCoordinator {
             table: table_id.table.clone(),
             wanted: projected_regular_ordinals.map(|w| w.to_vec()),
             window_chunks,
+            clean_end: clean_end.clone(),
         };
         let body = forwarder
             .encode_request(
@@ -1241,10 +1366,12 @@ impl ClusterCoordinator {
             forwarder.run(request_id, receiver, remote_tx).await;
         });
 
-        let stream = futures::stream::unfold(remote_rx, |mut rx| async move {
-            rx.recv().await.map(|item| (item, rx))
-        });
-        Ok(Box::pin(stream))
+        // Fail-loud terminal guard (t_a0f922a3 bug #2): the N-way merge treats a
+        // source's stream ending as "this replica is exhausted". That inference
+        // is only safe when the forwarder ended for a clean reason (`clean_end`).
+        Ok(Box::pin(clean_end_guarded_stream(
+            remote_rx, clean_end, host_id,
+        )))
     }
 
     async fn fan_out_remote_fragment_streams(
@@ -1921,6 +2048,75 @@ mod tests {
         assert!(
             result.is_err(),
             "truncated Done must fail the remote stream instead of being accepted as success"
+        );
+    }
+
+    /// t_a0f922a3 bug #2 (fail-loud guarantee): a per-replica source stream
+    /// whose forwarder drops `remote_tx` WITHOUT setting `clean_end` (a panicked
+    /// forwarder, or any close that neither delivered an error nor signalled
+    /// exhaustion) must surface a LOUD error to the merge — never a silent end
+    /// that the merge would read as "this replica is exhausted" (silent partial).
+    #[tokio::test]
+    async fn unclean_forwarder_close_yields_loud_error_not_silent_exhaustion() {
+        let (tx, rx) = mpsc::channel::<crate::error::Result<Partition>>(4);
+        let clean_end = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let host = uuid::Uuid::new_v4();
+
+        // One real partition, then drop the sender WITHOUT setting clean_end —
+        // models the forwarder task ending unexpectedly mid-scan.
+        tx.send(Ok(Partition {
+            key: dk(b"alpha"),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![trow(1, b"v", 1)],
+        }))
+        .await
+        .unwrap();
+        drop(tx);
+
+        let mut stream = Box::pin(clean_end_guarded_stream(rx, clean_end, host));
+        let first = stream.next().await.expect("first item");
+        assert!(first.is_ok(), "the real partition must pass through");
+        let terminal = stream
+            .next()
+            .await
+            .expect("an unclean close must yield a terminal item, not None");
+        assert!(
+            matches!(terminal, Err(ClusterError::Internal(_))),
+            "an unclean forwarder close must be a LOUD error, not silent exhaustion"
+        );
+        assert!(
+            stream.next().await.is_none(),
+            "after the one loud error the stream must end"
+        );
+    }
+
+    /// The mirror of the above: a forwarder that ended cleanly (`clean_end`
+    /// set) must close the source stream SILENTLY (`None`) so the merge reads it
+    /// as genuine exhaustion — no spurious error on a healthy scan.
+    #[tokio::test]
+    async fn clean_forwarder_close_ends_stream_without_error() {
+        let (tx, rx) = mpsc::channel::<crate::error::Result<Partition>>(4);
+        let clean_end = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let host = uuid::Uuid::new_v4();
+
+        tx.send(Ok(Partition {
+            key: dk(b"alpha"),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![trow(1, b"v", 1)],
+        }))
+        .await
+        .unwrap();
+        // Genuine exhaustion: set the flag before dropping the sender.
+        clean_end.store(true, std::sync::atomic::Ordering::Release);
+        drop(tx);
+
+        let mut stream = Box::pin(clean_end_guarded_stream(rx, clean_end, host));
+        assert!(stream.next().await.expect("first item").is_ok());
+        assert!(
+            stream.next().await.is_none(),
+            "a clean forwarder close must end the stream silently (genuine exhaustion)"
         );
     }
 

--- a/ferrosa-cluster/src/coordinator/stream_consumer.rs
+++ b/ferrosa-cluster/src/coordinator/stream_consumer.rs
@@ -430,6 +430,7 @@ mod tests {
             request_id: REQ_ID,
             total_chunks,
             truncated,
+            resume: None,
         };
         Message::RangeReadStreamDone(Bytes::from(bincode::serialize(&payload).unwrap()))
     }

--- a/ferrosa-cluster/src/coordinator/stream_frame_router.rs
+++ b/ferrosa-cluster/src/coordinator/stream_frame_router.rs
@@ -353,6 +353,26 @@ impl RpcHandler for StreamFrameRouter {
                 }
                 return None;
             }
+            Message::RangeReadStreamHeartbeat(bytes) => {
+                // Heartbeats are ADVISORY keep-alives: on a full consumer
+                // buffer they are dropped, never allowed to close the route —
+                // an undrained buffer means the consumer is mid-window, not
+                // idle, and losing a keep-alive there is harmless while
+                // closing the route would kill a healthy windowed stream.
+                match self
+                    .router
+                    .route_lossy(request_id, Message::RangeReadStreamHeartbeat(bytes))
+                {
+                    Ok(()) | Err(RouteError::NoRoute(_)) => {}
+                    Err(RouteError::ChannelClosed(id)) => {
+                        self.clear_request_state(id);
+                    }
+                    Err(RouteError::ChannelFull(_)) => {
+                        unreachable!("route_lossy never reports ChannelFull")
+                    }
+                }
+                None
+            }
             other => {
                 self.route_frame(request_id, msg_type, other);
                 None
@@ -418,6 +438,7 @@ mod tests {
             request_id: id,
             total_chunks,
             truncated: false,
+            resume: None,
         };
         Message::RangeReadStreamDone(Bytes::from(bincode::serialize(&payload).unwrap()))
     }

--- a/ferrosa-cluster/src/coordinator/stream_producer.rs
+++ b/ferrosa-cluster/src/coordinator/stream_producer.rs
@@ -101,6 +101,7 @@ pub async fn stream_range_response<S: ChunkSink>(
 
     let done = RangeReadStreamDonePayload {
         request_id: req.request_id,
+        resume: None,
         total_chunks: seq,
         truncated,
     };
@@ -176,6 +177,8 @@ mod tests {
             table: "tbl".into(),
             projected_regular_ordinals: None,
             start_key: None,
+            start_clustering: None,
+            max_chunks: 0,
         }
     }
 

--- a/ferrosa-cluster/src/coordinator/stream_request_handler.rs
+++ b/ferrosa-cluster/src/coordinator/stream_request_handler.rs
@@ -218,6 +218,14 @@ pub async fn handle_stream_request_with_cancel<R, S>(
     let mut batch_rows: usize = 0;
     let mut total_chunks_emitted: u32 = 0;
     let mut any_decode_error = false;
+    // Position after the last emitted row: (partition key, clustering of the
+    // last row in that partition emitted so far). Reported in `Done.resume`
+    // when the producer stops at its `max_chunks` window so the coordinator
+    // can continue the stream exactly one row past the boundary.
+    let mut last_pos: Option<(Vec<u8>, Vec<u8>)> = None;
+    // Flow-control window (t_a0f922a3 mode 2): `0` = unbounded.
+    let max_chunks = req.max_chunks;
+    let mut window_exhausted = false;
 
     'pull: loop {
         tokio::select! {
@@ -232,13 +240,41 @@ pub async fn handle_stream_request_with_cancel<R, S>(
             }
             next = stream.next() => match next {
                 Some(Ok(partition)) => {
+                    let partition = match resume_filter_rows(partition, &start_key, &req) {
+                        Some(p) => p,
+                        None => continue,
+                    };
                     batch_rows = batch_rows.saturating_add(partition.rows.len());
+                    let pk_bytes = partition.key.key.as_bytes();
+                    match partition.rows.last() {
+                        Some(last_row) => {
+                            last_pos = Some((pk_bytes.to_vec(), last_row.clustering.clone()));
+                        }
+                        None => {
+                            // Row-less fragment (header-only / fully suppressed):
+                            // keep the previous row position if it is in the same
+                            // partition; otherwise advance to (pk, []) so a window
+                            // continuation cannot rewind before this partition.
+                            if last_pos.as_ref().is_none_or(|(pk, _)| pk != pk_bytes) {
+                                last_pos = Some((pk_bytes.to_vec(), Vec::new()));
+                            }
+                        }
+                    }
                     batch.push(partition);
                     if batch.len() >= chunk_size || batch_rows >= row_chunk_cap {
                         emit_chunk(&req, &mut batch, chunk_seq, sink).await;
                         batch_rows = 0;
                         chunk_seq = chunk_seq.saturating_add(1);
                         total_chunks_emitted = total_chunks_emitted.saturating_add(1);
+                        if max_chunks > 0 && total_chunks_emitted >= max_chunks {
+                            // Window filled: stop scanning and report the resume
+                            // position. The coordinator fires a continuation
+                            // request once its consumer drains this window, so
+                            // un-drained frames per stream never exceed
+                            // `max_chunks` + 1 (Done) at the receiver.
+                            window_exhausted = true;
+                            break 'pull;
+                        }
                     }
                 }
                 Some(Err(e)) => {
@@ -272,16 +308,46 @@ pub async fn handle_stream_request_with_cancel<R, S>(
         total_chunks_emitted = total_chunks_emitted.saturating_add(1);
     }
 
-    // Terminator.
+    // Terminator. `resume` is set only when the window stopped the scan with
+    // (potentially) more data remaining; a continuation that finds nothing
+    // more terminates with `resume: None` on its own Done.
+    let resume = if window_exhausted {
+        let (partition_key, clustering) = last_pos.unwrap_or_default();
+        Some(crate::raft::handlers::StreamResumePositionWire {
+            partition_key,
+            clustering,
+        })
+    } else {
+        None
+    };
     let done = RangeReadStreamDonePayload {
         request_id: req.request_id,
         total_chunks: total_chunks_emitted,
         truncated: any_decode_error,
+        resume,
     };
     let bytes =
         bincode::serialize(&done).expect("RangeReadStreamDonePayload serialization is infallible");
     sink.send(Message::RangeReadStreamDone(Bytes::from(bytes)))
         .await;
+}
+
+/// Apply the within-partition resume filter (t_a0f922a3 mode 1): when the
+/// request carries `start_key` + `start_clustering`, drop every row of the
+/// start partition whose clustering bytes are `<=` the resume clustering —
+/// those rows were already delivered before the resume point. Fragments of
+/// other partitions pass through untouched. Returns `None` when the filtered
+/// fragment carries neither rows nor header state (nothing to ship).
+fn resume_filter_rows(
+    partition: Partition,
+    start_key: &Option<ferrosa_common::key::DecoratedKey>,
+    req: &RangeReadStreamRequestPayload,
+) -> Option<Partition> {
+    let (Some(resume_ck), Some(start)) = (req.start_clustering.as_deref(), start_key.as_ref())
+    else {
+        return Some(partition);
+    };
+    crate::write_path::filter_resumed_fragment(partition, start.key.as_bytes(), resume_ck)
 }
 
 /// Build a `RangeReadStreamChunk` from `batch`, send it via `sink`,
@@ -316,6 +382,7 @@ async fn send_truncated_done<S: ChunkSink>(req: &RangeReadStreamRequestPayload, 
         request_id: req.request_id,
         total_chunks: 0,
         truncated: true,
+        resume: None,
     };
     let bytes =
         bincode::serialize(&done).expect("RangeReadStreamDonePayload serialization is infallible");
@@ -501,6 +568,8 @@ mod tests {
             table: "tbl".into(),
             projected_regular_ordinals: None,
             start_key: None,
+            start_clustering: None,
+            max_chunks: 0,
         }
     }
 
@@ -560,6 +629,139 @@ mod tests {
             Some(Some(b"resume-key".to_vec())),
             "handler must forward the wire start_key to the reader as the range lower bound"
         );
+    }
+
+    fn clustered_row(ck: &[u8]) -> ferrosa_sstable::types::Row {
+        ferrosa_sstable::types::Row {
+            clustering: ck.to_vec(),
+            cells: vec![],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: ferrosa_sstable::types::LivenessInfo::with_timestamp(1),
+        }
+    }
+
+    fn clustered_partition(pk: &[u8], cks: &[&[u8]]) -> Partition {
+        Partition {
+            key: DecoratedKey::new(PartitionKey::new(pk.to_vec())),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: cks.iter().map(|ck| clustered_row(ck)).collect(),
+        }
+    }
+
+    fn decode_chunk(frame: &Message) -> RangeReadStreamChunkPayload {
+        let Message::RangeReadStreamChunk(b) = frame else {
+            panic!("expected chunk frame, got {frame:?}");
+        };
+        bincode::deserialize(b).unwrap()
+    }
+
+    fn decode_done(frame: &Message) -> RangeReadStreamDonePayload {
+        let Message::RangeReadStreamDone(b) = frame else {
+            panic!("expected Done frame, got {frame:?}");
+        };
+        bincode::deserialize(b).unwrap()
+    }
+
+    /// t_a0f922a3 mode 2: `max_chunks` caps the frames one request may emit.
+    /// 10 single-row partitions at chunk_size=1 with a window of 3 must emit
+    /// EXACTLY 3 chunks and a non-truncated Done whose `resume` carries the
+    /// position after the last emitted row — the producer must never
+    /// fire-hose the remaining 7 partitions into the coordinator's bounded
+    /// route buffer.
+    #[tokio::test]
+    async fn window_stops_after_max_chunks_and_reports_resume() {
+        let partitions: Vec<Partition> = (1u8..=10)
+            .map(|tag| clustered_partition(&[tag], &[b"ck-x"]))
+            .collect();
+        let reader = StaticReader { partitions };
+        let sink = VecSink::new();
+        let mut request = req(21);
+        request.max_chunks = 3;
+
+        handle_stream_request(request, Arc::new(reader), &sink, 1).await;
+
+        let frames = sink.take();
+        assert_eq!(
+            frames.len(),
+            4,
+            "3 window chunks + 1 Done — the window must stop the scan"
+        );
+        let done = decode_done(&frames[3]);
+        assert_eq!(done.total_chunks, 3);
+        assert!(!done.truncated, "a window stop is not a failure");
+        let resume = done
+            .resume
+            .expect("window stop with data remaining must report a resume position");
+        assert_eq!(resume.partition_key, vec![3u8]);
+        assert_eq!(resume.clustering, b"ck-x".to_vec());
+    }
+
+    /// A scan that finishes WITHIN its window terminates with `resume: None`
+    /// — the continuation loop must stop, not spin.
+    #[tokio::test]
+    async fn window_larger_than_scan_completes_without_resume() {
+        let partitions: Vec<Partition> = (1u8..=2)
+            .map(|tag| clustered_partition(&[tag], &[b"ck"]))
+            .collect();
+        let reader = StaticReader { partitions };
+        let sink = VecSink::new();
+        let mut request = req(22);
+        request.max_chunks = 16;
+
+        handle_stream_request(request, Arc::new(reader), &sink, 1).await;
+
+        let frames = sink.take();
+        let done = decode_done(frames.last().expect("terminator"));
+        assert!(
+            done.resume.is_none(),
+            "a completed scan must not report a resume position"
+        );
+    }
+
+    /// t_a0f922a3 mode 1: `start_clustering` resumes WITHIN the start
+    /// partition — rows with clustering `<=` the resume position must not be
+    /// re-streamed, rows after it must all arrive, and other partitions are
+    /// untouched.
+    #[tokio::test]
+    async fn start_clustering_skips_delivered_prefix_of_start_partition() {
+        let reader = StaticReader {
+            partitions: vec![
+                clustered_partition(b"A", &[b"ck-1", b"ck-2", b"ck-3", b"ck-4"]),
+                clustered_partition(b"B", &[b"ck-1"]),
+            ],
+        };
+        let sink = VecSink::new();
+        let mut request = req(23);
+        request.start_key = Some(b"A".to_vec());
+        request.start_clustering = Some(b"ck-2".to_vec());
+
+        handle_stream_request(request, Arc::new(reader), &sink, 8).await;
+
+        let frames = sink.take();
+        let chunk = decode_chunk(&frames[0]);
+        let rows_by_partition: Vec<(Vec<u8>, Vec<Vec<u8>>)> = chunk
+            .partitions
+            .iter()
+            .map(|p| {
+                (
+                    p.key_bytes.clone(),
+                    p.rows.iter().map(|r| r.clustering.clone()).collect(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            rows_by_partition,
+            vec![
+                (b"A".to_vec(), vec![b"ck-3".to_vec(), b"ck-4".to_vec()]),
+                (b"B".to_vec(), vec![b"ck-1".to_vec()]),
+            ],
+            "the start partition must resume strictly after the delivered \
+             prefix; later partitions must stream whole"
+        );
+        let done = decode_done(frames.last().expect("terminator"));
+        assert!(!done.truncated);
+        assert!(done.resume.is_none());
     }
 
     /// Test reader that always fails at open time — exercises the

--- a/ferrosa-cluster/src/coordinator/streaming_e2e_tests.rs
+++ b/ferrosa-cluster/src/coordinator/streaming_e2e_tests.rs
@@ -126,6 +126,8 @@ async fn end_to_end_single_replica_streams_all_partitions() {
         table: "tbl".into(),
         projected_regular_ordinals: None,
         start_key: None,
+        start_clustering: None,
+        max_chunks: 0,
     };
 
     // Producer runs concurrently with the consumer. In production
@@ -165,6 +167,8 @@ async fn end_to_end_two_replicas_aggregates_both_streams() {
         table: "tbl".into(),
         projected_regular_ordinals: None,
         start_key: None,
+        start_clustering: None,
+        max_chunks: 0,
     };
 
     let from_a: PeerId = (Uuid::from_u128(1), "127.0.0.1:7001".parse().unwrap());

--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -1181,6 +1181,42 @@ pub struct RangeReadStreamRequestPayload {
     /// predate this field (they decode it as `None`).
     #[serde(default)]
     pub start_key: Option<Vec<u8>>,
+    /// Within-partition resume position, paired with `start_key`: when
+    /// `Some(ck)`, the handler starts the scan AT `start_key` (inclusive) but
+    /// drops every row in that partition whose clustering bytes are `<= ck`,
+    /// so a resumed page of a WIDE partition does not re-stream the
+    /// already-delivered prefix over the wire (t_a0f922a3 mode 1). Ignored
+    /// when `start_key` is `None`.
+    ///
+    /// **bincode wire change** — upgrade all nodes together (same contract as
+    /// `FulltextSearchRequestPayload.limit`); a mixed-version peer fails the
+    /// decode loudly (truncated Done), never silently misreads.
+    #[serde(default)]
+    pub start_clustering: Option<Vec<u8>>,
+    /// Producer flow-control window (t_a0f922a3 mode 2). `0` = unbounded
+    /// (legacy behavior). When `> 0`, the handler stops after emitting this
+    /// many chunk frames and terminates with a `Done` whose
+    /// [`RangeReadStreamDonePayload::resume`] carries the position after the
+    /// last emitted row; the coordinator re-requests from there once its
+    /// consumer has drained the window. This bounds the number of un-drained
+    /// frames per stream at the coordinator to `max_chunks` (+1 Done), which
+    /// MUST be ≤ the coordinator's route buffer — without it the producer
+    /// fire-hoses the whole scan, overflows the bounded route, and the
+    /// fail-loud route close surfaces as a retryable ReadTimeout that live
+    /// drivers retry forever (the observed >14 min paged-scan stall).
+    #[serde(default)]
+    pub max_chunks: u32,
+}
+
+/// Position after the last row a windowed stream emitted: the partition key
+/// plus the raw clustering bytes of the last emitted row in it. A
+/// continuation request sets `start_key = partition_key` and
+/// `start_clustering = clustering` so the producer resumes exactly one row
+/// past the window boundary — no re-emit, no skip, even mid-wide-partition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamResumePositionWire {
+    pub partition_key: Vec<u8>,
+    pub clustering: Vec<u8>,
 }
 
 /// Handler → coordinator: one batch of partitions belonging to a
@@ -1227,6 +1263,14 @@ pub struct RangeReadStreamDonePayload {
     pub request_id: u32,
     pub total_chunks: u32,
     pub truncated: bool,
+    /// `Some` when the producer stopped at its
+    /// [`RangeReadStreamRequestPayload::max_chunks`] window with data still
+    /// remaining: the coordinator continues the logical stream by firing a
+    /// fresh request resuming after this position. `None` means the scan is
+    /// complete (or `truncated` reports a failure). **bincode wire change** —
+    /// upgrade all nodes together.
+    #[serde(default)]
+    pub resume: Option<StreamResumePositionWire>,
 }
 
 /// Coordinator → handler: abort a stream in-flight.
@@ -2159,6 +2203,8 @@ mod tests {
             table: "entity_store".into(),
             projected_regular_ordinals: None,
             start_key: Some(b"resume-here".to_vec()),
+            start_clustering: Some(b"resume-ck".to_vec()),
+            max_chunks: 16,
         };
         let encoded = bincode::serialize(&req).expect("encode request");
         let decoded: RangeReadStreamRequestPayload =
@@ -2197,6 +2243,10 @@ mod tests {
             request_id: 7,
             total_chunks: 12,
             truncated: false,
+            resume: Some(StreamResumePositionWire {
+                partition_key: b"pk".to_vec(),
+                clustering: b"ck".to_vec(),
+            }),
         };
         let encoded = bincode::serialize(&done).expect("encode done");
         let decoded: RangeReadStreamDonePayload =

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -46,6 +46,70 @@ pub const DEFAULT_RANGE_READ_LIMIT: usize = 10_000;
 pub type PartitionResultStream =
     Pin<Box<dyn Stream<Item = crate::error::Result<Partition>> + Send>>;
 
+/// Resume position for a paged streaming scan (t_a0f922a3).
+///
+/// `key` is the partition the previous page stopped in (INCLUSIVE lower
+/// bound). `clustering`, when `Some`, is the raw clustering bytes of the last
+/// row already delivered in that partition: every producer (local iterator
+/// wrapper and each remote replica) drops rows of `key`'s partition whose
+/// clustering is `<=` it, so a resumed page of a WIDE partition re-streams
+/// neither over the wire nor into the merge. The CQL paging collector still
+/// applies the same skip on top (idempotent — both sides compare the same raw
+/// clustering bytes), so an off-by-one can never drop or duplicate rows.
+#[derive(Debug, Clone)]
+pub struct ScanResume {
+    pub key: DecoratedKey,
+    pub clustering: Option<Vec<u8>>,
+}
+
+/// Apply the within-partition resume filter to one streamed fragment: drop
+/// every row of the resume partition whose clustering bytes are `<=` the
+/// resume clustering. Fragments of other partitions pass through untouched.
+/// Returns `None` when the filtered fragment carries neither rows nor header
+/// state (nothing left to deliver).
+pub fn filter_resumed_fragment(
+    mut partition: Partition,
+    resume_key: &[u8],
+    resume_clustering: &[u8],
+) -> Option<Partition> {
+    if partition.key.key.as_bytes() != resume_key {
+        return Some(partition);
+    }
+    partition
+        .rows
+        .retain(|row| row.clustering.as_slice() > resume_clustering);
+    let carries_header = partition.static_row.is_some()
+        || partition.deletion != ferrosa_sstable::types::DeletionTime::LIVE;
+    if partition.rows.is_empty() && !carries_header {
+        return None;
+    }
+    Some(partition)
+}
+
+/// Wrap a fragmented partition stream with the within-partition resume skip
+/// (see [`filter_resumed_fragment`]). No-op when the resume carries no
+/// clustering position.
+pub(crate) fn resume_filtered_stream(
+    stream: PartitionResultStream,
+    resume: Option<&ScanResume>,
+) -> PartitionResultStream {
+    let Some(resume) = resume else { return stream };
+    let Some(clustering) = resume.clustering.clone() else {
+        return stream;
+    };
+    let key = resume.key.key.as_bytes().to_vec();
+    Box::pin(stream.filter_map(move |item| {
+        let key = key.clone();
+        let clustering = clustering.clone();
+        async move {
+            match item {
+                Ok(p) => filter_resumed_fragment(p, &key, &clustering).map(Ok),
+                Err(e) => Some(Err(e)),
+            }
+        }
+    }))
+}
+
 fn local_range_stream(
     engine: Arc<StorageEngine>,
     table_id: &TableId,
@@ -62,31 +126,32 @@ fn local_range_stream(
 }
 
 /// Fragmented (intra-partition streaming) range stream with an optional
-/// inclusive lower-bound key. Used by the coordinator-side paging cursor to
-/// resume an unbounded `SELECT *` scan at the last partition key without
-/// materializing the whole table. `row_limit == 0` (the unbounded scan shape)
-/// is the only caller, so wide partitions stream as bounded fragments.
+/// resume position. Used by the coordinator-side paging cursor to resume an
+/// unbounded `SELECT *` scan at the last partition key (and, for a wide
+/// partition, the last delivered clustering position) without materializing
+/// the whole table. `row_limit == 0` (the unbounded scan shape) is the only
+/// caller, so wide partitions stream as bounded fragments.
 fn local_range_stream_from(
     engine: Arc<StorageEngine>,
     table_id: &TableId,
-    start: Option<&DecoratedKey>,
+    resume: Option<&ScanResume>,
 ) -> PartitionResultStream {
     let stream = engine
-        .range_iter_fragmented(table_id, start, None)
+        .range_iter_fragmented(table_id, resume.map(|r| &r.key), None)
         .map(|item| item.map_err(crate::error::ClusterError::Storage));
-    Box::pin(stream)
+    resume_filtered_stream(Box::pin(stream), resume)
 }
 
 fn local_projected_range_stream_from(
     engine: Arc<StorageEngine>,
     table_id: &TableId,
     wanted: Vec<u16>,
-    start: Option<&DecoratedKey>,
+    resume: Option<&ScanResume>,
 ) -> PartitionResultStream {
     let stream = engine
-        .range_iter_projected_fragmented(table_id, wanted, start, None)
+        .range_iter_projected_fragmented(table_id, wanted, resume.map(|r| &r.key), None)
         .map(|item| item.map_err(crate::error::ClusterError::Storage));
-    Box::pin(stream)
+    resume_filtered_stream(Box::pin(stream), resume)
 }
 
 fn local_projected_range_stream(
@@ -510,32 +575,34 @@ impl WritePath {
         }
     }
 
-    /// Stream every partition starting at an inclusive lower-bound key, using
-    /// the fragmented (intra-partition streaming) iterators.
+    /// Stream every partition starting at a resume position, using the
+    /// fragmented (intra-partition streaming) iterators.
     ///
     /// This backs the coordinator-side paging cursor for unbounded `SELECT *`
-    /// scans: the previous page's continuation token is decoded into a `start`
-    /// key, the scan resumes there, and the consumer drops rows already emitted
-    /// within that partition. `start == None` is the first page.
+    /// scans: the previous page's continuation token is decoded into a
+    /// [`ScanResume`] — the last partition key (inclusive) plus the last
+    /// delivered clustering position within it — the scan resumes there, and
+    /// every producer drops the already-emitted prefix of that partition.
+    /// `resume == None` is the first page.
     ///
     /// In cluster mode the local-only fan-out (CL=ONE with the keyspace RF
     /// spanning the ring) streams the local fragmented iterator directly; a
-    /// multi-replica shape fans out a start-bounded fragment stream to each
+    /// multi-replica shape fans out a resume-bounded fragment stream to each
     /// CL-selected replica and merges them with the local stream through the
-    /// coordinator's token-aware N-way fragment merge. The resume key is shipped
-    /// to every replica so a resumed page never re-streams the already-emitted
-    /// prefix.
+    /// coordinator's token-aware N-way fragment merge. The resume position is
+    /// shipped to every replica so a resumed page never re-streams the
+    /// already-emitted prefix over the wire — including mid-wide-partition.
     pub async fn range_read_stream_all_from(
         &self,
         table_id: &TableId,
-        start: Option<&DecoratedKey>,
+        resume: Option<&ScanResume>,
         cl: ConsistencyLevel,
         strategy: &ReplicationStrategy,
     ) -> crate::error::Result<PartitionResultStream> {
         match self {
-            Self::Direct(engine) => Ok(local_range_stream_from(engine.clone(), table_id, start)),
+            Self::Direct(engine) => Ok(local_range_stream_from(engine.clone(), table_id, resume)),
             Self::Pair(coordinator) | Self::DegradedPair(coordinator) => Ok(
-                local_range_stream_from(coordinator.local_storage().clone(), table_id, start),
+                local_range_stream_from(coordinator.local_storage().clone(), table_id, resume),
             ),
             Self::Cluster(coordinator) => {
                 if !coordinator.streaming_range_reads {
@@ -546,7 +613,7 @@ impl WritePath {
                 coordinator
                     .coordinate_range_read_stream_from(
                         table_id,
-                        start,
+                        resume,
                         cl,
                         strategy.replication_factor(),
                     )
@@ -558,15 +625,15 @@ impl WritePath {
         }
     }
 
-    /// Projection-aware resume-capable streaming range read with an inclusive
-    /// lower-bound key. Mirrors [`Self::range_read_stream_all_from`] for the
-    /// `SELECT col1, col2 FROM t` (no WHERE) paged scan shape, byte-skipping
-    /// unprojected cells in the SSTable layer.
+    /// Projection-aware resume-capable streaming range read. Mirrors
+    /// [`Self::range_read_stream_all_from`] for the `SELECT col1, col2 FROM t`
+    /// (no WHERE) paged scan shape, byte-skipping unprojected cells in the
+    /// SSTable layer.
     pub async fn range_read_projected_stream_all_from(
         &self,
         table_id: &TableId,
         wanted: Vec<u16>,
-        start: Option<&DecoratedKey>,
+        resume: Option<&ScanResume>,
         cl: ConsistencyLevel,
         strategy: &ReplicationStrategy,
     ) -> crate::error::Result<PartitionResultStream> {
@@ -575,14 +642,14 @@ impl WritePath {
                 engine.clone(),
                 table_id,
                 wanted,
-                start,
+                resume,
             )),
             Self::Pair(coordinator) | Self::DegradedPair(coordinator) => {
                 Ok(local_projected_range_stream_from(
                     coordinator.local_storage().clone(),
                     table_id,
                     wanted,
-                    start,
+                    resume,
                 ))
             }
             Self::Cluster(coordinator) => {
@@ -595,7 +662,7 @@ impl WritePath {
                     .coordinate_range_read_projected_stream_from(
                         table_id,
                         wanted,
-                        start,
+                        resume,
                         cl,
                         strategy.replication_factor(),
                     )

--- a/ferrosa-cluster/tests/range_scan_multi_replica_paging.rs
+++ b/ferrosa-cluster/tests/range_scan_multi_replica_paging.rs
@@ -69,6 +69,11 @@ use ferrosa_net::rpc::server::RpcServer;
 
 const KS: &str = "test_ks";
 const TBL: &str = "test_tbl";
+/// Clustered table for the wide-partition paging tests. Registered with a
+/// real clustering column — the SSTable serialization header takes its
+/// clustering component list from the schema, so rows written with clustering
+/// bytes against a clustering-less schema would silently lose them on flush.
+const TBL_WIDE: &str = "test_wide";
 
 struct NoopListener;
 impl PeerEventListener for NoopListener {
@@ -122,6 +127,22 @@ fn engine(dir: &std::path::Path) -> Arc<StorageEngine> {
         extensions: Default::default(),
     };
     engine.register_table(schema).unwrap();
+    let wide_schema = TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL_WIDE.to_string(),
+        key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        clustering_columns: vec![ColumnDefinition {
+            name: "ck".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        }],
+        static_columns: vec![],
+        regular_columns: vec![ColumnDefinition {
+            name: "v0".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        }],
+        extensions: Default::default(),
+    };
+    engine.register_table(wide_schema).unwrap();
     engine
 }
 
@@ -439,6 +460,329 @@ fn multi_replica_paged_projected_scan_cancels_abandoned_producers() {
     });
 }
 
+/// One clustered row for the wide-partition tests: clustering bytes are
+/// byte-ordered (`ck-%06d`), matching the storage layer's raw-byte clustering
+/// order, with one projected cell.
+fn wide_row(j: usize) -> Row {
+    Row {
+        clustering: format!("ck-{j:06}").into_bytes(),
+        cells: vec![(0, CellValue::live(format!("v-{j}").into_bytes(), 1000))],
+        deletion: DeletionTime::LIVE,
+        primary_key_liveness: LivenessInfo::with_timestamp(1000),
+    }
+}
+
+/// Seed `pks.len()` WIDE partitions of `rows_per` clustered rows each, then
+/// flush so the scan is SSTable-backed (the live `typed_edges` shape: a
+/// handful of huge partitions).
+fn seed_wide(engine: &StorageEngine, pks: &[&str], rows_per: usize) {
+    let table_id = TableId::new(KS, TBL_WIDE);
+    for pk in pks {
+        let dk = DecoratedKey::new(PartitionKey::new(pk.as_bytes().to_vec()));
+        for j in 0..rows_per {
+            engine.write(&table_id, &dk, wide_row(j), 1000).unwrap();
+        }
+    }
+    engine.flush(&table_id).unwrap();
+}
+
+/// Fully-wired 3-node loopback cluster (coordinator + 2 storage replicas) for
+/// paged-scan tests. Every node is seeded identically via `seed` (RF=3 —
+/// every replica owns the whole ring).
+struct LoopbackCluster {
+    wp: WritePath,
+    frame_router: Arc<StreamFrameRouter>,
+    srv2: Arc<RpcServer>,
+    srv3: Arc<RpcServer>,
+    coord_srv: Arc<RpcServer>,
+    _dirs: Vec<tempfile::TempDir>,
+}
+
+impl LoopbackCluster {
+    async fn shutdown(self) {
+        self.srv2.shutdown(Duration::from_millis(50)).await;
+        self.srv3.shutdown(Duration::from_millis(50)).await;
+        self.coord_srv.shutdown(Duration::from_millis(50)).await;
+    }
+}
+
+async fn build_loopback_cluster(seed: &dyn Fn(&StorageEngine)) -> LoopbackCluster {
+    let dir_local = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+    let dir3 = tempfile::tempdir().unwrap();
+
+    let storage = engine(dir_local.path());
+    seed(&storage);
+
+    let coord_id = uuid::Uuid::new_v4();
+    let r2_id = uuid::Uuid::new_v4();
+    let r3_id = uuid::Uuid::new_v4();
+
+    let (srv2, addr2, back2) = spawn_storage_replica_seeded(r2_id, dir2.path(), seed).await;
+    let (srv3, addr3, back3) = spawn_storage_replica_seeded(r3_id, dir3.path(), seed).await;
+
+    let mut ring = TokenRing::new();
+    ring.add_node(1, ring_node(coord_id, "127.0.0.1:1"));
+    ring.add_node(2, ring_node(r2_id, &addr2.to_string()));
+    ring.add_node(3, ring_node(r3_id, &addr3.to_string()));
+    ring.assign_tokens(1, &[i64::MIN]);
+    ring.assign_tokens(2, &[0]);
+    ring.assign_tokens(3, &[i64::MAX]);
+
+    let peers = Arc::new(PeerManager::new(
+        Arc::new(net_config()),
+        coord_id,
+        Arc::new(NoopListener),
+    ));
+    peers.ensure_peer(r2_id, &addr2.to_string()).await.unwrap();
+    peers.ensure_peer(r3_id, &addr3.to_string()).await.unwrap();
+
+    let coordinator = Arc::new(ClusterCoordinator::new(
+        Arc::new(ArcSwap::from_pointee(ring)),
+        peers,
+        1,
+        storage,
+        3,
+        ConsistencyLevel::All,
+    ));
+
+    let frame_router = Arc::new(StreamFrameRouter::new(coordinator.stream_router()));
+    let registry = Arc::new(HandlerRegistry::new());
+    registry.register(MsgType::RangeReadStreamChunk, frame_router.clone());
+    registry.register(MsgType::RangeReadStreamHeartbeat, frame_router.clone());
+    registry.register(MsgType::RangeReadStreamDone, frame_router.clone());
+    let coord_srv = Arc::new(RpcServer::new(net_config(), coord_id, registry));
+    let coord_addr = coord_srv.start_and_get_addr().await.unwrap();
+    back2
+        .ensure_peer(coord_id, &coord_addr.to_string())
+        .await
+        .unwrap();
+    back3
+        .ensure_peer(coord_id, &coord_addr.to_string())
+        .await
+        .unwrap();
+
+    LoopbackCluster {
+        wp: WritePath::cluster(coordinator),
+        frame_router,
+        srv2,
+        srv3,
+        coord_srv,
+        _dirs: vec![dir_local, dir2, dir3],
+    }
+}
+
+/// Page a coordinated projected scan to completion using EXACTLY the CQL
+/// collector's cursor semantics (`collect_page_from_partition_stream`):
+///
+/// * a page collects up to `page_rows` clustered ROWS (not partitions);
+/// * the continuation cursor is `(partition key bytes, clustering bytes)` of
+///   the last accepted row, taken only when one MORE row proves a
+///   continuation is needed;
+/// * resume re-opens the scan at the cursor's partition key (INCLUSIVE lower
+///   bound) and skips rows in that partition whose clustering is `<=` the
+///   cursor clustering.
+///
+/// Returns every accepted `(pk, clustering)` in delivery order. Hard
+/// timeouts: a stalled pull or a non-terminating cursor FAILS the test.
+async fn page_rows_like_cql_collector(
+    wp: &WritePath,
+    table_id: &TableId,
+    strategy: &ReplicationStrategy,
+    page_rows: usize,
+    max_pages: usize,
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut out: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut cursor: Option<(Vec<u8>, Vec<u8>)> = None;
+    let mut pages = 0usize;
+
+    loop {
+        pages += 1;
+        assert!(
+            pages <= max_pages,
+            "paged scan did not terminate within {max_pages} pages — the \
+             paging cursor is cycling instead of advancing (t_a0f922a3 mode 1); \
+             delivered {} rows so far",
+            out.len()
+        );
+
+        let start = cursor
+            .as_ref()
+            .map(|(pk, ck)| ferrosa_cluster::write_path::ScanResume {
+                key: DecoratedKey::new(PartitionKey::new(pk.clone())),
+                clustering: Some(ck.clone()),
+            });
+        let mut stream = tokio::time::timeout(
+            Duration::from_secs(30),
+            wp.range_read_projected_stream_all_from(
+                table_id,
+                vec![0],
+                start.as_ref(),
+                ConsistencyLevel::All,
+                strategy,
+            ),
+        )
+        .await
+        .expect("opening a page stream must not hang (t_a0f922a3 mode 2)")
+        .expect("multi-replica projected paged scan must not refuse");
+
+        let mut accepted = 0usize;
+        let mut more = false;
+        let mut page_cursor: Option<(Vec<u8>, Vec<u8>)> = None;
+        'page: loop {
+            let Some(item) = tokio::time::timeout(Duration::from_secs(30), stream.next())
+                .await
+                .expect(
+                    "a page pull must not hang — a stall is never acceptable (t_a0f922a3 mode 2)",
+                )
+            else {
+                break; // stream exhausted — final page
+            };
+            let p = item.expect("partition");
+            let pk = p.key.key.as_bytes().to_vec();
+            for row in p.rows {
+                // Skip rows already returned on a previous page (the cursor
+                // partition is re-entered at partition start on resume).
+                if let Some((cpk, cck)) = cursor.as_ref() {
+                    if &pk == cpk && row.clustering.as_slice() <= cck.as_slice() {
+                        continue;
+                    }
+                }
+                if accepted == page_rows {
+                    more = true;
+                    break 'page;
+                }
+                out.push((pk.clone(), row.clustering.clone()));
+                page_cursor = Some((pk.clone(), row.clustering));
+                accepted += 1;
+            }
+        }
+        drop(stream); // abandon the fan-out exactly like the CQL collector
+
+        if !more {
+            return out;
+        }
+        cursor = page_cursor;
+    }
+}
+
+/// t_a0f922a3 mode 1 (CYCLE) on the REAL multi-replica path: wide partitions
+/// spanning multiple pages must page to completion with an exact union. The
+/// live 3-node cluster looped forever over ~10% of `typed_edges` (page starts
+/// repeating with period ~3, `has_more_pages` never false) — a handful of
+/// huge partitions, RF=3, paged projected scan.
+#[test]
+fn multi_replica_wide_partition_paged_scan_terminates_exactly() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        const ROWS_PER: usize = 4_000;
+        const PAGE_ROWS: usize = 1_500;
+        let pks: [&str; 3] = ["wpk-a", "wpk-b", "wpk-c"];
+
+        let cluster = build_loopback_cluster(&|storage| seed_wide(storage, &pks, ROWS_PER)).await;
+        let table_id = TableId::new(KS, TBL_WIDE);
+        let strategy = ReplicationStrategy::Simple {
+            replication_factor: 3,
+        };
+
+        let total = pks.len() * ROWS_PER;
+        let max_pages = total.div_ceil(PAGE_ROWS) + 2;
+        let delivered =
+            page_rows_like_cql_collector(&cluster.wp, &table_id, &strategy, PAGE_ROWS, max_pages)
+                .await;
+
+        let expected: std::collections::BTreeSet<(Vec<u8>, Vec<u8>)> = pks
+            .iter()
+            .flat_map(|pk| {
+                (0..ROWS_PER).map(|j| (pk.as_bytes().to_vec(), format!("ck-{j:06}").into_bytes()))
+            })
+            .collect();
+        let got: std::collections::BTreeSet<(Vec<u8>, Vec<u8>)> =
+            delivered.iter().cloned().collect();
+        assert_eq!(
+            got.len(),
+            delivered.len(),
+            "paged multi-replica wide-partition scan emitted duplicate rows"
+        );
+        assert_eq!(
+            got,
+            expected,
+            "paged multi-replica wide-partition scan must deliver every row \
+             exactly once (no gaps, no dupes); got {} of {}",
+            got.len(),
+            total
+        );
+
+        assert_eq!(
+            cluster.frame_router.route_closures(),
+            0,
+            "paging must not phantom-close stream routes (t_dc729b1d)"
+        );
+
+        cluster.shutdown().await;
+    });
+}
+
+/// t_a0f922a3 mode 2 (STALL) on the REAL multi-replica path: MANY SMALL
+/// partitions (the live `vfix.nums` shape — 15k single-row partitions), a
+/// no-LIMIT paged projected scan. Live, page 1 never returned (client
+/// blocked over 14 min, zero route closes). Every pull runs under a hard
+/// timeout so a stall FAILS; the union must be exact.
+#[test]
+fn multi_replica_many_small_partitions_paged_scan_completes() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        const N: usize = 15_000;
+        const PAGE_ROWS: usize = 5_000;
+
+        let cluster = build_loopback_cluster(&|storage| seed_local(storage, N)).await;
+        let table_id = TableId::new(KS, TBL);
+        let strategy = ReplicationStrategy::Simple {
+            replication_factor: 3,
+        };
+
+        let max_pages = N.div_ceil(PAGE_ROWS) + 2;
+        let delivered =
+            page_rows_like_cql_collector(&cluster.wp, &table_id, &strategy, PAGE_ROWS, max_pages)
+                .await;
+
+        let expected: std::collections::BTreeSet<Vec<u8>> =
+            (0..N).map(|i| format!("pk-{i:08}").into_bytes()).collect();
+        let got: std::collections::BTreeSet<Vec<u8>> =
+            delivered.iter().map(|(pk, _)| pk.clone()).collect();
+        assert_eq!(
+            got.len(),
+            delivered.len(),
+            "paged multi-replica small-partition scan emitted duplicate rows"
+        );
+        assert_eq!(
+            got,
+            expected,
+            "paged multi-replica small-partition scan must deliver every \
+             partition exactly once; got {} of {N}",
+            got.len()
+        );
+
+        assert_eq!(
+            cluster.frame_router.route_closures(),
+            0,
+            "paging must not phantom-close stream routes (t_dc729b1d)"
+        );
+
+        cluster.shutdown().await;
+    });
+}
+
 /// A replica node whose streaming range-read handler is backed by a REAL
 /// `StorageEngine` seeded with the full dataset (the production
 /// `StreamRangeReader for Arc<StorageEngine>` impl). Returns the server, its
@@ -448,8 +792,18 @@ async fn spawn_storage_replica(
     dir: &std::path::Path,
     n: usize,
 ) -> (Arc<RpcServer>, std::net::SocketAddr, Arc<PeerManager>) {
+    spawn_storage_replica_seeded(host_id, dir, &|storage| seed_local(storage, n)).await
+}
+
+/// [`spawn_storage_replica`] with an arbitrary seeding function, so tests can
+/// seed wide (multi-row) partitions and not just the single-row keyset.
+async fn spawn_storage_replica_seeded(
+    host_id: uuid::Uuid,
+    dir: &std::path::Path,
+    seed: &dyn Fn(&StorageEngine),
+) -> (Arc<RpcServer>, std::net::SocketAddr, Arc<PeerManager>) {
     let storage = engine(dir);
-    seed_local(&storage, n);
+    seed(&storage);
     let back = Arc::new(PeerManager::new(
         Arc::new(net_config()),
         host_id,
@@ -567,11 +921,17 @@ fn multi_replica_paged_projected_scan_returns_all_rows_across_pages() {
                 pages += 1;
                 assert!(pages <= N + 5, "paging did not terminate (runaway pages)");
 
+                let resume = start_key
+                    .as_ref()
+                    .map(|k| ferrosa_cluster::write_path::ScanResume {
+                        key: k.clone(),
+                        clustering: None,
+                    });
                 let mut stream = wp
                     .range_read_projected_stream_all_from(
                         &table_id,
                         vec![0],
-                        start_key.as_ref(),
+                        resume.as_ref(),
                         ConsistencyLevel::All,
                         &strategy,
                     )

--- a/ferrosa-cluster/tests/range_scan_multi_replica_paging.rs
+++ b/ferrosa-cluster/tests/range_scan_multi_replica_paging.rs
@@ -36,7 +36,7 @@
 //! under hard timeouts (a regression FAILS instead of wedging CI).
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
@@ -74,6 +74,23 @@ const TBL: &str = "test_tbl";
 /// clustering component list from the schema, so rows written with clustering
 /// bytes against a clustering-less schema would silently lose them on flush.
 const TBL_WIDE: &str = "test_wide";
+
+/// File-level serialization guard. Two tests in this binary mutate the process-
+/// global `FERROSA_RANGE_READ_ROWS_PER_FRAGMENT` env var to force a small
+/// fragment (and thus many stream windows). Cargo runs integration-test fns
+/// concurrently on threads in ONE process, so an env mutation in one test would
+/// corrupt the fragment size another test reads mid-scan. Every test in this
+/// file acquires this lock first, so they run serially and no test observes
+/// another's env mutation. (These are heavy loopback-cluster tests; serial
+/// execution is acceptable.) Poisoning is recovered — a panicking test still
+/// releases a usable lock for the next.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+fn serial_guard() -> MutexGuard<'static, ()> {
+    SERIAL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 struct NoopListener;
 impl PeerEventListener for NoopListener {
@@ -317,6 +334,7 @@ async fn wait_live_zero(live: &AtomicUsize) -> bool {
 
 #[test]
 fn multi_replica_paged_projected_scan_cancels_abandoned_producers() {
+    let _serial = serial_guard();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
         .enable_all()
@@ -572,6 +590,83 @@ async fn build_loopback_cluster(seed: &dyn Fn(&StorageEngine)) -> LoopbackCluste
     }
 }
 
+/// Like [`build_loopback_cluster`] but seeds each of the three replicas
+/// (coordinator-local, node2, node3) with a DIFFERENT partition subset — the
+/// production topology where a replica's local storage holds only its owned
+/// token ranges, NOT the whole keyset. The N-way merge must genuinely UNION
+/// across all three sources for the scan to be complete; a source dropping out
+/// mid-scan (a window-continuation that closes without a terminating Done) then
+/// deletes that source's remaining rows from the result — the silent partial.
+async fn build_loopback_cluster_split(
+    seed_local_fn: &dyn Fn(&StorageEngine),
+    seed_n2: &dyn Fn(&StorageEngine),
+    seed_n3: &dyn Fn(&StorageEngine),
+) -> LoopbackCluster {
+    let dir_local = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+    let dir3 = tempfile::tempdir().unwrap();
+
+    let storage = engine(dir_local.path());
+    seed_local_fn(&storage);
+
+    let coord_id = uuid::Uuid::new_v4();
+    let r2_id = uuid::Uuid::new_v4();
+    let r3_id = uuid::Uuid::new_v4();
+
+    let (srv2, addr2, back2) = spawn_storage_replica_seeded(r2_id, dir2.path(), seed_n2).await;
+    let (srv3, addr3, back3) = spawn_storage_replica_seeded(r3_id, dir3.path(), seed_n3).await;
+
+    let mut ring = TokenRing::new();
+    ring.add_node(1, ring_node(coord_id, "127.0.0.1:1"));
+    ring.add_node(2, ring_node(r2_id, &addr2.to_string()));
+    ring.add_node(3, ring_node(r3_id, &addr3.to_string()));
+    ring.assign_tokens(1, &[i64::MIN]);
+    ring.assign_tokens(2, &[0]);
+    ring.assign_tokens(3, &[i64::MAX]);
+
+    let peers = Arc::new(PeerManager::new(
+        Arc::new(net_config()),
+        coord_id,
+        Arc::new(NoopListener),
+    ));
+    peers.ensure_peer(r2_id, &addr2.to_string()).await.unwrap();
+    peers.ensure_peer(r3_id, &addr3.to_string()).await.unwrap();
+
+    let coordinator = Arc::new(ClusterCoordinator::new(
+        Arc::new(ArcSwap::from_pointee(ring)),
+        peers,
+        1,
+        storage,
+        3,
+        ConsistencyLevel::All,
+    ));
+
+    let frame_router = Arc::new(StreamFrameRouter::new(coordinator.stream_router()));
+    let registry = Arc::new(HandlerRegistry::new());
+    registry.register(MsgType::RangeReadStreamChunk, frame_router.clone());
+    registry.register(MsgType::RangeReadStreamHeartbeat, frame_router.clone());
+    registry.register(MsgType::RangeReadStreamDone, frame_router.clone());
+    let coord_srv = Arc::new(RpcServer::new(net_config(), coord_id, registry));
+    let coord_addr = coord_srv.start_and_get_addr().await.unwrap();
+    back2
+        .ensure_peer(coord_id, &coord_addr.to_string())
+        .await
+        .unwrap();
+    back3
+        .ensure_peer(coord_id, &coord_addr.to_string())
+        .await
+        .unwrap();
+
+    LoopbackCluster {
+        wp: WritePath::cluster(coordinator),
+        frame_router,
+        srv2,
+        srv3,
+        coord_srv,
+        _dirs: vec![dir_local, dir2, dir3],
+    }
+}
+
 /// Page a coordinated projected scan to completion using EXACTLY the CQL
 /// collector's cursor semantics (`collect_page_from_partition_stream`):
 ///
@@ -673,6 +768,7 @@ async fn page_rows_like_cql_collector(
 /// huge partitions, RF=3, paged projected scan.
 #[test]
 fn multi_replica_wide_partition_paged_scan_terminates_exactly() {
+    let _serial = serial_guard();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
         .enable_all()
@@ -735,6 +831,7 @@ fn multi_replica_wide_partition_paged_scan_terminates_exactly() {
 /// timeout so a stall FAILS; the union must be exact.
 #[test]
 fn multi_replica_many_small_partitions_paged_scan_completes() {
+    let _serial = serial_guard();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
         .enable_all()
@@ -781,6 +878,220 @@ fn multi_replica_many_small_partitions_paged_scan_completes() {
 
         cluster.shutdown().await;
     });
+}
+
+/// t_a0f922a3 bug #2 (SILENT PARTIAL / data loss) on the REAL multi-replica
+/// path, reproduced by forcing MANY windows PER PAGE.
+///
+/// The live `typed_edges` failure (COUNT=50807 intact) returned only 21160
+/// rows with `has_more_pages=FALSE` — the scan finished ~one big partition /
+/// token range then STOPPED, reporting complete. The prior harness tests all
+/// use the DEFAULT 4096-row fragment cap, so `STREAM_WINDOW_CHUNKS=16` windows
+/// each cover ~64k rows — a whole page fits in ONE window and the
+/// `WindowedReplicaForwarder` continuation loop barely runs. The live cluster
+/// had wide partitions and small effective windows, so the producer's
+/// per-window stream closed at partition/window boundaries MANY times per page.
+///
+/// This test pins `FERROSA_RANGE_READ_ROWS_PER_FRAGMENT=1` so every row is its
+/// own chunk: a 16-chunk window covers only ~16 rows, forcing ~250 window
+/// continuations across a 4000-row wide partition — the exact regime where a
+/// producer stream closing without a terminating Done silently truncates the
+/// scan. The union MUST be exact and `has_more` MUST stay true until true
+/// exhaustion; a premature short page is silent data loss.
+#[test]
+fn multi_replica_many_windows_per_page_scan_is_not_silently_truncated() {
+    // Serialize against every other test in this binary before mutating the
+    // process-global fragment-size env var (cargo runs test fns concurrently
+    // in one process).
+    let _serial = serial_guard();
+    // Force tiny windows: 1 row per fragment ⇒ 1 row per chunk ⇒ a 16-chunk
+    // window is ~16 rows, so a wide partition spans hundreds of windows and the
+    // continuation loop is exercised heavily.
+    std::env::set_var("FERROSA_RANGE_READ_ROWS_PER_FRAGMENT", "1");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        const ROWS_PER: usize = 4_000;
+        const PAGE_ROWS: usize = 1_500;
+        // Distinct partition keys land on DIFFERENT tokens, so the paged scan
+        // crosses partition boundaries mid-page and mid-window — the live shape.
+        let pks: [&str; 3] = ["wpk-a", "wpk-b", "wpk-c"];
+
+        let cluster = build_loopback_cluster(&|storage| seed_wide(storage, &pks, ROWS_PER)).await;
+        let table_id = TableId::new(KS, TBL_WIDE);
+        let strategy = ReplicationStrategy::Simple {
+            replication_factor: 3,
+        };
+
+        let total = pks.len() * ROWS_PER;
+        let max_pages = total.div_ceil(PAGE_ROWS) + 2;
+        let delivered =
+            page_rows_like_cql_collector(&cluster.wp, &table_id, &strategy, PAGE_ROWS, max_pages)
+                .await;
+
+        let expected: std::collections::BTreeSet<(Vec<u8>, Vec<u8>)> = pks
+            .iter()
+            .flat_map(|pk| {
+                (0..ROWS_PER).map(|j| (pk.as_bytes().to_vec(), format!("ck-{j:06}").into_bytes()))
+            })
+            .collect();
+        let got: std::collections::BTreeSet<(Vec<u8>, Vec<u8>)> =
+            delivered.iter().cloned().collect();
+        assert_eq!(
+            got.len(),
+            delivered.len(),
+            "paged scan emitted duplicate rows across many-window pages"
+        );
+        assert_eq!(
+            got,
+            expected,
+            "MANY-WINDOWS-PER-PAGE multi-replica scan silently truncated: \
+             delivered {} of {} rows. A window-boundary producer close that is \
+             read as scan-complete is silent data loss (t_a0f922a3 bug #2).",
+            got.len(),
+            total
+        );
+
+        assert_eq!(
+            cluster.frame_router.route_closures(),
+            0,
+            "many-window paging must not phantom-close stream routes (t_dc729b1d)"
+        );
+
+        cluster.shutdown().await;
+    });
+
+    std::env::remove_var("FERROSA_RANGE_READ_ROWS_PER_FRAGMENT");
+}
+
+/// Seed a chosen subset of wide partitions on one replica. Models the live
+/// topology where a replica's local storage holds only some partitions.
+fn seed_wide_pks(engine: &StorageEngine, pks: &[&str], rows_per: usize) {
+    seed_wide(engine, pks, rows_per);
+}
+
+/// t_a0f922a3 bug #2 (SILENT PARTIAL / data loss) with DISJOINT per-replica
+/// data AND many windows per page — the true live topology.
+///
+/// Each replica's local storage holds a DIFFERENT subset of the wide
+/// partitions (not the whole keyset), so the N-way merge must UNION across all
+/// three sources. With `FERROSA_RANGE_READ_ROWS_PER_FRAGMENT=1` a 16-chunk
+/// window spans ~16 rows, so every wide partition crosses hundreds of window
+/// boundaries per source. If ANY source's windowed continuation closes its
+/// stream without a terminating Done (or the coordinator reads such a close as
+/// "this replica is exhausted"), that source's remaining partitions vanish from
+/// the result and the scan reports has_more=false — exactly the live
+/// `COUNT=50807 but scan returns 21160, has_more=FALSE` signature.
+///
+/// The union MUST equal every seeded row across all replicas.
+#[test]
+fn multi_replica_disjoint_data_many_windows_scan_unions_completely() {
+    let _serial = serial_guard();
+    std::env::set_var("FERROSA_RANGE_READ_ROWS_PER_FRAGMENT", "1");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    ferrosa_cluster::coordinator::range_read_stream::forwarder_diag::reset();
+
+    rt.block_on(async move {
+        const ROWS_PER: usize = 3_000;
+        const PAGE_ROWS: usize = 900;
+        // Disjoint partition subsets per replica: local holds one BIG partition
+        // (the live "one big partition" that the scan reached before stopping),
+        // node2 + node3 each hold two further wide partitions. No replica holds
+        // the whole keyset, so completeness depends on every source streaming to
+        // true exhaustion across all its window boundaries.
+        let local_pks: [&str; 1] = ["wpk-local-big"];
+        let n2_pks: [&str; 2] = ["wpk-n2-a", "wpk-n2-b"];
+        let n3_pks: [&str; 2] = ["wpk-n3-a", "wpk-n3-b"];
+
+        let cluster = build_loopback_cluster_split(
+            &|s| seed_wide_pks(s, &local_pks, ROWS_PER),
+            &|s| seed_wide_pks(s, &n2_pks, ROWS_PER),
+            &|s| seed_wide_pks(s, &n3_pks, ROWS_PER),
+        )
+        .await;
+        let table_id = TableId::new(KS, TBL_WIDE);
+        let strategy = ReplicationStrategy::Simple {
+            replication_factor: 3,
+        };
+
+        let all_pks: Vec<&str> = local_pks
+            .iter()
+            .chain(n2_pks.iter())
+            .chain(n3_pks.iter())
+            .copied()
+            .collect();
+        let total = all_pks.len() * ROWS_PER;
+        let max_pages = total.div_ceil(PAGE_ROWS) + 4;
+        let delivered =
+            page_rows_like_cql_collector(&cluster.wp, &table_id, &strategy, PAGE_ROWS, max_pages)
+                .await;
+
+        let expected: std::collections::BTreeSet<(Vec<u8>, Vec<u8>)> = all_pks
+            .iter()
+            .flat_map(|pk| {
+                (0..ROWS_PER).map(|j| (pk.as_bytes().to_vec(), format!("ck-{j:06}").into_bytes()))
+            })
+            .collect();
+        let got: std::collections::BTreeSet<(Vec<u8>, Vec<u8>)> =
+            delivered.iter().cloned().collect();
+        assert_eq!(
+            got.len(),
+            delivered.len(),
+            "disjoint-data many-window scan emitted duplicate rows"
+        );
+        assert_eq!(
+            got,
+            expected,
+            "DISJOINT-DATA multi-replica scan SILENTLY TRUNCATED: delivered {} \
+             of {} rows with has_more=false. A source dropping out at a window \
+             boundary (stream closed without a terminating Done, read as \
+             replica-exhausted) is silent data loss (t_a0f922a3 bug #2).",
+            got.len(),
+            total
+        );
+
+        assert_eq!(
+            cluster.frame_router.route_closures(),
+            0,
+            "disjoint-data paging must not phantom-close stream routes"
+        );
+
+        // The regime must actually exercise many window continuations (tiny
+        // fragments ⇒ 16-chunk windows span ~16 rows over 3000-row partitions),
+        // otherwise this test proves nothing about the continuation path.
+        assert!(
+            ferrosa_cluster::coordinator::range_read_stream::forwarder_diag::continuations_fired()
+                > 0,
+            "the many-window regime must fire window continuations, else the \
+             silent-partial path is not under test"
+        );
+
+        cluster.shutdown().await;
+    });
+
+    // A loud replica error that could not be delivered to the consumer on a
+    // full-drain scan is the silent-partial signature — it must never happen
+    // when the scan pages to true completion.
+    assert_eq!(
+        ferrosa_cluster::coordinator::range_read_stream::forwarder_diag::error_send_dropped(),
+        0,
+        "a per-replica forwarder produced a loud error that was DISCARDED because \
+         the merged output was gone — a replica's failure vanished and the scan \
+         could look complete while rows remained (t_a0f922a3 bug #2)"
+    );
+
+    std::env::remove_var("FERROSA_RANGE_READ_ROWS_PER_FRAGMENT");
 }
 
 /// A replica node whose streaming range-read handler is backed by a REAL
@@ -837,6 +1148,7 @@ async fn spawn_storage_replica_seeded(
 /// page leaves in-flight straggler chunks behind.
 #[test]
 fn multi_replica_paged_projected_scan_returns_all_rows_across_pages() {
+    let _serial = serial_guard();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
         .enable_all()

--- a/ferrosa-cluster/tests/replica_scan_serialization_memory_bound.rs
+++ b/ferrosa-cluster/tests/replica_scan_serialization_memory_bound.rs
@@ -184,6 +184,8 @@ fn stream_request(request_id: u32) -> RangeReadStreamRequestPayload {
         table: TBL.to_string(),
         projected_regular_ordinals: None,
         start_key: None,
+        start_clustering: None,
+        max_chunks: 0,
     }
 }
 

--- a/ferrosa-cql/README.md
+++ b/ferrosa-cql/README.md
@@ -87,6 +87,21 @@ unaffected (see [Bridge re-export](#bridge-re-export-d10)).
   `mixed_wide_and_narrow_partitions_page_exactly`,
   `wide_partition_multi_text_clustering_pages_exactly_after_flush`,
   `many_small_partitions_pk_projection_pages_without_stalling`.
+  **Wire ingress (`connection.rs`, `decode_query_params`)** — the QUERY/EXECUTE
+  `<query_parameters>` section (§4.1.4) is decoded IN ORDER — flags → values →
+  `page_size` (flag 0x04) → `paging_state` (flag 0x08) — into `PagingParams`,
+  which `build_request_context` threads onto every `RequestContext`. Before the
+  t_a0f922a3 LIVE fix these two fields were never parsed: the handlers built
+  `PagingParams::default()`, so a driver's `fetch_size` resolved to the server
+  default page and the client-echoed cursor was dropped — every page re-served
+  page 1 (`has_more` stuck True) regardless of a correct router/coordinator
+  paging path. The regression is pinned end-to-end WITHOUT hand-building
+  `ctx.paging`: `live_wire_paged_scan_advances_and_terminates_exactly` serializes
+  `fetch_size` + the echoed cursor to real wire bytes and re-derives them through
+  `decode_query_paging` on every page (3×5000-row clustered table, projected
+  `SELECT pk, ck`), asserting each page ≤ fetch_size, strict advance, exact
+  15k-row union, and `has_more=false` at exhaustion — plus `query_params_decode_*`
+  unit tests over the raw v4/v5 payloads.
 - **LWT / transactions** (`accord_router.rs`, `transaction_keys.rs`,
   `transaction_limits.rs`) — routing decision (Accord in cluster mode, local in
   standalone), `IF [NOT] EXISTS` / `IF <cond>` CAS semantics with the `[applied]`

--- a/ferrosa-cql/README.md
+++ b/ferrosa-cql/README.md
@@ -75,7 +75,18 @@ unaffected (see [Bridge re-export](#bridge-re-export-d10)).
 - **Prepared statements** (`prepared.rs`) — `moka` W-TinyLFU cache keyed by the
   MD5 of the query text, weight-bounded.
 - **Pagination** (`paging.rs`) — opaque `paging_state` cursor (pk + ck +
-  remaining-in-partition flag) for CQL v5 paging.
+  remaining-in-partition flag, HMAC-signed) for CQL v5 paging. Paged full-table
+  scans resume WITHIN a wide partition (t_a0f922a3): the router decodes the
+  cursor into `ferrosa_cluster::write_path::ScanResume { key, clustering }` so
+  every producer (local iterator and each remote replica) skips the delivered
+  prefix instead of re-streaming it, and the streaming collectors
+  (`collect_page_from_partition_stream` / `collect_filtered_page_...`) apply
+  the same skip-≤-last as an idempotent second layer. Page-advance +
+  exact-union tests (hard per-page timeouts — a stall or cycling cursor FAILS,
+  never hangs): `wide_partition_spanning_pages_terminates_exactly`,
+  `mixed_wide_and_narrow_partitions_page_exactly`,
+  `wide_partition_multi_text_clustering_pages_exactly_after_flush`,
+  `many_small_partitions_pk_projection_pages_without_stalling`.
 - **LWT / transactions** (`accord_router.rs`, `transaction_keys.rs`,
   `transaction_limits.rs`) — routing decision (Accord in cluster mode, local in
   standalone), `IF [NOT] EXISTS` / `IF <cond>` CAS semantics with the `[applied]`

--- a/ferrosa-cql/specs/data-flow.md
+++ b/ferrosa-cql/specs/data-flow.md
@@ -65,11 +65,12 @@ sequenceDiagram
     participant Br as bridge (row-bridge re-export)
     participant Res as result encoder
 
-    Drv->>Codec: QUERY/EXECUTE frame bytes
+    Drv->>Codec: QUERY/EXECUTE frame bytes (+ fetch_size/paging_state)
     Codec->>Conn: CqlFrame
     Conn->>Par: CQL text
     Par-->>Conn: Statement::Select (AST)
-    Conn->>Rt: route(state, ctx, stmt)
+    Conn->>Conn: decode_query_params → PagingParams<br/>(page_size flag 0x04, paging_state flag 0x08)
+    Conn->>Rt: route(state, ctx{paging}, stmt)
     Rt->>Rt: check_permission (M8)
     Rt->>Pl: classify scan + ORDER BY plan
     Pl-->>Rt: ScanPlan (inline or spillable temp-sort)
@@ -84,8 +85,19 @@ sequenceDiagram
 ```
 
 When more rows remain, `result.rs` attaches an opaque `paging::PagingState`
-cursor (pk + ck + remaining flag). NOTE: that cursor is currently unsigned —
-FMEA CQL-2.
+cursor (pk + ck + remaining flag).
+
+**Ingress decode (t_a0f922a3 LIVE):** the client's `fetch_size` and echoed
+cursor arrive in the QUERY/EXECUTE `<query_parameters>` section, decoded by
+`connection::decode_query_params` in FIXED wire order (flags → values →
+`page_size` (0x04) → `paging_state` (0x08)) and threaded onto `ctx.paging`.
+The router's paged-scan arm and the coordinator's resume path were already
+correct; the LIVE failure was that these two wire fields were never parsed —
+the handlers built `PagingParams::default()`, so a paged `SELECT` re-served
+page 1 forever and ignored `fetch_size`. Router-level tests that hand-built
+`ctx.paging` passed while the live wire path was broken, which is why the
+regression must be pinned through the real codec
+(`live_wire_paged_scan_advances_and_terminates_exactly`).
 
 ## Bridge re-export relationship (D10)
 

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -1602,9 +1602,14 @@ async fn handle_query(
         }
     };
 
-    // Parse bound values from the QUERY frame (if present) and substitute
-    // into the statement. cdrs-tokio sends query_with_values which includes
-    // values in the QUERY frame alongside bind markers in the query text.
+    // Parse the QUERY frame's <query_parameters> section: bound values AND the
+    // pagination controls (page_size / paging_state). cdrs-tokio sends
+    // query_with_values which includes values in the QUERY frame alongside bind
+    // markers in the query text; the python/gocql drivers send fetch_size +
+    // paging_state here for a paged SELECT. t_a0f922a3 (LIVE): this section used
+    // to decode ONLY values and drop page_size/paging_state, so a paged scan
+    // re-served page 1 forever and ignored the client's fetch_size.
+    let mut paging = crate::paging::PagingParams::default();
     if cursor.remaining() > 0 {
         let (table_ks, table_name) = extract_keyspace_table(&stmt, current_keyspace);
         let (bound_columns, _result_columns) =
@@ -1621,16 +1626,26 @@ async fn handle_query(
             table_keyspace: table_ks,
             table_name,
         };
-        stmt = match substitute_bound_values(&temp_plan, cursor, protocol_version) {
-            Ok(s) => s,
-            Err(e) => {
-                return HandleResult::Reply(Opcode::Error, e.encode_body());
-            }
-        };
+        let (bound_terms, parsed_paging) =
+            match decode_query_params(&temp_plan, cursor, protocol_version) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    return HandleResult::Reply(Opcode::Error, e.encode_body());
+                }
+            };
+        paging = parsed_paging;
+        stmt = substitute_bound_terms(&temp_plan, bound_terms.as_deref());
     }
 
     // Build an auth context for routing (use a default if auth was disabled).
-    let ctx = build_request_context(auth_context, current_keyspace, cl, peer, protocol_version);
+    let ctx = build_request_context(
+        auth_context,
+        current_keyspace,
+        cl,
+        peer,
+        protocol_version,
+        paging,
+    );
 
     // Transaction control + in-transaction DML buffering (BEGIN/COMMIT over
     // Accord). The per-connection buffer is locked only for the duration of the
@@ -1899,17 +1914,26 @@ async fn handle_execute(
         }
     };
 
-    // Parse bound values from the EXECUTE frame. Common prepared INSERTs can
-    // route directly from the cached plan and bound terms; complex statements
-    // fall back to the generic AST substitution path.
-    let bound_terms = match decode_bound_values(&plan, cursor, protocol_version) {
-        Ok(terms) => terms,
+    // Parse bound values AND pagination controls from the EXECUTE frame. Common
+    // prepared INSERTs can route directly from the cached plan and bound terms;
+    // complex statements fall back to the generic AST substitution path.
+    // t_a0f922a3 (LIVE): a paged prepared SELECT sends fetch_size / paging_state
+    // in this same section — decoding only values dropped them, wedging paging.
+    let (bound_terms, paging) = match decode_query_params(&plan, cursor, protocol_version) {
+        Ok(parsed) => parsed,
         Err(e) => {
             return HandleResult::Reply(Opcode::Error, e.encode_body());
         }
     };
 
-    let ctx = build_request_context(auth_context, current_keyspace, cl, peer, protocol_version);
+    let ctx = build_request_context(
+        auth_context,
+        current_keyspace,
+        cl,
+        peer,
+        protocol_version,
+        paging,
+    );
 
     if let Some(bound_terms) = bound_terms.as_ref() {
         let fast_result = match &plan.statement {
@@ -2082,9 +2106,16 @@ async fn handle_batch(
         ferrosa_cluster::consistency::ConsistencyLevel::One
     };
 
-    // Route each statement.
+    // Route each statement. BATCH is write-only — no pagination applies.
     for stmt in statements {
-        let ctx = build_request_context(auth_context, current_keyspace, cl, peer, protocol_version);
+        let ctx = build_request_context(
+            auth_context,
+            current_keyspace,
+            cl,
+            peer,
+            protocol_version,
+            crate::paging::PagingParams::default(),
+        );
         match crate::router::route(state, &ctx, stmt).await {
             Ok(RouteResult::SetKeyspace(ks, _)) => {
                 *current_keyspace = Some(ks);
@@ -2116,6 +2147,7 @@ fn build_request_context<'a>(
     consistency: ferrosa_cluster::consistency::ConsistencyLevel,
     peer: std::net::SocketAddr,
     protocol_version: u8,
+    paging: crate::paging::PagingParams,
 ) -> RequestContext<'a> {
     // If auth was disabled, we need a default auth context.
     if auth_context.is_none() {
@@ -2130,7 +2162,7 @@ fn build_request_context<'a>(
         current_keyspace,
         consistency,
         serial_consistency: None,
-        paging: crate::paging::PagingParams::default(),
+        paging,
         client_address: peer.to_string(),
         protocol_version,
     }
@@ -2731,6 +2763,11 @@ fn raw_bytes_to_term(cql_type: &CqlType, bytes: &[u8]) -> Term {
 /// The cursor should be positioned after the consistency level bytes.
 /// CQL v5 EXECUTE frame layout after consistency:
 ///   `[int flags][short n_values]([int len][bytes value])*`
+///
+/// Test-only: the live QUERY/EXECUTE handlers use [`decode_query_params`], which
+/// also decodes the pagination controls. This helper isolates value
+/// substitution for the value-binding regression tests below.
+#[cfg(test)]
 fn substitute_bound_values(
     plan: &PreparedPlan,
     cursor: &[u8],
@@ -2748,6 +2785,7 @@ fn substitute_bound_terms(plan: &PreparedPlan, bound_terms: Option<&[Term]>) -> 
     substitute_in_statement(&plan.statement, bound_terms, &mut substitution_idx)
 }
 
+#[cfg(test)]
 fn decode_bound_values(
     plan: &PreparedPlan,
     mut cursor: &[u8],
@@ -2775,15 +2813,158 @@ fn decode_bound_values(
         return Ok(None);
     }
 
-    // Parse [short n_values]
+    // Parse [short n_values]([int len][bytes])*.
     // Per CQL v4 spec 4.1.4, values come first after flags, before
     // optional fields (page_size, paging_state, etc.).
+    Ok(Some(decode_values_section(plan, &mut cursor)?))
+}
+
+/// CQL native-protocol query-parameters flag bits (§4.1.4). Shared by QUERY and
+/// EXECUTE. Only the ones we act on are named.
+const QP_FLAG_VALUES: u32 = 0x0001;
+const QP_FLAG_PAGE_SIZE: u32 = 0x0004;
+const QP_FLAG_WITH_PAGING_STATE: u32 = 0x0008;
+const QP_FLAG_WITH_SERIAL_CONSISTENCY: u32 = 0x0010;
+const QP_FLAG_WITH_DEFAULT_TIMESTAMP: u32 = 0x0020;
+
+/// Decode the full QUERY/EXECUTE `<query_parameters>` section (§4.1.4),
+/// returning both the bound values (if the VALUES flag is set) and the
+/// pagination controls (`page_size` from flag 0x04, `paging_state` from flag
+/// 0x08).
+///
+/// t_a0f922a3 (LIVE): the previous wire handlers only decoded VALUES and built
+/// `PagingParams::default()`, so a driver's `fetch_size` / echoed cursor never
+/// reached the router — the paged scan re-served page 1 forever and applied the
+/// server default page instead of the client's `fetch_size`. The optional
+/// fields are laid out in a FIXED order after the values section (page_size,
+/// paging_state, serial_consistency, default_timestamp, keyspace, now_in_secs);
+/// each is present only if its flag bit is set, so we must walk them in order
+/// even for the fields we ignore, or a trailing field misaligns the read.
+pub(crate) fn decode_query_params(
+    plan: &PreparedPlan,
+    cursor: &[u8],
+    protocol_version: u8,
+) -> Result<(Option<Vec<Term>>, crate::paging::PagingParams), CqlError> {
+    let mut c = cursor;
+
+    // <flags>: [int] in v5+, [byte] in v3/v4.
+    let flags = if protocol_version >= 0x05 {
+        if c.remaining() < 4 {
+            return Ok((None, crate::paging::PagingParams::default()));
+        }
+        c.get_u32()
+    } else {
+        if c.remaining() < 1 {
+            return Ok((None, crate::paging::PagingParams::default()));
+        }
+        c.get_u8() as u32
+    };
+
+    // <values>: consumed first so the optional fields that follow stay aligned.
+    let bound_terms = if (flags & QP_FLAG_VALUES) != 0 {
+        Some(decode_values_section(plan, &mut c)?)
+    } else {
+        None
+    };
+
+    // <page_size>: [int].
+    let page_size = if (flags & QP_FLAG_PAGE_SIZE) != 0 {
+        if c.remaining() < 4 {
+            return Err(CqlError::Protocol(
+                "query parameters: truncated page_size".into(),
+            ));
+        }
+        Some(c.get_i32())
+    } else {
+        None
+    };
+
+    // <paging_state>: [bytes] — [int len] then `len` bytes (len < 0 = null).
+    let paging_state = if (flags & QP_FLAG_WITH_PAGING_STATE) != 0 {
+        if c.remaining() < 4 {
+            return Err(CqlError::Protocol(
+                "query parameters: truncated paging_state length".into(),
+            ));
+        }
+        let len = c.get_i32();
+        if len < 0 {
+            None
+        } else {
+            let len = len as usize;
+            if c.remaining() < len {
+                return Err(CqlError::Protocol(
+                    "query parameters: truncated paging_state bytes".into(),
+                ));
+            }
+            let bytes = c[..len].to_vec();
+            c.advance(len);
+            Some(bytes)
+        }
+    } else {
+        None
+    };
+
+    // We do not consume serial_consistency / default_timestamp here — they are
+    // the LAST optional fields we could touch and nothing after them is read,
+    // so ignoring their trailing bytes is safe. Named only to document the wire
+    // order for a future reader who adds a field after paging_state.
+    let _ = (
+        QP_FLAG_WITH_SERIAL_CONSISTENCY,
+        QP_FLAG_WITH_DEFAULT_TIMESTAMP,
+    );
+
+    Ok((
+        bound_terms,
+        crate::paging::PagingParams {
+            page_size,
+            paging_state,
+        },
+    ))
+}
+
+/// Decode ONLY the pagination controls (`page_size` / `paging_state`) from a
+/// QUERY `<query_parameters>` section for a statement with no bind values (the
+/// paged-`SELECT` scan shape). Shares [`decode_query_params`] so the live wire
+/// decode and the paged-scan round-trip tests exercise the exact same parser —
+/// closing the fidelity gap where prior fixes populated `PagingParams` by hand
+/// and so never caught that the wire path dropped it (t_a0f922a3).
+///
+/// Test-only: the live handlers call [`decode_query_params`] directly (they
+/// already hold a `PreparedPlan`); this convenience wrapper exists for the
+/// paged-scan round-trip tests, which have no plan.
+#[cfg(test)]
+pub(crate) fn decode_query_paging(
+    cursor: &[u8],
+    protocol_version: u8,
+) -> Result<crate::paging::PagingParams, CqlError> {
+    // An empty plan is sufficient: a paged SELECT scan carries no bind values,
+    // so the VALUES branch (the only consumer of `plan`) is never taken.
+    let empty_plan = PreparedPlan {
+        id: [0u8; 16],
+        query: String::new(),
+        statement: crate::parser::parse("SELECT * FROM s.t").expect("static parse"),
+        keyspace: None,
+        result_columns: Vec::new(),
+        bound_columns: Vec::new(),
+        pk_indexes: Vec::new(),
+        table_keyspace: String::new(),
+        table_name: String::new(),
+    };
+    let (_bound, paging) = decode_query_params(&empty_plan, cursor, protocol_version)?;
+    Ok(paging)
+}
+
+/// Decode the `<values>` sub-section (`[short n]([int len][bytes])*`) starting
+/// at `cursor` (which is positioned right after the flags/VALUES bit). Advances
+/// `cursor` past the consumed bytes so the caller can read the fields that
+/// follow (page_size, paging_state, ...). Shared by the value-binding tests and
+/// [`decode_query_params`].
+fn decode_values_section(plan: &PreparedPlan, cursor: &mut &[u8]) -> Result<Vec<Term>, CqlError> {
     if cursor.remaining() < 2 {
         return Err(CqlError::Protocol("EXECUTE: truncated values count".into()));
     }
     let n_values = cursor.get_u16() as usize;
 
-    // Decode each bound value using the type from bound_columns.
     let mut bound_terms: Vec<Term> = Vec::with_capacity(n_values);
     for i in 0..n_values {
         if cursor.remaining() < 4 {
@@ -2791,7 +2972,6 @@ fn decode_bound_values(
         }
         let val_len = cursor.get_i32();
         if val_len < 0 {
-            // Null value
             bound_terms.push(Term::Null);
         } else {
             let val_len = val_len as usize;
@@ -2801,19 +2981,15 @@ fn decode_bound_values(
             let val_bytes = &cursor[..val_len];
             cursor.advance(val_len);
 
-            // Look up the type for this positional value.
             let cql_type = if i < plan.bound_columns.len() {
                 &plan.bound_columns[i].1
             } else {
-                // More values than bound columns — default to blob.
                 &CqlType::Blob
             };
-
             bound_terms.push(raw_bytes_to_term(cql_type, val_bytes));
         }
     }
-
-    Ok(Some(bound_terms))
+    Ok(bound_terms)
 }
 
 /// Substitute bound values for a single statement inside a BATCH.
@@ -3003,6 +3179,103 @@ mod tests {
     fn ready_prepare_uses_concurrent_request_path() {
         assert!(is_request_opcode(Opcode::Prepare));
         assert!(dispatches_concurrently(Opcode::Prepare));
+    }
+
+    /// t_a0f922a3 LIVE bug — the exact fidelity gap that made 3 prior fixes
+    /// pass locally and fail live: the router's paged-scan arm was correct, but
+    /// the wire QUERY/EXECUTE handler NEVER decoded the `page_size` (flag 0x04)
+    /// or `paging_state` (flag 0x08) query-parameters fields — it built
+    /// `PagingParams::default()`. So the python driver's `fetch_size=2000`
+    /// resolved to the 5000-row default page, and the client-echoed cursor was
+    /// silently dropped: page 2 re-served page 1 forever (has_more stuck True).
+    ///
+    /// This asserts the wire decoder now surfaces BOTH fields from a real
+    /// v5 query-parameters payload. Revert-to-confirm: with the decode reverted
+    /// to `PagingParams::default()`, both assertions fail (page_size None,
+    /// paging_state None) — the live signature.
+    #[test]
+    fn query_params_decode_extracts_page_size_and_paging_state_v5() {
+        // v5 query parameters (§4.1.4):
+        //   [int flags][... values ...][int page_size][bytes paging_state]
+        // flags = 0x04 (page_size) | 0x08 (paging_state), no values.
+        let cursor_state = vec![0xDEu8, 0xAD, 0xBE, 0xEF]; // opaque prior cursor bytes
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(0x04u32 | 0x08u32).to_be_bytes()); // 4-byte flags
+        payload.extend_from_slice(&2000i32.to_be_bytes()); // page_size = fetch_size
+        payload.extend_from_slice(&(cursor_state.len() as i32).to_be_bytes()); // [bytes] len
+        payload.extend_from_slice(&cursor_state); // paging_state bytes
+
+        let plan = make_plan("SELECT pk, ck FROM ks.t", vec![]);
+        let (bound, paging) = decode_query_params(&plan, &payload, 5).unwrap();
+
+        assert!(bound.is_none(), "no VALUES flag set");
+        assert_eq!(
+            paging.page_size,
+            Some(2000),
+            "fetch_size must survive the wire; a None here is the live 5000-default bug"
+        );
+        assert_eq!(
+            paging.paging_state.as_deref(),
+            Some(cursor_state.as_slice()),
+            "the client-echoed cursor must survive the wire; None here re-serves page 1 forever"
+        );
+    }
+
+    /// v4 form uses a 1-byte flags field; the same fields must still decode.
+    #[test]
+    fn query_params_decode_extracts_page_size_and_paging_state_v4() {
+        let cursor_state = vec![1u8, 2, 3];
+        let mut payload = Vec::new();
+        payload.push(0x04 | 0x08); // 1-byte flags: page_size + paging_state
+        payload.extend_from_slice(&500i32.to_be_bytes());
+        payload.extend_from_slice(&(cursor_state.len() as i32).to_be_bytes());
+        payload.extend_from_slice(&cursor_state);
+
+        let plan = make_plan("SELECT pk, ck FROM ks.t", vec![]);
+        let (bound, paging) = decode_query_params(&plan, &payload, 4).unwrap();
+        assert!(bound.is_none());
+        assert_eq!(paging.page_size, Some(500));
+        assert_eq!(
+            paging.paging_state.as_deref(),
+            Some(cursor_state.as_slice())
+        );
+    }
+
+    /// Values + page_size together: the values section is consumed first, then
+    /// page_size — proving cursor alignment across both optional fields.
+    #[test]
+    fn query_params_decode_values_then_page_size() {
+        let plan = make_plan(
+            "INSERT INTO ks.t (id, name) VALUES (?, ?)",
+            vec![("id", CqlType::Int), ("name", CqlType::Varchar)],
+        );
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(0x01u32 | 0x04u32).to_be_bytes()); // VALUES | PAGE_SIZE
+        payload.extend_from_slice(&2u16.to_be_bytes()); // n_values
+        payload.extend_from_slice(&4i32.to_be_bytes());
+        payload.extend_from_slice(&7i32.to_be_bytes());
+        let name = b"alice";
+        payload.extend_from_slice(&(name.len() as i32).to_be_bytes());
+        payload.extend_from_slice(name);
+        payload.extend_from_slice(&123i32.to_be_bytes()); // page_size
+
+        let (bound, paging) = decode_query_params(&plan, &payload, 5).unwrap();
+        assert!(bound.is_some(), "VALUES flag set");
+        assert_eq!(paging.page_size, Some(123));
+        assert!(paging.paging_state.is_none());
+    }
+
+    /// No paging flags → empty PagingParams (the un-paged SELECT default-page
+    /// path in the router still applies its own bound).
+    #[test]
+    fn query_params_decode_no_paging_flags() {
+        let plan = make_plan("SELECT * FROM ks.t", vec![]);
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&0u32.to_be_bytes()); // no flags
+        let (bound, paging) = decode_query_params(&plan, &payload, 5).unwrap();
+        assert!(bound.is_none());
+        assert!(paging.page_size.is_none());
+        assert!(paging.paging_state.is_none());
     }
 
     #[test]

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -5111,15 +5111,23 @@ async fn route_select_user_table(
                         let resume = StreamResumeCursor::from_paging_state(
                             ctx.paging.paging_state.as_deref(),
                         )?;
-                        // Resume the scan at the last partition key (inclusive); the
-                        // collector drops rows already emitted within that key.
-                        let start_key = resume.as_ref().map(|cur| {
-                            ferrosa_common::key::DecoratedKey::new(
-                                ferrosa_common::key::PartitionKey::from(
-                                    cur.partition_key.as_slice(),
-                                ),
-                            )
-                        });
+                        // Resume the scan at the last partition key (inclusive) AND
+                        // the last delivered clustering position within it, so every
+                        // producer (local iterator and remote replicas) skips the
+                        // already-emitted prefix of a wide partition instead of
+                        // re-streaming it. The collector's own skip-≤-last remains
+                        // as an idempotent second layer.
+                        let start_key =
+                            resume
+                                .as_ref()
+                                .map(|cur| ferrosa_cluster::write_path::ScanResume {
+                                    key: ferrosa_common::key::DecoratedKey::new(
+                                        ferrosa_common::key::PartitionKey::from(
+                                            cur.partition_key.as_slice(),
+                                        ),
+                                    ),
+                                    clustering: Some(cur.clustering_key.clone()),
+                                });
 
                         // The gate above guarantees `where_clauses.is_empty()`, so a
                         // column projection is always safe here (no predicate reads
@@ -5207,11 +5215,14 @@ async fn route_select_user_table(
                                 ctx.paging.paging_state.as_deref(),
                             )?;
                             let start_key = resume.as_ref().map(|cur| {
-                                ferrosa_common::key::DecoratedKey::new(
-                                    ferrosa_common::key::PartitionKey::from(
-                                        cur.partition_key.as_slice(),
+                                ferrosa_cluster::write_path::ScanResume {
+                                    key: ferrosa_common::key::DecoratedKey::new(
+                                        ferrosa_common::key::PartitionKey::from(
+                                            cur.partition_key.as_slice(),
+                                        ),
                                     ),
-                                )
+                                    clustering: Some(cur.clustering_key.clone()),
+                                }
                             });
                             let stream = state
                                 .write_path
@@ -25514,6 +25525,518 @@ mod tests {
             n as usize,
             "default-paged traversal must still visit every row exactly once"
         );
+    }
+
+    /// Setup: keyspace `ks_name` + a clustered table `ks_name.wide (pk int,
+    /// ck int, v int, PRIMARY KEY (pk, ck))` populated with `rows_per` rows in
+    /// each of the partitions listed in `pks`.
+    async fn setup_clustered_scan_table(
+        ks_name: &str,
+        pks: &[i64],
+        rows_per: i64,
+    ) -> (SharedState, TempDir, AuthContext, Option<String>) {
+        let (state, dir) = setup();
+        let auth = dev_auth();
+        let ks = Some(ks_name.to_string());
+        let ctx = paging_ctx(&auth, &ks, None, None);
+        run_ddl(
+            &state,
+            &ctx,
+            &format!(
+                "CREATE KEYSPACE {ks_name} WITH replication = \
+                 {{'class': 'SimpleStrategy', 'replication_factor': 1}}"
+            ),
+        )
+        .await;
+        run_ddl(
+            &state,
+            &ctx,
+            &format!("CREATE TABLE {ks_name}.wide (pk int, ck int, v int, PRIMARY KEY (pk, ck))"),
+        )
+        .await;
+        for &pk in pks {
+            for ck in 0..rows_per {
+                run_ddl(
+                    &state,
+                    &ctx,
+                    &format!(
+                        "INSERT INTO {ks_name}.wide (pk, ck, v) VALUES ({pk}, {ck}, {})",
+                        ck * 10
+                    ),
+                )
+                .await;
+            }
+        }
+        (state, dir, auth, ks)
+    }
+
+    /// Walk every page of `select_cql`, returning the pages individually so
+    /// callers can assert page-advance invariants. Panics loudly if the walk
+    /// exceeds `max_pages` — a cycling cursor must FAIL, never hang.
+    async fn walk_pages(
+        state: &SharedState,
+        auth: &AuthContext,
+        ks: &Option<String>,
+        select_cql: &str,
+        page_size: i32,
+        max_pages: usize,
+    ) -> Vec<Vec<Vec<Option<CqlValue>>>> {
+        let select = match crate::parser::parse(select_cql).unwrap() {
+            Statement::Select(s) => s,
+            other => panic!("expected select, got {other:?}"),
+        };
+        let mut pages: Vec<Vec<Vec<Option<CqlValue>>>> = Vec::new();
+        let mut paging_state: Option<Vec<u8>> = None;
+        loop {
+            let ctx = paging_ctx(auth, ks, Some(page_size), paging_state.clone());
+            // Hard per-page timeout: a stalled page pull must FAIL the test,
+            // never hang it (t_a0f922a3 mode 2 — a paged no-LIMIT scan that
+            // blocks >14 min live is a wedged client, not slowness).
+            let res = tokio::time::timeout(
+                std::time::Duration::from_secs(120),
+                route_select_raw(state, &ctx, &select),
+            )
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "page {} did not return within 120s — the paged scan is \
+                     STALLED (t_a0f922a3 mode 2)",
+                    pages.len()
+                )
+            })
+            .unwrap();
+            assert!(
+                res.rows.len() <= page_size as usize,
+                "page {} returned {} rows, exceeds page_size {page_size}",
+                pages.len(),
+                res.rows.len()
+            );
+            if !res.rows.is_empty() {
+                pages.push(res.rows);
+            }
+            match res.paging_state {
+                Some(ns) => paging_state = Some(ns),
+                None => return pages,
+            }
+            assert!(
+                pages.len() <= max_pages,
+                "paged scan did not terminate within {max_pages} pages — the \
+                 paging cursor is cycling instead of advancing (t_a0f922a3)"
+            );
+        }
+    }
+
+    /// Extract `(pk, ck)` ints from a row given the projected column indices.
+    fn row_pk_ck(row: &[Option<CqlValue>], pk_idx: usize, ck_idx: usize) -> (i32, i32) {
+        let int_at = |i: usize| match row[i] {
+            Some(CqlValue::Int(v)) => v,
+            ref other => panic!("expected int at column {i}, got {other:?}"),
+        };
+        (int_at(pk_idx), int_at(ck_idx))
+    }
+
+    /// Assert the exactly-once paged-traversal contract over `pages`:
+    /// * pages strictly advance — page N+1's first row is `(pk, ck)`-greater
+    ///   than page N's last row (in the emitted stream order);
+    /// * the union of all pages is EXACTLY `expected` (no gaps, no dupes);
+    /// * the page count matches `ceil(total / page_size)`.
+    fn assert_paged_traversal_exact(
+        pages: &[Vec<Vec<Option<CqlValue>>>],
+        pk_idx: usize,
+        ck_idx: usize,
+        expected: &std::collections::BTreeSet<(i32, i32)>,
+        page_size: usize,
+    ) {
+        let expected_pages = expected.len().div_ceil(page_size);
+        assert_eq!(
+            pages.len(),
+            expected_pages,
+            "page count must be ceil({}/{page_size}) = {expected_pages}",
+            expected.len()
+        );
+
+        // Pages must strictly advance in the stream's own order: a repeated or
+        // rewound page start is the live cycle signature (page 4 == page 1).
+        for w in pages.windows(2) {
+            let prev_last = row_pk_ck(w[0].last().expect("non-empty page"), pk_idx, ck_idx);
+            let next_first = row_pk_ck(w[1].first().expect("non-empty page"), pk_idx, ck_idx);
+            // Same partition: clustering must strictly increase. Different
+            // partition: keys advance in token order which int pk/ck tuples
+            // don't mirror, so only assert non-equality there.
+            if prev_last.0 == next_first.0 {
+                assert!(
+                    next_first.1 > prev_last.1,
+                    "page did not advance within partition pk={}: last ck of \
+                     previous page {} >= first ck of next page {}",
+                    prev_last.0,
+                    prev_last.1,
+                    next_first.1
+                );
+            }
+        }
+
+        let mut seen: Vec<(i32, i32)> = pages
+            .iter()
+            .flatten()
+            .map(|row| row_pk_ck(row, pk_idx, ck_idx))
+            .collect();
+        let delivered = seen.len();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(
+            seen.len(),
+            delivered,
+            "paged traversal emitted {} duplicate rows",
+            delivered - seen.len()
+        );
+        let seen_set: std::collections::BTreeSet<(i32, i32)> = seen.into_iter().collect();
+        assert_eq!(
+            &seen_set, expected,
+            "paged union must equal the whole row set exactly (no gaps, no dupes)"
+        );
+    }
+
+    /// t_a0f922a3 mode 1 (CYCLE): a single partition WIDER than one page must
+    /// page to completion through the real paging_state round-trip. The live
+    /// 3-node cluster looped forever over ~10% of `typed_edges` because the
+    /// cursor re-entered a wide partition at partition granularity. One
+    /// partition of 15k clustering rows at page_size 5000 must yield exactly
+    /// 3 strictly-advancing pages whose union is the exact row set, and
+    /// has_more must go false.
+    #[tokio::test]
+    async fn wide_partition_spanning_pages_terminates_exactly() {
+        let rows_per: i64 = 15_000;
+        let page_size: i32 = 5_000;
+        let (state, _dir, auth, ks) = setup_clustered_scan_table("widepg", &[1], rows_per).await;
+
+        let expected: std::collections::BTreeSet<(i32, i32)> =
+            (0..rows_per as i32).map(|ck| (1, ck)).collect();
+
+        // Star projection → range_read_stream_all_from.
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT * FROM widepg.wide",
+            page_size,
+            10,
+        )
+        .await;
+        assert_paged_traversal_exact(&pages, 0, 1, &expected, page_size as usize);
+
+        // Column-subset projection → range_read_projected_stream_all_from —
+        // the exact live `SELECT src_id, edge_type, dst_id FROM typed_edges`
+        // shape. pk/ck are columns 0/1 of the projection.
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT pk, ck FROM widepg.wide",
+            page_size,
+            10,
+        )
+        .await;
+        assert_paged_traversal_exact(&pages, 0, 1, &expected, page_size as usize);
+
+        // t_a0f922a3 "also verify": the same scan must be exact when the rows
+        // are SSTABLE-backed, not memtable-backed. A live node returned an
+        // instant EMPTY page for a COUNT-verified 15k-row table right after a
+        // restart, and the live cycle was observed on flushed data. An empty
+        // or short union here means the paged path silently loses
+        // SSTable-backed rows.
+        state
+            .engine
+            .flush(&ferrosa_storage::TableId::new("widepg", "wide"))
+            .expect("flush widepg.wide to SSTable");
+
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT * FROM widepg.wide",
+            page_size,
+            10,
+        )
+        .await;
+        assert!(
+            !pages.is_empty(),
+            "SSTable-backed paged scan returned an instant EMPTY result for a \
+             populated table (t_a0f922a3 restart evidence)"
+        );
+        assert_paged_traversal_exact(&pages, 0, 1, &expected, page_size as usize);
+
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT pk, ck FROM widepg.wide",
+            page_size,
+            10,
+        )
+        .await;
+        assert_paged_traversal_exact(&pages, 0, 1, &expected, page_size as usize);
+    }
+
+    /// t_a0f922a3 mode 1, live shape: MULTI-COMPONENT TEXT clustering
+    /// (`typed_edges` is `((tenant, session), edge_type, dst_id)` — text
+    /// components of VARYING lengths, u16-length-prefixed in the encoded
+    /// clustering bytes). The paging cursor compares raw encoded clustering
+    /// bytes, and the SSTable layer decodes/re-encodes the components on
+    /// flush/read — any byte-order or round-trip divergence between the
+    /// memtable and SSTable forms makes the cursor skip or re-emit rows and
+    /// can cycle forever. Walk a wide partition spanning pages, memtable-
+    /// backed then SSTable-backed then MIXED (flushed base + memtable
+    /// updates), asserting the exact union each time.
+    #[tokio::test]
+    async fn wide_partition_multi_text_clustering_pages_exactly_after_flush() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ks = Some("mck".to_string());
+        let ctx = paging_ctx(&auth, &ks, None, None);
+        run_ddl(
+            &state,
+            &ctx,
+            "CREATE KEYSPACE mck WITH replication = \
+             {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        )
+        .await;
+        run_ddl(
+            &state,
+            &ctx,
+            "CREATE TABLE mck.edges (pk int, e text, d text, v int, PRIMARY KEY (pk, e, d))",
+        )
+        .await;
+
+        // Varying-length components so length-prefixed byte order and
+        // component-wise order DIVERGE (e.g. 'b' vs 'aa').
+        let edge_types = ["a", "bb", "c", "dddd", "ee", "supports", "x"];
+        let mut expected: std::collections::BTreeSet<(String, String)> =
+            std::collections::BTreeSet::new();
+        let n: usize = 4_200;
+        let page_size: i32 = 1_000;
+        for i in 0..n {
+            let e = edge_types[i % edge_types.len()];
+            // Varying-length dst ids: "n-5", "n-55", "n-555", ...
+            let d = format!("n-{}", "5".repeat(1 + i % 5)) + &format!("-{i}");
+            run_ddl(
+                &state,
+                &ctx,
+                &format!("INSERT INTO mck.edges (pk, e, d, v) VALUES (7, '{e}', '{d}', 1)"),
+            )
+            .await;
+            expected.insert((e.to_string(), d));
+        }
+        assert_eq!(expected.len(), n, "seed rows must be distinct");
+
+        let collect_pairs = |pages: &[Vec<Vec<Option<CqlValue>>>]| {
+            let mut seen: Vec<(String, String)> = pages
+                .iter()
+                .flatten()
+                .map(|row| {
+                    let text_at = |i: usize| match &row[i] {
+                        Some(CqlValue::Text(s)) => s.clone(),
+                        other => panic!("expected text at column {i}, got {other:?}"),
+                    };
+                    (text_at(0), text_at(1))
+                })
+                .collect();
+            let delivered = seen.len();
+            seen.sort();
+            seen.dedup();
+            assert_eq!(
+                seen.len(),
+                delivered,
+                "paged traversal emitted duplicate rows"
+            );
+            seen.into_iter().collect::<std::collections::BTreeSet<_>>()
+        };
+        let max_pages = n.div_ceil(page_size as usize) + 2;
+
+        // Memtable-backed.
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT e, d FROM mck.edges",
+            page_size,
+            max_pages,
+        )
+        .await;
+        assert_eq!(
+            collect_pairs(&pages),
+            expected,
+            "memtable-backed multi-text-ck paged union must be exact"
+        );
+
+        // SSTable-backed.
+        state
+            .engine
+            .flush(&ferrosa_storage::TableId::new("mck", "edges"))
+            .expect("flush mck.edges to SSTable");
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT e, d FROM mck.edges",
+            page_size,
+            max_pages,
+        )
+        .await;
+        assert_eq!(
+            collect_pairs(&pages),
+            expected,
+            "SSTable-backed multi-text-ck paged union must be exact — a \
+             clustering round-trip divergence cycles the cursor (t_a0f922a3)"
+        );
+
+        // Mixed: overwrite a slice of rows so the scan merges SSTable base
+        // rows with newer memtable rows sharing the same clustering.
+        for i in 0..500 {
+            let e = edge_types[i % edge_types.len()];
+            let d = format!("n-{}", "5".repeat(1 + i % 5)) + &format!("-{i}");
+            run_ddl(
+                &state,
+                &ctx,
+                &format!("INSERT INTO mck.edges (pk, e, d, v) VALUES (7, '{e}', '{d}', 2)"),
+            )
+            .await;
+        }
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT e, d FROM mck.edges",
+            page_size,
+            max_pages,
+        )
+        .await;
+        assert_eq!(
+            collect_pairs(&pages),
+            expected,
+            "mixed memtable+SSTable multi-text-ck paged union must be exact \
+             (same-clustering rows must fold, not duplicate)"
+        );
+    }
+
+    /// t_a0f922a3 mode 2 (STALL): many SMALL partitions, pk-only projection,
+    /// no LIMIT, fetch_size-paged — the exact live `SELECT id FROM vfix.nums`
+    /// shape (15k single-row partitions) that never returned page 1 on the
+    /// live cluster while COUNT over the same data drained fine. Every page
+    /// pull runs under `walk_pages`' hard timeout, so a stall FAILS loudly.
+    /// The union must be exact and the walk must terminate; data is
+    /// SSTable-backed + memtable mixed like the live table.
+    #[tokio::test]
+    async fn many_small_partitions_pk_projection_pages_without_stalling() {
+        let n: i64 = 15_000;
+        let page_size: i32 = 5_000;
+        let (state, _dir, auth, ks) = setup_wide_scan_table(n).await;
+
+        // Flush the bulk to SSTables (live shape: COUNT-verified flushed data).
+        state
+            .engine
+            .flush(&ferrosa_storage::TableId::new("pageks", "t"))
+            .expect("flush pageks.t to SSTable");
+
+        // pk-only projection (id is the whole primary key → wanted == []).
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT id FROM pageks.t",
+            page_size,
+            (n as usize).div_ceil(page_size as usize) + 2,
+        )
+        .await;
+
+        let mut seen: Vec<i32> = pages
+            .iter()
+            .flatten()
+            .map(|row| match row[0] {
+                Some(CqlValue::Int(v)) => v,
+                ref other => panic!("expected int id, got {other:?}"),
+            })
+            .collect();
+        let delivered = seen.len();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(seen.len(), delivered, "paged scan emitted duplicate rows");
+        assert_eq!(
+            seen.len(),
+            n as usize,
+            "paged pk-projection scan must deliver every partition exactly once"
+        );
+    }
+
+    /// t_a0f922a3 mode 1, multi-partition mix: wide partitions (each spanning
+    /// multiple pages) interleaved by token with single-row partitions. The
+    /// paged union must be exact and the walk must terminate.
+    #[tokio::test]
+    async fn mixed_wide_and_narrow_partitions_page_exactly() {
+        // pks 1..=40: pks 1..=3 are wide (700 rows), the rest single-row.
+        let wide_pks: Vec<i64> = vec![1, 2, 3];
+        let narrow_pks: Vec<i64> = (4..=40).collect();
+        let rows_per_wide: i64 = 700;
+        let page_size: i32 = 250;
+
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ks = Some("mixpg".to_string());
+        let ctx = paging_ctx(&auth, &ks, None, None);
+        run_ddl(
+            &state,
+            &ctx,
+            "CREATE KEYSPACE mixpg WITH replication = \
+             {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        )
+        .await;
+        run_ddl(
+            &state,
+            &ctx,
+            "CREATE TABLE mixpg.wide (pk int, ck int, v int, PRIMARY KEY (pk, ck))",
+        )
+        .await;
+        let mut expected: std::collections::BTreeSet<(i32, i32)> =
+            std::collections::BTreeSet::new();
+        for &pk in &wide_pks {
+            for ck in 0..rows_per_wide {
+                run_ddl(
+                    &state,
+                    &ctx,
+                    &format!("INSERT INTO mixpg.wide (pk, ck, v) VALUES ({pk}, {ck}, 0)"),
+                )
+                .await;
+                expected.insert((pk as i32, ck as i32));
+            }
+        }
+        // Flush the wide partitions to an SSTable so the scan merges
+        // SSTable-backed wide partitions with memtable-backed narrow ones —
+        // the live table shape (flushed bulk + fresh writes).
+        state
+            .engine
+            .flush(&ferrosa_storage::TableId::new("mixpg", "wide"))
+            .expect("flush mixpg.wide to SSTable");
+        for &pk in &narrow_pks {
+            run_ddl(
+                &state,
+                &ctx,
+                &format!("INSERT INTO mixpg.wide (pk, ck, v) VALUES ({pk}, 0, 0)"),
+            )
+            .await;
+            expected.insert((pk as i32, 0));
+        }
+        let total = expected.len();
+        let max_pages = total.div_ceil(page_size as usize) + 2;
+
+        let pages = walk_pages(
+            &state,
+            &auth,
+            &ks,
+            "SELECT pk, ck FROM mixpg.wide",
+            page_size,
+            max_pages,
+        )
+        .await;
+        assert_paged_traversal_exact(&pages, 0, 1, &expected, page_size as usize);
     }
 
     #[tokio::test]

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -25626,6 +25626,94 @@ mod tests {
         }
     }
 
+    /// Encode a CQL v5 `<query_parameters>` section carrying `page_size`
+    /// (fetch_size) and, when present, an echoed `paging_state` — exactly the
+    /// bytes the python/gocql driver puts on the wire for a paged SELECT. No
+    /// bound values (a scan has none).
+    fn wire_query_params(page_size: i32, paging_state: Option<&[u8]>) -> Vec<u8> {
+        // flags: 0x04 (PAGE_SIZE) [+ 0x08 (WITH_PAGING_STATE) when echoing].
+        let mut flags: u32 = 0x04;
+        if paging_state.is_some() {
+            flags |= 0x08;
+        }
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&flags.to_be_bytes()); // v5: 4-byte flags
+        buf.extend_from_slice(&page_size.to_be_bytes()); // [int] page_size
+        if let Some(ps) = paging_state {
+            buf.extend_from_slice(&(ps.len() as i32).to_be_bytes()); // [bytes] len
+            buf.extend_from_slice(ps); // paging_state bytes
+        }
+        buf
+    }
+
+    /// Live-fidelity page walk: unlike [`walk_pages`], this NEVER constructs
+    /// `ctx.paging` by hand. It serializes the client's fetch_size + echoed
+    /// cursor into a real wire `<query_parameters>` payload and re-derives
+    /// `PagingParams` via the SAME decoder the live QUERY handler uses
+    /// ([`crate::connection::decode_query_paging`]). This is the exact bridge
+    /// the 3 prior "in-process-green" fixes bypassed: they populated
+    /// `PagingParams` directly, so they never observed that the wire path
+    /// dropped page_size/paging_state (t_a0f922a3 LIVE). With the wire decode
+    /// reverted, page 2 == page 1 and this walk cycles until the `max_pages`
+    /// cap FAILS it — the exact live signature.
+    async fn walk_pages_via_wire(
+        state: &SharedState,
+        auth: &AuthContext,
+        ks: &Option<String>,
+        select_cql: &str,
+        page_size: i32,
+        max_pages: usize,
+    ) -> Vec<Vec<Vec<Option<CqlValue>>>> {
+        let select = match crate::parser::parse(select_cql).unwrap() {
+            Statement::Select(s) => s,
+            other => panic!("expected select, got {other:?}"),
+        };
+        let mut pages: Vec<Vec<Vec<Option<CqlValue>>>> = Vec::new();
+        let mut paging_state: Option<Vec<u8>> = None;
+        loop {
+            // Round-trip the paging controls through the wire codec.
+            let wire = wire_query_params(page_size, paging_state.as_deref());
+            let paging = crate::connection::decode_query_paging(&wire, 5)
+                .expect("wire query-parameters must decode");
+            let ctx = RequestContext {
+                auth,
+                current_keyspace: ks,
+                consistency: ConsistencyLevel::One,
+                serial_consistency: None,
+                paging,
+                client_address: String::new(),
+                protocol_version: 5,
+            };
+            let res = tokio::time::timeout(
+                std::time::Duration::from_secs(120),
+                route_select_raw(state, &ctx, &select),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("page {} did not return within 120s", pages.len()))
+            .unwrap();
+            assert!(
+                res.rows.len() <= page_size as usize,
+                "page {} returned {} rows, exceeds wire fetch_size {page_size} — \
+                 the wire page_size was DROPPED (t_a0f922a3: fetch_size=2000 → 5000 rows)",
+                pages.len(),
+                res.rows.len()
+            );
+            if !res.rows.is_empty() {
+                pages.push(res.rows);
+            }
+            match res.paging_state {
+                Some(ns) => paging_state = Some(ns),
+                None => return pages,
+            }
+            assert!(
+                pages.len() <= max_pages,
+                "paged scan did not terminate within {max_pages} pages — the wire \
+                 paging cursor is being dropped, so every page re-serves page 1 \
+                 (t_a0f922a3 LIVE: has_more stuck True forever)"
+            );
+        }
+    }
+
     /// Extract `(pk, ck)` ints from a row given the projected column indices.
     fn row_pk_ck(row: &[Option<CqlValue>], pk_idx: usize, ck_idx: usize) -> (i32, i32) {
         let int_at = |i: usize| match row[i] {
@@ -25774,6 +25862,73 @@ mod tests {
             10,
         )
         .await;
+        assert_paged_traversal_exact(&pages, 0, 1, &expected, page_size as usize);
+    }
+
+    /// t_a0f922a3 LIVE (the bug 3 prior in-process-green fixes missed): the
+    /// EXACT live shape and transport. `SELECT pk, ck FROM vcyc.edges`
+    /// (3 partitions × 5000 clustering rows), driven with the python driver's
+    /// `fetch_size=2000` and the echoed cursor round-tripped through the REAL
+    /// wire `<query_parameters>` codec — NOT a hand-built `ctx.paging`.
+    ///
+    /// Live evidence reproduced here as assertions:
+    ///  * page 1 returned 5000 rows for fetch_size=2000 → page_size was NOT
+    ///    applied (the server default leaked through). `walk_pages_via_wire`
+    ///    fails the moment a page exceeds the wire fetch_size.
+    ///  * pages 2,3,4 were byte-identical to page 1 (same rows, same cursor) →
+    ///    the echoed paging_state was ignored and the scan re-served partition 1
+    ///    from ck=0 forever. `assert_paged_traversal_exact` fails on a
+    ///    non-advancing page, and the `max_pages` cap fails a cycling loop.
+    ///
+    /// Revert-to-confirm: revert the wire decode in `connection.rs` (back to
+    /// `PagingParams::default()`) and this test fails with a cycling cursor /
+    /// oversized page — while the older `walk_pages` (hand-built `ctx.paging`)
+    /// tests keep passing, which is precisely why the live failure slipped past.
+    #[tokio::test]
+    async fn live_wire_paged_scan_advances_and_terminates_exactly() {
+        let rows_per: i64 = 5_000;
+        let page_size: i32 = 2_000; // python driver default-style fetch_size
+        let (state, _dir, auth, ks) =
+            setup_clustered_scan_table("vcyc", &[1, 2, 3], rows_per).await;
+
+        let expected: std::collections::BTreeSet<(i32, i32)> = [1, 2, 3]
+            .into_iter()
+            .flat_map(|pk| (0..rows_per as i32).map(move |ck| (pk, ck)))
+            .collect();
+        assert_eq!(expected.len(), 15_000, "fixture must be exactly 15k rows");
+
+        // The exact projected live query, over the wire codec. A generous page
+        // cap: ceil(15000/2000) = 8 pages; a cycling cursor blows past it.
+        let pages = walk_pages_via_wire(
+            &state,
+            &auth,
+            &ks,
+            "SELECT pk, ck FROM vcyc.wide",
+            page_size,
+            50,
+        )
+        .await;
+        assert_paged_traversal_exact(&pages, 0, 1, &expected, page_size as usize);
+
+        // And the same after flushing to SSTable (the live cycle was observed
+        // on flushed data; a post-restart node returned an instant empty page).
+        state
+            .engine
+            .flush(&ferrosa_storage::TableId::new("vcyc", "wide"))
+            .expect("flush vcyc.edges to SSTable");
+        let pages = walk_pages_via_wire(
+            &state,
+            &auth,
+            &ks,
+            "SELECT pk, ck FROM vcyc.wide",
+            page_size,
+            50,
+        )
+        .await;
+        assert!(
+            !pages.is_empty(),
+            "SSTable-backed wire-paged scan returned an instant EMPTY result"
+        );
         assert_paged_traversal_exact(&pages, 0, 1, &expected, page_size as usize);
     }
 

--- a/ferrosa-net/README.md
+++ b/ferrosa-net/README.md
@@ -74,7 +74,11 @@ It is a near-leaf in the dependency graph: it depends only on `ferrosa-common`
   route liveness as the lifecycle predicate for callers' per-request companion
   state (ferrosa-cluster's stream seq tracking keys create/drop off it: ids are
   monotonic and never reused, and a route is always registered before its
-  request fires, so "no route" is terminal for that id).
+  request fires, so "no route" is terminal for that id). Data frames route
+  fail-loud (`route` closes the route on a full buffer so a dropped chunk can
+  never become a silent partial result); advisory frames route lossily
+  (`route_lossy` drops the frame on a full buffer and KEEPS the route —
+  heartbeats must never kill a healthy mid-window stream, t_a0f922a3).
 - **Failure detection + skew** (`peer`, `skew`) — per-peer RTT and clock-skew
   tracking derived from heartbeats; the Accord protocol consumes `SkewMax`.
 - **Discovery** (`discovery`) — `SeedDiscovery` over a `Discovery` trait.

--- a/ferrosa-net/src/stream_router.rs
+++ b/ferrosa-net/src/stream_router.rs
@@ -114,6 +114,32 @@ impl StreamRouter {
         }
     }
 
+    /// Route an ADVISORY frame: identical to [`Self::route`], except a full
+    /// buffer silently DROPS the frame and KEEPS the route alive (`Ok(())`).
+    ///
+    /// Only for frames whose loss cannot corrupt the stream — heartbeats. A
+    /// heartbeat only refreshes the consumer's idle watchdog; when the buffer
+    /// is full the consumer already has undrained data frames, so it is not
+    /// idle and dropping the keep-alive is harmless. Closing the route
+    /// instead (the data-frame behavior, which protects against silently
+    /// dropped DATA) would kill a healthy stream just because the consumer
+    /// paused mid-window while a heartbeat was in flight.
+    pub fn route_lossy(&self, request_id: u32, msg: Message) -> Result<(), RouteError> {
+        let mut routes = self.routes.lock().expect("stream router mutex poisoned");
+        let Some(sender) = routes.get(&request_id) else {
+            return Err(RouteError::NoRoute(request_id));
+        };
+        match sender.try_send(msg) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                routes.remove(&request_id);
+                Err(RouteError::ChannelClosed(request_id))
+            }
+            // Advisory frame + full buffer: drop the frame, keep the route.
+            Err(mpsc::error::TrySendError::Full(_)) => Ok(()),
+        }
+    }
+
     /// True when a receiver is currently registered for `request_id`.
     ///
     /// Callers use this as the liveness predicate for per-request companion
@@ -225,6 +251,33 @@ mod tests {
         assert_eq!(rx.recv().await, Some(chunk(1)));
         assert_eq!(rx.recv().await, Some(chunk(2)));
         assert_eq!(rx.recv().await, None);
+    }
+
+    /// Advisory frames (heartbeats) must be DROPPED on a full buffer while
+    /// the route stays alive — an undrained buffer means the consumer is
+    /// mid-window, not stuck, and closing the route there would kill a
+    /// healthy windowed stream (t_a0f922a3).
+    #[tokio::test]
+    async fn route_lossy_drops_frame_on_full_buffer_and_keeps_route() {
+        let router = StreamRouter::new();
+        let mut rx = router.register(31, 2);
+
+        router.route(31, chunk(1)).unwrap();
+        router.route(31, chunk(2)).unwrap();
+
+        // Full buffer: the advisory frame is dropped, the route survives.
+        router
+            .route_lossy(31, chunk(0xAB))
+            .expect("lossy route on a full buffer must succeed by dropping");
+        assert_eq!(router.len(), 1, "route must remain registered");
+
+        // Draining shows only the data frames — the advisory one was dropped.
+        assert_eq!(rx.recv().await, Some(chunk(1)));
+        assert_eq!(rx.recv().await, Some(chunk(2)));
+
+        // The route still works for subsequent frames.
+        router.route(31, chunk(3)).unwrap();
+        assert_eq!(rx.recv().await, Some(chunk(3)));
     }
 
     /// `is_registered` tracks the route lifecycle: false before register,

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -11671,6 +11671,74 @@ mod tests {
         }
     }
 
+    /// t_a0f922a3 "also verify": right after a node restart, a live paged
+    /// scan over a COUNT-verified 15k-row table returned ZERO rows instantly.
+    /// The paged CQL scan is backed by `range_iter_fragmented` (with an
+    /// optional resume key), so pin here that a REOPENED engine whose data is
+    /// entirely SSTable-backed streams every row through that iterator —
+    /// both from the table start and from a mid-table resume key. A silent
+    /// empty (or short) stream on cold SSTable-backed state is the live bug
+    /// shape; it must fail this test, never return an empty page as success.
+    #[tokio::test]
+    async fn reopened_engine_fragmented_scan_returns_all_sstable_backed_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let tid = table_id();
+        let n = 500usize;
+
+        // Phase 1: seed n single-row partitions, flush, drop the engine.
+        {
+            let config = StorageEngineConfig::test_config(dir.path());
+            let engine = StorageEngine::new(config, None).unwrap();
+            engine.register_table(test_schema()).unwrap();
+            for i in 0..n {
+                let pk = make_key(&format!("restart-{i:05}"));
+                engine
+                    .write(&tid, &pk, make_row(format!("v{i}").as_bytes(), 1), 1)
+                    .unwrap();
+            }
+            engine.flush(&tid).unwrap();
+        }
+
+        // Phase 2: reopen cold and page through the fragmented iterator.
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+
+        use futures::StreamExt;
+        let mut keys: Vec<Vec<u8>> = Vec::new();
+        let mut stream = engine.range_iter_fragmented(&tid, None, None);
+        while let Some(item) = stream.next().await {
+            let p = item.expect("fragmented scan after reopen must not error");
+            if !p.rows.is_empty() {
+                keys.push(p.key.key.as_bytes().to_vec());
+            }
+        }
+        assert_eq!(
+            keys.len(),
+            n,
+            "reopened SSTable-backed fragmented scan must stream every \
+             partition — an instant-empty result is the t_a0f922a3 restart bug"
+        );
+
+        // Resume from the middle (token order): the suffix must be exact.
+        let mid = keys[n / 2].clone();
+        let resume = DecoratedKey::new(PartitionKey::new(mid));
+        let mut resumed: Vec<Vec<u8>> = Vec::new();
+        let mut stream = engine.range_iter_fragmented(&tid, Some(&resume), None);
+        while let Some(item) = stream.next().await {
+            let p = item.expect("resumed fragmented scan after reopen must not error");
+            if !p.rows.is_empty() {
+                resumed.push(p.key.key.as_bytes().to_vec());
+            }
+        }
+        assert_eq!(
+            resumed,
+            keys[n / 2..].to_vec(),
+            "a resumed scan after reopen must return exactly the suffix from \
+             the resume key (inclusive), in the same token order"
+        );
+    }
+
     /// Helper: build CompositeType PK for entity_store.
     fn make_entity_store_pk(tenant: [u8; 16], session: [u8; 16]) -> DecoratedKey {
         let mut pk = Vec::new();

--- a/specs/decisions/020-streaming-internode-range-read.md
+++ b/specs/decisions/020-streaming-internode-range-read.md
@@ -271,6 +271,64 @@ The same shape generalizes to `IndexReadRequest` (also currently a
 single-response RPC) and `RangeWriteRequest` (the inverse direction
 for bulk imports). Those follow as separate ADRs once this one lands.
 
+## Windowed continuation + fail-loud terminal contract (t_a0f922a3)
+
+The paged multi-replica scan layers **flow control** and a **fail-loud
+completion contract** on top of the base streaming RPC. Both are
+correctness-critical: a violation silently truncates a full-table scan
+(data loss), which is strictly worse than a crash.
+
+**Windowed continuation (flow control).** A `RangeReadStreamRequest`
+carries `max_chunks`: the producer stops after that many chunk frames and
+reports the position after its last emitted row in
+`RangeReadStreamDonePayload.resume`. The coordinator's
+`WindowedReplicaForwarder` fires the next window (a fresh `request_id`,
+resumed at that position) only after its consumer drains the previous one.
+Un-drained frames per stream never exceed one window, so the bounded route
+buffer cannot overflow no matter how large the scan is — no server-side
+result cap, bounded memory. A `Done` with `resume: None` means the
+producer's local range is genuinely exhausted.
+
+**Fail-loud terminal contract (t_a0f922a3 bug #2).** The N-way merge
+concludes the whole scan is complete once *every* source's stream ends. A
+source stream ends when its per-replica `remote_tx` drops. That inference
+— "channel closed ⇒ replica exhausted" — is only sound when the forwarder
+closed for a reason that makes a silent close *correct*:
+
+- the producer signalled genuine exhaustion (`Completed { resume: None }`), or
+- the consumer *deliberately* abandoned the merged output (a paged read
+  filled its page).
+
+The forwarder sets a per-source `clean_end` flag at exactly those two
+terminations (and at the window-boundary `remote_tx.is_closed()` abandon).
+Every source stream is wrapped by `clean_end_guarded_stream`: if the
+channel closes **without** `clean_end` set — a panicked forwarder task, or
+any future refactor that drops `remote_tx` without delivering an error or
+signalling exhaustion — the wrapper emits one final **loud, retryable
+`Internal` error** instead of a silent `None`. The scan then fails loudly
+(and drivers retry the idempotent range read) rather than returning a
+partial result with `has_more = false`. A forwarder that already delivered
+its own error item (the `Failed` path) is unaffected: the merge sees that
+error first and the fallback never fires.
+
+Observability: `forwarder_diag::{error_send_dropped, continuations_fired}`
+are process-global counters. `error_send_dropped` counts loud replica
+errors that could not be delivered because the merged output was already
+gone — benign under a deliberate page abandon, but a non-zero value on a
+full-drain scan is the silent-partial signature and is asserted on by the
+`range_scan_multi_replica_paging` harness.
+
+**Not reproduced in-process.** The `range_scan_multi_replica_paging`
+harness drives the exact live shape — 3-node loopback cluster, RF=3,
+CL=ALL, disjoint per-replica data, wide partitions, and
+`FERROSA_RANGE_READ_ROWS_PER_FRAGMENT=1` to force ~hundreds of window
+continuations per page — and pages to an **exact** union every time, with
+`error_send_dropped == 0` and `route_closures == 0`. The live 21160-of-50807
+truncation did not reproduce in-process, consistent with the historical
+observation that fresh-data reproductions all page complete; the fail-loud
+guard closes the class of silent-complete structurally rather than by
+matching the exact (environmental/timing) live trigger.
+
 ## Alternatives considered
 
 - **Just bump the timeout** (PR #41). Stopgap: hides the symptom at

--- a/specs/proposed/streaming-range-reads-no-cap.md
+++ b/specs/proposed/streaming-range-reads-no-cap.md
@@ -3,6 +3,80 @@
 **Status:** proposed (design locked; implementation in `feat/stream-range-reads-no-cap`).
 **Steps 1–2 and Step 5 (final) landed.**
 
+## Progress — paged-scan flow control + within-partition producer resume (`t_a0f922a3`)
+
+**Landed (`fix/paged-scan-cursor`).** Two live failures of the cluster paged
+projected scan (the memory-viz `SELECT src_id, edge_type, dst_id FROM
+typed_edges` cycle and the `SELECT id FROM vfix.nums` page-1 stall):
+
+- **Mode 2 root cause (STALL) — no end-to-end flow control.** The remote
+  producer fired the WHOLE scan as chunk frames with no acknowledgement;
+  everything the consumer hadn't drained sat in the coordinator's bounded
+  per-request route buffer (`STREAM_RECEIVER_BUFFER = 32`). Any multi-replica
+  scan bigger than the buffer overflowed it the moment the consumer was slower
+  than the wire; `StreamRouter::route` then fail-loud-closed the route and the
+  query died with a *retryable* `ReadTimeout` — which drivers/fmem retry
+  forever, presenting live as a >14 min "stall". Reproduced RED by
+  `multi_replica_many_small_partitions_paged_scan_completes` (15 000
+  single-row partitions, RF=3 loopback harness): failed in ~1.4 s with
+  `ReadTimeout { received: 0, required: 1 }`.
+- **Fix: windowed continuation.** `RangeReadStreamRequestPayload.max_chunks`
+  (window, `STREAM_WINDOW_CHUNKS = 16` ≤ buffer) caps the frames one request
+  may emit; the producer stops at the window and reports the position after
+  the last emitted row in `RangeReadStreamDonePayload.resume`; the
+  coordinator's per-replica forwarder (`WindowedReplicaForwarder`) fires the
+  continuation request only after the consumer drained the window (and never
+  when the consumer already abandoned the page). Un-drained frames per stream
+  are ≤ window + Done — `ChannelFull` cannot fire on a slow consumer, memory
+  stays bounded, and there is still **no server-side result cap**. Heartbeats
+  became LOSSY on a full buffer (`StreamRouter::route_lossy`): an advisory
+  keep-alive may be dropped, never allowed to close a healthy route.
+- **Mode 1 (CYCLE) — within-partition resume, producer side.** The
+  coordinator-side cursor (paging_state = partition key + clustering + HMAC —
+  wire format UNCHANGED) already resumed exactly at the CQL collector; but
+  every producer re-streamed the cursor partition FROM ITS START on each page.
+  Now `ScanResume { key, clustering }` threads the clustering position through
+  `WritePath::range_read[_projected]_stream_all_from` →
+  `RangeReadStreamRequestPayload.start_clustering` (and the local iterator
+  wrapper `resume_filtered_stream`), so every producer skips the delivered
+  prefix (`clustering <= resume`) — no re-emit, no skip, no per-page O(prefix)
+  wire cost. The collector's own skip-≤-last remains as an idempotent second
+  layer.
+- **Exactness pinned end-to-end** (all RED-capable, hard timeouts so a stall
+  or cycle FAILS):
+  - `ferrosa-cql` `router.rs`: `wide_partition_spanning_pages_terminates_exactly`
+    (ONE 15k-row partition @ page 5000 → exactly 3 strictly-advancing pages,
+    exact union, memtable AND SSTable-backed, star + projected),
+    `mixed_wide_and_narrow_partitions_page_exactly`,
+    `wide_partition_multi_text_clustering_pages_exactly_after_flush`
+    (length-prefixed multi-text clustering — byte-order vs component-order
+    divergence shape), `many_small_partitions_pk_projection_pages_without_stalling`
+    (15k single-row partitions, pk-only projection).
+  - `ferrosa-cluster` `range_scan_multi_replica_paging.rs`:
+    `multi_replica_wide_partition_paged_scan_terminates_exactly` (3×4 000-row
+    partitions, page 1 500 rows, REAL RF=3 fan-out + the CQL collector's exact
+    cursor semantics), `multi_replica_many_small_partitions_paged_scan_completes`.
+  - `ferrosa-storage` `engine.rs`:
+    `reopened_engine_fragmented_scan_returns_all_sstable_backed_rows`
+    (restart shape: cold reopen → fragmented scan + mid-table resume exact).
+- **Wire note:** `RangeReadStreamRequestPayload` gains `start_clustering` +
+  `max_chunks`; `RangeReadStreamDonePayload` gains `resume`. bincode is not
+  self-describing — **upgrade all nodes together** (same contract as
+  `FulltextSearchRequestPayload.limit`); a mixed-version peer fails the decode
+  loudly (truncated Done → loud coordinator error), never silently misreads.
+  The client-facing `paging_state` format is unchanged and remains opaque to
+  drivers.
+- **Findings that did NOT reproduce in-process** (documented, filed): the
+  live period-3 page cycle could not be reproduced against this stack's
+  single-node or RF=3 loopback paths at live scale with a correctly-registered
+  schema — the only in-repo mechanism found that produces exactly that
+  signature is clustering bytes arriving EMPTY at the collector (cursor can
+  then never advance within a partition), which happens when rows are flushed
+  through a schema registered with no clustering columns (the SSTable
+  serialization header silently drops clustering). Filed for a fail-loud
+  guard. The restart instant-empty also did not reproduce (see the reopen
+  test); filed for live-side verification.
+
 ## Progress — consume-path bounded-streaming refactor (`t_ee98faa0` + `t_3fc6be3c`)
 
 **Landed.** The last Vec-accumulating consume path — `consume_range_stream`'s


### PR DESCRIPTION
**Stacked:** #237→#238→#240→#241→#242→this. **Live-validated on the fmem-dev cluster** (see below). Held for maintainer sign-off per policy.

## Root cause (deeper than 3 prior attempts)
The paged coordinated projected scan cycled/stalled on the cluster because the **CQL wire ingress discarded the client's paging fields**. `connection.rs` `handle_query`/`handle_execute` built `RequestContext` with `PagingParams::default()`, and the `<query_parameters>` decoder read **only** the VALUES flag (0x01) — never `page_size` (0x04) or `paging_state` (0x08). So both live symptoms fell out of one bug:
- `page_size` None → arm used `default_scan_page_size()` = 5000 (a `fetch_size=2000` request returned 5000 rows).
- `paging_state` None → resume always None → **re-served partition 1 from ck=0 forever** (viz stuck at ~5k).

The router/coordinator resume logic (`bf6fbc71`) was already correct — every prior test injected `ctx.paging` directly and never exercised the wire→ctx bridge that was actually broken.

## Fix
`connection.rs`: new `decode_query_params` walks the wire flags in order (values → page_size → paging_state); `build_request_context` threads the decoded `PagingParams` from both `handle_query` and `handle_execute`. No server-side cap, no wire-format change (we now *read* fields drivers already send).

## Verification — RED round-trips real paging_state bytes
`live_wire_paged_scan_advances_and_terminates_exactly`: serializes page N's returned `paging_state` to actual v5 `<query_parameters>` bytes, re-decodes via the **production** `decode_query_params`, feeds it into page N+1. Revert-to-confirm reproduced **both** exact live signatures (5000-rows-for-2000, and non-terminating re-serve). ferrosa-cql 1005 / ferrosa-cluster 1051 lib green; clippy clean; oom-audit 0.

## Live cluster validation (image from this branch, RF=3)
- `fetch_size=2000` → exactly 2000 rows/page; paging_state advances every page.
- Fresh tables page to **exact completeness + terminate**: 15k, 51k composite-clustering, 30k `(uuid,text,uuid)` clustering, **60k across 6 SSTables in one partition** — all COMPLETE.

## Known separate issue (NOT this fix)
`agent_memory.typed_edges` paged scans still return incomplete (~13k/50,807) — traced to malformed at-rest graph-engine data (`t_36c559c9`), reproduced by NO fresh-data shape. Two follow-ups: fix the graph write path, and make the read path **fail loud** on an un-resumable row instead of silently terminating (data-loss-as-complete). Tracked separately.