### PR TITLE
fix(cluster): cancel abandoned range-scan pages even when the merge is parked on a stalled source

### DIFF
--- a/ferrosa-cluster/src/coordinator/range_read_stream.rs
+++ b/ferrosa-cluster/src/coordinator/range_read_stream.rs
@@ -918,6 +918,35 @@ async fn run_fragment_merge_nway<S>(
 ) where
     S: futures::Stream<Item = Result<Partition, ClusterError>> + Unpin,
 {
+    // The merge parks in `FragmentCursor::ensure_peeked` (`stream.next().await`)
+    // whenever a source has neither yielded its next fragment nor closed — which
+    // is exactly what a still-scanning remote producer does after it emits its
+    // flow-control window and parks between batches. In that state the merge
+    // only ever observes consumer abandonment through `out_tx.send` (via
+    // `send_or_abort` / `try_or_forward`), and it never reaches a send. A page
+    // abandoned while the merge is parked on a stalled source would therefore
+    // deadlock: the merge waits on `remote_rx.recv()` while that replica's
+    // forwarder waits on `remote_tx.closed()`, which only fires once the merge
+    // drops its cursor. Racing the whole merge against `out_tx.closed()` breaks
+    // the wait — when the consumer drops the merged stream this returns, the
+    // cursors (and their `remote_rx`) drop, and each forwarder observes
+    // `tx.closed()` and fires `RangeReadStreamCancel` (t_3fc6be3c). `closed()`
+    // stays pending for the whole scan while the consumer is reading, so this is
+    // inert on the normal path.
+    tokio::select! {
+        biased;
+        _ = out_tx.closed() => {}
+        _ = run_fragment_merge_nway_inner(cursors, k, &out_tx) => {}
+    }
+}
+
+async fn run_fragment_merge_nway_inner<S>(
+    cursors: Vec<FragmentCursor<S>>,
+    k: usize,
+    out_tx: &mpsc::Sender<crate::error::Result<Partition>>,
+) where
+    S: futures::Stream<Item = Result<Partition, ClusterError>> + Unpin,
+{
     macro_rules! send_or_abort {
         ($item:expr) => {
             if out_tx.send($item).await.is_err() {


### PR DESCRIPTION
## Problem

Main CI (Test + Coverage) fails on `multi_replica_paged_projected_scan_cancels_abandoned_producers`: "replica 2 producer was not cancelled after the page was abandoned — the coordinator leaked an uncancelled multi-replica scan (t_3fc6be3c HANG)".

This is a pre-existing race that #266's recompile of `ferrosa-cluster` shifted across its timing threshold on the 2-vCPU runner — #266's diff touches only `raft/network.rs`, which the failing scan path never reaches.

## Root cause

`run_fragment_merge_nway` (`coordinator/range_read_stream.rs`) only notices consumer abandonment when it calls `out_tx.send`. When the merge parks in `FragmentCursor::ensure_peeked` on a stalled remote source, a circular wait forms: the merge awaits `remote_rx.recv()`, the `WindowedReplicaForwarder` awaits `remote_tx.closed()` (which fires only when the merge drops its cursor), and `fire_stream_cancel` never runs — the remote producers leak.

Fast hosts usually see the consumer's `drop(stream)` land mid-send (prompt abort, GREEN); slow/contended runners let the merge drain the page and park first (deadlock, RED).

## Fix

Race the merge body against `out_tx.closed()` in a `tokio::select!` (loop extracted to `run_fragment_merge_nway_inner`). When the consumer drops the merged stream, the merge returns, cursors and `remote_rx` drop, each forwarder observes `tx.closed()`, and the cancel fires. `closed()` is inert while the consumer still reads.

## Verification

- Deadlock reproduced deterministically by forcing the merge to park before the drop (300 ms pre-drop delay): exact CI panic before the fix; green after. Instrumentation reverted; final diff is code-only.
- `range_scan_multi_replica_paging`: 6/6 green.
- `ferrosa-cluster --lib`: 1070/1070 green (includes #266's raft::network tests).
- `range_scan_streaming_memory_bound`, `replica_scan_serialization_memory_bound`, `correctness`, `integration`: green.
- clippy `-p ferrosa-cluster --tests`: clean.

## Follow-up (filed: forge t_577dd385)

Deterministic regression pin: force the parked-merge interleaving via a synchronization signal instead of relying on runner timing.
