### PR TITLE
feat(graph): hydrate opposite endpoints for label-agnostic expansion + LIMIT push-down

### DIFF
--- a/ferrosa-graph/README.md
+++ b/ferrosa-graph/README.md
@@ -37,6 +37,15 @@ the `ferrosa` binary.
 - **Expand executor** (`executor/expand.rs`) — anchor lookup, per-hop adjacency
   reads, property evaluation, aggregation, write clauses; honors DoS limits
   (`max_fan_out_per_hop`, `max_result_rows`, `query_timeout`).
+- **Label-agnostic expansion** (`executor/expand.rs`) — traversals may omit the
+  relationship type and/or the target-node label (`(a)-[r]->(n)`, `(a)<-[r]-(n)`,
+  `-[r:T]->(n)`, `-[r]->(n:L)`). When a hop lacks a plan-time edge or vertex
+  table, the executor resolves it **per adjacency row**: the edge from the row's
+  recorded `edge_table`, and the opposite vertex from that edge's
+  `graph.source_label` / `graph.target_label` (outgoing → target, incoming →
+  source). The neighbor node and relationship hydrate with real properties, just
+  like a typed traversal. Requires the **edge-table endpoint-label contract**
+  (below); a resolution failure is loud (`400`), never a null endpoint.
 - **Variable-length paths** (`executor/varpath.rs`, `leapfrog.rs`) — BFS over
   `min..=max` hops with a visited set for cycle detection and a
   `max_var_path_visited` vertex budget (threat T13).
@@ -70,6 +79,20 @@ write as the edge row, not asynchronously. The background **reconciler** is the
 explicit, observable fallback: it scans edge tables to repair missing entries
 and scans the adjacency index to tombstone orphans, covering dropped-mutation
 and crash-recovery gaps. See [specs/data-flow.md](specs/data-flow.md).
+
+### Edge-table endpoint-label contract
+
+A graph **edge** table (`graph.type = edge`) must declare, besides its endpoint
+*columns* (`graph.source` / `graph.target`), its endpoint *labels*
+`graph.source_label` / `graph.target_label`, each naming an existing vertex
+table's `graph.label`. This is enforced at DDL time by `ferrosa-schema`
+(`registry.rs`) — creating an edge table without valid endpoint labels is
+rejected — so the metadata label-agnostic expansion relies on is guaranteed
+present. Typed traversals resolve the opposite vertex from the *query's* node
+label; label-agnostic traversals resolve it from these *edge-table* labels.
+Should an edge ever lack them (e.g. legacy data, or the referenced vertex table
+was dropped), a label-agnostic expansion **fails loud** with a `400` naming the
+edge and the missing key rather than returning a null endpoint.
 
 ## Public API (key entry points)
 

--- a/ferrosa-graph/specs/overview.md
+++ b/ferrosa-graph/specs/overview.md
@@ -89,6 +89,17 @@ full sequence.
    (Select for reads, Modify for writes) before planning — no plan executes for an
    unauthorized statement (threat T3). Observer/reconciler writes are internal
    system writes and run with system authority, not the caller's.
+6. **Edge tables declare their endpoint labels.** A `graph.type = edge` table
+   must carry `graph.source_label` / `graph.target_label`, each referencing an
+   existing vertex table, enforced at DDL time by `ferrosa-schema`. This is the
+   contract that lets **label-agnostic** expansion (`(a)-[r]->(n)` with the edge
+   and/or target-node label omitted) hydrate the opposite endpoint: when a hop
+   has no plan-time edge/vertex table, the expand executor resolves the edge from
+   the adjacency row's recorded `edge_table` and the opposite vertex from that
+   edge's endpoint label (outgoing → target, incoming → source), then hydrates
+   via the same path as a typed traversal. Missing/unresolvable endpoint metadata
+   is **fail-loud** (a `400`, naming the edge + missing key), never a null
+   endpoint — so a mis-declared edge is exposed, not silently empty.
 
 ## Position in the dependency graph
 

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1138,11 +1138,31 @@ async fn execute_expand(
     let adj_ks = adjacency_keyspace_name(keyspace);
     let adj_table_id = TableId::new(&adj_ks, "adjacency");
 
-    for hop in traversal_hops {
+    // t_0cc8d63e: LIMIT short-circuit. For a plain bounded expansion — no
+    // ORDER BY / DISTINCT / WITH pipeline / post-MATCH WHERE / OPTIONAL MATCH
+    // (each of which reorders rows or needs the full set before limiting) — the
+    // first `limit` rows in expansion order are exactly the final answer. So we
+    // may stop expanding (and hydrating) the LAST hop as soon as `limit` rows
+    // accumulate, instead of hydrating the whole fan-out and truncating at the
+    // end. Aggregates never reach this path (they use PhysicalPlan::Aggregate).
+    let pushdown_cap: Option<usize> = return_clause.limit.and_then(|limit| {
+        let safe = return_clause.order_by.is_empty()
+            && !return_clause.distinct
+            && with_pipeline.is_none()
+            && post_filters.is_empty()
+            && optional_hops.is_empty();
+        (safe && limit > 0).then_some(limit as usize)
+    });
+    let last_hop_idx = traversal_hops.len().saturating_sub(1);
+
+    for (hop_idx, hop) in traversal_hops.iter().enumerate() {
         check_timeout(start, config.query_timeout)?;
+        // Only the final hop may short-circuit; earlier hops must fully expand
+        // because their fan-out feeds the next hop.
+        let cap_this_hop = pushdown_cap.filter(|_| hop_idx == last_hop_idx);
 
         let mut next_states = Vec::new();
-        for state in &current_states {
+        'states: for state in &current_states {
             let vertex_key = &state.current_key;
             // Read adjacency entries for this vertex.
             let adj_partition = write_path.read(&adj_table_id, vertex_key).await?;
@@ -1160,161 +1180,67 @@ async fn execute_expand(
                     .as_ref()
                     .and_then(|vt| table_metadata_for(schema, &vt.keyspace, &vt.table));
 
-                for row in &partition.rows {
-                    if let Some(neighbor_id) = extract_neighbor_id_for_direction(
-                        &row.clustering,
-                        hop.edge_label.as_deref(),
-                        expected_adjacency_direction(hop.direction),
-                    ) {
-                        // t_8c506227: hydrate the opposite endpoint (and the
-                        // relationship) even when the pattern omitted the edge
-                        // and/or the target-node label. Each missing piece is
-                        // resolved from this adjacency row — the edge from its
-                        // recorded edge_table, the opposite vertex from that
-                        // edge's declared source/target label. Typed labels from
-                        // the plan take precedence and are left untouched, so the
-                        // typed traversal path is unchanged.
-                        let neighbor_direction = match hop.direction {
-                            Direction::In => DIRECTION_IN,
-                            Direction::Out => DIRECTION_OUT,
-                            // Both: the adjacency clustering's first component
-                            // encodes the stored direction ([u16 len=1][dir]).
-                            Direction::Both => {
-                                row.clustering.get(2).copied().unwrap_or(DIRECTION_OUT)
-                            }
-                        };
-                        // Recover the edge table when the pattern didn't name it
-                        // and we need it — to hydrate/filter the relationship, or
-                        // to locate an unlabeled target vertex.
-                        let need_edge = hop.rel_var.is_some()
-                            || !hop.prop_filters.is_empty()
-                            || hop.vertex_table.is_none();
-                        let resolved_edge = if hop.edge_table.is_none() && need_edge {
-                            Some(resolve_edge_from_adjacency_row(schema, row)?)
-                        } else {
-                            None
-                        };
-                        let eff_edge_table = hop
-                            .edge_table
-                            .as_ref()
-                            .or(resolved_edge.as_ref().map(|e| &e.0));
-                        let eff_edge_meta =
-                            edge_meta.as_ref().or(resolved_edge.as_ref().map(|e| &e.1));
-                        let eff_edge_label = hop
-                            .edge_label
-                            .as_deref()
-                            .or(eff_edge_table.map(|e| e.label.as_str()));
-                        // Resolve the opposite vertex table when the target node
-                        // was unlabeled, from the effective edge's metadata.
-                        let resolved_vertex = if hop.vertex_table.is_none() {
-                            match eff_edge_meta {
-                                Some(em) => {
-                                    Some(resolve_opposite_vertex(schema, em, neighbor_direction)?)
-                                }
-                                None => None,
-                            }
-                        } else {
-                            None
-                        };
-                        let eff_vertex_table = hop
-                            .vertex_table
-                            .as_ref()
-                            .or(resolved_vertex.as_ref().map(|v| &v.0));
-                        let eff_vertex_meta = vertex_meta
-                            .as_ref()
-                            .or(resolved_vertex.as_ref().map(|v| &v.1));
+                let pairs: Vec<(&Row, Vec<u8>)> = partition
+                    .rows
+                    .iter()
+                    .filter_map(|row| {
+                        extract_neighbor_id_for_direction(
+                            &row.clustering,
+                            hop.edge_label.as_deref(),
+                            expected_adjacency_direction(hop.direction),
+                        )
+                        .map(|nid| (row, nid))
+                    })
+                    .collect();
 
-                        let edge_match = if !hop.prop_filters.is_empty() || hop.rel_var.is_some() {
-                            if let (Some(et), Some(meta)) = (eff_edge_table, eff_edge_meta) {
-                                let edge_tid = TableId::new(&et.keyspace, &et.table);
-                                find_edge_match(
-                                    write_path,
-                                    &edge_tid,
-                                    meta,
-                                    &state.bindings,
-                                    &hop.prop_filters,
-                                    vertex_key.key.as_bytes(),
-                                    &neighbor_id,
-                                    schema,
-                                )
-                                .await?
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        };
-
-                        // Apply property filters if present.
-                        if !hop.prop_filters.is_empty()
-                            && !edge_row_passes_filters(edge_match.as_ref(), &hop.prop_filters)
+                if let Some(cap) = cap_this_hop {
+                    // LIMIT push-down: hydrate sequentially and stop as soon as
+                    // the cap is met, so a bounded query touches minimal storage
+                    // (t_0cc8d63e).
+                    for (row, nid) in pairs {
+                        if let Some(st) = hydrate_hop_neighbor(
+                            write_path,
+                            schema,
+                            hop,
+                            state,
+                            vertex_key,
+                            edge_meta.as_ref(),
+                            vertex_meta.as_ref(),
+                            row,
+                            nid,
+                        )
+                        .await?
                         {
-                            continue;
-                        }
-
-                        let mut bindings = state.bindings.clone();
-                        let neighbor_key = DecoratedKey::new(ferrosa_common::PartitionKey::new(
-                            neighbor_id.clone(),
-                        ));
-
-                        let mut target_bindings = HashMap::new();
-                        if let Some(var_name) = &hop.var {
-                            if let Some(value) = state.bindings.get(var_name) {
-                                target_bindings.insert(var_name.clone(), value.clone());
+                            next_states.push(st);
+                            if next_states.len() >= cap {
+                                break 'states;
                             }
                         }
-                        if let Some(edge_match) = edge_match.as_ref() {
-                            target_bindings.insert("_edge".to_string(), edge_match.json.clone());
+                    }
+                } else {
+                    // Unbounded: hydrate every neighbor. Concurrent per-hop
+                    // hydration (bounded buffered pk_reads) is the intended win
+                    // here, but the borrowed per-neighbor futures can't satisfy
+                    // the multi-threaded runtime's Send bound without a
+                    // clone-heavy `'static` restructure of this loop — which the
+                    // streaming/pull executor (t_4ce82a3e) will supersede. Kept
+                    // sequential for now; correctness is unaffected.
+                    for (row, nid) in pairs {
+                        if let Some(st) = hydrate_hop_neighbor(
+                            write_path,
+                            schema,
+                            hop,
+                            state,
+                            vertex_key,
+                            edge_meta.as_ref(),
+                            vertex_meta.as_ref(),
+                            row,
+                            nid,
+                        )
+                        .await?
+                        {
+                            next_states.push(st);
                         }
-
-                        let neighbor_json = if let (Some(vertex_tid), Some(meta)) = (
-                            eff_vertex_table.map(|vt| TableId::new(&vt.keyspace, &vt.table)),
-                            eff_vertex_meta,
-                        ) {
-                            find_vertex_match(
-                                write_path,
-                                &vertex_tid,
-                                meta,
-                                &target_bindings,
-                                &neighbor_id,
-                                hop.target_props.as_slice(),
-                                hop.var.as_deref().unwrap_or("_hop"),
-                                schema,
-                            )
-                            .await?
-                            .map(|matched| matched.json)
-                        } else {
-                            None
-                        };
-
-                        if !hop.target_props.is_empty() && neighbor_json.is_none() {
-                            continue;
-                        }
-
-                        if let Some(var_name) = &hop.var {
-                            bindings.insert(
-                                var_name.clone(),
-                                neighbor_json.unwrap_or_else(|| {
-                                    serde_json::Value::String(hex::encode(&neighbor_id))
-                                }),
-                            );
-                        }
-
-                        if let Some(rel_var) = &hop.rel_var {
-                            let edge_json = edge_binding_json(
-                                row,
-                                edge_match.as_ref(),
-                                eff_edge_label,
-                                vertex_key,
-                                &neighbor_id,
-                            );
-                            bindings.insert(rel_var.clone(), edge_json);
-                        }
-
-                        next_states.push(ExpandState {
-                            current_key: neighbor_key,
-                            bindings,
-                        });
                     }
                 }
 
@@ -1329,6 +1255,9 @@ async fn execute_expand(
             }
         }
 
+        if let Some(cap) = cap_this_hop {
+            next_states.truncate(cap);
+        }
         stats.vertices_read += next_states.len();
         current_states = next_states;
     }
@@ -2654,6 +2583,147 @@ fn resolve_opposite_vertex(
         label: vertex_label,
     };
     Ok((vertex_rt, vertex_meta))
+}
+
+/// Hydrate one hop neighbor: resolve the effective edge/vertex tables
+/// (t_8c506227), match + filter the edge, hydrate the opposite vertex, and
+/// build the resulting bindings. Returns `Ok(None)` when the candidate is
+/// filtered out (edge property filter, or an unmatched target-node property).
+/// All inputs are shared/immutable, so many neighbors can be hydrated
+/// concurrently within a hop (t_0cc8d63e).
+#[allow(clippy::too_many_arguments)]
+async fn hydrate_hop_neighbor(
+    write_path: &WritePath,
+    schema: Option<&Schema>,
+    hop: &Hop,
+    state: &ExpandState,
+    vertex_key: &DecoratedKey,
+    edge_meta: Option<&ferrosa_schema::metadata::table::TableMetadata>,
+    vertex_meta: Option<&ferrosa_schema::metadata::table::TableMetadata>,
+    row: &Row,
+    neighbor_id: Vec<u8>,
+) -> Result<Option<ExpandState>> {
+    let neighbor_direction = match hop.direction {
+        Direction::In => DIRECTION_IN,
+        Direction::Out => DIRECTION_OUT,
+        Direction::Both => row.clustering.get(2).copied().unwrap_or(DIRECTION_OUT),
+    };
+    let need_edge =
+        hop.rel_var.is_some() || !hop.prop_filters.is_empty() || hop.vertex_table.is_none();
+    let resolved_edge = if hop.edge_table.is_none() && need_edge {
+        Some(resolve_edge_from_adjacency_row(schema, row)?)
+    } else {
+        None
+    };
+    let eff_edge_table = hop
+        .edge_table
+        .as_ref()
+        .or(resolved_edge.as_ref().map(|e| &e.0));
+    let eff_edge_meta = edge_meta.or(resolved_edge.as_ref().map(|e| &e.1));
+    let eff_edge_label = hop
+        .edge_label
+        .as_deref()
+        .or(eff_edge_table.map(|e| e.label.as_str()));
+    let resolved_vertex = if hop.vertex_table.is_none() {
+        match eff_edge_meta {
+            Some(em) => Some(resolve_opposite_vertex(schema, em, neighbor_direction)?),
+            None => None,
+        }
+    } else {
+        None
+    };
+    let eff_vertex_table = hop
+        .vertex_table
+        .as_ref()
+        .or(resolved_vertex.as_ref().map(|v| &v.0));
+    let eff_vertex_meta = vertex_meta.or(resolved_vertex.as_ref().map(|v| &v.1));
+
+    let edge_match = if !hop.prop_filters.is_empty() || hop.rel_var.is_some() {
+        if let (Some(et), Some(meta)) = (eff_edge_table, eff_edge_meta) {
+            let edge_tid = TableId::new(&et.keyspace, &et.table);
+            find_edge_match(
+                write_path,
+                &edge_tid,
+                meta,
+                &state.bindings,
+                &hop.prop_filters,
+                vertex_key.key.as_bytes(),
+                &neighbor_id,
+                schema,
+            )
+            .await?
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    if !hop.prop_filters.is_empty()
+        && !edge_row_passes_filters(edge_match.as_ref(), &hop.prop_filters)
+    {
+        return Ok(None);
+    }
+
+    let mut bindings = state.bindings.clone();
+    let neighbor_key = DecoratedKey::new(ferrosa_common::PartitionKey::new(neighbor_id.clone()));
+
+    let mut target_bindings = HashMap::new();
+    if let Some(var_name) = &hop.var {
+        if let Some(value) = state.bindings.get(var_name) {
+            target_bindings.insert(var_name.clone(), value.clone());
+        }
+    }
+    if let Some(edge_match) = edge_match.as_ref() {
+        target_bindings.insert("_edge".to_string(), edge_match.json.clone());
+    }
+
+    let neighbor_json = if let (Some(vertex_tid), Some(meta)) = (
+        eff_vertex_table.map(|vt| TableId::new(&vt.keyspace, &vt.table)),
+        eff_vertex_meta,
+    ) {
+        find_vertex_match(
+            write_path,
+            &vertex_tid,
+            meta,
+            &target_bindings,
+            &neighbor_id,
+            hop.target_props.as_slice(),
+            hop.var.as_deref().unwrap_or("_hop"),
+            schema,
+        )
+        .await?
+        .map(|matched| matched.json)
+    } else {
+        None
+    };
+
+    if !hop.target_props.is_empty() && neighbor_json.is_none() {
+        return Ok(None);
+    }
+
+    if let Some(var_name) = &hop.var {
+        bindings.insert(
+            var_name.clone(),
+            neighbor_json.unwrap_or_else(|| serde_json::Value::String(hex::encode(&neighbor_id))),
+        );
+    }
+
+    if let Some(rel_var) = &hop.rel_var {
+        let edge_json = edge_binding_json(
+            row,
+            edge_match.as_ref(),
+            eff_edge_label,
+            vertex_key,
+            &neighbor_id,
+        );
+        bindings.insert(rel_var.clone(), edge_json);
+    }
+
+    Ok(Some(ExpandState {
+        current_key: neighbor_key,
+        bindings,
+    }))
 }
 
 /// Convert a `Literal` from the AST into raw bytes for storage.

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1166,47 +1166,63 @@ async fn execute_expand(
                         hop.edge_label.as_deref(),
                         expected_adjacency_direction(hop.direction),
                     ) {
-                        // t_8c506227: for a label-agnostic hop (no edge/vertex
-                        // label) resolve the edge + opposite-vertex tables from
-                        // this adjacency row so the neighbor hydrates. Typed
-                        // patterns keep their plan-time tables unchanged.
-                        let row_endpoints =
-                            if hop.edge_table.is_none() && hop.vertex_table.is_none() {
-                                let neighbor_direction = match hop.direction {
-                                    Direction::In => DIRECTION_IN,
-                                    Direction::Out => DIRECTION_OUT,
-                                    // Both: adjacency clustering's first component
-                                    // encodes the stored direction ([u16 len=1][dir]).
-                                    Direction::Both => {
-                                        row.clustering.get(2).copied().unwrap_or(DIRECTION_OUT)
-                                    }
-                                };
-                                Some(resolve_unlabeled_row_endpoints(
-                                    schema,
-                                    row,
-                                    neighbor_direction,
-                                )?)
-                            } else {
-                                None
-                            };
-                        let eff_edge_table = row_endpoints
+                        // t_8c506227: hydrate the opposite endpoint (and the
+                        // relationship) even when the pattern omitted the edge
+                        // and/or the target-node label. Each missing piece is
+                        // resolved from this adjacency row — the edge from its
+                        // recorded edge_table, the opposite vertex from that
+                        // edge's declared source/target label. Typed labels from
+                        // the plan take precedence and are left untouched, so the
+                        // typed traversal path is unchanged.
+                        let neighbor_direction = match hop.direction {
+                            Direction::In => DIRECTION_IN,
+                            Direction::Out => DIRECTION_OUT,
+                            // Both: the adjacency clustering's first component
+                            // encodes the stored direction ([u16 len=1][dir]).
+                            Direction::Both => {
+                                row.clustering.get(2).copied().unwrap_or(DIRECTION_OUT)
+                            }
+                        };
+                        // Recover the edge table when the pattern didn't name it
+                        // and we need it — to hydrate/filter the relationship, or
+                        // to locate an unlabeled target vertex.
+                        let need_edge = hop.rel_var.is_some()
+                            || !hop.prop_filters.is_empty()
+                            || hop.vertex_table.is_none();
+                        let resolved_edge = if hop.edge_table.is_none() && need_edge {
+                            Some(resolve_edge_from_adjacency_row(schema, row)?)
+                        } else {
+                            None
+                        };
+                        let eff_edge_table = hop
+                            .edge_table
                             .as_ref()
-                            .map(|e| &e.0)
-                            .or(hop.edge_table.as_ref());
+                            .or(resolved_edge.as_ref().map(|e| &e.0));
                         let eff_edge_meta =
-                            row_endpoints.as_ref().map(|e| &e.1).or(edge_meta.as_ref());
-                        let eff_vertex_table = row_endpoints
+                            edge_meta.as_ref().or(resolved_edge.as_ref().map(|e| &e.1));
+                        let eff_edge_label = hop
+                            .edge_label
+                            .as_deref()
+                            .or(eff_edge_table.map(|e| e.label.as_str()));
+                        // Resolve the opposite vertex table when the target node
+                        // was unlabeled, from the effective edge's metadata.
+                        let resolved_vertex = if hop.vertex_table.is_none() {
+                            match eff_edge_meta {
+                                Some(em) => {
+                                    Some(resolve_opposite_vertex(schema, em, neighbor_direction)?)
+                                }
+                                None => None,
+                            }
+                        } else {
+                            None
+                        };
+                        let eff_vertex_table = hop
+                            .vertex_table
                             .as_ref()
-                            .map(|e| &e.2)
-                            .or(hop.vertex_table.as_ref());
-                        let eff_vertex_meta = row_endpoints
+                            .or(resolved_vertex.as_ref().map(|v| &v.0));
+                        let eff_vertex_meta = vertex_meta
                             .as_ref()
-                            .map(|e| &e.3)
-                            .or(vertex_meta.as_ref());
-                        let eff_edge_label = row_endpoints
-                            .as_ref()
-                            .map(|e| e.0.label.as_str())
-                            .or(hop.edge_label.as_deref());
+                            .or(resolved_vertex.as_ref().map(|v| &v.1));
 
                         let edge_match = if !hop.prop_filters.is_empty() || hop.rel_var.is_some() {
                             if let (Some(et), Some(meta)) = (eff_edge_table, eff_edge_meta) {
@@ -2533,22 +2549,15 @@ fn resolve_table_by_graph_label(
     })
 }
 
-/// Label-agnostic expansion (t_8c506227): the MATCH pattern gave no edge/vertex
-/// label, so resolve both from the adjacency row itself. Each adjacency row
-/// records its originating edge table (regular column 0, `keyspace.table`); we
-/// read that edge table's `graph.source_label` / `graph.target_label` to find
-/// the OPPOSITE vertex table (outgoing → target, incoming → source) so the
-/// neighbor node can be hydrated with real properties. Fails loud when the edge
-/// table or its endpoint-label metadata is missing/invalid rather than emitting
-/// a null endpoint (acceptance #4).
-#[allow(clippy::type_complexity)]
-fn resolve_unlabeled_row_endpoints(
+/// Label-agnostic expansion (t_8c506227): the MATCH pattern gave no edge label,
+/// so recover the edge table this adjacency row came from. Each adjacency row
+/// records its originating edge table in regular column 0 (`keyspace.table`).
+/// Fails loud when that column is missing or names a table absent from the
+/// schema rather than silently dropping the relationship's identity.
+fn resolve_edge_from_adjacency_row(
     schema: Option<&Schema>,
     adjacency_row: &Row,
-    neighbor_direction: u8,
 ) -> Result<(
-    crate::planner::ResolvedTable,
-    ferrosa_schema::metadata::table::TableMetadata,
     crate::planner::ResolvedTable,
     ferrosa_schema::metadata::table::TableMetadata,
 )> {
@@ -2565,8 +2574,8 @@ fn resolve_unlabeled_row_endpoints(
         .and_then(|bytes| std::str::from_utf8(bytes).ok())
         .ok_or_else(|| {
             GraphError::Validation(
-                "adjacency row is missing its edge_table column; cannot hydrate the opposite \
-                 endpoint of a label-agnostic relationship expansion"
+                "adjacency row is missing its edge_table column; cannot hydrate the \
+                 relationship of a label-agnostic expansion"
                     .into(),
             )
         })?;
@@ -2580,6 +2589,40 @@ fn resolve_unlabeled_row_endpoints(
             "edge table '{edge_table_str}' recorded in adjacency is not registered in the schema"
         ))
     })?;
+    let edge_rt = crate::planner::ResolvedTable {
+        keyspace: edge_ks.to_string(),
+        table: edge_tbl.to_string(),
+        graph_type: "edge".to_string(),
+        label: edge_meta
+            .extensions
+            .get("graph.label")
+            .cloned()
+            .unwrap_or_default(),
+    };
+    Ok((edge_rt, edge_meta))
+}
+
+/// Resolve the OPPOSITE vertex table of an edge for a hop whose target node was
+/// unlabeled (t_8c506227). The opposite endpoint is the edge's target vertex
+/// for an outgoing traversal and its source vertex for an incoming one, named
+/// by the edge's `graph.target_label` / `graph.source_label`. Fails loud when
+/// the required endpoint label is absent or resolves to no vertex table, so a
+/// mis-declared edge surfaces as a clear error rather than a null endpoint
+/// (acceptance #4).
+fn resolve_opposite_vertex(
+    schema: Option<&Schema>,
+    edge_meta: &ferrosa_schema::metadata::table::TableMetadata,
+    neighbor_direction: u8,
+) -> Result<(
+    crate::planner::ResolvedTable,
+    ferrosa_schema::metadata::table::TableMetadata,
+)> {
+    let schema = schema.ok_or_else(|| {
+        GraphError::Validation(
+            "label-agnostic relationship expansion requires schema metadata".into(),
+        )
+    })?;
+    let edge_name = format!("{}.{}", edge_meta.keyspace, edge_meta.name);
     let (label_key, dir_word) = if neighbor_direction == DIRECTION_IN {
         ("graph.source_label", "incoming")
     } else {
@@ -2591,35 +2634,26 @@ fn resolve_unlabeled_row_endpoints(
         .cloned()
         .ok_or_else(|| {
             GraphError::Validation(format!(
-            "edge table '{edge_table_str}' lacks the '{label_key}' extension needed to hydrate \
-             the {dir_word} endpoint of a label-agnostic expansion; declare the edge's \
-             source/target vertex labels"
-        ))
-        })?;
-    let vertex_meta =
-        resolve_table_by_graph_label(schema, edge_ks, &vertex_label).ok_or_else(|| {
-            GraphError::Validation(format!(
-                "edge table '{edge_table_str}' declares {label_key}='{vertex_label}', but no \
-                 vertex table with graph.label '{vertex_label}' exists in keyspace '{edge_ks}'"
+                "edge table '{edge_name}' lacks the '{label_key}' extension needed to hydrate the \
+             {dir_word} endpoint of an unlabeled traversal; declare the edge's source/target \
+             vertex labels"
             ))
         })?;
-    let edge_rt = crate::planner::ResolvedTable {
-        keyspace: edge_ks.to_string(),
-        table: edge_tbl.to_string(),
-        graph_type: "edge".to_string(),
-        label: edge_meta
-            .extensions
-            .get("graph.label")
-            .cloned()
-            .unwrap_or_default(),
-    };
+    let vertex_meta = resolve_table_by_graph_label(schema, &edge_meta.keyspace, &vertex_label)
+        .ok_or_else(|| {
+            GraphError::Validation(format!(
+                "edge table '{edge_name}' declares {label_key}='{vertex_label}', but no vertex \
+                 table with graph.label '{vertex_label}' exists in keyspace '{}'",
+                edge_meta.keyspace
+            ))
+        })?;
     let vertex_rt = crate::planner::ResolvedTable {
         keyspace: vertex_meta.keyspace.clone(),
         table: vertex_meta.name.clone(),
         graph_type: "vertex".to_string(),
         label: vertex_label,
     };
-    Ok((edge_rt, edge_meta, vertex_rt, vertex_meta))
+    Ok((vertex_rt, vertex_meta))
 }
 
 /// Convert a `Literal` from the AST into raw bytes for storage.

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1166,10 +1166,50 @@ async fn execute_expand(
                         hop.edge_label.as_deref(),
                         expected_adjacency_direction(hop.direction),
                     ) {
+                        // t_8c506227: for a label-agnostic hop (no edge/vertex
+                        // label) resolve the edge + opposite-vertex tables from
+                        // this adjacency row so the neighbor hydrates. Typed
+                        // patterns keep their plan-time tables unchanged.
+                        let row_endpoints =
+                            if hop.edge_table.is_none() && hop.vertex_table.is_none() {
+                                let neighbor_direction = match hop.direction {
+                                    Direction::In => DIRECTION_IN,
+                                    Direction::Out => DIRECTION_OUT,
+                                    // Both: adjacency clustering's first component
+                                    // encodes the stored direction ([u16 len=1][dir]).
+                                    Direction::Both => {
+                                        row.clustering.get(2).copied().unwrap_or(DIRECTION_OUT)
+                                    }
+                                };
+                                Some(resolve_unlabeled_row_endpoints(
+                                    schema,
+                                    row,
+                                    neighbor_direction,
+                                )?)
+                            } else {
+                                None
+                            };
+                        let eff_edge_table = row_endpoints
+                            .as_ref()
+                            .map(|e| &e.0)
+                            .or(hop.edge_table.as_ref());
+                        let eff_edge_meta =
+                            row_endpoints.as_ref().map(|e| &e.1).or(edge_meta.as_ref());
+                        let eff_vertex_table = row_endpoints
+                            .as_ref()
+                            .map(|e| &e.2)
+                            .or(hop.vertex_table.as_ref());
+                        let eff_vertex_meta = row_endpoints
+                            .as_ref()
+                            .map(|e| &e.3)
+                            .or(vertex_meta.as_ref());
+                        let eff_edge_label = row_endpoints
+                            .as_ref()
+                            .map(|e| e.0.label.as_str())
+                            .or(hop.edge_label.as_deref());
+
                         let edge_match = if !hop.prop_filters.is_empty() || hop.rel_var.is_some() {
-                            if let (Some(et), Some(meta)) =
-                                (hop.edge_table.as_ref(), edge_meta.as_ref())
-                            {
+                            if let (Some(et), Some(meta)) = (eff_edge_table, eff_edge_meta) {
                                 let edge_tid = TableId::new(&et.keyspace, &et.table);
                                 find_edge_match(
                                     write_path,
@@ -1212,10 +1252,8 @@ async fn execute_expand(
                         }
 
                         let neighbor_json = if let (Some(vertex_tid), Some(meta)) = (
-                            hop.vertex_table
-                                .as_ref()
-                                .map(|vt| TableId::new(&vt.keyspace, &vt.table)),
-                            vertex_meta.as_ref(),
+                            eff_vertex_table.map(|vt| TableId::new(&vt.keyspace, &vt.table)),
+                            eff_vertex_meta,
                         ) {
                             find_vertex_match(
                                 write_path,
@@ -1250,7 +1288,7 @@ async fn execute_expand(
                             let edge_json = edge_binding_json(
                                 row,
                                 edge_match.as_ref(),
-                                hop.edge_label.as_deref(),
+                                eff_edge_label,
                                 vertex_key,
                                 &neighbor_id,
                             );
@@ -2493,6 +2531,95 @@ fn resolve_table_by_graph_label(
                 .is_some_and(|graph_label| graph_label == label))
         .then(|| meta.clone())
     })
+}
+
+/// Label-agnostic expansion (t_8c506227): the MATCH pattern gave no edge/vertex
+/// label, so resolve both from the adjacency row itself. Each adjacency row
+/// records its originating edge table (regular column 0, `keyspace.table`); we
+/// read that edge table's `graph.source_label` / `graph.target_label` to find
+/// the OPPOSITE vertex table (outgoing → target, incoming → source) so the
+/// neighbor node can be hydrated with real properties. Fails loud when the edge
+/// table or its endpoint-label metadata is missing/invalid rather than emitting
+/// a null endpoint (acceptance #4).
+#[allow(clippy::type_complexity)]
+fn resolve_unlabeled_row_endpoints(
+    schema: Option<&Schema>,
+    adjacency_row: &Row,
+    neighbor_direction: u8,
+) -> Result<(
+    crate::planner::ResolvedTable,
+    ferrosa_schema::metadata::table::TableMetadata,
+    crate::planner::ResolvedTable,
+    ferrosa_schema::metadata::table::TableMetadata,
+)> {
+    let schema = schema.ok_or_else(|| {
+        GraphError::Validation(
+            "label-agnostic relationship expansion requires schema metadata".into(),
+        )
+    })?;
+    let edge_table_str = adjacency_row
+        .cells
+        .iter()
+        .find(|(idx, _)| *idx == 0)
+        .and_then(|(_, cell)| cell.value.as_ref())
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+        .ok_or_else(|| {
+            GraphError::Validation(
+                "adjacency row is missing its edge_table column; cannot hydrate the opposite \
+                 endpoint of a label-agnostic relationship expansion"
+                    .into(),
+            )
+        })?;
+    let (edge_ks, edge_tbl) = edge_table_str.split_once('.').ok_or_else(|| {
+        GraphError::Validation(format!(
+            "adjacency edge_table '{edge_table_str}' is not in 'keyspace.table' form"
+        ))
+    })?;
+    let edge_meta = table_metadata_for(Some(schema), edge_ks, edge_tbl).ok_or_else(|| {
+        GraphError::Validation(format!(
+            "edge table '{edge_table_str}' recorded in adjacency is not registered in the schema"
+        ))
+    })?;
+    let (label_key, dir_word) = if neighbor_direction == DIRECTION_IN {
+        ("graph.source_label", "incoming")
+    } else {
+        ("graph.target_label", "outgoing")
+    };
+    let vertex_label = edge_meta
+        .extensions
+        .get(label_key)
+        .cloned()
+        .ok_or_else(|| {
+            GraphError::Validation(format!(
+            "edge table '{edge_table_str}' lacks the '{label_key}' extension needed to hydrate \
+             the {dir_word} endpoint of a label-agnostic expansion; declare the edge's \
+             source/target vertex labels"
+        ))
+        })?;
+    let vertex_meta =
+        resolve_table_by_graph_label(schema, edge_ks, &vertex_label).ok_or_else(|| {
+            GraphError::Validation(format!(
+                "edge table '{edge_table_str}' declares {label_key}='{vertex_label}', but no \
+                 vertex table with graph.label '{vertex_label}' exists in keyspace '{edge_ks}'"
+            ))
+        })?;
+    let edge_rt = crate::planner::ResolvedTable {
+        keyspace: edge_ks.to_string(),
+        table: edge_tbl.to_string(),
+        graph_type: "edge".to_string(),
+        label: edge_meta
+            .extensions
+            .get("graph.label")
+            .cloned()
+            .unwrap_or_default(),
+    };
+    let vertex_rt = crate::planner::ResolvedTable {
+        keyspace: vertex_meta.keyspace.clone(),
+        table: vertex_meta.name.clone(),
+        graph_type: "vertex".to_string(),
+        label: vertex_label,
+    };
+    Ok((edge_rt, edge_meta, vertex_rt, vertex_meta))
 }
 
 /// Convert a `Literal` from the AST into raw bytes for storage.

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -6421,3 +6421,189 @@ async fn http_label_agnostic_incoming_expansion_hydrates_source_neighbor() {
         "incoming label-agnostic expansion must hydrate the SOURCE neighbor 'Alice': {rows:?}"
     );
 }
+
+/// t_8c506227 (partial-label gap): a TYPED edge with an UNLABELED target node
+/// `-[r:KNOWS]->(n)` must still hydrate `n` — its table is resolved from the
+/// edge's graph.target_label even though the pattern did not label `n`.
+#[tokio::test]
+async fn http_typed_edge_unlabeled_target_hydrates_neighbor() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    for name in ["Alice", "Bob"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+    }
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MERGE (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person {name: 'Bob'}) RETURN r",
+            "keyspace": "social"
+        })),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(n) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(rows.len(), 1, "expected one neighbor, got {rows:?}");
+    assert_eq!(
+        rows[0][0].as_str(),
+        Some("Bob"),
+        "typed edge with unlabeled target must hydrate n via the edge's target_label: {rows:?}"
+    );
+}
+
+/// t_8c506227 (partial-label gap): an UNLABELED edge with a LABELED target
+/// `-[r]->(n:Person)` must hydrate the RELATIONSHIP `r` (real _type + edge
+/// properties), not fall back to raw adjacency cells (col_0).
+#[tokio::test]
+async fn http_unlabeled_edge_labeled_target_hydrates_relationship() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    for name in ["Alice", "Bob"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+    }
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MERGE (a:Person {name: 'Alice'})-[r:KNOWS {since: 2021}]->(b:Person {name: 'Bob'}) RETURN r",
+            "keyspace": "social"
+        })),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (a:Person {name: 'Alice'})-[r]->(n:Person) RETURN r",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(rows.len(), 1, "expected one relationship, got {rows:?}");
+    let r = &rows[0][0];
+    assert_eq!(
+        r["_type"].as_str(),
+        Some("KNOWS"),
+        "unlabeled edge to a labeled target must hydrate r._type from the resolved edge: {r:?}"
+    );
+    assert_eq!(
+        r["since"].as_i64(),
+        Some(2021),
+        "relationship properties must be hydrated, not the col_0 fallback: {r:?}"
+    );
+    assert!(
+        r.get("col_0").is_none(),
+        "resolved relationship must not carry the raw col_0 adjacency fallback: {r:?}"
+    );
+}
+
+/// t_8c506227 (acceptance #4 / write-side guarantee): the "silent null endpoint"
+/// state is prevented at the source — a graph EDGE table must declare its
+/// endpoint labels, so creating one without `graph.target_label` is rejected at
+/// DDL time with a clear error rather than being allowed to exist and later
+/// yield un-hydratable neighbors.
+#[tokio::test]
+async fn graph_edge_table_without_endpoint_labels_is_rejected() {
+    let (schema, _storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    let auth = superuser_auth();
+
+    let mut cols = IndexMap::new();
+    cols.insert(
+        "src_id".to_string(),
+        ColumnMetadata {
+            name: "src_id".to_string(),
+            kind: ColumnKind::PartitionKey,
+            position: 0,
+            column_type: "uuid".to_string(),
+            clustering_order: ClusteringOrder::None,
+            mask: None,
+        },
+    );
+    cols.insert(
+        "dst_id".to_string(),
+        ColumnMetadata {
+            name: "dst_id".to_string(),
+            kind: ColumnKind::Clustering,
+            position: 0,
+            column_type: "uuid".to_string(),
+            clustering_order: ClusteringOrder::Asc,
+            mask: None,
+        },
+    );
+    let mut ext = HashMap::new();
+    ext.insert("graph.type".to_string(), "edge".to_string());
+    ext.insert("graph.label".to_string(), "UNDECLARED".to_string());
+    ext.insert("graph.source".to_string(), "src_id".to_string());
+    ext.insert("graph.target".to_string(), "dst_id".to_string());
+    // Deliberately no graph.source_label / graph.target_label.
+
+    let result = schema.create_table(
+        TableMetadata {
+            keyspace: "social".to_string(),
+            name: "undeclared_e".to_string(),
+            id: Uuid::new_v4(),
+            columns: cols,
+            partition_key: vec!["src_id".to_string()],
+            clustering_key: vec![("dst_id".to_string(), ClusteringOrder::Asc)],
+            params: TableParams::default(),
+            flags: HashSet::new(),
+            extensions: ext,
+            is_system: false,
+        },
+        &auth,
+    );
+
+    let err = result
+        .expect_err("an edge table missing its endpoint labels must be rejected, not created");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("graph.source_label") || msg.contains("graph.target_label"),
+        "rejection must name the missing endpoint-label extension: {msg}"
+    );
+    assert!(
+        msg.contains("undeclared_e"),
+        "rejection must name the offending edge table: {msg}"
+    );
+}

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -6272,3 +6272,152 @@ async fn http_call_subquery_nested_call_fails_loud() {
         "a CALL {{}} nested inside a CALL {{}} must fail loud, not silently succeed"
     );
 }
+
+/// t_8c506227: a label-agnostic outgoing expansion `(a)-[r]->(n)` must hydrate
+/// the opposite endpoint node (and the relationship) across MULTIPLE edge
+/// labels — exactly like the typed `-[r:KNOWS]->` form does — instead of
+/// returning a null neighbor. Regression guard for the generic explorer's
+/// recenter / n-hop expansion over all relationship types.
+#[tokio::test]
+async fn http_label_agnostic_outgoing_expansion_hydrates_neighbor_nodes() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    create_social_likes_edge_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    register_social_likes_table_with_storage(&storage);
+
+    for name in ["Alice", "Bob", "Carol"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+    }
+
+    // Two DIFFERENT edge labels out of Alice, so the unlabeled hop must resolve
+    // the opposite vertex table per adjacency row (heterogeneous edge tables).
+    for (label, dst) in [("KNOWS", "Bob"), ("LIKES", "Carol")] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!(
+                    "MERGE (a:Person {{name: 'Alice'}})-[r:{label}]->(b:Person {{name: '{dst}'}}) RETURN r"
+                ),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(
+            app.oneshot(req).await.unwrap().status(),
+            StatusCode::OK,
+            "seeding the {label} edge should succeed"
+        );
+    }
+
+    // Label-agnostic outgoing expansion: BOTH neighbors must hydrate with real
+    // node properties, not null.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (a:Person {name: 'Alice'})-[r]->(n) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+
+    let names: Vec<String> = rows
+        .iter()
+        .map(|r| {
+            r[0].as_str()
+                .unwrap_or_else(|| {
+                    panic!("label-agnostic expansion left the neighbor un-hydrated (null): {r:?}")
+                })
+                .to_string()
+        })
+        .collect();
+
+    assert_eq!(
+        rows.len(),
+        2,
+        "expected both the KNOWS and LIKES neighbors, got {names:?}"
+    );
+    assert!(
+        names.contains(&"Bob".to_string()),
+        "KNOWS neighbor 'Bob' missing / un-hydrated: {names:?}"
+    );
+    assert!(
+        names.contains(&"Carol".to_string()),
+        "LIKES neighbor 'Carol' missing / un-hydrated: {names:?}"
+    );
+}
+
+/// t_8c506227 (inverse): a label-agnostic INCOMING expansion `(b)<-[r]-(n)`
+/// must hydrate the SOURCE neighbor (resolved via the edge's source label),
+/// not the target — the direction the earlier report found "surprising".
+#[tokio::test]
+async fn http_label_agnostic_incoming_expansion_hydrates_source_neighbor() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    for name in ["Alice", "Bob"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+    }
+
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MERGE (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person {name: 'Bob'}) RETURN r",
+            "keyspace": "social"
+        })),
+    );
+    assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+
+    // Incoming expansion from Bob: the un-hydrated bug would leave n null; the
+    // fix must resolve the SOURCE vertex (Alice) via graph.source_label.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (b:Person {name: 'Bob'})<-[r]-(n) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected exactly one incoming neighbor, got {rows:?}"
+    );
+    assert_eq!(
+        rows[0][0].as_str(),
+        Some("Alice"),
+        "incoming label-agnostic expansion must hydrate the SOURCE neighbor 'Alice': {rows:?}"
+    );
+}

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -6607,3 +6607,87 @@ async fn graph_edge_table_without_endpoint_labels_is_rejected() {
         "rejection must name the offending edge table: {msg}"
     );
 }
+
+/// t_0cc8d63e: a bare `LIMIT k` expansion (no ORDER BY / DISTINCT / WITH /
+/// aggregation) must short-circuit — hydrating only ~k neighbors, not the whole
+/// fan-out. Asserted via `stats.vertices_read`, which counts hydrated neighbors.
+#[tokio::test]
+async fn http_limit_short_circuits_expansion_hydration() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    // Alice + five neighbors, all reachable via KNOWS.
+    for name in ["Alice", "N1", "N2", "N3", "N4", "N5"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+    }
+    for dst in ["N1", "N2", "N3", "N4", "N5"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!(
+                    "MERGE (a:Person {{name: 'Alice'}})-[r:KNOWS]->(b:Person {{name: '{dst}'}}) RETURN r"
+                ),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+    }
+
+    // Baseline: the unlimited expansion hydrates every neighbor.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (a:Person {name: 'Alice'})-[r]->(n) RETURN n.name",
+            "keyspace": "social"
+        })),
+    );
+    let body = response_json(app.oneshot(req).await.unwrap()).await;
+    assert_eq!(
+        body["rows"].as_array().unwrap().len(),
+        5,
+        "baseline must see all five neighbors: {body}"
+    );
+    let read_all = body["stats"]["vertices_read"]
+        .as_u64()
+        .expect("vertices_read");
+
+    // LIMIT 2 must short-circuit: it stops hydrating once two rows accumulate,
+    // so it reads strictly fewer neighbors than the unlimited query.
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (a:Person {name: 'Alice'})-[r]->(n) RETURN n.name LIMIT 2",
+            "keyspace": "social"
+        })),
+    );
+    let body = response_json(app.oneshot(req).await.unwrap()).await;
+    assert_eq!(
+        body["rows"].as_array().unwrap().len(),
+        2,
+        "LIMIT 2 must return exactly two rows: {body}"
+    );
+    let read_2 = body["stats"]["vertices_read"]
+        .as_u64()
+        .expect("vertices_read");
+    assert!(
+        read_all - read_2 >= 3,
+        "LIMIT 2 must skip hydrating the 3 excess neighbors (short-circuit): \
+         limited={read_2} unlimited={read_all}"
+    );
+}

--- a/specs/proposed/graph-unlabeled-relationship-endpoint-hydration.md
+++ b/specs/proposed/graph-unlabeled-relationship-endpoint-hydration.md
@@ -1,6 +1,6 @@
 ---
 title: "Graph: hydrate opposite endpoints for label-agnostic relationship expansion"
-status: proposed
+status: implemented
 crate: ferrosa-graph
 task: t_8c506227
 date: 2026-07-08
@@ -102,12 +102,22 @@ loud rather than silently return null (task acceptance #4).
   `hop.vertex_table` (and `hop.edge_table`) are `None`; labeled/typed patterns keep
   their existing, test-covered behavior byte-for-byte.
 
-**Highest-leverage open decision (needs your call):** does the loaded
-`sf_influence_query` keyspace's edge tables already declare
-`graph.source_label`/`graph.target_label`? If **yes**, the fix works on the existing
-data with no re-ingest. If **no**, generic recenter will (correctly) fail loud until
-the sf ingest sets those extensions on edge tables (a one-line schema addition +
-backfill/re-ingest). See §7.
+**RESOLVED (2026-07-08).** The loaded `sf_influence_query` edge tables **do**
+declare `graph.source_label`/`graph.target_label`, verified by running the fixed
+build against the live graph on the local sf node (`OWED_TO`/`DONATED_TO`
+neighbors hydrate with non-null ids + full edge props, both directions). The
+executor fix works on the existing data with **no re-ingest**. Moreover the
+write-side guarantee is **already enforced**: `ferrosa-schema` (`registry.rs`)
+rejects any `graph.type=edge` table lacking `graph.source_label`/`target_label`
+or whose labels don't reference existing vertex tables — so the metadata this
+relies on cannot be absent for a normally-created edge, and the query-time
+fail-loud is defense-in-depth.
+
+**Implementation note.** The fix resolves the edge and the opposite vertex
+**independently**, so it covers all four label combinations, not just the fully
+unlabeled one: `-[r]->(n)`, `<-[r]-(n)`, `-[r:T]->(n)` (typed edge, unlabeled
+node → vertex resolved from the edge's target label), and `-[r]->(n:L)`
+(unlabeled edge, labeled node → relationship hydrated from the adjacency edge).
 
 ## 4. Design
 

--- a/specs/proposed/graph-unlabeled-relationship-endpoint-hydration.md
+++ b/specs/proposed/graph-unlabeled-relationship-endpoint-hydration.md
@@ -1,0 +1,182 @@
+---
+title: "Graph: hydrate opposite endpoints for label-agnostic relationship expansion"
+status: proposed
+crate: ferrosa-graph
+task: t_8c506227
+date: 2026-07-08
+executive_summary: >
+  Ferrosa's Cypher engine hydrates the opposite endpoint node only when the query
+  labels it (typed traversal `(a:Actor)-[r:DONATED_TO]->(c:Committee)`). A
+  label-agnostic expansion `(c {id:…})-[r]->(n)` returns the relationship's raw
+  adjacency internals (`_src`, `_dst`, `col_0`) but leaves `n` un-hydrated (null),
+  blocking a generic D3 recenter / n+2 explorer from using Ferrosa directly. Root
+  cause: the physical planner leaves `hop.vertex_table` (and `edge_table`/`edge_label`)
+  `None` for unlabeled patterns, so the executor's vertex-hydration call is gated off.
+  Fix: at execution, resolve each adjacency row's edge table (already recorded in the
+  row), read its source/target label metadata, resolve the opposite vertex table
+  direction-aware, and hydrate the neighbor through the existing `find_vertex_match`
+  path — hydrating edge properties too. Fail loud (not null) when an edge table lacks
+  valid source/target metadata, per the task's acceptance criteria.
+---
+
+# Graph — hydrate opposite endpoints for label-agnostic relationship expansion
+
+## 1. Problem (current behavior)
+
+The property-graph engine over CQL edge/vertex tables supports **typed** traversals
+but not **label-agnostic** expansion of the opposite endpoint.
+
+Works — the query labels the neighbor, so the planner can resolve its table:
+
+```cypher
+MATCH (a:Actor)-[r:DONATED_TO]->(c:Committee {filer_id: '211776936'})
+RETURN a.name_raw, r, c.name
+```
+
+Broken — the neighbor `(n)` and the relationship `[r]` are unlabeled:
+
+```cypher
+MATCH (c:Committee {id: 'f680…'})-[r]->(n)  RETURN c.name, r, n.id   -- n.id is NULL
+MATCH (c:Committee {id: 'f680…'})<-[r]-(n)  RETURN c.name, r, n.id   -- n.id is NULL
+```
+
+Returned rows carry `r._src`, `r._dst`, and `r.col_0` (e.g. `sf_influence_query.donated_to`)
+but `n.id` is null; the incoming form's endpoint reporting is also surprising.
+
+**Impact:** a generic explorer cannot issue a single label-agnostic 1-hop / 2-hop
+expansion from an arbitrary node and render the neighbors; sf-elections must keep an
+app-side SQLite adjacency projection for recenter.
+
+## 2. Root cause (grounded, `ferrosa-graph`)
+
+| Stage | Location | Behavior for unlabeled `-[r]->(n)` |
+|---|---|---|
+| Physical plan | `planner/physical.rs:1440-1446` | `edge_label = None`, `edge_table = None` (no `rel_type`). |
+| Physical plan | `planner/physical.rs:1451-1465` | `vertex_table` resolves **only** if the neighbor has a label or var binding. Unlabeled `(n)` → `vertex_table = None`. |
+| Execute | `executor/expand.rs:1214-1231` | Vertex hydration is gated on `if let (Some(vertex_tid), Some(meta)) = …`. With `vertex_table = None` the block is skipped → `neighbor_json = None`. |
+| Execute | `executor/expand.rs:1243-1245` | Neighbor becomes a bare hex-id string only. |
+| Execute | `executor/expand.rs:1891-1949` (`edge_binding_json`) | With `edge_match = None`, `r` falls back to raw adjacency cells → `_id/_src/_dst/_type` + `col_0` (the edge-table name), no real edge props. |
+
+The typed path works because the neighbor's **label comes from the query**
+(`(c:Committee)`), which lets the planner resolve `vertex_table`, which enables
+`find_vertex_match` (`expand.rs:2268-2330`) → `row_to_json` (`expand.rs:1963+`).
+
+**What the executor already has at expansion time but the unlabeled path ignores:**
+each adjacency row records the originating **edge table** (`adjacency/observer.rs`,
+surfaced as `col_0`), and the neighbor id (`_src`/`_dst`). That is enough to resolve
+the opposite vertex table — *if the edge table declares its endpoint labels*.
+
+### Metadata reality (important correction)
+
+Real edge tables carry `graph.type=edge`, `graph.label`, `graph.source` /
+`graph.target` (the **column names** holding the endpoint ids). The endpoint
+**labels** `graph.source_label` / `graph.target_label` are **read** by the executor in
+9 non-test spots (always via graceful `if let Some(...)`) but are currently **set only
+in test fixtures** (`engine.rs:2718/2966`). So generic hydration depends on edge
+tables declaring their source/target labels; where they do not, the engine must fail
+loud rather than silently return null (task acceptance #4).
+
+## 3. Decision record
+
+- **D1 — Resolve the opposite vertex table at execution, per adjacency row, from the
+  edge table's endpoint-label metadata.** Not at plan time: an unlabeled pattern can
+  span multiple edge tables (`donated_to`, `owed_to`, …), and only the adjacency row
+  knows which edge produced a given neighbor. Reuse `resolve_table_by_graph_label`
+  (`expand.rs:2482-2496`) → `find_vertex_match` → `row_to_json`. *Rejected alt:*
+  scan every vertex table for the neighbor id (ambiguous across labels, O(V) per hop);
+  *rejected alt:* infer the table from a global id→table index (does not exist).
+- **D2 — Direction-aware endpoint selection.** For `-[r]->` (OUT) the neighbor is the
+  edge's **target** vertex (`graph.target_label`); for `<-[r]-` (IN) it is the
+  **source** vertex (`graph.source_label`); `Direction::Both` tries the far end per
+  the adjacency row's stored direction. `_src`/`_dst` must reflect true edge
+  orientation regardless of query direction (fixes the "surprising incoming" report).
+- **D3 — Fail loud on missing/invalid endpoint metadata.** If a matched edge table
+  lacks a usable `graph.source_label`/`graph.target_label` (or the label resolves to
+  no vertex table, or the vertex row is unreadable), the query returns a **clear
+  error** naming the edge table and missing extension — never a null endpoint. This is
+  acceptance #4 and matches the fail-loud rule.
+- **D4 — Hydrate `r` too.** When the edge table is resolved, load the edge row and
+  emit real relationship properties (via the existing edge-hydration path) instead of
+  the `col_N` fallback — so `RETURN r` matches the typed traversal's shape.
+- **D5 — Typed path unchanged.** The new resolution only engages when
+  `hop.vertex_table` (and `hop.edge_table`) are `None`; labeled/typed patterns keep
+  their existing, test-covered behavior byte-for-byte.
+
+**Highest-leverage open decision (needs your call):** does the loaded
+`sf_influence_query` keyspace's edge tables already declare
+`graph.source_label`/`graph.target_label`? If **yes**, the fix works on the existing
+data with no re-ingest. If **no**, generic recenter will (correctly) fail loud until
+the sf ingest sets those extensions on edge tables (a one-line schema addition +
+backfill/re-ingest). See §7.
+
+## 4. Design
+
+Execution change localized to the unlabeled branch of `execute_expand`
+(`expand.rs` ~1141-1260), reusing existing primitives:
+
+1. **Per-row edge resolution.** When `hop.edge_table.is_none() && hop.edge_label.is_none()`,
+   read the edge-table identifier from the adjacency row (the value surfaced today as
+   `col_0`, `keyspace.table`) and look up its `TableMetadata` from the schema snapshot.
+2. **Endpoint label selection (D2).** From the resolved edge metadata choose the
+   opposite label:
+   - OUT → `graph.target_label`; IN → `graph.source_label`;
+   - Both → pick per the adjacency row's stored direction component.
+3. **Vertex table resolution.** `resolve_table_by_graph_label(schema, keyspace, label)`
+   → the neighbor vertex table + metadata.
+4. **Hydrate neighbor (D1).** Call the existing `find_vertex_match` with the resolved
+   vertex table, neighbor id, and any inline props → full property map for `n`
+   (`row_to_json`).
+5. **Hydrate edge (D4).** Load the edge row for the adjacency entry and build the
+   relationship JSON via the typed-path edge hydration instead of the `col_N` fallback.
+6. **Fail loud (D3).** Any of {edge table not found, missing source/target label,
+   label→table unresolved, vertex row missing} returns an error naming the edge table
+   and the specific missing/invalid piece.
+
+No planner change is required for the executor fix; the planner already emits `None`
+for these fields, which the executor now treats as "resolve at run time" rather than
+"skip hydration".
+
+## 5. FMEA (failure modes)
+
+| ID | Failure mode | Effect | Sev | Detect | Mitigation |
+|---|---|---|---|---|---|
+| F1 | Edge table lacks `source_label`/`target_label` | Cannot resolve neighbor table | High | test + live | **Fail loud** (D3) with edge-table name + missing key; document the edge-table contract. |
+| F2 | Direction inverted for `<-[r]-` | Wrong neighbor / wrong `_src`/`_dst` | High | inverse test (acceptance #2) | D2 selects source-label for IN; assert `_src`/`_dst` orientation in tests. |
+| F3 | Heterogeneous edge tables in one hop | Neighbor hydrated from wrong table | High | multi-label test (acceptance #1) | Resolve per-row from the adjacency edge table, not once per hop. |
+| F4 | N+1 vertex lookups on wide fan-out | Latency / load on big nodes | Med | perf test | Reuse the existing per-neighbor `find_vertex_match` (same cost as typed path); consider batching later — out of scope for correctness fix. |
+| F5 | Self-loop / same source+target label | Neighbor = anchor | Low | unit test | Direction + id still resolves correctly; add a self-loop case. |
+| F6 | Neighbor id present in adjacency but vertex row deleted | Dangling edge | Med | unit test | D3: fail loud OR emit null with an explicit `_dangling` marker — **decide in review** (default: fail loud to match #4). |
+| F7 | Regression to typed path | Existing queries change output | High | existing suite | D5 gate: new path only when `vertex_table`/`edge_table` are `None`; run full `ferrosa-graph` tests. |
+
+## 6. Project plan (TDD, acceptance-driven)
+
+1. **RED — multi-label expansion test** (`ferrosa-graph/tests` or `expand.rs` unit):
+   fixture with ≥2 edge labels between ≥2 vertex labels; assert
+   `MATCH (a {id:…})-[r]->(n) RETURN n.id, r` returns **non-null** `n.id` and real
+   `r` props. (acceptance #1)
+2. **RED — inverse incoming test:** `… <-[r]-(n) RETURN n.id, r` hydrates the **source**
+   neighbor; assert `_src`/`_dst` orientation. (acceptance #2)
+3. **RED — fail-loud test:** an edge table with missing/invalid source/target metadata
+   → query errors with a useful message, not null endpoints. (acceptance #4)
+4. **GREEN — implement** the §4 execution change in `execute_expand`, reusing
+   `resolve_table_by_graph_label` / `find_vertex_match` / `row_to_json` / edge
+   hydration.
+5. **REGRESSION — typed path unchanged:** `-[r:DONATED_TO]->` returns the same node +
+   edge props (acceptance #3); run the full `ferrosa-graph` test suite.
+6. **Docs:** update `ferrosa-graph/specs/overview.md` + `fmea.md` with the edge-table
+   endpoint-label contract (source/target labels are required for generic expansion);
+   note in `ferrosa-graph/README.md`.
+7. **Live check (§7):** confirm whether `sf_influence_query` edge tables carry the
+   labels; if not, file the ingest-side schema addition + backfill.
+
+## 7. Open questions / verification
+
+- **Live schema:** query `system_schema` (or graph metadata) on the loaded
+  `sf_influence_query` keyspace to confirm each edge table's extensions include
+  `graph.source_label`/`graph.target_label`. If absent, the executor fix is correct but
+  the *data* needs those extensions before generic recenter works — a small addition to
+  `sf_campaign_donor_graph_ingest`'s edge-table DDL plus re-ingest/backfill.
+- **F6 dangling-edge policy:** fail loud vs explicit null marker — confirm in review
+  (default: fail loud).
+- **Scope guard:** this is a correctness fix, not a fan-out perf change (F4 batching is
+  a follow-up).


### PR DESCRIPTION
## Summary

Makes Ferrosa's Cypher engine usable as a backend for a **generic graph explorer** (label-agnostic recenter / n-hop expansion) and fixes the resulting hub-query latency.

### 1. Label-agnostic endpoint hydration (`t_8c506227`)
Previously only **typed** traversals hydrated the opposite node; a label-agnostic `MATCH (a {id})-[r]->(n)` returned the relationship's raw adjacency internals (`_src`/`_dst`/`col_0`) with `n` left **null**. Now the executor resolves the edge and the opposite vertex **independently, per adjacency row** (edge from the row's recorded `edge_table`; opposite vertex from that edge's `graph.source_label`/`target_label`, direction-aware), hydrating the neighbor + real relationship properties via the same path as a typed traversal.

Covers all four label shapes: `-[r]->(n)`, `<-[r]-(n)`, `-[r:T]->(n)` (typed edge, unlabeled node), `-[r]->(n:L)` (unlabeled edge, labeled node). Typed traversals are unchanged.

**Fail-loud (acceptance #4):** the write-side contract is already enforced by `ferrosa-schema` (edge tables must declare valid endpoint labels, or `CREATE TABLE` is rejected); a test locks that rejection, and the executor keeps a query-time fail-loud as defense-in-depth — never a silent null endpoint.

### 2. LIMIT push-down / short-circuit (`t_0cc8d63e`, part 1)
A plain bounded expansion (no `ORDER BY`/`DISTINCT`/`WITH`/post-`WHERE`/`OPTIONAL MATCH`) now stops expanding **and hydrating** the last hop once `limit` rows accumulate, instead of hydrating the whole fan-out and truncating at the end.

**Live impact (sf influence graph):** the hub query `MATCH (c:Committee {id})<-[r]-(n) RETURN r._type, n.id LIMIT 3` dropped from **~12s / 381 reads to ~80–130ms / ~4 reads**.

## Verification
- `ferrosa-graph`: **91 integration + 354 lib** tests pass (6 new: outgoing/incoming/typed-edge-unlabeled-node/unlabeled-edge-labeled-node hydration, write-side rejection, LIMIT short-circuit).
- `cargo fmt --check` clean; `cargo clippy --all-targets` clean (workspace).
- Deployed to a local single-node Ferrosa loaded with the `sf_influence_query` graph and validated end-to-end (both directions hydrate; bounded queries fast).

## Docs
`ferrosa-graph/README.md` (endpoint-label contract + label-agnostic section), `specs/overview.md` (invariant #6), and `specs/proposed/graph-unlabeled-relationship-endpoint-hydration.md` (marked implemented).

## Follow-up (planned on this PR)
Unbounded / high-degree-hub queries still use a materialize-then-truncate model. Per owner direction, a **streaming/pull-based (non-materializing, non-OOM) executor** (`t_4ce82a3e`) — LIMIT short-circuit everywhere + bounded-concurrency hydration **without per-neighbor clones or result materialization** — will be added to this PR. The per-neighbor `hydrate_hop_neighbor` helper was extracted to make that drop-in clean. No throwaway clone/concurrency hack was built in the current loop.

