### PR TITLE
fix(fulltext): apply the index analyzer to query terms

### DIFF
--- a/ferrosa-index/README.md
+++ b/ferrosa-index/README.md
@@ -93,6 +93,25 @@ Memory model (t_ee98faa0 layer 2 — the replica-side `fts_match` OOM):
   serialize→deserialize round trip (used by the transient memtable / fallback
   scans in `ferrosa-storage`).
 
+**Analyzer parity (query side == index side).** Documents are indexed through
+the index's `analyzer`, which for the default `StandardAnalyzer` strips English
+stop words and splits on punctuation. The query side must apply the *same*
+analyzer to its terms, or a token the analyzer would drop/rewrite looks up a
+posting list that can never exist. `query::analyze_query(query, analyzer)`
+re-analyzes a parsed `FtsQuery` before evaluation: a term that analyzes to
+nothing (a stop word) is **dropped** from a conjunction rather than required, a
+term that splits on punctuation becomes a conjunction of its tokens, `Prefix` is
+left untouched, and a query that reduces to no searchable terms returns `None`
+(matches nothing, without erroring). `FullTextIndexReader` carries its analyzer
+(`open`/`from_index` default to the shared `analyzer::default_analyzer()`;
+`open_with_analyzer`/`from_index_with_analyzer` accept a non-default one) and
+normalizes inside `search`/`search_top_k`, so every caller — memtable, sidecar,
+and missing-sidecar scans — inherits parity. The single-`Term` streaming fast
+path in `ferrosa-storage` normalizes the term with the same analyzer before the
+`stream` walk. Without this, `fts_match('reports were emitted')` returned zero
+rows even when documents contained "reports … emitted" (live repro:
+ferrosa-memory `fixed_document_search_survives_fts_stopword_absent_from_corpus`).
+
 ### 4. Geospatial — the `geo` library (Phase 1, pure functions)
 
 A space-filling-curve **point** index: encode `(lat, lon)` to a sortable `u64`

--- a/ferrosa-index/specs/fmea.md
+++ b/ferrosa-index/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-index
 doc: fmea
-last_updated: 2026-06-19
+last_updated: 2026-07-16
 ---
 
 # ferrosa-index — FMEA / Known Issues
@@ -23,6 +23,7 @@ corruption) dominates the high scores.
 | IDX-8 | Thin test coverage on quantized IVF builder & FTI builder | A change passes `cargo test -p ferrosa-index` while breaking the artifact path | 7 | 4 | 6 | 168 | quantized `ivf.rs` has 1 test, `ivf_staged.rs` 3, `fulltext/builder.rs` 3. **Open gap** — uneven coverage relative to risk. |
 | IDX-9 | Index file truncation/corruption read as valid | Partial/garbage index served as real results | 8 | 2 | 5 | 80 | `crc32fast` available; container/codec readers fail loud on malformed pages. **Verify CRC is checked on every artifact kind, not just `.qvec`.** |
 | IDX-10 | `nearest`/`range` on an unsupported kind | Caller assumes empty result is "no matches" | 6 | 2 | 3 | 36 | Kinds return `IndexError::Unsupported` (fail loud) rather than `Ok(vec![])`; covered by per-kind unit tests. |
+| IDX-11 | FTS query terms not run through the index analyzer (asymmetry) | Any natural-language `fts_match` query containing an English stop word (or a punctuation-bearing term) requires a posting list the analyzer never created → **deterministic false-empty result** even when documents match | 8 | 6 | 7 | 336 | **Fixed.** `query::analyze_query` normalizes the parsed query with the reader's analyzer inside `search`/`search_top_k`; the `ferrosa-storage` single-`Term` stream fast path normalizes the term too. Guarded by `reader.rs` parity tests, `query.rs` `analyze_*` unit tests, and `ferrosa-storage` `fts_stopword_bearing_query_matches_after_flush`. Live repro was ferrosa-memory `fixed_document_search_survives_fts_stopword_absent_from_corpus`. **Residual: analyzer is not persisted in the FTI; a future non-default per-index analyzer must be threaded to `open_with_analyzer` or parity breaks again.** |
 
 ## Top risks to act on
 
@@ -36,6 +37,13 @@ corruption) dominates the high scores.
 3. **IDX-5 (RPN 126)** — composite prefix ordering is only exact for equal-length
    components; variable-length component ordering needs a property test or a
    documented prohibition enforced at construction.
+4. **IDX-11 residual** — the query-vs-index analyzer asymmetry is fixed, but the
+   analyzer choice is *not persisted* in the FTI. Parity holds today only
+   because every builder and reader defaults to `analyzer::default_analyzer()`.
+   When a per-index analyzer option (`WITH OPTIONS {'analyzer': ...}`) is
+   actually threaded, the FTI must record it (or the read path must recover it
+   from index metadata) and open via `open_with_analyzer`, or the false-empty
+   failure returns for non-default analyzers.
 
 ## Detection assets
 

--- a/ferrosa-index/specs/overview.md
+++ b/ferrosa-index/specs/overview.md
@@ -59,7 +59,7 @@ bincode tag order is asserted stable (`lib.rs::bincode_index_type_variant_tag_st
 | `vector/hnsw` (~669) | HNSW graph ANN (JSON artifact) |
 | `vector/ivfflat` (~504) | k-means inverted-file ANN (JSON artifact) |
 | `vector/quantized/*` (~2200) | Paged `.qvec` container, scalar codec, deterministic quantized-IVF builder, staged page-budget reader |
-| `fulltext/*` (~2600) | Analyzer, builder, BM25 reader (`search` + bounded `search_top_k`), query parser, scoring, compaction merge, streaming sidecar term search (`stream`), bounded top-k selection (`topk`) |
+| `fulltext/*` (~2600) | Analyzer (+ `analyze_query` query-side parity so stop-word/punctuation terms match the index), builder, BM25 reader (`search` + bounded `search_top_k`), query parser, scoring, compaction merge, streaming sidecar term search (`stream`), bounded top-k selection (`topk`) |
 | `geo/*` (~2300) | Cell-id encode, bbox/radius/k-NN cover, exact refine, R-tree, ST predicates |
 
 ## Data flow

--- a/ferrosa-index/src/fulltext/analyzer.rs
+++ b/ferrosa-index/src/fulltext/analyzer.rs
@@ -101,6 +101,19 @@ impl Analyzer for KeywordAnalyzer {
 
 // ── Factory ───────────────────────────────────────────────────────────────────
 
+/// The analyzer used when no per-index analyzer option is threaded.
+///
+/// Both the write side ([`super::builder::FullTextIndexBuilder::new`], document
+/// indexing) and the read side ([`super::reader::FullTextIndexReader`], query-
+/// term normalization) construct their default analyzer here, so the two sides
+/// stay in lock-step. If they diverge, a query term the analyzer would drop or
+/// rewrite looks up a posting list that can never exist → a deterministic
+/// false-empty result. When a per-index analyzer option is eventually persisted
+/// and threaded, both sides must be handed the *same* analyzer instance kind.
+pub fn default_analyzer() -> Box<dyn Analyzer> {
+    Box::new(StandardAnalyzer::new())
+}
+
 /// Select an analyzer from a CQL index `WITH OPTIONS` map.
 ///
 /// Recognized option keys:

--- a/ferrosa-index/src/fulltext/builder.rs
+++ b/ferrosa-index/src/fulltext/builder.rs
@@ -30,7 +30,7 @@
 
 use std::collections::HashMap;
 
-use super::analyzer::{Analyzer, StandardAnalyzer};
+use super::analyzer::{default_analyzer, Analyzer};
 
 /// Magic bytes for FTI files.
 pub const FTI_MAGIC: &[u8; 4] = b"FTIX";
@@ -91,9 +91,9 @@ pub struct FullTextIndexBuilder {
 }
 
 impl FullTextIndexBuilder {
-    /// Create a builder using the default [`StandardAnalyzer`].
+    /// Create a builder using the shared [`default_analyzer`].
     pub fn new() -> Self {
-        Self::with_analyzer(Box::new(StandardAnalyzer::new()))
+        Self::with_analyzer(default_analyzer())
     }
 
     /// Create a builder with a custom analyzer.

--- a/ferrosa-index/src/fulltext/query.rs
+++ b/ferrosa-index/src/fulltext/query.rs
@@ -10,6 +10,8 @@
 //!
 //! Parsing is case-insensitive for the `AND`/`OR` operators.
 
+use super::analyzer::Analyzer;
+
 /// A parsed full-text search query.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FtsQuery {
@@ -58,6 +60,79 @@ pub fn parse_fts_query(query: &str) -> Result<FtsQuery, String> {
 
     // Build the expression tree from raw tokens.
     build_expr(&raw_tokens)
+}
+
+/// Re-analyze a parsed query's terms with the SAME analyzer the index applied
+/// to its documents, so query-side tokens can match index-side tokens.
+///
+/// The parser only lowercases and splits on whitespace; the index, by contrast,
+/// ran every document through an [`Analyzer`] that lowercases, splits on
+/// punctuation, and (for the default `StandardAnalyzer`) strips English stop
+/// words. Without this step a plain conjunction like `reports were emitted`
+/// requires a posting list for the stop word `were` that the analyzer
+/// guarantees can never exist, so the query deterministically returns nothing.
+///
+/// Normalization rules (operator semantics are preserved):
+/// - A term that analyzes to **nothing** (a stop word) is DROPPED — it is never
+///   required by a conjunction and contributes nothing to a disjunction.
+/// - A term that analyzes to **several** tokens (punctuation split) becomes a
+///   conjunction of those tokens, matching how the index stored them.
+/// - `Prefix` is left untouched: analyzing a prefix fragment (stop-word or
+///   punctuation filtering) would corrupt the intended wildcard.
+/// - An `And`/`Or` operand that collapses to nothing yields its sibling; a
+///   `Not` whose operand analyzes away keeps the original operand verbatim, so
+///   `NOT <stop-word>` still excludes nothing (matches every document).
+///
+/// Returns `None` when the whole query reduces to no searchable terms (e.g.
+/// every term is a stop word). Callers treat `None` as "matches nothing"
+/// **without** erroring the query.
+pub fn analyze_query(query: &FtsQuery, analyzer: &dyn Analyzer) -> Option<FtsQuery> {
+    match query {
+        FtsQuery::Term(t) => from_tokens(analyzer.analyze(t)),
+        FtsQuery::MultiTerm(terms) => {
+            let tokens: Vec<String> = terms.iter().flat_map(|t| analyzer.analyze(t)).collect();
+            from_tokens(tokens)
+        }
+        FtsQuery::Phrase(words) => {
+            // Preserve order; drop words that analyze away. Phrase evaluation
+            // requires each surviving word to be present in the document.
+            let kept: Vec<String> = words.iter().flat_map(|w| analyzer.analyze(w)).collect();
+            if kept.is_empty() {
+                None
+            } else {
+                Some(FtsQuery::Phrase(kept))
+            }
+        }
+        // Wildcards are matched by prefix, not by exact token — leave as-is.
+        FtsQuery::Prefix(p) => Some(FtsQuery::Prefix(p.clone())),
+        FtsQuery::And(l, r) => match (analyze_query(l, analyzer), analyze_query(r, analyzer)) {
+            (Some(a), Some(b)) => Some(FtsQuery::And(Box::new(a), Box::new(b))),
+            (Some(only), None) | (None, Some(only)) => Some(only),
+            (None, None) => None,
+        },
+        FtsQuery::Or(l, r) => match (analyze_query(l, analyzer), analyze_query(r, analyzer)) {
+            (Some(a), Some(b)) => Some(FtsQuery::Or(Box::new(a), Box::new(b))),
+            (Some(only), None) | (None, Some(only)) => Some(only),
+            (None, None) => None,
+        },
+        FtsQuery::Not(inner) => match analyze_query(inner, analyzer) {
+            Some(i) => Some(FtsQuery::Not(Box::new(i))),
+            // Excluding an all-stop-word operand excludes nothing. Keep the
+            // operand verbatim so the evaluator's exclusion set is empty and
+            // every document qualifies — the pre-existing, correct behavior.
+            None => Some(FtsQuery::Not(inner.clone())),
+        },
+    }
+}
+
+/// Build a query from analyzed tokens: none → dropped, one → `Term`, many → a
+/// `MultiTerm` conjunction.
+fn from_tokens(tokens: Vec<String>) -> Option<FtsQuery> {
+    match tokens.len() {
+        0 => None,
+        1 => Some(FtsQuery::Term(tokens.into_iter().next().unwrap())),
+        _ => Some(FtsQuery::MultiTerm(tokens)),
+    }
 }
 
 // ── Internal tokenizer ────────────────────────────────────────────────────────
@@ -337,6 +412,110 @@ mod tests {
         let result = parse_fts_query("*");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("bare wildcard"));
+    }
+
+    // ── analyze_query (query-side analyzer parity) ────────────────────────────
+
+    use crate::fulltext::analyzer::{KeywordAnalyzer, StandardAnalyzer};
+
+    #[test]
+    fn analyze_drops_stopword_from_multiterm_conjunction() {
+        let a = StandardAnalyzer::new();
+        let q = parse_fts_query("reports were emitted").unwrap();
+        let norm = analyze_query(&q, &a).expect("has searchable terms");
+        assert_eq!(
+            norm,
+            FtsQuery::MultiTerm(vec!["reports".into(), "emitted".into()])
+        );
+    }
+
+    #[test]
+    fn analyze_all_stopwords_yields_none() {
+        let a = StandardAnalyzer::new();
+        let q = parse_fts_query("was there").unwrap();
+        assert_eq!(analyze_query(&q, &a), None);
+    }
+
+    #[test]
+    fn analyze_single_stopword_term_yields_none() {
+        let a = StandardAnalyzer::new();
+        let q = parse_fts_query("were").unwrap();
+        assert_eq!(analyze_query(&q, &a), None);
+    }
+
+    #[test]
+    fn analyze_and_operand_stopword_collapses_to_sibling() {
+        let a = StandardAnalyzer::new();
+        let q = parse_fts_query("reports AND were").unwrap();
+        assert_eq!(
+            analyze_query(&q, &a),
+            Some(FtsQuery::Term("reports".into()))
+        );
+        // Symmetric.
+        let q2 = parse_fts_query("were AND reports").unwrap();
+        assert_eq!(
+            analyze_query(&q2, &a),
+            Some(FtsQuery::Term("reports".into()))
+        );
+    }
+
+    #[test]
+    fn analyze_or_operand_stopword_collapses_to_sibling() {
+        let a = StandardAnalyzer::new();
+        let q = parse_fts_query("reports OR were").unwrap();
+        assert_eq!(
+            analyze_query(&q, &a),
+            Some(FtsQuery::Term("reports".into()))
+        );
+    }
+
+    #[test]
+    fn analyze_term_with_punctuation_splits_into_conjunction() {
+        let a = StandardAnalyzer::new();
+        // A single token carrying punctuation is analyzed as the index stored it.
+        let q = parse_fts_query("foo-bar").unwrap();
+        assert_eq!(
+            analyze_query(&q, &a),
+            Some(FtsQuery::MultiTerm(vec!["foo".into(), "bar".into()]))
+        );
+    }
+
+    #[test]
+    fn analyze_prefix_is_left_untouched() {
+        let a = StandardAnalyzer::new();
+        let q = parse_fts_query("rep*").unwrap();
+        assert_eq!(analyze_query(&q, &a), Some(FtsQuery::Prefix("rep".into())));
+    }
+
+    #[test]
+    fn analyze_phrase_drops_stopword_preserving_order() {
+        let a = StandardAnalyzer::new();
+        let q = parse_fts_query("\"reports were emitted\"").unwrap();
+        assert_eq!(
+            analyze_query(&q, &a),
+            Some(FtsQuery::Phrase(vec!["reports".into(), "emitted".into()]))
+        );
+    }
+
+    #[test]
+    fn analyze_not_stopword_keeps_operand_verbatim() {
+        let a = StandardAnalyzer::new();
+        // `NOT was` must remain a Not so the evaluator excludes nothing — it
+        // must not collapse to None (which would match nothing).
+        let q = parse_fts_query("NOT was").unwrap();
+        assert_eq!(
+            analyze_query(&q, &a),
+            Some(FtsQuery::Not(Box::new(FtsQuery::Term("was".into()))))
+        );
+    }
+
+    #[test]
+    fn analyze_keyword_analyzer_has_no_stopwords() {
+        // Parity must follow the INDEX's analyzer: a keyword analyzer keeps the
+        // whole string, so a "stop word" is a real, matchable token.
+        let a = KeywordAnalyzer;
+        let q = parse_fts_query("were").unwrap();
+        assert_eq!(analyze_query(&q, &a), Some(FtsQuery::Term("were".into())));
     }
 
     #[test]

--- a/ferrosa-index/src/fulltext/reader.rs
+++ b/ferrosa-index/src/fulltext/reader.rs
@@ -6,8 +6,9 @@
 
 use std::collections::HashMap;
 
+use super::analyzer::{default_analyzer, Analyzer};
 use super::builder::{FullTextIndex, Posting, TermEntry, FTI_MAGIC, FTI_VERSION};
-use super::query::{parse_fts_query, FtsQuery};
+use super::query::{analyze_query, parse_fts_query, FtsQuery};
 use super::scoring::{bm25_score, Bm25Params};
 use super::topk::TopK;
 
@@ -23,24 +24,49 @@ pub struct FtsHit {
 /// Wraps a deserialized [`FullTextIndex`] and exposes query operations.
 pub struct FullTextIndexReader {
     index: FullTextIndex,
+    /// The analyzer applied to query terms before evaluation. It MUST be the
+    /// same analyzer the builder used to index the documents, or query tokens
+    /// won't match index tokens (see [`analyze_query`]). The serialized FTI
+    /// format does not record the analyzer, so callers that build with a
+    /// non-default analyzer must open with the matching `*_with_analyzer`
+    /// constructor.
+    analyzer: Box<dyn Analyzer>,
 }
 
 impl FullTextIndexReader {
-    /// Open an FTI from raw bytes.
+    /// Open an FTI from raw bytes, using the shared [`default_analyzer`].
     ///
     /// Validates the magic/version header before deserializing.
     pub fn open(bytes: Vec<u8>) -> Result<Self, String> {
-        let fti = deserialize_fti(&bytes)?;
-        Ok(Self { index: fti })
+        Self::open_with_analyzer(bytes, default_analyzer())
     }
 
-    /// Wrap an already-built in-memory [`FullTextIndex`] directly.
+    /// Open an FTI from raw bytes with an explicit query-side analyzer.
+    ///
+    /// Use this when the index was built with a non-default analyzer, to keep
+    /// query-term normalization in parity with document indexing.
+    pub fn open_with_analyzer(bytes: Vec<u8>, analyzer: Box<dyn Analyzer>) -> Result<Self, String> {
+        let fti = deserialize_fti(&bytes)?;
+        Ok(Self {
+            index: fti,
+            analyzer,
+        })
+    }
+
+    /// Wrap an already-built in-memory [`FullTextIndex`] directly, using the
+    /// shared [`default_analyzer`].
     ///
     /// Avoids the `serialize_fti` → `deserialize_fti` round trip that the
     /// transient memtable / sidecar-less-SSTable search paths used to pay
     /// (3× the indexed text held at once — t_ee98faa0 layer 2).
     pub fn from_index(index: FullTextIndex) -> Self {
-        Self { index }
+        Self::from_index_with_analyzer(index, default_analyzer())
+    }
+
+    /// Wrap an already-built in-memory [`FullTextIndex`] with an explicit
+    /// query-side analyzer (parity with a non-default index analyzer).
+    pub fn from_index_with_analyzer(index: FullTextIndex, analyzer: Box<dyn Analyzer>) -> Self {
+        Self { index, analyzer }
     }
 
     /// Total number of documents in this index.
@@ -68,8 +94,15 @@ impl FullTextIndexReader {
     /// Results are sorted by descending BM25 score. Deduplication by
     /// partition key is applied: the maximum score for any key wins.
     pub fn search(&self, query: &FtsQuery) -> Vec<FtsHit> {
+        // Normalize query terms through the index's analyzer first, so a term
+        // the index dropped/rewrote (e.g. a stop word) can't silently force a
+        // false-empty result. A query that analyzes away entirely matches
+        // nothing (without erroring).
+        let Some(normalized) = analyze_query(query, self.analyzer.as_ref()) else {
+            return vec![];
+        };
         let mut score_map: HashMap<&[u8], f64> = HashMap::new();
-        self.eval_query(query, &mut score_map);
+        self.eval_query(&normalized, &mut score_map);
 
         let mut hits: Vec<FtsHit> = score_map
             .into_iter()
@@ -115,8 +148,13 @@ impl FullTextIndexReader {
         if k == 0 {
             return vec![];
         }
+        // Analyzer parity (same as `search`): normalize before evaluating so a
+        // stop-word/punctuation term can't force a false-empty result.
+        let Some(normalized) = analyze_query(query, self.analyzer.as_ref()) else {
+            return vec![];
+        };
         let mut topk = TopK::new(k);
-        match query {
+        match &normalized {
             FtsQuery::Term(term) => self.stream_term_top_k(term, &mut topk),
             FtsQuery::MultiTerm(terms) | FtsQuery::Phrase(terms) => {
                 self.stream_conjunction_top_k(terms, &mut topk);
@@ -642,6 +680,122 @@ mod tests {
         let hits = reader.search_str("a*").unwrap();
         assert!(!hits.is_empty(), "prefix search must return results");
         assert!(hits.len() <= 500, "must not exceed doc count");
+    }
+
+    // ── Analyzer parity (query side == index side) ────────────────────────────
+    //
+    // Documents are indexed through the index's analyzer, which for the default
+    // `StandardAnalyzer` strips English stop words (a, an, ..., was, were, ...).
+    // The query side must apply the SAME analyzer to its terms, or a natural-
+    // language query carrying a stop word looks up a posting list the analyzer
+    // guarantees can never exist → a deterministic false-empty result. Live
+    // repro: ferrosa-memory `fixed_document_search_survives_fts_stopword_
+    // absent_from_corpus`.
+
+    #[test]
+    fn search_matches_when_query_contains_stopword_absent_from_corpus() {
+        // "by"/"the" are stripped at index time; "were" must be stripped at
+        // query time so the plain conjunction reduces to reports AND emitted.
+        let reader = make_reader(&[
+            (
+                b"pk1",
+                "quarterly latency reports emitted by the ingest pipeline",
+            ),
+            (b"pk2", "python scripting only"),
+        ]);
+        let hits = reader.search_str("reports were emitted").unwrap();
+        let pks: Vec<_> = hits.iter().map(|h| h.partition_key.as_slice()).collect();
+        assert!(
+            pks.contains(&b"pk1".as_slice()),
+            "stop word 'were' must be dropped, not required — pk1 has reports+emitted"
+        );
+        assert!(
+            !pks.contains(&b"pk2".as_slice()),
+            "pk2 lacks reports/emitted"
+        );
+    }
+
+    #[test]
+    fn search_all_stopword_query_matches_nothing_without_error() {
+        let reader = make_reader(&[(b"pk1", "reports emitted")]);
+        // Every term analyzes away; the query must not error, it matches nothing.
+        let hits = reader.search_str("was there").expect("must not error");
+        assert!(hits.is_empty(), "all-stop-word query matches nothing");
+    }
+
+    #[test]
+    fn search_stopword_dropped_from_explicit_and() {
+        let reader = make_reader(&[
+            (b"pk1", "reports emitted here"),
+            (b"pk2", "nothing relevant"),
+        ]);
+        // The stop-word operand collapses to its sibling in both orders.
+        for q in ["reports AND were", "were AND reports"] {
+            let hits = reader.search_str(q).unwrap();
+            let pks: Vec<_> = hits.iter().map(|h| h.partition_key.as_slice()).collect();
+            assert!(pks.contains(&b"pk1".as_slice()), "{q}: pk1 has 'reports'");
+            assert!(
+                !pks.contains(&b"pk2".as_slice()),
+                "{q}: pk2 lacks 'reports'"
+            );
+        }
+    }
+
+    #[test]
+    fn search_stopword_dropped_from_explicit_or() {
+        let reader = make_reader(&[(b"pk1", "reports emitted"), (b"pk2", "python scripting")]);
+        let hits = reader.search_str("reports OR were").unwrap();
+        let pks: Vec<_> = hits.iter().map(|h| h.partition_key.as_slice()).collect();
+        assert!(pks.contains(&b"pk1".as_slice()), "pk1 has 'reports'");
+        assert!(
+            !pks.contains(&b"pk2".as_slice()),
+            "pk2 has neither 'reports' nor a real 'were' token"
+        );
+    }
+
+    #[test]
+    fn search_phrase_with_stopword_matches() {
+        let reader = make_reader(&[
+            (
+                b"pk1",
+                "quarterly latency reports emitted by the ingest pipeline",
+            ),
+            (b"pk2", "reports without the other word"),
+        ]);
+        // Phrase eval approximates as a conjunction of present terms; the stop
+        // word 'were' must drop so the phrase reduces to reports + emitted.
+        let hits = reader.search_str("\"reports were emitted\"").unwrap();
+        let pks: Vec<_> = hits.iter().map(|h| h.partition_key.as_slice()).collect();
+        assert!(pks.contains(&b"pk1".as_slice()), "pk1 has reports+emitted");
+        assert!(!pks.contains(&b"pk2".as_slice()), "pk2 lacks 'emitted'");
+    }
+
+    #[test]
+    fn search_query_term_with_trailing_punctuation_matches() {
+        // A single query term carrying punctuation must analyze to the same
+        // token the index stored ("emitted." → "emitted"), not be looked up
+        // verbatim.
+        let reader = make_reader(&[(b"pk1", "latency reports emitted")]);
+        let hits = reader.search_str("emitted.").unwrap();
+        assert_eq!(hits.len(), 1, "'emitted.' must match indexed 'emitted'");
+        assert_eq!(hits[0].partition_key, b"pk1");
+    }
+
+    #[test]
+    fn search_not_with_only_stopword_still_returns_all_docs() {
+        // `NOT was` excludes documents containing 'was'; since the analyzer
+        // never indexed 'was', nothing is excluded → every document qualifies.
+        let reader = make_reader(&[(b"pk1", "reports emitted"), (b"pk2", "python only")]);
+        let hits = reader.search_str("NOT was").unwrap();
+        let pks: Vec<_> = hits.iter().map(|h| h.partition_key.as_slice()).collect();
+        assert!(
+            pks.contains(&b"pk1".as_slice()),
+            "pk1 not excluded by 'was'"
+        );
+        assert!(
+            pks.contains(&b"pk2".as_slice()),
+            "pk2 not excluded by 'was'"
+        );
     }
 
     #[test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -6363,7 +6363,8 @@ impl StorageEngine {
         query: &str,
         limit: Option<usize>,
     ) -> ferrosa_common::Result<Vec<Vec<u8>>> {
-        use ferrosa_index::fulltext::query::parse_fts_query;
+        use ferrosa_index::fulltext::analyzer::default_analyzer;
+        use ferrosa_index::fulltext::query::{analyze_query, parse_fts_query};
         use ferrosa_index::fulltext::reader::FullTextIndexReader;
         use std::collections::{HashMap, HashSet};
 
@@ -6400,6 +6401,16 @@ impl StorageEngine {
         let parsed = parse_fts_query(query).map_err(|e| {
             ferrosa_common::Error::InvalidFormat(format!("fts_match query error: {e}"))
         })?;
+        // Normalize through the index analyzer so the single-`Term` streaming
+        // fast path below looks up an analyzed token (not a raw stop word or a
+        // punctuation-bearing term). The reader/memtable/fallback paths also
+        // normalize internally; this keeps the fast path in parity. A query
+        // that analyzes away entirely matches nothing.
+        let analyzer = default_analyzer();
+        let parsed = match analyze_query(&parsed, analyzer.as_ref()) {
+            Some(q) => q,
+            None => return Ok(vec![]),
+        };
 
         let mut score_map: HashMap<Vec<u8>, f64> = HashMap::new();
         let merge_hits = |score_map: &mut HashMap<Vec<u8>, f64>, hits: Vec<(Vec<u8>, f64)>| {
@@ -6541,7 +6552,8 @@ impl StorageEngine {
         query: &str,
         on_hit: &mut dyn FnMut(Vec<u8>) -> std::ops::ControlFlow<()>,
     ) -> ferrosa_common::Result<()> {
-        use ferrosa_index::fulltext::query::{parse_fts_query, FtsQuery};
+        use ferrosa_index::fulltext::analyzer::default_analyzer;
+        use ferrosa_index::fulltext::query::{analyze_query, parse_fts_query, FtsQuery};
         use std::collections::HashSet;
         use std::ops::ControlFlow;
 
@@ -6550,6 +6562,13 @@ impl StorageEngine {
         let parsed = parse_fts_query(query).map_err(|e| {
             ferrosa_common::Error::InvalidFormat(format!("fts_match query error: {e}"))
         })?;
+        // Analyzer parity for the single-`Term` streaming fast path (see
+        // `fulltext_search`). A query that analyzes away matches nothing.
+        let analyzer = default_analyzer();
+        let parsed = match analyze_query(&parsed, analyzer.as_ref()) {
+            Some(q) => q,
+            None => return Ok(()),
+        };
 
         if !self.tables.read().contains_key(table_id) {
             return Ok(());
@@ -20529,6 +20548,63 @@ mod tests {
             !result_keys.contains(&"r3".to_string()),
             "r3 has neither term"
         );
+    }
+
+    /// Analyzer-parity end-to-end: a natural-language query carrying an English
+    /// stop word absent from the corpus must still match. Mirrors the live
+    /// ferrosa-memory failure `fixed_document_search_survives_fts_stopword_
+    /// absent_from_corpus`. Exercises the flushed-sidecar path through the real
+    /// engine (not just the reader unit).
+    #[test]
+    fn fts_stopword_bearing_query_matches_after_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+        engine.add_fulltext_index(&tid, "idx_body", 0).unwrap();
+
+        engine
+            .write(
+                &tid,
+                &make_key("r1"),
+                make_row(
+                    b"quarterly latency reports emitted by the ingest pipeline",
+                    1000,
+                ),
+                1000,
+            )
+            .unwrap();
+        engine
+            .write(
+                &tid,
+                &make_key("r2"),
+                make_row(b"python scripting only", 1000),
+                1000,
+            )
+            .unwrap();
+        engine.flush(&tid).unwrap();
+
+        // "were" is stripped by the index analyzer and never appears in any
+        // posting list — before the fix this conjunction returned 0 rows.
+        let results = engine
+            .fulltext_search(&tid, "idx_body", "reports were emitted", None)
+            .unwrap();
+        let keys: Vec<String> = results
+            .iter()
+            .filter_map(|dk| {
+                ferrosa_index::fulltext::keys::doc_key_partition(dk)
+                    .map(|pk| String::from_utf8_lossy(pk).to_string())
+            })
+            .collect();
+        assert!(keys.contains(&"r1".to_string()), "r1 has reports+emitted");
+        assert!(!keys.contains(&"r2".to_string()), "r2 lacks both terms");
+
+        // An all-stop-word query matches nothing but must not error.
+        let empty = engine
+            .fulltext_search(&tid, "idx_body", "was there", None)
+            .unwrap();
+        assert!(empty.is_empty(), "all-stop-word query matches nothing");
     }
 
     #[test]


### PR DESCRIPTION
## The asymmetry

Documents are indexed through the index's analyzer. `FullTextIndexBuilder::add_document`
runs text through `StandardAnalyzer` (`ferrosa-index/src/fulltext/analyzer.rs`),
which strips its default English stop words (`a, an, and, are, ..., was, were,
will, with`) and splits on punctuation.

The **query** side never applied the analyzer. `parse_fts_query`
(`ferrosa-index/src/fulltext/query.rs`) only lowercased and split on whitespace,
so plain adjacent terms became `FtsQuery::MultiTerm` — an implicit AND evaluated
by verbatim posting-list lookup (`reader.rs` `search` / `search_top_k` /
`stream_conjunction_top_k`, `self.index.terms.get(term)`).

Consequence: `fts_match('reports were emitted')` requires a posting list for
`were`, which the analyzer guarantees can **never** exist — the query
deterministically returns 0 hits even when documents contain "reports … emitted".
Any natural-language query containing an English stop word (or a
punctuation-bearing term such as `emitted.`) matched nothing.

## Live repro

ferrosa-memory CI failure
`fixed_document_search_survives_fts_stopword_absent_from_corpus`.

## Fix — apply the index analyzer to query terms

New `query::analyze_query(query, analyzer)` re-analyzes a parsed `FtsQuery` with
the **index's** analyzer, at the layer where the parsed query meets the index so
every caller benefits:

- A term that analyzes to nothing (a stop word) is **dropped** from a
  conjunction rather than required.
- A term that splits on punctuation becomes a conjunction of its tokens (parity
  with how the index stored them).
- A conjunction whose every term drops (e.g. `was there`) matches nothing —
  **without erroring the query**.
- Operator semantics are preserved: `Prefix` is left untouched; an `And`/`Or`
  operand that collapses to nothing yields its sibling; `NOT <stop-word>` keeps
  its operand verbatim so it still excludes nothing (matches every document).

`FullTextIndexReader` now carries its analyzer (`open`/`from_index` default to
the shared `analyzer::default_analyzer()`; `open_with_analyzer` /
`from_index_with_analyzer` accept a non-default one) and normalizes inside
`search`/`search_top_k`. This covers the memtable (`store.rs`
`fulltext_memtable_search`), sidecar (`engine.rs` `fulltext_search`), and
missing-sidecar (`store.rs` `fulltext_sstable_scan_missing_sidecar`) read paths.
The single-`Term` streaming fast path in `engine.rs` normalizes the term with
the same analyzer before the `stream` walk.

Parity uses the **index's** analyzer, not a hardcoded `StandardAnalyzer`: the
reader holds the analyzer, and both the builder default and reader default route
through one `analyzer::default_analyzer()`. (Today every FTI is built with the
default; a residual is filed in the FMEA for the day a per-index analyzer option
is actually threaded — the analyzer is not yet persisted in the FTI.)

## Validation

- `ferrosa-index --lib` — 282 passed (new `reader.rs` parity tests + `query.rs`
  `analyze_*` unit tests).
- `ferrosa-storage --lib` — 987 passed (incl. new engine e2e
  `fts_stopword_bearing_query_matches_after_flush`).
- `ferrosa-cql --lib` — 1016 passed.
- `cargo fmt --check`; clippy on the three touched crates `--all-targets` (zero
  warnings); `cargo doc --no-deps` on the touched crates with `-D warnings`.

Per-crate docs updated: `ferrosa-index` README (analyzer-parity subsection),
`specs/overview.md`, and `specs/fmea.md` (new IDX-11 row + persisted-analyzer
residual).
