### PR TITLE
fix: clean up pr244 index follow-ups

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -46,7 +46,9 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   types, UDFs/UDAs, members, token map, per-node index status, cluster config.
   `DropTable` apply removes the table's index entries from `RaftState` and, via
   `engine.unregister_table`, cascades tombstones over the dropped table's
-  `system_schema.indexes` registrations (t_ae06e925).
+  `system_schema.indexes` registrations (t_ae06e925). `DropIndex` apply now
+  also calls `engine.drop_index`, so live memtable/sidecar/vector index state and
+  `IndexStateTracker` entries are removed on the applying node immediately.
 - `SledLogStore` — sled-backed log + meta trees, legacy-format migration, log
   inspection/reset tooling.
 - `election_guard.rs` — `run_election_guard` watchdog (P0-17/P0-19): a burst
@@ -98,7 +100,10 @@ strict-serializable multi-key / cross-shard transactions and LWT.
 - `coordinator/batch.rs` — 3-phase logged batchlog (write → fan out → delete only
   on full success) with replay task; `DEFAULT_BATCH_CONCURRENCY = 32`.
 - `coordinator/{range_read_stream,stream_*}.rs` — ADR-020 streaming range reads
-  (default; legacy capped path behind `FERROSA_BULK_STREAMING_RANGE_READ=0`).
+  and projected streaming scans; the old Vec-returning
+  `WritePath::range_read_projected` wrapper has been removed, so projected
+  scans use `range_read_projected_stream_all_*` directly (default; legacy capped
+  path behind `FERROSA_BULK_STREAMING_RANGE_READ=0`).
   `DEFAULT_RANGE_READ_LIMIT` (10_000) is **not** a result cap on streamable
   shapes: `range_read_limited_rows` and `coordinate_range_read_stream_limited_rows`
   honor the caller's own bound (a user `LIMIT N`) uncapped; the const now only

--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -47,8 +47,9 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   `DropTable` apply removes the table's index entries from `RaftState` and, via
   `engine.unregister_table`, cascades tombstones over the dropped table's
   `system_schema.indexes` registrations (t_ae06e925). `DropIndex` apply now
-  also calls `engine.drop_index`, so live memtable/sidecar/vector index state and
-  `IndexStateTracker` entries are removed on the applying node immediately.
+  also calls `engine.drop_index`, so live memtable/vector index state, sidecar
+  read guards, and `IndexStateTracker` entries are removed on the applying node
+  immediately.
 - `SledLogStore` — sled-backed log + meta trees, legacy-format migration, log
   inspection/reset tooling.
 - `election_guard.rs` — `run_election_guard` watchdog (P0-17/P0-19): a burst

--- a/ferrosa-cluster/specs/overview.md
+++ b/ferrosa-cluster/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cluster
 status: implemented
-last_updated: 2026-06-19
+last_updated: 2026-07-03
 executive_summary: >
   The distribution layer that turns single-node ferrosa-storage engines into a
   cluster: Raft metadata consensus (openraft 0.9 fork with PreVote + CheckQuorum),
@@ -64,6 +64,12 @@ digest reads, then resolves. On digest mismatch it fail-loud re-fetches the newe
 copy and repairs stale replicas inline; on a corrupt local SSTable it fails over
 to a healthy replica and enqueues a background anti-entropy refill.
 
+**Range read.** The public write-path range-read surface is streaming-first:
+projected scans use `range_read_projected_stream_all_from` /
+`range_read_projected_stream_all_with`, and the old `Vec<Partition>`-returning
+`range_read_projected` wrapper has been removed so projected scans cannot drift
+back to local-only materialization.
+
 **Keyed index read (t_430c4188).** `coordinate_index_read_in_partition`
 serves `WHERE <full partition key> AND <indexed_col> = ?`: it resolves the
 partition's replicas from the ring under the keyspace strategy and sends each an
@@ -85,7 +91,9 @@ locally). Fixes the coordinator-local non-determinism of BUG-F-007.
 
 **DDL / membership.** Mutations are wrapped as `RaftOp`, proposed via
 `raft.client_write` (forwarded to the leader if needed via `raft_forward`),
-committed, and applied deterministically into `RaftState` on every node.
+committed, and applied deterministically into `RaftState` on every node. DROP
+INDEX also calls `StorageEngine::drop_index` in Direct, pair, and Raft apply
+paths so live `TableStore`/index-tracker state follows the replicated schema.
 
 **Accord transaction.** `AccordCoordinator` runs PreAccept → (fast path or Accept)
 → Commit → Apply across the participating shards, dep-waiting on conflicting

--- a/ferrosa-cluster/src/ddl_path.rs
+++ b/ferrosa-cluster/src/ddl_path.rs
@@ -317,6 +317,9 @@ fn apply_direct(op: &DdlOperation, schema: &Schema, engine: &Arc<StorageEngine>)
             schema
                 .drop_index_internal(keyspace, table, index)
                 .map_err(|e| ClusterError::Internal(format!("drop_index: {e}")))?;
+            engine
+                .drop_index(&ferrosa_storage::TableId::new(keyspace, table), index)
+                .map_err(ClusterError::Storage)?;
             SystemTableWriter::new(Arc::clone(engine))
                 .apply(
                     ferrosa_schema::system::persistence::SystemTableMutation::IndexDropped {

--- a/ferrosa-cluster/src/pair/ddl.rs
+++ b/ferrosa-cluster/src/pair/ddl.rs
@@ -348,6 +348,9 @@ impl DdlCoordinator {
                 self.schema
                     .drop_index_internal(keyspace, table, index)
                     .map_err(|e| ClusterError::Internal(format!("drop_index: {e}")))?;
+                self.engine
+                    .drop_index(&ferrosa_storage::TableId::new(keyspace, table), index)
+                    .map_err(ClusterError::Storage)?;
                 crate::system_table_writer::SystemTableWriter::new(Arc::clone(&self.engine))
                     .apply(
                         ferrosa_schema::system::persistence::SystemTableMutation::IndexDropped {

--- a/ferrosa-cluster/src/raft/state_machine.rs
+++ b/ferrosa-cluster/src/raft/state_machine.rs
@@ -1155,6 +1155,14 @@ impl FerrosStateMachine {
                         tracing::error!(%e, "Raft apply: schema.drop_index_internal failed");
                     }
                 }
+                if let Some(engine) = &self.engine {
+                    if let Err(e) = engine.drop_index(&TableId::new(&keyspace, &table), &index) {
+                        tracing::error!(%e, "Raft apply: engine.drop_index failed — stale index state may remain");
+                        apply_errors.push(ApplyError::Other(format!(
+                            "engine.drop_index({keyspace}.{table}.{index}) failed: {e}"
+                        )));
+                    }
+                }
             }
             RaftOp::IndexStatus {
                 node_id,

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -715,7 +715,7 @@ impl WritePath {
                     .await
             }
             Self::Unavailable => Err(crate::error::ClusterError::Internal(
-                "range_read_projected unavailable: write path is in degraded mode".into(),
+                "coordinate_range_read_projected_stream_from unavailable: write path is in degraded mode".into(),
             )),
         }
     }
@@ -785,7 +785,7 @@ impl WritePath {
                     .await
             }
             Self::Unavailable => Err(crate::error::ClusterError::Internal(
-                "range_read_projected unavailable: write path is in degraded mode".into(),
+                "coordinate_range_read_projected_stream_all_with unavailable: write path is in degraded mode".into(),
             )),
         }
     }

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -790,56 +790,6 @@ impl WritePath {
         }
     }
 
-    /// Projection-aware range read. Returns partitions whose
-    /// `rows[*].cells` contains only cells whose ordinals are in
-    /// `wanted` — SSTable cells outside the projection are
-    /// byte-skipped via `read_cell_skip`. Used by the CQL fast
-    /// path for `SELECT col1, col2 FROM t` on wide tables (esp.
-    /// embedding vectors).
-    ///
-    /// The caller is expected to have already verified that the
-    /// projection is safe — i.e., no WHERE clause references
-    /// cells outside `wanted` — otherwise predicates would fail
-    /// to evaluate against the trimmed rows. CQL router enforces
-    /// this; raw callers should too.
-    pub async fn range_read_projected(
-        &self,
-        table_id: &TableId,
-        wanted: Vec<u16>,
-        partition_limit: Option<usize>,
-    ) -> crate::error::Result<Vec<Partition>> {
-        use futures::stream::StreamExt;
-        let engine = match self {
-            Self::Direct(engine) => engine.clone(),
-            Self::Pair(coordinator) | Self::DegradedPair(coordinator) => {
-                coordinator.local_storage().clone()
-            }
-            Self::Cluster(coordinator) => coordinator.storage.clone(),
-            Self::Unavailable => {
-                return Err(crate::error::ClusterError::Internal(
-                    "range_read_projected unavailable: write path is in degraded mode".into(),
-                ));
-            }
-        };
-        // Push `partition_limit` into the producer so the merger
-        // stops emitting after N partitions — without this, the
-        // bounded mpsc buffer means the producer races ahead by
-        // `STREAM_BUFFER` body decodes after the consumer has
-        // already read enough, and on cold cache each of those
-        // wasted body decodes is ~hundreds of ms.
-        let mut stream = engine.range_iter_projected(table_id, wanted, partition_limit, None, None);
-        let cap = partition_limit.unwrap_or(usize::MAX);
-        let mut out = Vec::new();
-        while let Some(item) = stream.next().await {
-            out.push(item.map_err(crate::error::ClusterError::Storage)?);
-            if out.len() >= cap {
-                drop(stream);
-                break;
-            }
-        }
-        Ok(out)
-    }
-
     /// Read up to `limit` partitions for unordered full-scan consumers.
     ///
     /// This lets CQL `LIMIT` and protocol page-size produce the first page
@@ -1448,7 +1398,7 @@ mod tests {
         let projected_body = source
             .split("pub async fn range_read_projected_stream_all_with")
             .nth(1)
-            .and_then(|rest| rest.split("/// Projection-aware range read").next())
+            .and_then(|rest| rest.split("/// Read up to `limit` partitions").next())
             .expect("projected streaming range-read body must be present");
         assert!(
             projected_body.contains("local_projected_range_stream")

--- a/ferrosa-cql/README.md
+++ b/ferrosa-cql/README.md
@@ -60,7 +60,10 @@ unaffected (see [Bridge re-export](#bridge-re-export-d10)).
   `PartitionKeyLookup` (full PK), `PartitionIndexLookup` (full PK **plus** an
   indexed residual `=` predicate — t_430c4188: keyed secondary-index consult
   restricted to the partition, O(matching rows) instead of O(partition rows),
-  routed to the partition's replicas, no ALLOW FILTERING needed),
+  routed to the partition's replicas, no ALLOW FILTERING needed). Empty keyed
+  consults rescan the one partition only while storage reports the index is not
+  current; once `IndexStateTracker` is `Current`, an empty consult is accepted as
+  a real miss,
   `SingleIndex` / `IndexScanWithFilter` / `IndexIntersection` (global index
   scatter-gathers), `VectorAnn` / `GeoIndex` / `FullTextIndex` (dedicated
   branches), `FullScan`. `EXPLAIN SELECT …` renders the same plan the router

--- a/ferrosa-cql/specs/overview.md
+++ b/ferrosa-cql/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 status: implemented
-last_updated: 2026-06-27
+last_updated: 2026-07-03
 executive_summary: >
   The CQL native-protocol (v3/v4/v5) server and the largest, most central crate in
   the workspace (~54k LoC). It owns the full client path — TCP accept, frame
@@ -79,7 +79,11 @@ KEYED index consult: `WritePath::index_read_in_partition` routes to the
 partition's replicas, each consults its secondary index restricted to that
 partition, and only the matching rows are point-read — O(matching rows), never
 O(partition rows), with an EXPLAIN plan of `PartitionIndexLookup`. The router
-then decomposes partitions to rows via the re-exported
+trusts an empty keyed consult only when the local write path can treat the
+storage `IndexStateTracker` as authoritative and that tracker reports the index
+current with no pending SSTable backfill; clustered reads keep the bounded
+partition fallback so remote replica lag cannot hide matches. The router then
+decomposes partitions to rows via the re-exported
 `partition_to_rows_with_storage_mapping` (tombstone/TTL skipping, storage→table
 column mapping), applies projection/LIMIT/paging, and `result.rs` encodes the
 Rows RESULT frame (with `paging_state` when more pages remain).

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -212,8 +212,8 @@ fn prepare_order_by_execution(
 /// ADR-020 projection fast path eligibility + ordinal computation.
 ///
 /// Returns `Some(wanted)` if the SELECT statement is safe to route
-/// through `WritePath::range_read_projected`, where `wanted` is the
-/// storage-ordinal Vec of regular columns the projection asks for.
+/// through `WritePath::range_read_projected_stream_all_*`, where `wanted` is
+/// the storage-ordinal Vec of regular columns the projection asks for.
 /// Returns `None` otherwise — the caller falls back to the legacy
 /// `range_read` path.
 ///
@@ -5369,10 +5369,10 @@ async fn route_select_user_table(
                             )
                             .unwrap_or(0);
                             // ADR-020 projection fast path. Route through
-                            // range_read_projected whenever the query only needs a subset
-                            // of regular cells, so the SSTable layer byte-skips bulky
-                            // unneeded payloads. Big win on wide tables with bulky cells
-                            // (e.g. entity_store's entity_embedding column).
+                            // range_read_projected_stream_all_* whenever the query only
+                            // needs a subset of regular cells, so the SSTable layer
+                            // byte-skips bulky unneeded payloads. Big win on wide tables
+                            // with bulky cells (e.g. entity_store's entity_embedding column).
                             //
                             // Non-count SELECT requires no WHERE because predicates over
                             // unprojected regular columns would evaluate against NULL.

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -21,7 +21,7 @@ use sha2::{Digest, Sha256};
 
 use ferrosa_cluster::consistency::ConsistencyLevel;
 use ferrosa_cluster::pair::ddl::DdlOperation;
-use ferrosa_cluster::DdlPath;
+use ferrosa_cluster::{DdlPath, WritePath};
 use ferrosa_common::DataType;
 use ferrosa_index::IndexType;
 use ferrosa_schema::{
@@ -4475,78 +4475,70 @@ async fn route_select_user_table(
             extract_clustering_key_values(&s.where_clauses, table_meta, ks, &state.schema)?
                 .map(|values| bridge::build_clustering_key(&values))
         };
-        let partitions: Vec<ferrosa_sstable::types::Partition> =
-            if let Some(clustering) = exact_clustering {
-                state
-                    .write_path
-                    .load()
-                    .pk_read_clustering_row(
-                        &table_id,
-                        &decorated_key,
-                        &clustering,
-                        ctx.consistency,
-                        &read_strategy,
-                    )
-                    .await?
-                    .into_iter()
-                    .collect()
-            } else if let Some((index_name, index_key)) =
-                keyed_index_consult(state, &snap, ks, s, table_meta)
-            {
-                // Keyed secondary-index consult (t_430c4188): `WHERE <full
-                // partition key> AND <indexed_col> = ?`. Consult the index
-                // restricted to the specified partition and point-read only the
-                // matching rows — O(matching rows), never O(partition rows).
-                // Routing is keyed to the partition's replicas (never the global
-                // index scatter-gather), and no ALLOW FILTERING is required: the
-                // shape is fully keyed.
-                state
-                    .index_usage_tracker
-                    .record(ks, &s.table, &index_name, "PartitionIndexLookup");
-                let consulted = state
-                    .write_path
-                    .load()
-                    .index_read_in_partition(
-                        &table_id,
-                        &decorated_key,
-                        &index_name,
-                        &index_key,
-                        &read_strategy,
-                    )
-                    .await?;
-                if consulted.is_empty() {
-                    // DESIGNED fallback, mirroring the staleness masking of the
-                    // global `SingleIndex` arm (its empty-result fallback rescans
-                    // the table): a secondary index created over pre-existing data
-                    // is backfilled asynchronously, so an empty consult is not yet
-                    // proof of an empty result. Re-verify with a partition-scoped
-                    // read + post-filter — bounded by ONE partition, never the
-                    // whole table — so the keyed path's consistency is never worse
-                    // than the global index path it bypasses.
-                    tracing::debug!(
-                        keyspace = ks,
-                        table = %s.table,
-                        index = %index_name,
-                        "keyed index consult returned no rows; \
-                         re-verifying with a partition-scoped scan"
-                    );
-                    state
-                        .write_path
-                        .load()
-                        .pk_read_limited_rows(
-                            &table_id,
-                            &decorated_key,
-                            ctx.consistency,
-                            &read_strategy,
-                            row_limit,
-                        )
-                        .await?
-                        .into_iter()
-                        .collect()
-                } else {
-                    consulted
-                }
-            } else {
+        let partitions: Vec<ferrosa_sstable::types::Partition> = if let Some(clustering) =
+            exact_clustering
+        {
+            state
+                .write_path
+                .load()
+                .pk_read_clustering_row(
+                    &table_id,
+                    &decorated_key,
+                    &clustering,
+                    ctx.consistency,
+                    &read_strategy,
+                )
+                .await?
+                .into_iter()
+                .collect()
+        } else if let Some((index_name, index_key)) =
+            keyed_index_consult(state, &snap, ks, s, table_meta)
+        {
+            // Keyed secondary-index consult (t_430c4188): `WHERE <full
+            // partition key> AND <indexed_col> = ?`. Consult the index
+            // restricted to the specified partition and point-read only the
+            // matching rows — O(matching rows), never O(partition rows).
+            // Routing is keyed to the partition's replicas (never the global
+            // index scatter-gather), and no ALLOW FILTERING is required: the
+            // shape is fully keyed.
+            state
+                .index_usage_tracker
+                .record(ks, &s.table, &index_name, "PartitionIndexLookup");
+            let consulted = state
+                .write_path
+                .load()
+                .index_read_in_partition(
+                    &table_id,
+                    &decorated_key,
+                    &index_name,
+                    &index_key,
+                    &read_strategy,
+                )
+                .await?;
+            let keyed_index_current = {
+                let write_path = state.write_path.load();
+                let local_tracker_authoritative = matches!(
+                    &**write_path,
+                    WritePath::Direct(_) | WritePath::Pair(_) | WritePath::DegradedPair(_)
+                );
+                local_tracker_authoritative && state.engine.index_is_current(&table_id, &index_name)
+            };
+            if consulted.is_empty() && !keyed_index_current {
+                // DESIGNED fallback, mirroring the staleness masking of the
+                // global `SingleIndex` arm (its empty-result fallback rescans
+                // the table): a secondary index created over pre-existing data
+                // is backfilled asynchronously, so an empty consult is not yet
+                // proof of an empty result. Re-verify with a partition-scoped
+                // read + post-filter — bounded by ONE partition, never the
+                // whole table — so the keyed path's consistency is never worse
+                // than the global index path it bypasses.
+                tracing::debug!(
+                    keyspace = ks,
+                    table = %s.table,
+                    index = %index_name,
+                    "keyed index consult returned no rows; \
+                     re-verifying with a partition-scoped scan"
+                );
                 state
                     .write_path
                     .load()
@@ -4560,7 +4552,24 @@ async fn route_select_user_table(
                     .await?
                     .into_iter()
                     .collect()
-            };
+            } else {
+                consulted
+            }
+        } else {
+            state
+                .write_path
+                .load()
+                .pk_read_limited_rows(
+                    &table_id,
+                    &decorated_key,
+                    ctx.consistency,
+                    &read_strategy,
+                    row_limit,
+                )
+                .await?
+                .into_iter()
+                .collect()
+        };
         let mut pk_rows = Vec::new();
         for partition in &partitions {
             pk_rows.extend(bridge::partition_to_rows_with_storage_mapping(
@@ -9303,6 +9312,10 @@ async fn route_drop_index(
             state
                 .schema
                 .drop_index(ks, &table_name, &s.name, ctx.auth)?;
+            state
+                .engine
+                .drop_index(&TableId::new(ks, &table_name), &s.name)
+                .map_err(|e| CqlError::ServerError(format!("drop index storage cleanup: {e}")))?;
             // Tombstone the dogfooded system_schema.indexes row (cluster/pair
             // paths do this via SystemTableWriter; Direct mode does it here).
             tombstone_index_row_direct(&state.engine, ks, &table_name, &s.name);

--- a/ferrosa-index-builder/README.md
+++ b/ferrosa-index-builder/README.md
@@ -37,6 +37,10 @@ and the `/internal/index/build` route) *is* the interface — see
   fully-encoded `FilterPredicate` on the wire and threads it into the
   `IndexBuildJob`, so the remote sidecar contains exactly the matching rows —
   never an unfiltered sidecar.
+- **Clustering-column index support**: build requests may carry
+  `clustering_source` (`component`, `total`) for indexes on CLUSTERING columns;
+  the worker threads it into `IndexBuildJob` so `LocalBackend` extracts the
+  value from the composite clustering key instead of looking for a row cell.
 - **Fail-closed for quantized vectors**: a `direct_upload` + `hvq_qvec` request
   returns `status: "failed"` with an explicit "not implemented" message rather
   than silently producing an unpublishable artifact.
@@ -87,8 +91,8 @@ builds carry `sidecar_s3_path` + `entries_built`.
   taxonomy and the partial-index predicate carried on the wire).
 - **`ferrosa-sstable`** — SSTable component shapes consumed during a build.
 - **`ferrosa-storage`** — `LocalBackend`, `IndexBuildJob`, `BuildPriority`,
-  `SidecarWriter`, `ArtifactManifestEntry`, `upload::hex_prefix_for` (the actual
-  index-build engine this service wraps).
+  `ClusteringComponentRef`, `SidecarWriter`, `ArtifactManifestEntry`,
+  `upload::hex_prefix_for` (the actual index-build engine this service wraps).
 
 External: `axum`, `tokio`, `object_store` (aws), `reqwest`, `clap`, `serde`,
 `serde_json`, `bytes`, `tracing`.

--- a/ferrosa-index-builder/specs/overview.md
+++ b/ferrosa-index-builder/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-index-builder
 status: implemented
-last_updated: 2026-06-19
+last_updated: 2026-07-03
 executive_summary: >
   A standalone HTTP service binary that offloads secondary-index construction
   from the Ferrosa engine. When FERROSA_INDEX_BACKEND=remote, the engine's
@@ -64,6 +64,8 @@ optional `artifact_kind` + `direct_upload` (quantized vectors), S3 coordinates
 (`s3_endpoint` / `s3_bucket` / `s3_prefix`), `table` as a
 `(keyspace, table)` pair, `column_position`, `priority`, and an optional
 `filter_predicate` (`Option&lt;FilterPredicate&gt;`, present only for `filtered`
+builds) plus optional `clustering_source`
+(`Option&lt;ClusteringComponentRef&gt;`, present for clustering-column index
 builds).
 
 `BuildResponse` carries `status` (`"completed"` | `"failed"`), optional `error`,
@@ -80,12 +82,16 @@ and on success either `sidecar_s3_path` + `entries_built` (sidecar builds) or an
    `filter_predicate` is threaded through `build_job` into the `IndexBuildJob`
    so `LocalBackend` filters rows; otherwise the remote sidecar would be an
    UNFILTERED superset — a silent correctness bug.
-3. **Quantized `.qvec` direct-upload fails closed.** `is_quantized_direct_upload`
+3. **A clustering-column build must carry its component source.** The wire
+   `clustering_source` is threaded through `build_job` into `IndexBuildJob` so
+   remote builds use the same clustering-key component extraction as in-process
+   scheduler jobs.
+4. **Quantized `.qvec` direct-upload fails closed.** `is_quantized_direct_upload`
    short-circuits to `status: "failed"` rather than emitting an unvalidated
    artifact the engine cannot publish.
-4. **Remote build == in-process build.** The service wraps the engine's own
+5. **Remote build == in-process build.** The service wraps the engine's own
    `LocalBackend`; it adds no second index encoder.
-5. **`CompressionInfo.db` is optional; every other component is mandatory.** A
+6. **`CompressionInfo.db` is optional; every other component is mandatory.** A
    missing mandatory component fails the job and cleans up the temp dir.
 
 ## Position in the dependency graph

--- a/ferrosa-index-builder/src/pull.rs
+++ b/ferrosa-index-builder/src/pull.rs
@@ -88,6 +88,7 @@ pub async fn run(
                             s3_prefix: sstable_prefix,
                             table: (entry.keyspace.clone(), entry.table.clone()),
                             column_position: *col_pos,
+                            clustering_source: None,
                             priority: "normal".into(),
                             // Pull mode rebuilds btree indexes only; no partial predicate.
                             filter_predicate: None,

--- a/ferrosa-index-builder/src/worker.rs
+++ b/ferrosa-index-builder/src/worker.rs
@@ -15,7 +15,9 @@ use object_store::ObjectStore;
 
 use ferrosa_index::IndexType;
 use ferrosa_storage::index::sidecar::SidecarWriter;
-use ferrosa_storage::index::{BuildPriority, IndexBuildBackend, IndexBuildJob, LocalBackend};
+use ferrosa_storage::index::{
+    BuildPriority, ClusteringComponentRef, IndexBuildBackend, IndexBuildJob, LocalBackend,
+};
 
 /// Request sent to the worker pool from the HTTP handler.
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -32,6 +34,10 @@ pub struct BuildRequest {
     pub s3_prefix: String,
     pub table: (String, String),
     pub column_position: usize,
+    /// Clustering-key component metadata for indexes on CLUSTERING columns.
+    /// Omitted for regular/static-column indexes.
+    #[serde(default)]
+    pub clustering_source: Option<ClusteringComponentRef>,
     pub priority: String,
     /// Partial-index predicate. `Some` only for a `filtered` index build: the
     /// fully-encoded [`ferrosa_index::FilterPredicate`] (value bytes already in
@@ -298,10 +304,11 @@ impl BuildRequest {
     }
 }
 
-/// Build an [`IndexBuildJob`] from a [`BuildRequest`], carrying the partial
-/// predicate (if any) so a `filtered` build applies it at build time. This is
-/// the single place the wire request is mapped to a job; extracted so the
-/// predicate plumbing is unit-testable without spinning up the HTTP path.
+/// Build an [`IndexBuildJob`] from a [`BuildRequest`], carrying the optional
+/// clustering-key source and partial predicate so remote builds match the local
+/// scheduler semantics. This is the single place the wire request is mapped to
+/// a job; extracted so protocol plumbing is unit-testable without spinning up
+/// the HTTP path.
 fn build_job(req: &BuildRequest) -> Result<IndexBuildJob, String> {
     let index_type = parse_index_type(&req.index_type)?;
     Ok(IndexBuildJob {
@@ -312,10 +319,7 @@ fn build_job(req: &BuildRequest) -> Result<IndexBuildJob, String> {
         priority: parse_priority(&req.priority),
         enqueued_at: Instant::now(),
         column_position: req.column_position,
-        // The remote-build wire protocol has no clustering-column field yet;
-        // clustering-column index jobs are built locally by the engine
-        // (RemoteBackend routes them to its local fallback, t_430c4188).
-        clustering_source: None,
+        clustering_source: req.clustering_source,
         filter_predicate: req.filter_predicate.clone(),
     })
 }
@@ -417,6 +421,37 @@ mod tests {
     }
 
     #[test]
+    fn build_request_threads_clustering_source_into_job() {
+        let json = serde_json::json!({
+            "sstable_id": "gen-9",
+            "index_name": "ck_idx",
+            "index_type": "btree",
+            "s3_endpoint": "memory://",
+            "s3_bucket": "b",
+            "s3_prefix": "p/ks.tbl/gen-9",
+            "table": ["ks", "tbl"],
+            "column_position": 1,
+            "clustering_source": {
+                "component": 1,
+                "total": 3
+            },
+            "priority": "initial",
+        });
+        let req: BuildRequest = serde_json::from_value(json).unwrap();
+        let job = build_job(&req).unwrap();
+
+        assert_eq!(
+            job.clustering_source,
+            Some(ClusteringComponentRef {
+                component: 1,
+                total: 3
+            })
+        );
+        assert_eq!(job.column_position, 1);
+        assert!(matches!(job.priority, BuildPriority::Initial));
+    }
+
+    #[test]
     fn parse_priorities() {
         assert!(matches!(parse_priority("high"), BuildPriority::High));
         assert!(matches!(parse_priority("normal"), BuildPriority::Normal));
@@ -440,6 +475,7 @@ mod tests {
                 s3_prefix: "prod/42/ks.tbl/gen-42".into(),
                 table: ("ks".into(), "tbl".into()),
                 column_position: 0,
+                clustering_source: None,
                 priority: "normal".into(),
                 filter_predicate: None,
             })

--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -83,10 +83,20 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
 - **Secondary-index pipeline** (`index/`, `memtable/eager_index.rs`) —
   per-index state tracker, channel-based build scheduler, local/remote/off
   backends, FTI + vector (HNSW/IVFFlat) sidecars, artifact manifest.
+  `LocalBackend` resolves SSTable components under the engine layout
+  `<data_dir>/sstables/<keyspace>.<table>` and writes local sidecars beside the
+  table's SSTables; legacy flat test layouts are still accepted. Remote build
+  requests carry filtered predicates and clustering-column source metadata so
+  remote sidecars match local builds. Existing SSTables and flush-time eager
+  builds are marked pending in `IndexStateTracker` before async build
+  submission, giving read planners a real completeness signal.
   Registrations are dogfooded to `system_schema.indexes`; `unregister_table`
   (the DROP TABLE choke point for every DDL route) cascades tombstones over the
   dropped table's registrations via `write_index_tombstones_for_table` and
-  sweeps its tracker entries (t_ae06e925). Boot-time
+  sweeps its tracker entries (t_ae06e925). `StorageEngine::drop_index` is the
+  DROP INDEX choke point for live storage state: it removes the table store's
+  memtable/sidecar/vector metadata and the tracker entry immediately, before
+  restart. Boot-time
   `reload_indexes_from_system_schema` returns an `IndexReloadOutcome`
   (`restored`/`skipped`); unresolvable rows emit one summary warn plus the
   `ferrosa_storage_index_reload_skipped_rows_total` counter (per-row detail at

--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -95,8 +95,9 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
   dropped table's registrations via `write_index_tombstones_for_table` and
   sweeps its tracker entries (t_ae06e925). `StorageEngine::drop_index` is the
   DROP INDEX choke point for live storage state: it removes the table store's
-  memtable/sidecar/vector metadata and the tracker entry immediately, before
-  restart. Boot-time
+  memtable/vector metadata, sidecar read guards, and the tracker entry
+  immediately, before restart; tracker cleanup is still idempotent when the
+  table is not registered in this engine process. Boot-time
   `reload_indexes_from_system_schema` returns an `IndexReloadOutcome`
   (`restored`/`skipped`); unresolvable rows emit one summary warn plus the
   `ferrosa_storage_index_reload_skipped_rows_total` counter (per-row detail at

--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -97,7 +97,10 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
   DROP INDEX choke point for live storage state: it removes the table store's
   memtable/vector metadata, sidecar read guards, and the tracker entry
   immediately, before restart; tracker cleanup is still idempotent when the
-  table is not registered in this engine process. Boot-time
+  table is not registered in this engine process. Re-registering an already
+  loaded table with index declarations merges any missing declarations into the
+  existing store, keeping disk-loaded sidecars readable after `schema.json`
+  boot preload. Boot-time
   `reload_indexes_from_system_schema` returns an `IndexReloadOutcome`
   (`restored`/`skipped`); unresolvable rows emit one summary warn plus the
   `ferrosa_storage_index_reload_skipped_rows_total` counter (per-row detail at

--- a/ferrosa-storage/specs/overview.md
+++ b/ferrosa-storage/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-storage
 status: implemented
-last_updated: 2026-06-30
+last_updated: 2026-07-03
 executive_summary: >
   The single-node storage engine and durable substrate of the platform:
   memtable, write-ahead commit log, flush to BTI SSTables, S3 write-behind
@@ -33,7 +33,7 @@ about CQL/SQL protocol framing or query planning — those belong to the front-e
 | Module | Responsibility |
 |--------|----------------|
 | `engine` (`src/engine.rs`, ~18.8k LoC) | `StorageEngine` + `StorageEngineConfig`: composition root; write/read/range/batch API, registration, snapshot/PITR orchestration, maintenance |
-| `store` (`src/store.rs`, ~9.2k LoC) | `TableStore`: lock-free `ArcSwap<StoreView>` per table; flush serialization; reader-pool wiring; index/FTI sidecar flush; secondary indexes on regular cells AND clustering-key components (`add_clustering_index`), incl. the partition-keyed consult `read_by_index_in_partition` (t_430c4188) |
+| `store` (`src/store.rs`, ~9.2k LoC) | `TableStore`: lock-free `ArcSwap<StoreView>` per table; flush serialization; reader-pool wiring; index/FTI sidecar flush; secondary indexes on regular cells AND clustering-key components (`add_clustering_index`), live index removal (`remove_index`), incl. the partition-keyed consult `read_by_index_in_partition` (t_430c4188) |
 | `memtable/` | `Memtable` trait; `SkipListMemtable` (default), `ShardedBTreeMemtable`; eager-index + vector-index hooks |
 | `commitlog/` | Segmented WAL: `segment` (CAS alloc), `sync` (Batch/Periodic/Group), `reader` (replay), `archiver` (S3/PITR), `cdc`, `checkpoint`, `manifest` |
 | `flush` | `FlushTarget` trait + `FileFlushTarget`/`InMemoryFlushTarget`; serialization-header construction |
@@ -41,7 +41,7 @@ about CQL/SQL protocol framing or query planning — those belong to the front-e
 | `compaction/` | `CompactionExecutor`, STCS + UCS strategies, `CompactionGate`, validator (oracle + differential) |
 | `upload/` | `UploadManager` (tokio task), `ObjectStoreConfig`, pending-upload log + replay across flat and generation-dir SSTable layouts |
 | `cache`, `pin_config` | `LocalCache` LRU + pinning; NVMe `PinMode` |
-| `index/` | Index state tracker, build scheduler, local/remote/off backends, artifact manifest, virtual table |
+| `index/` | Index state tracker (registered/pending/current completeness), build scheduler, local/remote/off backends, artifact manifest, virtual table; `LocalBackend` resolves flat and engine table-dir SSTable layouts and writes sidecars beside table SSTables |
 | `snapshot/`, `restore/` | S3 snapshot manager + restore manager + validation (PITR) |
 | `quarantine`, `self_heal/` | Malformed-row quarantine sidecar; deterministic self-heal control loop + corrupt-SSTable detector |
 | `accord/` | Per-shard conflict index + protocol log for Accord transactions |

--- a/ferrosa-storage/specs/roadmap.md
+++ b/ferrosa-storage/specs/roadmap.md
@@ -61,7 +61,8 @@ open work lives in specs and the items below.
 
 - **DROP INDEX live-state cleanup + index build path fixes (2026-07-03).**
   `StorageEngine::drop_index` now unwires declared indexes from the live
-  `TableStore` and `IndexStateTracker` in Direct, pair, and Raft DDL paths.
+  `TableStore` and `IndexStateTracker` in Direct, pair, and Raft DDL paths,
+  and remains idempotent when only tracker state exists locally.
   Keyed partition-index reads trust an empty consult only when the local storage
   tracker is authoritative and reports the index current with no pending SSTable
   backfill; otherwise they keep the bounded partition fallback. The local index

--- a/ferrosa-storage/specs/roadmap.md
+++ b/ferrosa-storage/specs/roadmap.md
@@ -62,7 +62,10 @@ open work lives in specs and the items below.
 - **DROP INDEX live-state cleanup + index build path fixes (2026-07-03).**
   `StorageEngine::drop_index` now unwires declared indexes from the live
   `TableStore` and `IndexStateTracker` in Direct, pair, and Raft DDL paths,
-  and remains idempotent when only tracker state exists locally.
+  and remains idempotent when only tracker state exists locally. Re-registering
+  an already loaded table now merges missing regular secondary-index
+  declarations so sidecars loaded during `schema.json` boot preload remain
+  visible to declared index reads.
   Keyed partition-index reads trust an empty consult only when the local storage
   tracker is authoritative and reports the index current with no pending SSTable
   backfill; otherwise they keep the bounded partition fallback. The local index

--- a/ferrosa-storage/specs/roadmap.md
+++ b/ferrosa-storage/specs/roadmap.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-storage
 doc: roadmap
-last_updated: 2026-07-01
+last_updated: 2026-07-03
 ---
 
 # ferrosa-storage — Roadmap
@@ -59,6 +59,15 @@ open work lives in specs and the items below.
 
 ## Recently landed
 
+- **DROP INDEX live-state cleanup + index build path fixes (2026-07-03).**
+  `StorageEngine::drop_index` now unwires declared indexes from the live
+  `TableStore` and `IndexStateTracker` in Direct, pair, and Raft DDL paths.
+  Keyed partition-index reads trust an empty consult only when the local storage
+  tracker is authoritative and reports the index current with no pending SSTable
+  backfill; otherwise they keep the bounded partition fallback. The local index
+  backend also resolves engine table-dir SSTables under
+  `sstables/<keyspace>.<table>` and writes generated sidecars beside those table
+  SSTables.
 - **DROP TABLE index-tombstone cascade (t_ae06e925, 2026-07-01).**
   `unregister_table` — the choke point for every DDL route (Direct, pair,
   cluster/Raft, and DROP KEYSPACE per-table) — tombstones the dropped table's

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -3513,6 +3513,26 @@ impl StorageEngine {
         self.add_index_with_predicate(table_id, index_name, column_position, index_type, None)
     }
 
+    /// Removes a secondary index from live storage state.
+    ///
+    /// Schema/system-table persistence is owned by the DDL layer; this method
+    /// only unwires the engine-side structures that otherwise keep serving a
+    /// dropped index until restart: the table store's memtable/sidecar/vector
+    /// maps and the engine-wide [`crate::index::IndexStateTracker`].
+    pub fn drop_index(&self, table_id: &TableId, index_name: &str) -> ferrosa_common::Result<bool> {
+        let mut tables = self.tables.write();
+        let state = tables.get_mut(table_id).ok_or_else(|| {
+            ferrosa_common::Error::InvalidFormat(format!("table not registered: {table_id}"))
+        })?;
+
+        let removed_store_state = state.store.remove_index(index_name);
+        let removed_tracker_state =
+            self.index_tracker
+                .remove_index(table_id.keyspace(), table_id.table(), index_name);
+
+        Ok(removed_store_state || removed_tracker_state)
+    }
+
     /// Registers a secondary index, optionally carrying a partial-index
     /// `FilterPredicate`.
     ///
@@ -3544,10 +3564,19 @@ impl StorageEngine {
             filter_predicate.clone(),
         );
 
-        // Submit rebuild jobs for all existing SSTables.
-        if let Some(ref scheduler) = self.index_scheduler {
-            let sstable_ids = state.store.sstable_generation_ids();
-            for sst_id in sstable_ids {
+        // Submit rebuild jobs for all existing SSTables. Mark them pending
+        // before enqueueing so query planning can distinguish a complete empty
+        // index from an asynchronously backfilled one.
+        let sstable_ids = state.store.sstable_generation_ids();
+        for sst_id in sstable_ids {
+            self.index_tracker.mark_pending(
+                table_id.keyspace(),
+                table_id.table(),
+                index_name,
+                &sst_id,
+                0,
+            );
+            if let Some(ref scheduler) = self.index_scheduler {
                 let job = crate::index::IndexBuildJob {
                     sstable_id: sst_id,
                     index_name: index_name.to_string(),
@@ -3599,11 +3628,19 @@ impl StorageEngine {
             .add_clustering_index(index_name.to_string(), clustering_component, index_type);
 
         // Submit rebuild jobs for all existing SSTables so pre-existing data
-        // is backfilled from its clustering-key components.
-        if let Some(ref scheduler) = self.index_scheduler {
-            let ck_total = state.store.clustering_column_count();
-            let sstable_ids = state.store.sstable_generation_ids();
-            for sst_id in sstable_ids {
+        // is backfilled from its clustering-key components. Mark them pending
+        // first so an empty keyed consult can trust Current only after backfill.
+        let ck_total = state.store.clustering_column_count();
+        let sstable_ids = state.store.sstable_generation_ids();
+        for sst_id in sstable_ids {
+            self.index_tracker.mark_pending(
+                table_id.keyspace(),
+                table_id.table(),
+                index_name,
+                &sst_id,
+                0,
+            );
+            if let Some(ref scheduler) = self.index_scheduler {
                 let job = crate::index::IndexBuildJob {
                     sstable_id: sst_id,
                     index_name: index_name.to_string(),
@@ -6738,11 +6775,19 @@ impl StorageEngine {
                     );
                     // Only submit if the index needs building (not already current).
                     if let Some(idx_state) = tracker_state {
-                        if !idx_state.indexed_sstables.contains(&format!("{gen}")) {
+                        let sstable_id = format!("{gen}");
+                        if !idx_state.indexed_sstables.contains(&sstable_id) {
+                            self.index_tracker.mark_pending(
+                                table_id.keyspace(),
+                                table_id.table(),
+                                &index_name,
+                                &sstable_id,
+                                0,
+                            );
                             let job = eager_index_build_job(
                                 &state.store,
                                 table_id,
-                                format!("{gen}"),
+                                sstable_id,
                                 &index_name,
                                 col_pos,
                                 clustering_source,
@@ -7851,6 +7896,13 @@ impl StorageEngine {
     /// Returns the shared index state tracker.
     pub fn index_tracker(&self) -> &Arc<crate::index::IndexStateTracker> {
         &self.index_tracker
+    }
+
+    /// Returns true when the named index is registered and its build tracker
+    /// has no known pending or failed work.
+    pub fn index_is_current(&self, table_id: &TableId, index_name: &str) -> bool {
+        self.index_tracker
+            .is_current(table_id.keyspace(), table_id.table(), index_name)
     }
 
     /// Returns the S3 object store and config, if S3 is configured.
@@ -18043,6 +18095,60 @@ mod tests {
                 now_micros_for_test(),
             )
             .unwrap();
+    }
+
+    #[test]
+    fn drop_index_unwires_live_storage_state_before_restart() {
+        use ferrosa_index::{IndexKey, IndexType};
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        let table_id = TableId::new("test_ks", "test_table");
+        engine.register_table(test_schema()).unwrap();
+        engine
+            .add_index(&table_id, "val_idx", 0, IndexType::BTree)
+            .unwrap();
+
+        let key = make_key("pk");
+        engine
+            .write(&table_id, &key, make_row(b"indexed", 1000), 1000)
+            .unwrap();
+        assert_eq!(
+            engine
+                .read_by_index(&table_id, "val_idx", &IndexKey(b"indexed".to_vec()))
+                .unwrap()
+                .len(),
+            1,
+            "sanity check: index serves the live row before DROP INDEX"
+        );
+        assert!(engine
+            .index_tracker()
+            .get_state("test_ks", "test_table", "val_idx")
+            .is_some());
+
+        assert!(
+            engine.drop_index(&table_id, "val_idx").unwrap(),
+            "drop_index should report removed live state"
+        );
+        assert!(
+            engine
+                .index_tracker()
+                .get_state("test_ks", "test_table", "val_idx")
+                .is_none(),
+            "tracker state must be removed immediately"
+        );
+        assert!(
+            engine
+                .read_by_index(&table_id, "val_idx", &IndexKey(b"indexed".to_vec()))
+                .unwrap()
+                .is_empty(),
+            "dropped index must not serve stale live index state before restart"
+        );
+        assert!(
+            !engine.drop_index(&table_id, "val_idx").unwrap(),
+            "second cleanup is idempotent"
+        );
     }
 
     /// DROP TABLE cascade (forge t_ae06e925): `unregister_table` — the engine

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -2851,7 +2851,9 @@ impl StorageEngine {
     }
 
     /// Internal: create a `TableStore` for a table, loading existing SSTables
-    /// and sidecar files from disk. Idempotent: skips already-registered tables.
+    /// and sidecar files from disk. Idempotent: already-registered tables keep
+    /// their loaded store, but merge any missing index declarations supplied by
+    /// the caller.
     fn register_table_inner(
         &self,
         schema: TableSchema,
@@ -2862,6 +2864,7 @@ impl StorageEngine {
             let tables = self.tables.read();
             if tables.contains_key(&table_id) {
                 drop(tables);
+                self.merge_index_declarations_for_registered_table(&table_id, &indexed_columns)?;
                 self.replay_deferred_mutations_for_table(&table_id);
                 return Ok(());
             }
@@ -2896,6 +2899,48 @@ impl StorageEngine {
         }
 
         self.replay_deferred_mutations_for_table(&table_id);
+
+        Ok(())
+    }
+
+    fn merge_index_declarations_for_registered_table(
+        &self,
+        table_id: &TableId,
+        indexed_columns: &[(String, usize)],
+    ) -> ferrosa_common::Result<()> {
+        if indexed_columns.is_empty() {
+            return Ok(());
+        }
+
+        let mut tables = self.tables.write();
+        let Some(state) = tables.get_mut(table_id) else {
+            return Ok(());
+        };
+
+        for (index_name, column_position) in indexed_columns {
+            match state
+                .store
+                .indexed_columns()
+                .iter()
+                .find(|(name, _)| name == index_name)
+                .map(|(_, pos)| *pos)
+            {
+                Some(existing_position) if existing_position == *column_position => {}
+                Some(existing_position) => {
+                    return Err(ferrosa_common::Error::InvalidFormat(format!(
+                        "index {index_name} already registered on {table_id} at column {existing_position}, not {column_position}"
+                    )));
+                }
+                None => state.store.add_index(
+                    index_name.clone(),
+                    *column_position,
+                    ferrosa_index::IndexType::BTree,
+                ),
+            }
+
+            self.index_tracker
+                .register_index(table_id.keyspace(), table_id.table(), index_name);
+        }
 
         Ok(())
     }

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -3516,16 +3516,17 @@ impl StorageEngine {
     /// Removes a secondary index from live storage state.
     ///
     /// Schema/system-table persistence is owned by the DDL layer; this method
-    /// only unwires the engine-side structures that otherwise keep serving a
-    /// dropped index until restart: the table store's memtable/sidecar/vector
-    /// maps and the engine-wide [`crate::index::IndexStateTracker`].
+    /// only unwires the engine-side structures that otherwise keep serving or
+    /// tracking a dropped index until restart: the table store's live index
+    /// maps, sidecar read guards, vector metadata, and the engine-wide
+    /// [`crate::index::IndexStateTracker`]. If the table is not registered in
+    /// this engine process, tracker cleanup still runs and the operation is a
+    /// no-op for table-local state.
     pub fn drop_index(&self, table_id: &TableId, index_name: &str) -> ferrosa_common::Result<bool> {
         let mut tables = self.tables.write();
-        let state = tables.get_mut(table_id).ok_or_else(|| {
-            ferrosa_common::Error::InvalidFormat(format!("table not registered: {table_id}"))
-        })?;
-
-        let removed_store_state = state.store.remove_index(index_name);
+        let removed_store_state = tables
+            .get_mut(table_id)
+            .is_some_and(|state| state.store.remove_index(index_name));
         let removed_tracker_state =
             self.index_tracker
                 .remove_index(table_id.keyspace(), table_id.table(), index_name);
@@ -18148,6 +18149,33 @@ mod tests {
         assert!(
             !engine.drop_index(&table_id, "val_idx").unwrap(),
             "second cleanup is idempotent"
+        );
+    }
+
+    #[test]
+    fn drop_index_clears_tracker_when_table_is_not_registered() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        let table_id = TableId::new("test_ks", "missing_table");
+        engine
+            .index_tracker()
+            .register_index("test_ks", "missing_table", "val_idx");
+
+        assert!(
+            engine.drop_index(&table_id, "val_idx").unwrap(),
+            "tracker-only cleanup should report state removed"
+        );
+        assert!(
+            engine
+                .index_tracker()
+                .get_state("test_ks", "missing_table", "val_idx")
+                .is_none(),
+            "tracker state must be removed even when table-local state is absent"
+        );
+        assert!(
+            !engine.drop_index(&table_id, "val_idx").unwrap(),
+            "second tracker-only cleanup is idempotent"
         );
     }
 

--- a/ferrosa-storage/src/index/remote_backend.rs
+++ b/ferrosa-storage/src/index/remote_backend.rs
@@ -368,31 +368,19 @@ fn build_request_body(job: &IndexBuildJob, resolver: &S3PathResolver) -> serde_j
         body["filter_predicate"] = serde_json::to_value(predicate)
             .expect("FilterPredicate serializes to JSON (Vec<u8>/enum/usize)");
     }
+    if let Some(src) = &job.clustering_source {
+        body["clustering_source"] = serde_json::to_value(src)
+            .expect("ClusteringComponentRef serializes to JSON (usize fields)");
+    }
 
     body
 }
 
 impl IndexBuildBackend for RemoteBackend {
     fn build(&self, job: &IndexBuildJob) -> Result<IndexBuildResult, String> {
-        // Clustering-column index jobs (t_430c4188) are not yet part of the
-        // remote builder protocol (`build_request_body` has no field for
-        // `clustering_source`, and a remote builder would silently build the
-        // WRONG index from `column_position`). Build locally instead — a
-        // designed, visible fallback, never a silent wrong build.
-        if let Some(src) = job.clustering_source {
-            tracing::warn!(
-                sstable_id = %job.sstable_id,
-                index_name = %job.index_name,
-                component = src.component,
-                "remote index builder does not support clustering-column indexes yet; \
-                 building locally"
-            );
-            return self.local_fallback.build(job);
-        }
-
-        // Try each available endpoint. A partial (Filtered) index carries its
-        // predicate in the request body (see `build_request_body`), so the
-        // builder filters at build time — no local-only fallback needed.
+        // Try each available endpoint. Partial (Filtered) and clustering-column
+        // jobs carry their extra build metadata in the request body, so the
+        // remote worker builds the same sidecar the local backend would.
         let n = self.endpoints.len();
         let start = self.next_endpoint.fetch_add(1, Ordering::Relaxed) as usize;
         let mut last_error = String::new();
@@ -635,6 +623,37 @@ mod tests {
         let decoded: FilterPredicate =
             serde_json::from_value(body["filter_predicate"].clone()).unwrap();
         assert_eq!(decoded, predicate);
+    }
+
+    #[test]
+    fn clustering_job_request_body_carries_source() {
+        let resolver = S3PathResolver {
+            bucket: "b".into(),
+            endpoint: "memory://".into(),
+            prefix: "p".into(),
+        };
+        let source = super::super::scheduler::ClusteringComponentRef {
+            component: 1,
+            total: 3,
+        };
+        let job = IndexBuildJob {
+            sstable_id: "gen-9".to_string(),
+            index_name: "ck_idx".to_string(),
+            index_type: ferrosa_index::IndexType::BTree,
+            table: ("ks".to_string(), "tbl".to_string()),
+            priority: super::super::scheduler::BuildPriority::Initial,
+            enqueued_at: Instant::now(),
+            column_position: 1,
+            clustering_source: Some(source),
+            filter_predicate: None,
+        };
+
+        let body = build_request_body(&job, &resolver);
+        let decoded: super::super::scheduler::ClusteringComponentRef =
+            serde_json::from_value(body["clustering_source"].clone()).unwrap();
+
+        assert_eq!(decoded, source);
+        assert_eq!(body["column_position"], 1);
     }
 
     /// A non-filtered job carries no `filter_predicate` field (it is omitted, not

--- a/ferrosa-storage/src/index/scheduler.rs
+++ b/ferrosa-storage/src/index/scheduler.rs
@@ -8,7 +8,7 @@
 //! reading and index building will be wired in a later task.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -37,7 +37,7 @@ pub enum BuildPriority {
 /// value lives inside the row's composite clustering-key bytes. The builder
 /// needs both the component's index and the table's total clustering-column
 /// count to split the composite encoding correctly.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct ClusteringComponentRef {
     /// Zero-based index of the component within the clustering key.
     pub component: usize,
@@ -130,6 +130,84 @@ impl LocalBackend {
     /// Create a new `LocalBackend` rooted at the given data directory.
     pub fn new(data_dir: PathBuf) -> Self {
         Self { data_dir }
+    }
+}
+
+fn table_path_component(job: &IndexBuildJob) -> String {
+    format!("{}.{}", job.table.0, job.table.1)
+}
+
+fn table_data_dir(data_dir: &Path, job: &IndexBuildJob) -> PathBuf {
+    data_dir.join("sstables").join(table_path_component(job))
+}
+
+fn sstable_component_path(data_dir: &Path, job: &IndexBuildJob, component: &str) -> PathBuf {
+    let gen = &job.sstable_id;
+    let flat = data_dir.join(format!("{gen}-{component}"));
+    if flat.exists() {
+        return flat;
+    }
+
+    let table_dir = table_data_dir(data_dir, job);
+    let nested = table_dir.join(gen).join(format!("{gen}-{component}"));
+    if nested.exists() {
+        return nested;
+    }
+
+    let table_flat = table_dir.join(format!("{gen}-{component}"));
+    if table_flat.exists() {
+        return table_flat;
+    }
+
+    let table_dir_without_sstables = data_dir.join(table_path_component(job));
+    let alternate_nested = table_dir_without_sstables
+        .join(gen)
+        .join(format!("{gen}-{component}"));
+    if alternate_nested.exists() {
+        return alternate_nested;
+    }
+
+    let alternate_flat = table_dir_without_sstables.join(format!("{gen}-{component}"));
+    if alternate_flat.exists() {
+        return alternate_flat;
+    }
+
+    table_flat
+}
+
+fn sidecar_output_dir(data_dir: &Path, job: &IndexBuildJob) -> PathBuf {
+    let gen = &job.sstable_id;
+    let flat_data = data_dir.join(format!("{gen}-Data.db"));
+    if flat_data.exists() {
+        return data_dir.to_path_buf();
+    }
+
+    let table_dir = table_data_dir(data_dir, job);
+    let nested_data = table_dir.join(gen).join(format!("{gen}-Data.db"));
+    if nested_data.exists() {
+        return table_dir.join(gen);
+    }
+
+    let table_flat_data = table_dir.join(format!("{gen}-Data.db"));
+    if table_flat_data.exists() {
+        return table_dir;
+    }
+
+    let alternate_table_dir = data_dir.join(table_path_component(job));
+    let alternate_nested_data = alternate_table_dir.join(gen).join(format!("{gen}-Data.db"));
+    if alternate_nested_data.exists() {
+        return alternate_table_dir.join(gen);
+    }
+
+    let alternate_flat_data = alternate_table_dir.join(format!("{gen}-Data.db"));
+    if alternate_flat_data.exists() {
+        return alternate_table_dir;
+    }
+
+    if table_dir.exists() {
+        table_dir
+    } else {
+        data_dir.to_path_buf()
     }
 }
 
@@ -228,21 +306,25 @@ impl IndexBuildBackend for LocalBackend {
             });
         }
 
-        let gen = &job.sstable_id;
-        let dir = &self.data_dir;
-
         // Open SSTable components.
-        let data = FileReadAt::open(dir.join(format!("{gen}-Data.db")))
+        let data = FileReadAt::open(sstable_component_path(&self.data_dir, job, "Data.db"))
             .map_err(|e| format!("open data: {e}"))?;
-        let partitions_file = FileReadAt::open(dir.join(format!("{gen}-Partitions.db")))
-            .map_err(|e| format!("open partitions: {e}"))?;
-        let rows_file = FileReadAt::open(dir.join(format!("{gen}-Rows.db")))
+        let partitions_file =
+            FileReadAt::open(sstable_component_path(&self.data_dir, job, "Partitions.db"))
+                .map_err(|e| format!("open partitions: {e}"))?;
+        let rows_file = FileReadAt::open(sstable_component_path(&self.data_dir, job, "Rows.db"))
             .map_err(|e| format!("open rows: {e}"))?;
-        let filter = std::fs::read(dir.join(format!("{gen}-Filter.db")))
+        let filter = std::fs::read(sstable_component_path(&self.data_dir, job, "Filter.db"))
             .map_err(|e| format!("read filter: {e}"))?;
-        let statistics = std::fs::read(dir.join(format!("{gen}-Statistics.db")))
-            .map_err(|e| format!("read statistics: {e}"))?;
-        let compression_info = std::fs::read(dir.join(format!("{gen}-CompressionInfo.db"))).ok();
+        let statistics =
+            std::fs::read(sstable_component_path(&self.data_dir, job, "Statistics.db"))
+                .map_err(|e| format!("read statistics: {e}"))?;
+        let compression_info = std::fs::read(sstable_component_path(
+            &self.data_dir,
+            job,
+            "CompressionInfo.db",
+        ))
+        .ok();
 
         let reader = SSTableReader::open(SSTableComponents {
             data,
@@ -638,7 +720,7 @@ impl IndexBuildScheduler {
                                     if entries.is_empty() {
                                         continue;
                                     }
-                                    let path = data_dir
+                                    let path = sidecar_output_dir(data_dir, &job)
                                         .join(format!("{}-{}.sidecar", job.sstable_id, index_name));
                                     if let Err(e) = SidecarWriter::write(&path, entries) {
                                         tracing::error!(%e, path = %path.display(), "index-build: failed to write sidecar");
@@ -1499,19 +1581,16 @@ mod tests {
         assert_eq!(callback_count.load(Ordering::SeqCst), 0);
     }
 
-    /// Build a single-column SSTable with one UTF-8 text value per partition and
-    /// return its data directory and generation id. The column to index is at
+    /// Build a single-column SSTable with one UTF-8 text value per partition in
+    /// `sstable_dir` and return its generation id. The column to index is at
     /// position 0 (the lone regular column).
-    fn write_text_sstable(values: &[(&[u8], &[u8])]) -> (tempfile::TempDir, String) {
+    fn write_text_sstable_to(sstable_dir: PathBuf, values: &[(&[u8], &[u8])]) -> String {
         use ferrosa_common::cell::CellValue;
         use ferrosa_common::key::{DecoratedKey, PartitionKey};
         use ferrosa_common::schema::{ColumnDefinition, TableSchema};
         use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Partition, Row};
         use ferrosa_sstable::writer::SSTableWriter;
         use ferrosa_sstable::WriteOptions;
-
-        let dir = tempfile::tempdir().unwrap();
-        let sstable_dir = dir.path().to_path_buf();
 
         let schema = TableSchema {
             keyspace: "ks".to_string(),
@@ -1560,7 +1639,123 @@ mod tests {
         let flush_target = crate::flush::FileFlushTarget::new(sstable_dir).unwrap();
         let _reader = flush_target.flush(output).unwrap();
         let gen = flush_target.generation();
-        (dir, format!("{gen}"))
+        format!("{gen}")
+    }
+
+    /// Build a single-column SSTable with one UTF-8 text value per partition and
+    /// return its data directory and generation id. The column to index is at
+    /// position 0 (the lone regular column).
+    fn write_text_sstable(values: &[(&[u8], &[u8])]) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let gen = write_text_sstable_to(dir.path().to_path_buf(), values);
+        (dir, gen)
+    }
+
+    #[test]
+    fn local_backend_resolves_sstable_under_engine_table_dir() {
+        let root = tempfile::tempdir().unwrap();
+        let table_dir = root.path().join("sstables").join("ks.tbl");
+        std::fs::create_dir_all(&table_dir).unwrap();
+        let gen = write_text_sstable_to(table_dir, &[(b"pk1", b"alice")]);
+        let backend = LocalBackend::new(root.path().to_path_buf());
+        let job = IndexBuildJob {
+            sstable_id: gen,
+            index_name: "name_idx".to_string(),
+            index_type: IndexType::BTree,
+            table: ("ks".to_string(), "tbl".to_string()),
+            priority: BuildPriority::Normal,
+            enqueued_at: Instant::now(),
+            column_position: 0,
+            clustering_source: None,
+            filter_predicate: None,
+        };
+
+        let result = backend
+            .build(&job)
+            .expect("engine data_dir root should resolve table SSTable dir");
+        let entries = result
+            .sidecar_entries
+            .get("name_idx")
+            .expect("btree build should produce sidecar entries");
+
+        assert_eq!(entries.len(), 1);
+        let (key, _) = &entries[0];
+        assert_eq!(key.0, b"alice".to_vec());
+    }
+
+    #[test]
+    fn scheduler_writes_sidecars_under_engine_table_dir() {
+        use ferrosa_index::{IndexKey, RowPosition};
+
+        let root = tempfile::tempdir().unwrap();
+        let table_dir = root.path().join("sstables").join("ks.tbl");
+        std::fs::create_dir_all(&table_dir).unwrap();
+        let gen = write_text_sstable_to(table_dir.clone(), &[(b"pk1", b"alice")]);
+
+        struct SidecarBackend;
+        impl IndexBuildBackend for SidecarBackend {
+            fn build(&self, job: &IndexBuildJob) -> std::result::Result<IndexBuildResult, String> {
+                let mut sidecar_entries = HashMap::new();
+                sidecar_entries.insert(
+                    job.index_name.clone(),
+                    vec![(
+                        IndexKey(b"alice".to_vec()),
+                        RowPosition {
+                            partition_key: b"pk1".to_vec(),
+                            clustering_key: vec![],
+                        },
+                    )],
+                );
+                Ok(IndexBuildResult {
+                    sstable_id: job.sstable_id.clone(),
+                    index_type: job.index_type,
+                    sidecar_entries,
+                    build_duration: Duration::from_millis(1),
+                    sidecar_written_to_s3: false,
+                    artifact_manifest_entries: Vec::new(),
+                })
+            }
+        }
+
+        let tracker = Arc::new(IndexStateTracker::new());
+        tracker.register_index("ks", "tbl", "name_idx");
+        tracker.mark_pending("ks", "tbl", "name_idx", &gen, 100);
+
+        let scheduler = IndexBuildScheduler::with_backend_and_data_dir(
+            1,
+            Arc::clone(&tracker),
+            Arc::new(SidecarBackend),
+            root.path().to_path_buf(),
+        );
+
+        scheduler
+            .submit(IndexBuildJob {
+                sstable_id: gen.clone(),
+                index_name: "name_idx".to_string(),
+                index_type: IndexType::BTree,
+                table: ("ks".to_string(), "tbl".to_string()),
+                priority: BuildPriority::Normal,
+                enqueued_at: Instant::now(),
+                column_position: 0,
+                clustering_source: None,
+                filter_predicate: None,
+            })
+            .unwrap();
+
+        std::thread::sleep(Duration::from_millis(500));
+        scheduler.shutdown();
+
+        let table_sidecar_path = table_dir.join(format!("{gen}-name_idx.sidecar"));
+        let root_sidecar_path = root.path().join(format!("{gen}-name_idx.sidecar"));
+        assert!(
+            table_sidecar_path.exists(),
+            "sidecar should be written beside table SSTables at {}",
+            table_sidecar_path.display()
+        );
+        assert!(
+            !root_sidecar_path.exists(),
+            "sidecar must not be written at the engine data_dir root"
+        );
     }
 
     #[test]

--- a/ferrosa-storage/src/index/tracker.rs
+++ b/ferrosa-storage/src/index/tracker.rs
@@ -251,6 +251,15 @@ impl IndexStateTracker {
         self.states.read().get(&key).cloned()
     }
 
+    /// Returns true when the index is registered and has no known pending or
+    /// failed build work.
+    pub fn is_current(&self, keyspace: &str, table: &str, index_name: &str) -> bool {
+        self.get_state(keyspace, table, index_name)
+            .is_some_and(|state| {
+                matches!(state.status, IndexStatus::Current) && state.pending_sstables.is_empty()
+            })
+    }
+
     /// Returns the indexed and unindexed SSTable sets for a given index.
     ///
     /// Returns `(indexed, unindexed)` where unindexed is the set of pending
@@ -403,15 +412,39 @@ mod tests {
         let tracker = IndexStateTracker::new();
         tracker.register_index("ks", "tbl", "idx");
         assert_eq!(tracker.all_states().len(), 1);
+        assert!(tracker.is_current("ks", "tbl", "idx"));
 
         let removed = tracker.remove_index("ks", "tbl", "idx");
         assert!(removed);
         assert!(tracker.all_states().is_empty());
         assert!(tracker.get_state("ks", "tbl", "idx").is_none());
+        assert!(!tracker.is_current("ks", "tbl", "idx"));
 
         // Removing again returns false.
         let removed = tracker.remove_index("ks", "tbl", "idx");
         assert!(!removed);
+    }
+
+    #[test]
+    fn is_current_tracks_pending_and_failed_work() {
+        let tracker = IndexStateTracker::new();
+        tracker.register_index("ks", "tbl", "idx");
+        assert!(tracker.is_current("ks", "tbl", "idx"));
+
+        tracker.mark_pending("ks", "tbl", "idx", "sst-1", 1);
+        assert!(!tracker.is_current("ks", "tbl", "idx"));
+
+        tracker.mark_indexed("ks", "tbl", "idx", "sst-1");
+        assert!(tracker.is_current("ks", "tbl", "idx"));
+
+        tracker.mark_failed(
+            "ks",
+            "tbl",
+            "idx",
+            "boom".to_string(),
+            Duration::from_secs(1),
+        );
+        assert!(!tracker.is_current("ks", "tbl", "idx"));
     }
 
     #[test]

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -4543,6 +4543,71 @@ impl<F: FlushTarget> TableStore<F> {
         self.view.store(Arc::new(new_view));
     }
 
+    /// Removes a declared secondary index from every live store layer.
+    ///
+    /// This is the storage-side inverse of [`add_index`](Self::add_index) /
+    /// [`add_clustering_index`](Self::add_clustering_index): future writes no
+    /// longer update a memtable index, reads no longer consult active or
+    /// sidecar state for the name, and vector-index metadata is unwired too.
+    /// Persisted sidecar files are left on disk as inert orphan artifacts; the
+    /// metadata and read path stop naming them immediately.
+    pub fn remove_index(&mut self, index_name: &str) -> bool {
+        let before_regular = self.indexed_columns.len();
+        self.indexed_columns.retain(|(name, _)| name != index_name);
+        let before_clustering = self.indexed_clustering_columns.len();
+        self.indexed_clustering_columns
+            .retain(|(name, _)| name != index_name);
+        let mut removed = before_regular != self.indexed_columns.len()
+            || before_clustering != self.indexed_clustering_columns.len();
+
+        removed |= self.index_types.remove(index_name).is_some();
+        removed |= self.index_filter_predicates.remove(index_name).is_some();
+        removed |= self.vector_index_methods.remove(index_name).is_some();
+        let before_vector_configs = self.vector_index_configs.len();
+        self.vector_index_configs
+            .retain(|cfg| cfg.index_name != index_name);
+        removed |= before_vector_configs != self.vector_index_configs.len();
+        removed |= self.vector_index_scopes.lock().remove(index_name).is_some();
+
+        let current = self.view.load();
+        let mut new_indexes = (*current.indexes).clone();
+        removed |= new_indexes.remove(index_name).is_some();
+
+        let mut new_vector_indexes = (*current.vector_indexes).clone();
+        removed |= new_vector_indexes.remove(index_name).is_some();
+
+        let mut removed_sidecar = false;
+        let new_sidecars: Vec<_> = current
+            .sidecar_indexes
+            .iter()
+            .map(|sidecars| {
+                if sidecars.contains_key(index_name) {
+                    removed_sidecar = true;
+                    let mut filtered = (**sidecars).clone();
+                    filtered.remove(index_name);
+                    Arc::new(filtered)
+                } else {
+                    Arc::clone(sidecars)
+                }
+            })
+            .collect();
+        removed |= removed_sidecar;
+
+        let new_view = StoreView {
+            active: Arc::clone(&current.active),
+            flushing: current.flushing.clone(),
+            sstables: Arc::clone(&current.sstables),
+            sstable_ids: Arc::clone(&current.sstable_ids),
+            indexes: Arc::new(new_indexes),
+            sidecar_indexes: Arc::new(new_sidecars),
+            vector_indexes: Arc::new(new_vector_indexes),
+        };
+        new_view.check_invariants("remove_index");
+        self.view.store(Arc::new(new_view));
+
+        removed
+    }
+
     /// Dynamically adds a secondary index on a CLUSTERING column
     /// (t_430c4188). Future writes extract the indexed value from the row's
     /// composite clustering-key bytes at `clustering_component` — a
@@ -5737,6 +5802,66 @@ mod tests {
             store.index_type_for("emb_idx"),
             IndexType::Vector,
             "a vector index is no longer mis-stamped as BTree"
+        );
+    }
+
+    #[test]
+    fn remove_index_unwires_future_index_reads() {
+        let mut store = test_store();
+        store.add_index("val_idx".to_string(), 0, IndexType::BTree);
+        store.write(&make_key("k"), make_row(b"v", 1000)).unwrap();
+
+        let before_drop = store
+            .read_by_index("val_idx", &IndexKey(b"v".to_vec()))
+            .unwrap();
+        assert_eq!(before_drop.len(), 1);
+
+        assert!(
+            store.remove_index("val_idx"),
+            "declared index state should be removed"
+        );
+        assert!(store.indexed_columns().is_empty());
+
+        let after_drop = store
+            .read_by_index("val_idx", &IndexKey(b"v".to_vec()))
+            .unwrap();
+        assert!(
+            after_drop.is_empty(),
+            "dropped index must not consult stale memtable index state"
+        );
+        assert!(
+            !store.remove_index("val_idx"),
+            "second removal is idempotent and reports no state removed"
+        );
+    }
+
+    #[test]
+    fn remove_index_unwires_clustering_and_vector_metadata() {
+        let mut store = test_store();
+        store.add_clustering_index("ck_idx".to_string(), 0, IndexType::BTree);
+        store.add_quantized_vector_index(VectorIndexConfig {
+            index_name: "vec_idx".to_string(),
+            column_position: 0,
+            dims: 2,
+            m: 8,
+            ef_construction: 16,
+            metric: DistanceMetric::Cosine,
+        });
+
+        assert_eq!(store.indexed_clustering_columns().len(), 1);
+        assert_eq!(
+            store.vector_index_method("vec_idx"),
+            VectorIndexMethod::QuantizedIvf
+        );
+
+        assert!(store.remove_index("ck_idx"));
+        assert!(store.indexed_clustering_columns().is_empty());
+
+        assert!(store.remove_index("vec_idx"));
+        assert_eq!(
+            store.vector_index_method("vec_idx"),
+            VectorIndexMethod::Hnsw,
+            "dropped vector index falls back to the default method"
         );
     }
 

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -4237,6 +4237,10 @@ impl<F: FlushTarget> TableStore<F> {
     /// Deduplicates by `(partition_key, clustering_key)` so that the same
     /// row appearing in both memtable and sidecar indexes is returned once.
     pub fn read_by_index(&self, index_name: &str, key: &IndexKey) -> Result<Vec<Partition>> {
+        if !self.secondary_index_declared(index_name) {
+            return Ok(Vec::new());
+        }
+
         let guard = self.view.load();
 
         // Per-type read dispatch: encode the raw query term into the index's
@@ -4337,6 +4341,10 @@ impl<F: FlushTarget> TableStore<F> {
         key: &IndexKey,
         partition_key: &[u8],
     ) -> Result<Vec<Partition>> {
+        if !self.secondary_index_declared(index_name) {
+            return Ok(Vec::new());
+        }
+
         let guard = self.view.load();
 
         // Same per-type key encoding as `read_by_index` (see there for why a
@@ -4433,6 +4441,10 @@ impl<F: FlushTarget> TableStore<F> {
         index_name: &str,
         ranges: &[(u64, u64)],
     ) -> Result<Vec<Partition>> {
+        if !self.secondary_index_declared(index_name) {
+            return Ok(Vec::new());
+        }
+
         let guard = self.view.load();
 
         let mut positions: Vec<RowPosition> = Vec::new();
@@ -4549,8 +4561,8 @@ impl<F: FlushTarget> TableStore<F> {
     /// [`add_clustering_index`](Self::add_clustering_index): future writes no
     /// longer update a memtable index, reads no longer consult active or
     /// sidecar state for the name, and vector-index metadata is unwired too.
-    /// Persisted sidecar files are left on disk as inert orphan artifacts; the
-    /// metadata and read path stop naming them immediately.
+    /// Persisted sidecar files/readers are left as inert orphan artifacts; the
+    /// declaration metadata and read guards stop naming them immediately.
     pub fn remove_index(&mut self, index_name: &str) -> bool {
         let before_regular = self.indexed_columns.len();
         self.indexed_columns.retain(|(name, _)| name != index_name);
@@ -4576,30 +4588,13 @@ impl<F: FlushTarget> TableStore<F> {
         let mut new_vector_indexes = (*current.vector_indexes).clone();
         removed |= new_vector_indexes.remove(index_name).is_some();
 
-        let mut removed_sidecar = false;
-        let new_sidecars: Vec<_> = current
-            .sidecar_indexes
-            .iter()
-            .map(|sidecars| {
-                if sidecars.contains_key(index_name) {
-                    removed_sidecar = true;
-                    let mut filtered = (**sidecars).clone();
-                    filtered.remove(index_name);
-                    Arc::new(filtered)
-                } else {
-                    Arc::clone(sidecars)
-                }
-            })
-            .collect();
-        removed |= removed_sidecar;
-
         let new_view = StoreView {
             active: Arc::clone(&current.active),
             flushing: current.flushing.clone(),
             sstables: Arc::clone(&current.sstables),
             sstable_ids: Arc::clone(&current.sstable_ids),
             indexes: Arc::new(new_indexes),
-            sidecar_indexes: Arc::new(new_sidecars),
+            sidecar_indexes: Arc::clone(&current.sidecar_indexes),
             vector_indexes: Arc::new(new_vector_indexes),
         };
         new_view.check_invariants("remove_index");
@@ -4658,6 +4653,18 @@ impl<F: FlushTarget> TableStore<F> {
     pub fn get_memtable_index(&self, name: &str) -> Option<Arc<MemtableIndex>> {
         let guard = self.view.load();
         guard.indexes.get(name).cloned()
+    }
+
+    fn secondary_index_declared(&self, index_name: &str) -> bool {
+        self.index_types.contains_key(index_name)
+            || self
+                .indexed_columns
+                .iter()
+                .any(|(name, _)| name == index_name)
+            || self
+                .indexed_clustering_columns
+                .iter()
+                .any(|(name, _)| name == index_name)
     }
 
     /// Returns the current secondary index declarations.
@@ -5836,16 +5843,52 @@ mod tests {
     }
 
     #[test]
+    fn remove_index_unwires_flushed_sidecar_reads() {
+        let mut store = TableStore::new_with_indexes(
+            test_schema(),
+            InMemoryFlushTarget::new(),
+            WriteOptions {
+                compression: None,
+                ..WriteOptions::default()
+            },
+            vec![("val_idx".to_string(), 0_usize)],
+        );
+        store.write(&make_key("k"), make_row(b"v", 1000)).unwrap();
+        store.flush().unwrap();
+
+        assert_eq!(
+            store
+                .read_by_index("val_idx", &IndexKey(b"v".to_vec()))
+                .unwrap()
+                .len(),
+            1,
+            "sanity check: flushed sidecar serves the declared index"
+        );
+
+        assert!(store.remove_index("val_idx"));
+        assert!(
+            store
+                .read_by_index("val_idx", &IndexKey(b"v".to_vec()))
+                .unwrap()
+                .is_empty(),
+            "dropped index must not consult stale sidecar readers"
+        );
+        assert!(
+            !store.remove_index("val_idx"),
+            "orphan sidecar readers must not make removal non-idempotent"
+        );
+    }
+
+    #[test]
     fn remove_index_unwires_clustering_and_vector_metadata() {
         let mut store = test_store();
         store.add_clustering_index("ck_idx".to_string(), 0, IndexType::BTree);
         store.add_quantized_vector_index(VectorIndexConfig {
             index_name: "vec_idx".to_string(),
             column_position: 0,
-            dims: 2,
             m: 8,
             ef_construction: 16,
-            metric: DistanceMetric::Cosine,
+            metric: DistanceMetric::L2,
         });
 
         assert_eq!(store.indexed_clustering_columns().len(), 1);

--- a/specs/proposed/streaming-range-reads-no-cap.md
+++ b/specs/proposed/streaming-range-reads-no-cap.md
@@ -341,12 +341,14 @@ paths — used by the **non-projected** complex arm (`range_read_limited_rows_ch
 fail-loud at `router.rs ~4695`) and simple coordinated reads. **Those are the cap sites to
 remove in steps 2+.** (#234, a server-side fail-loud guard, was rejected as the wrong fix.)
 
-Two follow-ups from step 1: (a) `range_read_projected` is now orphaned (no real callers;
-survives only as `pub`) — delete it once streaming is complete; (b) a cluster projected
+One follow-up remains from step 1: a cluster projected
 scan **with** a `scan_bound` (LIMIT/page_size) now fail-louds (`partition_limit`
 unimplemented for the coordinated projected stream) instead of returning local-only
 partial — implement coordinated projected partition-limit if that shape needs cluster
 support.
+
+The orphaned `range_read_projected` wrapper was deleted in the follow-up stacked
+on #244; projected scans now use the streaming write-path methods directly.
 
 ## Principle
 
@@ -374,7 +376,7 @@ Safety comes from bounding **memory**, not result count:
 | Other aggregates (`SUM`/`MIN`/`MAX`/`AVG`) | ~~capped at 10k~~ **was fail-loud refused** | **done (step 2)** — O(1) streaming accumulator (`stream_builtin_aggregates`) |
 | User `LIMIT N` (> OOM guard) | ~~clamped to 10k (Vec)~~ | **done (step 2)** — `range_read_stream_all_with().take(N)` |
 | `DISTINCT <partition key>` | capped at 10k | **done (step 1)** — token-ordered scan visits each partition once, no dedup buffer |
-| Projected scan (subset of columns) | `range_read_projected(.., scan_bound)` capped | **done (step 1)** — `range_read_projected_stream_all_with` (`write_path.rs:619`) |
+| Projected scan (subset of columns) | old `range_read_projected(.., scan_bound)` wrapper deleted | **done (step 1 + #244 follow-up)** — streaming-only `range_read_projected_stream_all_with` |
 | `GROUP BY` (high cardinality) | N/A — not parsed in the AST yet | add per-group accumulator + spill when `GROUP BY` lands (deferred; not step 5) |
 | `ORDER BY` (no `LIMIT`, arbitrary) | ~~capped + fail-loud~~ | **done (step 5)** — spilling external merge sort (`ExternalSorter` + cascade k-way merge); complete, correctly ordered, memory bounded by the spill threshold, no cap |
 | `ORDER BY … LIMIT N` / clustering-order | bounded | bounded top-N heap (size N), no spill |

--- a/xtask/src/oom_audit.rs
+++ b/xtask/src/oom_audit.rs
@@ -480,10 +480,10 @@ fn contains_stream_source(expr: &syn::Expr) -> bool {
 }
 
 /// Call sites we flag as materializing range reads (rule:
-/// materializing-range-read-call-site): the plain/projected variants, excluding
-/// stream and `_from`/`_limited_rows` siblings.
+/// materializing-range-read-call-site): the plain Vec-returning variant,
+/// excluding stream and `_from`/`_limited_rows` siblings.
 fn is_materializing_range_read_call(method: &str) -> bool {
-    method == "range_read" || method == "range_read_projected"
+    method == "range_read"
 }
 
 /// True if two CONSECUTIVE arguments are both the literal `None` — the
@@ -1716,11 +1716,10 @@ mod tests {
 
     // -- Rule 3: materializing-range-read-call-site ------------------------
     #[test]
-    fn rule_materializing_call_site_fires_on_range_read_and_projected() {
+    fn rule_materializing_call_site_fires_on_range_read() {
         let src = r#"
             fn a(wp: W, table_id: T) {
                 let _x = wp.range_read(&table_id, bound);
-                let _y = wp.range_read_projected(&table_id, wanted, bound);
             }
         "#;
         let f = audit_source("x.rs", src, &no_allow());
@@ -1728,7 +1727,7 @@ mod tests {
             .iter()
             .filter(|x| x.rule == rule::MATERIALIZING_RANGE_READ_CALL_SITE)
             .count();
-        assert_eq!(count, 2, "range_read + range_read_projected fire: {f:?}");
+        assert_eq!(count, 1, "range_read fires: {f:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Follow-up to #244 that completes the index cleanup work across storage, cluster DDL, CQL routing, and the index-builder path.
- Unwire `DROP INDEX` from live `TableStore` and `IndexStateTracker` state in Direct, pair, CQL direct, and Raft apply paths.
- Thread clustering-column index metadata through remote index-builder requests, and make local sidecar builds resolve/write under engine table SSTable directories.
- Gate empty keyed-index consults on an authoritative `Current` tracker state, remove the orphaned `range_read_projected` materializing wrapper, and update crate docs/specs.

## Review follow-ups
- Fixed the `SidecarReader` compile break without making readers cloneable; dropped indexes now stop reads via declaration guards while orphan sidecar readers remain inert.
- Made `StorageEngine::drop_index` idempotent when only tracker state exists locally.
- Merged missing index declarations when an already-loaded table is re-registered, keeping disk-loaded sidecars readable after `schema.json` boot preload.
- Updated stale `range_read_projected` comments/error strings to name the streaming projected read paths.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p ferrosa-storage --all-targets -- -D warnings`
- `cargo test -p xtask oom_audit::tests::rule_materializing_call_site_fires_on_range_read -- --exact`
- `cargo test -p ferrosa-storage engine::tests::sidecar_survives_table_reregistration -- --exact --nocapture`
- `cargo test -p ferrosa-storage engine::tests::drop_index_clears_tracker_when_table_is_not_registered -- --exact`
- `cargo test -p ferrosa-storage store::tests::remove_index_unwires_flushed_sidecar_reads -- --exact`
- `cargo test -p ferrosa-cluster ddl_path::tests::direct_drop_index_tombstones_row_in_system_schema_indexes -- --exact`
- `cargo test -p ferrosa-cluster --test range_scan_multi_replica_paging multi_replica_paged_projected_scan_cancels_abandoned_producers -- --exact --nocapture`
- GitHub Actions: all checks passing on latest head `7b4c2852`. `Test + Coverage` initially hit the projected-scan cancellation timing test, the exact test passed locally, and the rerun passed.