### PR TITLE
fix(jepsen): run multi-DC nightly against live faulted cluster

### DIFF
--- a/.github/workflows/jepsen-multi-dc-nightly.yml
+++ b/.github/workflows/jepsen-multi-dc-nightly.yml
@@ -141,6 +141,10 @@ jobs:
       - name: Run tier-multi-dc 1h bank workload
         env:
           FERROSA_TEST_CONTAINERS: '1'
+          # The T3 stack is brought up in the preceding step. Supplying every
+          # host-mapped CQL endpoint makes this a live workload rather than an
+          # in-process MockCqlSession run.
+          FERROSA_TEST_CLUSTER_NODES: 'localhost:29042,localhost:29043,localhost:29044,localhost:29142,localhost:29143,localhost:29144'
           # 10-min bank workload: 6 Docker containers on a 16 GB GitHub-hosted
           # runner OOM before the original 1-hour budget. The 10-min window
           # still exercises cross-DC Accord drift under nemesis injection.
@@ -164,6 +168,8 @@ jobs:
           ./driver/ferrosa-jepsen \
             run \
             --tier multi-dc \
+            --pattern bank \
+            --nemesis dc-partition+dc-slow \
             --output-dir ./jepsen-out \
             2>&1 | tee tier-multi-dc.log
 

--- a/deploy/fly-bench/ferrosa-main.Dockerfile
+++ b/deploy/fly-bench/ferrosa-main.Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         sysstat \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/target/release/ferrosa /usr/local/bin/
-COPY ferrosa-entrypoint.sh /usr/local/bin/
+COPY deploy/fly-bench/ferrosa-entrypoint.sh /usr/local/bin/
 EXPOSE 9042 7000 9090
 ENV FERROSA_DATA_DIR=/var/lib/ferrosa
 ENTRYPOINT ["ferrosa-entrypoint.sh"]

--- a/ferrosa-jepsen/README.md
+++ b/ferrosa-jepsen/README.md
@@ -52,15 +52,21 @@ graph. It calls `ferrosa-sim` for the simulator-backed endurance path.
   to per-language Docker images (Python/Go/Node/Java/C#) — `phase2`, not used by
   the default tier resolution.
 - **Cluster backends**:
-  - **Docker Compose** (`docker_provision.rs`) — the **wired** provisioning path.
-    The orchestrator provisions a 3-node cluster when `FERROSA_TEST_CONTAINERS`
-    is set and the topology has ≤3 nodes; otherwise it runs combinations against
-    an in-process `MockCqlSession`. Uses `container_runtime()` (docker→podman).
+  - **Docker Compose / external contacts** (`docker_provision.rs`) — the
+    orchestrator provisions a 3-node cluster when `FERROSA_TEST_CONTAINERS` is
+    set. A caller can instead provide `FERROSA_TEST_CLUSTER_NODES` (including
+    six T3 endpoints); those endpoints are always dialed as a real CQL cluster
+    and are never torn down by the driver. The multi-DC tier rejects a missing
+    live cluster rather than silently using `MockCqlSession`. Uses
+    `container_runtime()` (docker→podman).
   - **Firecracker** (`firecracker.rs`, `cluster.rs`) — microVM provisioning
     primitives exist but are **not wired** into the orchestrator/run path;
     `cluster.rs` is the only consumer and is itself unreferenced.
-  - **Fly.io** (`flyio.rs`) — machine-management types/primitives for the
-    multi-DC topologies (T3/T4) exist but are **not wired** into the run path.
+  - **Fly.io** (`flyio.rs`, `chaos/`) — machine-management primitives and a
+    Fly-SSH nemesis transport for T3/T4. Set `FERROSA_JEPSEN_FLY_APP` plus
+    ordered `FERROSA_JEPSEN_FLY_MACHINE_IDS` to execute WAN chaos on real Fly
+    machines; the same WAN actions use `container_runtime exec` for the local
+    T3 compose topology.
 - **Endurance sim** (`endurance_sim.rs`) — the **sim-equivalent endurance run**
   (W8.9, ADR-016). Drives `ferrosa_sim::multi_dc::DualDcBankSim` (voters +
   per-DC learners) over a 24-simulated-hour horizon with periodic rolling-window
@@ -113,4 +119,5 @@ External: `tokio`, `scylla` (CQL driver), `russh` (SSH for fault injection),
 ## Specs
 
 - [Architecture overview](specs/overview.md) — module map, run pipeline, data flow
+- [FMEA](specs/fmea.md) — live-cluster, driver-routing, and WAN-nemesis failure controls
 - [Roadmap](specs/roadmap.md) — Now / Next / Later

--- a/ferrosa-jepsen/specs/fmea.md
+++ b/ferrosa-jepsen/specs/fmea.md
@@ -1,0 +1,20 @@
+---
+crate: ferrosa-jepsen
+doc: fmea
+last_updated: 2026-07-16
+---
+
+# ferrosa-jepsen — Failure Modes and Effects Analysis
+
+| Failure mode | Effect | Detection | Mitigation / current control |
+|---|---|---|---|
+| T3 has no live CQL contact points | A multi-DC test could appear to run against `MockCqlSession`. | `Tier::MultiDc` returns an error before the combination starts. | Require exactly the topology's count of `FERROSA_TEST_CLUSTER_NODES`; do not provision a mock fallback for T3/T4. |
+| Port-mapped nodes advertise their container port | The Scylla driver discovers addresses it cannot dial and loses its pool. | Real T3 bank setup fails while creating the keyspace. | Each T3 node sets `FERROSA_CQL_BROADCAST` to its distinct host-mapped port; `t3_topology` guards all six mappings. |
+| Driver pins a coordinator absent from a new session's metadata | The load-balancing policy returns an empty plan before the workload begins. | CQL query reports an empty load-balancing plan. | Pin the second session to the live node object from the probe session rather than re-looking up a host ID before topology refresh completes. |
+| WAN nemesis is selected but never executed | A report labels a faulted run that only tested normal workload behavior. | Orchestrator unit test records inject/heal calls; real runs fail on missing executor. | Run the selected non-`noop` action concurrently with workload and propagate injection/heal failures. |
+| WAN command lacks network privilege, tools, or the right IP family | `dc-partition`/`dc-slow` fail instead of changing connectivity. | Command exit status is included in the run failure; the Fly validation applies and removes IPv6 partition and `tc` rules on a real machine. | T3 image installs `iptables` and `iproute2`; all six T3 services declare `NET_ADMIN`; topology test guards capability; WAN partition selects `ip6tables` for Fly private IPv6 addresses. |
+| Stale Docker CLI masks a functioning Podman daemon | Local fault executor targets an unavailable Docker service. | Runtime selection fails or commands cannot start. | `container_runtime()` checks `info` and chooses a usable daemon; `FERROSA_CONTAINER_RUNTIME` can explicitly select one. |
+| Local Apple Podman emulates AMD64 netfilter incompletely | `iptables`/`tc` cannot exercise a Linux WAN fault locally. | The command fails loudly with its kernel error. | Treat this as an unsupported local fault host; validate the compose path on native Linux CI or Fly, never turn the nemesis into a no-op. |
+
+The controls above deliberately prefer a loud, diagnosable failure to a
+successful-looking test that did not use its requested topology or fault.

--- a/ferrosa-jepsen/specs/overview.md
+++ b/ferrosa-jepsen/specs/overview.md
@@ -1,13 +1,13 @@
 ---
 crate: ferrosa-jepsen
 status: implemented
-last_updated: 2026-06-19
+last_updated: 2026-07-16
 executive_summary: >
   Jepsen-style distributed correctness harness for Ferrosa. Generates
   concurrent workloads, injects faults (nemeses) over SSH, records an operation
   history, and checks it for linearizability and membership-invariant
-  violations. Docker Compose is the wired cluster backend; Firecracker and
-  Fly.io primitives exist but are not yet wired into the run path. A
+  violations. Docker Compose and caller-provisioned live clusters are wired
+  backends; Firecracker primitives remain unwired. A
   ferrosa-sim-backed endurance run is the headline acceptance gate when Fly.io
   is unavailable. Leaf crate — nothing depends on it.
 ---
@@ -32,15 +32,15 @@ SSH (`russh`) for fault injection, and to the simulator via `ferrosa-sim`.
 
 | Module | Responsibility |
 |--------|----------------|
-| `orchestrator` (`src/orchestrator.rs`) | Run loop: provision → iterate combinations → record → check → `RunReport`. Resolves real-cluster vs `MockCqlSession`. |
+| `orchestrator` (`src/orchestrator.rs`) | Run loop: provision/accept external contacts → iterate selected combinations → record → check → `RunReport`. Rejects a multi-DC run without live contact points and runs a named nemesis concurrently with its workload. |
 | `config` (`src/config.rs`) | `Tier`, `Topology` (T1–T4), `Concurrency`, `RunConfig` and their tier-driven resolution. |
 | `workload` (`src/workload/`) | `Workload` trait + registry: `register`, `bank`, 16 `lwt-*`, `forward-probe`, `membership-churn`, `late-join-flood`. |
-| `chaos` (`src/chaos/`) | `NemesisAction` trait + registry: network, process, clock, disk, WAN/cross-DC, composed nemeses. Inject/heal via SSH (`iptables`/`tc`/signals). |
+| `chaos` (`src/chaos/`) | `NemesisAction` trait + registry: network, process, clock, disk, WAN/cross-DC, composed nemeses. WAN actions execute via SSH, Fly SSH, or `container_runtime() exec` (`iptables`/`tc`/signals). |
 | `checker` (`src/checker/`) | Linearizability (native WGL backtracking), membership invariants, Knossos (subprocess), Elle (stub). |
 | `driver` (`src/driver/`) | `rust_driver` (real `scylla` connection); `ContainerDriver` (per-language Docker images, not in default tiers). |
-| `docker_provision` (`src/docker_provision.rs`) | **Wired** cluster backend: Docker Compose 3-node cluster, `container_runtime()` (docker→podman). |
+| `docker_provision` (`src/docker_provision.rs`) | **Wired** backend: managed Docker Compose for up to three nodes and non-owning external contact points for T3/Fly. `container_runtime()` selects a usable Docker/Podman daemon, not merely an installed CLI. |
 | `firecracker` / `cluster` | microVM provisioning primitives — present but **not wired** into the run path. |
-| `flyio` (`src/flyio.rs`) | Fly.io machine management for T3/T4 — present but **not wired**. |
+| `flyio` (`src/flyio.rs`) | Fly.io machine management primitives. A caller-provisioned Fly T3/T4 becomes a real run via `FERROSA_TEST_CLUSTER_NODES`; `FERROSA_JEPSEN_FLY_APP` plus ordered machine IDs selects Fly-SSH WAN faults. |
 | `endurance` / `endurance_sim` | `ferrosa-sim`-backed sim-equivalent 24h endurance run (W8.9, ADR-016). |
 | `history` (`src/history.rs`) | `Operation`/`Op`/`OpResult`, JSONL I/O, per-key filtering. |
 | `report` / `alert` / `archive` / `ssh` / `cql_session` / `test_env` | Reporting (JSON/HTML/timeline/anomaly/comparison), webhook alerting, run archiving, SSH client, CQL session, env helpers. |
@@ -50,25 +50,34 @@ SSH (`russh`) for fault injection, and to the simulator via `ferrosa-sim`.
 
 ```mermaid
 flowchart TD
-    CLI["ferrosa-jepsen run --tier T"] --> RESOLVE["config: resolve topologies x concurrency x drivers x nemeses x workloads"]
-    RESOLVE --> PROV{"FERROSA_TEST_CONTAINERS set and nodes &lt;= 3?"}
+    CLI["ferrosa-jepsen run --tier T"] --> RESOLVE["config: resolve selected topology, driver, nemesis, workload"]
+    RESOLVE --> EXTERNAL{"FERROSA_TEST_CLUSTER_NODES set?"}
+    EXTERNAL -- yes --> LIVE["non-owning live CQL contacts"]
+    EXTERNAL -- no --> PROV{"containers set and nodes &lt;= 3?"}
     PROV -- yes --> DOCKER["provision_docker_cluster (Docker Compose)"]
-    PROV -- no --> MOCK["MockCqlSession (in-process, no I/O)"]
-    DOCKER --> COMB["run_single_combination"]
+    PROV -- no --> REJECT{"multi-DC?"}
+    REJECT -- yes --> ERROR["fail loud: live cluster required"]
+    REJECT -- no --> MOCK["MockCqlSession (in-process, no I/O)"]
+    LIVE --> COMB["run_single_combination"]
+    DOCKER --> COMB
     MOCK --> COMB
     COMB --> WL["workload.setup + run -> HistoryRecorder"]
-    WL --> NEM["nemesis inject/heal over SSH"]
-    NEM --> HIST["history -> JSONL"]
+    COMB --> NEM["selected nemesis inject -> hold -> heal"]
+    WL --> HIST["history -> JSONL"]
+    NEM --> HIST
     HIST --> LIN["check_linearizability (native WGL)"]
     HIST --> INV["workload.check_invariant"]
     LIN --> REP["RunReport (results.json + report.html)"]
     INV --> REP
 ```
 
-The orchestrator currently provisions via Docker only; when no container
-runtime is requested it runs every combination against the in-process
-`MockCqlSession`, so unit-level combinations execute without infrastructure.
-Firecracker and Fly.io paths are not reached from this loop.
+The orchestrator accepts `FERROSA_TEST_CLUSTER_NODES` before considering
+managed provisioning. This makes a six-node T3 compose stack or Fly topology a
+real CQL run without giving the harness ownership of its lifecycle. T3 refuses
+to silently fall back to `MockCqlSession`. The nightly T3 compose stack maps
+every CQL port to the host and advertises that mapped address back to the
+driver; its nodes have `NET_ADMIN` because the selected WAN nemesis applies
+`iptables` and `tc` inside them. Firecracker provisioning remains unwired.
 
 ## Checker stack
 
@@ -103,6 +112,13 @@ written history; Elle is type-only (`elle_result = None`).
 4. **Sim endurance is a real gate.** The tri-DC endurance sim must report zero
    conservation failures, zero learner divergence, and final convergence — it
    runs under default `cargo test`, not behind live-infra gating.
+5. **A named fault is not a label.** Non-`noop` runs require a real cluster and
+   invoke the selected nemesis, then heal it even when the concurrent workload
+   fails. A missing executor or unsuccessful fault command fails the run.
+6. **WAN filters match the address family.** Docker T3 bridge addresses use
+   `iptables`; Fly private IPv6 addresses use `ip6tables`. The partition action
+   selects the filter binary from the target address rather than applying a
+   no-op/invalid IPv4 rule to a Fly node.
 
 ## Position in the dependency graph
 

--- a/ferrosa-jepsen/specs/roadmap.md
+++ b/ferrosa-jepsen/specs/roadmap.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-jepsen
 doc: roadmap
-last_updated: 2026-06-19
+last_updated: 2026-07-16
 ---
 
 # ferrosa-jepsen — Roadmap
@@ -14,13 +14,12 @@ external checkers.
 
 ## Now (highest value)
 
-- **Wire (or remove) the Firecracker/Fly.io cluster backends.** `firecracker.rs`
-  and `cluster.rs` (microVM provisioning) and `flyio.rs` (T3/T4 machines) are
-  implemented but unreachable from the orchestrator — `cluster.rs` itself has no
-  callers and carries a `// TODO: SSH into each node, run setup-guest.sh, start
-  ferrosa`. Today only Docker Compose (≤3 nodes) is wired, so T2/T3/T4 tiers fall
-  back to `MockCqlSession`. Either route the orchestrator through these backends
-  or drop the dead code (fail-loud: don't let a multi-node tier silently mock).
+- **Wire (or remove) Firecracker provisioning.** `firecracker.rs` and
+  `cluster.rs` (microVM provisioning) are still unreachable; `cluster.rs`
+  carries a `// TODO: SSH into each node, run setup-guest.sh, start ferrosa`.
+  T3 now accepts externally provisioned contacts and fails loud without them,
+  and a Fly caller can select Fly-SSH WAN faults; what remains is automated
+  Firecracker lifecycle ownership.
 - **Implement the `report` CLI subcommands.** `report list`/`compare`/`render`
   log "not yet implemented" (`main.rs`) despite `report/{comparison,timeline,
   anomaly}` modules existing. Finish wiring them to the archive.
@@ -42,10 +41,10 @@ external checkers.
 
 ## Later
 
-- **Real multi-DC (T3/T4) endurance on Fly.io.** The sim-equivalent endurance
-  run (`endurance_sim.rs`, ADR-016) stands in for the Fly.io tri-DC run; once
-  the Fly.io backend is wired, run the real 24h tier and compare against the
-  sim gate.
+- **Automate real multi-DC (T3/T4) endurance on Fly.io.** The run path now
+  accepts a caller-provisioned Fly topology and executes WAN faults over Fly
+  SSH, but it does not create/destroy the machine fleet itself. Add an explicit
+  cost-gated launcher and run the real 24h tier alongside the sim gate.
 - **Broaden checker models.** The native checker models a single-value register
   (read/write/CAS/serial-read); the `bank` and LWT workloads rely on
   workload-specific invariants. Consider a list/set/transactional model for

--- a/ferrosa-jepsen/src/chaos/mod.rs
+++ b/ferrosa-jepsen/src/chaos/mod.rs
@@ -36,9 +36,129 @@ pub struct NemesisContext {
     pub ssh_key_path: PathBuf,
     /// SSH port.
     pub ssh_port: u16,
+    /// How chaos commands reach nodes. Fly's managed SSH transport is used
+    /// for real multi-DC machines; local Firecracker tests use direct SSH.
+    pub executor: NemesisExecutor,
+}
+
+/// Transport used to execute a nemesis command on a particular node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NemesisExecutor {
+    Ssh,
+    Docker {
+        container_names: Vec<String>,
+    },
+    Fly {
+        app_name: String,
+        machine_ids: Vec<String>,
+    },
 }
 
 impl NemesisContext {
+    /// Build a Fly-backed context. Machine order must match `node_ips`, so the
+    /// first half remains DC-A and the second half DC-B for WAN nemeses.
+    pub fn fly(
+        node_ips: Vec<String>,
+        app_name: impl Into<String>,
+        machine_ids: Vec<String>,
+    ) -> Result<Self> {
+        if node_ips.len() != machine_ids.len() {
+            anyhow::bail!(
+                "Fly nemesis needs one machine ID per node: {} nodes, {} machine IDs",
+                node_ips.len(),
+                machine_ids.len()
+            );
+        }
+        Ok(Self {
+            node_ips,
+            ssh_user: "root".to_string(),
+            ssh_key_path: PathBuf::new(),
+            ssh_port: 22,
+            executor: NemesisExecutor::Fly {
+                app_name: app_name.into(),
+                machine_ids,
+            },
+        })
+    }
+
+    fn fly_ssh_args(&self, node_index: usize, command: &str) -> Result<Vec<String>> {
+        let NemesisExecutor::Fly {
+            app_name,
+            machine_ids,
+        } = &self.executor
+        else {
+            anyhow::bail!("Fly command requested for a non-Fly nemesis context");
+        };
+        let machine_id = machine_ids
+            .get(node_index)
+            .ok_or_else(|| anyhow::anyhow!("missing Fly machine ID for node index {node_index}"))?;
+        let quoted = command.replace('\'', "'\"'\"'");
+        Ok(vec![
+            "ssh".to_string(),
+            "console".to_string(),
+            "--app".to_string(),
+            app_name.clone(),
+            "--machine".to_string(),
+            machine_id.clone(),
+            "--command".to_string(),
+            format!("sh -lc '{quoted}'"),
+        ])
+    }
+
+    /// Execute a command on one ordered cluster node through the configured
+    /// transport. WAN nemeses use this rather than assuming direct SSH.
+    pub async fn exec_on(
+        &self,
+        node_index: usize,
+        command: &str,
+    ) -> Result<crate::ssh::CommandOutput> {
+        match &self.executor {
+            NemesisExecutor::Ssh => {
+                let ip = self
+                    .node_ips
+                    .get(node_index)
+                    .ok_or_else(|| anyhow::anyhow!("missing node IP for index {node_index}"))?;
+                self.ssh_to(ip).await?.exec(command).await
+            }
+            NemesisExecutor::Fly { .. } => {
+                let args = self.fly_ssh_args(node_index, command)?;
+                let output = tokio::process::Command::new("fly")
+                    .args(args)
+                    .output()
+                    .await?;
+                let status = output.status.code().unwrap_or(255);
+                let result = crate::ssh::CommandOutput {
+                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                    exit_code: status,
+                };
+                if output.status.success() {
+                    Ok(result)
+                } else {
+                    anyhow::bail!(
+                        "Fly command on node {node_index} failed with {status}: {}",
+                        result.stderr
+                    );
+                }
+            }
+            NemesisExecutor::Docker { container_names } => {
+                let container = container_names.get(node_index).ok_or_else(|| {
+                    anyhow::anyhow!("missing Docker container for node index {node_index}")
+                })?;
+                let output =
+                    tokio::process::Command::new(crate::docker_provision::container_runtime())
+                        .args(["exec", container, "sh", "-lc", command])
+                        .output()
+                        .await?;
+                Ok(crate::ssh::CommandOutput {
+                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                    exit_code: output.status.code().unwrap_or(255),
+                })
+            }
+        }
+    }
+
     /// Get IPs for "majority" partition (more than half).
     pub fn majority_ips(&self) -> Vec<String> {
         let n = (self.node_ips.len() / 2) + 1;
@@ -267,6 +387,7 @@ mod tests {
             ssh_user: "root".into(),
             ssh_key_path: PathBuf::from("/tmp/key"),
             ssh_port: 22,
+            executor: NemesisExecutor::Ssh,
         };
         assert_eq!(ctx.majority_ips(), vec!["1", "2"]);
         assert_eq!(ctx.minority_ips(), vec!["3"]);
@@ -279,9 +400,36 @@ mod tests {
             ssh_user: "root".into(),
             ssh_key_path: PathBuf::from("/tmp/key"),
             ssh_port: 22,
+            executor: NemesisExecutor::Ssh,
         };
         assert_eq!(ctx.majority_ips().len(), 3);
         assert_eq!(ctx.minority_ips().len(), 2);
+    }
+
+    #[test]
+    fn fly_context_targets_the_matching_machine_with_shell_quoting() {
+        let ctx = NemesisContext::fly(
+            vec!["fdaa:0:1::1".into(), "fdaa:0:1::2".into()],
+            "ferrosa-jepsen-live",
+            vec!["machine-a".into(), "machine-b".into()],
+        )
+        .expect("one Fly machine ID per node");
+
+        assert_eq!(
+            ctx.fly_ssh_args(1, "iptables -A OUTPUT -d 'fdaa:0:1::1' -j DROP")
+                .expect("Fly command"),
+            vec![
+                "ssh",
+                "console",
+                "--app",
+                "ferrosa-jepsen-live",
+                "--machine",
+                "machine-b",
+                "--command",
+                "sh -lc 'iptables -A OUTPUT -d '\"'\"'fdaa:0:1::1'\"'\"' -j DROP'",
+            ],
+            "the WAN action must execute on the selected Fly machine, not the local runner"
+        );
     }
 
     #[test]

--- a/ferrosa-jepsen/src/chaos/wan_bridge.rs
+++ b/ferrosa-jepsen/src/chaos/wan_bridge.rs
@@ -3,6 +3,32 @@ use async_trait::async_trait;
 
 use super::{NemesisAction, NemesisContext};
 
+/// Execute a WAN-chaos command through the context's configured transport and
+/// fail loudly if the remote node rejects it. This keeps Fly and direct-SSH
+/// runs on the same fault semantics.
+async fn exec_required(ctx: &NemesisContext, node_index: usize, command: &str) -> Result<()> {
+    let output = ctx.exec_on(node_index, command).await?;
+    if output.exit_code != 0 {
+        anyhow::bail!(
+            "WAN chaos command failed on node {node_index} with {}: {}",
+            output.exit_code,
+            output.stderr
+        );
+    }
+    Ok(())
+}
+
+/// Select the netfilter family for a peer address. Docker's T3 bridge uses
+/// IPv4, while Fly private addresses are IPv6; invoking `iptables` for the
+/// latter either rejects the address or leaves the WAN path untouched.
+fn iptables_binary_for(address: &str) -> &'static str {
+    if address.contains(':') {
+        "ip6tables"
+    } else {
+        "iptables"
+    }
+}
+
 /// WAN bridge sidecar for injecting inter-DC failures.
 pub struct WanBridge {
     pub bridge_ip: String,
@@ -26,23 +52,40 @@ impl NemesisAction for DcPartition {
         let dc_b = &ctx.node_ips[mid..];
 
         // On each DC-A node, drop all DC-B traffic.
-        for ip_a in dc_a {
-            let ssh = ctx.ssh_to(ip_a).await?;
+        for (a_index, _) in dc_a.iter().enumerate() {
             for ip_b in dc_b {
-                ssh.exec(&format!("iptables -A INPUT -s {} -j DROP", ip_b))
-                    .await?;
-                ssh.exec(&format!("iptables -A OUTPUT -d {} -j DROP", ip_b))
-                    .await?;
+                let iptables = iptables_binary_for(ip_b);
+                exec_required(
+                    ctx,
+                    a_index,
+                    &format!("{iptables} -A INPUT -s {ip_b} -j DROP"),
+                )
+                .await?;
+                exec_required(
+                    ctx,
+                    a_index,
+                    &format!("{iptables} -A OUTPUT -d {ip_b} -j DROP"),
+                )
+                .await?;
             }
         }
         // And vice versa.
-        for ip_b in dc_b {
-            let ssh = ctx.ssh_to(ip_b).await?;
+        for (b_offset, _) in dc_b.iter().enumerate() {
+            let b_index = mid + b_offset;
             for ip_a in dc_a {
-                ssh.exec(&format!("iptables -A INPUT -s {} -j DROP", ip_a))
-                    .await?;
-                ssh.exec(&format!("iptables -A OUTPUT -d {} -j DROP", ip_a))
-                    .await?;
+                let iptables = iptables_binary_for(ip_a);
+                exec_required(
+                    ctx,
+                    b_index,
+                    &format!("{iptables} -A INPUT -s {ip_a} -j DROP"),
+                )
+                .await?;
+                exec_required(
+                    ctx,
+                    b_index,
+                    &format!("{iptables} -A OUTPUT -d {ip_a} -j DROP"),
+                )
+                .await?;
             }
         }
         tracing::info!("Injected dc-partition between {:?} and {:?}", dc_a, dc_b);
@@ -50,10 +93,10 @@ impl NemesisAction for DcPartition {
     }
 
     async fn heal(&self, ctx: &NemesisContext) -> Result<()> {
-        for ip in &ctx.node_ips {
-            let ssh = ctx.ssh_to(ip).await?;
-            ssh.exec("iptables -F INPUT").await?;
-            ssh.exec("iptables -F OUTPUT").await?;
+        for node_index in 0..ctx.node_ips.len() {
+            let iptables = iptables_binary_for(&ctx.node_ips[node_index]);
+            exec_required(ctx, node_index, &format!("{iptables} -F INPUT")).await?;
+            exec_required(ctx, node_index, &format!("{iptables} -F OUTPUT")).await?;
         }
         tracing::info!("Healed dc-partition");
         Ok(())
@@ -73,10 +116,13 @@ impl NemesisAction for DcSlow {
         let mid = ctx.node_ips.len() / 2;
         let dc_b = &ctx.node_ips[mid..];
         // Add 200ms delay on DC-B nodes (simulates WAN latency).
-        for ip in dc_b {
-            let ssh = ctx.ssh_to(ip).await?;
-            ssh.exec("tc qdisc add dev eth0 root netem delay 200ms 50ms")
-                .await?;
+        for b_offset in 0..dc_b.len() {
+            exec_required(
+                ctx,
+                mid + b_offset,
+                "tc qdisc add dev eth0 root netem delay 200ms 50ms",
+            )
+            .await?;
         }
         tracing::info!("Injected dc-slow on DC-B nodes");
         Ok(())
@@ -84,10 +130,13 @@ impl NemesisAction for DcSlow {
 
     async fn heal(&self, ctx: &NemesisContext) -> Result<()> {
         let mid = ctx.node_ips.len() / 2;
-        for ip in &ctx.node_ips[mid..] {
-            let ssh = ctx.ssh_to(ip).await?;
-            ssh.exec("tc qdisc del dev eth0 root 2>/dev/null || true")
-                .await?;
+        for node_index in mid..ctx.node_ips.len() {
+            exec_required(
+                ctx,
+                node_index,
+                "tc qdisc del dev eth0 root 2>/dev/null || true",
+            )
+            .await?;
         }
         tracing::info!("Healed dc-slow");
         Ok(())
@@ -211,6 +260,12 @@ impl NemesisAction for DcLossy {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn partition_uses_ip6tables_for_fly_private_addresses() {
+        assert_eq!(iptables_binary_for("fdaa:79:e2c:a7b::2"), "ip6tables");
+        assert_eq!(iptables_binary_for("10.0.0.42"), "iptables");
+    }
 
     #[test]
     fn name_dc_partition() {

--- a/ferrosa-jepsen/src/cql_session.rs
+++ b/ferrosa-jepsen/src/cql_session.rs
@@ -28,13 +28,14 @@ impl ScyllaCqlSession {
     /// would scatter the statements across coordinators and the buffered DML would
     /// never reach the `BEGIN`'s connection (silently non-atomic).
     ///
-    /// Pinning is by **`host_id`** (a stable cluster identity), discovered via a
-    /// short-lived probe session — NOT by address. A node's advertised address
-    /// differs from the port-mapped contact point in Docker/Fly, which is exactly
-    /// why the earlier `AllowListHostFilter` attempt filtered out the only node
-    /// and broke all connectivity (t_ec740b8f). The full topology stays connected
-    /// (`known_nodes` + `PoolSize(1)`); the pinned node forwards writes as the
-    /// Accord coordinator, so cross-shard fan-out still happens.
+    /// Pinning uses the **live node object** discovered by a short-lived probe
+    /// session — not an address and not a host-ID lookup in the freshly-created
+    /// session. A node's advertised address differs from the port-mapped contact
+    /// point in Docker/Fly, and a new session can execute before its topology
+    /// refresh has populated a host-ID map. Either alternative can leave the
+    /// load-balancing policy with no coordinator. The full topology stays
+    /// connected (`known_nodes` + `PoolSize(1)`); the pinned node forwards writes
+    /// as the Accord coordinator, so cross-shard fan-out still happens.
     pub async fn connect(contact_points: &[String]) -> Result<Self> {
         assert!(
             !contact_points.is_empty(),
@@ -52,13 +53,13 @@ impl ScyllaCqlSession {
             .get_nodes_info()
             .iter()
             .min_by_key(|n| n.host_id) // deterministic across topology refreshes
-            .map(|n| n.host_id)
+            .cloned()
             .context("cluster reports no known nodes to pin to")?;
         drop(probe);
 
         // Phase 2 — pin all queries to that node (one connection ⇒ transaction
         // affinity), keeping the full topology connected for reachability.
-        let policy = SingleTargetLoadBalancingPolicy::new(NodeIdentifier::HostId(target), None);
+        let policy = SingleTargetLoadBalancingPolicy::new(NodeIdentifier::Node(target), None);
         let profile = ExecutionProfile::builder()
             .load_balancing_policy(policy)
             .build();

--- a/ferrosa-jepsen/src/docker_provision.rs
+++ b/ferrosa-jepsen/src/docker_provision.rs
@@ -20,30 +20,53 @@ use crate::config::Topology;
 // CQL ports assigned to each of the three Jepsen cluster nodes on localhost.
 const NODE_CQL_PORTS: [u16; 3] = [49042, 49043, 49044];
 
-/// Detect whether `docker` or `podman` is available and return the binary name.
+/// Detect whether `docker` or `podman` is usable and return the binary name.
 ///
-/// Checks `docker` first (most common on Linux CI), then falls back to `podman`.
-/// Returns `"docker"` or `"podman"`. Panics if neither is found in PATH.
+/// `FERROSA_CONTAINER_RUNTIME` can explicitly select either engine. Otherwise
+/// this checks `docker` first (most common on Linux CI), then falls back to
+/// `podman`. A binary alone is insufficient: its daemon must also answer
+/// `info`, so a stale Docker CLI does not mask a working Podman machine.
+/// Returns `"docker"` or `"podman"`. Panics if neither is usable.
 pub fn container_runtime() -> &'static str {
-    // Check docker first, then podman.
-    for candidate in &["docker", "podman"] {
-        let found = std::process::Command::new(candidate)
-            .arg("--version")
+    let requested = std::env::var("FERROSA_CONTAINER_RUNTIME").ok();
+    let runtime = select_container_runtime(requested.as_deref(), |candidate| {
+        std::process::Command::new(candidate)
+            .arg("info")
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
             .map(|s| s.success())
-            .unwrap_or(false);
-        if found {
-            // Return a &'static str by matching on the known candidates.
-            if *candidate == "docker" {
-                return "docker";
-            } else {
-                return "podman";
-            }
-        }
+            .unwrap_or(false)
+    });
+
+    if let Some(runtime) = runtime {
+        return runtime;
     }
-    panic!("neither 'docker' nor 'podman' found in PATH — install one to run container tests");
+
+    if let Some(requested) = requested {
+        panic!("FERROSA_CONTAINER_RUNTIME={requested:?} is not a usable docker or podman engine");
+    }
+
+    panic!(
+        "neither a usable 'docker' nor 'podman' engine found — start one to run container tests"
+    );
+}
+
+fn select_container_runtime(
+    requested: Option<&str>,
+    is_usable: impl Fn(&str) -> bool,
+) -> Option<&'static str> {
+    let candidates: &[&str] = match requested {
+        Some("docker") => &["docker"],
+        Some("podman") => &["podman"],
+        Some(_) => return None,
+        None => &["docker", "podman"],
+    };
+
+    candidates
+        .iter()
+        .copied()
+        .find(|candidate| is_usable(candidate))
 }
 
 /// Information about a single provisioned node.
@@ -60,7 +83,14 @@ pub struct NodeInfo {
 impl NodeInfo {
     /// CQL contact address as `host:port`.
     pub fn cql_address(&self) -> String {
-        format!("{}:{}", self.host, self.cql_port)
+        // Fly private addresses are IPv6. CQL contact points use the standard
+        // bracketed IPv6 host:port form so the Scylla driver can parse them.
+        let host = if self.host.contains(':') && !self.host.starts_with('[') {
+            format!("[{}]", self.host)
+        } else {
+            self.host.clone()
+        };
+        format!("{host}:{}", self.cql_port)
     }
 
     /// Return `true` if the CQL port accepts a TCP connection.
@@ -102,11 +132,23 @@ impl NodeInfo {
 pub struct ClusterInfo {
     /// The nodes in this cluster, in order.
     pub nodes: Vec<NodeInfo>,
-    /// Compose file used to provision the cluster.
-    pub(crate) compose_file: PathBuf,
+    /// Compose file used to provision the cluster. `None` means an external
+    /// (for example Fly.io) cluster owned by the caller.
+    pub(crate) compose_file: Option<PathBuf>,
 }
 
 impl ClusterInfo {
+    /// Describe a cluster already provisioned outside this process.
+    ///
+    /// The driver can use its CQL contact points but must not try to tear it
+    /// down: Fly lifecycle belongs to the invoking harness.
+    pub fn external(nodes: Vec<NodeInfo>) -> Self {
+        Self {
+            nodes,
+            compose_file: None,
+        }
+    }
+
     /// Assert that the number of nodes matches the topology.
     pub fn assert_node_count(&self, topology: Topology) {
         assert_eq!(
@@ -291,7 +333,7 @@ pub async fn provision_docker_cluster(topology: Topology) -> Result<ClusterInfo>
 
     let cluster = ClusterInfo {
         nodes,
-        compose_file,
+        compose_file: Some(compose_file),
     };
 
     // Wait for all nodes to accept CQL connections.
@@ -350,7 +392,11 @@ async fn wait_for_cluster_ready(cluster: &ClusterInfo) -> Result<()> {
 /// Runs `compose down -v` to remove containers and volumes.
 pub async fn teardown_docker_cluster(cluster: ClusterInfo) -> Result<()> {
     let rt = container_runtime();
-    let compose_file = cluster.compose_file.to_str().unwrap().to_owned();
+    let Some(compose_file) = cluster.compose_file else {
+        info!("external cluster lifecycle is owned by the caller; skipping compose teardown");
+        return Ok(());
+    };
+    let compose_file = compose_file.to_str().unwrap().to_owned();
 
     info!(compose_file = %compose_file, runtime = rt, "tearing down Docker cluster");
 
@@ -396,10 +442,38 @@ mod tests {
                     cql_port: 49044,
                 },
             ],
-            compose_file: PathBuf::from("/tmp/fake.yml"),
+            compose_file: Some(PathBuf::from("/tmp/fake.yml")),
         };
         // T1 = 3 nodes — should not panic.
         cluster.assert_node_count(Topology::T1);
+    }
+
+    #[test]
+    fn external_cluster_keeps_fly_contact_points_without_owning_teardown() {
+        let cluster = ClusterInfo::external(vec![
+            NodeInfo {
+                host: "fdaa:0:1234::1".to_string(),
+                cql_port: 9042,
+            },
+            NodeInfo {
+                host: "fdaa:0:1234::2".to_string(),
+                cql_port: 9042,
+            },
+        ]);
+
+        assert_eq!(
+            cluster
+                .nodes
+                .iter()
+                .map(NodeInfo::cql_address)
+                .collect::<Vec<_>>(),
+            vec!["[fdaa:0:1234::1]:9042", "[fdaa:0:1234::2]:9042"],
+            "an externally provisioned Fly cluster must retain routable CQL endpoints"
+        );
+        assert!(
+            cluster.compose_file.is_none(),
+            "the Jepsen driver must not tear down a cluster it did not create"
+        );
     }
 
     /// Sanity check the FERROSA_SEED parser on a hand-crafted snippet.
@@ -506,6 +580,13 @@ services:
             rt == "docker" || rt == "podman",
             "container_runtime() returned unexpected value: {rt}"
         );
+    }
+
+    #[test]
+    fn container_runtime_prefers_a_usable_engine_over_an_unusable_docker_binary() {
+        let runtime = select_container_runtime(None, |candidate| candidate == "podman");
+
+        assert_eq!(runtime, Some("podman"));
     }
 
     /// Provision a 3-node Docker cluster and verify all CQL ports are reachable.

--- a/ferrosa-jepsen/src/orchestrator.rs
+++ b/ferrosa-jepsen/src/orchestrator.rs
@@ -1,9 +1,9 @@
 use std::time::{Duration, Instant};
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::chaos::NemesisRegistry;
+use crate::chaos::{NemesisAction, NemesisContext, NemesisRegistry};
 use crate::checker::{check_linearizability, CheckResult};
 use crate::config::{Concurrency, RunConfig, Tier, Topology};
 use crate::cql_session::ScyllaCqlSession;
@@ -46,6 +46,114 @@ pub(crate) fn resolve_session_source(cluster: Option<&ClusterInfo>) -> SessionSo
         }
         None => SessionSource::Mock,
     }
+}
+
+/// Build a non-owning cluster description from caller-provisioned CQL contact
+/// points. This is the live path for Fly: the workload runner may dial the
+/// machines but must never create or tear down their lifecycle.
+fn cluster_from_preprovisioned_nodes(
+    topology: Topology,
+    contact_points: &str,
+) -> Result<ClusterInfo> {
+    let nodes = contact_points
+        .split(',')
+        .map(str::trim)
+        .filter(|point| !point.is_empty())
+        .map(|point| {
+            let (host, port) = point
+                .rsplit_once(':')
+                .ok_or_else(|| anyhow::anyhow!("CQL contact point `{point}` must be host:port"))?;
+            let host = host.trim_matches(['[', ']']);
+            if host.is_empty() {
+                bail!("CQL contact point `{point}` has an empty host");
+            }
+            let cql_port = port.parse::<u16>().map_err(|e| {
+                anyhow::anyhow!("CQL contact point `{point}` has invalid port: {e}")
+            })?;
+            Ok(crate::docker_provision::NodeInfo {
+                host: host.to_string(),
+                cql_port,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if nodes.len() != topology.node_count() {
+        bail!(
+            "{:?} requires exactly {} CQL contact points, got {}",
+            topology,
+            topology.node_count(),
+            nodes.len()
+        );
+    }
+    Ok(ClusterInfo::external(nodes))
+}
+
+/// Build the command transport for a live nemesis run. Fly machine IDs are
+/// required when the caller selects the Fly transport; otherwise this retains
+/// the direct-SSH path used by Firecracker-based tests.
+fn nemesis_context_for_cluster(cluster: &ClusterInfo) -> Result<NemesisContext> {
+    let node_ips = cluster.nodes.iter().map(|node| node.host.clone()).collect();
+    if let Ok(app_name) = std::env::var("FERROSA_JEPSEN_FLY_APP") {
+        let machine_ids = std::env::var("FERROSA_JEPSEN_FLY_MACHINE_IDS")
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "FERROSA_JEPSEN_FLY_APP is set but FERROSA_JEPSEN_FLY_MACHINE_IDS is missing"
+                )
+            })?
+            .split(',')
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+            .collect();
+        return NemesisContext::fly(node_ips, app_name, machine_ids);
+    }
+
+    if std::env::var("FERROSA_TEST_CONTAINERS").is_ok() {
+        let container_names = [
+            "ferrosa-jepsen-t3-dc1-node1",
+            "ferrosa-jepsen-t3-dc1-node2",
+            "ferrosa-jepsen-t3-dc1-node3",
+            "ferrosa-jepsen-t3-dc2-node1",
+            "ferrosa-jepsen-t3-dc2-node2",
+            "ferrosa-jepsen-t3-dc2-node3",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+        return Ok(NemesisContext {
+            node_ips,
+            ssh_user: "root".to_string(),
+            ssh_key_path: std::path::PathBuf::new(),
+            ssh_port: 0,
+            executor: crate::chaos::NemesisExecutor::Docker { container_names },
+        });
+    }
+
+    Ok(NemesisContext {
+        node_ips,
+        ssh_user: std::env::var("FERROSA_SSH_USER").unwrap_or_else(|_| "root".to_string()),
+        ssh_key_path: std::env::var("FERROSA_SSH_KEY")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::path::PathBuf::from("rootfs/test_key")),
+        ssh_port: std::env::var("FERROSA_SSH_PORT")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(22),
+        executor: crate::chaos::NemesisExecutor::Ssh,
+    })
+}
+
+/// Inject one fault window and always heal it before returning. The workload
+/// runs concurrently with this cycle, so a named Jepsen nemesis is evidence,
+/// not merely a label in the final report.
+async fn run_nemesis_cycle(
+    nemesis: &dyn NemesisAction,
+    ctx: &NemesisContext,
+    inject_duration: Duration,
+) -> Result<()> {
+    nemesis.inject(ctx).await?;
+    tokio::time::sleep(inject_duration).await;
+    nemesis.heal(ctx).await
 }
 
 /// Result of a single test combination (one workload + one nemesis).
@@ -99,22 +207,35 @@ pub async fn run(config: &RunConfig) -> Result<RunReport> {
         // FERROSA_TEST_CONTAINERS is set; otherwise we fall back to a
         // no-op cluster (placeholder) so the orchestrator can still run
         // unit-level combinations without container infrastructure.
-        let cluster_opt: Option<ClusterInfo> =
-            if std::env::var("FERROSA_TEST_CONTAINERS").is_ok() && topology.node_count() <= 3 {
-                match provision_docker_cluster(*topology).await {
-                    Ok(c) => Some(c),
-                    Err(e) => {
-                        tracing::error!(
-                            ?topology,
-                            error = %e,
-                            "Docker cluster provisioning failed; skipping topology"
-                        );
-                        continue;
-                    }
+        let cluster_opt: Option<ClusterInfo> = if let Ok(contact_points) =
+            std::env::var("FERROSA_TEST_CLUSTER_NODES")
+        {
+            Some(cluster_from_preprovisioned_nodes(
+                *topology,
+                &contact_points,
+            )?)
+        } else if std::env::var("FERROSA_TEST_CONTAINERS").is_ok() && topology.node_count() <= 3 {
+            match provision_docker_cluster(*topology).await {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    tracing::error!(
+                        ?topology,
+                        error = %e,
+                        "Docker cluster provisioning failed; skipping topology"
+                    );
+                    continue;
                 }
-            } else {
-                None
-            };
+            }
+        } else {
+            None
+        };
+
+        if matches!(config.tier, Tier::MultiDc) && cluster_opt.is_none() {
+            bail!(
+                "tier multi-dc requires a preprovisioned six-node cluster; set \
+                 FERROSA_TEST_CLUSTER_NODES=host1:9042,...,host6:9042"
+            );
+        }
 
         for concurrency in &concurrency_levels {
             for driver_name in &driver_names {
@@ -255,12 +376,34 @@ async fn run_single_combination(
     // Set up schema.
     workload.setup(session.as_ref()).await?;
 
-    // Run workload for configured duration.
+    // Run the workload while the selected fault is actually active. `noop`
+    // remains the control case; every other name must execute and heal rather
+    // than merely appearing in the report label.
     let run_duration = Duration::from_secs(config.run_duration_secs());
     let mut recorder = HistoryRecorder::new(&format!("{driver_name}-{workload_name}"));
-    workload
-        .run(session.as_ref(), &mut recorder, run_duration)
-        .await?;
+    if nemesis_name == "noop" {
+        workload
+            .run(session.as_ref(), &mut recorder, run_duration)
+            .await?;
+    } else {
+        let cluster = cluster.ok_or_else(|| {
+            anyhow::anyhow!(
+                "nemesis `{nemesis_name}` requires a live cluster; refusing to label a mock run as faulted"
+            )
+        })?;
+        let nemesis_registry = resolve_nemesis_registry(config.tier);
+        let nemesis = nemesis_registry
+            .get(nemesis_name)
+            .ok_or_else(|| anyhow::anyhow!("unknown nemesis `{nemesis_name}`"))?;
+        let context = nemesis_context_for_cluster(cluster)?;
+        let inject_duration = run_duration.min(Duration::from_secs(60));
+        let (workload_result, nemesis_result) = tokio::join!(
+            workload.run(session.as_ref(), &mut recorder, run_duration),
+            run_nemesis_cycle(nemesis, &context, inject_duration),
+        );
+        workload_result?;
+        nemesis_result?;
+    }
     let history = recorder.finish();
 
     // Write history JSONL to output directory.
@@ -358,7 +501,7 @@ mod tests {
                     cql_port: 49044,
                 },
             ],
-            compose_file: std::path::PathBuf::from("/tmp/fake.yml"),
+            compose_file: Some(std::path::PathBuf::from("/tmp/fake.yml")),
         };
 
         let source = resolve_session_source(Some(&cluster));
@@ -386,6 +529,30 @@ mod tests {
     fn orchestrator_uses_mock_when_no_cluster_provided() {
         let source = resolve_session_source(None);
         assert_eq!(source, SessionSource::Mock);
+    }
+
+    #[test]
+    fn multi_dc_uses_preprovisioned_fly_nodes_as_real_cql_contacts() {
+        let cluster = cluster_from_preprovisioned_nodes(
+            Topology::T3,
+            "fdaa:0:abcd::1:9042,fdaa:0:abcd::2:9042,fdaa:0:abcd::3:9042,\
+             fdaa:0:dcba::1:9042,fdaa:0:dcba::2:9042,fdaa:0:dcba::3:9042",
+        )
+        .expect("six Fly nodes are a valid T3 cluster");
+
+        assert_eq!(cluster.nodes.len(), 6);
+        assert_eq!(
+            resolve_session_source(Some(&cluster)),
+            SessionSource::Real(vec![
+                "[fdaa:0:abcd::1]:9042".to_string(),
+                "[fdaa:0:abcd::2]:9042".to_string(),
+                "[fdaa:0:abcd::3]:9042".to_string(),
+                "[fdaa:0:dcba::1]:9042".to_string(),
+                "[fdaa:0:dcba::2]:9042".to_string(),
+                "[fdaa:0:dcba::3]:9042".to_string(),
+            ]),
+            "multi-DC runs must dial the supplied Fly cluster rather than use MockCqlSession"
+        );
     }
 
     #[tokio::test]
@@ -432,5 +599,75 @@ mod tests {
         // History file should exist.
         let history_path = dir.path().join("test-run").join("T1-noop-register.jsonl");
         assert!(history_path.exists(), "history JSONL must be written");
+    }
+
+    #[tokio::test]
+    async fn selected_nemesis_is_injected_and_healed() {
+        use std::sync::{Arc, Mutex};
+
+        struct RecordingNemesis(Arc<Mutex<Vec<&'static str>>>);
+
+        #[async_trait::async_trait]
+        impl crate::chaos::NemesisAction for RecordingNemesis {
+            fn name(&self) -> &str {
+                "recording"
+            }
+
+            async fn inject(&self, _ctx: &crate::chaos::NemesisContext) -> anyhow::Result<()> {
+                self.0.lock().unwrap().push("inject");
+                Ok(())
+            }
+
+            async fn heal(&self, _ctx: &crate::chaos::NemesisContext) -> anyhow::Result<()> {
+                self.0.lock().unwrap().push("heal");
+                Ok(())
+            }
+        }
+
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let nemesis = RecordingNemesis(Arc::clone(&events));
+        let ctx = crate::chaos::NemesisContext {
+            node_ips: vec!["127.0.0.1".into()],
+            ssh_user: "root".into(),
+            ssh_key_path: std::path::PathBuf::from("/tmp/not-used"),
+            ssh_port: 22,
+            executor: crate::chaos::NemesisExecutor::Ssh,
+        };
+
+        run_nemesis_cycle(&nemesis, &ctx, Duration::ZERO)
+            .await
+            .expect("nemesis cycle succeeds");
+        assert_eq!(*events.lock().unwrap(), ["inject", "heal"]);
+    }
+
+    #[tokio::test]
+    async fn named_nemesis_refuses_to_run_against_the_mock_cluster() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = RunConfig {
+            tier: Tier::Smoke,
+            topology: None,
+            nemesis: None,
+            pattern: None,
+            driver: None,
+            concurrency: None,
+            run_id: "mock-fault".into(),
+            output_dir: dir.path().to_path_buf(),
+            fly_regions: vec![],
+            alert_webhook: None,
+            output_json: false,
+        };
+
+        let error = run_single_combination(
+            Topology::T1,
+            "partition-halves",
+            "register",
+            "rust",
+            Concurrency::Low,
+            &config,
+            None,
+        )
+        .await
+        .expect_err("a named fault must never silently run against MockCqlSession");
+        assert!(error.to_string().contains("requires a live cluster"));
     }
 }

--- a/ferrosa-jepsen/tests/ci_workflow.rs
+++ b/ferrosa-jepsen/tests/ci_workflow.rs
@@ -97,6 +97,24 @@ fn multi_dc_nightly_workload_invokes_current_run_subcommand() {
         !step.contains("--run-id"),
         "ferrosa-jepsen no longer accepts --run-id on the run command"
     );
+
+    // This is one bounded, named correctness experiment—not the entire
+    // workload × nemesis matrix. Without these filters each combination gets
+    // the full JEPSEN_RUN_DURATION_SECS budget and a nominal 10-minute nightly
+    // cannot complete in its 45-minute job window.
+    assert!(
+        step.contains("--pattern bank"),
+        "nightly multi-DC must run only the bank workload; step was:\n{step}"
+    );
+    assert!(
+        step.contains("--nemesis dc-partition+dc-slow"),
+        "nightly multi-DC must run its named WAN nemesis; step was:\n{step}"
+    );
+    assert!(
+        step.contains("FERROSA_TEST_CLUSTER_NODES"),
+        "nightly multi-DC must provide the six already-running T3 CQL endpoints so \
+         the driver cannot fall back to MockCqlSession; step was:\n{step}"
+    );
 }
 
 #[test]

--- a/ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml
+++ b/ferrosa-jepsen/tests/docker/jepsen-cluster-t3.yml
@@ -109,6 +109,8 @@ services:
       FERROSA_INTERNODE_BROADCAST: "dc1-node1:7000"
       FERROSA_SEED: "dc1-node2:7000,dc1-node3:7000"
       FERROSA_CQL_BIND: "0.0.0.0:9042"
+      # The host-side Jepsen driver must reconnect through this mapped port.
+      FERROSA_CQL_BROADCAST: "127.0.0.1:29042"
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_CLUSTER_NAME: "ferrosa-jepsen-t3"
       FERROSA_DATA_DIR: "/var/lib/ferrosa"
@@ -125,6 +127,7 @@ services:
       FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
       FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
       FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
+    cap_add: [NET_ADMIN]
     volumes:
       - jepsen-t3-dc1-node1-data:/var/lib/ferrosa
     deploy:
@@ -161,6 +164,7 @@ services:
       FERROSA_INTERNODE_BROADCAST: "dc1-node2:7000"
       FERROSA_SEED: "dc1-node1:7000,dc1-node3:7000"
       FERROSA_CQL_BIND: "0.0.0.0:9042"
+      FERROSA_CQL_BROADCAST: "127.0.0.1:29043"
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_CLUSTER_NAME: "ferrosa-jepsen-t3"
       FERROSA_DATA_DIR: "/var/lib/ferrosa"
@@ -177,6 +181,7 @@ services:
       FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
       FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
       FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
+    cap_add: [NET_ADMIN]
     volumes:
       - jepsen-t3-dc1-node2-data:/var/lib/ferrosa
     deploy:
@@ -211,6 +216,7 @@ services:
       FERROSA_INTERNODE_BROADCAST: "dc1-node3:7000"
       FERROSA_SEED: "dc1-node1:7000,dc1-node2:7000"
       FERROSA_CQL_BIND: "0.0.0.0:9042"
+      FERROSA_CQL_BROADCAST: "127.0.0.1:29044"
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_CLUSTER_NAME: "ferrosa-jepsen-t3"
       FERROSA_DATA_DIR: "/var/lib/ferrosa"
@@ -227,6 +233,7 @@ services:
       FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
       FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
       FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
+    cap_add: [NET_ADMIN]
     volumes:
       - jepsen-t3-dc1-node3-data:/var/lib/ferrosa
     deploy:
@@ -264,6 +271,7 @@ services:
       FERROSA_INTERNODE_BROADCAST: "dc2-node1:7000"
       FERROSA_SEED: "dc2-node2:7000,dc2-node3:7000"
       FERROSA_CQL_BIND: "0.0.0.0:9042"
+      FERROSA_CQL_BROADCAST: "127.0.0.1:29142"
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_CLUSTER_NAME: "ferrosa-jepsen-t3"
       FERROSA_DATA_DIR: "/var/lib/ferrosa"
@@ -280,6 +288,7 @@ services:
       FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
       FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
       FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
+    cap_add: [NET_ADMIN]
     volumes:
       - jepsen-t3-dc2-node1-data:/var/lib/ferrosa
     deploy:
@@ -314,6 +323,7 @@ services:
       FERROSA_INTERNODE_BROADCAST: "dc2-node2:7000"
       FERROSA_SEED: "dc2-node1:7000,dc2-node3:7000"
       FERROSA_CQL_BIND: "0.0.0.0:9042"
+      FERROSA_CQL_BROADCAST: "127.0.0.1:29143"
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_CLUSTER_NAME: "ferrosa-jepsen-t3"
       FERROSA_DATA_DIR: "/var/lib/ferrosa"
@@ -330,6 +340,7 @@ services:
       FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
       FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
       FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
+    cap_add: [NET_ADMIN]
     volumes:
       - jepsen-t3-dc2-node2-data:/var/lib/ferrosa
     deploy:
@@ -364,6 +375,7 @@ services:
       FERROSA_INTERNODE_BROADCAST: "dc2-node3:7000"
       FERROSA_SEED: "dc2-node1:7000,dc2-node2:7000"
       FERROSA_CQL_BIND: "0.0.0.0:9042"
+      FERROSA_CQL_BROADCAST: "127.0.0.1:29144"
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_CLUSTER_NAME: "ferrosa-jepsen-t3"
       FERROSA_DATA_DIR: "/var/lib/ferrosa"
@@ -380,6 +392,7 @@ services:
       FERROSA_CACHE_MAX_BYTES: "536870912"             # 512 MiB (was 10 GiB default)
       FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728" # 128 MiB
       FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"        # 32 MiB
+    cap_add: [NET_ADMIN]
     volumes:
       - jepsen-t3-dc2-node3-data:/var/lib/ferrosa
     deploy:

--- a/ferrosa-jepsen/tests/nemesis_correctness.rs
+++ b/ferrosa-jepsen/tests/nemesis_correctness.rs
@@ -14,7 +14,7 @@
 use std::path::PathBuf;
 
 use ferrosa_jepsen::{
-    chaos::{NemesisContext, NemesisRegistry},
+    chaos::{NemesisContext, NemesisExecutor, NemesisRegistry},
     cluster::FerrosCluster,
     config::Topology,
     test_env::TestClusterEnv,
@@ -54,6 +54,7 @@ async fn disk_fail_no_phantom_commits() {
         ssh_user: "root".to_string(),
         ssh_key_path: env.ssh_key.clone(),
         ssh_port: env.ssh_port,
+        executor: NemesisExecutor::Ssh,
     };
 
     let registry = NemesisRegistry::phase2();
@@ -102,6 +103,7 @@ async fn packet_reorder_linearizability() {
         ssh_user: "root".to_string(),
         ssh_key_path: env.ssh_key.clone(),
         ssh_port: env.ssh_port,
+        executor: NemesisExecutor::Ssh,
     };
 
     let registry = NemesisRegistry::phase1();
@@ -147,6 +149,7 @@ async fn lwt_batch_atomicity_all_nemeses() {
         ssh_user: "root".to_string(),
         ssh_key_path: env.ssh_key.clone(),
         ssh_port: env.ssh_port,
+        executor: NemesisExecutor::Ssh,
     };
 
     let registry = NemesisRegistry::phase1();
@@ -188,6 +191,7 @@ fn mock_ctx_3_nodes() -> NemesisContext {
         ssh_user: "root".into(),
         ssh_key_path: PathBuf::from("/tmp/mock_key"),
         ssh_port: 22,
+        executor: NemesisExecutor::Ssh,
     }
 }
 
@@ -236,6 +240,7 @@ async fn nemesis_partition_halves_docker() {
             .ok()
             .and_then(|p| p.parse().ok())
             .unwrap_or(22),
+        executor: NemesisExecutor::Ssh,
     };
 
     // inject and heal — allowed to fail (SSH unreachable on mock IPs) but must

--- a/ferrosa-jepsen/tests/t3_topology.rs
+++ b/ferrosa-jepsen/tests/t3_topology.rs
@@ -141,6 +141,70 @@ fn t3_compose_seeds_within_each_dc() {
 }
 
 #[test]
+fn t3_compose_advertises_host_reachable_cql_ports() {
+    let raw = std::fs::read_to_string(compose_path()).expect("read compose yaml");
+    let parsed: serde_yaml::Value = serde_yaml::from_str(&raw).expect("parse compose yaml");
+    let services = parsed.get("services").and_then(|v| v.as_mapping()).unwrap();
+
+    for (node, port) in [
+        ("dc1-node1", 29042),
+        ("dc1-node2", 29043),
+        ("dc1-node3", 29044),
+        ("dc2-node1", 29142),
+        ("dc2-node2", 29143),
+        ("dc2-node3", 29144),
+    ] {
+        let service = services
+            .get(serde_yaml::Value::String(node.into()))
+            .unwrap_or_else(|| panic!("service {node} missing"));
+        let env = service
+            .get("environment")
+            .and_then(|v| v.as_mapping())
+            .unwrap_or_else(|| panic!("{node} missing environment"));
+        let actual = env
+            .get(serde_yaml::Value::String("FERROSA_CQL_BROADCAST".into()))
+            .and_then(|v| v.as_str());
+
+        assert_eq!(
+            actual,
+            Some(format!("127.0.0.1:{port}").as_str()),
+            "{node} must advertise the CQL endpoint reachable by the host workload driver"
+        );
+    }
+}
+
+#[test]
+fn t3_compose_grants_nodes_network_admin_for_wan_nemeses() {
+    let raw = std::fs::read_to_string(compose_path()).expect("read compose yaml");
+    let parsed: serde_yaml::Value = serde_yaml::from_str(&raw).expect("parse compose yaml");
+    let services = parsed.get("services").and_then(|v| v.as_mapping()).unwrap();
+
+    for node in [
+        "dc1-node1",
+        "dc1-node2",
+        "dc1-node3",
+        "dc2-node1",
+        "dc2-node2",
+        "dc2-node3",
+    ] {
+        let service = services
+            .get(serde_yaml::Value::String(node.into()))
+            .unwrap_or_else(|| panic!("service {node} missing"));
+        let capabilities = service
+            .get("cap_add")
+            .and_then(|value| value.as_sequence())
+            .unwrap_or_else(|| panic!("{node} must declare cap_add for WAN nemeses"));
+
+        assert!(
+            capabilities
+                .iter()
+                .any(|value| value.as_str() == Some("NET_ADMIN")),
+            "{node} must grant NET_ADMIN so dc-partition and dc-slow can apply iptables/tc"
+        );
+    }
+}
+
+#[test]
 fn t3_compose_attaches_each_dc_to_its_network_and_wan() {
     let raw = std::fs::read_to_string(compose_path()).expect("read compose yaml");
     let parsed: serde_yaml::Value = serde_yaml::from_str(&raw).expect("parse compose yaml");

--- a/tests/Dockerfile.nightly-deb
+++ b/tests/Dockerfile.nightly-deb
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gdb \
         procps \
         curl \
+        iproute2 \
+        iptables \
     && rm -rf /var/lib/apt/lists/*
 
 # The caller must supply ferrosa.deb (nightly release artifact).

--- a/tests/ci/test_fly_bench_dockerfile.py
+++ b/tests/ci/test_fly_bench_dockerfile.py
@@ -1,0 +1,24 @@
+"""Regression guards for the root-context Fly image build."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = ROOT / "deploy" / "fly-bench" / "ferrosa-main.Dockerfile"
+
+
+class FlyBenchDockerfileTest(unittest.TestCase):
+    def test_entrypoint_is_copied_from_its_repository_path(self) -> None:
+        dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "COPY deploy/fly-bench/ferrosa-entrypoint.sh /usr/local/bin/",
+            dockerfile,
+            "the Fly Dockerfile must build directly from the repository root; "
+            "it must not require a caller to stage ferrosa-entrypoint.sh",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Executive Summary

Repair the multi-DC nightly so it uses the six-node T3 cluster and actually applies `dc-partition+dc-slow`, rather than running mocked or unfaulted combinations.

## Changes

- Wire pre-provisioned CQL contacts, Docker/Fly fault transports, and selected nemesis execution into the orchestrator.
- Make T3 advertise host-mapped CQL ports; add `NET_ADMIN` and netfilter tools for WAN faults.
- Make Fly IPv6 partition rules use `ip6tables`; verify the exact partition and `tc` commands on a temporary six-node Fly topology.
- Add regressions and update the Jepsen README/specs/FMEA.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --lib`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- Focused Jepsen workflow/T3/Python guards
- Local six-node Podman run reached real CQL setup and WAN injection; Apple AMD64 emulation rejects netfilter, while the exact IPv6 rules and `tc` lifecycle passed on Fly Linux.