### PR TITLE
add bounded incremental compaction endpoint

### DIFF
--- a/ferrosa-storage/src/compaction/executor.rs
+++ b/ferrosa-storage/src/compaction/executor.rs
@@ -452,7 +452,12 @@ impl CompactionExecutor {
     }
 
     /// Submits a compaction task to the background thread.
-    pub fn submit(&self, task: CompactionTask) -> ferrosa_common::Result<()> {
+    ///
+    /// Returns `Ok(false)` when one or more input SSTables are already claimed
+    /// by another queued or running task. Callers that need to report whether
+    /// a bounded maintenance batch was actually accepted can use this result
+    /// instead of treating overlap suppression as a successful submission.
+    pub fn try_submit(&self, task: CompactionTask) -> ferrosa_common::Result<bool> {
         crate::metrics::inc_compaction_submitted();
         if !Self::try_claim_in_flight_inputs(&self.in_flight_inputs, &task) {
             crate::metrics::inc_compaction_skipped_overlap();
@@ -461,7 +466,7 @@ impl CompactionExecutor {
                 inputs = task.inputs.len(),
                 "compaction: skipping overlapping task already in flight"
             );
-            return Ok(());
+            return Ok(false);
         }
 
         let worker_idx = self.next_worker.fetch_add(1, Ordering::Relaxed) % self.task_txs.len();
@@ -471,7 +476,7 @@ impl CompactionExecutor {
             queued_at: Instant::now(),
         };
         match self.task_txs[worker_idx].send(queued) {
-            Ok(()) => Ok(()),
+            Ok(()) => Ok(true),
             Err(err) => {
                 crate::metrics::dec_compaction_queue_depth();
                 Self::release_in_flight_inputs(&self.in_flight_inputs, &err.0.task);
@@ -480,6 +485,12 @@ impl CompactionExecutor {
                 ))
             }
         }
+    }
+
+    /// Submits a compaction task and preserves the historical overlap behavior
+    /// for callers that do not need to distinguish a skipped task.
+    pub fn submit(&self, task: CompactionTask) -> ferrosa_common::Result<()> {
+        self.try_submit(task).map(|_| ())
     }
 
     /// Polls for completed compaction results (non-blocking).

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -417,6 +417,36 @@ pub struct StorageEngineConfig {
     pub memtable_num_shards: usize,
 }
 
+/// The outcome of scheduling one bounded incremental compaction batch.
+///
+/// A batch is deliberately limited to a small set of SSTables. The caller must
+/// wait for it to swap before requesting the next batch, which keeps both the
+/// compaction working set and temporary on-disk output bounded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IncrementalCompactionSchedule {
+    /// The requested table is not registered on this node.
+    TableNotFound,
+    /// Fewer than two SSTables fit within the caller's batch limits.
+    NoEligibleBatch { available_sstables: usize },
+    /// A selected input is already part of a queued or running compaction.
+    InFlight {
+        input_sstables: usize,
+        input_bytes: u64,
+    },
+    /// The batch would violate the local disk reserve while its staged output
+    /// coexists with the input SSTables.
+    InsufficientDisk {
+        available_bytes: u64,
+        required_bytes: u64,
+    },
+    /// Exactly one bounded, streaming compaction task was accepted.
+    Scheduled {
+        input_sstables: usize,
+        input_bytes: u64,
+        available_sstables: usize,
+    },
+}
+
 impl StorageEngineConfig {
     /// Reads configuration from `FERROSA_*` environment variables.
     pub fn from_env() -> ferrosa_common::Result<Self> {
@@ -755,6 +785,45 @@ thread_local! {
     /// orphaned/dangling registrations (t_ee98faa0 layer 2, suspect 2).
     pub(crate) static FTS_SIDECAR_FILES_CONSULTED: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+}
+
+/// Select the next compaction batch without accumulating an unbounded input
+/// set. Sorting by component size keeps early passes cheap and lets repeated
+/// calls progressively consolidate small SSTables before larger outputs.
+fn select_incremental_compaction_batch(
+    mut metadata: Vec<crate::compaction::metadata::SSTableMetadata>,
+    max_sstables: usize,
+    max_input_bytes: u64,
+) -> Vec<crate::compaction::metadata::SSTableMetadata> {
+    metadata.sort_by(|left, right| {
+        left.size_bytes
+            .cmp(&right.size_bytes)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let mut selected = Vec::with_capacity(max_sstables);
+    let mut selected_bytes = 0_u64;
+    for sstable in metadata {
+        if selected.len() >= max_sstables {
+            break;
+        }
+        let next_bytes = selected_bytes.saturating_add(sstable.size_bytes);
+        if next_bytes > max_input_bytes {
+            break;
+        }
+        selected_bytes = next_bytes;
+        selected.push(sstable);
+    }
+    selected
+}
+
+/// Reserve room for both the staged raw output and its promoted SSTable while
+/// preserving the normal write-path free-space reserve. The compaction writer
+/// is streaming, but file promotion can briefly require two output copies.
+fn incremental_compaction_disk_reservation(input_bytes: u64, disk_reserve_bytes: u64) -> u64 {
+    input_bytes
+        .saturating_mul(2)
+        .saturating_add(disk_reserve_bytes)
 }
 
 /// Top-level storage engine.
@@ -7648,6 +7717,91 @@ impl StorageEngine {
         }
     }
 
+    /// Schedule one bounded, streaming compaction batch for a single table.
+    ///
+    /// Unlike [`Self::force_compact_all`], this never submits an entire table
+    /// at once. It chooses the smallest SSTables first, caps both input count
+    /// and input bytes, and requires enough free disk for a staged output plus
+    /// the configured write reserve before it queues work. A caller should
+    /// wait for the batch to swap before requesting another one.
+    pub fn schedule_incremental_compaction(
+        &self,
+        table_id: &TableId,
+        max_sstables: usize,
+        max_input_bytes: u64,
+    ) -> ferrosa_common::Result<IncrementalCompactionSchedule> {
+        if max_sstables < 2 || max_input_bytes == 0 {
+            return Ok(IncrementalCompactionSchedule::NoEligibleBatch {
+                available_sstables: self.sstable_count(table_id),
+            });
+        }
+
+        let (available_sstables, inputs, schema) = {
+            let tables = self.tables.read();
+            let Some(state) = tables.get(table_id) else {
+                return Ok(IncrementalCompactionSchedule::TableNotFound);
+            };
+            let metadata = self.collect_sstable_metadata(table_id, state);
+            let available_sstables = metadata.len();
+            let inputs =
+                select_incremental_compaction_batch(metadata, max_sstables, max_input_bytes);
+            (available_sstables, inputs, state.schema.clone())
+        };
+
+        if inputs.len() < 2 {
+            return Ok(IncrementalCompactionSchedule::NoEligibleBatch { available_sstables });
+        }
+
+        let input_bytes = inputs.iter().map(|input| input.size_bytes).sum::<u64>();
+        let available_bytes = self.disk_free_bytes_cached();
+        let required_bytes = incremental_compaction_disk_reservation(
+            input_bytes,
+            self.config.local_disk_free_reserve_bytes,
+        );
+        if available_bytes < required_bytes {
+            tracing::warn!(
+                %table_id,
+                input_sstables = inputs.len(),
+                input_bytes,
+                available_bytes,
+                required_bytes,
+                "incremental compaction refused: insufficient disk headroom"
+            );
+            return Ok(IncrementalCompactionSchedule::InsufficientDisk {
+                available_bytes,
+                required_bytes,
+            });
+        }
+
+        let task = crate::compaction::metadata::CompactionTask {
+            inputs,
+            output_dir: self.config.compaction.output_dir.join(table_id.to_string()),
+            schema,
+            table_id: table_id.clone(),
+        };
+        let input_sstables = task.inputs.len();
+        match self.compaction_executor.try_submit(task)? {
+            true => {
+                tracing::info!(
+                    %table_id,
+                    input_sstables,
+                    input_bytes,
+                    available_sstables,
+                    "incremental compaction batch scheduled"
+                );
+                Ok(IncrementalCompactionSchedule::Scheduled {
+                    input_sstables,
+                    input_bytes,
+                    available_sstables,
+                })
+            }
+            false => Ok(IncrementalCompactionSchedule::InFlight {
+                input_sstables,
+                input_bytes,
+            }),
+        }
+    }
+
     fn maybe_compact(&self, table_id: &TableId, state: &TableState) {
         let metadata = self.collect_sstable_metadata(table_id, state);
         let strategy = self.strategy_for_table(state);
@@ -9217,6 +9371,124 @@ mod tests {
     #[cfg(feature = "live-infra-tests")]
     use ferrosa_sstable::statistics::{CompactionMetadata, StatsMetadata};
     use ferrosa_sstable::types::{DeletionTime, LivenessInfo};
+
+    fn incremental_batch_metadata(
+        id: &str,
+        size_bytes: u64,
+    ) -> crate::compaction::metadata::SSTableMetadata {
+        crate::compaction::metadata::SSTableMetadata {
+            id: id.to_string(),
+            path: std::path::PathBuf::new(),
+            size_bytes,
+            min_token: 0,
+            max_token: 0,
+            min_timestamp: 0,
+            max_timestamp: 0,
+            partition_count: 1,
+            legacy_format: false,
+        }
+    }
+
+    #[test]
+    fn incremental_compaction_batch_is_bounded_by_count_and_bytes() {
+        let selected = select_incremental_compaction_batch(
+            vec![
+                incremental_batch_metadata("4", 64),
+                incremental_batch_metadata("2", 64),
+                incremental_batch_metadata("1", 64),
+                incremental_batch_metadata("3", 64),
+            ],
+            3,
+            128,
+        );
+
+        assert_eq!(selected.len(), 2, "the byte cap must win over file count");
+        assert_eq!(
+            selected
+                .iter()
+                .map(|sstable| sstable.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1", "2"],
+            "equal-sized SSTables are selected deterministically"
+        );
+        assert!(
+            selected
+                .iter()
+                .map(|sstable| sstable.size_bytes)
+                .sum::<u64>()
+                <= 128,
+            "a scheduled batch must never exceed its input byte cap"
+        );
+    }
+
+    #[test]
+    fn incremental_compaction_reserves_two_output_copies_and_write_reserve() {
+        assert_eq!(incremental_compaction_disk_reservation(256, 64), 576);
+        assert_eq!(
+            incremental_compaction_disk_reservation(u64::MAX, 64),
+            u64::MAX,
+            "the disk reservation must saturate instead of wrapping"
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_compaction_schedules_one_bounded_batch_and_refuses_overlap() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = StorageEngineConfig::test_config(dir.path());
+        config.compaction.min_threshold = 100;
+        config.local_disk_free_reserve_bytes = 64;
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let table_id = table_id();
+
+        for (key, value, timestamp) in [
+            ("batch-1", b"one".as_slice(), 1_000),
+            ("batch-2", b"two".as_slice(), 2_000),
+            ("batch-3", b"three".as_slice(), 3_000),
+        ] {
+            engine
+                .write(
+                    &table_id,
+                    &make_key(key),
+                    make_row(value, timestamp),
+                    timestamp,
+                )
+                .unwrap();
+            engine.flush(&table_id).unwrap();
+        }
+
+        engine.set_disk_free_cache_for_test(64);
+        assert!(matches!(
+            engine
+                .schedule_incremental_compaction(&table_id, 2, 1024 * 1024)
+                .unwrap(),
+            IncrementalCompactionSchedule::InsufficientDisk { .. }
+        ));
+
+        engine.set_disk_free_cache_for_test(1024 * 1024 * 1024);
+        let first = engine
+            .schedule_incremental_compaction(&table_id, 2, 1024 * 1024)
+            .unwrap();
+        assert!(matches!(
+            first,
+            IncrementalCompactionSchedule::Scheduled {
+                input_sstables: 2,
+                available_sstables: 3,
+                ..
+            }
+        ));
+
+        let second = engine
+            .schedule_incremental_compaction(&table_id, 2, 1024 * 1024)
+            .unwrap();
+        assert!(matches!(
+            second,
+            IncrementalCompactionSchedule::InFlight {
+                input_sstables: 2,
+                ..
+            }
+        ));
+    }
 
     /// Regression (issue #172): a fresh install passes its data dir via
     /// `[storage].data_dir` in the TOML, which `main` resolves and exports as

--- a/ferrosa-storage/src/lib.rs
+++ b/ferrosa-storage/src/lib.rs
@@ -58,9 +58,9 @@ pub use compaction::{
 };
 pub use data_store::{DataStore, LocalDataStore};
 pub use engine::{
-    BatchOp, BatchTxn, IndexReloadOutcome, PersistedIndexRow, StorageEngine, StorageEngineConfig,
-    TempSortTableReservation, TimeSeriesWasmAggregateExecutor, TimeSeriesWasmAggregateInvocation,
-    FILTER_PREDICATE_OPTION_KEY,
+    BatchOp, BatchTxn, IncrementalCompactionSchedule, IndexReloadOutcome, PersistedIndexRow,
+    StorageEngine, StorageEngineConfig, TempSortTableReservation, TimeSeriesWasmAggregateExecutor,
+    TimeSeriesWasmAggregateInvocation, FILTER_PREDICATE_OPTION_KEY,
 };
 pub use external_sort::{ExternalSorter, RowOrder, SortedRows};
 pub use flush::{FileFlushTarget, FlushTarget, InMemoryFlushTarget};

--- a/ferrosa/src/web/debug.rs
+++ b/ferrosa/src/web/debug.rs
@@ -14,12 +14,13 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 use serde::Deserialize;
+use serde_json::json;
 use tokio::sync::Mutex;
 
 use super::WebAppState;
@@ -30,11 +31,28 @@ const MAX_SECONDS: u64 = 60;
 /// Maximum collected folded-stack data before we stop (64 MB).
 const MAX_COLLECT_BYTES: usize = 64 * 1024 * 1024;
 
+/// Default input cap for one operator-triggered incremental compaction batch.
+const DEFAULT_INCREMENTAL_COMPACTION_MAX_BYTES: u64 = 256 * 1024 * 1024;
+/// Never let the debug endpoint schedule more SSTables than normal STCS does.
+const MAX_INCREMENTAL_COMPACTION_SSTABLES: usize = 32;
+/// Never let a debug request exceed the normal default STCS byte cap.
+const MAX_INCREMENTAL_COMPACTION_BYTES: u64 = 512 * 1024 * 1024;
+const DEFAULT_INCREMENTAL_COMPACTION_SSTABLES: usize = 8;
+
 /// Query parameters for the flamechart endpoint.
 #[derive(Debug, Deserialize)]
 pub struct FlamechartParams {
     /// Duration in seconds to profile.
     seconds: Option<u64>,
+}
+
+/// Optional bounds for one incremental compaction batch.
+#[derive(Debug, Deserialize)]
+pub struct IncrementalCompactionParams {
+    /// Maximum input SSTables. Defaults to 8 and is capped at 32.
+    max_sstables: Option<usize>,
+    /// Maximum combined input bytes. Defaults to 256 MiB and is capped at 512 MiB.
+    max_input_bytes: Option<u64>,
 }
 
 /// Shared state for the debug profiler — one profiling session at a time.
@@ -63,6 +81,10 @@ pub fn debug_routes() -> Router<WebAppState> {
     Router::new()
         .route("/flamechart", get(flamechart_handler))
         .route("/force-compact", axum::routing::post(force_compact_handler))
+        .route(
+            "/incremental-compact/{keyspace}/{table}",
+            post(incremental_compact_handler),
+        )
 }
 
 /// Force compaction for all tables. Useful for debugging compaction issues.
@@ -73,6 +95,126 @@ async fn force_compact_handler(State(state): State<WebAppState>) -> impl IntoRes
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     state.storage.poll_compactions().await;
     (StatusCode::OK, "compaction triggered and polled\n")
+}
+
+/// Schedule one bounded, streaming compaction batch for a table.
+///
+/// `POST /api/debug/incremental-compact/{keyspace}/{table}`
+///
+/// The request deliberately schedules only one batch. Operators wait for the
+/// normal maintenance loop to promote it, then call this endpoint again. That
+/// prevents a full-table rewrite from accumulating an unbounded queue, memory
+/// working set, or temporary disk footprint.
+async fn incremental_compact_handler(
+    headers: axum::http::HeaderMap,
+    Path((keyspace, table)): Path<(String, String)>,
+    Query(params): Query<IncrementalCompactionParams>,
+    State(state): State<WebAppState>,
+) -> Response {
+    if let Err(resp) = check_auth(&headers) {
+        return resp;
+    }
+    if let Err(resp) = check_ip_whitelist(None) {
+        return resp;
+    }
+
+    let max_sstables = params
+        .max_sstables
+        .unwrap_or(DEFAULT_INCREMENTAL_COMPACTION_SSTABLES);
+    if !(2..=MAX_INCREMENTAL_COMPACTION_SSTABLES).contains(&max_sstables) {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("max_sstables must be between 2 and {MAX_INCREMENTAL_COMPACTION_SSTABLES}"),
+        )
+            .into_response();
+    }
+
+    let max_input_bytes = params
+        .max_input_bytes
+        .unwrap_or(DEFAULT_INCREMENTAL_COMPACTION_MAX_BYTES);
+    if !(1..=MAX_INCREMENTAL_COMPACTION_BYTES).contains(&max_input_bytes) {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("max_input_bytes must be between 1 and {MAX_INCREMENTAL_COMPACTION_BYTES}"),
+        )
+            .into_response();
+    }
+
+    let table_id = ferrosa_storage::TableId::new(&keyspace, &table);
+    match state.storage.schedule_incremental_compaction(
+        &table_id,
+        max_sstables,
+        max_input_bytes,
+    ) {
+        Ok(ferrosa_storage::IncrementalCompactionSchedule::TableNotFound) => (
+            StatusCode::NOT_FOUND,
+            axum::Json(json!({
+                "error": "table not found",
+                "keyspace": keyspace,
+                "table": table,
+            })),
+        )
+            .into_response(),
+        Ok(ferrosa_storage::IncrementalCompactionSchedule::NoEligibleBatch {
+            available_sstables,
+        }) => (
+            StatusCode::OK,
+            axum::Json(json!({
+                "status": "complete",
+                "available_sstables": available_sstables,
+                "message": "fewer than two SSTables fit within the requested batch limits",
+            })),
+        )
+            .into_response(),
+        Ok(ferrosa_storage::IncrementalCompactionSchedule::InFlight {
+            input_sstables,
+            input_bytes,
+        }) => (
+            StatusCode::CONFLICT,
+            axum::Json(json!({
+                "status": "in_flight",
+                "input_sstables": input_sstables,
+                "input_bytes": input_bytes,
+                "message": "wait for the current batch to swap before scheduling another",
+            })),
+        )
+            .into_response(),
+        Ok(ferrosa_storage::IncrementalCompactionSchedule::InsufficientDisk {
+            available_bytes,
+            required_bytes,
+        }) => (
+            StatusCode::CONFLICT,
+            axum::Json(json!({
+                "status": "insufficient_disk",
+                "available_bytes": available_bytes,
+                "required_bytes": required_bytes,
+                "message": "the batch needs staged-output headroom plus the configured disk reserve",
+            })),
+        )
+            .into_response(),
+        Ok(ferrosa_storage::IncrementalCompactionSchedule::Scheduled {
+            input_sstables,
+            input_bytes,
+            available_sstables,
+        }) => (
+            StatusCode::ACCEPTED,
+            axum::Json(json!({
+                "status": "scheduled",
+                "keyspace": keyspace,
+                "table": table,
+                "input_sstables": input_sstables,
+                "input_bytes": input_bytes,
+                "available_sstables": available_sstables,
+                "message": "wait for this batch to swap before requesting the next batch",
+            })),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({ "error": error.to_string() })),
+        )
+            .into_response(),
+    }
 }
 
 /// Check the admin auth token from the `Authorization: Bearer <token>` header.
@@ -678,6 +820,50 @@ mod tests {
             StatusCode::NOT_FOUND,
             "GET /api/debug/flamechart must not return 404"
         );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env)]
+    async fn incremental_compaction_endpoint_requires_auth_and_reports_missing_table() {
+        unsafe {
+            std::env::set_var("FERROSA_DEBUG_AUTH_TOKEN", "test-secret-42");
+        }
+        let state = make_state();
+        let router = crate::web::build_router(state);
+        let req = axum::http::Request::builder()
+            .uri("/api/debug/incremental-compact/missing/table")
+            .header(axum::http::header::AUTHORIZATION, "Bearer test-secret-42")
+            .method("POST")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(router, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        unsafe {
+            std::env::remove_var("FERROSA_DEBUG_AUTH_TOKEN");
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env)]
+    async fn incremental_compaction_endpoint_rejects_unbounded_batch_limits() {
+        unsafe {
+            std::env::set_var("FERROSA_DEBUG_AUTH_TOKEN", "test-secret-42");
+        }
+        let state = make_state();
+        let router = crate::web::build_router(state);
+        let req = axum::http::Request::builder()
+            .uri("/api/debug/incremental-compact/missing/table?max_sstables=33")
+            .header(axum::http::header::AUTHORIZATION, "Bearer test-secret-42")
+            .method("POST")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(router, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        unsafe {
+            std::env::remove_var("FERROSA_DEBUG_AUTH_TOKEN");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds an authenticated per-table endpoint for one bounded incremental compaction batch.

## Root Cause

The existing debug force-compaction API submits every SSTable in a table as one task, which is unsafe for large dormant tables because the rewrite can require unbounded temporary disk space.

## Changes

- Add `POST /api/debug/incremental-compact/{keyspace}/{table}`.
- Limit each request to one streaming batch, defaulting to 8 SSTables and 256 MiB of inputs.
- Enforce hard ceilings of 32 SSTables and 512 MiB.
- Refuse batches that cannot preserve the local disk reserve while staging output.
- Return explicit scheduled, in-flight, complete, and insufficient-disk responses.
- Preserve input-claim overlap protection while exposing whether a task was accepted.

## Operator Impact

Operators can compact a large table incrementally by waiting for a batch to swap, then invoking the endpoint again. Existing force compaction behavior is unchanged.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ferrosa-storage -p ferrosa incremental_compaction`