### PR TITLE
fix(jepsen): stop bank false-failing on register linearizability; make container DC-partition real

### DIFF
--- a/ferrosa-jepsen/README.md
+++ b/ferrosa-jepsen/README.md
@@ -38,9 +38,19 @@ graph. It calls `ferrosa-sim` for the simulator-backed endurance path.
   `full` (25+ incl. WAN + composed).
 - **Checkers** (`checker/`):
   - **Linearizability** — a native Rust WGL-style backtracking checker
-    (`check_linearizability`) with a register model (read/write/CAS/serial-read),
-    a 100k-node search bound, and minimal counterexamples. This is the checker
-    that actually runs in unit tests and CI.
+    (`check_linearizability`) with a single-value register model
+    (read/write/CAS/serial-read), a 100k-node search bound, and minimal
+    counterexamples. This is the checker that actually runs in unit tests and CI.
+    It only applies to workloads whose history is a set of single-key register
+    ops: a workload opts in/out via `Workload::register_linearizable()` (default
+    `true`). Transactional workloads such as `bank` return `false` — their writes
+    record transfer *deltas* and their reads are multi-key snapshots
+    (`CurrentValues`), which a single-value register model cannot represent, so
+    the orchestrator would otherwise false-report every conserved bank run as
+    non-linearizable. Bank's safety is judged by conservation
+    (`check_invariant`); strict serializability of the Accord path is a separate
+    (Elle) check. Per-key linearizability is deliberately *not* asserted over the
+    eventually-consistent base.
   - **Membership invariants** (`checker/membership.rs`) — structural checks
     I-06–I-10, I-13 over per-node membership snapshots.
   - **Knossos** (`checker/knossos.rs`) — shells out to Clojure/`lein`; only runs
@@ -66,7 +76,10 @@ graph. It calls `ferrosa-sim` for the simulator-backed endurance path.
     Fly-SSH nemesis transport for T3/T4. Set `FERROSA_JEPSEN_FLY_APP` plus
     ordered `FERROSA_JEPSEN_FLY_MACHINE_IDS` to execute WAN chaos on real Fly
     machines; the same WAN actions use `container_runtime exec` for the local
-    T3 compose topology.
+    T3 compose topology. In container mode the DC-partition nemesis targets each
+    node's **WAN-network IP** (resolved via `container_runtime inspect`), not the
+    host-mapped `localhost` CQL contacts — otherwise the injected `iptables`
+    DROP rules would hit loopback and silently sever nothing.
 - **Endurance sim** (`endurance_sim.rs`) — the **sim-equivalent endurance run**
   (W8.9, ADR-016). Drives `ferrosa_sim::multi_dc::DualDcBankSim` (voters +
   per-DC learners) over a 24-simulated-hour horizon with periodic rolling-window
@@ -86,7 +99,7 @@ ferrosa-jepsen report list                       # (report subcommands are stubs
 
 ## Tests
 
-- **232** in-crate unit tests (checker correctness, registries, config
+- **233** in-crate unit tests (checker correctness, registries, config
   resolution, the endurance-sim smoke + tri-DC headline runs, etc.) — these run
   under default `cargo test -p ferrosa-jepsen`.
 - **30** integration test functions across `tests/`. The live-infra ones

--- a/ferrosa-jepsen/src/orchestrator.rs
+++ b/ferrosa-jepsen/src/orchestrator.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::chaos::{NemesisAction, NemesisContext, NemesisRegistry};
@@ -109,7 +109,7 @@ fn nemesis_context_for_cluster(cluster: &ClusterInfo) -> Result<NemesisContext> 
     }
 
     if std::env::var("FERROSA_TEST_CONTAINERS").is_ok() {
-        let container_names = [
+        let container_names: Vec<String> = [
             "ferrosa-jepsen-t3-dc1-node1",
             "ferrosa-jepsen-t3-dc1-node2",
             "ferrosa-jepsen-t3-dc1-node3",
@@ -120,6 +120,12 @@ fn nemesis_context_for_cluster(cluster: &ClusterInfo) -> Result<NemesisContext> 
         .into_iter()
         .map(str::to_string)
         .collect();
+        // The DC-partition nemesis installs iptables DROP rules *inside* the
+        // containers, so it must target each node's real cross-DC (WAN) network
+        // address. The outer `node_ips` come from the host-mapped CQL contacts
+        // (`localhost:2904x`); using those would make the partition drop
+        // loopback and silently sever nothing. Resolve the container WAN IPs.
+        let node_ips = resolve_container_wan_ips(&container_names)?;
         return Ok(NemesisContext {
             node_ips,
             ssh_user: "root".to_string(),
@@ -141,6 +147,51 @@ fn nemesis_context_for_cluster(cluster: &ClusterInfo) -> Result<NemesisContext> 
             .unwrap_or(22),
         executor: crate::chaos::NemesisExecutor::Ssh,
     })
+}
+
+/// Resolve each container's WAN-network IP (the address cross-DC peers actually
+/// use), in the same order as `containers`. Container mode otherwise has no
+/// route to the internal IPs — the CQL contacts are host-mapped `localhost`
+/// ports — so the DC-partition nemesis needs this to drop real inter-DC traffic
+/// instead of loopback.
+fn resolve_container_wan_ips(containers: &[String]) -> Result<Vec<String>> {
+    let runtime = crate::docker_provision::container_runtime();
+    containers
+        .iter()
+        .map(|c| {
+            let out = std::process::Command::new(runtime)
+                .args([
+                    "inspect",
+                    c,
+                    "--format",
+                    "{{json .NetworkSettings.Networks}}",
+                ])
+                .output()
+                .with_context(|| format!("failed to inspect container {c}"))?;
+            if !out.status.success() {
+                bail!(
+                    "{runtime} inspect {c} failed: {}",
+                    String::from_utf8_lossy(&out.stderr)
+                );
+            }
+            let networks: serde_json::Value = serde_json::from_slice(&out.stdout)
+                .with_context(|| format!("parsing networks JSON for {c}"))?;
+            let obj = networks
+                .as_object()
+                .with_context(|| format!("networks for {c} not a JSON object"))?;
+            // Prefer the shared WAN network (the only one spanning both DCs);
+            // fall back to the first network if the naming differs.
+            let ip = obj
+                .iter()
+                .find(|(name, _)| name.contains("wan"))
+                .or_else(|| obj.iter().next())
+                .and_then(|(_, v)| v.get("IPAddress"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .with_context(|| format!("no IPAddress for container {c}"))?;
+            Ok(ip.to_string())
+        })
+        .collect()
 }
 
 /// Inject one fault window and always heal it before returning. The workload
@@ -412,8 +463,19 @@ async fn run_single_combination(
     let history_path = run_dir.join(format!("{topology:?}-{nemesis_name}-{workload_name}.jsonl"));
     history.to_jsonl(&history_path)?;
 
-    // Check linearizability.
-    let linearizability = check_linearizability(&history);
+    // Check linearizability — only for workloads whose history is a set of
+    // single-value register operations (register/LWT). Transactional workloads
+    // like `bank` opt out (`register_linearizable() == false`): their delta
+    // writes and multi-key snapshot reads cannot be modelled as a single-value
+    // register, and per-key linearizability is not a guarantee the
+    // eventually-consistent base makes. Their safety is judged by
+    // `check_invariant` (conservation) and, for transactions, strict
+    // serializability (Elle). An empty result vector is vacuously all-linear.
+    let linearizability = if workload.register_linearizable() {
+        check_linearizability(&history)
+    } else {
+        Vec::new()
+    };
     let all_linear = linearizability.iter().all(|r| r.valid);
 
     // Check workload-specific invariants.

--- a/ferrosa-jepsen/src/workload/bank.rs
+++ b/ferrosa-jepsen/src/workload/bank.rs
@@ -42,6 +42,16 @@ impl Workload for BankWorkload {
         "bank"
     }
 
+    /// Bank is a transactional workload: writes record transfer *deltas* and
+    /// reads are whole-cluster balance snapshots, which the single-value
+    /// register linearizability model cannot represent (and per-key
+    /// linearizability is not a guarantee Ferrosa's eventually-consistent base
+    /// makes). Correctness is judged by value conservation ([`Self::check_invariant`])
+    /// and, for the Accord transaction path, by strict serializability (Elle).
+    fn register_linearizable(&self) -> bool {
+        false
+    }
+
     async fn setup(&self, session: &dyn CqlSession) -> Result<()> {
         session
             .execute(
@@ -313,5 +323,62 @@ mod tests {
 
         let wl = BankWorkload;
         assert!(wl.check_invariant(&history).is_err());
+    }
+
+    /// Regression guard for the register-model false-positive. A bank history
+    /// (delta writes + multi-key snapshot reads) is not a single-value register
+    /// history, so the generic linearizability checker reports it as
+    /// non-linearizable even when every balance was conserved. Bank therefore
+    /// opts out of that check and is judged by conservation (+ strict
+    /// serializability via Elle) instead.
+    #[test]
+    fn bank_opts_out_of_register_linearizability() {
+        use crate::checker::check_linearizability;
+
+        let wl = BankWorkload;
+        assert!(
+            !wl.register_linearizable(),
+            "bank must not be gated by the single-value register model"
+        );
+
+        // A conserved bank history: the write records the transfer *delta*, and
+        // a snapshot read sums to the expected total.
+        let history = History {
+            operations: vec![
+                make_op(
+                    "c1",
+                    100,
+                    200,
+                    Op::Write {
+                        key: "account-1".into(),
+                        value: 37,
+                    },
+                    OpResult::Ok,
+                ),
+                make_op(
+                    "c1",
+                    300,
+                    400,
+                    Op::SerialRead {
+                        key: "all-accounts".into(),
+                    },
+                    OpResult::CurrentValues(
+                        (0..NUM_ACCOUNTS)
+                            .map(|i| (format!("account-{i}"), INITIAL_BALANCE.to_string()))
+                            .collect(),
+                    ),
+                ),
+            ],
+        };
+
+        // Conservation holds…
+        assert!(wl.check_invariant(&history).is_ok());
+        // …yet the single-value register model still flags it, which is exactly
+        // why the orchestrator must skip linearizability for this workload.
+        let lin = check_linearizability(&history);
+        assert!(
+            lin.iter().any(|r| !r.valid),
+            "register model is expected to false-fail a (conserved) bank history"
+        );
     }
 }

--- a/ferrosa-jepsen/src/workload/mod.rs
+++ b/ferrosa-jepsen/src/workload/mod.rs
@@ -53,6 +53,27 @@ pub trait Workload: Send + Sync {
 
     /// Check the history for correctness invariants.
     fn check_invariant(&self, history: &History) -> Result<()>;
+
+    /// Whether the generic per-key **single-value register linearizability**
+    /// check ([`crate::checker::check_linearizability`]) applies to this
+    /// workload's history.
+    ///
+    /// `true` (the default) fits register/LWT workloads whose history is a set
+    /// of single-key `read`/`write`/`cas` operations against a linearizable
+    /// register — the model the checker implements.
+    ///
+    /// Transactional workloads such as `bank` return `false`: their writes
+    /// record transfer *deltas* (not the resulting value) and their reads are
+    /// multi-key snapshots (`CurrentValues`), so a single-value register model
+    /// cannot represent the history — it reports every such history as
+    /// non-linearizable regardless of what the database did. More
+    /// fundamentally, per-key linearizability is not a property Ferrosa's
+    /// eventually-consistent base claims; the transaction path's guarantee is
+    /// *strict serializability* (validated by Elle), and the bank workload's
+    /// own safety property is value conservation ([`Self::check_invariant`]).
+    fn register_linearizable(&self) -> bool {
+        true
+    }
 }
 
 /// Registry of all available workloads.


### PR DESCRIPTION
## Summary

The nightly **tier-multi-dc** run (`bank` / `dc-partition+dc-slow` on T3) has been failing every night with `violated an invariant` and an empty detail (e.g. #272/#273), filing a fresh issue each time. Root cause is **two harness bugs, not a database fault**. Reproduced locally on a 6-node T3 podman cluster: under a genuine cross-DC partition the bank workload **conserves money** (every snapshot read sums to 10000), yet the run was reported as failed.

## Bug 1 — register-model false-positive (the actual red)

`passed = all_linear && invariant_passed`. The orchestrator ran a **single-value register linearizability** check on *every* workload. But `bank` records transfer **deltas** as writes and whole-cluster **snapshot reads** (`CurrentValues`), which that model can't represent — so it flags every account key (and the aggregate) as non-linearizable regardless of what the DB did. `invariant_error` was `None` because the real safety check (conservation) *passed*.

Per-key linearizability also isn't a property Ferrosa's **eventually-consistent base** claims; the transaction path's guarantee is **strict serializability** (a separate Elle check), and bank's own safety property is conservation.

**Fix:** add `Workload::register_linearizable()` (default `true`; `register`/`lwt` keep the check); `bank` opts out; the orchestrator skips `check_linearizability` for opted-out workloads. A regression test proves a *conserved* bank history still trips the register model, so the opt-out is load-bearing — not a weakened check.

## Bug 2 — DC-partition was a no-op in container mode

`nemesis_context_for_cluster` derived peer IPs from the host-mapped CQL contacts (`localhost:2904x`), so `dc-partition` injected `iptables -A INPUT -s 127.0.0.1 -j DROP` **inside** each container — dropping loopback and severing nothing (only `dc-slow`'s netem was real). The nightly was never actually partitioning the DCs.

**Fix:** resolve each node's real **WAN-network IP** via `container_runtime inspect`. Verified mid-run: dc1 nodes now drop all three dc2 WAN IPs (172.30.0.4/5/6) on INPUT+OUTPUT, and heal afterward.

## Verification (local, 6-node T3 dual-DC on podman)

- **Before:** exact nightly failure reproduced — conservation held (all snapshot reads = 10000) yet all 11 keys flagged non-linearizable, `invariant_error=None`.
- **After:** `bank` **passes** under a *real* `dc-partition+dc-slow` (189/189 snapshot reads = 10000; 425 ops correctly error under partition).
- `cargo fmt --check` clean, `cargo clippy --all-targets -D warnings` clean, **233** lib tests pass, `tier_multi_dc_resolves_to_t3` + `dc_partition_plus_dc_slow_nemesis_registered` pass.

## Scope / not in this PR

Conservation is **necessary but not sufficient** for strict serializability. Wiring **Elle** to certify the Accord transaction path as `:strict-serializable` is tracked separately — this PR turns the nightly green *and* makes it a genuine partition test for the first time, but a green nightly means "conserved under real partition", not "strict-serializable".

Closes #273. Supersedes the duplicate #272.