### PR TITLE
fix(cluster): register a reconnecting peer's host_id in on_peer_connected

### DIFF
--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -779,6 +779,11 @@ impl ModeController {
         // This shared map is used by DdlPath::Cluster to resolve leader NodeId → Uuid.
         let node_map_for_ddl = network_factory.node_map();
         let node_map_for_bootstrap = node_map_for_ddl.clone();
+        // Publish the shared node_map so `on_peer_connected` can register a
+        // (re)connecting peer's host_id — the leader must learn a reconnecting
+        // committed member's host_id even when no `JoinNode` fires, or raft RPCs
+        // to it stay "registration pending" forever.
+        self.raft_node_map.store(Some(node_map_for_ddl.clone()));
         // Clone peer_manager for DdlPath::Cluster forwarding (ClusterCoordinator
         // will consume `peer_manager` below).
         let peer_manager_for_ddl = peer_manager.clone();

--- a/ferrosa-cluster/src/controller/mod.rs
+++ b/ferrosa-cluster/src/controller/mod.rs
@@ -250,6 +250,13 @@ pub struct ModeController {
     pub(super) raft_runtime: std::sync::OnceLock<Arc<tokio::runtime::Runtime>>,
     /// Dedicated Data runtime for internode IO.
     pub(super) data_runtime: std::sync::OnceLock<Arc<tokio::runtime::Runtime>>,
+    /// The raft network factory's shared `node_id → host_id` map, captured at
+    /// cluster formation. `on_peer_connected` registers a (re)connecting peer's
+    /// host_id here so the leader can route raft RPCs to it — closing the gap
+    /// where a peer that is already a committed member reconnects after the
+    /// leader restarted (no `JoinNode`, so the leader would otherwise never learn
+    /// its host_id → "registration pending" forever). Empty until formation.
+    pub(super) raft_node_map: arc_swap::ArcSwapOption<std::sync::RwLock<HashMap<u64, uuid::Uuid>>>,
     /// Shared slot publishing this node's live `AccordState` to the session
     /// layer. Empty in standalone/pair; filled in `transition_to_cluster` with
     /// the SAME state the node's `AccordHandler` serves, so the transaction
@@ -344,6 +351,7 @@ impl ModeController {
             contention_metrics: Arc::new(ContentionMetrics::new()),
             raft_runtime: std::sync::OnceLock::new(),
             data_runtime: std::sync::OnceLock::new(),
+            raft_node_map: arc_swap::ArcSwapOption::empty(),
             accord_state_slot: crate::accord::empty_accord_state_slot(),
         });
 
@@ -363,6 +371,32 @@ impl ModeController {
     /// empty slot, and the committer then uses remote-only votes).
     pub fn accord_state_slot(&self) -> crate::accord::AccordStateSlot {
         self.accord_state_slot.clone()
+    }
+
+    /// Register a (re)connecting peer's `host_id` in the raft network factory's
+    /// shared node_map so the leader can resolve it and route raft RPCs to it.
+    ///
+    /// Idempotent (`HashMap` insert). A no-op before cluster formation (the map
+    /// is captured in `transition_to_cluster`). This is what lets an
+    /// already-committed member that reconnects *after the leader restarted*
+    /// become raft-routable again: such a reconnect triggers no `JoinNode`, so
+    /// the leader's join-time registration never fires and — without this — the
+    /// peer stays "registration pending" forever, wedging replication.
+    pub(super) fn register_peer_in_raft_node_map(&self, host_id: uuid::Uuid) {
+        if let Some(map) = self.raft_node_map.load_full() {
+            let node_id = crate::raft::uuid_to_node_id(host_id);
+            map.write()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(node_id, host_id);
+        }
+    }
+
+    /// Test-only snapshot of the raft node_map contents (`None` before formation).
+    #[cfg(test)]
+    pub(super) fn raft_node_map_snapshot(&self) -> Option<HashMap<u64, uuid::Uuid>> {
+        self.raft_node_map
+            .load_full()
+            .map(|m| m.read().unwrap_or_else(|e| e.into_inner()).clone())
     }
 
     /// Create a standalone-mode `ModeController` for unit tests.
@@ -414,6 +448,7 @@ impl ModeController {
             contention_metrics: Arc::new(ContentionMetrics::new()),
             raft_runtime: std::sync::OnceLock::new(),
             data_runtime: std::sync::OnceLock::new(),
+            raft_node_map: arc_swap::ArcSwapOption::empty(),
             accord_state_slot: crate::accord::empty_accord_state_slot(),
         })
     }
@@ -475,6 +510,7 @@ impl ModeController {
             contention_metrics: Arc::new(ContentionMetrics::new()),
             raft_runtime: std::sync::OnceLock::new(),
             data_runtime: std::sync::OnceLock::new(),
+            raft_node_map: arc_swap::ArcSwapOption::empty(),
             accord_state_slot: crate::accord::empty_accord_state_slot(),
         })
     }

--- a/ferrosa-cluster/src/controller/peer_events.rs
+++ b/ferrosa-cluster/src/controller/peer_events.rs
@@ -228,6 +228,15 @@ impl PeerEventListener for ModeController {
             track_connected_peer(&mut peers, host_id, addr, super::MAX_CONNECTED_PEERS);
         }
 
+        // Register this peer's host_id in the raft network factory's node_map so
+        // the leader can route raft RPCs to it. Idempotent, and a no-op before
+        // cluster formation. Critically this covers an already-committed member
+        // that reconnects AFTER the leader restarted: no `JoinNode` fires (it is
+        // already a member) and it may be absent from the leader's freshly
+        // recovered formation map, so without registering here every raft RPC to
+        // it stays "registration pending" forever and the leader churns.
+        self.register_peer_in_raft_node_map(host_id);
+
         // Hold the transition guard across mode-check-and-transition to prevent
         // two simultaneous peer connections from both triggering transition_to_pair.
         let guard_start = std::time::Instant::now();

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -1367,6 +1367,84 @@ async fn approved_peer_triggers_join_in_cluster_mode() {
     );
 }
 
+/// Regression: a peer that connects in cluster mode must have its
+/// `host_id → node_id` registered in the raft network factory's node_map.
+///
+/// Without this, an already-committed member reconnecting *after the leader
+/// restarted* triggers no `JoinNode` (it is already a member), so the leader's
+/// join-time registration never fires and every raft RPC to it fails
+/// "no registered host_id yet (registration pending)" — the leader loses quorum
+/// contact, steps down, and the cluster churns indefinitely. Reproduced live on
+/// the fmem cluster during a rolling restart (2026-07-18).
+#[tokio::test]
+async fn on_peer_connected_registers_peer_host_id_in_raft_node_map() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = test_storage(dir.path());
+    let schema = test_schema();
+    let config = Arc::new(ClusterConfig {
+        auto_join: true,
+        raft_data_dir: Some(dir.path().join("raft")),
+        ..ClusterConfig::default()
+    });
+    let net_config = Arc::new(NetConfig::default());
+    let local_id = Uuid::new_v4();
+    let peer1_id = Uuid::new_v4();
+    let peer2_id = Uuid::new_v4();
+
+    let registry = Arc::new(HandlerRegistry::new());
+    let (controller, _handles) = ModeController::new(
+        config,
+        net_config.clone(),
+        local_id,
+        storage,
+        schema,
+        registry,
+    );
+    let pm = Arc::new(PeerManager::new(net_config, local_id, controller.clone()));
+    controller.set_peer_manager(pm);
+
+    // Two peers → cluster mode (this runs transition_to_cluster, which captures
+    // the raft node_map).
+    controller.on_peer_connected((peer1_id, "127.0.0.1:7001".parse().unwrap()));
+    controller.on_peer_connected((peer2_id, "127.0.0.2:7002".parse().unwrap()));
+    assert_eq!(controller.mode(), DeploymentMode::Cluster);
+
+    controller
+        .raft_node_map_snapshot()
+        .expect("raft node_map must be captured once in cluster mode");
+
+    // Simulate the leader having RESTARTED and finished raft-init before this
+    // peer reconnected: its host_id is absent from the freshly-recovered node_map
+    // (it was not in the formation peer list, and being an already-committed
+    // member it triggers no JoinNode on reconnect).
+    let reconnecting = peer2_id;
+    let node_id = crate::raft::uuid_to_node_id(reconnecting);
+    {
+        let m = controller.raft_node_map.load_full().unwrap();
+        m.write()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&node_id);
+    }
+    assert!(
+        !controller
+            .raft_node_map_snapshot()
+            .unwrap()
+            .contains_key(&node_id),
+        "precondition: peer must be absent from the node_map before reconnect"
+    );
+
+    // The existing member reconnects.
+    controller.on_peer_connected((reconnecting, "127.0.0.2:7002".parse().unwrap()));
+
+    let map = controller.raft_node_map_snapshot().unwrap();
+    assert_eq!(
+        map.get(&node_id),
+        Some(&reconnecting),
+        "on_peer_connected must (re)register the reconnecting peer's host_id in the raft node_map \
+         so the leader can route raft RPCs to it; got map={map:?}"
+    );
+}
+
 #[tokio::test]
 async fn existing_cluster_member_does_not_queue_duplicate_join() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Fixes a cluster-restart deadlock where an already-committed member that
reconnects **after the raft leader restarted** is never made raft-routable, so
the leader repeatedly loses quorum contact and the cluster churns indefinitely.

Hit live during a rolling restart of the local ferrosa-memory cluster
(2026-07-18): after node3 (leader) restarted and finished raft-init, node2
reconnected but every raft RPC to it failed *"raft node … has no registered
host_id yet (registration pending)"*; node3 stepped down on `CheckQuorum` in a
loop and reads timed out.

## Root cause

The raft network factory routes RPCs by resolving `node_id → host_id` from a
shared `node_map` (resolved per-RPC by the `93161c50` heal). That map is
populated in exactly two places:

1. **raft-init** — from the formation peer list known at that instant.
2. **`join_as_learner`** — only on a `JoinNode` commit (a *new* node joining).

`on_peer_connected` never registers it. So a peer that is **already a committed
member** and reconnects after the leader restarted hits neither path — no
`JoinNode` (already a member; cf. `existing_cluster_member_does_not_queue_duplicate_join`)
and it was absent from the leader's freshly-recovered formation map. It stays
unregistered forever, and the per-RPC heal can't help because `register_node` is
never called for it.

## Fix

- Capture the shared `node_map` on `ModeController` at `transition_to_cluster`.
- In `on_peer_connected`, register the (re)connecting peer's `host_id → node_id`
  in that map (idempotent `HashMap` insert; no-op before cluster formation).

Any reconnecting peer now becomes raft-routable, so a rolling restart in **any**
order re-forms cleanly.

## Testing

- **TDD (red→green):** `on_peer_connected_registers_peer_host_id_in_raft_node_map`
  — form a cluster, drop a member from the node_map (simulating the leader
  restart that lost its registration), reconnect it, assert `on_peer_connected`
  re-registers it. Fails before the fix, passes after.
- `ferrosa-cluster` controller suite: **138 pass**. `cargo fmt --check`,
  `cargo clippy --workspace --all-targets`, `cargo doc -D warnings`: clean.
- **Verified live:** rebuilt + rolled out to the churning 3-node fmem cluster —
  **zero** `registration pending` / `CheckQuorum` step-downs after the restart,
  all nodes re-formed, and the memory graph is queryable again (was timing out).
