### PR TITLE
fix(accord): count the coordinator's own PreAccept and Accept votes (RF>=3 liveness)

### DIFF
--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -985,18 +985,29 @@ impl AccordCoordinatorDriver {
         let self_is_replica =
             self.self_id != uuid::Uuid::nil() && self.replica_ids.contains(&self.self_id);
         let has_remote_replica = self.replica_ids.iter().any(|&p| p != self.self_id);
-        // Process our OWN PreAccept locally ONLY when we are the sole replica
-        // (RF=1, no remote to hear from) — the deployed "Accord quorum unavailable"
-        // bug: a node is never in its own peer map, so a self-send fails and the
-        // sole replica collects zero votes. When remote replicas exist we leave the
-        // whole flow to the fan-out below (self filtered out): the remotes register
-        // the txn in their conflict indexes and vote, which is what lets the
-        // ReadVote dep-wait serialize concurrent conditional txns (INSERT IF NOT
-        // EXISTS / LWT). Touching our own local state machine here would instead
-        // make a racing coordinator's PreAccept observe the conflict and refuse the
-        // fast path, and `fast_quorum_size` can be 1 so our lone local vote would
-        // fast-path and skip the fan-out entirely — both break LWT linearizability.
-        if self_is_replica && !self.coordinator.is_leaseholder && !has_remote_replica {
+        // Process our OWN PreAccept locally when we are a replica — a node is never
+        // in its own peer map, so a self-send fails "unknown peer" and loses the
+        // coordinator's vote. The coordinator is a replica in the common case (the
+        // node serving the request), so this is the norm, not an edge case.
+        //
+        // The self-vote is required for LIVENESS whenever `fast_quorum_size(rf)`
+        // equals the full replica count (RF≥3): the coordinator gathers only the
+        // RF-1 REMOTE votes, so if they all AGREE the driver can neither fast-commit
+        // (needs all RF, i.e. the coordinator's own vote too) nor slow-path (no
+        // disagreement) — it stalls at `Pending` → "Accord quorum unavailable". The
+        // self-vote supplies the missing RF-th vote.
+        //
+        // The one case we must NOT self-vote is when it would SHORT-CIRCUIT the
+        // remote fan-out: at RF=2, `fast_quorum_size(2) == 1`, so a lone local vote
+        // fast-paths and skips telling the remote replica — which breaks the LWT
+        // ReadVote dep-wait serialization (the remote must register the txn to
+        // serialize concurrent INSERT IF NOT EXISTS). RF=1 has no remote to skip, so
+        // the sole-replica self-vote is always correct. Hence: self-vote when we are
+        // the sole replica OR when `fast_quorum_size(rf) > 1` (RF≥3), where the
+        // self-vote can never reach quorum alone and the fan-out always runs.
+        let self_vote_cannot_short_circuit =
+            !has_remote_replica || fast_quorum_size(self.coordinator.rf) > 1;
+        if self_is_replica && !self.coordinator.is_leaseholder && self_vote_cannot_short_circuit {
             if let Some(local_sm) = &self.local_accord_state {
                 let keys: Vec<&[u8]> = self.write_set.iter().map(|w| w.key.as_slice()).collect();
                 let resp =
@@ -2771,6 +2782,94 @@ mod tests {
         assert!(
             targets.contains(&remote1) && targets.contains(&remote2),
             "coordinator must fan Accept out to BOTH remote replicas; sent to {targets:?}"
+        );
+    }
+
+    /// A transport whose remote replicas AGREE with the coordinator: each echoes
+    /// back the coordinator's proposed `t0` with no dependencies, so the fast path
+    /// hinges entirely on whether the coordinator counts its OWN vote. Records
+    /// every peer that received a PreAccept.
+    struct AgreeingPreAcceptTransport {
+        preaccept_targets: parking_lot::Mutex<Vec<uuid::Uuid>>,
+    }
+
+    #[async_trait::async_trait]
+    impl AccordTransport for AgreeingPreAcceptTransport {
+        async fn send(
+            &self,
+            host_id: uuid::Uuid,
+            msg: Message,
+            _lane: ferrosa_net::codec::Lane,
+        ) -> ferrosa_net::error::Result<Message> {
+            use crate::accord::wire::{PreAcceptOkPayload, PreAcceptPayload};
+            match msg {
+                Message::AccordPreAccept(b) => {
+                    self.preaccept_targets.lock().push(host_id);
+                    // Echo the coordinator's own t0 so this replica genuinely agrees.
+                    let pa: PreAcceptPayload = bincode::deserialize(&b).unwrap();
+                    let payload = PreAcceptOkPayload {
+                        from: node_id_of(host_id),
+                        t: pa.t0,
+                        deps: vec![],
+                    };
+                    Ok(Message::AccordPreAcceptOK(Bytes::from(
+                        bincode::serialize(&payload).unwrap(),
+                    )))
+                }
+                // Commit / Apply / anything else: ack.
+                _ => Ok(Message::AccordApplyOK(Bytes::new())),
+            }
+        }
+    }
+
+    /// Regression for the RF≥3 stall: when the coordinator is a replica and every
+    /// REMOTE replica agrees on the PreAccept, the driver reaches `fast_quorum` (=RF)
+    /// only if the coordinator counts its OWN PreAccept vote. Without it the RF-1
+    /// remote votes can neither fast-commit (need all RF) nor slow-path (no
+    /// disagreement), so the driver stalls at `Pending` → QuorumUnavailable. This is
+    /// the exact live failure: `decision=Pending pa_votes=2 rf=3` on every commit.
+    #[tokio::test]
+    async fn preaccept_self_vote_reaches_fast_quorum_rf3() {
+        use crate::accord::state_machine::AccordStateMachine;
+        use ferrosa_storage::accord::sync_writer::MockSyncWriter;
+
+        let self_host = uuid::Uuid::from_u128(0xC0DE);
+        let remote1 = uuid::Uuid::from_u128(0x1111);
+        let remote2 = uuid::Uuid::from_u128(0x2222);
+        let self_node = node_id_of(self_host);
+
+        let local_state: crate::accord::handlers::AccordState = Arc::new(parking_lot::Mutex::new(
+            AccordStateMachine::new(self_node, Arc::new(MockSyncWriter::new())),
+        ));
+
+        let transport = Arc::new(AgreeingPreAcceptTransport {
+            preaccept_targets: parking_lot::Mutex::new(Vec::new()),
+        });
+        let clock = HybridLogicalClock::new(self_node, 0);
+
+        let mut driver = AccordCoordinatorDriver::new_multi_with_transport(
+            self_node,
+            vec![self_host, remote1, remote2], // RF=3, coordinator is a replica
+            transport.clone(),
+            false, // not leaseholder
+            &clock,
+            vec![(b"k".to_vec(), b"m".to_vec())],
+        )
+        .with_local_accord_state(local_state)
+        .with_local_applier(Arc::new(crate::accord::apply::NoopStorageApplier::new()));
+
+        let result = driver.run_transaction().await;
+        assert!(
+            result.is_ok(),
+            "RF=3 coordinator-is-replica txn with all remotes AGREEING must fast-commit \
+             via the coordinator's OWN PreAccept vote (fast_quorum=3), not stall at \
+             Pending; got {result:?}"
+        );
+
+        let targets = transport.preaccept_targets.lock();
+        assert!(
+            !targets.contains(&self_host),
+            "coordinator must never send PreAccept to itself; sent to {targets:?}"
         );
     }
 

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -1082,42 +1082,75 @@ impl AccordCoordinatorDriver {
                 let ac_bytes = bincode::serialize(&accept_payload)
                     .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
                 let ac_msg = Message::AccordAccept(Bytes::from(ac_bytes));
-
-                let ac_futs: Vec<_> = self
-                    .replica_ids
-                    .iter()
-                    .map(|&peer_id| {
-                        let peers = Arc::clone(&self.peers);
-                        let msg = ac_msg.clone();
-                        async move { peers.send(peer_id, msg, Lane::Data).await }
-                    })
-                    .collect();
-
-                let ac_responses = futures::future::join_all(ac_futs).await;
+                let accept_deps: Vec<TxnId> = deps.iter().copied().collect();
 
                 let mut ac_decision = CoordinatorDecision::Pending;
-                for result in &ac_responses {
-                    match result {
-                        Ok(Message::AccordAcceptOK(b)) if !b.is_empty() => {
-                            let ok: AcceptOkPayload = bincode::deserialize(b)
-                                .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
-                            let resp = AcceptResponse {
-                                from: ok.txn_id.0.node, // node ID embedded in txn_id
+
+                // The coordinator processes its OWN Accept LOCALLY and fans out to
+                // the REMOTE replicas only. A node is never in its own peer map, so
+                // an Accept self-send fails "unknown peer" and loses the
+                // coordinator's own vote — the slow path then needs EVERY remote
+                // replica, so under concurrency (which is what pushes a txn onto
+                // the slow path in the first place) many transactions fail "Accord
+                // quorum unavailable". This mirrors the PreAccept self-vote.
+                let self_is_replica =
+                    self.self_id != uuid::Uuid::nil() && self.replica_ids.contains(&self.self_id);
+                if self_is_replica {
+                    if let Some(local_sm) = &self.local_accord_state {
+                        let resp = local_sm.lock().handle_accept(
+                            txn_id,
+                            t0,
+                            t,
+                            accept_deps.clone(),
+                            BallotNumber(1),
+                        );
+                        if let crate::accord::state_machine::SmResponse::AcceptOK { .. } = resp {
+                            ac_decision = self.coordinator.handle_accept_ok(AcceptResponse {
+                                from: self.coordinator.node_id,
                                 ballot: BallotNumber(1),
-                                deps: deps.iter().copied().collect(),
-                            };
-                            ac_decision = self.coordinator.handle_accept_ok(resp);
-                            if ac_decision != CoordinatorDecision::Pending {
-                                break;
-                            }
+                                deps: accept_deps.clone(),
+                            });
                         }
-                        Ok(_) => {}
-                        Err(e) => {
-                            tracing::warn!(
-                                txn_id = ?txn_id,
-                                error = %e,
-                                "accord: Accept RPC failed"
-                            );
+                    }
+                }
+
+                if ac_decision == CoordinatorDecision::Pending {
+                    let ac_futs: Vec<_> = self
+                        .replica_ids
+                        .iter()
+                        .filter(|&&peer_id| peer_id != self.self_id)
+                        .map(|&peer_id| {
+                            let peers = Arc::clone(&self.peers);
+                            let msg = ac_msg.clone();
+                            async move { peers.send(peer_id, msg, Lane::Data).await }
+                        })
+                        .collect();
+
+                    let ac_responses = futures::future::join_all(ac_futs).await;
+
+                    for result in &ac_responses {
+                        match result {
+                            Ok(Message::AccordAcceptOK(b)) if !b.is_empty() => {
+                                let ok: AcceptOkPayload = bincode::deserialize(b)
+                                    .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
+                                let resp = AcceptResponse {
+                                    from: ok.txn_id.0.node, // node ID embedded in txn_id
+                                    ballot: BallotNumber(1),
+                                    deps: accept_deps.clone(),
+                                };
+                                ac_decision = self.coordinator.handle_accept_ok(resp);
+                                if ac_decision != CoordinatorDecision::Pending {
+                                    break;
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                tracing::warn!(
+                                    txn_id = ?txn_id,
+                                    error = %e,
+                                    "accord: Accept RPC failed"
+                                );
+                            }
                         }
                     }
                 }
@@ -2595,6 +2628,149 @@ mod tests {
         assert!(
             !transport.sent.lock().contains_key(&host),
             "coordinator must never send PreAccept to itself (its id is not in the peer map)"
+        );
+    }
+
+    /// A transport that drives a coordinator-is-a-replica transaction onto the
+    /// slow (Accept) path and then makes ONE remote replica time out during
+    /// Accept. It records every peer that received an `AccordAccept`.
+    ///
+    /// - PreAccept: `remote2` proposes a higher timestamp + a dependency, so the
+    ///   two remote votes disagree → the coordinator needs an Accept round.
+    /// - Accept: `remote1` votes; `remote2` times out. Slow quorum (RF=3) is 2,
+    ///   so the transaction can ONLY commit if the coordinator counts its OWN
+    ///   Accept vote locally. Under the pre-fix code the coordinator instead sent
+    ///   `AccordAccept` to itself (which fails "unknown peer" in production and
+    ///   is silently dropped here), so it saw one remote vote and failed.
+    /// - Commit/Apply: every remote acks, so only the Accept phase is stressed.
+    struct SlowPathSelfVoteTransport {
+        remote1: uuid::Uuid,
+        remote2: uuid::Uuid,
+        t0: Timestamp,
+        conflict_t: Timestamp,
+        conflict_dep: TxnId,
+        accept_targets: parking_lot::Mutex<Vec<uuid::Uuid>>,
+    }
+
+    fn node_id_of(host: uuid::Uuid) -> u64 {
+        u64::from_be_bytes(host.as_bytes()[..8].try_into().unwrap())
+    }
+
+    #[async_trait::async_trait]
+    impl AccordTransport for SlowPathSelfVoteTransport {
+        async fn send(
+            &self,
+            host_id: uuid::Uuid,
+            msg: Message,
+            _lane: ferrosa_net::codec::Lane,
+        ) -> ferrosa_net::error::Result<Message> {
+            use crate::accord::wire::{AcceptOkPayload, AcceptPayload, PreAcceptOkPayload};
+            match msg {
+                Message::AccordPreAccept(_) | Message::AccordPreAcceptV2(_) => {
+                    let (t, deps) = if host_id == self.remote1 {
+                        (self.t0, vec![])
+                    } else if host_id == self.remote2 {
+                        (self.conflict_t, vec![self.conflict_dep])
+                    } else {
+                        panic!("PreAccept to an unexpected host {host_id} (self must be local)");
+                    };
+                    let payload = PreAcceptOkPayload {
+                        from: node_id_of(host_id),
+                        t,
+                        deps,
+                    };
+                    Ok(Message::AccordPreAcceptOK(Bytes::from(
+                        bincode::serialize(&payload).unwrap(),
+                    )))
+                }
+                Message::AccordAccept(b) => {
+                    self.accept_targets.lock().push(host_id);
+                    if host_id == self.remote1 {
+                        let ap: AcceptPayload = bincode::deserialize(&b).unwrap();
+                        let ok = AcceptOkPayload { txn_id: ap.txn_id };
+                        Ok(Message::AccordAcceptOK(Bytes::from(
+                            bincode::serialize(&ok).unwrap(),
+                        )))
+                    } else if host_id == self.remote2 {
+                        // remote2 is slow during Accept — its vote never arrives,
+                        // so the coordinator's own local vote is what reaches quorum.
+                        Err(ferrosa_net::error::NetError::Timeout(
+                            "slow remote during Accept".into(),
+                        ))
+                    } else {
+                        // A self-send would land here under the pre-fix code — the
+                        // recorded target is what the test's assertion catches.
+                        Err(ferrosa_net::error::NetError::Timeout(
+                            "unexpected Accept target (self must be local)".into(),
+                        ))
+                    }
+                }
+                // Commit / Apply / anything else: ack so only Accept is stressed.
+                _ => Ok(Message::AccordApplyOK(Bytes::new())),
+            }
+        }
+    }
+
+    /// Regression for the Accept-phase self-send bug (sibling of the PreAccept
+    /// fix). When the coordinator is itself a replica (RF=3), the slow path must
+    /// process its OWN Accept LOCALLY and fan `AccordAccept` out to the REMOTE
+    /// replicas only. A node is never in its own peer map, so an Accept self-send
+    /// fails "unknown peer" and loses the coordinator's vote — and because a
+    /// transaction only reaches the slow path under contention (exactly when a
+    /// remote is likely slow), losing that vote made ~61% of concurrent
+    /// transactions fail "Accord quorum unavailable" in the live Elle run.
+    #[tokio::test]
+    async fn accept_self_is_processed_locally_never_sent_rf3() {
+        use crate::accord::state_machine::AccordStateMachine;
+        use ferrosa_storage::accord::sync_writer::MockSyncWriter;
+
+        let self_host = uuid::Uuid::from_u128(0xC0DE);
+        let remote1 = uuid::Uuid::from_u128(0x1111);
+        let remote2 = uuid::Uuid::from_u128(0x2222);
+        let self_node = node_id_of(self_host);
+
+        let local_state: crate::accord::handlers::AccordState = Arc::new(parking_lot::Mutex::new(
+            AccordStateMachine::new(self_node, Arc::new(MockSyncWriter::new())),
+        ));
+
+        let t0 = make_ts(1000);
+        let transport = Arc::new(SlowPathSelfVoteTransport {
+            remote1,
+            remote2,
+            t0,
+            conflict_t: make_ts(2000),
+            conflict_dep: make_txn_id(7, 500),
+            accept_targets: parking_lot::Mutex::new(Vec::new()),
+        });
+        let clock = HybridLogicalClock::new(self_node, 0);
+
+        let mut driver = AccordCoordinatorDriver::new_multi_with_transport(
+            self_node,
+            vec![self_host, remote1, remote2], // RF=3, coordinator is a replica
+            transport.clone(),
+            false, // not leaseholder
+            &clock,
+            vec![(b"k".to_vec(), b"m".to_vec())],
+        )
+        .with_local_accord_state(local_state)
+        .with_local_applier(Arc::new(crate::accord::apply::NoopStorageApplier::new()));
+
+        let result = driver.run_transaction().await;
+        assert!(
+            result.is_ok(),
+            "slow-path transaction must commit via the coordinator's LOCAL Accept \
+             vote when one remote is slow (self + remote1 = slow quorum 2); got {result:?}"
+        );
+
+        let targets = transport.accept_targets.lock();
+        assert!(
+            !targets.contains(&self_host),
+            "coordinator must never send AccordAccept to itself (its id is not in \
+             the peer map); sent to {targets:?}"
+        );
+        assert!(
+            targets.contains(&remote1) && targets.contains(&remote2),
+            "coordinator must fan Accept out to BOTH remote replicas; sent to {targets:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Two sibling bugs in the Accord coordinator caused RF>=3 transactions to fail
`AccordDriverError::QuorumUnavailable` — the coordinator never counted its **own**
votes, so it always needed a full *remote* quorum. Surfaced by an Elle
list-append run against a live 3-node cluster (RF=3): single-threaded commits
failed ~65%, concurrent ~61%.

Root cause in both phases: a node is never in its own peer map, so any RPC the
coordinator "sends to itself" fails `unknown peer` and its vote is lost.

### 1. PreAccept phase (`fix(accord): count coordinator's own PreAccept vote at RF>=3`)
The PreAccept self-vote was gated to the sole-replica case (`!has_remote_replica`),
so a coordinator that was one of several replicas gathered only the RF-1 remote
votes. At RF>=3, `fast_quorum_size(rf) == rf`: if the remotes agree, the driver can
neither fast-commit (needs all RF) nor slow-path (no disagreement) and **stalls at
`Pending` -> QuorumUnavailable**. Live diagnostic on every failure:
`decision=Pending pa_votes=2 rf=3`.

The `!has_remote_replica` gate was over-broad — it existed to avoid an RF=2
`fast_quorum_size(2) == 1` short-circuit that skipped the remote fan-out and broke
the LWT ReadVote dep-wait. Gate on that condition directly instead: self-vote when
we are the sole replica **or** `fast_quorum_size(rf) > 1` (RF>=3), where the
self-vote can never reach quorum alone and the fan-out always runs. RF=2 keeps the
conservative remote-only behavior.

### 2. Accept phase (`fix(accord): process coordinator's own Accept vote locally`)
The Accept fan-out sent `AccordAccept` to every replica id including self. The
self-send fails `unknown peer`, so the slow path needed every remote replica —
and since a txn only reaches the slow path under contention (when a remote is
likely slow), this dropped ~61% of concurrent transactions. Mirror the PreAccept
fix: apply the coordinator's own Accept to its local state machine, count that
vote, and fan out to remote replicas only.

## Tests
- `preaccept_self_vote_reaches_fast_quorum_rf3` — RF=3, coordinator-is-replica,
  all remotes agree -> must fast-commit via its own vote (pre-fix: QuorumUnavailable).
- `accept_self_is_processed_locally_never_sent_rf3` — RF=3 slow path with one slow
  remote -> commits on self + one remote, never sends Accept to itself.
- All 1078 ferrosa-cluster lib tests pass, including the 7 `accord_lwt_concurrent`
  tests that motivated the original gate (LWT linearizability preserved).

## Live verification (3-node podman cluster, RF=3)
- Single-threaded: **0 failures** (was ~65% QuorumUnavailable).
- Concurrent (8 workers): **0 server-side quorum failures** across all nodes, 280
  transactions committed (was ~533 failures).

## Follow-ups (not in this PR)
- Elle then surfaced a **distinct read-visibility violation**: a committed Accord
  write is not visible to a subsequent SERIAL read (commit returns before apply is
  visible) — strict-serializability is still violated on the read path. Tracked
  separately.
- The list-append harness cannot pin a stateful CQL `BEGIN/UPDATE/COMMIT` to one
  connection under the scylla driver, contaminating concurrent Elle histories.