### PR TITLE
fix(fulltext): stream fts_match keys end to end with bounded memory; delete the geometric escalation loop

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -100,6 +100,18 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   leader-only serial, cross-DC Accord routing).
 - `coordinator/batch.rs` — 3-phase logged batchlog (write → fan out → delete only
   on full success) with replay task; `DEFAULT_BATCH_CONCURRENCY = 32`.
+- `coordinator/fulltext_stream.rs` — streaming fulltext search (t_4ae47a9f),
+  the `fts_match` twin of the ADR-020 range-read stream: the producer walks the
+  local FTI via `fulltext_search_each` on a blocking thread and fires bounded
+  `FulltextSearchStreamChunk` key batches (≤ 4096 keys) on `Lane::Bulk` with
+  heartbeats + Cancel; `coordinate_fulltext_search_stream` fans out to every
+  node, N-way merges over bounded channels, and dedups into one `seen` set —
+  the only O(distinct matches) allocation left in the path (scores and extra
+  copies are gone; the pre-fix union OOM-killed replicas, t_8fc24ce2). Any
+  replica failure fails the stream loudly — no silent partial union (stricter
+  than the legacy degrading path). `WritePath::fulltext_search_stream` is the
+  mode-dispatching entry; `FERROSA_BULK_STREAMING_FULLTEXT=0` falls back to
+  the legacy single-message union for mixed-version upgrades.
 - `coordinator/{range_read_stream,stream_*}.rs` — ADR-020 streaming range reads
   and projected streaming scans; the old Vec-returning
   `WritePath::range_read_projected` wrapper has been removed, so projected

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -924,6 +924,7 @@ impl ModeController {
         // on the next line and is no longer directly accessible.
         let stream_router_for_handler = coordinator.stream_router();
         let peer_manager_for_handler = coordinator.peer_manager.clone();
+        let peer_manager_for_fulltext = coordinator.peer_manager.clone();
 
         // 6. Swap write path — cluster coordinator handles replica routing.
         self.write_path
@@ -1085,7 +1086,42 @@ impl ModeController {
         self.registry
             .register(MsgType::RangeReadStreamHeartbeat, frame_router.clone());
         self.registry
-            .register(MsgType::RangeReadStreamDone, frame_router);
+            .register(MsgType::RangeReadStreamDone, frame_router.clone());
+
+        // Streaming fulltext search (t_4ae47a9f) — the fts_match twin of the
+        // ADR-020 streaming range read. Server side: walks the local FTI via
+        // fulltext_search_each on a blocking thread and fires bounded key
+        // chunks back on Lane::Bulk. Registered on every node alongside the
+        // legacy single-shot FulltextSearchRequest so mixed-mode clusters can
+        // serve either flow (the coordinator picks per query shape).
+        use crate::coordinator::fulltext_stream::{
+            FulltextSearchStreamRequestHandler, FULLTEXT_STREAM_CHUNK_KEYS,
+        };
+        let fulltext_sink_factory = Arc::new(
+            crate::coordinator::stream_request_handler::PeerManagerSinkFactory::new(
+                peer_manager_for_fulltext,
+            ),
+        );
+        let fulltext_stream_handler = Arc::new(FulltextSearchStreamRequestHandler::new(
+            Arc::new(self.storage.clone()),
+            fulltext_sink_factory,
+            FULLTEXT_STREAM_CHUNK_KEYS,
+        ));
+        self.registry.register(
+            MsgType::FulltextSearchStreamRequest,
+            fulltext_stream_handler.clone(),
+        );
+        // Same handler serves Cancel — it owns the per-request tokens.
+        self.registry
+            .register(MsgType::FulltextSearchStreamCancel, fulltext_stream_handler);
+        // Coordinator side: the shared StreamFrameRouter routes the fulltext
+        // response frames through the same seq/Done bookkeeping.
+        self.registry
+            .register(MsgType::FulltextSearchStreamChunk, frame_router.clone());
+        self.registry
+            .register(MsgType::FulltextSearchStreamHeartbeat, frame_router.clone());
+        self.registry
+            .register(MsgType::FulltextSearchStreamDone, frame_router);
 
         let index_read_handler = Arc::new(IndexReadHandler::new(self.storage.clone()));
         self.registry

--- a/ferrosa-cluster/src/coordinator/fulltext_stream.rs
+++ b/ferrosa-cluster/src/coordinator/fulltext_stream.rs
@@ -1,0 +1,990 @@
+//! Producer for streaming fulltext-search responses (t_4ae47a9f) — the
+//! `fts_match` twin of the ADR-020 streaming range read.
+//!
+//! An inbound `FulltextSearchStreamRequest` spawns the node-local FTI walk
+//! (`StorageEngine::fulltext_search_each`) on a blocking thread. The walk
+//! pushes each matching doc key into a **bounded** channel; the async side
+//! drains that channel into `FulltextSearchStreamChunk` frames of at most
+//! `chunk_keys` keys, emits `FulltextSearchStreamHeartbeat` while the walk is
+//! slow, and terminates with a single `FulltextSearchStreamDone`.
+//!
+//! Memory contract: the producer never materializes the match set. Resident
+//! is O(channel capacity + one chunk) regardless of how many docs match —
+//! the shape that OOM-killed replicas at the 2 GiB cap (t_8fc24ce2) held the
+//! ENTIRE match set in a score map plus a single up-to-256 MiB response
+//! buffer. Consumer-paced: if the coordinator cancels (or the walk's channel
+//! closes because this task dropped the receiver), the walk observes
+//! `ControlFlow::Break` on its next key and stops immediately.
+//!
+//! Fail loud: a walk error (malformed query, storage failure) discards any
+//! undelivered partial batch and terminates with `Done { truncated: true }`
+//! so the coordinator fails the whole search — a silent partial match set is
+//! never served (`skills/rules/safety.md`).
+//!
+//! Transport-free like `stream_producer`: frames leave through the shared
+//! [`ChunkSink`] trait (production: `PeerManager::fire` on `Lane::Bulk`;
+//! tests: an in-memory Vec).
+//!
+//! Last revised: 2026-07-16
+//! Last changed: Initial streaming fulltext producer (layer 4a of
+//! t_4ae47a9f).
+
+use std::ops::ControlFlow;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use dashmap::DashMap;
+use tokio_util::sync::CancellationToken;
+
+use ferrosa_net::message::Message;
+use ferrosa_net::rpc::handler::{PeerId, RpcHandler};
+use ferrosa_net::task_pool::TaskPool;
+use ferrosa_storage::TableId;
+
+use super::stream_producer::ChunkSink;
+use super::stream_request_handler::SinkFactory;
+use crate::raft::handlers::{
+    FulltextSearchStreamCancelPayload, FulltextSearchStreamChunkPayload,
+    FulltextSearchStreamDonePayload, FulltextSearchStreamHeartbeatPayload,
+    FulltextSearchStreamRequestPayload,
+};
+
+/// Keys per chunk frame. 4096 keys × ~40 B/key ≈ 160 KiB per frame — three
+/// orders of magnitude under the Bulk-lane 256 MiB envelope, so even the
+/// lane's message-count-only backpressure (256 queued frames) pins at most
+/// ~40 MiB for a pathological peer, not gigabytes.
+pub const FULLTEXT_STREAM_CHUNK_KEYS: usize = 4_096;
+
+/// Matches the range-read producer's heartbeat cadence: below the
+/// coordinator's idle timeout with margin.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Node-local key source the producer walks. Production is
+/// `Arc<StorageEngine>` via [`ferrosa_storage::StorageEngine::fulltext_search_each`];
+/// tests drive an in-memory source. The implementation MUST honor
+/// `ControlFlow::Break` from the callback by stopping the walk.
+pub trait FulltextKeySource: Send + Sync {
+    fn search_each(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        query: &str,
+        on_hit: &mut dyn FnMut(Vec<u8>) -> ControlFlow<()>,
+    ) -> ferrosa_common::Result<()>;
+}
+
+impl FulltextKeySource for Arc<ferrosa_storage::StorageEngine> {
+    fn search_each(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        query: &str,
+        on_hit: &mut dyn FnMut(Vec<u8>) -> ControlFlow<()>,
+    ) -> ferrosa_common::Result<()> {
+        ferrosa_storage::StorageEngine::fulltext_search_each(
+            self, table_id, index_name, query, on_hit,
+        )
+    }
+}
+
+/// Serve one streaming fulltext request: walk the local FTI on a blocking
+/// thread, emit bounded key chunks + heartbeats, terminate with Done.
+pub async fn handle_fulltext_stream_request_with_cancel<S, K>(
+    req: FulltextSearchStreamRequestPayload,
+    source: Arc<S>,
+    sink: &K,
+    chunk_keys: usize,
+    cancel: CancellationToken,
+) where
+    S: FulltextKeySource + 'static,
+    K: ChunkSink,
+{
+    assert!(chunk_keys >= 1, "chunk_keys must be >= 1");
+
+    let table_id = TableId::new(&req.keyspace, &req.table);
+
+    // Bounded hand-off between the blocking walk and the async framer. The
+    // capacity is the producer's ONLY buffering: when the async side stalls
+    // (slow peer, cancel racing in), the walk blocks on `blocking_send` —
+    // consumer-paced backpressure with an O(capacity) ceiling.
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(chunk_keys.saturating_mul(2));
+
+    let walk_source = source.clone();
+    let walk_index = req.index_name.clone();
+    let walk_query = req.query.clone();
+    let walk_table = table_id.clone();
+    let walk = tokio::task::spawn_blocking(move || {
+        walk_source.search_each(&walk_table, &walk_index, &walk_query, &mut |key| {
+            match tx.blocking_send(key) {
+                Ok(()) => ControlFlow::Continue(()),
+                // Receiver dropped: the framer stopped (cancel / task end).
+                Err(_) => ControlFlow::Break(()),
+            }
+        })
+    });
+
+    let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    ticker.tick().await; // discard the immediate first tick
+
+    let mut heartbeat_seq: u32 = 0;
+    let mut chunk_seq: u32 = 0;
+    let mut batch: Vec<Vec<u8>> = Vec::with_capacity(chunk_keys);
+    let mut cancelled = false;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                cancelled = true;
+                break;
+            }
+            next = rx.recv() => match next {
+                Some(key) => {
+                    batch.push(key);
+                    if batch.len() >= chunk_keys {
+                        emit_chunk(&req, &mut batch, chunk_seq, sink).await;
+                        chunk_seq = chunk_seq.saturating_add(1);
+                    }
+                }
+                None => break, // walk finished (or errored) and dropped tx
+            },
+            _ = ticker.tick() => {
+                let hb = FulltextSearchStreamHeartbeatPayload {
+                    request_id: req.request_id,
+                    seq: chunk_seq,
+                };
+                heartbeat_seq = heartbeat_seq.saturating_add(1);
+                let _ = heartbeat_seq; // debugging aid only
+                let bytes = bincode::serialize(&hb)
+                    .expect("FulltextSearchStreamHeartbeatPayload serialization is infallible");
+                sink.send(Message::FulltextSearchStreamHeartbeat(Bytes::from(bytes))).await;
+            }
+        }
+    }
+
+    if cancelled {
+        // Dropping rx makes the walk's next blocking_send fail → Break.
+        // No Done frame: the coordinator unregistered the route before
+        // firing the cancel (same contract as the range-read stream).
+        drop(rx);
+        let _ = walk.await;
+        return;
+    }
+
+    // The walk ended on its own — surface its result.
+    let walk_result = match walk.await {
+        Ok(r) => r,
+        Err(join_err) => Err(ferrosa_common::Error::InvalidData(format!(
+            "fulltext stream walk join: {join_err}"
+        ))),
+    };
+
+    let truncated = match walk_result {
+        Ok(()) => false,
+        Err(e) => {
+            tracing::warn!(
+                request_id = req.request_id,
+                keyspace = req.keyspace,
+                table = req.table,
+                "fulltext stream walk failed: {e}"
+            );
+            // Fail loud: never deliver a partial batch of a failed walk.
+            batch.clear();
+            true
+        }
+    };
+
+    if !truncated && !batch.is_empty() {
+        emit_chunk(&req, &mut batch, chunk_seq, sink).await;
+        chunk_seq = chunk_seq.saturating_add(1);
+    }
+
+    let done = FulltextSearchStreamDonePayload {
+        request_id: req.request_id,
+        total_chunks: if truncated { 0 } else { chunk_seq },
+        truncated,
+    };
+    let bytes = bincode::serialize(&done)
+        .expect("FulltextSearchStreamDonePayload serialization is infallible");
+    sink.send(Message::FulltextSearchStreamDone(Bytes::from(bytes)))
+        .await;
+}
+
+async fn emit_chunk<K: ChunkSink>(
+    req: &FulltextSearchStreamRequestPayload,
+    batch: &mut Vec<Vec<u8>>,
+    seq: u32,
+    sink: &K,
+) {
+    let payload = FulltextSearchStreamChunkPayload {
+        request_id: req.request_id,
+        seq,
+        keys: std::mem::take(batch),
+    };
+    let bytes = bincode::serialize(&payload)
+        .expect("FulltextSearchStreamChunkPayload serialization is infallible");
+    sink.send(Message::FulltextSearchStreamChunk(Bytes::from(bytes)))
+        .await;
+}
+
+/// `RpcHandler` shell: decodes `FulltextSearchStreamRequest`, spawns the
+/// streaming task, returns `None` (responses ride on fire-and-forget
+/// frames). Also owns the per-request `CancellationToken` map and serves
+/// `FulltextSearchStreamCancel`, mirroring `RangeReadStreamRequestHandler`.
+pub struct FulltextSearchStreamRequestHandler<S, F>
+where
+    S: FulltextKeySource + 'static,
+    F: SinkFactory + 'static,
+{
+    source: Arc<S>,
+    sink_factory: Arc<F>,
+    chunk_keys: usize,
+    cancellations: Arc<DashMap<u32, CancellationToken>>,
+}
+
+impl<S, F> FulltextSearchStreamRequestHandler<S, F>
+where
+    S: FulltextKeySource + 'static,
+    F: SinkFactory + 'static,
+{
+    pub fn new(source: Arc<S>, sink_factory: Arc<F>, chunk_keys: usize) -> Self {
+        Self {
+            source,
+            sink_factory,
+            chunk_keys,
+            cancellations: Arc::new(DashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl<S, F> RpcHandler for FulltextSearchStreamRequestHandler<S, F>
+where
+    S: FulltextKeySource + 'static,
+    F: SinkFactory + 'static,
+{
+    async fn handle(&self, from: PeerId, msg: Message) -> Option<Message> {
+        let bytes = match msg {
+            Message::FulltextSearchStreamRequest(b) => b,
+            Message::FulltextSearchStreamCancel(b) => {
+                let cancel: FulltextSearchStreamCancelPayload = match bincode::deserialize(&b) {
+                    Ok(cancel) => cancel,
+                    Err(e) => {
+                        tracing::warn!(
+                            "FulltextSearchStreamRequestHandler: cancel decode failed: {e}"
+                        );
+                        return None;
+                    }
+                };
+                if let Some((_request_id, token)) = self.cancellations.remove(&cancel.request_id) {
+                    token.cancel();
+                }
+                return None;
+            }
+            _ => return None,
+        };
+
+        let req: FulltextSearchStreamRequestPayload = match bincode::deserialize(&bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("FulltextSearchStreamRequestHandler: decode failed: {e}");
+                return None;
+            }
+        };
+
+        let sink = self.sink_factory.for_peer(from, req.request_id);
+        let source = self.source.clone();
+        let chunk_keys = self.chunk_keys;
+        let token = CancellationToken::new();
+        self.cancellations.insert(req.request_id, token.clone());
+        let cancellations = self.cancellations.clone();
+
+        TaskPool::current("fulltext-stream-request").spawn(async move {
+            let request_id = req.request_id;
+            handle_fulltext_stream_request_with_cancel(req, source, &sink, chunk_keys, token).await;
+            cancellations.remove(&request_id);
+        });
+
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Consumer + coordinator fan-out (layer 4b)
+// ---------------------------------------------------------------------------
+
+/// Route buffer for one replica's fulltext stream. Fulltext chunks are small
+/// (≤ [`FULLTEXT_STREAM_CHUNK_KEYS`] keys ≈ 160 KiB), and the per-replica
+/// consumer forwards each chunk promptly into the bounded merge channel, so a
+/// deeper buffer than the range-read stream's is safe and absorbs producer
+/// bursts without tripping the fail-loud route-full close.
+pub const FULLTEXT_STREAM_ROUTE_BUFFER: usize = 256;
+
+/// Producer inactivity bound — same rationale as the range-read stream's.
+const FULLTEXT_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Terminal outcome of consuming one replica's fulltext key stream.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FulltextConsumeOutcome {
+    /// The replica terminated cleanly with `Done { truncated: false }`.
+    Done,
+    /// The downstream merge stopped accepting keys (query satisfied or
+    /// abandoned). The caller must cancel the remote producer.
+    EarlyStop,
+}
+
+/// All the ways consuming one replica's fulltext stream can fail. Any of
+/// these fails the WHOLE search — a missing replica's keys would silently
+/// drop matching rows from the result (fail loud, never fake).
+#[derive(Debug)]
+pub enum FulltextConsumeError {
+    IdleTimeout { request_id: u32 },
+    Decode { request_id: u32, message: String },
+    UnexpectedFrame { request_id: u32 },
+    ChannelClosedBeforeDone { request_id: u32 },
+    TruncatedReplica { request_id: u32 },
+}
+
+impl std::fmt::Display for FulltextConsumeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IdleTimeout { request_id } => {
+                write!(f, "fulltext stream {request_id}: producer idle timeout")
+            }
+            Self::Decode {
+                request_id,
+                message,
+            } => write!(f, "fulltext stream {request_id}: frame decode: {message}"),
+            Self::UnexpectedFrame { request_id } => {
+                write!(f, "fulltext stream {request_id}: unexpected frame type")
+            }
+            Self::ChannelClosedBeforeDone { request_id } => write!(
+                f,
+                "fulltext stream {request_id}: route closed before Done (gap/overflow/producer death)"
+            ),
+            Self::TruncatedReplica { request_id } => write!(
+                f,
+                "fulltext stream {request_id}: replica reported truncated walk"
+            ),
+        }
+    }
+}
+
+/// Consume one replica's fulltext stream: decode chunk frames, forward each
+/// chunk's keys into `forward` (bounded — the back-pressure point), treat
+/// heartbeats as activity, finish on Done.
+pub async fn consume_fulltext_key_stream(
+    receiver: tokio::sync::mpsc::Receiver<Message>,
+    request_id: u32,
+    forward: &tokio::sync::mpsc::Sender<Vec<Vec<u8>>>,
+) -> Result<FulltextConsumeOutcome, FulltextConsumeError> {
+    let mut watchdog =
+        ferrosa_net::idle_timeout::IdleTimeoutWatchdog::new(receiver, FULLTEXT_STREAM_IDLE_TIMEOUT);
+    loop {
+        match watchdog.next().await {
+            Ok(Some(Message::FulltextSearchStreamChunk(bytes))) => {
+                let chunk: FulltextSearchStreamChunkPayload = bincode::deserialize(&bytes)
+                    .map_err(|e| FulltextConsumeError::Decode {
+                        request_id,
+                        message: format!("chunk: {e}"),
+                    })?;
+                if forward.send(chunk.keys).await.is_err() {
+                    return Ok(FulltextConsumeOutcome::EarlyStop);
+                }
+            }
+            Ok(Some(Message::FulltextSearchStreamHeartbeat(_))) => continue,
+            Ok(Some(Message::FulltextSearchStreamDone(bytes))) => {
+                let done: FulltextSearchStreamDonePayload =
+                    bincode::deserialize(&bytes).map_err(|e| FulltextConsumeError::Decode {
+                        request_id,
+                        message: format!("done: {e}"),
+                    })?;
+                if done.truncated {
+                    return Err(FulltextConsumeError::TruncatedReplica { request_id });
+                }
+                return Ok(FulltextConsumeOutcome::Done);
+            }
+            Ok(Some(_)) => return Err(FulltextConsumeError::UnexpectedFrame { request_id }),
+            Ok(None) => return Err(FulltextConsumeError::ChannelClosedBeforeDone { request_id }),
+            Err(_elapsed) => return Err(FulltextConsumeError::IdleTimeout { request_id }),
+        }
+    }
+}
+
+/// Fire a best-effort `FulltextSearchStreamCancel` so an abandoned remote
+/// walk stops instead of streaming keys to nobody (the fulltext analogue of
+/// the t_3fc6be3c range-read leak).
+async fn fire_fulltext_stream_cancel(
+    peers: &ferrosa_net::peer::PeerManager,
+    host_id: uuid::Uuid,
+    request_id: u32,
+) {
+    let payload = FulltextSearchStreamCancelPayload { request_id };
+    let body = bincode::serialize(&payload)
+        .expect("FulltextSearchStreamCancelPayload serialization is infallible");
+    match peers
+        .fire(
+            host_id,
+            Message::FulltextSearchStreamCancel(Bytes::from(body)),
+            ferrosa_net::codec::Lane::Bulk,
+        )
+        .await
+    {
+        Ok(()) => tracing::info!(
+            request_id,
+            peer = %host_id,
+            "streaming fulltext: fired cancel to stop the remote walk"
+        ),
+        Err(e) => tracing::warn!(
+            request_id,
+            peer = %host_id,
+            "streaming fulltext: cancel fire failed — remote walk runs to Done or disconnect: {e}"
+        ),
+    }
+}
+
+/// Internal merge event from one replica's feeder task.
+enum ReplicaEvent {
+    Keys(Vec<Vec<u8>>),
+    ReplicaDone,
+    ReplicaFailed(String),
+}
+
+impl crate::ClusterCoordinator {
+    /// Streaming cluster-wide fulltext search (t_4ae47a9f): fans a
+    /// `FulltextSearchStreamRequest` out to every node (walking the local FTI
+    /// in-process), N-way merges the returning key chunks over bounded
+    /// channels, dedups against a single `seen` set, and yields deduped key
+    /// batches through the returned bounded receiver.
+    ///
+    /// Memory: O(route buffers + merge channel + `seen`). The `seen` dedup
+    /// set is the one intentionally O(distinct matches) allocation in the
+    /// whole path — keys only, no scores, one copy, needed for corretness of
+    /// the cross-replica union. Every other hop is bounded.
+    ///
+    /// Fail loud: any replica failure (fire error, truncated walk, idle
+    /// timeout, route close) yields `Err` through the stream — never a
+    /// silent partial union (unlike the legacy degrading path). Dropping the
+    /// receiver early cancels every in-flight remote walk.
+    pub async fn coordinate_fulltext_search_stream(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        query: &str,
+    ) -> crate::error::Result<tokio::sync::mpsc::Receiver<crate::error::Result<Vec<Vec<u8>>>>> {
+        let ring = self.ring.load();
+        let node_ids = ring.node_ids();
+        let mut remotes: Vec<(uuid::Uuid, String)> = Vec::new();
+        for &id in node_ids.iter() {
+            if id == self.local_node_id {
+                continue;
+            }
+            match ring.get_node(id) {
+                Some(n) => remotes.push((n.host_id, n.addr.clone())),
+                None => {
+                    return Err(crate::error::ClusterError::Internal(format!(
+                        "streaming fulltext: ring node {id} has no address entry"
+                    )))
+                }
+            }
+        }
+        drop(ring);
+
+        let replica_count = remotes.len() + 1; // + local walk
+        let (merge_tx, mut merge_rx) = tokio::sync::mpsc::channel::<ReplicaEvent>(16);
+        let (out_tx, out_rx) = tokio::sync::mpsc::channel::<crate::error::Result<Vec<Vec<u8>>>>(8);
+
+        // --- local walk feeder -------------------------------------------------
+        {
+            let storage = self.storage.clone();
+            let table_id = table_id.clone();
+            let index_name = index_name.to_string();
+            let query = query.to_string();
+            let merge_tx = merge_tx.clone();
+            TaskPool::current("fulltext-stream-local").spawn(async move {
+                let feeder_tx = merge_tx.clone();
+                let walk = tokio::task::spawn_blocking(move || {
+                    let mut batch: Vec<Vec<u8>> = Vec::with_capacity(FULLTEXT_STREAM_CHUNK_KEYS);
+                    let result =
+                        storage.fulltext_search_each(&table_id, &index_name, &query, &mut |key| {
+                            batch.push(key);
+                            if batch.len() >= FULLTEXT_STREAM_CHUNK_KEYS {
+                                let full = std::mem::take(&mut batch);
+                                if feeder_tx.blocking_send(ReplicaEvent::Keys(full)).is_err() {
+                                    return ControlFlow::Break(());
+                                }
+                            }
+                            ControlFlow::Continue(())
+                        });
+                    match result {
+                        Ok(()) => {
+                            if !batch.is_empty() {
+                                let _ = feeder_tx.blocking_send(ReplicaEvent::Keys(batch));
+                            }
+                            let _ = feeder_tx.blocking_send(ReplicaEvent::ReplicaDone);
+                        }
+                        Err(e) => {
+                            let _ = feeder_tx
+                                .blocking_send(ReplicaEvent::ReplicaFailed(format!("local: {e}")));
+                        }
+                    }
+                });
+                if let Err(join_err) = walk.await {
+                    let _ = merge_tx
+                        .send(ReplicaEvent::ReplicaFailed(format!(
+                            "local walk join: {join_err}"
+                        )))
+                        .await;
+                }
+            });
+        }
+
+        // --- remote feeders ----------------------------------------------------
+        for (host_id, _addr) in remotes {
+            let request_id = self.next_stream_request_id();
+            let receiver = self
+                .stream_router
+                .register(request_id, FULLTEXT_STREAM_ROUTE_BUFFER);
+            let req = FulltextSearchStreamRequestPayload {
+                request_id,
+                keyspace: table_id.keyspace.clone(),
+                table: table_id.table.clone(),
+                index_name: index_name.to_string(),
+                query: query.to_string(),
+            };
+            let body = match bincode::serialize(&req) {
+                Ok(b) => Bytes::from(b),
+                Err(e) => {
+                    self.stream_router.unregister(request_id);
+                    return Err(crate::error::ClusterError::Internal(format!(
+                        "streaming fulltext: request encode: {e}"
+                    )));
+                }
+            };
+            if let Err(e) = self
+                .peer_manager
+                .fire(
+                    host_id,
+                    Message::FulltextSearchStreamRequest(body),
+                    ferrosa_net::codec::Lane::Bulk,
+                )
+                .await
+            {
+                self.stream_router.unregister(request_id);
+                return Err(crate::error::ClusterError::Internal(format!(
+                    "streaming fulltext: failed to fire request to {host_id}: {e} \
+                     (failing the search — a missing replica would silently drop matches)"
+                )));
+            }
+
+            let merge_tx = merge_tx.clone();
+            let stream_router = self.stream_router.clone();
+            let peers = self.peer_manager.clone();
+            TaskPool::current("fulltext-stream-consume").spawn(async move {
+                let (keys_tx, mut keys_rx) = tokio::sync::mpsc::channel::<Vec<Vec<u8>>>(4);
+                let consume = consume_fulltext_key_stream(receiver, request_id, &keys_tx);
+                tokio::pin!(consume);
+                let outcome = loop {
+                    tokio::select! {
+                        out = &mut consume => break out,
+                        batch = keys_rx.recv() => {
+                            if let Some(batch) = batch {
+                                if merge_tx.send(ReplicaEvent::Keys(batch)).await.is_err() {
+                                    // Merge gone: stop consuming; the dropped
+                                    // keys_rx makes consume return EarlyStop.
+                                    keys_rx.close();
+                                }
+                            }
+                        }
+                    }
+                };
+                // Drain any batches the consumer buffered before finishing.
+                while let Ok(batch) = keys_rx.try_recv() {
+                    let _ = merge_tx.send(ReplicaEvent::Keys(batch)).await;
+                }
+                stream_router.unregister(request_id);
+                match outcome {
+                    Ok(FulltextConsumeOutcome::Done) => {
+                        let _ = merge_tx.send(ReplicaEvent::ReplicaDone).await;
+                    }
+                    Ok(FulltextConsumeOutcome::EarlyStop) => {
+                        fire_fulltext_stream_cancel(&peers, host_id, request_id).await;
+                    }
+                    Err(e) => {
+                        fire_fulltext_stream_cancel(&peers, host_id, request_id).await;
+                        let _ = merge_tx
+                            .send(ReplicaEvent::ReplicaFailed(e.to_string()))
+                            .await;
+                    }
+                }
+            });
+        }
+        drop(merge_tx);
+
+        // --- merge + dedup -----------------------------------------------------
+        TaskPool::current("fulltext-stream-merge").spawn(async move {
+            let mut seen: std::collections::HashSet<Vec<u8>> = std::collections::HashSet::new();
+            let mut pending = replica_count;
+            while let Some(event) = merge_rx.recv().await {
+                match event {
+                    ReplicaEvent::Keys(batch) => {
+                        let unique: Vec<Vec<u8>> = batch
+                            .into_iter()
+                            .filter(|k| seen.insert(k.clone()))
+                            .collect();
+                        if !unique.is_empty() && out_tx.send(Ok(unique)).await.is_err() {
+                            // Consumer gone (query satisfied/abandoned):
+                            // exiting drops merge_rx; feeders observe closed
+                            // sends and cancel their remotes.
+                            return;
+                        }
+                    }
+                    ReplicaEvent::ReplicaDone => {
+                        pending -= 1;
+                        if pending == 0 {
+                            return; // clean end: out_tx drops, stream closes
+                        }
+                    }
+                    ReplicaEvent::ReplicaFailed(reason) => {
+                        let _ = out_tx
+                            .send(Err(crate::error::ClusterError::Internal(format!(
+                                "streaming fulltext failed (no partial union served): {reason}"
+                            ))))
+                            .await;
+                        return;
+                    }
+                }
+            }
+            // merge_rx closed with replicas still pending: feeders died
+            // without a terminal event — fail loud.
+            if pending > 0 {
+                let _ = out_tx
+                    .send(Err(crate::error::ClusterError::Internal(
+                        "streaming fulltext: feeder(s) ended without terminal signal".into(),
+                    )))
+                    .await;
+            }
+        });
+
+        Ok(out_rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Test sink: collect every emitted Message.
+    struct VecSink {
+        sent: Mutex<Vec<Message>>,
+    }
+    impl VecSink {
+        fn new() -> Self {
+            Self {
+                sent: Mutex::new(Vec::new()),
+            }
+        }
+        fn frames(&self) -> Vec<Message> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+    #[async_trait]
+    impl ChunkSink for VecSink {
+        async fn send(&self, msg: Message) {
+            self.sent.lock().unwrap().push(msg);
+        }
+    }
+
+    /// In-memory key source yielding `n` deterministic keys, honoring Break.
+    struct FakeSource {
+        n: usize,
+        fail: bool,
+    }
+    impl FulltextKeySource for FakeSource {
+        fn search_each(
+            &self,
+            _table_id: &TableId,
+            _index_name: &str,
+            _query: &str,
+            on_hit: &mut dyn FnMut(Vec<u8>) -> ControlFlow<()>,
+        ) -> ferrosa_common::Result<()> {
+            if self.fail {
+                return Err(ferrosa_common::Error::InvalidFormat(
+                    "fts_match query error: synthetic".into(),
+                ));
+            }
+            for i in 0..self.n {
+                if on_hit(format!("key-{i:08}").into_bytes()).is_break() {
+                    return Ok(());
+                }
+            }
+            Ok(())
+        }
+    }
+
+    fn req(id: u32) -> FulltextSearchStreamRequestPayload {
+        FulltextSearchStreamRequestPayload {
+            request_id: id,
+            keyspace: "ks".into(),
+            table: "tbl".into(),
+            index_name: "idx".into(),
+            query: "memory".into(),
+        }
+    }
+
+    fn decode_chunk(msg: &Message) -> FulltextSearchStreamChunkPayload {
+        match msg {
+            Message::FulltextSearchStreamChunk(b) => bincode::deserialize(b).expect("chunk"),
+            other => panic!("expected FulltextSearchStreamChunk, got {other:?}"),
+        }
+    }
+    fn decode_done(msg: &Message) -> FulltextSearchStreamDonePayload {
+        match msg {
+            Message::FulltextSearchStreamDone(b) => bincode::deserialize(b).expect("done"),
+            other => panic!("expected FulltextSearchStreamDone, got {other:?}"),
+        }
+    }
+
+    /// 10 keys at chunk size 4 → chunks of 4+4+2 with monotonic seq, then a
+    /// clean Done reporting total_chunks=3. Every key arrives exactly once,
+    /// in walk order.
+    #[tokio::test]
+    async fn chunks_keys_then_emits_done() {
+        let sink = VecSink::new();
+        handle_fulltext_stream_request_with_cancel(
+            req(7),
+            Arc::new(FakeSource { n: 10, fail: false }),
+            &sink,
+            4,
+            CancellationToken::new(),
+        )
+        .await;
+
+        let frames = sink.frames();
+        assert_eq!(frames.len(), 4, "3 chunks + 1 done: {frames:?}");
+        let sizes: Vec<usize> = frames[..3]
+            .iter()
+            .map(|f| decode_chunk(f).keys.len())
+            .collect();
+        assert_eq!(sizes, vec![4, 4, 2]);
+        for (i, f) in frames[..3].iter().enumerate() {
+            let c = decode_chunk(f);
+            assert_eq!(c.request_id, 7);
+            assert_eq!(c.seq, i as u32);
+        }
+        let all: Vec<Vec<u8>> = frames[..3]
+            .iter()
+            .flat_map(|f| decode_chunk(f).keys)
+            .collect();
+        let expected: Vec<Vec<u8>> = (0..10)
+            .map(|i| format!("key-{i:08}").into_bytes())
+            .collect();
+        assert_eq!(all, expected, "every key exactly once, in walk order");
+
+        let done = decode_done(&frames[3]);
+        assert_eq!(done.request_id, 7);
+        assert_eq!(done.total_chunks, 3);
+        assert!(!done.truncated);
+    }
+
+    /// Zero matches still terminates with a clean Done (total_chunks=0) —
+    /// the coordinator must observe a terminator for every replica.
+    #[tokio::test]
+    async fn empty_walk_emits_only_done() {
+        let sink = VecSink::new();
+        handle_fulltext_stream_request_with_cancel(
+            req(1),
+            Arc::new(FakeSource { n: 0, fail: false }),
+            &sink,
+            8,
+            CancellationToken::new(),
+        )
+        .await;
+        let frames = sink.frames();
+        assert_eq!(frames.len(), 1);
+        let done = decode_done(&frames[0]);
+        assert_eq!(done.total_chunks, 0);
+        assert!(!done.truncated);
+    }
+
+    /// A failed walk (malformed query / storage error) MUST NOT deliver any
+    /// partial batch: it terminates with Done{truncated:true} so the
+    /// coordinator fails the search instead of serving a silent subset.
+    #[tokio::test]
+    async fn walk_error_terminates_truncated_without_partial_keys() {
+        let sink = VecSink::new();
+        handle_fulltext_stream_request_with_cancel(
+            req(2),
+            Arc::new(FakeSource { n: 0, fail: true }),
+            &sink,
+            8,
+            CancellationToken::new(),
+        )
+        .await;
+        let frames = sink.frames();
+        assert_eq!(frames.len(), 1, "no chunks, only the truncated Done");
+        let done = decode_done(&frames[0]);
+        assert!(done.truncated);
+        assert_eq!(done.total_chunks, 0);
+    }
+
+    /// Cancellation stops the stream without a Done frame (the coordinator
+    /// unregisters the route before cancelling) and unblocks the walk.
+    #[tokio::test]
+    async fn cancel_stops_stream_without_done() {
+        let sink = VecSink::new();
+        let token = CancellationToken::new();
+        token.cancel(); // cancelled before the first frame
+        handle_fulltext_stream_request_with_cancel(
+            req(3),
+            Arc::new(FakeSource {
+                n: 1_000_000,
+                fail: false,
+            }),
+            &sink,
+            64,
+            token,
+        )
+        .await;
+        let frames = sink.frames();
+        assert!(
+            frames
+                .iter()
+                .all(|f| !matches!(f, Message::FulltextSearchStreamDone(_))),
+            "no Done after cancel: {frames:?}"
+        );
+    }
+
+    // --- consumer-side contract ---------------------------------------------
+
+    fn chunk_frame(request_id: u32, seq: u32, keys: Vec<Vec<u8>>) -> Message {
+        let payload = FulltextSearchStreamChunkPayload {
+            request_id,
+            seq,
+            keys,
+        };
+        Message::FulltextSearchStreamChunk(Bytes::from(bincode::serialize(&payload).unwrap()))
+    }
+    fn done_frame(request_id: u32, total_chunks: u32, truncated: bool) -> Message {
+        let payload = FulltextSearchStreamDonePayload {
+            request_id,
+            total_chunks,
+            truncated,
+        };
+        Message::FulltextSearchStreamDone(Bytes::from(bincode::serialize(&payload).unwrap()))
+    }
+
+    /// Chunks arrive → batches forward in order → clean Done outcome.
+    #[tokio::test]
+    async fn consume_forwards_batches_then_done() {
+        let (route_tx, route_rx) = tokio::sync::mpsc::channel(8);
+        let (fwd_tx, mut fwd_rx) = tokio::sync::mpsc::channel(8);
+        route_tx
+            .send(chunk_frame(9, 0, vec![b"a".to_vec(), b"b".to_vec()]))
+            .await
+            .unwrap();
+        route_tx
+            .send(chunk_frame(9, 1, vec![b"c".to_vec()]))
+            .await
+            .unwrap();
+        route_tx.send(done_frame(9, 2, false)).await.unwrap();
+        drop(route_tx);
+
+        let outcome = consume_fulltext_key_stream(route_rx, 9, &fwd_tx)
+            .await
+            .unwrap();
+        assert_eq!(outcome, FulltextConsumeOutcome::Done);
+        drop(fwd_tx);
+        assert_eq!(
+            fwd_rx.recv().await.unwrap(),
+            vec![b"a".to_vec(), b"b".to_vec()]
+        );
+        assert_eq!(fwd_rx.recv().await.unwrap(), vec![b"c".to_vec()]);
+        assert!(fwd_rx.recv().await.is_none());
+    }
+
+    /// `Done { truncated: true }` fails the replica — a truncated walk must
+    /// fail the search, never contribute a silent subset.
+    #[tokio::test]
+    async fn consume_truncated_done_is_an_error() {
+        let (route_tx, route_rx) = tokio::sync::mpsc::channel(4);
+        let (fwd_tx, _fwd_rx) = tokio::sync::mpsc::channel(4);
+        route_tx.send(done_frame(3, 0, true)).await.unwrap();
+        let err = consume_fulltext_key_stream(route_rx, 3, &fwd_tx)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FulltextConsumeError::TruncatedReplica { request_id: 3 }
+        ));
+    }
+
+    /// Route closing before Done (gap-close, producer death, buffer
+    /// overflow) is an error, not a short result.
+    #[tokio::test]
+    async fn consume_route_close_before_done_is_an_error() {
+        let (route_tx, route_rx) = tokio::sync::mpsc::channel(4);
+        let (fwd_tx, _fwd_rx) = tokio::sync::mpsc::channel(4);
+        route_tx
+            .send(chunk_frame(5, 0, vec![b"k".to_vec()]))
+            .await
+            .unwrap();
+        drop(route_tx); // closed without Done
+        let err = consume_fulltext_key_stream(route_rx, 5, &fwd_tx)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FulltextConsumeError::ChannelClosedBeforeDone { request_id: 5 }
+        ));
+    }
+
+    /// A dropped forward receiver = downstream satisfied/abandoned →
+    /// EarlyStop (the caller then cancels the remote walk).
+    #[tokio::test]
+    async fn consume_dropped_forward_is_early_stop() {
+        let (route_tx, route_rx) = tokio::sync::mpsc::channel(4);
+        let (fwd_tx, fwd_rx) = tokio::sync::mpsc::channel(1);
+        drop(fwd_rx);
+        route_tx
+            .send(chunk_frame(6, 0, vec![b"k".to_vec()]))
+            .await
+            .unwrap();
+        let outcome = consume_fulltext_key_stream(route_rx, 6, &fwd_tx)
+            .await
+            .unwrap();
+        assert_eq!(outcome, FulltextConsumeOutcome::EarlyStop);
+    }
+
+    /// The producer's resident set stays bounded: a walk of 200k keys with a
+    /// tiny chunk size never holds more than the channel capacity + one
+    /// batch. (Behavioral proxy: the stream completes and every key arrives
+    /// exactly once — the allocator-level bound is pinned end-to-end by the
+    /// storage-layer test and the cluster memory-bound test.)
+    #[tokio::test]
+    async fn large_walk_streams_completely() {
+        let sink = VecSink::new();
+        let n = 200_000;
+        handle_fulltext_stream_request_with_cancel(
+            req(4),
+            Arc::new(FakeSource { n, fail: false }),
+            &sink,
+            FULLTEXT_STREAM_CHUNK_KEYS,
+            CancellationToken::new(),
+        )
+        .await;
+        let frames = sink.frames();
+        let done = decode_done(frames.last().unwrap());
+        assert!(!done.truncated);
+        let total_keys: usize = frames[..frames.len() - 1]
+            .iter()
+            .map(|f| decode_chunk(f).keys.len())
+            .sum();
+        assert_eq!(total_keys, n);
+        assert_eq!(done.total_chunks as usize, frames.len() - 1);
+    }
+}

--- a/ferrosa-cluster/src/coordinator/mod.rs
+++ b/ferrosa-cluster/src/coordinator/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod batch;
 pub mod cl_routing;
+pub mod fulltext_stream;
 pub mod metrics;
 pub mod range_read_stream;
 pub mod read;
@@ -82,6 +83,13 @@ pub struct ClusterCoordinator {
     /// path applies a hard partition cap and cannot serve complete
     /// full-scan semantics.
     pub(crate) streaming_range_reads: bool,
+    /// When `true` (the default), no-`LIMIT` `fts_match` queries use the
+    /// streaming fulltext protocol (t_4ae47a9f) instead of the legacy
+    /// single-message `FulltextSearchRequest` union whose O(matches)
+    /// materialization OOM-killed replicas (t_8fc24ce2).
+    /// `FERROSA_BULK_STREAMING_FULLTEXT=0` opts into the legacy path for
+    /// mixed-version rolling upgrades.
+    pub(crate) streaming_fulltext: bool,
 }
 
 fn streaming_range_reads_enabled(value: Option<&str>) -> bool {
@@ -102,6 +110,15 @@ impl ClusterCoordinator {
     ) -> Self {
         let streaming_env = std::env::var("FERROSA_BULK_STREAMING_RANGE_READ").ok();
         let streaming_range_reads = streaming_range_reads_enabled(streaming_env.as_deref());
+        let streaming_fulltext_env = std::env::var("FERROSA_BULK_STREAMING_FULLTEXT").ok();
+        let streaming_fulltext = streaming_range_reads_enabled(streaming_fulltext_env.as_deref());
+        if !streaming_fulltext {
+            tracing::warn!(
+                "coordinator: legacy single-message fulltext search enabled via \
+                 FERROSA_BULK_STREAMING_FULLTEXT=0; broad no-LIMIT fts_match queries \
+                 materialize the match set on every replica (t_8fc24ce2 OOM shape)"
+            );
+        }
         if streaming_range_reads {
             tracing::info!(
                 configured = streaming_env.as_deref().unwrap_or("default"),
@@ -129,6 +146,7 @@ impl ClusterCoordinator {
             stream_router: Arc::new(StreamRouter::new()),
             next_request_id: Arc::new(AtomicU32::new(1)),
             streaming_range_reads,
+            streaming_fulltext,
         }
     }
 

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -1842,9 +1842,17 @@ impl ClusterCoordinator {
 
                 async move {
                     if node_id == local_id {
-                        storage
-                            .fulltext_search(&table_id, &index_name, &query, limit)
-                            .map_err(ClusterError::Storage)
+                        // Offload the blocking local FTI scan so it does not
+                        // starve raft heartbeats / CQL keepalives on the
+                        // coordinator's async runtime (t_8fc24ce2).
+                        tokio::task::spawn_blocking(move || {
+                            storage.fulltext_search(&table_id, &index_name, &query, limit)
+                        })
+                        .await
+                        .map_err(|e| {
+                            ClusterError::Internal(format!("fulltext_search task join: {e}"))
+                        })?
+                        .map_err(ClusterError::Storage)
                     } else {
                         let (hid, addr) = remote.ok_or_else(|| {
                             ClusterError::Internal(format!(

--- a/ferrosa-cluster/src/coordinator/stream_frame_router.rs
+++ b/ferrosa-cluster/src/coordinator/stream_frame_router.rs
@@ -37,6 +37,13 @@ struct PendingDone {
     message: Message,
 }
 
+/// Leading fields shared by every streaming Done payload family; lets the
+/// payload-agnostic seq bookkeeping reuse the field-access shape of the
+/// legacy full-payload decode.
+struct DoneHeader {
+    total_chunks: u32,
+}
+
 #[derive(Default)]
 struct StreamSeqState {
     next_chunk_seq: u32,
@@ -153,6 +160,20 @@ impl StreamFrameRouter {
         let Ok(payload) = bincode::deserialize::<RangeReadStreamChunkPayload>(bytes) else {
             return Some(None);
         };
+        self.accept_chunk_seq_value(from, request_id, payload.seq)
+    }
+
+    /// Payload-agnostic core of the chunk seq check: every streaming chunk
+    /// payload family (range-read partitions, fulltext keys) leads with
+    /// `request_id: u32, seq: u32`, so the seq bookkeeping is shared while
+    /// each `handle` arm decodes just enough of its own payload shape.
+    fn accept_chunk_seq_value(
+        &self,
+        from: PeerId,
+        request_id: u32,
+        seq: u32,
+    ) -> Option<Option<Message>> {
+        let payload_seq = seq;
         let key = (request_id, from.0);
         let mut guard = self
             .seq_state
@@ -165,18 +186,18 @@ impl StreamFrameRouter {
             tracing::debug!(
                 request_id,
                 peer = %from.0,
-                seq = payload.seq,
+                seq = payload_seq,
                 "straggler stream chunk for torn-down route; dropping"
             );
             return None;
         };
-        if payload.seq != state.next_chunk_seq {
+        if payload_seq != state.next_chunk_seq {
             tracing::warn!(
                 request_id,
                 peer = %from.0,
                 connection_addr = %from.1,
                 expected_seq = state.next_chunk_seq,
-                observed_seq = payload.seq,
+                observed_seq = payload_seq,
                 "stream chunk sequence gap/reorder; closing stream route"
             );
             drop(guard);
@@ -206,6 +227,19 @@ impl StreamFrameRouter {
         let Ok(payload) = bincode::deserialize::<RangeReadStreamDonePayload>(bytes) else {
             return Some(Some(msg));
         };
+        self.accept_done_seq_value(from, request_id, payload.total_chunks, msg)
+    }
+
+    /// Payload-agnostic core of the Done bookkeeping — every streaming Done
+    /// payload family leads with `request_id: u32, total_chunks: u32`.
+    fn accept_done_seq_value(
+        &self,
+        from: PeerId,
+        request_id: u32,
+        total_chunks: u32,
+        msg: Message,
+    ) -> Option<Option<Message>> {
+        let payload = DoneHeader { total_chunks };
         let key = (request_id, from.0);
         let mut guard = self
             .seq_state
@@ -316,6 +350,14 @@ fn peek_request_id(bytes: &[u8]) -> Option<u32> {
     Some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
 }
 
+/// Decode the second leading `u32` (`seq` on chunk/heartbeat frames,
+/// `total_chunks` on Done frames) from a bincode-serialized streaming
+/// payload. Same LE fixint layout contract as [`peek_request_id`].
+fn peek_second_u32(bytes: &[u8]) -> Option<u32> {
+    let b = bytes.get(4..8)?;
+    Some(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+}
+
 #[async_trait]
 impl RpcHandler for StreamFrameRouter {
     async fn handle(&self, from: PeerId, msg: Message) -> Option<Message> {
@@ -325,6 +367,15 @@ impl RpcHandler for StreamFrameRouter {
                 (peek_request_id(b), MsgType::RangeReadStreamHeartbeat)
             }
             Message::RangeReadStreamDone(b) => (peek_request_id(b), MsgType::RangeReadStreamDone),
+            Message::FulltextSearchStreamChunk(b) => {
+                (peek_request_id(b), MsgType::FulltextSearchStreamChunk)
+            }
+            Message::FulltextSearchStreamHeartbeat(b) => {
+                (peek_request_id(b), MsgType::FulltextSearchStreamHeartbeat)
+            }
+            Message::FulltextSearchStreamDone(b) => {
+                (peek_request_id(b), MsgType::FulltextSearchStreamDone)
+            }
             // Not ours — return None so the handler dispatch chain
             // can give a different handler a chance. (HandlerRegistry
             // currently dispatches by MsgType, so this is defensive.)
@@ -362,6 +413,52 @@ impl RpcHandler for StreamFrameRouter {
                 match self
                     .router
                     .route_lossy(request_id, Message::RangeReadStreamHeartbeat(bytes))
+                {
+                    Ok(()) | Err(RouteError::NoRoute(_)) => {}
+                    Err(RouteError::ChannelClosed(id)) => {
+                        self.clear_request_state(id);
+                    }
+                    Err(RouteError::ChannelFull(_)) => {
+                        unreachable!("route_lossy never reports ChannelFull")
+                    }
+                }
+                None
+            }
+            // Streaming fulltext frames (t_4ae47a9f): identical seq/Done
+            // bookkeeping via the payload-agnostic cores — both payload
+            // families lead with `request_id: u32` then `seq`/`total_chunks`.
+            Message::FulltextSearchStreamChunk(bytes) => {
+                let pending_done = match peek_second_u32(bytes.as_ref()) {
+                    Some(seq) => self.accept_chunk_seq_value(from, request_id, seq)?,
+                    // Malformed frame: route it anyway so the consumer's
+                    // decode fails the stream loudly (mirrors the range-read
+                    // decode-failure contract).
+                    None => None,
+                };
+                self.route_frame(
+                    request_id,
+                    msg_type,
+                    Message::FulltextSearchStreamChunk(bytes),
+                );
+                pending_done
+            }
+            Message::FulltextSearchStreamDone(bytes) => {
+                let msg = Message::FulltextSearchStreamDone(bytes.clone());
+                let route_done = match peek_second_u32(bytes.as_ref()) {
+                    Some(total_chunks) => {
+                        self.accept_done_seq_value(from, request_id, total_chunks, msg)?
+                    }
+                    None => Some(msg),
+                };
+                if let Some(done) = route_done {
+                    self.route_frame(request_id, msg_type, done);
+                }
+                return None;
+            }
+            Message::FulltextSearchStreamHeartbeat(bytes) => {
+                match self
+                    .router
+                    .route_lossy(request_id, Message::FulltextSearchStreamHeartbeat(bytes))
                 {
                     Ok(()) | Err(RouteError::NoRoute(_)) => {}
                     Err(RouteError::ChannelClosed(id)) => {

--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -1499,15 +1499,30 @@ impl RpcHandler for FulltextSearchHandler {
 
         let table_id = ferrosa_storage::TableId::new(&req.keyspace, &req.table);
 
-        let matching_keys = match self.storage.fulltext_search(
-            &table_id,
-            &req.index_name,
-            &req.query,
-            req.limit.map(|k| k as usize),
-        ) {
-            Ok(keys) => keys,
-            Err(e) => {
+        // Offload the blocking FTI scan (read_dir + sequential sidecar walks +
+        // whole-file reads) onto a blocking thread so it cannot starve raft
+        // heartbeats / CQL keepalives on this node's async runtime. Running it
+        // inline on the RPC worker was a co-cause of the Bulk-timeout → retry
+        // storm that multiplied buffers during the OOM cascade (t_8fc24ce2;
+        // same class as the PR #131 range-read offload).
+        let storage = self.storage.clone();
+        let index_name = req.index_name;
+        let query = req.query;
+        let limit = req.limit.map(|k| k as usize);
+        let matching_keys = match tokio::task::spawn_blocking(move || {
+            storage.fulltext_search(&table_id, &index_name, &query, limit)
+        })
+        .await
+        {
+            Ok(Ok(keys)) => keys,
+            Ok(Err(e)) => {
                 tracing::warn!("FulltextSearchHandler: fulltext_search failed: {e}");
+                vec![]
+            }
+            Err(join_err) => {
+                tracing::warn!(
+                    "FulltextSearchHandler: fulltext_search task join failed: {join_err}"
+                );
                 vec![]
             }
         };

--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -1287,6 +1287,70 @@ pub struct RangeReadStreamCancelPayload {
 }
 
 // ---------------------------------------------------------------------------
+// Streaming fulltext search (t_4ae47a9f) — the fts_match twin of the ADR-020
+// streaming range read. Matching doc KEYS flow back in bounded chunks instead
+// of one O(matches) FulltextSearchResponse frame; the producer's walk is
+// consumer-paced (bounded internal channel + Cancel), so no node materializes
+// the match set (the t_8fc24ce2 OOM shape).
+// ---------------------------------------------------------------------------
+
+/// Coordinator → handler: open a streaming fulltext search against one
+/// node's local FTI. There is deliberately no `limit` field: the streaming
+/// path exists for the no-`LIMIT` / escalated shape, and the consumer stops
+/// the stream via back-pressure + [`FulltextSearchStreamCancelPayload`] when
+/// it has enough. LIMIT-k queries keep using the bounded legacy
+/// [`FulltextSearchRequestPayload`] path (O(k) per replica already).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FulltextSearchStreamRequestPayload {
+    /// Per-coordinator-call correlation id, echoed in every frame of this
+    /// stream so the StreamRouter can dispatch to the right consumer.
+    pub request_id: u32,
+    pub keyspace: String,
+    pub table: String,
+    pub index_name: String,
+    pub query: String,
+}
+
+/// Handler → coordinator: one bounded batch of matching doc keys.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FulltextSearchStreamChunkPayload {
+    pub request_id: u32,
+    /// Monotonic 0-based chunk sequence within this stream.
+    pub seq: u32,
+    /// Raw doc keys (fulltext doc-key encoding, same bytes the legacy
+    /// `FulltextSearchResponsePayload.matching_keys` carries). Unordered;
+    /// may repeat across a node's sources — the coordinator dedups.
+    pub keys: Vec<Vec<u8>>,
+}
+
+/// Handler → coordinator: keep-alive while the FTI walk is slow to yield
+/// the next chunk. Resets the coordinator's idle-timeout watchdog.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FulltextSearchStreamHeartbeatPayload {
+    pub request_id: u32,
+    /// Sequence number of the next chunk the handler is working on.
+    pub seq: u32,
+}
+
+/// Handler → coordinator: terminator for a streaming fulltext search.
+/// `truncated = true` reports a walk failure (bad query, storage error) —
+/// the coordinator fails the whole search rather than serving a silent
+/// partial match set (fail loud, never fake).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FulltextSearchStreamDonePayload {
+    pub request_id: u32,
+    pub total_chunks: u32,
+    pub truncated: bool,
+}
+
+/// Coordinator → handler: abort a fulltext stream in-flight. The producer's
+/// walk observes the cancellation as a `ControlFlow::Break` between keys.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FulltextSearchStreamCancelPayload {
+    pub request_id: u32,
+}
+
+// ---------------------------------------------------------------------------
 // Index read handler
 // ---------------------------------------------------------------------------
 

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -281,6 +281,48 @@ async fn offloaded_fulltext_search(
     .map_err(crate::error::ClusterError::Storage)
 }
 
+/// Node-local streaming fulltext walk for Direct/Pair modes: the blocking
+/// `fulltext_search_each` walk feeds bounded key batches into the returned
+/// channel; the walk's own working set is O(1) (t_4ae47a9f layer 2b), so
+/// resident memory is O(channel + one batch) regardless of match count.
+/// Dropping the receiver stops the walk on its next key (Break).
+fn local_fulltext_key_stream(
+    engine: Arc<StorageEngine>,
+    table_id: &TableId,
+    index_name: &str,
+    query: &str,
+) -> tokio::sync::mpsc::Receiver<crate::error::Result<Vec<Vec<u8>>>> {
+    const BATCH_KEYS: usize = 4_096;
+    let (tx, rx) = tokio::sync::mpsc::channel::<crate::error::Result<Vec<Vec<u8>>>>(8);
+    let table_id = table_id.clone();
+    let index_name = index_name.to_string();
+    let query = query.to_string();
+    tokio::task::spawn_blocking(move || {
+        let mut batch: Vec<Vec<u8>> = Vec::with_capacity(BATCH_KEYS);
+        let result = engine.fulltext_search_each(&table_id, &index_name, &query, &mut |key| {
+            batch.push(key);
+            if batch.len() >= BATCH_KEYS {
+                let full = std::mem::take(&mut batch);
+                if tx.blocking_send(Ok(full)).is_err() {
+                    return std::ops::ControlFlow::Break(());
+                }
+            }
+            std::ops::ControlFlow::Continue(())
+        });
+        match result {
+            Ok(()) => {
+                if !batch.is_empty() {
+                    let _ = tx.blocking_send(Ok(batch));
+                }
+            }
+            Err(e) => {
+                let _ = tx.blocking_send(Err(crate::error::ClusterError::Storage(e)));
+            }
+        }
+    });
+    rx
+}
+
 /// The active write path. Swapped atomically via `ArcSwap` when the
 /// deployment mode changes (standalone → pair → cluster).
 ///
@@ -1031,6 +1073,64 @@ impl WritePath {
                 coordinator
                     .coordinate_fulltext_search(table_id, index_name, query, limit)
                     .await
+            }
+            Self::Unavailable => Err(crate::error::ClusterError::Internal(
+                "fulltext search unavailable: write path is in degraded mode".into(),
+            )),
+        }
+    }
+
+    /// Streaming fulltext search for the no-`LIMIT` / escalated shape
+    /// (t_4ae47a9f): yields batches of matching doc keys through a bounded
+    /// channel instead of one O(matches) `Vec` — the materialized union of a
+    /// broad `fts_match` is what OOM-killed replicas (t_8fc24ce2).
+    ///
+    /// Batch contract: cluster mode dedups across replicas at the
+    /// coordinator; Direct/Pair batches may contain cross-source duplicates
+    /// (memtable vs sidecar) — the caller dedups, exactly as it must for the
+    /// cluster path's cross-page keys. An `Err` item fails the whole search
+    /// (no silent partial match set); dropping the receiver cancels all
+    /// in-flight work.
+    ///
+    /// `FERROSA_BULK_STREAMING_FULLTEXT=0` (mixed-version rolling upgrades)
+    /// falls back to the legacy materializing union delivered as one batch —
+    /// degraded to the old memory profile, loudly logged at startup.
+    pub async fn fulltext_search_stream(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        query: &str,
+    ) -> crate::error::Result<tokio::sync::mpsc::Receiver<crate::error::Result<Vec<Vec<u8>>>>> {
+        match self {
+            Self::Direct(engine) => Ok(local_fulltext_key_stream(
+                engine.clone(),
+                table_id,
+                index_name,
+                query,
+            )),
+            Self::Pair(coordinator) | Self::DegradedPair(coordinator) => {
+                Ok(local_fulltext_key_stream(
+                    coordinator.local_storage().clone(),
+                    table_id,
+                    index_name,
+                    query,
+                ))
+            }
+            Self::Cluster(coordinator) => {
+                if coordinator.streaming_fulltext {
+                    coordinator
+                        .coordinate_fulltext_search_stream(table_id, index_name, query)
+                        .await
+                } else {
+                    // Legacy fallback: materialize the union (old memory
+                    // profile) and deliver it as a single batch.
+                    let keys = coordinator
+                        .coordinate_fulltext_search(table_id, index_name, query, None)
+                        .await?;
+                    let (tx, rx) = tokio::sync::mpsc::channel(1);
+                    let _ = tx.send(Ok(keys)).await;
+                    Ok(rx)
+                }
             }
             Self::Unavailable => Err(crate::error::ClusterError::Internal(
                 "fulltext search unavailable: write path is in degraded mode".into(),

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -254,6 +254,33 @@ fn committed_cdc_event(
     Some((bus, event))
 }
 
+/// Run a node-local full-text index scan on a blocking thread.
+///
+/// [`StorageEngine::fulltext_search`] is synchronous and blocking (directory
+/// enumeration + sequential sidecar walks + whole-file reads). Invoking it
+/// inline on an async worker starves that worker's other futures — raft
+/// heartbeats and CQL keepalives — which was a co-cause of the Bulk-lane
+/// timeout → retry storm during the OOM cascade (t_8fc24ce2; same class as the
+/// PR #131 range-read offload). Offloading it keeps the async runtime
+/// responsive while the scan runs.
+async fn offloaded_fulltext_search(
+    engine: Arc<StorageEngine>,
+    table_id: &TableId,
+    index_name: &str,
+    query: &str,
+    limit: Option<usize>,
+) -> crate::error::Result<Vec<Vec<u8>>> {
+    let table_id = table_id.clone();
+    let index_name = index_name.to_string();
+    let query = query.to_string();
+    tokio::task::spawn_blocking(move || {
+        engine.fulltext_search(&table_id, &index_name, &query, limit)
+    })
+    .await
+    .map_err(|e| crate::error::ClusterError::Internal(format!("fulltext_search task join: {e}")))?
+    .map_err(crate::error::ClusterError::Storage)
+}
+
 /// The active write path. Swapped atomically via `ArcSwap` when the
 /// deployment mode changes (standalone → pair → cluster).
 ///
@@ -987,13 +1014,19 @@ impl WritePath {
         limit: Option<usize>,
     ) -> crate::error::Result<Vec<Vec<u8>>> {
         match self {
-            Self::Direct(engine) => engine
-                .fulltext_search(table_id, index_name, query, limit)
-                .map_err(crate::error::ClusterError::Storage),
-            Self::Pair(coordinator) | Self::DegradedPair(coordinator) => coordinator
-                .local_storage()
-                .fulltext_search(table_id, index_name, query, limit)
-                .map_err(crate::error::ClusterError::Storage),
+            Self::Direct(engine) => {
+                offloaded_fulltext_search(engine.clone(), table_id, index_name, query, limit).await
+            }
+            Self::Pair(coordinator) | Self::DegradedPair(coordinator) => {
+                offloaded_fulltext_search(
+                    coordinator.local_storage().clone(),
+                    table_id,
+                    index_name,
+                    query,
+                    limit,
+                )
+                .await
+            }
             Self::Cluster(coordinator) => {
                 coordinator
                     .coordinate_fulltext_search(table_id, index_name, query, limit)

--- a/ferrosa-cluster/tests/fulltext_stream_memory_bound.rs
+++ b/ferrosa-cluster/tests/fulltext_stream_memory_bound.rs
@@ -1,0 +1,342 @@
+//! TDD guard (t_4ae47a9f, e2e): a broad no-`LIMIT` `fts_match` through the
+//! CLUSTER write path must stream its matching keys with a working set that
+//! is (a) complete, (b) independent of DOCUMENT size, and (c) inside a hard
+//! per-key budget.
+//!
+//! Live failure this pins (t_8fc24ce2): the legacy union path held the match
+//! set several times over — every replica's `score_map` (key + f64 score),
+//! the up-to-256 MiB bincode response frame, the coordinator's `seen` +
+//! `all_keys`, and the router's `matched` — and the compound-query arm
+//! `fs::read` the WHOLE FTI sidecar, so coordinator memory scaled with both
+//! the match count AND the indexed document bytes. Nodes at the intentional
+//! 2 GiB cap OOM-killed in cascade.
+//!
+//! The streaming path's ONLY O(distinct matches) allocation is the deduped
+//! key set itself (keys only — no scores, no extra copies, no row/doc
+//! bytes), so:
+//!   * doubling document size must NOT move the peak (assertion 2), and
+//!   * peak/key must fit a budget far below the multi-copy legacy shape
+//!     (assertion 3).
+//!
+//! Scope note (measured 2026-07-16): in THIS RF=1 single-node harness the
+//! legacy gate (`FERROSA_BULK_STREAMING_FULLTEXT=0`) measures ~187 B/key vs
+//! the stream's ~155 B/key — the earlier t_ee98faa0 layers already bound the
+//! node-LOCAL single-term path, and the legacy blowup's remaining copies
+//! (response frames, cross-replica unions) only exist with real remote
+//! replicas. So this test guards completeness/wiring/dedup, doc-size
+//! independence, the per-key backstop, and early-drop teardown; the sharp
+//! walk-level bound lives in
+//! `ferrosa-storage/tests/fulltext_streaming_each_memory_bound.rs`, and the
+//! multi-node validation is the live fly.io reproduction (t_4ae47a9f
+//! verification gate).
+//!
+//! Modeled on `range_scan_streaming_memory_bound.rs` (same single-node
+//! cluster WritePath harness — RF=1 exercises the full
+//! `coordinate_fulltext_search_stream` feeder/merge/dedup machinery with no
+//! remote fan-out) and `ferrosa-storage/tests/fulltext_replica_memory_bound.rs`
+//! (same peak-additional-heap tracker; seeding and flush run OUTSIDE the
+//! measurement window).
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+use ferrosa_common::key::{DecoratedKey, PartitionKey};
+use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+use ferrosa_common::{CellValue, Token};
+use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, TableId,
+};
+
+use ferrosa_cluster::consistency::ConsistencyLevel;
+use ferrosa_cluster::coordinator::ClusterCoordinator;
+use ferrosa_cluster::raft::{NodeInfo, NodeState};
+use ferrosa_cluster::ring::TokenRing;
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_net::config::NetConfig;
+use ferrosa_net::peer::{PeerEventListener, PeerManager};
+
+// --- peak-allocation tracker (scoped to this integration-test binary) ---
+struct TrackingAlloc;
+static ARMED: AtomicBool = AtomicBool::new(false);
+static LIVE: AtomicI64 = AtomicI64::new(0);
+static PEAK: AtomicI64 = AtomicI64::new(0);
+
+unsafe impl GlobalAlloc for TrackingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() && ARMED.load(Ordering::Relaxed) {
+            let live =
+                LIVE.fetch_add(layout.size() as i64, Ordering::Relaxed) + layout.size() as i64;
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        ptr
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if ARMED.load(Ordering::Relaxed) {
+            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+        }
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static ALLOC: TrackingAlloc = TrackingAlloc;
+
+static MEASURE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn measure_peak<R>(f: impl FnOnce() -> R) -> (R, i64) {
+    let _guard = MEASURE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    LIVE.store(0, Ordering::SeqCst);
+    PEAK.store(0, Ordering::SeqCst);
+    ARMED.store(true, Ordering::SeqCst);
+    let out = f();
+    ARMED.store(false, Ordering::SeqCst);
+    (out, PEAK.load(Ordering::SeqCst))
+}
+
+const KS: &str = "agent_memory";
+const TBL: &str = "entity_store";
+const IDX: &str = "idx_snippet";
+
+struct NoopListener;
+impl PeerEventListener for NoopListener {
+    fn on_peer_connected(&self, _peer: (uuid::Uuid, std::net::SocketAddr)) {}
+    fn on_peer_disconnected(&self, _peer: (uuid::Uuid, std::net::SocketAddr)) {}
+    fn on_peer_suspected(&self, _peer: (uuid::Uuid, std::net::SocketAddr)) {}
+    fn on_peer_recovered(&self, _peer_id: uuid::Uuid) {}
+    fn on_peer_failed(&self, _peer_id: uuid::Uuid) {}
+}
+
+fn engine(dir: &std::path::Path) -> Arc<StorageEngine> {
+    let config = StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            log_dir: dir.to_path_buf(),
+            checkpoint_dir: dir.to_path_buf(),
+            archive: None,
+            ..CommitLogConfig::default()
+        },
+        compaction: CompactionConfig::from_env(dir.join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        // Flush explicitly, once: one SSTable + one FTI sidecar, empty
+        // memtable inside the measurement window.
+        flush_threshold_bytes: u64::MAX,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 3600,
+        data_dir: dir.to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        auth_enabled: false,
+        auth_warn: false,
+        write_verify: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+    let schema = TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        clustering_columns: vec![],
+        static_columns: vec![],
+        regular_columns: vec![ColumnDefinition {
+            name: "context_snippet".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        }],
+        extensions: Default::default(),
+    };
+    engine.register_table(schema).unwrap();
+    engine
+        .add_fulltext_index(&TableId::new(KS, TBL), IDX, 0)
+        .unwrap();
+    engine
+}
+
+/// Seed `n` docs that ALL contain the broad term "memory", padding each
+/// snippet to ~`doc_bytes` so the FTI sidecar's size scales with the
+/// document payload while the doc KEYS stay identical across runs.
+fn seed_and_flush(engine: &StorageEngine, n: usize, doc_bytes: usize) {
+    let table_id = TableId::new(KS, TBL);
+    for i in 0..n {
+        let key_bytes = format!("entity-{i:016}").into_bytes();
+        let dk = DecoratedKey {
+            token: Token(i as i64),
+            key: PartitionKey::new(key_bytes),
+        };
+        // Distinct filler tokens per doc keep the index honest (real term
+        // dictionary growth), padded to the requested payload size.
+        let mut text = format!("memory snippet {i} durable typed agent entity {i}");
+        while text.len() < doc_bytes {
+            text.push_str(" filler");
+            text.push_str(&(text.len() % 97).to_string());
+        }
+        let row = Row {
+            clustering: vec![],
+            cells: vec![(0, CellValue::live(text.into_bytes(), 1000))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(1000),
+        };
+        engine.write(&table_id, &dk, row, 1000).unwrap();
+    }
+    engine.flush(&table_id).unwrap();
+}
+
+/// Single-node cluster `WritePath` (RF=1): exercises the full
+/// `coordinate_fulltext_search_stream` feeder → merge → dedup machinery with
+/// no remote fan-out.
+fn cluster_write_path(storage: Arc<StorageEngine>) -> WritePath {
+    let node_id = 1u64;
+    let mut ring = TokenRing::new();
+    ring.add_node(
+        node_id,
+        NodeInfo {
+            host_id: uuid::Uuid::new_v4(),
+            addr: "10.0.0.1:7000".to_string(),
+            data_center: "dc1".to_string(),
+            rack: "rack1".to_string(),
+            state: NodeState::Normal,
+            cql_broadcast: None,
+        },
+    );
+    ring.assign_tokens(node_id, &[i64::MIN, 0, i64::MAX]);
+    let peers = Arc::new(PeerManager::new(
+        Arc::new(NetConfig::default()),
+        uuid::Uuid::new_v4(),
+        Arc::new(NoopListener),
+    ));
+    let coordinator = ClusterCoordinator::new(
+        Arc::new(ArcSwap::from_pointee(ring)),
+        peers,
+        node_id,
+        storage,
+        1,
+        ConsistencyLevel::One,
+    );
+    WritePath::cluster(Arc::new(coordinator))
+}
+
+/// Drain a cluster streaming fulltext search, counting distinct keys without
+/// holding them; returns (distinct_keys, peak_additional_heap).
+fn cluster_fts_stream_peak(n: usize, doc_bytes: usize) -> (usize, i64) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = engine(dir.path());
+    seed_and_flush(&storage, n, doc_bytes);
+    let wp = cluster_write_path(storage);
+    let table_id = TableId::new(KS, TBL);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Warm sanity pass OUTSIDE the window: the stream is real and complete.
+    let warm: usize = rt.block_on(async {
+        let mut rx = wp
+            .fulltext_search_stream(&table_id, IDX, "memory")
+            .await
+            .expect("open fulltext stream");
+        let mut count = 0usize;
+        while let Some(item) = rx.recv().await {
+            count += item.expect("stream batch").len();
+        }
+        count
+    });
+    assert_eq!(warm, n, "warm pass must deliver every matching doc key");
+
+    measure_peak(|| {
+        rt.block_on(async {
+            let mut rx = wp
+                .fulltext_search_stream(&table_id, IDX, "memory")
+                .await
+                .expect("open fulltext stream");
+            let mut count = 0usize;
+            while let Some(item) = rx.recv().await {
+                count += item.expect("stream batch").len();
+            }
+            count
+        })
+    })
+}
+
+/// Per-key budget for the coordinator-side stream: the deduped key set
+/// (~22-byte keys in `HashSet<Vec<u8>>`, measured ~155 B/key with allocator
+/// overhead) plus bounded channels and one in-flight batch. A multi-copy
+/// regression (scores + duplicate unions, ~3× and up) trips this backstop.
+const PER_KEY_BUDGET_BYTES: i64 = 256;
+
+/// (a) completeness at scale through the full cluster write path,
+/// (b) peak independent of DOCUMENT bytes, (c) hard per-key budget.
+#[test]
+fn cluster_fulltext_stream_peak_bounded_and_doc_size_independent() {
+    const N: usize = 8_000;
+    const SMALL_DOC: usize = 64;
+    const LARGE_DOC: usize = 4_096; // 64× the payload, identical keys
+
+    let (count_small, peak_small) = cluster_fts_stream_peak(N, SMALL_DOC);
+    let (count_large, peak_large) = cluster_fts_stream_peak(N, LARGE_DOC);
+    eprintln!(
+        "cluster fts stream peak: doc={SMALL_DOC}B -> {peak_small} B, \
+         doc={LARGE_DOC}B -> {peak_large} B, ratio={:.2}; \
+         budget={} B (N={N} keys x {PER_KEY_BUDGET_BYTES} B)",
+        peak_large as f64 / peak_small.max(1) as f64,
+        N as i64 * PER_KEY_BUDGET_BYTES,
+    );
+
+    assert_eq!(count_small, N, "every matching key, exactly once (dedup)");
+    assert_eq!(count_large, N, "every matching key, exactly once (dedup)");
+
+    // (b) Document payload must not reach the key stream: 64× bigger docs
+    // may not move the peak beyond allocator noise. The legacy compound arm
+    // read the ENTIRE sidecar (O(index bytes)) and every arm carried scores;
+    // both scale with doc payload and fail this.
+    assert!(
+        peak_large < peak_small.max(256 * 1024) * 2,
+        "REGRESSION (t_4ae47a9f e2e): fulltext stream peak scales with document \
+         size — {SMALL_DOC}B docs: {peak_small} B vs {LARGE_DOC}B docs: {peak_large} B. \
+         Document/index bytes are leaking into the key-streaming path."
+    );
+
+    // (c) Hard budget: keys-only, one deduped copy, bounded plumbing.
+    let budget = N as i64 * PER_KEY_BUDGET_BYTES;
+    assert!(
+        peak_large < budget,
+        "REGRESSION (t_4ae47a9f e2e): fulltext stream peak {peak_large} B exceeds \
+         the {budget} B keys-only budget (N={N} × {PER_KEY_BUDGET_BYTES} B). The \
+         multi-copy legacy union (scores + response frames + duplicate sets) is back."
+    );
+}
+
+/// Dropping the receiver early must tear the stream down promptly (feeders
+/// observe closed channels and stop) — the consumer-paced cancel contract.
+/// Guards against a regression where an abandoned no-LIMIT search keeps
+/// walking and buffering in the background.
+#[test]
+fn cluster_fulltext_stream_early_drop_stops_cleanly() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = engine(dir.path());
+    seed_and_flush(&storage, 20_000, 64);
+    let wp = cluster_write_path(storage);
+    let table_id = TableId::new(KS, TBL);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let mut rx = wp
+            .fulltext_search_stream(&table_id, IDX, "memory")
+            .await
+            .expect("open fulltext stream");
+        // Take one batch, then abandon the stream.
+        let first = rx.recv().await.expect("at least one batch");
+        assert!(!first.expect("stream batch").is_empty());
+        drop(rx);
+        // The runtime must quiesce: give spawned feeders a beat to observe
+        // the closed channels. A hang here (walk still running unbounded)
+        // fails via the test harness timeout.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    });
+}

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -4087,6 +4087,16 @@ thread_local! {
 
 #[cfg(test)]
 thread_local! {
+    /// Test-only observability: how many times the `fts_match` arm fetched a
+    /// hit set (bounded top-k consult or complete stream) on this thread.
+    /// Pins the t_4ae47a9f contract: at most ONE bounded consult plus ONE
+    /// complete-stream fallback — never the removed geometric escalation
+    /// loop's unbounded re-consults (4 → 16 → 64 → …).
+    static FTS_MATCH_HIT_SET_FETCHES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+thread_local! {
     /// Test-only observability: rows MATERIALIZED by the full-partition-key
     /// SELECT branch on this thread, before the residual-predicate post-filter.
     /// Lets tests assert STRUCTURALLY that `WHERE <full pk> AND <indexed> = ?`
@@ -4215,60 +4225,73 @@ async fn route_select_user_table(
             None
         };
 
-        // Memory bounds for this arm (t_ee98faa0 — a broad `fts_match` over a
-        // large table OOM-killed live nodes, first at the coordinator, then
-        // layer 2 inside every replica's `fulltext_search`):
-        //   * LIMIT k — the bound is pushed down to every replica
-        //     (`fulltext_search(.., Some(requested))`), so each holds a bounded
-        //     top-k working set and the unioned hit set is O(replicas × k).
-        //     Post-filter key exhaustion is handled by GEOMETRIC ESCALATION
-        //     (below) — never by a server-side cap.
-        //   * no LIMIT — the complete match set is legitimately required
-        //     (`limit=None` down the stack); ROW memory is still bounded by
-        //     building one page per response with a `PagingState` continuation.
-        // The result is NEVER truncated server-side: it is bounded only by the
-        // query's own LIMIT (or delivered completely across pages).
-        //
-        // Escalation loop: start with `requested = k`. If the post-filter
-        // (non-fts predicates + row-granular doc-key retain) drops enough rows
-        // that fewer than `limit` survive AND the replica hit set may have been
-        // truncated (union size >= requested implies SOME replica may have hit
-        // its bound; union < requested proves every replica returned its
-        // complete local set), retry with `requested × 4`. Terminates because
-        // `requested` grows geometrically and once it exceeds every replica's
-        // local match count the union is provably complete. Peak memory is
-        // O(final requested) — derived from the query's LIMIT and the actual
-        // post-filter selectivity, not a server constant.
-        let mut requested: Option<usize> = fts_limit;
+        // Memory bounds for this arm (t_ee98faa0 replica top-k + t_4ae47a9f
+        // streaming — a broad `fts_match` used to OOM-kill live nodes):
+        //   * LIMIT k — ONE bounded consult (`fulltext_search(.., Some(k))`;
+        //     every replica holds a top-k working set, union is
+        //     O(replicas × k)). If the post-filter leaves fewer than k rows
+        //     AND the hit set may be truncated, fall back ONCE to the
+        //     complete streamed match set — the removed geometric ×4
+        //     escalation loop instead re-consulted every replica with a
+        //     widening k until its terminal round degraded to `limit=None`
+        //     materialization on every replica at once (the t_8fc24ce2 OOM
+        //     shape).
+        //   * no LIMIT — the complete match set is legitimately required and
+        //     is collected from the bounded streaming protocol
+        //     (`fulltext_search_stream`): replicas walk their FTI with an
+        //     O(1) working set and ship bounded key chunks; the ONLY
+        //     O(distinct matches) allocation left is the deduped key set
+        //     itself, which this arm needs for row-granular doc-key
+        //     retention. ROW memory stays bounded by per-page delivery with
+        //     a `PagingState` continuation.
+        // The result is NEVER truncated server-side: it is bounded only by
+        // the query's own LIMIT (or delivered completely across pages).
+        let mut use_complete_stream = fts_limit.is_none();
         let (fts_rows, fts_paging_state) = loop {
-            // Route the FTI lookup through the write path so it scatter-gathers
-            // across the cluster. `fts_match` carries no partition key, so its
-            // hits span all token ranges; a coordinator-local lookup returned
-            // 0/1 depending on which node served the query (BUG-F-007 /
-            // t_0d08aa43). Standalone/pair still resolves locally via the same
-            // call.
-            let matching_pks = state
-                .write_path
-                .load()
-                .fulltext_search(&table_id, index_name, fts_query, requested)
-                .await
-                .map_err(|e| CqlError::Invalid(format!("fts_match search failed: {e}")))?;
-
-            // Complete ⇔ no replica can have truncated its local hit set: a
-            // replica truncates only when its local matches exceed `requested`,
-            // in which case it returns exactly `requested` keys and the union
-            // has at least that many.
-            let hit_set_complete = match requested {
-                None => true,
-                Some(r) => matching_pks.len() < r,
-            };
-
-            // `matching_pks` are full-key document ids (partition +
-            // clustering), one per matching ROW. Read each distinct partition
-            // once, keep ONLY the rows whose full key actually matched — so
-            // non-matching clustering rows in a matched partition don't leak
-            // (t_da51e20c) — then post-filter.
-            let matched: std::collections::HashSet<Vec<u8>> = matching_pks.into_iter().collect();
+            // Route the lookup through the write path so it scatter-gathers
+            // across the cluster. `fts_match` carries no partition key, so
+            // its hits span all token ranges; a coordinator-local lookup
+            // returned 0/1 depending on which node served the query
+            // (BUG-F-007 / t_0d08aa43). Standalone/pair resolve locally via
+            // the same calls.
+            #[cfg(test)]
+            FTS_MATCH_HIT_SET_FETCHES.with(|c| c.set(c.get() + 1));
+            // `matched` holds full-key document ids (partition + clustering),
+            // one per matching ROW. Read each distinct partition once, keep
+            // ONLY the rows whose full key actually matched — so non-matching
+            // clustering rows in a matched partition don't leak (t_da51e20c)
+            // — then post-filter.
+            let (matched, hit_set_complete): (std::collections::HashSet<Vec<u8>>, bool) =
+                if use_complete_stream {
+                    let mut rx = state
+                        .write_path
+                        .load()
+                        .fulltext_search_stream(&table_id, index_name, fts_query)
+                        .await
+                        .map_err(|e| CqlError::Invalid(format!("fts_match search failed: {e}")))?;
+                    let mut matched: std::collections::HashSet<Vec<u8>> = Default::default();
+                    while let Some(item) = rx.recv().await {
+                        let batch = item.map_err(|e| {
+                            CqlError::Invalid(format!("fts_match search failed: {e}"))
+                        })?;
+                        matched.extend(batch);
+                    }
+                    (matched, true)
+                } else {
+                    let k = fts_limit.expect("bounded consult only runs with a LIMIT");
+                    let matching_pks = state
+                        .write_path
+                        .load()
+                        .fulltext_search(&table_id, index_name, fts_query, Some(k))
+                        .await
+                        .map_err(|e| CqlError::Invalid(format!("fts_match search failed: {e}")))?;
+                    // Complete ⇔ no replica can have truncated its local hit
+                    // set: a replica truncates only when its local matches
+                    // exceed `k`, in which case it returns exactly `k` keys
+                    // and the union has at least that many.
+                    let complete = matching_pks.len() < k;
+                    (matching_pks.into_iter().collect(), complete)
+                };
 
             // Distinct matched partitions in a DETERMINISTIC order (raw
             // partition-key bytes). CQL promises no ordering for this arm, but
@@ -4365,20 +4388,22 @@ async fn route_select_user_table(
             }
 
             match fts_limit {
-                Some(limit) if fts_rows.len() < limit && !hit_set_complete => {
+                Some(limit)
+                    if fts_rows.len() < limit && !hit_set_complete && !use_complete_stream =>
+                {
                     // Post-filtering exhausted the bounded hit set before the
-                    // LIMIT was satisfied and more matches may exist — escalate.
-                    let next = requested.unwrap_or(limit).max(1).saturating_mul(4);
+                    // LIMIT was satisfied and more matches may exist — fall
+                    // back ONCE to the complete streamed match set. Bounded
+                    // everywhere by construction, so no re-consult loop.
                     tracing::debug!(
                         keyspace = ks,
                         table = %s.table,
                         limit,
                         rows_surviving = fts_rows.len(),
-                        requested = ?requested,
-                        next_requested = next,
-                        "fts_match: post-filter exhausted the bounded hit set — escalating"
+                        "fts_match: post-filter exhausted the bounded hit set — \
+                         falling back to the complete streamed match set"
                     );
-                    requested = Some(next);
+                    use_complete_stream = true;
                 }
                 _ => break (fts_rows, fts_paging_state),
             }
@@ -20073,11 +20098,11 @@ mod tests {
     /// LIMIT counts only rows that SURVIVE the post-filter: rows dropped by
     /// non-fts predicates must not count toward LIMIT. With the replica-side
     /// bound pushed down (t_ee98faa0 layer 2) the hit set arrives as the k
-    /// best doc keys, so exhausting it via the post-filter triggers GEOMETRIC
-    /// ESCALATION (k → 4k) rather than a wrong short result:
-    ///   * round 1 (requested=2): keys {1,2}, both flag=0 → dropped → 2 reads;
-    ///   * round 2 (requested=8): keys {1..8}, reads 1..=5 (3 dropped + 2
-    ///     kept) then stops at the LIMIT bound → 5 reads.
+    /// best doc keys, so exhausting it via the post-filter triggers the ONE
+    /// complete-stream fallback (t_4ae47a9f) rather than a wrong short result:
+    ///   * round 1 (bounded, k=2): keys {1,2}, both flag=0 → dropped → 2 reads;
+    ///   * round 2 (complete stream): keys {1..10}, reads 1..=5 (3 dropped +
+    ///     2 kept) then stops at the LIMIT bound → 5 reads.
     #[tokio::test]
     async fn fts_match_limit_post_filtered_rows_do_not_count_toward_limit() {
         let (state, _dir) = setup();
@@ -20117,14 +20142,15 @@ mod tests {
         );
     }
 
-    /// Escalation completeness (t_ee98faa0 layer 2): when the post-filter can
-    /// drop MOST of the bounded hit set, the arm must keep escalating the
-    /// pushed-down k until either LIMIT rows survive or the hit set is
-    /// provably complete — the result must NEVER be short while more matches
-    /// exist. 30 matching rows, only the last 5 survive `flag = 1`; LIMIT 4
-    /// must return 4 rows even though requested starts at 4 « 25 dropped.
+    /// Fallback completeness (t_ee98faa0 layer 2 / t_4ae47a9f): when the
+    /// post-filter drops MOST of the bounded hit set, the arm must fall back
+    /// to the complete streamed match set so either LIMIT rows survive or the
+    /// hit set is provably complete — the result must NEVER be short while
+    /// more matches exist. 30 matching rows, only the last 5 survive
+    /// `flag = 1`; LIMIT 4 must return 4 rows even though the bounded round
+    /// requested only 4 « 25 dropped.
     #[tokio::test]
-    async fn fts_match_limit_escalates_until_limit_survives_post_filter() {
+    async fn fts_match_limit_fallback_completes_until_limit_survives_post_filter() {
         let (state, _dir) = setup();
         let ctx = RequestContext {
             auth: &dev_auth(),
@@ -20169,6 +20195,64 @@ mod tests {
             vec![26, 27, 28, 29, 30],
             "when the complete surviving set is smaller than LIMIT, exactly \
              that set must be returned (and the escalation loop must stop)"
+        );
+    }
+
+    /// t_4ae47a9f: the geometric escalation loop is GONE. A post-filter that
+    /// drops most of the bounded hit set triggers exactly ONE fallback to the
+    /// complete streamed match set — never repeated re-consults with a
+    /// widening pushed-down k (the old 4 → 16 → 64 loop, whose terminal
+    /// iteration degraded to `limit=None` materialization on every replica —
+    /// the t_8fc24ce2 OOM shape). No-LIMIT queries go straight to the
+    /// complete stream: exactly one hit-set fetch.
+    #[tokio::test]
+    async fn fts_match_limit_falls_back_to_complete_stream_at_most_once() {
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+            protocol_version: 4,
+        };
+        // ids 1..=25 flag=0 (post-filter drops them), ids 26..=30 flag=1.
+        seed_fts_docs(&state, &ctx, "fts_fb", "fbterm", 30, 25).await;
+
+        FTS_MATCH_HIT_SET_FETCHES.with(|c| c.set(0));
+        let raw = fts_select_raw(
+            &state,
+            &ctx,
+            "fts_fb",
+            "SELECT id FROM fts_fb.docs WHERE body = fts_match('fbterm') \
+             AND flag = 1 LIMIT 4 ALLOW FILTERING",
+        )
+        .await;
+        assert_eq!(fts_row_ids(&raw), vec![26, 27, 28, 29]);
+        let fetches = FTS_MATCH_HIT_SET_FETCHES.with(|c| c.get());
+        assert_eq!(
+            fetches, 2,
+            "LIMIT with a hostile post-filter must fetch the hit set exactly \
+             twice (bounded consult + one complete-stream fallback); {fetches} \
+             fetches means the geometric escalation loop is back"
+        );
+
+        // No LIMIT: straight to the complete stream — one fetch.
+        FTS_MATCH_HIT_SET_FETCHES.with(|c| c.set(0));
+        let raw = fts_select_raw(
+            &state,
+            &ctx,
+            "fts_fb",
+            "SELECT id FROM fts_fb.docs WHERE body = fts_match('fbterm') \
+             AND flag = 1 ALLOW FILTERING",
+        )
+        .await;
+        assert_eq!(fts_row_ids(&raw), vec![26, 27, 28, 29, 30]);
+        let fetches = FTS_MATCH_HIT_SET_FETCHES.with(|c| c.get());
+        assert_eq!(
+            fetches, 1,
+            "a no-LIMIT fts_match must consult the complete stream exactly once"
         );
     }
 

--- a/ferrosa-index/src/fulltext/stream.rs
+++ b/ferrosa-index/src/fulltext/stream.rs
@@ -92,7 +92,7 @@ pub fn scan_term_top_k(
 /// are identical to [`super::reader::FullTextIndexReader::search`] for a
 /// `FtsQuery::Term`.
 ///
-/// `on_hit` returns [`ControlFlow::Break`] to stop the walk early (consumer-paced
+/// `on_hit` returns [`std::ops::ControlFlow::Break`] to stop the walk early (consumer-paced
 /// backpressure — e.g. the downstream channel's receiver was dropped, or a
 /// `LIMIT` is already satisfied). Because the term dictionary is written sorted,
 /// the walk also early-exits as soon as it passes the target term.

--- a/ferrosa-index/src/fulltext/stream.rs
+++ b/ferrosa-index/src/fulltext/stream.rs
@@ -10,15 +10,25 @@
 //! [`super::builder`] for the layout) through a [`std::io::BufReader`]
 //! instead:
 //!
-//! * [`scan_term_top_k`] — single-term search (the live-OOM query shape).
-//!   Postings of the one matching term are scored as they are decoded and fed
-//!   into a bounded top-k heap when the query carries a `LIMIT k`; peak
-//!   additional memory is O(k), independent of the index or matching-doc
-//!   count. Without a limit the complete hit set is returned (O(matches) —
-//!   the result itself, nothing more).
+//! * [`scan_term_each`] — the non-materializing primitive: hands each match to
+//!   a callback as it is decoded, holding an O(1) working set (one posting key
+//!   at a time) and stopping early on [`std::ops::ControlFlow::Break`]. A caller
+//!   that forwards hits into a bounded channel keeps peak memory independent of
+//!   the matching-doc count even without a `LIMIT` — the shape that OOM-killed
+//!   replicas on a broad `fts_match` (t_8fc24ce2).
+//! * [`scan_term_top_k`] — single-term search (the live-OOM query shape), built
+//!   on `scan_term_each`. Postings of the one matching term are scored as they
+//!   are decoded and fed into a bounded top-k heap when the query carries a
+//!   `LIMIT k`; peak additional memory is O(k), independent of the index or
+//!   matching-doc count. Without a limit the complete hit set is returned
+//!   (O(matches) — the result itself, nothing more).
 //!
 //! The term dictionary is written sorted (see `serialize_fti`), so the walk
 //! early-exits as soon as it passes the target term.
+//!
+//! Last revised: 2026-07-15
+//! Last changed: Extracted `scan_term_each` (non-materializing callback walk)
+//! as the primitive underneath `scan_term_top_k`, for bounded-memory streaming.
 
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
@@ -47,6 +57,53 @@ pub fn scan_term_top_k(
     if limit == Some(0) {
         return Ok(vec![]);
     }
+    let mut topk = limit.map(TopK::new);
+    let mut all_hits: Vec<FtsHit> = Vec::new();
+
+    scan_term_each(path, term, |hit| {
+        match topk.as_mut() {
+            Some(t) => t.push_owned(hit.partition_key, hit.score),
+            None => all_hits.push(hit),
+        }
+        std::ops::ControlFlow::Continue(())
+    })?;
+
+    Ok(match topk {
+        Some(t) => t.into_hits(),
+        None => {
+            all_hits.sort_by(|a, b| {
+                b.score
+                    .total_cmp(&a.score)
+                    .then_with(|| a.partition_key.cmp(&b.partition_key))
+            });
+            all_hits
+        }
+    })
+}
+
+/// Streaming single-term search that hands each match to `on_hit` **as it is
+/// decoded**, holding no growing result buffer of its own.
+///
+/// This is the non-materializing primitive underneath [`scan_term_top_k`]: the
+/// walk's own working set is O(1) (one posting key at a time), so a caller that
+/// forwards hits into a bounded channel keeps peak memory independent of the
+/// matching-doc count — the shape that OOM-killed replicas on a broad
+/// `fts_match` with no `LIMIT` (t_8fc24ce2). Matching semantics and BM25 scores
+/// are identical to [`super::reader::FullTextIndexReader::search`] for a
+/// `FtsQuery::Term`.
+///
+/// `on_hit` returns [`ControlFlow::Break`] to stop the walk early (consumer-paced
+/// backpressure — e.g. the downstream channel's receiver was dropped, or a
+/// `LIMIT` is already satisfied). Because the term dictionary is written sorted,
+/// the walk also early-exits as soon as it passes the target term.
+///
+/// # Errors
+///
+/// Returns `Err` on I/O failure or a malformed/truncated FTI file.
+pub fn scan_term_each<F>(path: &Path, term: &str, mut on_hit: F) -> Result<(), String>
+where
+    F: FnMut(FtsHit) -> std::ops::ControlFlow<()>,
+{
     let file = File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
     let file_len = file
         .metadata()
@@ -92,8 +149,6 @@ pub fn scan_term_top_k(
     let params = Bm25Params::default();
     let target = term.as_bytes();
     let mut term_buf: Vec<u8> = Vec::new();
-    let mut topk = limit.map(TopK::new);
-    let mut all_hits: Vec<FtsHit> = Vec::new();
 
     for _ in 0..term_count {
         let term_len = read_u16(&mut reader)? as usize;
@@ -132,12 +187,13 @@ pub fn scan_term_top_k(
                         avgdl,
                         &params,
                     );
-                    match topk.as_mut() {
-                        Some(t) => t.push_owned(pk, score),
-                        None => all_hits.push(FtsHit {
-                            partition_key: pk,
-                            score,
-                        }),
+                    if on_hit(FtsHit {
+                        partition_key: pk,
+                        score,
+                    })
+                    .is_break()
+                    {
+                        return Ok(());
                     }
                 }
                 break; // dictionary is sorted; the term appears once.
@@ -146,17 +202,7 @@ pub fn scan_term_top_k(
         }
     }
 
-    Ok(match topk {
-        Some(t) => t.into_hits(),
-        None => {
-            all_hits.sort_by(|a, b| {
-                b.score
-                    .total_cmp(&a.score)
-                    .then_with(|| a.partition_key.cmp(&b.partition_key))
-            });
-            all_hits
-        }
-    })
+    Ok(())
 }
 
 fn read_u8(r: &mut impl Read) -> Result<u8, String> {
@@ -186,6 +232,8 @@ fn read_u64(r: &mut impl Read) -> Result<u64, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ops::ControlFlow;
+
     use crate::fulltext::builder::FullTextIndexBuilder;
     use crate::fulltext::reader::FullTextIndexReader;
 
@@ -264,6 +312,89 @@ mod tests {
             assert_eq!(a.partition_key, b.partition_key, "top-k must be the best k");
             assert!((a.score - b.score).abs() < 1e-12);
         }
+    }
+
+    #[test]
+    fn scan_term_each_yields_every_match_without_materializing() {
+        // The callback walk must visit exactly the same hit set (keys + scores)
+        // as `scan_term_top_k(.., None)`, one hit at a time, holding no growing
+        // result Vec of its own.
+        let dir = tempfile::tempdir().unwrap();
+        let docs: Vec<(Vec<u8>, String)> = (0..120)
+            .map(|i| {
+                let text = if i % 2 == 0 {
+                    format!("memory row {i}")
+                } else {
+                    format!("filler row {i}")
+                };
+                (format!("pk{i:04}").into_bytes(), text)
+            })
+            .collect();
+        let doc_refs: Vec<(&[u8], &str)> = docs
+            .iter()
+            .map(|(pk, t)| (pk.as_slice(), t.as_str()))
+            .collect();
+        let path = write_fti(dir.path(), &doc_refs);
+
+        let expected = scan_term_top_k(&path, "memory", None).unwrap();
+
+        let mut seen: Vec<FtsHit> = Vec::new();
+        scan_term_each(&path, "memory", |hit| {
+            seen.push(hit);
+            ControlFlow::Continue(())
+        })
+        .unwrap();
+
+        assert_eq!(seen.len(), expected.len(), "same number of matches");
+        let expected_keys: std::collections::HashSet<_> =
+            expected.iter().map(|h| h.partition_key.clone()).collect();
+        for hit in &seen {
+            assert!(expected_keys.contains(&hit.partition_key));
+            let exp = expected
+                .iter()
+                .find(|h| h.partition_key == hit.partition_key)
+                .unwrap();
+            assert!((exp.score - hit.score).abs() < 1e-12, "identical score");
+        }
+    }
+
+    #[test]
+    fn scan_term_each_early_exit_stops_the_walk() {
+        // Returning `Break` after the first hit must halt the walk immediately
+        // (consumer-paced backpressure): the callback is not invoked again.
+        let dir = tempfile::tempdir().unwrap();
+        let docs: Vec<(Vec<u8>, String)> = (0..50)
+            .map(|i| (format!("pk{i:04}").into_bytes(), "memory".to_string()))
+            .collect();
+        let doc_refs: Vec<(&[u8], &str)> = docs
+            .iter()
+            .map(|(pk, t)| (pk.as_slice(), t.as_str()))
+            .collect();
+        let path = write_fti(dir.path(), &doc_refs);
+
+        let mut count = 0usize;
+        scan_term_each(&path, "memory", |_hit| {
+            count += 1;
+            ControlFlow::Break(())
+        })
+        .unwrap();
+
+        assert_eq!(count, 1, "walk stops at the first Break");
+    }
+
+    #[test]
+    fn scan_term_each_truncated_file_fails_loudly() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_fti(dir.path(), &[(b"pk1", "hello world")]);
+        let bytes = std::fs::read(&path).unwrap();
+        let cut = dir.path().join("cut2.db");
+        std::fs::write(&cut, &bytes[..bytes.len() / 2]).unwrap();
+        let mut count = 0usize;
+        let res = scan_term_each(&cut, "hello", |_| {
+            count += 1;
+            ControlFlow::Continue(())
+        });
+        assert!(res.is_err());
     }
 
     #[test]

--- a/ferrosa-net/README.md
+++ b/ferrosa-net/README.md
@@ -36,7 +36,10 @@ It is a near-leaf in the dependency graph: it depends only on `ferrosa-common`
   length-prefixed encode/decode for lifecycle, Raft, mutation/read, repair,
   streaming, pair-mode, batchlog, index (incl. full-text scatter-gather and
   the keyed `IndexReadInPartition{Request,Response}` `0x66`/`0x67` pair,
-  t_430c4188), Accord
+  t_430c4188, and the streaming fulltext family
+  `FulltextSearchStream{Request,Chunk,Heartbeat,Done,Cancel}` `0x3B`..=`0x3F`,
+  t_4ae47a9f — the `fts_match` twin of the ADR-020 range-read stream whose
+  Chunk/Heartbeat/Done frames are `is_ordered_stream_response`), Accord
   (incl. the additive multi-key `AccordPreAcceptV2` `0x7B` / `AccordApplyV2` `0x7C`
   codes — bincode is not self-describing, so multi-key transactions get new codes
   rather than extending the single-key payloads), and bootstrap message types

--- a/ferrosa-net/src/codec.rs
+++ b/ferrosa-net/src/codec.rs
@@ -113,6 +113,14 @@ pub enum MsgType {
     RangeReadStreamHeartbeat = 0x38,
     RangeReadStreamDone = 0x39,
     RangeReadStreamCancel = 0x3A,
+    // Streaming fulltext search (t_4ae47a9f) — the fts_match twin of the
+    // ADR-020 range-read stream: matching doc KEYS flow back in bounded
+    // chunks keyed by request_id instead of one O(matches) FulltextSearchResponse.
+    FulltextSearchStreamRequest = 0x3B,
+    FulltextSearchStreamChunk = 0x3C,
+    FulltextSearchStreamHeartbeat = 0x3D,
+    FulltextSearchStreamDone = 0x3E,
+    FulltextSearchStreamCancel = 0x3F,
     // Streaming (row-based)
     StreamStart = 0x30,
     StreamChunk = 0x31,
@@ -211,7 +219,12 @@ impl MsgType {
     pub fn is_ordered_stream_response(self) -> bool {
         matches!(
             self,
-            Self::RangeReadStreamChunk | Self::RangeReadStreamHeartbeat | Self::RangeReadStreamDone
+            Self::RangeReadStreamChunk
+                | Self::RangeReadStreamHeartbeat
+                | Self::RangeReadStreamDone
+                | Self::FulltextSearchStreamChunk
+                | Self::FulltextSearchStreamHeartbeat
+                | Self::FulltextSearchStreamDone
         )
     }
 }
@@ -243,6 +256,11 @@ impl TryFrom<u8> for MsgType {
             0x38 => Ok(Self::RangeReadStreamHeartbeat),
             0x39 => Ok(Self::RangeReadStreamDone),
             0x3A => Ok(Self::RangeReadStreamCancel),
+            0x3B => Ok(Self::FulltextSearchStreamRequest),
+            0x3C => Ok(Self::FulltextSearchStreamChunk),
+            0x3D => Ok(Self::FulltextSearchStreamHeartbeat),
+            0x3E => Ok(Self::FulltextSearchStreamDone),
+            0x3F => Ok(Self::FulltextSearchStreamCancel),
             0x27 => Ok(Self::TruncateForward),
             0x28 => Ok(Self::TruncateAck),
             0x29 => Ok(Self::RepairMerkleRequest),
@@ -691,6 +709,30 @@ mod tests {
         let val = MsgType::IndexBuildComplete as u8;
         let parsed = MsgType::try_from(val).unwrap();
         assert_eq!(parsed, MsgType::IndexBuildComplete);
+    }
+
+    /// t_4ae47a9f: the streaming-fulltext frame family round-trips through
+    /// the wire ids 0x3B–0x3F, and its response frames (Chunk / Heartbeat /
+    /// Done) are classified as ordered stream responses so inbound dispatch
+    /// preserves wire order — exactly like the range-read stream family.
+    #[test]
+    fn fulltext_stream_msg_types_roundtrip_and_classify() {
+        let all = [
+            (MsgType::FulltextSearchStreamRequest, 0x3Bu8, false),
+            (MsgType::FulltextSearchStreamChunk, 0x3C, true),
+            (MsgType::FulltextSearchStreamHeartbeat, 0x3D, true),
+            (MsgType::FulltextSearchStreamDone, 0x3E, true),
+            (MsgType::FulltextSearchStreamCancel, 0x3F, false),
+        ];
+        for (ty, byte, ordered) in all {
+            assert_eq!(ty as u8, byte, "{ty:?} wire id");
+            assert_eq!(MsgType::try_from(byte).unwrap(), ty, "{ty:?} roundtrip");
+            assert_eq!(
+                ty.is_ordered_stream_response(),
+                ordered,
+                "{ty:?} ordered-stream classification"
+            );
+        }
     }
 
     #[test]

--- a/ferrosa-net/src/message.rs
+++ b/ferrosa-net/src/message.rs
@@ -176,6 +176,25 @@ pub enum Message {
     /// satisfied, KILL issued). Handler stops iterating between
     /// batches.
     RangeReadStreamCancel(Bytes),
+    /// t_4ae47a9f: client side of the streaming fulltext-search RPC —
+    /// the `fts_match` twin of `RangeReadStreamRequest`. Payload is a
+    /// bincoded `FulltextSearchStreamRequestPayload` (defined in
+    /// ferrosa-cluster) carrying `request_id`, keyspace/table,
+    /// index name, and query.
+    FulltextSearchStreamRequest(Bytes),
+    /// t_4ae47a9f: one bounded batch of matching doc KEYS belonging to
+    /// a streaming fulltext response, keyed by `request_id`. Payload is
+    /// a bincoded `FulltextSearchStreamChunkPayload`.
+    FulltextSearchStreamChunk(Bytes),
+    /// t_4ae47a9f: keep-alive emitted while the FTI walk is slow to
+    /// yield the next chunk; the coordinator's idle watchdog treats
+    /// heartbeats as activity.
+    FulltextSearchStreamHeartbeat(Bytes),
+    /// t_4ae47a9f: terminator for a streaming fulltext response.
+    FulltextSearchStreamDone(Bytes),
+    /// t_4ae47a9f: coordinator → handler abort signal; the producer's
+    /// walk observes it as a Break between chunks.
+    FulltextSearchStreamCancel(Bytes),
     TruncateForward(Bytes),
     TruncateAck(Bytes),
 
@@ -339,6 +358,11 @@ impl Message {
             Self::RangeReadStreamHeartbeat(_) => MsgType::RangeReadStreamHeartbeat,
             Self::RangeReadStreamDone(_) => MsgType::RangeReadStreamDone,
             Self::RangeReadStreamCancel(_) => MsgType::RangeReadStreamCancel,
+            Self::FulltextSearchStreamRequest(_) => MsgType::FulltextSearchStreamRequest,
+            Self::FulltextSearchStreamChunk(_) => MsgType::FulltextSearchStreamChunk,
+            Self::FulltextSearchStreamHeartbeat(_) => MsgType::FulltextSearchStreamHeartbeat,
+            Self::FulltextSearchStreamDone(_) => MsgType::FulltextSearchStreamDone,
+            Self::FulltextSearchStreamCancel(_) => MsgType::FulltextSearchStreamCancel,
             Self::TruncateForward(_) => MsgType::TruncateForward,
             Self::TruncateAck(_) => MsgType::TruncateAck,
             Self::RepairMerkleRequest(_) => MsgType::RepairMerkleRequest,
@@ -498,6 +522,11 @@ impl Message {
             | Self::RangeReadStreamHeartbeat(b)
             | Self::RangeReadStreamDone(b)
             | Self::RangeReadStreamCancel(b)
+            | Self::FulltextSearchStreamRequest(b)
+            | Self::FulltextSearchStreamChunk(b)
+            | Self::FulltextSearchStreamHeartbeat(b)
+            | Self::FulltextSearchStreamDone(b)
+            | Self::FulltextSearchStreamCancel(b)
             | Self::TruncateForward(b)
             | Self::TruncateAck(b)
             | Self::RepairMerkleRequest(b)
@@ -703,6 +732,21 @@ impl Message {
             }
             MsgType::RangeReadStreamCancel => {
                 Self::RangeReadStreamCancel(body.split_to(body.remaining()))
+            }
+            MsgType::FulltextSearchStreamRequest => {
+                Self::FulltextSearchStreamRequest(body.split_to(body.remaining()))
+            }
+            MsgType::FulltextSearchStreamChunk => {
+                Self::FulltextSearchStreamChunk(body.split_to(body.remaining()))
+            }
+            MsgType::FulltextSearchStreamHeartbeat => {
+                Self::FulltextSearchStreamHeartbeat(body.split_to(body.remaining()))
+            }
+            MsgType::FulltextSearchStreamDone => {
+                Self::FulltextSearchStreamDone(body.split_to(body.remaining()))
+            }
+            MsgType::FulltextSearchStreamCancel => {
+                Self::FulltextSearchStreamCancel(body.split_to(body.remaining()))
             }
             MsgType::TruncateForward => Self::TruncateForward(body.split_to(body.remaining())),
             MsgType::TruncateAck => Self::TruncateAck(body.split_to(body.remaining())),

--- a/ferrosa-net/src/protocol.rs
+++ b/ferrosa-net/src/protocol.rs
@@ -1556,7 +1556,12 @@ fn message_family_for_kind(kind: u16) -> MessageFamily {
             | MsgType::RangeReadStreamChunk
             | MsgType::RangeReadStreamHeartbeat
             | MsgType::RangeReadStreamDone
-            | MsgType::RangeReadStreamCancel,
+            | MsgType::RangeReadStreamCancel
+            | MsgType::FulltextSearchStreamRequest
+            | MsgType::FulltextSearchStreamChunk
+            | MsgType::FulltextSearchStreamHeartbeat
+            | MsgType::FulltextSearchStreamDone
+            | MsgType::FulltextSearchStreamCancel,
         ) => MessageFamily::Stream,
         Ok(
             MsgType::PairWriteForward

--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -131,6 +131,14 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
   `tests/fulltext_replica_memory_bound.rs` (allocator-tracked peak: O(k),
   independent of matching-doc count) and
   `engine::tests::fts_search_touches_only_queried_index_sidecars`.
+  The no-`LIMIT` shape has a streaming twin, **`fulltext_search_each(table,
+  index, query, on_hit)`** (t_4ae47a9f layer 2b): single-term walks hand each
+  matching doc key to the callback with an O(1) working set (no score map;
+  `ControlFlow::Break` = consumer-paced early exit), so replica memory is
+  independent of the match count even without a LIMIT — the shape that
+  OOM-killed nodes in t_8fc24ce2. Keys arrive unordered and may repeat across
+  sources (caller dedups); compound queries delegate to `fulltext_search`
+  internally. Guarded by `tests/fulltext_streaming_each_memory_bound.rs`.
 - **Snapshot / PITR** (`snapshot/`, `restore/`, `commitlog/archiver.rs`) —
   S3 snapshot manager, commit-log archiving, restore manager with validation.
 - **Quarantine + self-heal** (`quarantine.rs`, `self_heal/`) — malformed rows

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -6499,6 +6499,154 @@ impl StorageEngine {
         Ok(results.into_iter().map(|(pk, _)| pk).collect())
     }
 
+    /// Streaming full-text search: hands each matching doc key to `on_hit` as
+    /// it is found, holding a bounded working set — the non-materializing twin
+    /// of [`Self::fulltext_search`] for the no-`LIMIT` shape that OOM-killed
+    /// replicas on a broad `fts_match` (t_8fc24ce2 / t_4ae47a9f layer 2b).
+    ///
+    /// Memory contract, per source:
+    /// * **FTI sidecars** (the dominant source): walked via
+    ///   [`ferrosa_index::fulltext::stream::scan_term_each`] — O(1) working
+    ///   set, one posting key in flight, no score map. This is what makes the
+    ///   walk's peak independent of the matching-doc count.
+    /// * **Memtable overlay**: its matches are collected under the table lock
+    ///   and forwarded after release (the consumer is never invoked while
+    ///   `tables` is held — it may block on a bounded channel). Bounded by the
+    ///   memtable's own size.
+    /// * **Missing-sidecar fallback** (transient async-rebuild window,
+    ///   BUG-F-007): bounded by the matches of the uncovered generations;
+    ///   normally an empty set.
+    ///
+    /// Delivery contract:
+    /// * Keys arrive **unordered** and **may repeat across sources**
+    ///   (memtable vs sidecar vs fallback) — the caller dedups. Scores are not
+    ///   surfaced; the no-`LIMIT` consumers treat the result as a key set.
+    /// * `on_hit` returning [`ControlFlow::Break`] halts the entire walk
+    ///   immediately (consumer-paced backpressure: dropped downstream
+    ///   receiver, satisfied page). No callback fires after a Break.
+    /// * Compound (non-single-`Term`) queries have no streaming evaluator yet:
+    ///   they delegate to [`Self::fulltext_search`] internally and replay its
+    ///   keys, so callers get one code path for every query shape. Their
+    ///   memory is bounded by that path's contract, not this one's.
+    ///
+    /// # Errors
+    ///
+    /// Fails loudly on a malformed query BEFORE any walk work (no callback
+    /// fires), and on memtable/fallback scan errors. A corrupt individual
+    /// sidecar is logged and skipped, matching [`Self::fulltext_search`].
+    pub fn fulltext_search_each(
+        &self,
+        table_id: &TableId,
+        index_name: &str,
+        query: &str,
+        on_hit: &mut dyn FnMut(Vec<u8>) -> std::ops::ControlFlow<()>,
+    ) -> ferrosa_common::Result<()> {
+        use ferrosa_index::fulltext::query::{parse_fts_query, FtsQuery};
+        use std::collections::HashSet;
+        use std::ops::ControlFlow;
+
+        // Parse once, up front: an invalid query fails loudly before any
+        // sidecar/scan work and before any callback fires.
+        let parsed = parse_fts_query(query).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!("fts_match query error: {e}"))
+        })?;
+
+        if !self.tables.read().contains_key(table_id) {
+            return Ok(());
+        }
+
+        // Compound queries: delegate to the materializing evaluator and
+        // replay its keys through the callback (single caller-facing path).
+        let FtsQuery::Term(term) = &parsed else {
+            for key in self.fulltext_search(table_id, index_name, query, None)? {
+                if on_hit(key).is_break() {
+                    return Ok(());
+                }
+            }
+            return Ok(());
+        };
+
+        let table_dir = self
+            .config
+            .data_dir
+            .join("sstables")
+            .join(table_id.to_string());
+        let fti_suffix = format!("-FTI-{index_name}.db");
+        let mut fti_files: Vec<std::path::PathBuf> = Vec::new();
+        let mut covered_gens: HashSet<String> = HashSet::new();
+        if let Ok(entries) = std::fs::read_dir(&table_dir) {
+            for e in entries.flatten() {
+                let Some(name) = e.file_name().to_str().map(|s| s.to_string()) else {
+                    continue;
+                };
+                if let Some(gen) = name.strip_suffix(&fti_suffix) {
+                    covered_gens.insert(gen.to_string());
+                    fti_files.push(e.path());
+                }
+            }
+        }
+
+        // Memtable overlay — collect under the lock, forward after release.
+        let memtable_hits = {
+            let tables = self.tables.read();
+            let Some(state) = tables.get(table_id) else {
+                return Ok(());
+            };
+            state
+                .store
+                .fulltext_memtable_search(index_name, query, None)?
+        };
+        for (key, _score) in memtable_hits {
+            if on_hit(key).is_break() {
+                return Ok(());
+            }
+        }
+
+        // FTI sidecars — the O(1) streaming walk.
+        for fti_path in fti_files {
+            #[cfg(test)]
+            FTS_SIDECAR_FILES_CONSULTED.with(|c| c.set(c.get() + 1));
+            let mut stopped = false;
+            if let Err(e) =
+                ferrosa_index::fulltext::stream::scan_term_each(&fti_path, term, |hit| {
+                    if on_hit(hit.partition_key).is_break() {
+                        stopped = true;
+                        ControlFlow::Break(())
+                    } else {
+                        ControlFlow::Continue(())
+                    }
+                })
+            {
+                tracing::warn!(path = %fti_path.display(), "bad FTI (stream): {e}");
+                continue;
+            }
+            if stopped {
+                return Ok(());
+            }
+        }
+
+        // Missing-sidecar fallback (transient rebuild window) — collect under
+        // the lock, forward after release.
+        let fallback_hits = {
+            let tables = self.tables.read();
+            match tables.get(table_id) {
+                Some(state) => state.store.fulltext_sstable_scan_missing_sidecar(
+                    index_name,
+                    query,
+                    &covered_gens,
+                    None,
+                )?,
+                None => Vec::new(),
+            }
+        };
+        for (key, _score) in fallback_hits {
+            if on_hit(key).is_break() {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+
     /// Subsequent reads for this table will return empty results. Existing
     /// readers holding `Arc` references to old data will complete normally.
     pub fn truncate(&self, table_id: &TableId) -> ferrosa_common::Result<()> {

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -6521,7 +6521,7 @@ impl StorageEngine {
     /// * Keys arrive **unordered** and **may repeat across sources**
     ///   (memtable vs sidecar vs fallback) — the caller dedups. Scores are not
     ///   surfaced; the no-`LIMIT` consumers treat the result as a key set.
-    /// * `on_hit` returning [`ControlFlow::Break`] halts the entire walk
+    /// * `on_hit` returning [`std::ops::ControlFlow::Break`] halts the entire walk
     ///   immediately (consumer-paced backpressure: dropped downstream
     ///   receiver, satisfied page). No callback fires after a Break.
     /// * Compound (non-single-`Term`) queries have no streaming evaluator yet:

--- a/ferrosa-storage/tests/fulltext_streaming_each_memory_bound.rs
+++ b/ferrosa-storage/tests/fulltext_streaming_each_memory_bound.rs
@@ -1,0 +1,315 @@
+//! TDD guard (t_8fc24ce2 / t_4ae47a9f layer 2b — the NO-LIMIT replica-side
+//! fulltext OOM): `StorageEngine::fulltext_search_each` must hand matching doc
+//! keys to a callback one at a time with a bounded working set, INDEPENDENT of
+//! the matching-doc count — even when the query carries NO LIMIT.
+//!
+//! Live failure this pins: `fulltext_search(.., None)` (the broad `fts_match`
+//! shape, reached directly or via the router's geometric LIMIT escalation)
+//! scored EVERY matching posting into an owned `score_map: HashMap<Vec<u8>,
+//! f64>` on every replica at once — O(matches) per replica — which OOM-killed
+//! all three 2 GiB-capped nodes (t_8fc24ce2). The LIMIT-k path was already
+//! bounded (t_ee98faa0 layer 2); this file closes the `limit=None` hole by
+//! pinning the streaming callback primitive the cluster-level windowed
+//! producer will drive.
+//!
+//! Contract pinned here:
+//!   * every matching key is delivered exactly as `fulltext_search(.., None)`
+//!     would return it (parity, modulo cross-source duplicates — the caller
+//!     dedups);
+//!   * `ControlFlow::Break` from the callback halts the walk immediately
+//!     (consumer-paced backpressure);
+//!   * peak additional heap during the walk is bounded and independent of N.
+//!
+//! Modeled on `fulltext_replica_memory_bound.rs` (same engine harness and
+//! peak-additional-heap tracker; seeding/flush happen OUTSIDE the window).
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::ops::ControlFlow;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::Arc;
+
+use ferrosa_common::key::{DecoratedKey, PartitionKey};
+use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+use ferrosa_common::{CellValue, Token};
+use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, TableId,
+};
+
+// --- peak-additional-heap tracker (scoped to this integration-test binary) ---
+struct TrackingAlloc;
+static ARMED: AtomicBool = AtomicBool::new(false);
+static LIVE: AtomicI64 = AtomicI64::new(0);
+static PEAK: AtomicI64 = AtomicI64::new(0);
+
+unsafe impl GlobalAlloc for TrackingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() && ARMED.load(Ordering::Relaxed) {
+            let live =
+                LIVE.fetch_add(layout.size() as i64, Ordering::Relaxed) + layout.size() as i64;
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        ptr
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if ARMED.load(Ordering::Relaxed) {
+            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+        }
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static ALLOC: TrackingAlloc = TrackingAlloc;
+
+static MEASURE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn measure_peak<R>(f: impl FnOnce() -> R) -> (R, i64) {
+    let _guard = MEASURE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    LIVE.store(0, Ordering::SeqCst);
+    PEAK.store(0, Ordering::SeqCst);
+    ARMED.store(true, Ordering::SeqCst);
+    let out = f();
+    ARMED.store(false, Ordering::SeqCst);
+    (out, PEAK.load(Ordering::SeqCst))
+}
+
+const KS: &str = "agent_memory";
+const TBL: &str = "entity_store";
+const IDX: &str = "idx_snippet";
+
+fn engine(dir: &std::path::Path) -> Arc<StorageEngine> {
+    let config = StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            log_dir: dir.to_path_buf(),
+            checkpoint_dir: dir.to_path_buf(),
+            archive: None,
+            ..CommitLogConfig::default()
+        },
+        compaction: CompactionConfig::from_env(dir.join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        // Large threshold: we flush explicitly, once, so exactly one SSTable +
+        // one FTI sidecar exist and the memtable is empty during measurement.
+        flush_threshold_bytes: u64::MAX,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 3600,
+        data_dir: dir.to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        auth_enabled: false,
+        auth_warn: false,
+        write_verify: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let engine = Arc::new(StorageEngine::new(config, None).unwrap());
+    let schema = TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        clustering_columns: vec![],
+        static_columns: vec![],
+        regular_columns: vec![ColumnDefinition {
+            name: "context_snippet".to_string(),
+            type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+        }],
+        extensions: Default::default(),
+    };
+    engine.register_table(schema).unwrap();
+    engine
+        .add_fulltext_index(&TableId::new(KS, TBL), IDX, 0)
+        .unwrap();
+    engine
+}
+
+fn seed_and_flush(engine: &StorageEngine, n: usize) {
+    let table_id = TableId::new(KS, TBL);
+    for i in 0..n {
+        let key_bytes = format!("entity-{i:016}").into_bytes();
+        let dk = DecoratedKey {
+            token: Token(i as i64),
+            key: PartitionKey::new(key_bytes),
+        };
+        let text = format!(
+            "memory snippet {i} about durable typed agent knowledge graph \
+             entity number {i} stored context"
+        );
+        let row = Row {
+            clustering: vec![],
+            cells: vec![(0, CellValue::live(text.into_bytes(), 1000))],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(1000),
+        };
+        engine.write(&table_id, &dk, row, 1000).unwrap();
+    }
+    engine.flush(&table_id).unwrap();
+}
+
+/// Hard per-walk budget: covers the streaming walker's buffers + one key in
+/// flight + allocator jitter. Deliberately tiny next to the O(matches)
+/// score-map of the pre-fix `limit=None` shape.
+const STREAMING_WALK_BUDGET_BYTES: i64 = 1024 * 1024; // 1 MiB, << 2 GiB cap
+
+/// RED→GREEN for layer 2b: a NO-LIMIT single-term walk over the real engine
+/// (real FTI sidecar on disk) must hold a bounded working set independent of
+/// the matching-doc count. The consumer here counts and discards — the shape
+/// of a caller forwarding into a bounded channel whose receiver keeps up.
+#[test]
+fn no_limit_streaming_walk_peak_is_bounded_independent_of_matches() {
+    const SMALL_N: usize = 2_000;
+    const LARGE_N: usize = 32_000; // 16× more matching docs
+
+    fn walk_peak(n: usize) -> i64 {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = engine(dir.path());
+        seed_and_flush(&storage, n);
+        let table_id = TableId::new(KS, TBL);
+
+        // Sanity outside the window: the walk is real and complete.
+        let mut warm = 0usize;
+        storage
+            .fulltext_search_each(&table_id, IDX, "memory", &mut |_key: Vec<u8>| {
+                warm += 1;
+                ControlFlow::Continue(())
+            })
+            .unwrap();
+        assert_eq!(warm, n, "no-LIMIT walk must visit EVERY matching doc");
+
+        let (count, peak) = measure_peak(|| {
+            let mut count = 0usize;
+            storage
+                .fulltext_search_each(&table_id, IDX, "memory", &mut |_key: Vec<u8>| {
+                    count += 1;
+                    ControlFlow::Continue(())
+                })
+                .unwrap();
+            count
+        });
+        assert_eq!(count, n);
+        peak
+    }
+
+    let small = walk_peak(SMALL_N);
+    let large = walk_peak(LARGE_N);
+    eprintln!(
+        "no-LIMIT fulltext_search_each peak: small(N={SMALL_N})={small} B, \
+         large(N={LARGE_N})={large} B, ratio={:.2}; budget={STREAMING_WALK_BUDGET_BYTES} B",
+        large as f64 / small.max(1) as f64,
+    );
+
+    assert!(
+        large < STREAMING_WALK_BUDGET_BYTES,
+        "REGRESSION (t_4ae47a9f layer 2b): no-LIMIT streaming walk peak {large} B exceeds the \
+         {STREAMING_WALK_BUDGET_BYTES} B budget at N={LARGE_N} matching docs. This is the exact \
+         shape that OOM-killed every replica at the 2 GiB cap on a broad fts_match."
+    );
+    assert!(
+        large < small.max(65536) * 3,
+        "REGRESSION (t_4ae47a9f layer 2b): streaming walk peak scales with the match set — \
+         small(N={SMALL_N})={small} B, large(N={LARGE_N})={large} B ({}× more matching docs). \
+         Peak must be O(1), not O(matches).",
+        LARGE_N / SMALL_N,
+    );
+}
+
+/// Parity: the callback walk delivers exactly the key set of
+/// `fulltext_search(.., None)` (deduped — cross-source duplicates are the
+/// documented caller's concern).
+#[test]
+fn streaming_walk_matches_materializing_search_key_set() {
+    const N: usize = 1_500;
+    let dir = tempfile::tempdir().unwrap();
+    let storage = engine(dir.path());
+    seed_and_flush(&storage, N);
+    let table_id = TableId::new(KS, TBL);
+
+    let expected: std::collections::HashSet<Vec<u8>> = storage
+        .fulltext_search(&table_id, IDX, "memory", None)
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(expected.len(), N);
+
+    let mut streamed: std::collections::HashSet<Vec<u8>> = Default::default();
+    storage
+        .fulltext_search_each(&table_id, IDX, "memory", &mut |key: Vec<u8>| {
+            streamed.insert(key);
+            ControlFlow::Continue(())
+        })
+        .unwrap();
+
+    assert_eq!(
+        streamed, expected,
+        "same key set as the materializing search"
+    );
+}
+
+/// Compound (multi-term) queries fall back to the existing bounded evaluation
+/// internally but must still deliver the complete parity key set through the
+/// callback — callers get ONE code path regardless of query shape.
+#[test]
+fn streaming_walk_compound_query_parity() {
+    const N: usize = 800;
+    let dir = tempfile::tempdir().unwrap();
+    let storage = engine(dir.path());
+    seed_and_flush(&storage, N);
+    let table_id = TableId::new(KS, TBL);
+
+    let q = "memory AND snippet";
+    let expected: std::collections::HashSet<Vec<u8>> = storage
+        .fulltext_search(&table_id, IDX, q, None)
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(expected.len(), N, "every doc contains both terms");
+
+    let mut streamed: std::collections::HashSet<Vec<u8>> = Default::default();
+    storage
+        .fulltext_search_each(&table_id, IDX, q, &mut |key: Vec<u8>| {
+            streamed.insert(key);
+            ControlFlow::Continue(())
+        })
+        .unwrap();
+    assert_eq!(streamed, expected);
+}
+
+/// `ControlFlow::Break` from the callback halts the walk immediately — the
+/// consumer-paced backpressure hook (dropped downstream receiver, satisfied
+/// page/LIMIT). No further callbacks may arrive after a Break.
+#[test]
+fn streaming_walk_break_stops_immediately() {
+    const N: usize = 500;
+    let dir = tempfile::tempdir().unwrap();
+    let storage = engine(dir.path());
+    seed_and_flush(&storage, N);
+    let table_id = TableId::new(KS, TBL);
+
+    let mut calls = 0usize;
+    storage
+        .fulltext_search_each(&table_id, IDX, "memory", &mut |_key: Vec<u8>| {
+            calls += 1;
+            ControlFlow::Break(())
+        })
+        .unwrap();
+    assert_eq!(calls, 1, "walk must stop at the first Break");
+}
+
+/// Invalid query syntax fails loudly BEFORE any walk work — parity with
+/// `fulltext_search` (fail loud, never fake an empty result).
+#[test]
+fn streaming_walk_invalid_query_fails_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = engine(dir.path());
+    seed_and_flush(&storage, 10);
+    let table_id = TableId::new(KS, TBL);
+
+    let mut calls = 0usize;
+    let res = storage.fulltext_search_each(&table_id, IDX, "AND AND", &mut |_key: Vec<u8>| {
+        calls += 1;
+        ControlFlow::Continue(())
+    });
+    assert!(res.is_err(), "malformed fts query must be an error");
+    assert_eq!(calls, 0, "callback must never fire for an invalid query");
+}


### PR DESCRIPTION
## Problem

A broad no-`LIMIT` `fts_match` (reached directly or via the router's geometric LIMIT escalation) materialized its match set several times over: every replica scored all matches into a `score_map`, shipped one bincode response frame of up to 256 MiB, and the coordinator+router held the union in ~3 more copies. Concurrent scans OOM-killed all three 2 GiB-capped nodes in cascade (forge t_8fc24ce2); the blocking FTI walk also ran inline on the async runtime, starving raft heartbeats/CQL keepalives and turning Bulk-lane timeouts into a retry storm that multiplied the buffers.

## Fix (forge t_4ae47a9f) — streaming, non-materializing, backpressured; no result caps

- **ferrosa-index**: `scan_term_each` — non-materializing postings walk (O(1) working set, `ControlFlow` early-exit); `scan_term_top_k` reimplemented on it.
- **ferrosa-storage**: `fulltext_search_each` — streaming no-LIMIT walk over memtable + sidecars + missing-sidecar fallback; the walk holds no score map, and blocking scans now run via `spawn_blocking` at every call site (same class as PR #131).
- **ferrosa-net**: additive `FulltextSearchStream{Request,Chunk,Heartbeat,Done,Cancel}` wire family (0x3B–0x3F), ordered-stream classified like the ADR-020 range-read stream.
- **ferrosa-cluster**: producer walks the FTI on a blocking thread into a bounded channel and fires ≤4096-key chunks with heartbeats + cancel; `coordinate_fulltext_search_stream` fans out to every node, N-way merges over bounded channels, and dedups into a single `seen` set — the one intentional O(distinct matches) allocation left. Any replica failure fails the search loudly (no silent partial union). `FERROSA_BULK_STREAMING_FULLTEXT=0` selects the legacy path for mixed-version upgrades.
- **ferrosa-cql**: the `fts_match` arm consumes the stream for no-LIMIT; LIMIT-k keeps one bounded top-k consult with at most **one** complete-stream fallback — **the geometric ×4 escalation loop is deleted** (its terminal round degraded to `limit=None` materialization on every replica). Paging semantics unchanged.

## Verification

- `ferrosa-storage/tests/fulltext_streaming_each_memory_bound.rs`: allocator-tracked walk peak < 1 MiB, independent of a 16× match-count increase; parity/early-exit/fail-loud contracts.
- `ferrosa-cluster/tests/fulltext_stream_memory_bound.rs`: e2e completeness at N=8000 through the cluster write path, peak independent of a 64× doc-size increase, 256 B/key backstop, early-drop teardown.
- New structural router pin: hostile post-filter ⇒ exactly 2 hit-set fetches; no-LIMIT ⇒ 1 (a regression to the loop fails the pin).
- Full local gates: fmt check, clippy all-targets (0 findings), the whole workspace suite (only the pre-existing env-gated ferrosa-jepsen container tests fail without `FERROSA_TEST_CONTAINERS`), and the docs build with `-D warnings` — all clean.
- Multi-node fly.io validation staged (deploy/fly-stream-scan `fts_content_scan` probe is this exact query shape); tracked on t_4ae47a9f.

## Notes for reviewers

- Design delta from the original spec: no producer-side window/credit protocol — FTI postings can't resume by position without a sidecar format change; the producer's bounded internal channel already gives consumer pacing, and in-flight exposure is ≤160 KiB frames × route buffer. The e2e guard covers this; if a stalled-consumer profile ever shows growth, the credit-frame refinement is the follow-up.
- The streaming path is stricter than the legacy degrading union: a down replica now fails the query loudly instead of silently dropping its matches.
