### PR TITLE
CRDT collection D-write + strict-serializable concurrent list appends (Accord)

### DIFF
--- a/deploy/fly-accord-elle/certify.sh
+++ b/deploy/fly-accord-elle/certify.sh
@@ -72,6 +72,27 @@ flyctl deploy "$BUILD_CTX" --app "$APP" --config "$BUILD_CTX/fly.toml" \
   --dockerfile "$BUILD_CTX/Dockerfile.elle" --remote-only --build-only --push \
   --image-label "cert-${RUN_ID}" 2>&1 | tail -8 || die "image build/push failed"
 
+# Let the pushed manifest propagate before launching machines by digest —
+# otherwise the first `machine run` can 404 MANIFEST_UNKNOWN (fly registry race).
+log "image pushed; settling 30s for fly registry propagation"
+sleep 30
+
+# Launch a fly machine, retrying on the transient registry/manifest race.
+mrun() {
+  local i out
+  for i in 1 2 3 4 5; do
+    if out="$(flyctl machine run "$@" 2>&1)"; then printf '%s\n' "$out" | tail -3; return 0; fi
+    printf '%s\n' "$out" | tail -2
+    if printf '%s' "$out" | grep -qiE "MANIFEST_UNKNOWN|manifest unknown|not found|429|timeout|deadline"; then
+      log "transient machine-run error (attempt $i/5) — retry in 15s"
+      sleep 15
+      continue
+    fi
+    return 1
+  done
+  return 1
+}
+
 # 3. Common env (trimmed fly-lax pattern for a small healthy cluster).
 COMMON=(
   --env "FERROSA_DATA_DIR=/var/lib/ferrosa"
@@ -100,12 +121,12 @@ wait_ready() { # <machine-id> <name>
 
 # 4. Seed node (node1).
 log "run node1 (seed)"
-flyctl machine run "$IMAGE" --app "$APP" --org "$ORG" --region "$REGION" \
+mrun "$IMAGE" --app "$APP" --org "$ORG" --region "$REGION" \
   --name ferrosa-1 --restart always --rootfs-size 20 \
   --vm-cpu-kind "$CPU_KIND" --vm-cpus "$CPUS" --vm-memory "$MEM" \
   "${COMMON[@]}" \
   --env "FERROSA_HOST_ID=${HOST_IDS[0]}" \
-  --env "FERROSA_S3_PREFIX=accord-elle/${RUN_ID}/node1" 2>&1 | tail -4 || die "node1 run failed"
+  --env "FERROSA_S3_PREFIX=accord-elle/${RUN_ID}/node1" || die "node1 run failed"
 SEED_ID="$(mid ferrosa-1)"; [ -n "$SEED_ID" ] || die "no seed id"
 wait_ready "$SEED_ID" ferrosa-1
 SEED="$(dns "$SEED_ID"):17000"
@@ -113,13 +134,13 @@ SEED="$(dns "$SEED_ID"):17000"
 # 5. Joiners (node2, node3).
 for n in 2 3; do
   log "run node$n (join $SEED)"
-  flyctl machine run "$IMAGE" --app "$APP" --org "$ORG" --region "$REGION" \
+  mrun "$IMAGE" --app "$APP" --org "$ORG" --region "$REGION" \
     --name "ferrosa-${n}" --restart always --rootfs-size 20 \
     --vm-cpu-kind "$CPU_KIND" --vm-cpus "$CPUS" --vm-memory "$MEM" \
     "${COMMON[@]}" \
     --env "FERROSA_HOST_ID=${HOST_IDS[$((n-1))]}" \
     --env "FERROSA_S3_PREFIX=accord-elle/${RUN_ID}/node${n}" \
-    --env "FERROSA_SEED=${SEED}" 2>&1 | tail -4 || die "node$n run failed"
+    --env "FERROSA_SEED=${SEED}" || die "node$n run failed"
   wait_ready "$(mid ferrosa-${n})" "ferrosa-${n}"
 done
 

--- a/deploy/fly-accord-elle/certify.sh
+++ b/deploy/fly-accord-elle/certify.sh
@@ -150,7 +150,7 @@ sleep 20
 # 6. Run the Elle generator ON the seed (in-network → all peers reachable).
 log "run generator on seed: elle_list_append localhost:9042 /tmp/hist.edn $GEN_ARGS"
 flyctl ssh console --app "$APP" --machine "$SEED_ID" --command \
-  "sh -lc 'elle_list_append localhost:9042 /tmp/hist.edn ${GEN_ARGS}'" 2>&1 | tail -6 \
+  "sh -lc 'elle_list_append localhost:9042 /tmp/hist.edn ${GEN_ARGS}'" 2>&1 | tail -30 \
   || die "generator run failed"
 
 # 7. Retrieve the history EDN.

--- a/deploy/fly-accord-elle/certify.sh
+++ b/deploy/fly-accord-elle/certify.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Stand up a 3-node RF=3 ferrosa cluster on fly.io (current build), run the Elle
+# list-append generator IN-network on the seed, retrieve the history, and tear
+# the cluster down. Teardown ALWAYS runs (trap) so machines never leak.
+#
+# The Elle CHECK runs locally afterwards (see certify.sh output for the EDN path).
+# Reuses the proven fly-lax-benchmark deploy pattern (Tigris + fixed host-ids +
+# FERROSA_SEED wiring). Small + short-lived: 3 x performance-2x / 2 GiB, one region.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ORG="${ORG:-ferrosa}"
+REGION="${REGION:-lax}"
+APP="${APP:-ferrosa-accord-elle-cert}"
+# Unique per run: Tigris imposes a cooldown on reusing a just-deleted bucket name.
+BUCKET="${BUCKET:-ferrosa-accord-elle-${RANDOM}${RANDOM}}"
+RUN_ID="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+IMAGE="registry.fly.io/${APP}:cert-${RUN_ID}"
+CPU_KIND="${CPU_KIND:-performance}"
+CPUS="${CPUS:-2}"
+MEM="${MEM:-4096}"  # fly 'performance' CPU requires >= 2048 MiB per vCPU (2x -> 4096 min)
+OUT_EDN="${OUT_EDN:-${ROOT_DIR}/deploy/fly-accord-elle/elle-fly-history.edn}"
+# Workload: keys, ops/worker, workers, rf
+GEN_ARGS="${GEN_ARGS:-8 200 8 3}"
+
+log() { printf '\n[certify] %s\n' "$*" >&2; }
+die() { printf '\n[certify][FATAL] %s\n' "$*" >&2; exit 1; }
+mid() { flyctl machine list --app "$APP" --json 2>/dev/null | jq -r ".[]|select(.name==\"$1\")|.id" | head -1; }
+dns() { printf '%s.vm.%s.internal' "$1" "$APP"; }
+
+KEEP="${KEEP:-0}"
+teardown() {
+  if [ "$KEEP" = "1" ]; then log "KEEP=1 — NOT tearing down (app=$APP). Destroy manually!"; return; fi
+  log "=== teardown (always) app=$APP ==="
+  local ids; ids="$(flyctl machine list --app "$APP" --json 2>/dev/null | jq -r '.[].id' || true)"
+  for id in $ids; do flyctl machine destroy "$id" --app "$APP" --force 2>&1 | tail -1 || log "WARN: machine $id leak"; done
+  flyctl apps destroy "$APP" --yes 2>&1 | tail -1 || log "WARN: app $APP leak — check billing"
+  # apps destroy does NOT remove the Tigris bucket — destroy it explicitly or it leaks.
+  flyctl storage destroy "$BUCKET" --yes 2>&1 | tail -1 || log "WARN: bucket $BUCKET leak — flyctl storage destroy $BUCKET"
+}
+trap teardown EXIT
+
+command -v flyctl >/dev/null || die "flyctl not on PATH"
+command -v jq >/dev/null || die "jq not on PATH"
+
+# 1. App + Tigris bucket.
+log "app + tigris bucket"
+flyctl apps create "$APP" --org "$ORG" 2>&1 | tail -2 || true
+if ! flyctl storage status "$BUCKET" --app "$APP" >/dev/null 2>&1; then
+  flyctl storage create --org "$ORG" --app "$APP" --name "$BUCKET" --yes 2>&1 | tail -5 \
+    || die "tigris create failed (enable billing for org $ORG?)"
+fi
+flyctl secrets set --app "$APP" \
+  FERROSA_S3_ENDPOINT="https://fly.storage.tigris.dev" \
+  FERROSA_S3_BUCKET="$BUCKET" \
+  FERROSA_S3_REGION="auto" 2>&1 | tail -2
+
+# 2. Build + push the image (ferrosa + baked-in elle generator) from a clean ctx.
+log "build+push image $IMAGE (full workspace compile — ~10-15 min)"
+BUILD_CTX="$(mktemp -d)"
+trap 'rm -rf "$BUILD_CTX"; teardown' EXIT
+tar -C "$ROOT_DIR" --exclude .git --exclude target --exclude '.wt-*' \
+    --exclude .cargo/registry --exclude .cargo/git -cf - . | tar -x -C "$BUILD_CTX"
+cp "${ROOT_DIR}/deploy/fly-accord-elle/ferrosa-elle.Dockerfile" "$BUILD_CTX/Dockerfile.elle"
+cat > "$BUILD_CTX/fly.toml" <<EOF
+app = "${APP}"
+primary_region = "${REGION}"
+[build]
+  dockerfile = "Dockerfile.elle"
+EOF
+flyctl deploy "$BUILD_CTX" --app "$APP" --config "$BUILD_CTX/fly.toml" \
+  --dockerfile "$BUILD_CTX/Dockerfile.elle" --remote-only --build-only --push \
+  --image-label "cert-${RUN_ID}" 2>&1 | tail -8 || die "image build/push failed"
+
+# 3. Common env (trimmed fly-lax pattern for a small healthy cluster).
+COMMON=(
+  --env "FERROSA_DATA_DIR=/var/lib/ferrosa"
+  --env "FERROSA_RAFT_DATA_DIR=/var/lib/ferrosa-raft"
+  --env "FERROSA_CQL_BIND=[::]:9042"
+  --env "FERROSA_WEB_BIND=[::]:9090"
+  --env "FERROSA_INTERNODE_BIND=[::]:17000"
+  --env "FERROSA_CLUSTER_NAME=ferrosa-accord-elle"
+  --env "FERROSA_GRAPH_ENABLED=false"
+  --env "FERROSA_AUTH_ENABLED=false"
+  --env "FERROSA_FORMATION_TIMEOUT_SECS=120"
+)
+HOST_IDS=(aa111111-1111-1111-1111-111111111111 bb222222-2222-2222-2222-222222222222 cc333333-3333-3333-3333-333333333333)
+
+wait_ready() { # <machine-id> <name>
+  local id="$1" name="$2" i
+  for i in $(seq 1 40); do
+    if flyctl ssh console --app "$APP" --machine "$id" --command \
+        "sh -lc 'curl -sf http://localhost:9090/readyz'" 2>/dev/null | grep -q 'ready'; then
+      log "  $name ready"; return 0
+    fi
+    sleep 6
+  done
+  die "$name did not become ready"
+}
+
+# 4. Seed node (node1).
+log "run node1 (seed)"
+flyctl machine run "$IMAGE" --app "$APP" --org "$ORG" --region "$REGION" \
+  --name ferrosa-1 --restart always --rootfs-size 20 \
+  --vm-cpu-kind "$CPU_KIND" --vm-cpus "$CPUS" --vm-memory "$MEM" \
+  "${COMMON[@]}" \
+  --env "FERROSA_HOST_ID=${HOST_IDS[0]}" \
+  --env "FERROSA_S3_PREFIX=accord-elle/${RUN_ID}/node1" 2>&1 | tail -4 || die "node1 run failed"
+SEED_ID="$(mid ferrosa-1)"; [ -n "$SEED_ID" ] || die "no seed id"
+wait_ready "$SEED_ID" ferrosa-1
+SEED="$(dns "$SEED_ID"):17000"
+
+# 5. Joiners (node2, node3).
+for n in 2 3; do
+  log "run node$n (join $SEED)"
+  flyctl machine run "$IMAGE" --app "$APP" --org "$ORG" --region "$REGION" \
+    --name "ferrosa-${n}" --restart always --rootfs-size 20 \
+    --vm-cpu-kind "$CPU_KIND" --vm-cpus "$CPUS" --vm-memory "$MEM" \
+    "${COMMON[@]}" \
+    --env "FERROSA_HOST_ID=${HOST_IDS[$((n-1))]}" \
+    --env "FERROSA_S3_PREFIX=accord-elle/${RUN_ID}/node${n}" \
+    --env "FERROSA_SEED=${SEED}" 2>&1 | tail -4 || die "node$n run failed"
+  wait_ready "$(mid ferrosa-${n})" "ferrosa-${n}"
+done
+
+log "cluster up. settling 20s before workload."
+sleep 20
+
+# 6. Run the Elle generator ON the seed (in-network → all peers reachable).
+log "run generator on seed: elle_list_append localhost:9042 /tmp/hist.edn $GEN_ARGS"
+flyctl ssh console --app "$APP" --machine "$SEED_ID" --command \
+  "sh -lc 'elle_list_append localhost:9042 /tmp/hist.edn ${GEN_ARGS}'" 2>&1 | tail -6 \
+  || die "generator run failed"
+
+# 7. Retrieve the history EDN.
+log "fetch history -> $OUT_EDN"
+flyctl ssh console --app "$APP" --machine "$SEED_ID" --command \
+  "sh -lc 'cat /tmp/hist.edn'" > "$OUT_EDN" 2>/dev/null
+lines="$(wc -l < "$OUT_EDN" | tr -d ' ')"
+[ "$lines" -gt 2 ] || die "history looks empty ($lines lines) — see cluster logs"
+log "history retrieved: $lines lines -> $OUT_EDN"
+log "=== provisioning + run complete; teardown next (trap) ==="

--- a/deploy/fly-accord-elle/elle-fly-history.edn
+++ b/deploy/fly-accord-elle/elle-fly-history.edn
@@ -2,3201 +2,3201 @@
  {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
  {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
  {:process 0 :type :invoke :f :txn :value [[:append 7 1]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 1]]}
+ {:process 0 :type :ok :f :txn :value [[:append 7 1]]}
  {:process 0 :type :invoke :f :txn :value [[:append 6 2]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 2]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 2]]}
  {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
  {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
  {:process 0 :type :invoke :f :txn :value [[:append 4 3]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 3]]}
+ {:process 0 :type :ok :f :txn :value [[:append 4 3]]}
  {:process 0 :type :invoke :f :txn :value [[:append 3 4]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 4]]}
+ {:process 0 :type :ok :f :txn :value [[:append 3 4]]}
  {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
  {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
  {:process 0 :type :invoke :f :txn :value [[:append 1 5]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 5]]}
+ {:process 0 :type :ok :f :txn :value [[:append 1 5]]}
  {:process 0 :type :invoke :f :txn :value [[:append 0 6]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 6]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 6]]}
  {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 [1]]]}
  {:process 0 :type :invoke :f :txn :value [[:append 6 7]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 7]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 8]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 8]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 8]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 7]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 9]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 9]]}
  {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 9]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 9]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 10]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 10]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 [3]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 10]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 11]]}
+ {:process 0 :type :ok :f :txn :value [[:append 3 10]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 12]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 12]]}
  {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 11]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 11]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 12]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 12]]}
- {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 13]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 13]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 14]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 14]]}
- {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 15]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 15]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 16]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 16]]}
- {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 17]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 17]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 18]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 18]]}
- {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 19]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 19]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 20]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 20]]}
- {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 21]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 21]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 22]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 22]]}
- {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 23]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 23]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 24]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 24]]}
- {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 25]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 25]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 26]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 26]]}
- {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 27]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 27]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 28]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 28]]}
- {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 29]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 29]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 30]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 30]]}
- {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 31]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 31]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 32]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 32]]}
- {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 33]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 33]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 34]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 34]]}
- {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 35]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 35]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 36]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 36]]}
- {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 37]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 37]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 38]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 38]]}
- {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 39]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 39]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 40]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 40]]}
- {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 41]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 41]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 42]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 42]]}
- {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 43]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 43]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 44]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 44]]}
- {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 45]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 45]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 46]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 46]]}
- {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 47]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 47]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 48]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 48]]}
- {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 49]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 49]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 50]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 50]]}
- {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 51]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 51]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 52]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 52]]}
- {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 53]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 53]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 54]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 54]]}
- {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 55]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 55]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 56]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 56]]}
- {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 57]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 57]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 58]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 58]]}
- {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 59]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 59]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 60]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 60]]}
- {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 61]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 61]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 62]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 62]]}
- {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 63]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 63]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 64]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 64]]}
- {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 65]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 65]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 66]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 66]]}
- {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 67]]}
- {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 68]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 68]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 69]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 69]]}
- {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 70]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 70]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 71]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 71]]}
- {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 72]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 72]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 73]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 73]]}
- {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 74]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 74]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 75]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 75]]}
- {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 76]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 76]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 77]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 77]]}
- {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 78]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 78]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 79]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 79]]}
- {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 80]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 80]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 81]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 81]]}
- {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 82]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 82]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 83]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 83]]}
- {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 84]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 84]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 85]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 85]]}
- {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 86]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 86]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 87]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 87]]}
- {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 88]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 88]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 89]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 89]]}
- {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 90]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 90]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 91]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 91]]}
- {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 92]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 92]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 93]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 93]]}
- {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 94]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 94]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 95]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 95]]}
- {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 96]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 96]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 97]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 97]]}
- {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 98]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 98]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 99]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 99]]}
- {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 100]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 100]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 101]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 101]]}
- {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 102]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 102]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 103]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 103]]}
- {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 104]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 104]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 105]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 105]]}
- {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 106]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 106]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 107]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 107]]}
- {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 108]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 108]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 109]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 109]]}
- {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 110]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 110]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 111]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 111]]}
- {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 112]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 112]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 113]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 113]]}
- {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 114]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 114]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 115]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 115]]}
- {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 116]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 116]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 117]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 117]]}
- {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 118]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 118]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 119]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 119]]}
- {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 120]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 120]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 121]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 121]]}
- {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 122]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 122]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 123]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 123]]}
- {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 0 124]]}
- {:process 0 :type :fail :f :txn :value [[:append 0 124]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 125]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 125]]}
- {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 5 126]]}
- {:process 0 :type :fail :f :txn :value [[:append 5 126]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 127]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 127]]}
- {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 2 128]]}
- {:process 0 :type :fail :f :txn :value [[:append 2 128]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 129]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 129]]}
- {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 7 130]]}
- {:process 0 :type :fail :f :txn :value [[:append 7 130]]}
- {:process 0 :type :invoke :f :txn :value [[:append 6 131]]}
- {:process 0 :type :fail :f :txn :value [[:append 6 131]]}
- {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 4 132]]}
- {:process 0 :type :fail :f :txn :value [[:append 4 132]]}
- {:process 0 :type :invoke :f :txn :value [[:append 3 133]]}
- {:process 0 :type :fail :f :txn :value [[:append 3 133]]}
- {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 0 :type :invoke :f :txn :value [[:append 1 134]]}
- {:process 0 :type :fail :f :txn :value [[:append 1 134]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 135]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 135]]}
- {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 136]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 136]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 137]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 137]]}
- {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 67]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 138]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 139]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 139]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 140]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 140]]}
- {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 141]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 141]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 142]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 142]]}
- {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 143]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 143]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 144]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 144]]}
- {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 145]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 145]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 146]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 146]]}
- {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 147]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 147]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 148]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 148]]}
- {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 149]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 149]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 150]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 150]]}
- {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 151]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 151]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 152]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 152]]}
- {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 153]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 153]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 154]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 154]]}
- {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 155]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 155]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 156]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 156]]}
- {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 157]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 157]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 158]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 158]]}
- {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 159]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 159]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 160]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 160]]}
- {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 161]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 161]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 162]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 162]]}
- {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 163]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 163]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 164]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 164]]}
- {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 165]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 165]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 166]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 166]]}
- {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 167]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 167]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 168]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 168]]}
- {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 169]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 169]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 170]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 170]]}
- {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 171]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 171]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 172]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 172]]}
- {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 173]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 173]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 174]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 174]]}
- {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 175]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 175]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 176]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 176]]}
- {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 177]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 177]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 178]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 178]]}
- {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 179]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 179]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 180]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 180]]}
- {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 181]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 181]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 182]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 182]]}
- {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 183]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 183]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 184]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 184]]}
- {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 185]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 185]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 186]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 186]]}
- {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 187]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 187]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 188]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 188]]}
- {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 189]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 189]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 190]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 190]]}
- {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 191]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 191]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 192]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 192]]}
- {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 193]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 193]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 194]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 194]]}
- {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 195]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 195]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 196]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 196]]}
- {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 197]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 197]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 198]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 198]]}
- {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 199]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 199]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 200]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 200]]}
- {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 201]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 201]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 202]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 [5]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 13]]}
+ {:process 1 :type :info :f :txn :value [[:append 7 8]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 14]]}
  {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 202]]}
- {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 13]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 15]]}
  {:process 3 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 203]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 204]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 204]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 205]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 138]]}
- {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 206]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 205]]}
- {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 207]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 207]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 208]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 208]]}
- {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 209]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 209]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 210]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 210]]}
- {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 211]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 211]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 212]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 212]]}
- {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 213]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 213]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 214]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 214]]}
- {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 215]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 215]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 216]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 216]]}
- {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 217]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 217]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 218]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 218]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 16]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 15]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 [2 7]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 17]]}
+ {:process 2 :type :info :f :txn :value [[:append 2 11]]}
  {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
  {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 219]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 219]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 220]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 220]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 18]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 17]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 19]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 16]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 20]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 21]]}
+ {:process 1 :type :info :f :txn :value [[:append 2 14]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:append 4 19]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 22]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 [4 10]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 23]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 21]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 24]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 20]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 18]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 25]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 26]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 22]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 27]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 25]]}
  {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 221]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 221]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 28]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 27]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 23]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 29]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 30]]}
+ {:process 2 :type :ok :f :txn :value [[:append 1 28]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 31]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 32]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 31]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 24]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 33]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 34]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 34]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 35]]}
+ {:process 2 :type :info :f :txn :value [[:append 2 33]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 36]]}
+ {:process 4 :type :ok :f :txn :value [[:append 0 35]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 37]]}
+ {:process 2 :type :info :f :txn :value [[:append 5 36]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 [3 19 22]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 38]]}
+ {:process 4 :type :info :f :txn :value [[:append 6 37]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 39]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 38]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 40]]}
+ {:process 4 :type :ok :f :txn :value [[:append 5 39]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [3 19 22]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 41]]}
+ {:process 2 :type :info :f :txn :value [[:append 6 40]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [5 26 28 29]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 42]]}
+ {:process 4 :type :info :f :txn :value [[:append 3 41]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 43]]}
+ {:process 2 :type :ok :f :txn :value [[:append 0 42]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 44]]}
+ {:process 4 :type :ok :f :txn :value [[:append 2 43]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [5 26 28 29]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 45]]}
+ {:process 2 :type :info :f :txn :value [[:append 3 44]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [43]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 46]]}
+ {:process 4 :type :info :f :txn :value [[:append 0 45]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 47]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 46]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 48]]}
+ {:process 4 :type :ok :f :txn :value [[:append 7 47]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [2 7 37 40]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 49]]}
+ {:process 2 :type :info :f :txn :value [[:append 4 48]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [1 25 38 47]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 50]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 49]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 51]]}
+ {:process 2 :type :ok :f :txn :value [[:append 6 50]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 52]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 51]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [4 10 41 44]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 53]]}
+ {:process 2 :type :info :f :txn :value [[:append 1 52]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 54]]}
+ {:process 4 :type :info :f :txn :value [[:append 2 53]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 55]]}
+ {:process 2 :type :ok :f :txn :value [[:append 3 54]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 56]]}
+ {:process 4 :type :ok :f :txn :value [[:append 1 55]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 57]]}
+ {:process 2 :type :info :f :txn :value [[:append 2 56]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 58]]}
+ {:process 4 :type :info :f :txn :value [[:append 7 57]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 59]]}
+ {:process 2 :type :ok :f :txn :value [[:append 4 58]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 60]]}
+ {:process 3 :type :info :f :txn :value [[:append 1 26]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 61]]}
+ {:process 4 :type :ok :f :txn :value [[:append 6 59]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 62]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 60]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 61]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 63]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 64]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 65]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 62]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 66]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 32]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 67]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 30]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 29]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:append 7 63]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 68]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 69]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 65]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 70]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 71]]}
+ {:process 4 :type :info :f :txn :value [[:append 3 66]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 70]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [43 53 56]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 72]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 73]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 69]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 74]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 75]]}
+ {:process 6 :type :info :f :txn :value [[:append 0 68]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 74]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 76]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 77]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 73]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 78]]}
+ {:process 3 :type :info :f :txn :value [[:append 3 75]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 79]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 78]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 80]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 64]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 81]]}
+ {:process 5 :type :info :f :txn :value [[:append 6 77]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 82]]}
+ {:process 3 :type :info :f :txn :value [[:append 2 79]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 83]]}
+ {:process 2 :type :info :f :txn :value [[:append 0 81]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 67]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 84]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 71]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 85]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 83]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 86]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 87]]}
+ {:process 2 :type :ok :f :txn :value [[:append 2 84]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 88]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 85]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 89]]}
+ {:process 2 :type :info :f :txn :value [[:append 5 88]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 90]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 89]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 91]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 90]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 92]]}
+ {:process 0 :type :ok :f :txn :value [[:append 3 91]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 93]]}
+ {:process 2 :type :info :f :txn :value [[:append 6 92]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 94]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 93]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 95]]}
+ {:process 2 :type :ok :f :txn :value [[:append 0 94]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 96]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 95]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 97]]}
+ {:process 2 :type :info :f :txn :value [[:append 3 96]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 98]]}
+ {:process 0 :type :info :f :txn :value [[:append 6 97]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 99]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 98]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 100]]}
+ {:process 4 :type :info :f :txn :value [[:append 1 72]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 101]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 99]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 102]]}
+ {:process 2 :type :ok :f :txn :value [[:append 4 100]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 103]]}
+ {:process 0 :type :info :f :txn :value [[:append 3 102]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 104]]}
+ {:process 6 :type :info :f :txn :value [[:append 6 76]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 105]]}
+ {:process 2 :type :ok :f :txn :value [[:append 6 103]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 106]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 80]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 107]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 82]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:append 2 104]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 87]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 108]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 86]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 109]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 110]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 111]]}
+ {:process 2 :type :info :f :txn :value [[:append 1 106]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:append 1 108]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 101]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 112]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 113]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 114]]}
+ {:process 5 :type :ok :f :txn :value [[:append 5 110]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 115]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 114]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 116]]}
+ {:process 1 :type :info :f :txn :value [[:append 3 112]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 117]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 105]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:append 5 116]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 118]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 119]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 119]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 120]]}
+ {:process 6 :type :info :f :txn :value [[:append 1 118]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 121]]}
+ {:process 4 :type :ok :f :txn :value [[:append 2 120]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 107]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 122]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 123]]}
+ {:process 6 :type :info :f :txn :value [[:append 2 121]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 124]]}
+ {:process 4 :type :ok :f :txn :value [[:append 0 122]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 125]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 123]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 126]]}
+ {:process 4 :type :ok :f :txn :value [[:append 7 125]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 127]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 126]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 128]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 127]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 129]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 128]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 130]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 129]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 131]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 130]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 109]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 132]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 133]]}
+ {:process 4 :type :info :f :txn :value [[:append 2 131]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 134]]}
+ {:process 0 :type :ok :f :txn :value [[:append 7 132]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 135]]}
+ {:process 4 :type :info :f :txn :value [[:append 1 134]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 111]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 136]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 137]]}
+ {:process 0 :type :info :f :txn :value [[:append 5 135]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 138]]}
+ {:process 3 :type :info :f :txn :value [[:append 4 136]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 139]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 138]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 140]]}
+ {:process 3 :type :info :f :txn :value [[:append 2 139]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 141]]}
+ {:process 0 :type :ok :f :txn :value [[:append 2 140]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 142]]}
+ {:process 3 :type :ok :f :txn :value [[:append 1 141]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 115]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 143]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 144]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 142]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 145]]}
+ {:process 3 :type :ok :f :txn :value [[:append 7 143]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 146]]}
+ {:process 5 :type :info :f :txn :value [[:append 0 144]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 147]]}
+ {:process 2 :type :info :f :txn :value [[:append 3 113]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 148]]}
+ {:process 1 :type :info :f :txn :value [[:append 6 117]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:append 7 145]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 149]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 150]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 147]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 151]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 149]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:append 0 150]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 152]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 153]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 124]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 154]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 151]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 155]]}
+ {:process 1 :type :info :f :txn :value [[:append 7 152]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 156]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 133]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 157]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 157]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 158]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 137]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 159]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 159]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 160]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 146]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 161]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 160]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 162]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 148]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 163]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 162]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 155]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 164]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 165]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 165]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 166]]}
+ {:process 4 :type :info :f :txn :value [[:append 1 164]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 167]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 153]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 168]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 166]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 169]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 154]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :info :f :txn :value [[:append 1 156]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 170]]}
+ {:process 4 :type :info :f :txn :value [[:append 0 167]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 171]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 158]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 172]]}
+ {:process 5 :type :ok :f :txn :value [[:append 1 169]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 173]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 174]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 173]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 175]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 172]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 176]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 175]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 177]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 176]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 178]]}
+ {:process 5 :type :ok :f :txn :value [[:append 5 177]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 179]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 178]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 180]]}
+ {:process 5 :type :info :f :txn :value [[:append 3 179]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 181]]}
+ {:process 7 :type :ok :f :txn :value [[:append 4 180]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 182]]}
+ {:process 5 :type :ok :f :txn :value [[:append 0 181]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 183]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 182]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 184]]}
+ {:process 5 :type :info :f :txn :value [[:append 6 183]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 185]]}
+ {:process 7 :type :ok :f :txn :value [[:append 7 184]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 186]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 185]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 161]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 187]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 188]]}
+ {:process 7 :type :info :f :txn :value [[:append 0 186]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :info :f :txn :value [[:append 3 171]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 189]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 190]]}
+ {:process 3 :type :info :f :txn :value [[:append 3 187]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 191]]}
+ {:process 6 :type :ok :f :txn :value [[:append 4 189]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 192]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 190]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 193]]}
+ {:process 3 :type :ok :f :txn :value [[:append 1 191]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 194]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 163]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 195]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 192]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 196]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 168]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 197]]}
+ {:process 3 :type :info :f :txn :value [[:append 0 194]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 198]]}
+ {:process 6 :type :ok :f :txn :value [[:append 7 196]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 199]]}
+ {:process 0 :type :ok :f :txn :value [[:append 1 197]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 200]]}
+ {:process 3 :type :ok :f :txn :value [[:append 6 198]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 201]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 170]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 202]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 174]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 203]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 199]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 204]]}
+ {:process 3 :type :ok :f :txn :value [[:append 5 201]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 205]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 204]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 206]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 203]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 207]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 205]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 208]]}
+ {:process 6 :type :ok :f :txn :value [[:append 4 206]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 209]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 188]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 210]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 207]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 211]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 208]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 212]]}
+ {:process 6 :type :info :f :txn :value [[:append 1 209]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 213]]}
+ {:process 4 :type :ok :f :txn :value [[:append 2 211]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 214]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 193]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 212]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 215]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 216]]}
+ {:process 6 :type :ok :f :txn :value [[:append 7 213]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 217]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 215]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 195]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 218]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 200]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 219]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 220]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 216]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 221]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 219]]}
  {:process 2 :type :invoke :f :txn :value [[:append 0 222]]}
+ {:process 3 :type :info :f :txn :value [[:append 5 218]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 223]]}
  {:process 2 :type :fail :f :txn :value [[:append 0 222]]}
  {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 223]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 223]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 224]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 224]]}
- {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 225]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 225]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 226]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 226]]}
- {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 227]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 227]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 228]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 228]]}
- {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 229]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 229]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 230]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 230]]}
- {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 231]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 231]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 232]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 232]]}
- {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 233]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 233]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 234]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 234]]}
- {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 235]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 235]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 236]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 236]]}
- {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 237]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 237]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 238]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 238]]}
- {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 239]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 239]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 240]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 240]]}
- {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 241]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 241]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 242]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 242]]}
- {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 243]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 243]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 244]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 244]]}
- {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 245]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 245]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 246]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 246]]}
- {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 247]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 247]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 248]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 248]]}
- {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 249]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 249]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 250]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 250]]}
- {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 251]]}
- {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 252]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 252]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 253]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 206]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 254]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 254]]}
- {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 203]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 255]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 256]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 256]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 257]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 258]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 258]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 259]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 251]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 260]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 259]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 261]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 261]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 253]]}
- {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 262]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 263]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 263]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 264]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 255]]}
- {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 265]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 264]]}
- {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 257]]}
- {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 266]]}
- {:process 1 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 267]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 []]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 268]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 267]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 269]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 262]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 270]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 260]]}
- {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 2 :type :ok :f :txn :value [[:append 2 266]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 271]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 272]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 270]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 273]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 274]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 274]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 275]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 265]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 276]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 276]]}
- {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 268]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 277]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 278]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 278]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 279]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 271]]}
- {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 279]]}
- {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 272]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 280]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 269]]}
- {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 281]]}
- {:process 3 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 282]]}
- {:process 1 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 283]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 280]]}
- {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 275]]}
- {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 273]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 284]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 285]]}
- {:process 5 :type :ok :f :txn :value [[:r 3 []]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 286]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 285]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 287]]}
- {:process 7 :type :ok :f :txn :value [[:append 0 284]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 288]]}
- {:process 4 :type :info :f :txn :value [[:append 5 287]]}
- {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 289]]}
- {:process 7 :type :info :f :txn :value [[:append 2 288]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 290]]}
- {:process 4 :type :ok :f :txn :value [[:append 3 289]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 291]]}
- {:process 7 :type :ok :f :txn :value [[:append 3 290]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 []]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 292]]}
- {:process 4 :type :info :f :txn :value [[:append 2 291]]}
- {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 293]]}
- {:process 7 :type :info :f :txn :value [[:append 5 292]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 294]]}
- {:process 4 :type :ok :f :txn :value [[:append 0 293]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 295]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 283]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 296]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 277]]}
- {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 281]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 297]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 282]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 298]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 286]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 299]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 300]]}
- {:process 7 :type :ok :f :txn :value [[:append 6 294]]}
- {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 296]]}
- {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 7 []]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 301]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 298]]}
- {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 5 [287 292]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 302]]}
- {:process 3 :type :ok :f :txn :value [[:r 1 []]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 303]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 302]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 304]]}
- {:process 7 :type :ok :f :txn :value [[:append 0 301]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 305]]}
- {:process 3 :type :ok :f :txn :value [[:append 0 303]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 306]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 299]]}
- {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 6 [294 300]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 307]]}
- {:process 7 :type :ok :f :txn :value [[:append 1 305]]}
- {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 308]]}
- {:process 3 :type :ok :f :txn :value [[:append 7 306]]}
- {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 6 [294 300]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 309]]}
- {:process 5 :type :ok :f :txn :value [[:append 7 307]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 310]]}
- {:process 7 :type :ok :f :txn :value [[:append 3 308]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 311]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 297]]}
- {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 295]]}
- {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 304]]}
- {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 6 :type :info :f :txn :value [[:append 6 300]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 312]]}
- {:process 2 :type :ok :f :txn :value [[:r 1 [305]]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 313]]}
- {:process 4 :type :ok :f :txn :value [[:r 6 [294 300]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 314]]}
- {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 315]]}
- {:process 3 :type :ok :f :txn :value [[:append 5 309]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 316]]}
- {:process 7 :type :ok :f :txn :value [[:append 4 311]]}
- {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 317]]}
- {:process 6 :type :ok :f :txn :value [[:append 3 312]]}
- {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 318]]}
- {:process 7 :type :info :f :txn :value [[:append 6 317]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 319]]}
- {:process 6 :type :ok :f :txn :value [[:append 1 318]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 320]]}
- {:process 7 :type :ok :f :txn :value [[:append 7 319]]}
- {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 321]]}
- {:process 6 :type :info :f :txn :value [[:append 2 320]]}
- {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 322]]}
- {:process 7 :type :info :f :txn :value [[:append 1 321]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 323]]}
- {:process 6 :type :ok :f :txn :value [[:append 0 322]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 324]]}
- {:process 7 :type :ok :f :txn :value [[:append 2 323]]}
- {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 325]]}
- {:process 6 :type :info :f :txn :value [[:append 5 324]]}
- {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 326]]}
- {:process 7 :type :info :f :txn :value [[:append 4 325]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 327]]}
- {:process 6 :type :ok :f :txn :value [[:append 3 326]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 328]]}
- {:process 7 :type :ok :f :txn :value [[:append 5 327]]}
- {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 329]]}
- {:process 6 :type :info :f :txn :value [[:append 4 328]]}
- {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 330]]}
- {:process 7 :type :info :f :txn :value [[:append 7 329]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 331]]}
- {:process 6 :type :ok :f :txn :value [[:append 2 330]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 332]]}
- {:process 7 :type :ok :f :txn :value [[:append 0 331]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 333]]}
- {:process 6 :type :info :f :txn :value [[:append 7 332]]}
- {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 334]]}
- {:process 7 :type :info :f :txn :value [[:append 2 333]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 335]]}
- {:process 6 :type :ok :f :txn :value [[:append 5 334]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 336]]}
- {:process 7 :type :ok :f :txn :value [[:append 3 335]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 310]]}
- {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 316]]}
+ {:process 1 :type :info :f :txn :value [[:append 6 202]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 224]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 225]]}
+ {:process 3 :type :ok :f :txn :value [[:append 4 223]]}
  {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 337]]}
- {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 338]]}
- {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 339]]}
- {:process 6 :type :info :f :txn :value [[:append 6 336]]}
- {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 340]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 339]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 341]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 341]]}
- {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 314]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 342]]}
- {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 343]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 313]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 344]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 343]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 345]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 315]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 346]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 346]]}
- {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 347]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 347]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 348]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 348]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 226]]}
+ {:process 1 :type :ok :f :txn :value [[:append 5 224]]}
  {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 349]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 349]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 350]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 350]]}
+ {:process 2 :type :ok :f :txn :value [[:append 2 225]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 227]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 228]]}
+ {:process 3 :type :ok :f :txn :value [[:append 2 226]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 229]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 210]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 230]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 227]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:append 1 229]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 231]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 232]]}
+ {:process 5 :type :ok :f :txn :value [[:append 0 230]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 233]]}
+ {:process 0 :type :info :f :txn :value [[:append 6 220]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 234]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 231]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 235]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 233]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 236]]}
+ {:process 2 :type :info :f :txn :value [[:append 6 235]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 237]]}
+ {:process 5 :type :info :f :txn :value [[:append 7 236]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 238]]}
+ {:process 2 :type :ok :f :txn :value [[:append 0 237]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 239]]}
+ {:process 5 :type :ok :f :txn :value [[:append 4 238]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 240]]}
+ {:process 2 :type :info :f :txn :value [[:append 3 239]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 241]]}
+ {:process 5 :type :info :f :txn :value [[:append 2 240]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 242]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 241]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 243]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 242]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 244]]}
+ {:process 2 :type :info :f :txn :value [[:append 4 243]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 245]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 244]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 246]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 217]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:append 6 245]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 247]]}
+ {:process 4 :type :info :f :txn :value [[:append 0 214]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 248]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 249]]}
+ {:process 5 :type :ok :f :txn :value [[:append 6 246]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 250]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 249]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 251]]}
+ {:process 4 :type :info :f :txn :value [[:append 7 248]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :info :f :txn :value [[:append 1 247]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 252]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 253]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 251]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 221]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 254]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 255]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 252]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 256]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 228]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 257]]}
+ {:process 6 :type :info :f :txn :value [[:append 1 254]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 258]]}
+ {:process 4 :type :info :f :txn :value [[:append 4 256]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 259]]}
+ {:process 6 :type :info :f :txn :value [[:append 2 258]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 260]]}
+ {:process 4 :type :info :f :txn :value [[:append 2 259]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 261]]}
+ {:process 6 :type :ok :f :txn :value [[:append 0 260]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 262]]}
+ {:process 4 :type :ok :f :txn :value [[:append 1 261]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 263]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 262]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 264]]}
+ {:process 4 :type :info :f :txn :value [[:append 7 263]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 265]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 264]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 266]]}
+ {:process 4 :type :ok :f :txn :value [[:append 6 265]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 267]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 266]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 268]]}
+ {:process 4 :type :info :f :txn :value [[:append 4 267]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 269]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 268]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 270]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 269]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 271]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 270]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 232]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 272]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 273]]}
+ {:process 4 :type :ok :f :txn :value [[:append 1 271]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 274]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 274]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 275]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 234]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 276]]}
+ {:process 4 :type :ok :f :txn :value [[:append 6 275]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 277]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 253]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 278]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 278]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 279]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 250]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 280]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 280]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 281]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 255]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 282]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 282]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 283]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 257]]}
  {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 351]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 351]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 352]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 352]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 284]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 283]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 285]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 273]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 286]]}
+ {:process 3 :type :info :f :txn :value [[:append 6 272]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 287]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 286]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:append 4 285]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 288]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 289]]}
+ {:process 3 :type :ok :f :txn :value [[:append 4 287]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 290]]}
+ {:process 6 :type :ok :f :txn :value [[:append 4 288]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 291]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 289]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 292]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 291]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 276]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 293]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 294]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 292]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 295]]}
+ {:process 0 :type :info :f :txn :value [[:append 2 293]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 296]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 295]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 297]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 296]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 298]]}
+ {:process 7 :type :ok :f :txn :value [[:append 2 297]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 299]]}
+ {:process 0 :type :info :f :txn :value [[:append 7 298]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 300]]}
+ {:process 7 :type :info :f :txn :value [[:append 4 299]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 301]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 300]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 302]]}
+ {:process 7 :type :ok :f :txn :value [[:append 5 301]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 277]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 303]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 304]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 302]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 305]]}
+ {:process 2 :type :info :f :txn :value [[:append 4 279]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 306]]}
+ {:process 5 :type :info :f :txn :value [[:append 3 281]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 307]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 304]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 308]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 284]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 309]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 303]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 310]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 307]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 290]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 311]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 312]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 294]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 313]]}
+ {:process 1 :type :info :f :txn :value [[:append 3 309]]}
  {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 353]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 353]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 354]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 354]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 314]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 312]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 315]]}
+ {:process 5 :type :ok :f :txn :value [[:append 6 311]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 316]]}
+ {:process 6 :type :ok :f :txn :value [[:append 0 313]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 317]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 315]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :info :f :txn :value [[:append 5 314]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 318]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 319]]}
+ {:process 6 :type :ok :f :txn :value [[:append 6 317]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 320]]}
+ {:process 1 :type :ok :f :txn :value [[:append 0 318]]}
  {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 355]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 355]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 356]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 356]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 321]]}
+ {:process 6 :type :info :f :txn :value [[:append 3 320]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 305]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 322]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 323]]}
+ {:process 1 :type :info :f :txn :value [[:append 2 321]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 324]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 323]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 325]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 322]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 326]]}
+ {:process 6 :type :info :f :txn :value [[:append 2 325]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 327]]}
+ {:process 0 :type :info :f :txn :value [[:append 7 326]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 328]]}
+ {:process 6 :type :ok :f :txn :value [[:append 0 327]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 329]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 328]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 330]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 329]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 331]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 330]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 332]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 331]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 333]]}
+ {:process 0 :type :ok :f :txn :value [[:append 3 332]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 334]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 333]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 335]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 334]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 336]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 335]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 337]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 336]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 338]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 337]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 339]]}
+ {:process 0 :type :info :f :txn :value [[:append 6 338]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 340]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 308]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 341]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 339]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 342]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 340]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 310]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :info :f :txn :value [[:append 7 306]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 343]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 344]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 345]]}
+ {:process 4 :type :ok :f :txn :value [[:append 0 341]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 346]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 345]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 347]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 319]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 348]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 344]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 349]]}
+ {:process 2 :type :ok :f :txn :value [[:append 0 347]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :info :f :txn :value [[:append 7 316]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 350]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 351]]}
+ {:process 7 :type :info :f :txn :value [[:append 3 349]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :info :f :txn :value [[:append 1 324]]}
  {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 357]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 357]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 358]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 358]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 352]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 353]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 353]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 354]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 352]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 355]]}
+ {:process 1 :type :ok :f :txn :value [[:append 6 354]]}
  {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 359]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 359]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 360]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 360]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 356]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 355]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 357]]}
+ {:process 1 :type :info :f :txn :value [[:append 0 356]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 358]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 357]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 359]]}
+ {:process 1 :type :ok :f :txn :value [[:append 7 358]]}
  {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 361]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 361]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 360]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 359]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 361]]}
+ {:process 1 :type :info :f :txn :value [[:append 1 360]]}
  {:process 1 :type :invoke :f :txn :value [[:append 4 362]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 362]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 361]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 363]]}
+ {:process 1 :type :ok :f :txn :value [[:append 4 362]]}
  {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 363]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 363]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 364]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 364]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 364]]}
+ {:process 7 :type :info :f :txn :value [[:append 4 363]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 365]]}
+ {:process 1 :type :info :f :txn :value [[:append 6 364]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 366]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 365]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 367]]}
+ {:process 1 :type :ok :f :txn :value [[:append 5 366]]}
  {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 365]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 365]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 366]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 366]]}
- {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 367]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 367]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 368]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 368]]}
- {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 369]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 369]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 370]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 370]]}
- {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 371]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 371]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 372]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 372]]}
- {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 373]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 373]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 374]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 374]]}
- {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 375]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 375]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 376]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 376]]}
- {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 338]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 377]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 340]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 378]]}
- {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 379]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 337]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 380]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 379]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 381]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 344]]}
- {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 342]]}
- {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 2 :type :invoke :f :txn :value [[:append 5 382]]}
- {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 383]]}
- {:process 2 :type :fail :f :txn :value [[:append 5 382]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 384]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 345]]}
- {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 385]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 384]]}
- {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 2 :type :invoke :f :txn :value [[:append 6 386]]}
- {:process 2 :type :fail :f :txn :value [[:append 6 386]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 387]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 387]]}
- {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 2 :type :invoke :f :txn :value [[:append 3 388]]}
- {:process 2 :type :fail :f :txn :value [[:append 3 388]]}
- {:process 2 :type :invoke :f :txn :value [[:append 2 389]]}
- {:process 2 :type :fail :f :txn :value [[:append 2 389]]}
- {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 2 :type :invoke :f :txn :value [[:append 4 390]]}
- {:process 2 :type :fail :f :txn :value [[:append 4 390]]}
- {:process 2 :type :invoke :f :txn :value [[:append 7 391]]}
- {:process 2 :type :fail :f :txn :value [[:append 7 391]]}
- {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
- {:process 2 :type :invoke :f :txn :value [[:append 1 392]]}
- {:process 2 :type :fail :f :txn :value [[:append 1 392]]}
- {:process 2 :type :invoke :f :txn :value [[:append 0 393]]}
- {:process 2 :type :fail :f :txn :value [[:append 0 393]]}
- {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 2 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 377]]}
- {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 378]]}
- {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 394]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 395]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 395]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 396]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 380]]}
- {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 397]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 396]]}
- {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 381]]}
- {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 398]]}
- {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 399]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 383]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 400]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 399]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 401]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 398]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 402]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 400]]}
- {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 385]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 403]]}
- {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 404]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 404]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 405]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 405]]}
- {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 406]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 406]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 407]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 407]]}
- {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 408]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 408]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 409]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 409]]}
- {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 410]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 410]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 411]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 411]]}
- {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 412]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 412]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 413]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 413]]}
- {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 414]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 414]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 415]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 415]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 342]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 346]]}
  {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 416]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 416]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 368]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 369]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 370]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 367]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 371]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 370]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 372]]}
+ {:process 1 :type :info :f :txn :value [[:append 7 368]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 373]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 348]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 372]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 374]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 375]]}
+ {:process 0 :type :info :f :txn :value [[:append 3 343]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 376]]}
+ {:process 1 :type :ok :f :txn :value [[:append 2 373]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :info :f :txn :value [[:append 2 350]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 377]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 375]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 378]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 379]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 378]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 351]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 380]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 381]]}
+ {:process 3 :type :info :f :txn :value [[:append 3 374]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 382]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 381]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 383]]}
+ {:process 5 :type :info :f :txn :value [[:append 2 380]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 384]]}
+ {:process 4 :type :info :f :txn :value [[:append 6 383]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 385]]}
+ {:process 5 :type :info :f :txn :value [[:append 0 384]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 386]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 385]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 387]]}
+ {:process 5 :type :ok :f :txn :value [[:append 1 386]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 388]]}
+ {:process 4 :type :info :f :txn :value [[:append 3 387]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 389]]}
+ {:process 5 :type :info :f :txn :value [[:append 7 388]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 390]]}
+ {:process 4 :type :ok :f :txn :value [[:append 1 389]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 391]]}
+ {:process 5 :type :ok :f :txn :value [[:append 4 390]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 392]]}
+ {:process 4 :type :info :f :txn :value [[:append 0 391]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 393]]}
+ {:process 5 :type :info :f :txn :value [[:append 2 392]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 394]]}
+ {:process 4 :type :ok :f :txn :value [[:append 6 393]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 395]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 394]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 396]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 395]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 397]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 396]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 398]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 397]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 399]]}
+ {:process 5 :type :ok :f :txn :value [[:append 6 398]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 400]]}
+ {:process 4 :type :info :f :txn :value [[:append 2 399]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 401]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 400]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 402]]}
+ {:process 4 :type :ok :f :txn :value [[:append 0 401]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 403]]}
+ {:process 5 :type :ok :f :txn :value [[:append 5 402]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 404]]}
+ {:process 4 :type :info :f :txn :value [[:append 7 403]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 405]]}
+ {:process 5 :type :info :f :txn :value [[:append 3 404]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 406]]}
+ {:process 4 :type :ok :f :txn :value [[:append 5 405]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 407]]}
+ {:process 5 :type :ok :f :txn :value [[:append 0 406]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 408]]}
+ {:process 4 :type :info :f :txn :value [[:append 4 407]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 409]]}
+ {:process 5 :type :info :f :txn :value [[:append 6 408]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 410]]}
+ {:process 4 :type :ok :f :txn :value [[:append 2 409]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 411]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 410]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 412]]}
+ {:process 4 :type :info :f :txn :value [[:append 1 411]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 413]]}
+ {:process 5 :type :info :f :txn :value [[:append 5 412]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 414]]}
+ {:process 4 :type :ok :f :txn :value [[:append 7 413]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 415]]}
+ {:process 5 :type :ok :f :txn :value [[:append 2 414]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 416]]}
+ {:process 4 :type :info :f :txn :value [[:append 6 415]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412]]]}
  {:process 4 :type :invoke :f :txn :value [[:append 4 417]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 417]]}
- {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 418]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 418]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 419]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 419]]}
- {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 420]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 420]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 421]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 421]]}
- {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 422]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 422]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 423]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 423]]}
+ {:process 5 :type :info :f :txn :value [[:append 0 416]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 418]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 417]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 419]]}
+ {:process 5 :type :ok :f :txn :value [[:append 1 418]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 420]]}
+ {:process 4 :type :info :f :txn :value [[:append 3 419]]}
  {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 424]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 424]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 425]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 425]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 421]]}
+ {:process 5 :type :info :f :txn :value [[:append 7 420]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 422]]}
+ {:process 4 :type :ok :f :txn :value [[:append 1 421]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 423]]}
+ {:process 5 :type :ok :f :txn :value [[:append 4 422]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 424]]}
+ {:process 4 :type :info :f :txn :value [[:append 0 423]]}
  {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 369]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 425]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420]]]}
  {:process 4 :type :invoke :f :txn :value [[:append 6 426]]}
+ {:process 5 :type :info :f :txn :value [[:append 2 424]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 427]]}
  {:process 4 :type :fail :f :txn :value [[:append 6 426]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 427]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 427]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 428]]}
+ {:process 6 :type :info :f :txn :value [[:append 1 425]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 429]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 428]]}
  {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 428]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 428]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 429]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 429]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 430]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 429]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 431]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 430]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 432]]}
+ {:process 6 :type :ok :f :txn :value [[:append 0 431]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 433]]}
+ {:process 4 :type :info :f :txn :value [[:append 2 432]]}
  {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 430]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 430]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 431]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 431]]}
- {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 432]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 432]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 433]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 433]]}
- {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 434]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 434]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 435]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 435]]}
- {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 436]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 436]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 437]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 437]]}
- {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 438]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 438]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 439]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 439]]}
- {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 440]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 440]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 441]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 441]]}
- {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 442]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 442]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 443]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 443]]}
- {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 444]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 444]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 445]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 445]]}
- {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 446]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 446]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 447]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 447]]}
- {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 394]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 448]]}
- {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 449]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 449]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 450]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 397]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 451]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 451]]}
- {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 401]]}
- {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 452]]}
- {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 453]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 453]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 454]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 403]]}
- {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 402]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 434]]}
+ {:process 6 :type :info :f :txn :value [[:append 6 433]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 435]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 371]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 436]]}
+ {:process 4 :type :ok :f :txn :value [[:append 0 434]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 437]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 379]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 438]]}
+ {:process 2 :type :info :f :txn :value [[:append 5 377]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 435]]}
  {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 455]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 456]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 454]]}
- {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 457]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 455]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 458]]}
- {:process 6 :type :ok :f :txn :value [[:append 1 456]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 459]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 448]]}
+ {:process 3 :type :info :f :txn :value [[:append 2 382]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 439]]}
+ {:process 0 :type :info :f :txn :value [[:append 2 376]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 440]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 441]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 442]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 440]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 443]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 442]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 444]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 441]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 445]]}
+ {:process 5 :type :info :f :txn :value [[:append 3 427]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 446]]}
+ {:process 0 :type :ok :f :txn :value [[:append 7 444]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 447]]}
+ {:process 3 :type :ok :f :txn :value [[:append 7 445]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 436]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 448]]}
+ {:process 5 :type :ok :f :txn :value [[:append 1 446]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 449]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 450]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 447]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 451]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 449]]}
  {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 450]]}
- {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 460]]}
- {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 461]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 461]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 462]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 458]]}
- {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 452]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 463]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 464]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 462]]}
- {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 463]]}
- {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 465]]}
- {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 466]]}
- {:process 3 :type :ok :f :txn :value [[:append 6 464]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 467]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 465]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 468]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 459]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 452]]}
+ {:process 7 :type :info :f :txn :value [[:append 4 450]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 453]]}
+ {:process 5 :type :ok :f :txn :value [[:append 4 452]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 454]]}
+ {:process 7 :type :ok :f :txn :value [[:append 5 453]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :info :f :txn :value [[:append 7 437]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 438]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 455]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 456]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 457]]}
+ {:process 5 :type :info :f :txn :value [[:append 5 454]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 458]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 456]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 459]]}
+ {:process 1 :type :ok :f :txn :value [[:append 5 457]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 460]]}
+ {:process 3 :type :info :f :txn :value [[:append 5 448]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 461]]}
+ {:process 2 :type :info :f :txn :value [[:append 7 439]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 462]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 443]]}
  {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 469]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 468]]}
- {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :info :f :txn :value [[:append 4 457]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 458]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 463]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 464]]}
+ {:process 1 :type :info :f :txn :value [[:append 0 460]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:append 6 462]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 465]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 466]]}
+ {:process 6 :type :info :f :txn :value [[:append 0 464]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 467]]}
+ {:process 1 :type :info :f :txn :value [[:append 2 465]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 468]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 467]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 469]]}
+ {:process 1 :type :info :f :txn :value [[:append 1 468]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452]]]}
  {:process 1 :type :invoke :f :txn :value [[:append 3 470]]}
- {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 471]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 471]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 472]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 460]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 473]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 473]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 467]]}
- {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 466]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 474]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 475]]}
- {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 476]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 475]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 477]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 477]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 469]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 478]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 479]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 479]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 480]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 470]]}
- {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 481]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 480]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 472]]}
- {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 482]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 483]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 483]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 484]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 476]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 485]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 474]]}
- {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 486]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 485]]}
- {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 487]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 484]]}
- {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 488]]}
- {:process 7 :type :ok :f :txn :value [[:append 1 486]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 489]]}
- {:process 3 :type :ok :f :txn :value [[:append 0 487]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 490]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 489]]}
- {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 491]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 478]]}
- {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :ok :f :txn :value [[:append 7 490]]}
- {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 492]]}
- {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 493]]}
- {:process 7 :type :ok :f :txn :value [[:append 4 491]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 494]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 481]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 495]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 482]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 496]]}
- {:process 4 :type :info :f :txn :value [[:append 6 488]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 497]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 497]]}
- {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 498]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 493]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 499]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 499]]}
- {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 496]]}
- {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 500]]}
- {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 501]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 501]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 502]]}
- {:process 6 :type :info :f :txn :value [[:append 3 492]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 503]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 495]]}
- {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 503]]}
+ {:process 6 :type :info :f :txn :value [[:append 3 469]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 471]]}
+ {:process 1 :type :ok :f :txn :value [[:append 3 470]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 472]]}
+ {:process 6 :type :ok :f :txn :value [[:append 4 471]]}
  {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 504]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 494]]}
- {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 505]]}
- {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 506]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 504]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 507]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 507]]}
- {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 508]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 508]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 509]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 509]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 473]]}
+ {:process 1 :type :info :f :txn :value [[:append 6 472]]}
  {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 510]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 510]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 511]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 511]]}
- {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 512]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 512]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 513]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 513]]}
- {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 514]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 514]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 515]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 515]]}
- {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 516]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 516]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 517]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 517]]}
- {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 518]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 518]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 519]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 519]]}
- {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 520]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 520]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 521]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 521]]}
- {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 522]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 522]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 523]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 500]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 524]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 498]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 525]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 524]]}
- {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 502]]}
- {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 526]]}
- {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 527]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 527]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 528]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 506]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 529]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 505]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 530]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 530]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 474]]}
+ {:process 6 :type :info :f :txn :value [[:append 2 473]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 475]]}
+ {:process 1 :type :ok :f :txn :value [[:append 0 474]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 476]]}
+ {:process 6 :type :ok :f :txn :value [[:append 7 475]]}
  {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 531]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 531]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 532]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 532]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 477]]}
+ {:process 1 :type :info :f :txn :value [[:append 7 476]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 478]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 477]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 479]]}
+ {:process 1 :type :ok :f :txn :value [[:append 1 478]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 480]]}
+ {:process 6 :type :ok :f :txn :value [[:append 6 479]]}
  {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 533]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 533]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 534]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 534]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 481]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 480]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 482]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 481]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 483]]}
+ {:process 1 :type :ok :f :txn :value [[:append 6 482]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 484]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 483]]}
  {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 535]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 535]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 536]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 536]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 485]]}
+ {:process 1 :type :info :f :txn :value [[:append 5 484]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 451]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 486]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 487]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 485]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 488]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 488]]}
  {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 537]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 537]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 538]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 538]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 489]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 459]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 490]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 461]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:append 6 489]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 491]]}
+ {:process 1 :type :info :f :txn :value [[:append 7 486]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 492]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 455]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 493]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 494]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 492]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 463]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 495]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 496]]}
+ {:process 6 :type :info :f :txn :value [[:append 3 491]]}
  {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 539]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 539]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 540]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 540]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 466]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 497]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 498]]}
+ {:process 1 :type :ok :f :txn :value [[:append 4 495]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 499]]}
+ {:process 0 :type :info :f :txn :value [[:append 2 487]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 500]]}
+ {:process 5 :type :info :f :txn :value [[:append 6 496]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 501]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 490]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 502]]}
+ {:process 1 :type :ok :f :txn :value [[:append 3 499]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 503]]}
+ {:process 4 :type :ok :f :txn :value [[:append 1 502]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 494]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 504]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 505]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 505]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 506]]}
+ {:process 3 :type :info :f :txn :value [[:append 1 504]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 507]]}
+ {:process 4 :type :info :f :txn :value [[:append 6 506]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 508]]}
+ {:process 3 :type :info :f :txn :value [[:append 7 507]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 509]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 508]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 510]]}
+ {:process 3 :type :ok :f :txn :value [[:append 6 509]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 511]]}
+ {:process 4 :type :info :f :txn :value [[:append 3 510]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 512]]}
+ {:process 3 :type :info :f :txn :value [[:append 4 511]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 513]]}
+ {:process 4 :type :ok :f :txn :value [[:append 1 512]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 514]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 513]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 493]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 515]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 516]]}
+ {:process 4 :type :info :f :txn :value [[:append 0 514]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 517]]}
+ {:process 3 :type :ok :f :txn :value [[:append 1 515]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 518]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 516]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 519]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 497]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 520]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 518]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 521]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 519]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 522]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 520]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 523]]}
+ {:process 3 :type :ok :f :txn :value [[:append 6 521]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 524]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 500]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 498]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 525]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 526]]}
+ {:process 7 :type :ok :f :txn :value [[:append 5 522]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 527]]}
+ {:process 3 :type :ok :f :txn :value [[:append 5 524]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 528]]}
+ {:process 0 :type :ok :f :txn :value [[:append 7 526]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 529]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 527]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 530]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 528]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 531]]}
+ {:process 0 :type :info :f :txn :value [[:append 6 529]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 532]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 503]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 533]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 533]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 534]]}
+ {:process 5 :type :info :f :txn :value [[:append 7 501]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 535]]}
+ {:process 1 :type :ok :f :txn :value [[:append 2 534]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 536]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 517]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 537]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 537]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 538]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 523]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 539]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 538]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 540]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 525]]}
  {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526]]]}
  {:process 6 :type :invoke :f :txn :value [[:append 0 541]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 541]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 542]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 542]]}
- {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 543]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 543]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 544]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 544]]}
- {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 545]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 545]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 546]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 546]]}
- {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 547]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 547]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 548]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 548]]}
- {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 549]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 549]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 550]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 550]]}
- {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 551]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 551]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 552]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 523]]}
+ {:process 4 :type :ok :f :txn :value [[:append 2 540]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :info :f :txn :value [[:append 0 530]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 542]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 543]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 531]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 544]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 543]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 545]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 542]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 546]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 532]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 547]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 544]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 548]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 547]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 535]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 549]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 550]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 546]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 551]]}
+ {:process 5 :type :ok :f :txn :value [[:append 2 549]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :info :f :txn :value [[:append 1 536]]}
  {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 552]]}
- {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 552]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511]]]}
  {:process 1 :type :invoke :f :txn :value [[:append 3 553]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 554]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 554]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 555]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 525]]}
- {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 556]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 555]]}
- {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 526]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 557]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 558]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 558]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 559]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 529]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 528]]}
- {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 560]]}
- {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 561]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 559]]}
- {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 562]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 562]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 563]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 563]]}
- {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 564]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 564]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 565]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 565]]}
- {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 566]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 566]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 567]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 567]]}
- {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 568]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 568]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 569]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 569]]}
- {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 570]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 570]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 571]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 571]]}
- {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 572]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 572]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 573]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 573]]}
- {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 574]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 574]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 575]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 575]]}
- {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 576]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 576]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 577]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 577]]}
- {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 578]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 578]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 579]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 579]]}
- {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 580]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 580]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 581]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 581]]}
- {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 556]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 582]]}
- {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 583]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 583]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 584]]}
  {:process 1 :type :fail :f :txn :value [[:append 3 553]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 585]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 585]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 554]]}
+ {:process 5 :type :info :f :txn :value [[:append 0 552]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 555]]}
+ {:process 1 :type :ok :f :txn :value [[:append 6 554]]}
  {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 557]]}
- {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 586]]}
- {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 587]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 587]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 588]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 560]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 589]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 589]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 561]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 590]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 591]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 591]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 592]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 592]]}
- {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 593]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 593]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 594]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 594]]}
- {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 595]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 595]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 596]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 596]]}
- {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 597]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 597]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 598]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 598]]}
- {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 599]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 599]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 600]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 600]]}
- {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 601]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 601]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 602]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 602]]}
- {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 603]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 603]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 604]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 604]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 605]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 605]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 606]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 606]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 607]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 607]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 608]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 608]]}
- {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 609]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 609]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 610]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 610]]}
- {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 611]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 611]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 612]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 582]]}
- {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 584]]}
- {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 613]]}
- {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 614]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 612]]}
- {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 615]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 614]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 616]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 613]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 617]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 616]]}
- {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 618]]}
- {:process 4 :type :ok :f :txn :value [[:append 4 617]]}
- {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 619]]}
- {:process 6 :type :info :f :txn :value [[:append 4 618]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 620]]}
- {:process 4 :type :ok :f :txn :value [[:append 2 619]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 621]]}
- {:process 6 :type :ok :f :txn :value [[:append 1 620]]}
- {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 622]]}
- {:process 4 :type :info :f :txn :value [[:append 1 621]]}
- {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 623]]}
- {:process 6 :type :info :f :txn :value [[:append 7 622]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 624]]}
- {:process 4 :type :ok :f :txn :value [[:append 7 623]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 625]]}
- {:process 6 :type :ok :f :txn :value [[:append 0 624]]}
- {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 626]]}
- {:process 4 :type :info :f :txn :value [[:append 6 625]]}
- {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 627]]}
- {:process 6 :type :info :f :txn :value [[:append 6 626]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 628]]}
- {:process 4 :type :ok :f :txn :value [[:append 4 627]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 629]]}
- {:process 6 :type :ok :f :txn :value [[:append 3 628]]}
- {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 630]]}
- {:process 4 :type :info :f :txn :value [[:append 3 629]]}
- {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 631]]}
- {:process 6 :type :info :f :txn :value [[:append 1 630]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 632]]}
- {:process 4 :type :ok :f :txn :value [[:append 1 631]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 633]]}
- {:process 6 :type :ok :f :txn :value [[:append 2 632]]}
- {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 590]]}
- {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 588]]}
- {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 586]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 634]]}
- {:process 7 :type :info :f :txn :value [[:append 6 615]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 635]]}
- {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 636]]}
- {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 637]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 638]]}
- {:process 4 :type :info :f :txn :value [[:append 0 633]]}
- {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 635]]}
- {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 639]]}
- {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 640]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 639]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 641]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 636]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 642]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 642]]}
- {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 643]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 643]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 644]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 644]]}
- {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 645]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 645]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 646]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 634]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 556]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 555]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 557]]}
+ {:process 1 :type :info :f :txn :value [[:append 0 556]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 558]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 557]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 559]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 539]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 560]]}
+ {:process 1 :type :ok :f :txn :value [[:append 7 558]]}
  {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 638]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 647]]}
- {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 648]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 646]]}
- {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 637]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 649]]}
- {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 650]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 648]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 651]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 650]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 652]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 640]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 653]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 649]]}
- {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 654]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 652]]}
- {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 641]]}
- {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 655]]}
- {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 656]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 656]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 657]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 657]]}
- {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 658]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 658]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 659]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 659]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 541]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 561]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 562]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 559]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 563]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 561]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 564]]}
+ {:process 1 :type :ok :f :txn :value [[:append 1 562]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 565]]}
+ {:process 5 :type :ok :f :txn :value [[:append 2 563]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 566]]}
+ {:process 4 :type :info :f :txn :value [[:append 7 545]]}
  {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 660]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 660]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 661]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 661]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 567]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 564]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 568]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 566]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 548]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 569]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 570]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 567]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 571]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 569]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 572]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 571]]}
  {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 662]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 662]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 663]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 663]]}
- {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 651]]}
- {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 664]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 647]]}
- {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 665]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 666]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 665]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 667]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 653]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 573]]}
+ {:process 5 :type :info :f :txn :value [[:append 6 572]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 551]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 574]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 575]]}
+ {:process 4 :type :info :f :txn :value [[:append 2 573]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 576]]}
+ {:process 5 :type :ok :f :txn :value [[:append 4 574]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 577]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 575]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 578]]}
+ {:process 5 :type :ok :f :txn :value [[:append 5 577]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 579]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 578]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 580]]}
+ {:process 5 :type :info :f :txn :value [[:append 3 579]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 581]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 580]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 582]]}
+ {:process 5 :type :ok :f :txn :value [[:append 0 581]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 583]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 582]]}
  {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 654]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 668]]}
- {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 584]]}
+ {:process 5 :type :info :f :txn :value [[:append 6 583]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 585]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 550]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 586]]}
+ {:process 7 :type :ok :f :txn :value [[:append 4 584]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 587]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 585]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 560]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 588]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 589]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 589]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 590]]}
+ {:process 5 :type :info :f :txn :value [[:append 5 588]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 591]]}
+ {:process 2 :type :ok :f :txn :value [[:append 2 590]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 592]]}
+ {:process 5 :type :info :f :txn :value [[:append 2 591]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 593]]}
+ {:process 2 :type :info :f :txn :value [[:append 4 592]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 594]]}
+ {:process 5 :type :ok :f :txn :value [[:append 0 593]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 595]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 594]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 596]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 595]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 597]]}
+ {:process 2 :type :info :f :txn :value [[:append 1 596]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 598]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 597]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 599]]}
+ {:process 2 :type :ok :f :txn :value [[:append 0 598]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 600]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 599]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 601]]}
+ {:process 2 :type :info :f :txn :value [[:append 2 600]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 602]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 565]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:append 2 601]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 603]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 604]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 602]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 568]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 605]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 606]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 603]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 607]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 570]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 608]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 606]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 609]]}
+ {:process 2 :type :info :f :txn :value [[:append 7 605]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 610]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 576]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:append 4 608]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 611]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 612]]}
+ {:process 2 :type :ok :f :txn :value [[:append 6 610]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 587]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 613]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 614]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 614]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 615]]}
+ {:process 2 :type :info :f :txn :value [[:append 0 613]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 616]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 615]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 617]]}
+ {:process 2 :type :info :f :txn :value [[:append 3 616]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 618]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 617]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 619]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 618]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 620]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 619]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 621]]}
+ {:process 2 :type :info :f :txn :value [[:append 4 620]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 622]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 621]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 623]]}
+ {:process 2 :type :ok :f :txn :value [[:append 6 622]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 624]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 623]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 625]]}
+ {:process 0 :type :info :f :txn :value [[:append 0 586]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 626]]}
+ {:process 2 :type :info :f :txn :value [[:append 1 624]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 627]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 625]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 628]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 626]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 629]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 604]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 630]]}
+ {:process 2 :type :ok :f :txn :value [[:append 3 627]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 631]]}
+ {:process 0 :type :info :f :txn :value [[:append 5 629]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 632]]}
+ {:process 2 :type :info :f :txn :value [[:append 2 631]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 633]]}
+ {:process 0 :type :info :f :txn :value [[:append 3 632]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 634]]}
+ {:process 2 :type :ok :f :txn :value [[:append 4 633]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 635]]}
+ {:process 0 :type :ok :f :txn :value [[:append 2 634]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 636]]}
+ {:process 2 :type :info :f :txn :value [[:append 7 635]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 637]]}
+ {:process 0 :type :info :f :txn :value [[:append 0 636]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 638]]}
+ {:process 2 :type :ok :f :txn :value [[:append 1 637]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 639]]}
+ {:process 0 :type :ok :f :txn :value [[:append 7 638]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 640]]}
+ {:process 2 :type :info :f :txn :value [[:append 0 639]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 609]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 607]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 641]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 642]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 643]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 640]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 644]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 643]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 645]]}
+ {:process 5 :type :info :f :txn :value [[:append 6 641]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 646]]}
+ {:process 6 :type :info :f :txn :value [[:append 6 645]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 647]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 646]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 648]]}
+ {:process 6 :type :ok :f :txn :value [[:append 4 647]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 649]]}
+ {:process 5 :type :ok :f :txn :value [[:append 5 648]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 612]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 650]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 651]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 649]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 652]]}
+ {:process 3 :type :ok :f :txn :value [[:append 1 650]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 651]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 653]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 654]]}
+ {:process 6 :type :ok :f :txn :value [[:append 7 652]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 655]]}
+ {:process 4 :type :info :f :txn :value [[:append 7 611]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 656]]}
+ {:process 5 :type :info :f :txn :value [[:append 0 653]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 657]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 628]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 658]]}
+ {:process 5 :type :ok :f :txn :value [[:append 6 657]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 659]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 630]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 660]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 659]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 644]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 661]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 662]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 662]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 663]]}
+ {:process 5 :type :info :f :txn :value [[:append 5 661]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 664]]}
+ {:process 0 :type :ok :f :txn :value [[:append 1 663]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 665]]}
+ {:process 5 :type :info :f :txn :value [[:append 2 664]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 666]]}
+ {:process 0 :type :info :f :txn :value [[:append 7 665]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 667]]}
+ {:process 5 :type :ok :f :txn :value [[:append 0 666]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 668]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 658]]}
  {:process 7 :type :invoke :f :txn :value [[:append 4 669]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 667]]}
- {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 655]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 670]]}
- {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 671]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 671]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 672]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 672]]}
- {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 673]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 673]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 674]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 674]]}
- {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 675]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 675]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 676]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 676]]}
- {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 677]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 677]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 678]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 678]]}
- {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 679]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 679]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 680]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 680]]}
- {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 681]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 681]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 682]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 682]]}
- {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 683]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 683]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 684]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 664]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 685]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 684]]}
- {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 666]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 686]]}
- {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 687]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 687]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 688]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 668]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 689]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 688]]}
- {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :info :f :txn :value [[:append 2 642]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 670]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 667]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 656]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 671]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 672]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 654]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 673]]}
+ {:process 6 :type :info :f :txn :value [[:append 0 655]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 668]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:append 4 671]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 674]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 675]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 676]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 676]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 677]]}
+ {:process 3 :type :info :f :txn :value [[:append 6 673]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 678]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 677]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 660]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 679]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 680]]}
+ {:process 3 :type :info :f :txn :value [[:append 4 678]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 681]]}
  {:process 7 :type :fail :f :txn :value [[:append 4 669]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 690]]}
- {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 691]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 691]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 692]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 670]]}
- {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 693]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 692]]}
- {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 694]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 694]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 695]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 695]]}
- {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 696]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 696]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 697]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 697]]}
- {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 698]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 698]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 699]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 699]]}
- {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 700]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 700]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 701]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 701]]}
- {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 702]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 702]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 703]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 703]]}
- {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 704]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 704]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 705]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 705]]}
- {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 706]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 706]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 707]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 707]]}
- {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 708]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 708]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 709]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 709]]}
- {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 710]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 710]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 711]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 711]]}
- {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 686]]}
- {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 712]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 685]]}
- {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 713]]}
- {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 714]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 712]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 715]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 689]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 716]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 690]]}
- {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 717]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 716]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 718]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 715]]}
- {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 693]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 719]]}
- {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 720]]}
- {:process 7 :type :ok :f :txn :value [[:append 7 717]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 721]]}
- {:process 5 :type :ok :f :txn :value [[:append 6 718]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 722]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 713]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 723]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 714]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 724]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 724]]}
- {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 720]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 725]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 726]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 726]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 727]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 721]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 722]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 728]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 729]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 727]]}
- {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 730]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 729]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 731]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 728]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 732]]}
- {:process 4 :type :ok :f :txn :value [[:append 6 730]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 733]]}
- {:process 6 :type :info :f :txn :value [[:append 0 719]]}
- {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 734]]}
- {:process 5 :type :info :f :txn :value [[:append 2 731]]}
- {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 723]]}
- {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 735]]}
- {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 736]]}
- {:process 6 :type :ok :f :txn :value [[:append 6 734]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 737]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 735]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 738]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 725]]}
- {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 739]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 738]]}
- {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 740]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 740]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 741]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 737]]}
- {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 742]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 741]]}
- {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 743]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 742]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 744]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 732]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 745]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 744]]}
- {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 733]]}
- {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 746]]}
- {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 747]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 747]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 748]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 736]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 749]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 749]]}
- {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 739]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 750]]}
- {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 751]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 751]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 752]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 752]]}
- {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 753]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 753]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 754]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 754]]}
- {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 743]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 755]]}
- {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 756]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 756]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 757]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 745]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 758]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 746]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 759]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 758]]}
- {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 757]]}
- {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 760]]}
- {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 761]]}
- {:process 6 :type :ok :f :txn :value [[:append 5 759]]}
- {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 762]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 760]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 763]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 762]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 764]]}
- {:process 7 :type :ok :f :txn :value [[:append 1 763]]}
- {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 765]]}
- {:process 6 :type :info :f :txn :value [[:append 4 764]]}
- {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 766]]}
- {:process 7 :type :info :f :txn :value [[:append 3 765]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 767]]}
- {:process 6 :type :ok :f :txn :value [[:append 2 766]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 768]]}
- {:process 7 :type :ok :f :txn :value [[:append 4 767]]}
  {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759]]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 682]]}
+ {:process 1 :type :ok :f :txn :value [[:append 2 679]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 681]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 683]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 684]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 682]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 685]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 685]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 686]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 672]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 687]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 670]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :info :f :txn :value [[:append 3 674]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 688]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 689]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 687]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 686]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 690]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 691]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 689]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 692]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 688]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 693]]}
+ {:process 7 :type :ok :f :txn :value [[:append 2 690]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 694]]}
+ {:process 0 :type :info :f :txn :value [[:append 0 692]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 695]]}
+ {:process 7 :type :info :f :txn :value [[:append 4 694]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 696]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 695]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 697]]}
+ {:process 7 :type :ok :f :txn :value [[:append 5 696]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 698]]}
+ {:process 0 :type :info :f :txn :value [[:append 5 697]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 699]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 698]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 700]]}
+ {:process 0 :type :ok :f :txn :value [[:append 3 699]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 701]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 700]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 702]]}
+ {:process 0 :type :info :f :txn :value [[:append 2 701]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 703]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 702]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 704]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 703]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 705]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 704]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 706]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 675]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 707]]}
+ {:process 0 :type :info :f :txn :value [[:append 7 705]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 708]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 706]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 709]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 708]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 710]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 709]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 711]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 710]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 712]]}
+ {:process 7 :type :info :f :txn :value [[:append 0 711]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 713]]}
+ {:process 0 :type :ok :f :txn :value [[:append 2 712]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 714]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 713]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 715]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 714]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 680]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 716]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 717]]}
+ {:process 7 :type :info :f :txn :value [[:append 3 715]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 718]]}
+ {:process 5 :type :ok :f :txn :value [[:append 3 716]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 719]]}
+ {:process 7 :type :info :f :txn :value [[:append 4 718]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 720]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 719]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 721]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 720]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 722]]}
+ {:process 5 :type :ok :f :txn :value [[:append 6 721]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 723]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 722]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 724]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 723]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 725]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 724]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 726]]}
+ {:process 5 :type :ok :f :txn :value [[:append 5 725]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 727]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 726]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :info :f :txn :value [[:append 1 684]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 728]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 729]]}
+ {:process 5 :type :info :f :txn :value [[:append 3 727]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 730]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 683]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 731]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 728]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 732]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 693]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 733]]}
+ {:process 4 :type :info :f :txn :value [[:append 1 691]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 734]]}
+ {:process 3 :type :ok :f :txn :value [[:append 6 732]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 735]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 735]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 736]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 707]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 737]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 736]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 738]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 717]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 739]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 739]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 740]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 729]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 741]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 741]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 742]]}
+ {:process 5 :type :info :f :txn :value [[:append 0 730]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 731]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 743]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 744]]}
+ {:process 7 :type :ok :f :txn :value [[:append 7 742]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 745]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 733]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 746]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 746]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 747]]}
+ {:process 4 :type :info :f :txn :value [[:append 0 734]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 748]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 747]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 749]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 737]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 750]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 750]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 751]]}
+ {:process 3 :type :info :f :txn :value [[:append 2 738]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 752]]}
+ {:process 6 :type :ok :f :txn :value [[:append 0 751]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 753]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 740]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 754]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 754]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 755]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 743]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 756]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 756]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 757]]}
+ {:process 7 :type :info :f :txn :value [[:append 0 745]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 744]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 758]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 759]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 758]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:append 5 757]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 760]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 761]]}
+ {:process 7 :type :ok :f :txn :value [[:append 2 759]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 762]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 748]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 763]]}
+ {:process 5 :type :ok :f :txn :value [[:append 2 760]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 755]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 764]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 765]]}
+ {:process 7 :type :info :f :txn :value [[:append 3 762]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 766]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 764]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:append 0 765]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 767]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 768]]}
+ {:process 2 :type :info :f :txn :value [[:append 4 749]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:append 5 766]]}
  {:process 7 :type :invoke :f :txn :value [[:append 6 769]]}
- {:process 6 :type :info :f :txn :value [[:append 7 768]]}
- {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 770]]}
- {:process 7 :type :info :f :txn :value [[:append 6 769]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 771]]}
- {:process 6 :type :ok :f :txn :value [[:append 5 770]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 772]]}
- {:process 7 :type :ok :f :txn :value [[:append 7 771]]}
- {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 773]]}
- {:process 6 :type :info :f :txn :value [[:append 6 772]]}
- {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 774]]}
- {:process 7 :type :info :f :txn :value [[:append 1 773]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 775]]}
- {:process 6 :type :ok :f :txn :value [[:append 4 774]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 776]]}
- {:process 7 :type :ok :f :txn :value [[:append 2 775]]}
- {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 748]]}
- {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 777]]}
- {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 778]]}
- {:process 6 :type :info :f :txn :value [[:append 1 776]]}
- {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 750]]}
- {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 779]]}
- {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 780]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 780]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 781]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 781]]}
- {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 1 782]]}
- {:process 1 :type :fail :f :txn :value [[:append 1 782]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 783]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 783]]}
- {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 755]]}
- {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 6 784]]}
- {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 785]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 785]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 786]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 761]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 787]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 787]]}
- {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 778]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 788]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 789]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 789]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 790]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 779]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 791]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 777]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 792]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 791]]}
- {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 793]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 793]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 794]]}
- {:process 1 :type :fail :f :txn :value [[:append 6 784]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 795]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 794]]}
- {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 796]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 795]]}
- {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 7 797]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 796]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 798]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 792]]}
- {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 799]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 798]]}
- {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 786]]}
- {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 800]]}
- {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 801]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 801]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 802]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 788]]}
- {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 803]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 802]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 790]]}
- {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 804]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 805]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 805]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 806]]}
- {:process 1 :type :fail :f :txn :value [[:append 7 797]]}
- {:process 1 :type :invoke :f :txn :value [[:append 2 807]]}
- {:process 1 :type :fail :f :txn :value [[:append 2 807]]}
- {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 799]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 808]]}
- {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 4 809]]}
- {:process 1 :type :fail :f :txn :value [[:append 4 809]]}
- {:process 1 :type :invoke :f :txn :value [[:append 3 810]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 800]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 811]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 811]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 752]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 770]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 771]]}
+ {:process 5 :type :info :f :txn :value [[:append 1 767]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 770]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 772]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 753]]}
  {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 803]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 812]]}
- {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 813]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 813]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 814]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 804]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 815]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 815]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 806]]}
- {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 816]]}
- {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 817]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 817]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 818]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 808]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 819]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 818]]}
- {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 1 :type :fail :f :txn :value [[:append 3 810]]}
- {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 820]]}
- {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 1 :type :invoke :f :txn :value [[:append 5 821]]}
- {:process 1 :type :fail :f :txn :value [[:append 5 821]]}
- {:process 1 :type :invoke :f :txn :value [[:append 0 822]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 812]]}
- {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 823]]}
- {:process 1 :type :fail :f :txn :value [[:append 0 822]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 814]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 773]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 774]]}
+ {:process 2 :type :ok :f :txn :value [[:append 6 771]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 775]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 772]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 776]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 774]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 777]]}
+ {:process 3 :type :ok :f :txn :value [[:append 5 773]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 778]]}
+ {:process 2 :type :info :f :txn :value [[:append 1 775]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 761]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 779]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 780]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 777]]}
  {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 816]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 824]]}
- {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 2 825]]}
- {:process 6 :type :fail :f :txn :value [[:append 2 825]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 826]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 819]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 827]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 823]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 828]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 828]]}
- {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 820]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 829]]}
- {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 830]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 830]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 831]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 831]]}
- {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 832]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 832]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 833]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 833]]}
- {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 834]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 834]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 835]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 835]]}
- {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 836]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 836]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 837]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 837]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 781]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 763]]}
  {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 838]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 838]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 839]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 839]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 782]]}
+ {:process 1 :type :info :f :txn :value [[:append 1 779]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 783]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 781]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 784]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 782]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 785]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 769]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 786]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 768]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 787]]}
+ {:process 1 :type :ok :f :txn :value [[:append 3 783]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 788]]}
+ {:process 4 :type :ok :f :txn :value [[:append 2 785]]}
  {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 840]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 840]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 841]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 841]]}
- {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 842]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 842]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 843]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 843]]}
- {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 2 844]]}
- {:process 4 :type :fail :f :txn :value [[:append 2 844]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 845]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 845]]}
- {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 7 846]]}
- {:process 4 :type :fail :f :txn :value [[:append 7 846]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 847]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 847]]}
- {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 4 848]]}
- {:process 4 :type :fail :f :txn :value [[:append 4 848]]}
- {:process 4 :type :invoke :f :txn :value [[:append 3 849]]}
- {:process 4 :type :fail :f :txn :value [[:append 3 849]]}
- {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 1 850]]}
- {:process 4 :type :fail :f :txn :value [[:append 1 850]]}
- {:process 4 :type :invoke :f :txn :value [[:append 0 851]]}
- {:process 4 :type :fail :f :txn :value [[:append 0 851]]}
- {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 4 :type :invoke :f :txn :value [[:append 6 852]]}
- {:process 4 :type :fail :f :txn :value [[:append 6 852]]}
- {:process 4 :type :invoke :f :txn :value [[:append 5 853]]}
- {:process 4 :type :fail :f :txn :value [[:append 5 853]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 824]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 854]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 854]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 855]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 855]]}
- {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 856]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 856]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 857]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 857]]}
- {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 858]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 858]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 859]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 859]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 789]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 788]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :info :f :txn :value [[:append 0 786]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 790]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 791]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 778]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 792]]}
+ {:process 4 :type :ok :f :txn :value [[:append 0 789]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 793]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 790]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :info :f :txn :value [[:append 4 776]]}
  {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 860]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 860]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 861]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 861]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 794]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 795]]}
+ {:process 3 :type :ok :f :txn :value [[:append 2 792]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 796]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 780]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 797]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 794]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 798]]}
+ {:process 5 :type :info :f :txn :value [[:append 2 795]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 799]]}
+ {:process 2 :type :info :f :txn :value [[:append 2 797]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 800]]}
+ {:process 5 :type :info :f :txn :value [[:append 3 799]]}
  {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 827]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 862]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 863]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 863]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 864]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 826]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 801]]}
+ {:process 2 :type :info :f :txn :value [[:append 4 800]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 802]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 784]]}
  {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 5 865]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 864]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 803]]}
+ {:process 5 :type :ok :f :txn :value [[:append 1 801]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 804]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 802]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :info :f :txn :value [[:append 5 787]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 805]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 806]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 803]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 807]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 791]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 808]]}
+ {:process 2 :type :ok :f :txn :value [[:append 1 805]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 809]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 793]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 810]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 809]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 811]]}
+ {:process 1 :type :ok :f :txn :value [[:append 7 808]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 812]]}
+ {:process 4 :type :ok :f :txn :value [[:append 5 810]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 813]]}
+ {:process 2 :type :ok :f :txn :value [[:append 2 811]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 814]]}
+ {:process 1 :type :ok :f :txn :value [[:append 1 812]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 815]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 814]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 816]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 815]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 817]]}
+ {:process 2 :type :info :f :txn :value [[:append 7 816]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 818]]}
+ {:process 1 :type :ok :f :txn :value [[:append 6 817]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 819]]}
+ {:process 2 :type :ok :f :txn :value [[:append 6 818]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 820]]}
+ {:process 1 :type :info :f :txn :value [[:append 5 819]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 821]]}
+ {:process 2 :type :info :f :txn :value [[:append 0 820]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 822]]}
+ {:process 1 :type :ok :f :txn :value [[:append 7 821]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 823]]}
+ {:process 2 :type :ok :f :txn :value [[:append 3 822]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 824]]}
+ {:process 1 :type :info :f :txn :value [[:append 2 823]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 825]]}
+ {:process 2 :type :info :f :txn :value [[:append 5 824]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 826]]}
+ {:process 1 :type :ok :f :txn :value [[:append 4 825]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 827]]}
+ {:process 2 :type :ok :f :txn :value [[:append 4 826]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 828]]}
+ {:process 1 :type :info :f :txn :value [[:append 3 827]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 829]]}
+ {:process 2 :type :info :f :txn :value [[:append 6 828]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 830]]}
+ {:process 1 :type :ok :f :txn :value [[:append 5 829]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 831]]}
+ {:process 2 :type :ok :f :txn :value [[:append 1 830]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 832]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 796]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 833]]}
+ {:process 1 :type :info :f :txn :value [[:append 0 831]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 798]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 834]]}
+ {:process 2 :type :ok :f :txn :value [[:append 3 832]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 835]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 836]]}
+ {:process 3 :type :ok :f :txn :value [[:append 7 833]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 837]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 835]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 838]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 804]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 836]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 839]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 840]]}
+ {:process 2 :type :ok :f :txn :value [[:append 4 838]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 841]]}
+ {:process 7 :type :ok :f :txn :value [[:append 7 839]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 842]]}
+ {:process 2 :type :info :f :txn :value [[:append 7 841]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 843]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 842]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 844]]}
+ {:process 2 :type :ok :f :txn :value [[:append 1 843]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 845]]}
+ {:process 7 :type :ok :f :txn :value [[:append 2 844]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 846]]}
+ {:process 2 :type :info :f :txn :value [[:append 0 845]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 847]]}
+ {:process 7 :type :info :f :txn :value [[:append 4 846]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 848]]}
+ {:process 2 :type :ok :f :txn :value [[:append 2 847]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 849]]}
+ {:process 7 :type :ok :f :txn :value [[:append 5 848]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 850]]}
+ {:process 2 :type :info :f :txn :value [[:append 5 849]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 851]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 850]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 852]]}
+ {:process 2 :type :ok :f :txn :value [[:append 7 851]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 853]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 852]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 854]]}
+ {:process 2 :type :info :f :txn :value [[:append 6 853]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 855]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 854]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 856]]}
+ {:process 2 :type :ok :f :txn :value [[:append 0 855]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 857]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 856]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 858]]}
+ {:process 2 :type :info :f :txn :value [[:append 3 857]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 859]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 858]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 860]]}
+ {:process 2 :type :ok :f :txn :value [[:append 5 859]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 861]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 860]]}
  {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 829]]}
- {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 866]]}
- {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 867]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 867]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 868]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 868]]}
- {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 869]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 869]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 870]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 870]]}
- {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 871]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 871]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 872]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 872]]}
- {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 873]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 873]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 874]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 874]]}
- {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 875]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 875]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 876]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 876]]}
- {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 877]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 877]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 878]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 878]]}
- {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 879]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 879]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 880]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 880]]}
- {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 881]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 881]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 882]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 882]]}
- {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 883]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 883]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 884]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 884]]}
- {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 885]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 885]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 886]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 886]]}
- {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 887]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 887]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 888]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 888]]}
- {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 889]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 889]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 890]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 890]]}
- {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 891]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 891]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 892]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 892]]}
- {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 893]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 893]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 894]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 894]]}
- {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 895]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 895]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 896]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 896]]}
- {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 897]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 897]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 898]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 898]]}
- {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 899]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 899]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 900]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 900]]}
- {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 901]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 901]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 902]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 902]]}
- {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 903]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 903]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 904]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 904]]}
- {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 905]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 905]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 906]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 906]]}
- {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 907]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 907]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 908]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 908]]}
- {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 909]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 909]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 910]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 910]]}
- {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 911]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 911]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 912]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 912]]}
- {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 862]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 913]]}
- {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 914]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 914]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 915]]}
- {:process 6 :type :fail :f :txn :value [[:append 5 865]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 916]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 916]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 862]]}
+ {:process 2 :type :info :f :txn :value [[:append 4 861]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 807]]}
  {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 866]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 917]]}
- {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 4 918]]}
- {:process 6 :type :fail :f :txn :value [[:append 4 918]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 919]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 919]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 863]]}
+ {:process 0 :type :info :f :txn :value [[:append 3 806]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 864]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 813]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 865]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 866]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 864]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 865]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 867]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 868]]}
+ {:process 2 :type :info :f :txn :value [[:append 6 863]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 869]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 840]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 870]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 868]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 871]]}
+ {:process 1 :type :info :f :txn :value [[:append 2 834]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 872]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 837]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 867]]}
  {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 7 920]]}
- {:process 6 :type :fail :f :txn :value [[:append 7 920]]}
- {:process 6 :type :invoke :f :txn :value [[:append 0 921]]}
- {:process 6 :type :fail :f :txn :value [[:append 0 921]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 873]]}
+ {:process 2 :type :ok :f :txn :value [[:append 1 869]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 874]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 875]]}
+ {:process 0 :type :ok :f :txn :value [[:append 7 871]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:append 5 870]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 876]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 877]]}
+ {:process 3 :type :ok :f :txn :value [[:append 4 873]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 878]]}
+ {:process 6 :type :ok :f :txn :value [[:append 7 874]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 879]]}
+ {:process 2 :type :ok :f :txn :value [[:append 3 875]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 880]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 877]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 881]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 876]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 882]]}
+ {:process 2 :type :ok :f :txn :value [[:append 2 880]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :info :f :txn :value [[:append 0 862]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 883]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 884]]}
+ {:process 0 :type :ok :f :txn :value [[:append 4 882]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 885]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 883]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 886]]}
+ {:process 0 :type :info :f :txn :value [[:append 2 885]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 887]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 886]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 888]]}
+ {:process 0 :type :ok :f :txn :value [[:append 1 887]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 889]]}
+ {:process 7 :type :info :f :txn :value [[:append 4 888]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 890]]}
+ {:process 0 :type :info :f :txn :value [[:append 7 889]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 891]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 890]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 892]]}
+ {:process 0 :type :ok :f :txn :value [[:append 6 891]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 893]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 892]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 894]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 893]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 895]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 894]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 896]]}
+ {:process 0 :type :ok :f :txn :value [[:append 3 895]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 897]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 896]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 898]]}
+ {:process 0 :type :info :f :txn :value [[:append 1 897]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 899]]}
+ {:process 7 :type :ok :f :txn :value [[:append 4 898]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 900]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 899]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 901]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 900]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :info :f :txn :value [[:append 0 879]]}
  {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 6 922]]}
- {:process 6 :type :fail :f :txn :value [[:append 6 922]]}
- {:process 6 :type :invoke :f :txn :value [[:append 3 923]]}
- {:process 6 :type :fail :f :txn :value [[:append 3 923]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 902]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 881]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 903]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 904]]}
+ {:process 0 :type :info :f :txn :value [[:append 6 901]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 905]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 903]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 906]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 872]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:append 6 904]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 907]]}
+ {:process 4 :type :info :f :txn :value [[:append 2 866]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 908]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 909]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 908]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 910]]}
+ {:process 5 :type :info :f :txn :value [[:append 7 907]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898]]]}
+ {:process 3 :type :info :f :txn :value [[:append 3 878]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 884]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 911]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 912]]}
+ {:process 4 :type :info :f :txn :value [[:append 7 910]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 913]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 913]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 914]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 902]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 915]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 915]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 916]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 905]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :info :f :txn :value [[:append 3 906]]}
  {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 6 :type :invoke :f :txn :value [[:append 1 924]]}
- {:process 6 :type :fail :f :txn :value [[:append 1 924]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 913]]}
- {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 925]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 925]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 926]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 926]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 927]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 927]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 928]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 928]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 929]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 929]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 930]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 930]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 931]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 915]]}
- {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 931]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 932]]}
- {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 933]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 933]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 934]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 917]]}
- {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 935]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 934]]}
- {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 936]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 936]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 937]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 937]]}
- {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 938]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 938]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 939]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 939]]}
- {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 940]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 940]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 941]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 941]]}
- {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 942]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 942]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 943]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 943]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 917]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 918]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 909]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 919]]}
+ {:process 7 :type :ok :f :txn :value [[:append 2 916]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 920]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 917]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 921]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 920]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :info :f :txn :value [[:append 7 911]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :info :f :txn :value [[:append 1 912]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 922]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 923]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 924]]}
+ {:process 6 :type :info :f :txn :value [[:append 1 918]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 925]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 924]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 926]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 922]]}
  {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 944]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 944]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 945]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 945]]}
+ {:process 4 :type :info :f :txn :value [[:append 4 914]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 927]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 928]]}
+ {:process 2 :type :ok :f :txn :value [[:append 0 926]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927]]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 923]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 929]]}
+ {:process 4 :type :info :f :txn :value [[:append 3 927]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 930]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 929]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 921]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 931]]}
+ {:process 4 :type :info :f :txn :value [[:append 1 930]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 932]]}
+ {:process 0 :type :ok :f :txn :value [[:append 0 931]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 933]]}
+ {:process 4 :type :ok :f :txn :value [[:append 0 932]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910 933]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 934]]}
+ {:process 0 :type :info :f :txn :value [[:append 7 933]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 935]]}
+ {:process 4 :type :info :f :txn :value [[:append 6 934]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 936]]}
+ {:process 0 :type :ok :f :txn :value [[:append 5 935]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 937]]}
+ {:process 4 :type :ok :f :txn :value [[:append 5 936]]}
+ {:process 1 :type :info :f :txn :value [[:append 6 919]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 925]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 938]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910 933]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 939]]}
+ {:process 0 :type :info :f :txn :value [[:append 4 937]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 940]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 928]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 941]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 939]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 942]]}
+ {:process 1 :type :info :f :txn :value [[:append 0 938]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 943]]}
+ {:process 0 :type :ok :f :txn :value [[:append 2 940]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 944]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 942]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 945]]}
+ {:process 3 :type :info :f :txn :value [[:append 5 941]]}
  {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898 937]]]}
  {:process 3 :type :invoke :f :txn :value [[:append 3 946]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 946]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 947]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 947]]}
+ {:process 6 :type :info :f :txn :value [[:append 3 945]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 947]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 946]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 948]]}
+ {:process 6 :type :ok :f :txn :value [[:append 4 947]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 949]]}
+ {:process 3 :type :info :f :txn :value [[:append 2 948]]}
  {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 948]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 948]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 949]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 949]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 950]]}
+ {:process 6 :type :info :f :txn :value [[:append 2 949]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 951]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 950]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 952]]}
+ {:process 6 :type :ok :f :txn :value [[:append 7 951]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 953]]}
+ {:process 3 :type :info :f :txn :value [[:append 7 952]]}
  {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 5 950]]}
- {:process 3 :type :fail :f :txn :value [[:append 5 950]]}
- {:process 3 :type :invoke :f :txn :value [[:append 4 951]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 951]]}
- {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 2 952]]}
- {:process 3 :type :fail :f :txn :value [[:append 2 952]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 953]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 953]]}
- {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 7 954]]}
- {:process 3 :type :fail :f :txn :value [[:append 7 954]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 955]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 955]]}
- {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 954]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 953]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 955]]}
+ {:process 3 :type :ok :f :txn :value [[:append 5 954]]}
  {:process 3 :type :invoke :f :txn :value [[:append 4 956]]}
- {:process 3 :type :fail :f :txn :value [[:append 4 956]]}
- {:process 3 :type :invoke :f :txn :value [[:append 3 957]]}
- {:process 3 :type :fail :f :txn :value [[:append 3 957]]}
+ {:process 6 :type :ok :f :txn :value [[:append 6 955]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927 945 946]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 957]]}
+ {:process 3 :type :info :f :txn :value [[:append 4 956]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927 945 946]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 958]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 957]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 959]]}
+ {:process 3 :type :ok :f :txn :value [[:append 2 958]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 960]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 959]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 961]]}
+ {:process 3 :type :info :f :txn :value [[:append 1 960]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 962]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 961]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 963]]}
+ {:process 3 :type :ok :f :txn :value [[:append 7 962]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 964]]}
+ {:process 6 :type :ok :f :txn :value [[:append 0 963]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936 953 954]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 965]]}
+ {:process 3 :type :info :f :txn :value [[:append 6 964]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936 953 954]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 966]]}
+ {:process 6 :type :info :f :txn :value [[:append 6 965]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 967]]}
+ {:process 3 :type :ok :f :txn :value [[:append 4 966]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 968]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 967]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898 937 947 956 957 966]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 969]]}
+ {:process 3 :type :info :f :txn :value [[:append 3 968]]}
  {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 1 958]]}
- {:process 3 :type :fail :f :txn :value [[:append 1 958]]}
- {:process 3 :type :invoke :f :txn :value [[:append 0 959]]}
- {:process 3 :type :fail :f :txn :value [[:append 0 959]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 970]]}
+ {:process 6 :type :info :f :txn :value [[:append 1 969]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 971]]}
+ {:process 3 :type :ok :f :txn :value [[:append 1 970]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 972]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 971]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910 933 951 952 961 962]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 973]]}
+ {:process 3 :type :info :f :txn :value [[:append 0 972]]}
  {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 3 :type :invoke :f :txn :value [[:append 6 960]]}
- {:process 3 :type :fail :f :txn :value [[:append 6 960]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 932]]}
- {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 961]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 961]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 962]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 962]]}
- {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 963]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 963]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 964]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 964]]}
- {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 965]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 965]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 966]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 966]]}
- {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 967]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 967]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 968]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 968]]}
- {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 935]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 969]]}
- {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 970]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 970]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 971]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 971]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 972]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 972]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 973]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 973]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 974]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 974]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 975]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 975]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 976]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 976]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 977]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 977]]}
- {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 978]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 978]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 979]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 979]]}
- {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 980]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 980]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 981]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 981]]}
- {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 982]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 982]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 983]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 983]]}
- {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 984]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 984]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 985]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 985]]}
- {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 986]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 986]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 987]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 987]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 988]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 988]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 989]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 989]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 990]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 990]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 991]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 991]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 992]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 992]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 993]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 993]]}
- {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 994]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 994]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 995]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 995]]}
- {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 996]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 996]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 997]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 997]]}
- {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 998]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 998]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 999]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 999]]}
- {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 1000]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 1000]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 1001]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 1001]]}
- {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 1002]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 1002]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 1003]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 1003]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 1004]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 1004]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 1005]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 1005]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 1006]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 1006]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 1007]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 1007]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 1008]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 1008]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 1009]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 1009]]}
- {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 1010]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 1010]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 1011]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 1011]]}
- {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 1012]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 1012]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 1013]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 1013]]}
- {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 2 1014]]}
- {:process 5 :type :fail :f :txn :value [[:append 2 1014]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 1015]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 1015]]}
- {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 1 1016]]}
- {:process 5 :type :fail :f :txn :value [[:append 1 1016]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 1017]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 1017]]}
- {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 4 1018]]}
- {:process 5 :type :fail :f :txn :value [[:append 4 1018]]}
- {:process 5 :type :invoke :f :txn :value [[:append 5 1019]]}
- {:process 5 :type :fail :f :txn :value [[:append 5 1019]]}
- {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 3 1020]]}
- {:process 5 :type :fail :f :txn :value [[:append 3 1020]]}
- {:process 5 :type :invoke :f :txn :value [[:append 0 1021]]}
- {:process 5 :type :fail :f :txn :value [[:append 0 1021]]}
- {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 5 :type :invoke :f :txn :value [[:append 6 1022]]}
- {:process 5 :type :fail :f :txn :value [[:append 6 1022]]}
- {:process 5 :type :invoke :f :txn :value [[:append 7 1023]]}
- {:process 5 :type :fail :f :txn :value [[:append 7 1023]]}
- {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 969]]}
- {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 1024]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 1024]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 1025]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 1025]]}
- {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 1026]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 1026]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 1027]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 1027]]}
- {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 1028]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 1028]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 1029]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 1029]]}
- {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 1030]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 1030]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 1031]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 1031]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 1032]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 1032]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 1033]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 1033]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 1034]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 1034]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 1035]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 1035]]}
- {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 1036]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 1036]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 1037]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 1037]]}
- {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 1038]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 1038]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 1039]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 1039]]}
- {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 1040]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 1040]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 1041]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 1041]]}
- {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 1042]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 1042]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 1043]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 1043]]}
- {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 1044]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 1044]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 1045]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 1045]]}
- {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 1046]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 1046]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 1047]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 1047]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 1048]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 1048]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 1049]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 1049]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 1050]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 1050]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 1051]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 1051]]}
- {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 1052]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 1052]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 1053]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 1053]]}
- {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 1054]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 1054]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 1055]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 1055]]}
- {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 1056]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 1056]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 1057]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 1057]]}
- {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 1 1058]]}
- {:process 7 :type :fail :f :txn :value [[:append 1 1058]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 1059]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 1059]]}
- {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 4 1060]]}
- {:process 7 :type :fail :f :txn :value [[:append 4 1060]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 1061]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 1061]]}
- {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 7 1062]]}
- {:process 7 :type :fail :f :txn :value [[:append 7 1062]]}
- {:process 7 :type :invoke :f :txn :value [[:append 0 1063]]}
- {:process 7 :type :fail :f :txn :value [[:append 0 1063]]}
- {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 2 1064]]}
- {:process 7 :type :fail :f :txn :value [[:append 2 1064]]}
- {:process 7 :type :invoke :f :txn :value [[:append 3 1065]]}
- {:process 7 :type :fail :f :txn :value [[:append 3 1065]]}
- {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
- {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
- {:process 7 :type :invoke :f :txn :value [[:append 5 1066]]}
- {:process 7 :type :fail :f :txn :value [[:append 5 1066]]}
- {:process 7 :type :invoke :f :txn :value [[:append 6 1067]]}
- {:process 7 :type :fail :f :txn :value [[:append 6 1067]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910 933 951 952 961 962]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 974]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 943]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :info :f :txn :value [[:append 0 973]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 975]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958 971]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 976]]}
+ {:process 3 :type :ok :f :txn :value [[:append 6 974]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 977]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 944]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 975]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950 963 972 973]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 978]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934 955 964 965 974]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 979]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 979]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 980]]}
+ {:process 0 :type :info :f :txn :value [[:append 7 978]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 981]]}
+ {:process 6 :type :ok :f :txn :value [[:append 4 980]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930 959 960 969 970]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 982]]}
+ {:process 0 :type :info :f :txn :value [[:append 6 981]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936 953 954 975 977]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 983]]}
+ {:process 6 :type :info :f :txn :value [[:append 2 982]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 984]]}
+ {:process 0 :type :ok :f :txn :value [[:append 4 983]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 985]]}
+ {:process 6 :type :ok :f :txn :value [[:append 7 984]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950 963 972 973]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 986]]}
+ {:process 0 :type :info :f :txn :value [[:append 3 985]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958 971 982]]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 987]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 986]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 988]]}
+ {:process 0 :type :ok :f :txn :value [[:append 1 987]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 976]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 989]]}
+ {:process 6 :type :ok :f :txn :value [[:append 6 988]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927 945 946 967 968 985]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 990]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 989]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :info :f :txn :value [[:append 5 977]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927 945 946 967 968 985]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 991]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898 937 947 956 957 966 980 983 989 990]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 992]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 990]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 993]]}
+ {:process 1 :type :ok :f :txn :value [[:append 6 991]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 994]]}
+ {:process 3 :type :info :f :txn :value [[:append 3 992]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 995]]}
+ {:process 1 :type :ok :f :txn :value [[:append 5 994]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950 963 972 973]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 996]]}
+ {:process 3 :type :info :f :txn :value [[:append 2 995]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930 959 960 969 970 987]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 997]]}
+ {:process 1 :type :info :f :txn :value [[:append 7 996]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 998]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 997]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 999]]}
+ {:process 1 :type :ok :f :txn :value [[:append 2 998]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930 959 960 969 970 987]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 1000]]}
+ {:process 3 :type :info :f :txn :value [[:append 7 999]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934 955 964 965 974 981 988 991]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 1001]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 1000]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 1002]]}
+ {:process 3 :type :ok :f :txn :value [[:append 5 1001]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 1003]]}
+ {:process 1 :type :ok :f :txn :value [[:append 3 1002]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934 955 964 965 974 981 988 991]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 1004]]}
+ {:process 3 :type :info :f :txn :value [[:append 4 1003]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927 945 946 967 968 985 992 1002]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 1005]]}
+ {:process 1 :type :info :f :txn :value [[:append 5 1004]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 1006]]}
+ {:process 3 :type :ok :f :txn :value [[:append 2 1005]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 1007]]}
+ {:process 1 :type :ok :f :txn :value [[:append 0 1006]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910 933 951 952 961 962 984 996 999]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 1008]]}
+ {:process 3 :type :info :f :txn :value [[:append 1 1007]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950 963 972 973 997 1006]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 1009]]}
+ {:process 1 :type :info :f :txn :value [[:append 2 1008]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 1010]]}
+ {:process 3 :type :ok :f :txn :value [[:append 7 1009]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 1011]]}
+ {:process 1 :type :ok :f :txn :value [[:append 1 1010]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898 937 947 956 957 966 980 983 989 990 1000 1003]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 1012]]}
+ {:process 3 :type :info :f :txn :value [[:append 6 1011]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936 953 954 975 977 986 994 1001 1004]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 1013]]}
+ {:process 1 :type :info :f :txn :value [[:append 3 1012]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 1014]]}
+ {:process 3 :type :ok :f :txn :value [[:append 4 1013]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 1015]]}
+ {:process 1 :type :ok :f :txn :value [[:append 6 1014]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936 953 954 975 977 986 994 1001 1004]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 1016]]}
+ {:process 3 :type :info :f :txn :value [[:append 3 1015]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958 971 982 995 998 1005 1008]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 1017]]}
+ {:process 1 :type :info :f :txn :value [[:append 0 1016]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 1018]]}
+ {:process 3 :type :ok :f :txn :value [[:append 1 1017]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 1019]]}
+ {:process 1 :type :ok :f :txn :value [[:append 7 1018]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958 971 982 995 998 1005 1008]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 1020]]}
+ {:process 3 :type :info :f :txn :value [[:append 0 1019]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910 933 951 952 961 962 984 996 999 1009 1018]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 1021]]}
+ {:process 1 :type :info :f :txn :value [[:append 1 1020]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 1022]]}
+ {:process 3 :type :ok :f :txn :value [[:append 6 1021]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 1023]]}
+ {:process 1 :type :ok :f :txn :value [[:append 4 1022]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927 945 946 967 968 985 992 1002 1012 1015]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 1024]]}
+ {:process 3 :type :info :f :txn :value [[:append 5 1023]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898 937 947 956 957 966 980 983 989 990 1000 1003 1013 1022]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 1025]]}
+ {:process 1 :type :info :f :txn :value [[:append 6 1024]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 1026]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 1025]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 1027]]}
+ {:process 1 :type :ok :f :txn :value [[:append 5 1026]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950 963 972 973 997 1006 1016 1019]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 1028]]}
+ {:process 3 :type :info :f :txn :value [[:append 2 1027]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930 959 960 969 970 987 1007 1010 1017 1020]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 1029]]}
+ {:process 1 :type :info :f :txn :value [[:append 7 1028]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 1030]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 1029]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 1031]]}
+ {:process 1 :type :ok :f :txn :value [[:append 2 1030]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930 959 960 969 970 987 1007 1010 1017 1020]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 1032]]}
+ {:process 3 :type :info :f :txn :value [[:append 7 1031]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 993]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934 955 964 965 974 981 988 991 1011 1014 1021 1024]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 1033]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958 971 982 995 998 1005 1008 1027 1030]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 1034]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 1032]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 1035]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 1035]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934 955 964 965 974 981 988 991 1011 1014 1021 1024]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 1036]]}
+ {:process 1 :type :ok :f :txn :value [[:append 5 1036]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 1037]]}
+ {:process 1 :type :ok :f :txn :value [[:append 0 1037]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910 933 951 952 961 962 984 996 999 1009 1018 1028 1031]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 1038]]}
+ {:process 1 :type :ok :f :txn :value [[:append 2 1038]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 1039]]}
+ {:process 1 :type :ok :f :txn :value [[:append 1 1039]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898 937 947 956 957 966 980 983 989 990 1000 1003 1013 1022 1032]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 1040]]}
+ {:process 1 :type :ok :f :txn :value [[:append 3 1040]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 1041]]}
+ {:process 1 :type :ok :f :txn :value [[:append 6 1041]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936 953 954 975 977 986 994 1001 1004 1023 1026 1036]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 1042]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 1034]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 1043]]}
+ {:process 3 :type :info :f :txn :value [[:append 5 1033]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 1044]]}
+ {:process 1 :type :ok :f :txn :value [[:append 0 1042]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 1045]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 1044]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927 945 946 967 968 985 992 1002 1012 1015 1025 1040]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 1046]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 1045]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:append 2 1046]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 1047]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958 971 982 995 998 1005 1008 1027 1030 1038 1046]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 1048]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 1048]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 1049]]}
+ {:process 3 :type :info :f :txn :value [[:append 1 1047]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950 963 972 973 997 1006 1016 1019 1029 1037 1042 1043]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 1050]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 1049]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [4 10 41 44 54 66 69 75 91 96 102 162 166 179 187 205 207 239 242 251 264 269 283 304 309 320 331 332 349 361 387 394 397 404 419 430 435 458 469 470 510 513 519 528 538 546 564 566 579 603 616 619 627 632 651 681 699 704 715 716 727 736 762 782 783 794 799 806 822 827 832 856 857 875 878 886 895 927 945 946 967 968 985 992 1002 1012 1015 1025 1040]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 1051]]}
+ {:process 3 :type :info :f :txn :value [[:append 7 1050]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 1052]]}
+ {:process 1 :type :ok :f :txn :value [[:append 6 1051]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 1053]]}
+ {:process 3 :type :ok :f :txn :value [[:append 6 1052]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936 953 954 975 977 986 994 1001 1004 1023 1026 1036 1053]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 1054]]}
+ {:process 1 :type :info :f :txn :value [[:append 5 1053]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [6 13 35 42 45 61 81 83 94 95 122 128 144 150 167 181 186 194 212 214 230 237 260 296 313 315 318 327 336 341 356 357 384 391 401 406 416 423 431 434 441 460 464 474 514 518 544 556 581 586 593 598 615 625 636 639 653 666 692 700 703 711 728 730 751 764 765 789 820 831 845 852 855 862 879 899 926 931 932 950 963 972 973 997 1006 1016 1019 1029 1037 1042 1043]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 1055]]}
+ {:process 3 :type :info :f :txn :value [[:append 4 1054]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 1056]]}
+ {:process 1 :type :ok :f :txn :value [[:append 7 1055]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 1057]]}
+ {:process 3 :type :ok :f :txn :value [[:append 3 1056]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [43 53 56 79 80 84 104 120 121 131 139 140 178 190 192 225 226 240 258 259 268 293 297 321 325 335 350 373 380 392 399 409 414 424 432 473 516 534 540 549 563 573 582 590 591 600 601 606 617 631 634 664 679 690 701 702 712 726 759 760 785 792 795 811 823 844 847 854 866 880 885 896 916 940 948 949 958 971 982 995 998 1005 1008 1027 1030 1038 1046 1057]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 1058]]}
+ {:process 1 :type :info :f :txn :value [[:append 2 1057]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [5 26 28 29 52 55 93 106 108 130 134 141 142 147 169 176 191 197 209 229 233 244 261 271 291 295 322 334 359 360 386 389 396 411 418 421 425 446 468 478 483 502 512 515 550 555 562 580 595 596 624 637 649 650 663 668 691 713 714 719 724 767 779 790 801 805 812 830 842 843 869 883 887 894 897 930 959 960 969 970 987 1007 1010 1017 1020 1039 1058]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 1059]]}
+ {:process 3 :type :info :f :txn :value [[:append 1 1058]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 1060]]}
+ {:process 1 :type :ok :f :txn :value [[:append 4 1059]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 1061]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 1060]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [1 25 38 47 57 60 63 90 125 132 143 145 151 152 184 185 213 231 236 263 270 292 298 303 316 326 337 358 367 388 403 410 413 420 429 437 444 445 475 476 485 501 507 526 545 557 558 578 585 594 597 605 611 635 638 652 659 665 698 705 722 742 772 802 808 816 821 833 839 841 850 851 871 874 889 892 907 910 933 951 952 961 962 984 996 999 1009 1018 1028 1031 1050 1055]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 1062]]}
+ {:process 1 :type :info :f :txn :value [[:append 3 1061]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [2 7 37 40 50 59 77 85 92 97 103 117 126 149 183 198 235 245 246 265 275 289 317 328 338 354 355 364 365 383 393 398 408 415 433 472 479 482 489 496 506 509 521 527 529 554 572 575 583 610 622 623 626 645 657 667 682 695 709 720 721 732 771 817 818 828 836 853 860 863 890 891 901 904 929 934 955 964 965 974 981 988 991 1011 1014 1021 1024 1041 1051 1052 1062]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 1063]]}
+ {:process 3 :type :info :f :txn :value [[:append 6 1062]]}
+ {:process 6 :type :info :f :txn :value [[:append 0 1043]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [17 36 39 46 49 88 98 99 110 116 123 127 135 177 182 199 201 216 224 227 241 252 262 300 301 314 329 339 340 366 395 402 405 412 428 447 453 454 457 467 477 484 520 522 524 561 567 577 602 618 621 629 640 648 696 697 706 708 725 747 766 803 810 814 819 824 829 848 849 858 859 870 900 935 936 953 954 975 977 986 994 1001 1004 1023 1026 1036 1053 1063]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 1064]]}
+ {:process 1 :type :info :f :txn :value [[:append 5 1063]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 1065]]}
+ {:process 6 :type :ok :f :txn :value [[:append 6 1064]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 1066]]}
+ {:process 1 :type :ok :f :txn :value [[:append 0 1065]]}
+ {:process 6 :type :info :f :txn :value [[:append 3 1066]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [3 19 22 48 51 58 62 89 100 129 138 160 175 180 189 206 223 238 243 250 266 267 287 288 299 302 330 333 362 363 385 390 400 407 417 422 450 452 471 480 481 495 508 511 559 571 574 584 592 599 608 620 633 646 647 677 678 694 710 718 723 777 800 815 825 826 838 846 861 873 882 888 893 898 937 947 956 957 966 980 983 989 990 1000 1003 1013 1022 1032 1049 1054 1059]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 1067]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 1067]]}
 ]

--- a/deploy/fly-accord-elle/elle-fly-history.edn
+++ b/deploy/fly-accord-elle/elle-fly-history.edn
@@ -1,0 +1,3202 @@
+[
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 1]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 1]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 2]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 2]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 3]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 3]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 4]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 4]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 5]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 5]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 6]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 6]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 7]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 7]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 8]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 8]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 9]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 9]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 10]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 10]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 11]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 11]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 12]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 12]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 13]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 13]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 14]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 14]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 15]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 15]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 16]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 16]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 17]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 17]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 18]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 18]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 19]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 19]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 20]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 20]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 21]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 21]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 22]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 22]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 23]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 23]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 24]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 24]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 25]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 25]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 26]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 26]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 27]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 27]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 28]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 28]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 29]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 29]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 30]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 30]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 31]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 31]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 32]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 32]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 33]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 33]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 34]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 34]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 35]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 35]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 36]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 36]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 37]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 37]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 38]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 38]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 39]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 39]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 40]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 40]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 41]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 41]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 42]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 42]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 43]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 43]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 44]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 44]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 45]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 45]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 46]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 46]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 47]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 47]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 48]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 48]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 49]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 49]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 50]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 50]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 51]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 51]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 52]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 52]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 53]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 53]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 54]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 54]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 55]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 55]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 56]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 56]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 57]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 57]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 58]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 58]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 59]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 59]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 60]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 60]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 61]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 61]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 62]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 62]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 63]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 63]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 64]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 64]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 65]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 65]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 66]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 66]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 67]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 68]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 68]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 69]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 69]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 70]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 70]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 71]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 71]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 72]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 72]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 73]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 73]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 74]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 74]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 75]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 75]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 76]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 76]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 77]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 77]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 78]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 78]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 79]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 79]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 80]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 80]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 81]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 81]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 82]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 82]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 83]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 83]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 84]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 84]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 85]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 85]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 86]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 86]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 87]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 87]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 88]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 88]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 89]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 89]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 90]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 90]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 91]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 91]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 92]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 92]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 93]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 93]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 94]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 94]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 95]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 95]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 96]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 96]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 97]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 97]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 98]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 98]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 99]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 99]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 100]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 100]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 101]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 101]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 102]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 102]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 103]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 103]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 104]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 104]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 105]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 105]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 106]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 106]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 107]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 107]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 108]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 108]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 109]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 109]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 110]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 110]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 111]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 111]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 112]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 112]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 113]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 113]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 114]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 114]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 115]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 115]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 116]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 116]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 117]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 117]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 118]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 118]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 119]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 119]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 120]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 120]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 121]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 121]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 122]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 122]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 123]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 123]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 0 124]]}
+ {:process 0 :type :fail :f :txn :value [[:append 0 124]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 125]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 125]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 5 126]]}
+ {:process 0 :type :fail :f :txn :value [[:append 5 126]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 127]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 127]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 2 128]]}
+ {:process 0 :type :fail :f :txn :value [[:append 2 128]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 129]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 129]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 7 130]]}
+ {:process 0 :type :fail :f :txn :value [[:append 7 130]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 6 131]]}
+ {:process 0 :type :fail :f :txn :value [[:append 6 131]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 4 132]]}
+ {:process 0 :type :fail :f :txn :value [[:append 4 132]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 3 133]]}
+ {:process 0 :type :fail :f :txn :value [[:append 3 133]]}
+ {:process 0 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 0 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 0 :type :invoke :f :txn :value [[:append 1 134]]}
+ {:process 0 :type :fail :f :txn :value [[:append 1 134]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 135]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 135]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 136]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 136]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 137]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 137]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 67]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 138]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 139]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 139]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 140]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 140]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 141]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 141]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 142]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 142]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 143]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 143]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 144]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 144]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 145]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 145]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 146]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 146]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 147]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 147]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 148]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 148]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 149]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 149]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 150]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 150]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 151]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 151]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 152]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 152]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 153]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 153]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 154]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 154]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 155]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 155]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 156]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 156]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 157]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 157]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 158]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 158]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 159]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 159]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 160]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 160]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 161]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 161]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 162]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 162]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 163]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 163]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 164]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 164]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 165]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 165]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 166]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 166]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 167]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 167]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 168]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 168]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 169]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 169]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 170]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 170]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 171]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 171]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 172]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 172]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 173]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 173]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 174]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 174]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 175]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 175]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 176]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 176]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 177]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 177]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 178]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 178]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 179]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 179]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 180]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 180]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 181]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 181]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 182]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 182]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 183]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 183]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 184]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 184]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 185]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 185]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 186]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 186]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 187]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 187]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 188]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 188]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 189]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 189]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 190]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 190]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 191]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 191]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 192]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 192]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 193]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 193]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 194]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 194]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 195]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 195]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 196]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 196]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 197]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 197]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 198]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 198]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 199]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 199]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 200]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 200]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 201]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 201]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 202]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 202]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 203]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 204]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 204]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 205]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 138]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 206]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 205]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 207]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 207]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 208]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 208]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 209]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 209]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 210]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 210]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 211]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 211]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 212]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 212]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 213]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 213]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 214]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 214]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 215]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 215]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 216]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 216]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 217]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 217]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 218]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 218]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 219]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 219]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 220]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 220]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 221]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 221]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 222]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 222]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 223]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 223]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 224]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 224]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 225]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 225]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 226]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 226]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 227]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 227]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 228]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 228]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 229]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 229]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 230]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 230]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 231]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 231]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 232]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 232]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 233]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 233]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 234]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 234]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 235]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 235]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 236]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 236]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 237]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 237]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 238]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 238]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 239]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 239]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 240]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 240]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 241]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 241]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 242]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 242]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 243]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 243]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 244]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 244]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 245]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 245]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 246]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 246]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 247]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 247]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 248]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 248]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 249]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 249]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 250]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 250]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 251]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 252]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 252]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 253]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 206]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 254]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 254]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 203]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 255]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 256]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 256]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 257]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 258]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 258]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 259]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 251]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 260]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 259]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 261]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 261]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 253]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 262]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 263]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 263]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 264]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 255]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 265]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 264]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 257]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 266]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 267]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 []]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 268]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 267]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 269]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 262]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 270]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 260]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:append 2 266]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 271]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 272]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 270]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 273]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 274]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 274]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 275]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 265]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 276]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 276]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 268]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 277]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 278]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 278]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 279]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 271]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 279]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 272]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 280]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 269]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 281]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 282]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 283]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 280]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 275]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 273]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 284]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 285]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 []]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 286]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 285]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 287]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 284]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 288]]}
+ {:process 4 :type :info :f :txn :value [[:append 5 287]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 289]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 288]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 290]]}
+ {:process 4 :type :ok :f :txn :value [[:append 3 289]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 291]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 290]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 []]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 292]]}
+ {:process 4 :type :info :f :txn :value [[:append 2 291]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 293]]}
+ {:process 7 :type :info :f :txn :value [[:append 5 292]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 294]]}
+ {:process 4 :type :ok :f :txn :value [[:append 0 293]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 295]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 283]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 296]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 277]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 281]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 297]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 282]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 298]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 286]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 299]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 300]]}
+ {:process 7 :type :ok :f :txn :value [[:append 6 294]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 296]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 []]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 301]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 298]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [287 292]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 302]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 []]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 303]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 302]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 304]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 301]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 305]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 303]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 306]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 299]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [294 300]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 307]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 305]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 308]]}
+ {:process 3 :type :ok :f :txn :value [[:append 7 306]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [294 300]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 309]]}
+ {:process 5 :type :ok :f :txn :value [[:append 7 307]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 310]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 308]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 311]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 297]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 295]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 304]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :info :f :txn :value [[:append 6 300]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 312]]}
+ {:process 2 :type :ok :f :txn :value [[:r 1 [305]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 313]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [294 300]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 314]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 315]]}
+ {:process 3 :type :ok :f :txn :value [[:append 5 309]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 316]]}
+ {:process 7 :type :ok :f :txn :value [[:append 4 311]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 317]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 312]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 318]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 317]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 319]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 318]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 320]]}
+ {:process 7 :type :ok :f :txn :value [[:append 7 319]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 321]]}
+ {:process 6 :type :info :f :txn :value [[:append 2 320]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 322]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 321]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 323]]}
+ {:process 6 :type :ok :f :txn :value [[:append 0 322]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 324]]}
+ {:process 7 :type :ok :f :txn :value [[:append 2 323]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 325]]}
+ {:process 6 :type :info :f :txn :value [[:append 5 324]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 326]]}
+ {:process 7 :type :info :f :txn :value [[:append 4 325]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 327]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 326]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 328]]}
+ {:process 7 :type :ok :f :txn :value [[:append 5 327]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 329]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 328]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 330]]}
+ {:process 7 :type :info :f :txn :value [[:append 7 329]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 331]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 330]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 332]]}
+ {:process 7 :type :ok :f :txn :value [[:append 0 331]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 333]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 332]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 334]]}
+ {:process 7 :type :info :f :txn :value [[:append 2 333]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 335]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 334]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 336]]}
+ {:process 7 :type :ok :f :txn :value [[:append 3 335]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 310]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 316]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 337]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 338]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 339]]}
+ {:process 6 :type :info :f :txn :value [[:append 6 336]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 340]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 339]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 341]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 341]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 314]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 342]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 343]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 313]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 344]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 343]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 345]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 315]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 346]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 346]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 347]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 347]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 348]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 348]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 349]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 349]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 350]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 350]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 351]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 351]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 352]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 352]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 353]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 353]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 354]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 354]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 355]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 355]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 356]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 356]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 357]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 357]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 358]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 358]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 359]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 359]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 360]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 360]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 361]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 361]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 362]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 362]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 363]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 363]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 364]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 364]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 365]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 365]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 366]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 366]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 367]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 367]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 368]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 368]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 369]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 369]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 370]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 370]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 371]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 371]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 372]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 372]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 373]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 373]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 374]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 374]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 375]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 375]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 376]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 376]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 338]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 377]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 340]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 378]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 379]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 337]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 380]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 379]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 381]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 344]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 342]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 5 382]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 383]]}
+ {:process 2 :type :fail :f :txn :value [[:append 5 382]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 384]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 345]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 385]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 384]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 6 386]]}
+ {:process 2 :type :fail :f :txn :value [[:append 6 386]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 387]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 387]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 3 388]]}
+ {:process 2 :type :fail :f :txn :value [[:append 3 388]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 2 389]]}
+ {:process 2 :type :fail :f :txn :value [[:append 2 389]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 4 390]]}
+ {:process 2 :type :fail :f :txn :value [[:append 4 390]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 7 391]]}
+ {:process 2 :type :fail :f :txn :value [[:append 7 391]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 1 392]]}
+ {:process 2 :type :fail :f :txn :value [[:append 1 392]]}
+ {:process 2 :type :invoke :f :txn :value [[:append 0 393]]}
+ {:process 2 :type :fail :f :txn :value [[:append 0 393]]}
+ {:process 2 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 2 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 377]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 378]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 394]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 395]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 395]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 396]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 380]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 397]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 396]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 381]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 398]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 399]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 383]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 400]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 399]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 401]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 398]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 402]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 400]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 385]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 403]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 404]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 404]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 405]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 405]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 406]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 406]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 407]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 407]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 408]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 408]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 409]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 409]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 410]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 410]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 411]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 411]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 412]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 412]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 413]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 413]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 414]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 414]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 415]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 415]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 416]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 416]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 417]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 417]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 418]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 418]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 419]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 419]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 420]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 420]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 421]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 421]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 422]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 422]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 423]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 423]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 424]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 424]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 425]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 425]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 426]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 426]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 427]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 427]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 428]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 428]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 429]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 429]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 430]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 430]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 431]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 431]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 432]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 432]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 433]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 433]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 434]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 434]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 435]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 435]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 436]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 436]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 437]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 437]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 438]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 438]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 439]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 439]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 440]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 440]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 441]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 441]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 442]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 442]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 443]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 443]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 444]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 444]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 445]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 445]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 446]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 446]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 447]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 447]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 394]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 448]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 449]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 449]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 450]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 397]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 451]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 451]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 401]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 452]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 453]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 453]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 454]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 403]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 402]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 455]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 456]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 454]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 457]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 455]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 458]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 456]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 459]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 448]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 450]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 460]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 461]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 461]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 462]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 458]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 452]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 463]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 464]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 462]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 463]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 465]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 466]]}
+ {:process 3 :type :ok :f :txn :value [[:append 6 464]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 467]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 465]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 468]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 459]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 469]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 468]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :info :f :txn :value [[:append 4 457]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 470]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 471]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 471]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 472]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 460]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 473]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 473]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 467]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 466]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 474]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 475]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 476]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 475]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 477]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 477]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 469]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 478]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 479]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 479]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 480]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 470]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 481]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 480]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 472]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 482]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 483]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 483]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 484]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 476]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 485]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 474]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 486]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 485]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 487]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 484]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 488]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 486]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 489]]}
+ {:process 3 :type :ok :f :txn :value [[:append 0 487]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 490]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 489]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 491]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 478]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:append 7 490]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 492]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 493]]}
+ {:process 7 :type :ok :f :txn :value [[:append 4 491]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 494]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 481]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 495]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 482]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 496]]}
+ {:process 4 :type :info :f :txn :value [[:append 6 488]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 497]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 497]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 498]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 493]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 499]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 499]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 496]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 500]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 501]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 501]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 502]]}
+ {:process 6 :type :info :f :txn :value [[:append 3 492]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 503]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 495]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 503]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 504]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 494]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 505]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 506]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 504]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 507]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 507]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 508]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 508]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 509]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 509]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 510]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 510]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 511]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 511]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 512]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 512]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 513]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 513]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 514]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 514]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 515]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 515]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 516]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 516]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 517]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 517]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 518]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 518]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 519]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 519]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 520]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 520]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 521]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 521]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 522]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 522]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 523]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 500]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 524]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 498]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 525]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 524]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 502]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 526]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 527]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 527]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 528]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 506]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 529]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 505]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 530]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 530]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 531]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 531]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 532]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 532]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 533]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 533]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 534]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 534]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 535]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 535]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 536]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 536]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 537]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 537]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 538]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 538]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 539]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 539]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 540]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 540]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 541]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 541]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 542]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 542]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 543]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 543]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 544]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 544]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 545]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 545]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 546]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 546]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 547]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 547]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 548]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 548]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 549]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 549]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 550]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 550]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 551]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 551]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 552]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 523]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 552]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 553]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 554]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 554]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 555]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 525]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 556]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 555]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 526]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 557]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 558]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 558]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 559]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 529]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 528]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 560]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 561]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 559]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 562]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 562]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 563]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 563]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 564]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 564]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 565]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 565]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 566]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 566]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 567]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 567]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 568]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 568]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 569]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 569]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 570]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 570]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 571]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 571]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 572]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 572]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 573]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 573]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 574]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 574]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 575]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 575]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 576]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 576]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 577]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 577]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 578]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 578]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 579]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 579]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 580]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 580]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 581]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 581]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 556]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 582]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 583]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 583]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 584]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 553]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 585]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 585]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 557]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 586]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 587]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 587]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 588]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 560]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 589]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 589]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 561]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 590]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 591]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 591]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 592]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 592]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 593]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 593]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 594]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 594]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 595]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 595]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 596]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 596]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 597]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 597]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 598]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 598]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 599]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 599]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 600]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 600]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 601]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 601]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 602]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 602]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 603]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 603]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 604]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 604]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 605]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 605]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 606]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 606]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 607]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 607]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 608]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 608]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 609]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 609]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 610]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 610]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 611]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 611]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 612]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 582]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 584]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 613]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 614]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 612]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 615]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 614]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 616]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 613]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 617]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 616]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 618]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 617]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 619]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 618]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 620]]}
+ {:process 4 :type :ok :f :txn :value [[:append 2 619]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 621]]}
+ {:process 6 :type :ok :f :txn :value [[:append 1 620]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 622]]}
+ {:process 4 :type :info :f :txn :value [[:append 1 621]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 623]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 622]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 624]]}
+ {:process 4 :type :ok :f :txn :value [[:append 7 623]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 625]]}
+ {:process 6 :type :ok :f :txn :value [[:append 0 624]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 626]]}
+ {:process 4 :type :info :f :txn :value [[:append 6 625]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 627]]}
+ {:process 6 :type :info :f :txn :value [[:append 6 626]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 628]]}
+ {:process 4 :type :ok :f :txn :value [[:append 4 627]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 629]]}
+ {:process 6 :type :ok :f :txn :value [[:append 3 628]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 630]]}
+ {:process 4 :type :info :f :txn :value [[:append 3 629]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 631]]}
+ {:process 6 :type :info :f :txn :value [[:append 1 630]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 632]]}
+ {:process 4 :type :ok :f :txn :value [[:append 1 631]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 633]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 632]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 590]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 588]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 586]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 634]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 615]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 635]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 636]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 637]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 638]]}
+ {:process 4 :type :info :f :txn :value [[:append 0 633]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 635]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 639]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 640]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 639]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 641]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 636]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 642]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 642]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 643]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 643]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 644]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 644]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 645]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 645]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 646]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 634]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 638]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 647]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 648]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 646]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 637]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 649]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 650]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 648]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 651]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 650]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 652]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 640]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 653]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 649]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 654]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 652]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 641]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 655]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 656]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 656]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 657]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 657]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 658]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 658]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 659]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 659]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 660]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 660]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 661]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 661]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 662]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 662]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 663]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 663]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 651]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 664]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 647]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 665]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 666]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 665]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 667]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 653]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 654]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 668]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 669]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 667]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 655]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 670]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 671]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 671]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 672]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 672]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 673]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 673]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 674]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 674]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 675]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 675]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 676]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 676]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 677]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 677]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 678]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 678]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 679]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 679]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 680]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 680]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 681]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 681]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 682]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 682]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 683]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 683]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 684]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 664]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 685]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 684]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 666]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 686]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 687]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 687]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 688]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 668]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 689]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 688]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 669]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 690]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 691]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 691]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 692]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 670]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 693]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 692]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 694]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 694]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 695]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 695]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 696]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 696]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 697]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 697]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 698]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 698]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 699]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 699]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 700]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 700]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 701]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 701]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 702]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 702]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 703]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 703]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 704]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 704]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 705]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 705]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 706]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 706]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 707]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 707]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 708]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 708]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 709]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 709]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 710]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 710]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 711]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 711]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 686]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 712]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 685]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 713]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 714]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 712]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 715]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 689]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 716]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 690]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 717]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 716]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 718]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 715]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 693]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 719]]}
+ {:process 1 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 720]]}
+ {:process 7 :type :ok :f :txn :value [[:append 7 717]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 721]]}
+ {:process 5 :type :ok :f :txn :value [[:append 6 718]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 722]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 713]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 723]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 714]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 724]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 724]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 720]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 725]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 726]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 726]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 727]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 721]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 722]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 728]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 729]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 727]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 730]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 729]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 731]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 728]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 732]]}
+ {:process 4 :type :ok :f :txn :value [[:append 6 730]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 733]]}
+ {:process 6 :type :info :f :txn :value [[:append 0 719]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 734]]}
+ {:process 5 :type :info :f :txn :value [[:append 2 731]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 723]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 735]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 736]]}
+ {:process 6 :type :ok :f :txn :value [[:append 6 734]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 737]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 735]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 738]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 725]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 739]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 738]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 740]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 740]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 741]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 737]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 742]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 741]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 743]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 742]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 744]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 732]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 745]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 744]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 733]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 746]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 747]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 747]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 748]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 736]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 749]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 749]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 739]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 750]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 751]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 751]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 752]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 752]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 753]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 753]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 754]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 754]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 743]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 755]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 756]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 756]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 757]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 745]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 758]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 746]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 759]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 758]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 757]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 760]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 761]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 759]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 762]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 760]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 763]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 762]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 764]]}
+ {:process 7 :type :ok :f :txn :value [[:append 1 763]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 765]]}
+ {:process 6 :type :info :f :txn :value [[:append 4 764]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 766]]}
+ {:process 7 :type :info :f :txn :value [[:append 3 765]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 767]]}
+ {:process 6 :type :ok :f :txn :value [[:append 2 766]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 768]]}
+ {:process 7 :type :ok :f :txn :value [[:append 4 767]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 769]]}
+ {:process 6 :type :info :f :txn :value [[:append 7 768]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 770]]}
+ {:process 7 :type :info :f :txn :value [[:append 6 769]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 771]]}
+ {:process 6 :type :ok :f :txn :value [[:append 5 770]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 772]]}
+ {:process 7 :type :ok :f :txn :value [[:append 7 771]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 773]]}
+ {:process 6 :type :info :f :txn :value [[:append 6 772]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 774]]}
+ {:process 7 :type :info :f :txn :value [[:append 1 773]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 775]]}
+ {:process 6 :type :ok :f :txn :value [[:append 4 774]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 776]]}
+ {:process 7 :type :ok :f :txn :value [[:append 2 775]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 748]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 777]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 778]]}
+ {:process 6 :type :info :f :txn :value [[:append 1 776]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 750]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 779]]}
+ {:process 1 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 780]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 780]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 781]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 781]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 1 782]]}
+ {:process 1 :type :fail :f :txn :value [[:append 1 782]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 783]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 783]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 755]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 6 784]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 785]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 785]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 786]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 761]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 787]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 787]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 778]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 788]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 789]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 789]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 790]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 779]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 791]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 777]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 792]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 791]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 793]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 793]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 794]]}
+ {:process 1 :type :fail :f :txn :value [[:append 6 784]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 795]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 794]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 796]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 795]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 1 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 7 797]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 796]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 798]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 792]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 799]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 798]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 786]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 800]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 801]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 801]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 802]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 788]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 803]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 802]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 790]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 804]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 805]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 805]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 806]]}
+ {:process 1 :type :fail :f :txn :value [[:append 7 797]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 2 807]]}
+ {:process 1 :type :fail :f :txn :value [[:append 2 807]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 799]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 808]]}
+ {:process 1 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 4 809]]}
+ {:process 1 :type :fail :f :txn :value [[:append 4 809]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 3 810]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 800]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 811]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 811]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 803]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 812]]}
+ {:process 6 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 813]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 813]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 814]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 804]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 815]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 815]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 806]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 816]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 817]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 817]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 818]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 808]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 819]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 818]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 1 :type :fail :f :txn :value [[:append 3 810]]}
+ {:process 1 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 820]]}
+ {:process 1 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 5 821]]}
+ {:process 1 :type :fail :f :txn :value [[:append 5 821]]}
+ {:process 1 :type :invoke :f :txn :value [[:append 0 822]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 812]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 823]]}
+ {:process 1 :type :fail :f :txn :value [[:append 0 822]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 814]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 816]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 824]]}
+ {:process 6 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 2 825]]}
+ {:process 6 :type :fail :f :txn :value [[:append 2 825]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 826]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 819]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 827]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 823]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 828]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 828]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 820]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 829]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 830]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 830]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 831]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 831]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 832]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 832]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 833]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 833]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 834]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 834]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 835]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 835]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 836]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 836]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 837]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 837]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 838]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 838]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 839]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 839]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 840]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 840]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 841]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 841]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 842]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 842]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 843]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 843]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 2 844]]}
+ {:process 4 :type :fail :f :txn :value [[:append 2 844]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 845]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 845]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 7 846]]}
+ {:process 4 :type :fail :f :txn :value [[:append 7 846]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 847]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 847]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 4 848]]}
+ {:process 4 :type :fail :f :txn :value [[:append 4 848]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 3 849]]}
+ {:process 4 :type :fail :f :txn :value [[:append 3 849]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 1 850]]}
+ {:process 4 :type :fail :f :txn :value [[:append 1 850]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 0 851]]}
+ {:process 4 :type :fail :f :txn :value [[:append 0 851]]}
+ {:process 4 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 4 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 6 852]]}
+ {:process 4 :type :fail :f :txn :value [[:append 6 852]]}
+ {:process 4 :type :invoke :f :txn :value [[:append 5 853]]}
+ {:process 4 :type :fail :f :txn :value [[:append 5 853]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 824]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 854]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 854]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 855]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 855]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 856]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 856]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 857]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 857]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 858]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 858]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 859]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 859]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 860]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 860]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 861]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 861]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 827]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 862]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 863]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 863]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 864]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 826]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 5 865]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 864]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 829]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 866]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 867]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 867]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 868]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 868]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 869]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 869]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 870]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 870]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 871]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 871]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 872]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 872]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 873]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 873]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 874]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 874]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 875]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 875]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 876]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 876]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 877]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 877]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 878]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 878]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 879]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 879]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 880]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 880]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 881]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 881]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 882]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 882]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 883]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 883]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 884]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 884]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 885]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 885]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 886]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 886]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 887]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 887]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 888]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 888]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 889]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 889]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 890]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 890]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 891]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 891]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 892]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 892]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 893]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 893]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 894]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 894]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 895]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 895]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 896]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 896]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 897]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 897]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 898]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 898]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 899]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 899]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 900]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 900]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 901]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 901]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 902]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 902]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 903]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 903]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 904]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 904]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 905]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 905]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 906]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 906]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 907]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 907]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 908]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 908]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 909]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 909]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 910]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 910]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 911]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 911]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 912]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 912]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 862]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 913]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 914]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 914]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 915]]}
+ {:process 6 :type :fail :f :txn :value [[:append 5 865]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 916]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 916]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 866]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 917]]}
+ {:process 6 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 4 918]]}
+ {:process 6 :type :fail :f :txn :value [[:append 4 918]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 919]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 919]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 7 920]]}
+ {:process 6 :type :fail :f :txn :value [[:append 7 920]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 0 921]]}
+ {:process 6 :type :fail :f :txn :value [[:append 0 921]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 6 922]]}
+ {:process 6 :type :fail :f :txn :value [[:append 6 922]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 3 923]]}
+ {:process 6 :type :fail :f :txn :value [[:append 3 923]]}
+ {:process 6 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 6 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 6 :type :invoke :f :txn :value [[:append 1 924]]}
+ {:process 6 :type :fail :f :txn :value [[:append 1 924]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 913]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 925]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 925]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 926]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 926]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 927]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 927]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 928]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 928]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 929]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 929]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 930]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 930]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 931]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 915]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 931]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 932]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 933]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 933]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 934]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 917]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 935]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 934]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 936]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 936]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 937]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 937]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 938]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 938]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 939]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 939]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 940]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 940]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 941]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 941]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 942]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 942]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 943]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 943]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 944]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 944]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 945]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 945]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 946]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 946]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 947]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 947]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 948]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 948]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 949]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 949]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 5 950]]}
+ {:process 3 :type :fail :f :txn :value [[:append 5 950]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 951]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 951]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 2 952]]}
+ {:process 3 :type :fail :f :txn :value [[:append 2 952]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 953]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 953]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 7 954]]}
+ {:process 3 :type :fail :f :txn :value [[:append 7 954]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 955]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 955]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 4 956]]}
+ {:process 3 :type :fail :f :txn :value [[:append 4 956]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 3 957]]}
+ {:process 3 :type :fail :f :txn :value [[:append 3 957]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 1 958]]}
+ {:process 3 :type :fail :f :txn :value [[:append 1 958]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 0 959]]}
+ {:process 3 :type :fail :f :txn :value [[:append 0 959]]}
+ {:process 3 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 3 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 3 :type :invoke :f :txn :value [[:append 6 960]]}
+ {:process 3 :type :fail :f :txn :value [[:append 6 960]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 932]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 961]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 961]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 962]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 962]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 963]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 963]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 964]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 964]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 965]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 965]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 966]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 966]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 967]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 967]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 968]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 968]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 935]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 969]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 970]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 970]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 971]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 971]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 972]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 972]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 973]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 973]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 974]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 974]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 975]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 975]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 976]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 976]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 977]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 977]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 978]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 978]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 979]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 979]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 980]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 980]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 981]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 981]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 982]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 982]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 983]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 983]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 984]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 984]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 985]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 985]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 986]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 986]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 987]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 987]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 988]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 988]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 989]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 989]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 990]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 990]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 991]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 991]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 992]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 992]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 993]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 993]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 994]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 994]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 995]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 995]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 996]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 996]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 997]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 997]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 998]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 998]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 999]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 999]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 1000]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 1000]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 1001]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 1001]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 1002]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 1002]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 1003]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 1003]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 1004]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 1004]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 1005]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 1005]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 1006]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 1006]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 1007]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 1007]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 1008]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 1008]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 1009]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 1009]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 1010]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 1010]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 1011]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 1011]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 1012]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 1012]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 1013]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 1013]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 2 1014]]}
+ {:process 5 :type :fail :f :txn :value [[:append 2 1014]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 1015]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 1015]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 1 1016]]}
+ {:process 5 :type :fail :f :txn :value [[:append 1 1016]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 1017]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 1017]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 4 1018]]}
+ {:process 5 :type :fail :f :txn :value [[:append 4 1018]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 5 1019]]}
+ {:process 5 :type :fail :f :txn :value [[:append 5 1019]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 3 1020]]}
+ {:process 5 :type :fail :f :txn :value [[:append 3 1020]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 0 1021]]}
+ {:process 5 :type :fail :f :txn :value [[:append 0 1021]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 6 1022]]}
+ {:process 5 :type :fail :f :txn :value [[:append 6 1022]]}
+ {:process 5 :type :invoke :f :txn :value [[:append 7 1023]]}
+ {:process 5 :type :fail :f :txn :value [[:append 7 1023]]}
+ {:process 5 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 5 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 969]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 1024]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 1024]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 1025]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 1025]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 1026]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 1026]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 1027]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 1027]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 1028]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 1028]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 1029]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 1029]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 1030]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 1030]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 1031]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 1031]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 1032]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 1032]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 1033]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 1033]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 1034]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 1034]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 1035]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 1035]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 1036]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 1036]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 1037]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 1037]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 1038]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 1038]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 1039]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 1039]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 1040]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 1040]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 1041]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 1041]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 1042]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 1042]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 1043]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 1043]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 1044]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 1044]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 1045]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 1045]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 1046]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 1046]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 1047]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 1047]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 1048]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 1048]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 1049]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 1049]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 1050]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 1050]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 1051]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 1051]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 7 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 7 [306 307 319 329 332 490 622 623 717 768 771]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 1052]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 1052]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 1053]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 1053]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 2 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 2 [266 288 291 320 323 330 333 619 632 731 766 775]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 1054]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 1054]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 1055]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 1055]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 5 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 5 [287 292 309 324 327 334 759 770]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 1056]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 1056]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 1057]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 1057]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 0 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 0 [284 293 301 303 322 331 487 624 633 719]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 1 1058]]}
+ {:process 7 :type :fail :f :txn :value [[:append 1 1058]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 1059]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 1059]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 3 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 3 [289 290 308 312 326 335 492 628 629 765]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 4 1060]]}
+ {:process 7 :type :fail :f :txn :value [[:append 4 1060]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 1061]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 1061]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 6 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 6 [294 300 317 336 464 488 615 625 626 718 730 734 769 772]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 7 1062]]}
+ {:process 7 :type :fail :f :txn :value [[:append 7 1062]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 0 1063]]}
+ {:process 7 :type :fail :f :txn :value [[:append 0 1063]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 1 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 1 [305 318 321 456 486 620 621 630 631 763 773 776]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 2 1064]]}
+ {:process 7 :type :fail :f :txn :value [[:append 2 1064]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 3 1065]]}
+ {:process 7 :type :fail :f :txn :value [[:append 3 1065]]}
+ {:process 7 :type :invoke :f :txn :value [[:r 4 nil]]}
+ {:process 7 :type :ok :f :txn :value [[:r 4 [311 325 328 457 491 617 618 627 764 767 774]]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 5 1066]]}
+ {:process 7 :type :fail :f :txn :value [[:append 5 1066]]}
+ {:process 7 :type :invoke :f :txn :value [[:append 6 1067]]}
+ {:process 7 :type :fail :f :txn :value [[:append 6 1067]]}
+]

--- a/deploy/fly-accord-elle/ferrosa-elle.Dockerfile
+++ b/deploy/fly-accord-elle/ferrosa-elle.Dockerfile
@@ -1,0 +1,65 @@
+FROM rust:1.94 AS builder
+WORKDIR /build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends capnproto \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock ./
+COPY ferrosa/Cargo.toml ferrosa/Cargo.toml
+COPY ferrosa-common/Cargo.toml ferrosa-common/Cargo.toml
+COPY ferrosa-sstable/Cargo.toml ferrosa-sstable/Cargo.toml
+COPY ferrosa-storage/Cargo.toml ferrosa-storage/Cargo.toml
+COPY ferrosa-schema/Cargo.toml ferrosa-schema/Cargo.toml
+COPY ferrosa-cql/Cargo.toml ferrosa-cql/Cargo.toml
+COPY ferrosa-index/Cargo.toml ferrosa-index/Cargo.toml
+COPY ferrosa-net/Cargo.toml ferrosa-net/Cargo.toml
+COPY ferrosa-cluster/Cargo.toml ferrosa-cluster/Cargo.toml
+COPY ferrosa-graph/Cargo.toml ferrosa-graph/Cargo.toml
+COPY ferrosa-udf/Cargo.toml ferrosa-udf/Cargo.toml
+COPY ferrosa-worker/Cargo.toml ferrosa-worker/Cargo.toml
+COPY ferrosa-sparql/Cargo.toml ferrosa-sparql/Cargo.toml
+COPY ferrosa-ctl/Cargo.toml ferrosa-ctl/Cargo.toml
+COPY ferrosa-jepsen/Cargo.toml ferrosa-jepsen/Cargo.toml
+COPY ferrosa-loadgen/Cargo.toml ferrosa-loadgen/Cargo.toml
+COPY ferrosa-index-builder/Cargo.toml ferrosa-index-builder/Cargo.toml
+COPY ferrosa-sim/Cargo.toml ferrosa-sim/Cargo.toml
+
+RUN for d in ferrosa ferrosa-common ferrosa-sstable ferrosa-storage ferrosa-schema \
+            ferrosa-cql ferrosa-index ferrosa-net ferrosa-cluster ferrosa-graph \
+            ferrosa-udf ferrosa-worker ferrosa-sparql ferrosa-ctl ferrosa-jepsen \
+            ferrosa-loadgen ferrosa-index-builder ferrosa-sim; do \
+      mkdir -p "$d/src" && echo "" > "$d/src/lib.rs"; \
+    done && \
+    echo 'fn main() {}' > ferrosa/src/main.rs && \
+    echo 'fn main() {}' > ferrosa-ctl/src/main.rs && \
+    echo 'fn main() {}' > ferrosa-jepsen/src/main.rs && \
+    echo 'fn main() {}' > ferrosa-loadgen/src/main.rs && \
+    echo 'fn main() {}' > ferrosa-index-builder/src/main.rs && \
+    echo 'fn main() {}' > ferrosa-worker/src/main.rs
+
+ENV CARGO_BUILD_JOBS=4
+ENV RUSTFLAGS="-C force-frame-pointers=yes -C debuginfo=1"
+RUN cargo build --release -p ferrosa 2>&1 || true
+
+COPY . .
+RUN find . -name "lib.rs" -o -name "main.rs" | xargs touch
+RUN cargo build --release -p ferrosa
+RUN cargo build --release -p ferrosa-jepsen --example elle_list_append
+
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gdb \
+        linux-perf \
+        procps \
+        sysstat \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/target/release/ferrosa /usr/local/bin/
+COPY --from=builder /build/target/release/examples/elle_list_append /usr/local/bin/
+COPY deploy/fly-bench/ferrosa-entrypoint.sh /usr/local/bin/
+EXPOSE 9042 7000 9090
+ENV FERROSA_DATA_DIR=/var/lib/ferrosa
+ENTRYPOINT ["ferrosa-entrypoint.sh"]
+CMD ["ferrosa"]

--- a/deploy/fly-accord-elle/ferrosa-elle.Dockerfile
+++ b/deploy/fly-accord-elle/ferrosa-elle.Dockerfile
@@ -39,7 +39,16 @@ RUN for d in ferrosa ferrosa-common ferrosa-sstable ferrosa-storage ferrosa-sche
     echo 'fn main() {}' > ferrosa-worker/src/main.rs
 
 ENV CARGO_BUILD_JOBS=4
-ENV RUSTFLAGS="-C force-frame-pointers=yes -C debuginfo=1"
+# Fast-but-optimized build for the ephemeral cert cluster: opt-level=1 keeps
+# Accord/raft timing healthy (unlike a debug build) while compiling far faster
+# than opt-level 3; high codegen-units + no debuginfo cut compile time further so
+# the whole cert run fits inside the background-job window (the fly remote builder
+# does not persist cache between runs, so every build is cold).
+ENV CARGO_PROFILE_RELEASE_OPT_LEVEL=1
+ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256
+ENV CARGO_PROFILE_RELEASE_DEBUG=false
+ENV CARGO_PROFILE_RELEASE_LTO=false
+ENV RUSTFLAGS="-C force-frame-pointers=yes"
 RUN cargo build --release -p ferrosa 2>&1 || true
 
 COPY . .

--- a/ferrosa-cluster/src/accord/apply.rs
+++ b/ferrosa-cluster/src/accord/apply.rs
@@ -435,13 +435,17 @@ impl StorageApplier for EngineStorageApplier {
             // Snapshot the idempotency set under the lock to decide what to skip.
             let already = self.applied.lock();
             for mutation in &mutations {
-                // Decode the self-describing commit-log mutation (one partition).
-                // Fail loud on garbage.
+                // Decode the self-describing commit-log mutation (one partition),
+                // rebinding any Accord `list` append cell's path from the
+                // coordinator-local wall clock to the agreed execution timestamp
+                // `mutation.t` (t_68f226b5) so concurrent appends serialize in the
+                // Accord order. Non-list cells are untouched. Fail loud on garbage.
                 let mut decoded =
-                    Mutation::deserialize_from(&mutation.data).map_err(|e| ApplyError {
-                        txn_id,
-                        reason: format!("failed to decode apply mutation: {e}"),
-                    })?;
+                    Mutation::deserialize_from_rebinding_list_paths(&mutation.data, mutation.t)
+                        .map_err(|e| ApplyError {
+                            txn_id,
+                            reason: format!("failed to decode apply mutation: {e}"),
+                        })?;
 
                 // Idempotency gate: an already-applied (txn,key,t) is a no-op.
                 // Checked AFTER decode so the partition key is available — this is
@@ -733,7 +737,10 @@ impl CdcPublishingApplier {
         {
             return None;
         }
-        Mutation::deserialize_from(&mutation.data)
+        // Rebind list paths to the agreed `t` so the CDC event mirrors the
+        // durably-applied rows (not the coordinator-clock paths), matching
+        // `EngineStorageApplier::apply_writeset`.
+        Mutation::deserialize_from_rebinding_list_paths(&mutation.data, mutation.t)
             .ok()
             .map(|m| ferrosa_cdc::CdcEvent {
                 stream: ferrosa_cdc::CdcStream::CommittedToCluster,
@@ -1476,6 +1483,85 @@ mod engine_applier_tests {
             "the row written by apply must be readable via the engine — \
              not a phantom write"
         );
+    }
+
+    /// Applying a mutation with an Accord `list` append cell (flagged 0x4000)
+    /// rebinds the cell's path to the agreed execution timestamp `t` — not the
+    /// coordinator wall clock baked in at materialize — while preserving the
+    /// element_seq. This is what makes concurrent list appends strict-
+    /// serializable (t_68f226b5): the persisted path orders by the Accord `t`,
+    /// so a read observes the Accord serialization order.
+    #[test]
+    fn apply_rebinds_flagged_list_cell_path_to_accord_ts() {
+        use ferrosa_common::accord_list_cell_path;
+        const REBIND_FLAG: u16 = 0x4000;
+
+        let (engine, _dir) = make_engine();
+        let applier = EngineStorageApplier::new(engine.clone());
+
+        let key = make_key("pk-list");
+        let element_seq = 2u16;
+        // Coordinator-clock list path: a huge wall-clock time, but it carries the
+        // element_seq the rebind must preserve.
+        let coord_path = accord_list_cell_path(&accord_ts(9_999_999), element_seq);
+        let row = Row {
+            clustering: vec![0x00, 0x00, 0x00, 0x01],
+            cells: vec![(
+                REBIND_FLAG, // storage column 0, flagged for rebind
+                CellValue::live(b"L".to_vec(), 9_999_999).with_path(coord_path.clone()),
+            )],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(9_999_999),
+        };
+        let m = Mutation::new(
+            KS.to_string(),
+            TABLE.to_string(),
+            key.clone(),
+            vec![row],
+            9_999_999,
+        );
+        let mut buf = vec![0u8; m.serialized_size()];
+        m.serialize_into(&mut buf);
+
+        // The agreed execution ts is tiny (777) — far below the wall clock stamped
+        // at materialize — so a rebound path proves the Accord ts drove it.
+        let agreed = accord_ts(777);
+        applier
+            .apply(
+                txn(1, 777),
+                ApplyMutation {
+                    data: buf,
+                    t: agreed,
+                    deps: vec![],
+                },
+            )
+            .expect("apply must decode, rebind, and persist");
+
+        let partition = engine
+            .read(&TableId::new(KS, TABLE), &key)
+            .unwrap()
+            .unwrap();
+        let (idx, cell) = partition.rows[0]
+            .cells
+            .iter()
+            .find(|(_, c)| c.path.is_some())
+            .expect("the persisted list cell must have a path");
+        assert_eq!(
+            *idx & 0xC000,
+            0,
+            "stored column index carries no transient flag"
+        );
+        assert_eq!(
+            cell.path.as_deref(),
+            Some(accord_list_cell_path(&agreed, element_seq).as_slice()),
+            "list cell path rebound to the Accord execution ts, element_seq preserved"
+        );
+        assert_ne!(
+            cell.path.as_deref(),
+            Some(coord_path.as_slice()),
+            "the coordinator wall-clock path must NOT survive"
+        );
+        assert_eq!(cell.timestamp, 777, "cell ts restamped to the agreed t");
     }
 
     // -----------------------------------------------------------------------

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -229,7 +229,7 @@ impl AccordStateMachine {
     /// Wire the node's shared [`HybridLogicalClock`] — the same `Arc` the
     /// transaction committer mints `t0` from — so this replica advances that
     /// clock past every execution timestamp it witnesses through consensus (see
-    /// the [`clock`](Self::clock) field). Builder; returns `self`.
+    /// the `clock` field). Builder; returns `self`.
     #[must_use]
     pub fn with_clock(mut self, clock: Arc<HybridLogicalClock>) -> Self {
         self.clock = Some(clock);

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -412,7 +412,11 @@ impl AccordStateMachine {
             let entry = InFlightWrite {
                 txn_id,
                 t0,
-                accord_ts: None,
+                // Record the bumped PROPOSED execution timestamp as this txn's
+                // effective serialization point, so a concurrent PreAccept bumps
+                // past `t` (not the stale `t0`). Finalized at Accept/Commit
+                // (t_813caf39). `t == t0` when there was no conflict to bump past.
+                accord_ts: Some(t),
                 status: TxnStatus::PreAccepted,
             };
             // Don't fail the protocol message on capacity errors, but log them.
@@ -502,6 +506,10 @@ impl AccordStateMachine {
         let deps_set: HashSet<TxnId> = deps.iter().copied().collect();
         state.accept(AcceptedBallot(ballot), t, deps_set);
 
+        // The slow path may move the execution timestamp; keep the conflict index
+        // in sync so a later PreAccept bumps past the accepted `t` (t_813caf39).
+        self.conflict_index.set_commit_ts(&txn_id, t);
+
         // Persist before reply.
         let data = format!("Accepted:{}:{}:{}", txn_id.0.time, t.time, ballot.0);
         let result = self.sync_writer.write_and_sync(data.as_bytes());
@@ -567,6 +575,13 @@ impl AccordStateMachine {
             state.commit(t, deps_set);
         }
         self.committed_txns.insert(txn_id);
+
+        // Lock the committed execution timestamp into the conflict index so a
+        // later PreAccept on this key bumps past this txn's real serialization
+        // point, not its stale proposed `t0` (t_813caf39). Without this a
+        // committed append whose `t` was bumped high is under-counted and a later
+        // append lands before it — a list-order real-time inversion.
+        self.conflict_index.set_commit_ts(&txn_id, t);
 
         // Wake dep waiters.
         self.last_notified.clear();
@@ -1028,6 +1043,54 @@ mod tests {
 
         let state = sm.get_state(&txn_id).expect("state must exist");
         assert_eq!(state.phase, TxnPhase::PreAccepted);
+    }
+
+    /// Protocol-level regression for the Accord list-append real-time inversion
+    /// (t_813caf39): a committed txn A whose execution `t` was bumped high (past
+    /// an earlier conflict that has since applied + been GC'd) must still order a
+    /// LATER PreAccept B after it — B's execution `t` must exceed A's. Before the
+    /// fix the conflict index tracked only A's proposed `t0`, so B (with a `t0`
+    /// above A's `t0` but below A's execution `t`) was NOT bumped and landed
+    /// before A — reordering the list element ahead of A.
+    #[test]
+    fn preaccept_bumps_past_committed_conflicts_execution_ts_not_t0() {
+        let (mut sm, _w) = make_sm(1);
+        let key = b"k";
+
+        // C: an early high-t0 conflict on the key.
+        let c = txn(9, 1000);
+        sm.handle_preaccept(c, ts(1000), key, BallotNumber(0), 0);
+
+        // A: a lagging coordinator proposes t0 = 500, but A bumps its execution t
+        // past C. Commit A at that execution t.
+        let a = txn(2, 500);
+        let a_t = match sm.handle_preaccept(a, ts(500), key, BallotNumber(0), 0) {
+            SmResponse::PreAcceptOK { t, .. } => t,
+            other => panic!("expected PreAcceptOK, got {other:?}"),
+        };
+        assert!(
+            a_t > ts(500),
+            "A must bump its execution t past the C conflict"
+        );
+        sm.handle_commit(a, ts(500), a_t, vec![]);
+
+        // C applies and is GC'd, leaving only A on the key — registered with the
+        // stale proposed t0=500 but a HIGH execution t.
+        sm.conflict_index.mark_applied(&c);
+        sm.conflict_index.gc_applied();
+
+        // B: a later append, proposed t0 = 600 (above A's t0 but below A's exec t).
+        let b = txn(3, 600);
+        let b_t = match sm.handle_preaccept(b, ts(600), key, BallotNumber(0), 0) {
+            SmResponse::PreAcceptOK { t, .. } => t,
+            other => panic!("expected PreAcceptOK, got {other:?}"),
+        };
+
+        assert!(
+            b_t > a_t,
+            "a later append B must be ordered AFTER committed A (b_t={b_t:?} > a_t={a_t:?}); \
+             a b_t below a_t reorders the list element ahead of A (t_813caf39)"
+        );
     }
 
     /// Accept after PreAccept moves to Accepted.

--- a/ferrosa-cluster/src/accord/state_machine.rs
+++ b/ferrosa-cluster/src/accord/state_machine.rs
@@ -28,7 +28,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use ferrosa_common::accord::{
-    AcceptedBallot, BallotNumber, PromisedBallot, Timestamp, TxnId, TxnPhase, TxnState,
+    AcceptedBallot, BallotNumber, HybridLogicalClock, PromisedBallot, Timestamp, TxnId, TxnPhase,
+    TxnState,
 };
 use ferrosa_storage::accord::conflict_index::{ConflictIndex, InFlightWrite, TxnStatus};
 use ferrosa_storage::accord::sync_writer::SyncWriter;
@@ -115,6 +116,16 @@ pub struct AccordStateMachine {
     /// always re-checks the unapplied-conflict condition under the lock after a
     /// wake — a spurious or coalesced wake just costs one extra re-check.
     applied_notify: Arc<Notify>,
+    /// The node's shared hybrid logical clock (the same `Arc` the transaction
+    /// committer mints `t0` from). When set, every timestamp this replica
+    /// observes through consensus — a PreAccept's proposed/bumped `t`, a
+    /// committed execution `t` — is fed to [`HybridLogicalClock::witness`], so
+    /// this node's clock tracks the global-max execution timestamp. That keeps a
+    /// later transaction's `t0` above every already-committed conflict even after
+    /// the conflict has been GC'd from the [`ConflictIndex`] — the write-side
+    /// monotonicity that makes concurrent list appends strict-serializable
+    /// (t_813caf39). `None` in protocol-only tests that mint no timestamps.
+    clock: Option<Arc<HybridLogicalClock>>,
 }
 
 impl AccordStateMachine {
@@ -135,6 +146,7 @@ impl AccordStateMachine {
             apply_engine: Arc::new(DepWaitApplier::new(Arc::new(NoopStorageApplier::new()))),
             reader: None,
             applied_notify: Arc::new(Notify::new()),
+            clock: None,
         }
     }
 
@@ -157,6 +169,7 @@ impl AccordStateMachine {
             apply_engine: Arc::new(DepWaitApplier::new(Arc::new(NoopStorageApplier::new()))),
             reader: None,
             applied_notify: Arc::new(Notify::new()),
+            clock: None,
         }
     }
 
@@ -181,6 +194,7 @@ impl AccordStateMachine {
             apply_engine: Arc::new(DepWaitApplier::new(applier)),
             reader: None,
             applied_notify: Arc::new(Notify::new()),
+            clock: None,
         }
     }
 
@@ -208,6 +222,25 @@ impl AccordStateMachine {
             apply_engine: Arc::new(DepWaitApplier::new(applier)),
             reader: Some(reader),
             applied_notify: Arc::new(Notify::new()),
+            clock: None,
+        }
+    }
+
+    /// Wire the node's shared [`HybridLogicalClock`] — the same `Arc` the
+    /// transaction committer mints `t0` from — so this replica advances that
+    /// clock past every execution timestamp it witnesses through consensus (see
+    /// the [`clock`](Self::clock) field). Builder; returns `self`.
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<HybridLogicalClock>) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
+    /// Feed a witnessed execution timestamp to the node's shared clock, if wired,
+    /// so a subsequently minted `t0` is `>= t`. No-op when no clock is wired.
+    fn witness_timestamp(&self, t: Timestamp) {
+        if let Some(clock) = &self.clock {
+            clock.witness(t);
         }
     }
 
@@ -406,6 +439,11 @@ impl AccordStateMachine {
             _ => t0,
         };
 
+        // Witness the proposed execution timestamp into the node's shared clock so
+        // a later `t0` minted here is `>= t` (t_813caf39). `t >= t0`, so this also
+        // covers the remote coordinator's proposed `t0`.
+        self.witness_timestamp(t);
+
         // Register the txn under EVERY key it writes, so a later conflicting
         // txn on any of them sees it as a dependency.
         for key in keys {
@@ -507,8 +545,10 @@ impl AccordStateMachine {
         state.accept(AcceptedBallot(ballot), t, deps_set);
 
         // The slow path may move the execution timestamp; keep the conflict index
-        // in sync so a later PreAccept bumps past the accepted `t` (t_813caf39).
+        // in sync so a later PreAccept bumps past the accepted `t` (t_813caf39),
+        // and advance the node's shared clock past it too.
         self.conflict_index.set_commit_ts(&txn_id, t);
+        self.witness_timestamp(t);
 
         // Persist before reply.
         let data = format!("Accepted:{}:{}:{}", txn_id.0.time, t.time, ballot.0);
@@ -582,6 +622,13 @@ impl AccordStateMachine {
         // committed append whose `t` was bumped high is under-counted and a later
         // append lands before it — a list-order real-time inversion.
         self.conflict_index.set_commit_ts(&txn_id, t);
+
+        // Advance the node's shared clock past this execution timestamp so the
+        // next `t0` this node mints is `> t` — which keeps a later append after
+        // this one even once this txn is applied and GC'd from the conflict index
+        // (the index-only bump above cannot survive GC). This is the write-side
+        // monotonicity that makes concurrent list appends strict-serializable.
+        self.witness_timestamp(t);
 
         // Wake dep waiters.
         self.last_notified.clear();
@@ -925,6 +972,7 @@ pub fn build_accord_state_machine(
     node_id: u64,
     sync_writer: Arc<dyn SyncWriter>,
     storage: Arc<ferrosa_storage::engine::StorageEngine>,
+    clock: Option<Arc<HybridLogicalClock>>,
 ) -> AccordStateMachine {
     let engine_applier = Arc::new(crate::accord::apply::EngineStorageApplier::new(
         storage.clone(),
@@ -940,7 +988,13 @@ pub fn build_accord_state_machine(
         None => engine_applier,
     };
     let reader = Arc::new(crate::accord::apply::EngineStorageReader::new(storage));
-    AccordStateMachine::with_applier_and_reader(node_id, sync_writer, applier, reader)
+    let sm = AccordStateMachine::with_applier_and_reader(node_id, sync_writer, applier, reader);
+    // Share the node's HLC so the replica advances it past every witnessed
+    // execution timestamp (t_813caf39). `None` in setups with no shared clock.
+    match clock {
+        Some(c) => sm.with_clock(c),
+        None => sm,
+    }
 }
 
 // Helper extension for TxnPhase to expose rank for comparison.
@@ -1090,6 +1144,41 @@ mod tests {
             b_t > a_t,
             "a later append B must be ordered AFTER committed A (b_t={b_t:?} > a_t={a_t:?}); \
              a b_t below a_t reorders the list element ahead of A (t_813caf39)"
+        );
+    }
+
+    /// A node's shared HLC must advance past every execution timestamp it
+    /// commits, so a LATER append's `t0` is `>` earlier-committed appends' `t` —
+    /// even after the earlier conflict is GC'd from the index. Without this a
+    /// later append mints a low `t0` and lands mid-list: the write-side
+    /// strict-serializability failure the fly cert exposed (t_813caf39).
+    #[test]
+    fn commit_witnesses_execution_ts_into_shared_clock() {
+        use ferrosa_common::accord::HybridLogicalClock;
+        let clock = Arc::new(HybridLogicalClock::new(1, 0));
+        let (sm, _w) = make_sm(1);
+        let mut sm = sm.with_clock(clock.clone());
+
+        // An execution t 100 ms ahead of the node's wall clock (well within the
+        // 500 ms drift guard) — as a conflict bump against a faster peer would
+        // produce. The margin is wide enough that plain wall-clock advancement
+        // during handle_commit cannot cross it, so the assertion is only met if
+        // the clock actually *witnesses* the committed timestamp.
+        let now0 = clock.now();
+        let high = Timestamp {
+            epoch: 0,
+            time: now0.time + 100_000_000,
+            seq: 0,
+            node: 2,
+        };
+        let id = TxnId::new(2, high);
+        sm.handle_commit(id, high, high, vec![]);
+
+        let next = clock.now();
+        assert!(
+            next > high,
+            "committing execution t={high:?} must advance the node's shared clock so the next \
+             minted t0 ({next:?}) is > it — else a later append lands mid-list (t_813caf39)"
         );
     }
 
@@ -2533,7 +2622,7 @@ mod production_wiring_tests {
 
         // Build EXACTLY as the controller does: the production factory.
         let writer = Arc::new(MockSyncWriter::new());
-        let mut sm = build_accord_state_machine(7, writer, engine.clone());
+        let mut sm = build_accord_state_machine(7, writer, engine.clone(), None);
 
         let key = make_key("pk-prod");
         let txn_id = txn(1, 1000);
@@ -2570,7 +2659,7 @@ mod production_wiring_tests {
     fn production_apply_failure_does_not_fake_applied() {
         let (engine, _dir) = make_engine();
         let writer = Arc::new(MockSyncWriter::new());
-        let mut sm = build_accord_state_machine(7, writer, engine.clone());
+        let mut sm = build_accord_state_machine(7, writer, engine.clone(), None);
 
         let key = make_key("pk-missing-table");
         let txn_id = txn(2, 2000);

--- a/ferrosa-cluster/src/accord/transaction_commit.rs
+++ b/ferrosa-cluster/src/accord/transaction_commit.rs
@@ -417,6 +417,138 @@ mod tests {
         );
     }
 
+    /// END-TO-END rebind (t_813caf39): a `BEGIN..COMMIT` list-append cell flagged
+    /// with the transient rebind bit must persist a path bound to the AGREED
+    /// Accord execution timestamp — not the coordinator materialize clock baked in
+    /// at `build_transaction_write`. This proves the 0x4000 flag survives the whole
+    /// committer → PreAccept/Commit/Apply → `EngineStorageApplier` path against a
+    /// REAL storage engine, closing the gap between the isolated apply unit test
+    /// (which proves the applier rebinds) and the live commit path (which must
+    /// deliver a flagged, un-mangled payload to that applier).
+    #[tokio::test]
+    async fn sole_replica_commit_rebinds_flagged_list_path_end_to_end() {
+        use crate::accord::apply::EngineStorageApplier;
+        use crate::accord::handlers::AccordState;
+        use crate::accord::state_machine::AccordStateMachine;
+        use ferrosa_common::schema::{ColumnDefinition, TableSchema};
+        use ferrosa_common::{accord_list_cell_path, list_path_element_seq};
+        use ferrosa_common::{CellValue, DecoratedKey, PartitionKey};
+        use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
+        use ferrosa_storage::accord::sync_writer::MockSyncWriter;
+        use ferrosa_storage::{
+            Mutation, StorageEngine, StorageEngineConfig, TableId, CELL_REBIND_LIST_PATH_FLAG,
+        };
+
+        // Real engine + a table to persist the row into.
+        let dir = tempfile::tempdir().unwrap();
+        let engine = Arc::new(
+            StorageEngine::new(StorageEngineConfig::test_config(dir.path()), None).unwrap(),
+        );
+        engine
+            .register_table(TableSchema {
+                keyspace: "ks".to_string(),
+                table: "t".to_string(),
+                key_type: "org.apache.cassandra.db.marshal.Int32Type".to_string(),
+                clustering_columns: vec![],
+                static_columns: vec![],
+                regular_columns: vec![ColumnDefinition {
+                    name: "v".to_string(),
+                    type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+                }],
+                extensions: Default::default(),
+            })
+            .unwrap();
+        let engine_applier: Arc<dyn StorageApplier> =
+            Arc::new(EngineStorageApplier::new(engine.clone()));
+
+        // A flagged list-append cell whose path carries an OBVIOUSLY WRONG
+        // coordinator-clock time (t.time = 1). If the rebind is live end-to-end,
+        // apply overwrites it with the agreed execution ts (~now); if a wiring gap
+        // drops the flag, this ancient path survives.
+        let element_seq = 0u16;
+        let coord_path = accord_list_cell_path(
+            &ferrosa_common::accord::Timestamp {
+                epoch: 0,
+                time: 1,
+                seq: 0,
+                node: 0,
+            },
+            element_seq,
+        );
+        let key = DecoratedKey::new(PartitionKey::new(vec![0, 0, 0, 5]));
+        let row = Row {
+            clustering: vec![],
+            cells: vec![(
+                CELL_REBIND_LIST_PATH_FLAG, // storage col 0, flagged for rebind
+                CellValue::live(b"L".to_vec(), 1).with_path(coord_path.clone()),
+            )],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(1),
+        };
+        let m = Mutation::new("ks".into(), "t".into(), key.clone(), vec![row], 1);
+        let mut buf = vec![0u8; m.serialized_size()];
+        m.serialize_into(&mut buf);
+
+        // Sole-replica committer wired to the REAL engine applier on both the
+        // committer boundary and the coordinator's own state machine.
+        let host = Uuid::from_u128(0xD0);
+        let node_id = node_id_of(host);
+        let clock = Arc::new(HybridLogicalClock::new(node_id, 0));
+        let local_state: AccordState =
+            Arc::new(parking_lot::Mutex::new(AccordStateMachine::with_applier(
+                node_id,
+                Arc::new(MockSyncWriter::new()),
+                engine_applier.clone(),
+            )));
+        let resolve: ReplicaResolver = Arc::new(move |_ks: &str, _key: &[u8]| Some(vec![host]));
+        let committer = AccordTransactionCommitter::new(
+            node_id,
+            clock,
+            Arc::new(NoPeersTransport),
+            engine_applier.clone(),
+            resolve,
+        )
+        .with_local_accord_state(local_state);
+
+        let outcome = committer
+            .commit(vec![write("ks", &[0, 0, 0, 5], &buf)])
+            .await
+            .expect("sole-replica list-append commit must succeed");
+        assert_eq!(outcome, CommitOutcome::Committed);
+
+        // Read back the persisted cell and inspect its path.
+        let partition = engine
+            .read(&TableId::new("ks", "t"), &key)
+            .unwrap()
+            .expect("the committed row must be persisted");
+        let (idx, cell) = partition.rows[0]
+            .cells
+            .iter()
+            .find(|(_, c)| c.path.is_some())
+            .expect("the persisted list cell must have a path");
+
+        assert_eq!(
+            *idx & 0xC000,
+            0,
+            "stored column index carries no transient flag"
+        );
+        assert_ne!(
+            cell.path.as_deref(),
+            Some(coord_path.as_slice()),
+            "REBIND NOT ACTIVE end-to-end: the coordinator-clock path (t.time=1) survived the \
+             commit path — the 0x4000 flag was dropped between build_transaction_write and apply"
+        );
+        assert_eq!(
+            list_path_element_seq(cell.path.as_deref().unwrap()),
+            Some(element_seq),
+            "the rebound path preserves the element_seq"
+        );
+        assert_ne!(
+            cell.timestamp, 1,
+            "the cell timestamp is restamped to the agreed execution ts, confirming apply ran"
+        );
+    }
+
     #[tokio::test]
     async fn sole_replica_commit_uses_local_state_from_populated_slot() {
         // The session layer wires the committer from an AccordStateSlot the

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -1205,6 +1205,7 @@ impl ModeController {
                 uuid_to_node_id(self.local_host_id),
                 sync_writer,
                 self.storage.clone(),
+                self.accord_clock(),
             )));
             // Publish into the shared slot so the session layer's transaction
             // committer votes the coordinator's own PreAccept against THIS exact

--- a/ferrosa-cluster/src/controller/mod.rs
+++ b/ferrosa-cluster/src/controller/mod.rs
@@ -264,6 +264,13 @@ pub struct ModeController {
     /// is never in its own peer map). Read by `SessionCore` via
     /// [`Self::accord_state_slot`].
     pub(super) accord_state_slot: crate::accord::AccordStateSlot,
+    /// The node's shared hybrid logical clock — the same `Arc` the CQL layer's
+    /// transaction committer mints `t0` from. Set once at startup via
+    /// [`Self::set_accord_clock`] and handed to the node's `AccordStateMachine`
+    /// at formation so the replica advances it past every execution timestamp it
+    /// witnesses (write-side monotonicity for strict-serializable list appends,
+    /// t_813caf39). Empty until set.
+    pub(super) accord_clock: std::sync::OnceLock<Arc<ferrosa_common::accord::HybridLogicalClock>>,
 }
 
 /// Handles returned from ModeController::new() for wiring into SharedState.
@@ -353,6 +360,7 @@ impl ModeController {
             data_runtime: std::sync::OnceLock::new(),
             raft_node_map: arc_swap::ArcSwapOption::empty(),
             accord_state_slot: crate::accord::empty_accord_state_slot(),
+            accord_clock: std::sync::OnceLock::new(),
         });
 
         let handles = ModeControllerHandles {
@@ -371,6 +379,20 @@ impl ModeController {
     /// empty slot, and the committer then uses remote-only votes).
     pub fn accord_state_slot(&self) -> crate::accord::AccordStateSlot {
         self.accord_state_slot.clone()
+    }
+
+    /// Register the node's shared [`HybridLogicalClock`](ferrosa_common::accord::HybridLogicalClock)
+    /// — the same `Arc` the CQL transaction committer mints `t0` from — so the
+    /// state machine built at formation advances it past every witnessed
+    /// execution timestamp (t_813caf39). Called once at startup, before
+    /// formation. Idempotent: a second set is ignored (the clock is process-wide).
+    pub fn set_accord_clock(&self, clock: Arc<ferrosa_common::accord::HybridLogicalClock>) {
+        let _ = self.accord_clock.set(clock);
+    }
+
+    /// The node's shared HLC, if registered ([`Self::set_accord_clock`]).
+    pub(super) fn accord_clock(&self) -> Option<Arc<ferrosa_common::accord::HybridLogicalClock>> {
+        self.accord_clock.get().cloned()
     }
 
     /// Register a (re)connecting peer's `host_id` in the raft network factory's
@@ -450,6 +472,7 @@ impl ModeController {
             data_runtime: std::sync::OnceLock::new(),
             raft_node_map: arc_swap::ArcSwapOption::empty(),
             accord_state_slot: crate::accord::empty_accord_state_slot(),
+            accord_clock: std::sync::OnceLock::new(),
         })
     }
 
@@ -512,6 +535,7 @@ impl ModeController {
             data_runtime: std::sync::OnceLock::new(),
             raft_node_map: arc_swap::ArcSwapOption::empty(),
             accord_state_slot: crate::accord::empty_accord_state_slot(),
+            accord_clock: std::sync::OnceLock::new(),
         })
     }
 

--- a/ferrosa-common/src/accord.rs
+++ b/ferrosa-common/src/accord.rs
@@ -195,9 +195,15 @@ const DEFAULT_MAX_DRIFT_NS: u64 = 500_000_000;
 /// A hybrid logical clock (HLC) that produces monotonic [`Timestamp`]s.
 ///
 /// Combines wall-clock time (nanoseconds) with a logical sequence counter
-/// so that timestamps never regress, even under wall-clock jitter. The
-/// `merge` method advances the local clock past a remote timestamp while
-/// rejecting excessive drift.
+/// so that timestamps never regress, even under wall-clock jitter.
+///
+/// Cross-node monotonicity flows through one seam: [`witness`](Self::witness)
+/// ingests a timestamp observed from another node (a proposal, an agreed or
+/// committed `t`) and returns a fresh local stamp advanced past it. It is built
+/// on the lower-level [`merge`](Self::merge) primitive (advance-past-remote,
+/// drift-rejecting). New Accord code should call `witness`, not `now`, wherever a
+/// remote timestamp has just been observed — so the invariant is honored by
+/// construction rather than by convention.
 ///
 /// All operations are lock-free via [`AtomicU64`] / [`AtomicU32`].
 pub struct HybridLogicalClock {
@@ -323,6 +329,26 @@ impl HybridLogicalClock {
                 return Ok(());
             }
         }
+    }
+
+    /// Ingest a timestamp `remote` observed from another node, then mint a fresh
+    /// monotonic timestamp. This is the single seam through which the Accord path
+    /// should consume any timestamp it did not itself mint (a PreAccept proposal,
+    /// an agreed execution `t`, a committed `t`): it advances the local clock past
+    /// `remote` — so a subsequently minted [`now`](Self::now) is `>= remote` —
+    /// then returns that fresh stamp.
+    ///
+    /// Encapsulates the cross-node monotonicity invariant that [`merge`](Self::merge)
+    /// only *offers* (nothing on the Accord path calls `merge` directly). If
+    /// `remote` is beyond `max_drift_ns` ahead of the wall clock the advance is
+    /// skipped (the drift guard), but a fresh local stamp is still returned — so a
+    /// caller always gets a usable, locally-monotonic timestamp.
+    pub fn witness(&self, remote: Timestamp) -> Timestamp {
+        // Advance past the witnessed timestamp where the drift guard permits; a
+        // rejected (too-far-ahead) remote leaves the local clock untouched, same
+        // as `merge`. Either way `now()` then yields a fresh monotonic stamp.
+        let _ = self.merge(remote);
+        self.now()
     }
 }
 
@@ -872,6 +898,55 @@ mod tests {
             after.time <= before.time + max_drift * 10,
             "HLC must not have jumped to remote time: after={:?}",
             after,
+        );
+    }
+
+    /// `witness` is the single ingestion seam: it advances the clock past an
+    /// observed (drift-permitting) timestamp AND hands back a fresh, locally
+    /// monotonic stamp reflecting that floor.
+    #[test]
+    fn hlc_witness_advances_past_remote_and_stays_monotonic() {
+        let hlc = HybridLogicalClock::new(1, DEFAULT_MAX_DRIFT_NS);
+        let base = hlc.now();
+        let remote = Timestamp {
+            epoch: 0,
+            time: HybridLogicalClock::wall_clock_ns() + 1_000, // 1 us ahead — within drift
+            seq: 5,
+            node: 2,
+        };
+        let stamped = hlc.witness(remote);
+        assert!(
+            stamped.time >= remote.time,
+            "witness advances the clock past the observed time: stamped={stamped:?}, remote={remote:?}"
+        );
+        assert!(stamped >= base, "witness returns a locally-monotonic stamp");
+        assert!(
+            hlc.now() >= stamped,
+            "a later now() stays past the witnessed floor"
+        );
+    }
+
+    /// A drift-rejected witness must NOT adopt the absurd remote time, yet must
+    /// still return a usable, locally-monotonic stamp (never error/panic).
+    #[test]
+    fn hlc_witness_beyond_drift_still_returns_local_stamp() {
+        let max_drift = 1_000_000u64; // 1 ms
+        let hlc = HybridLogicalClock::new(1, max_drift);
+        let before = hlc.now();
+        let remote = Timestamp {
+            epoch: 0,
+            time: HybridLogicalClock::wall_clock_ns() + max_drift * 1_000, // way beyond drift
+            seq: 0,
+            node: 9,
+        };
+        let stamped = hlc.witness(remote);
+        assert!(
+            stamped >= before,
+            "a drift-rejected witness still yields a monotonic local stamp"
+        );
+        assert!(
+            stamped.time < remote.time,
+            "the absurd remote time must NOT be adopted (drift guard held): stamped={stamped:?}"
         );
     }
 

--- a/ferrosa-common/src/complex_cell.rs
+++ b/ferrosa-common/src/complex_cell.rs
@@ -279,6 +279,110 @@ impl CounterCell {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Accord-ordered list cell paths — the single source of truth for the 16-byte
+// v1-TimeUUID layout shared by the read-side assembly (`ferrosa-row-bridge`,
+// which re-exports [`accord_list_cell_path`]) and the Accord apply-time rebind
+// (`ferrosa-storage::commitlog::mutation`). Co-locating the mint here keeps the
+// two byte-for-byte consistent — a drift would silently reorder or drop list
+// elements.
+// ---------------------------------------------------------------------------
+
+/// 100-nanosecond intervals between the UUID epoch (1582-10-15) and the Unix
+/// epoch (1970-01-01) — the offset a v1 TimeUUID's 60-bit time field carries.
+pub const UUID_EPOCH_OFFSET: u64 = 0x01B2_1DD2_1381_4000;
+
+/// Mint a globally-unique, **Accord-ordered** `list` cell path from the AGREED
+/// Accord execution timestamp `t` (never a coordinator-local wall clock).
+///
+/// Concurrent list appends must serialize by the Accord total order
+/// `(time, seq, node)` on read, and must never collide on one path (which would
+/// silently drop an element). This encodes:
+///   - **time field** ← `t.time` (HLC nanos): primary order, respects real-time.
+///   - **clock_seq**  ← `element_seq`: order of elements within one append.
+///   - **node field** ← `t.seq` (bytes 10..14) then `t.node` low 16 bits
+///     (14..16): the Accord secondary order `(seq, node)` — a deterministic
+///     tiebreak for concurrent same-`time` appends AND global uniqueness across
+///     coordinators.
+///
+/// The read-assembly orders list cells by `(time, clock_seq, node-bytes)`, so
+/// the assembled order equals the Accord order `(time, element_seq, seq, node)`.
+/// Legacy coordinator-clock paths (`node = 0`) sort unchanged. The bytes are a
+/// valid v1 TimeUUID (Cassandra layout).
+pub fn accord_list_cell_path(t: &crate::accord::Timestamp, element_seq: u16) -> Vec<u8> {
+    let uuid_ts = t.time.wrapping_add(UUID_EPOCH_OFFSET);
+    let time_low = (uuid_ts & 0xFFFF_FFFF) as u32;
+    let time_mid = ((uuid_ts >> 32) & 0xFFFF) as u16;
+    let time_hi = ((uuid_ts >> 48) & 0x0FFF) as u16 | 0x1000; // version 1
+    let clock_seq = (element_seq & 0x3FFF) | 0x8000; // variant 1
+    let mut b = [0u8; 16];
+    b[0..4].copy_from_slice(&time_low.to_be_bytes());
+    b[4..6].copy_from_slice(&time_mid.to_be_bytes());
+    b[6..8].copy_from_slice(&time_hi.to_be_bytes());
+    b[8..10].copy_from_slice(&clock_seq.to_be_bytes());
+    b[10..14].copy_from_slice(&t.seq.to_be_bytes());
+    b[14..16].copy_from_slice(&((t.node & 0xFFFF) as u16).to_be_bytes());
+    b.to_vec()
+}
+
+/// Extract the element-seq (the v1 TimeUUID's low-14-bit clock_seq) from a
+/// 16-byte list cell path. This is the `element_seq` an [`accord_list_cell_path`]
+/// (or the legacy coordinator-clock `list_cell_path`) baked in — the apply-time
+/// rebind recovers it from the pre-consensus path so the rebound path preserves
+/// the element's within-append order. Returns `None` if `path` is not 16 bytes.
+pub fn list_path_element_seq(path: &[u8]) -> Option<u16> {
+    if path.len() != 16 {
+        return None;
+    }
+    Some(u16::from_be_bytes([path[8], path[9]]) & 0x3FFF)
+}
+
+#[cfg(test)]
+mod accord_list_path_tests {
+    use super::*;
+    use crate::accord::Timestamp;
+
+    fn ts(time: u64, seq: u32, node: u64) -> Timestamp {
+        Timestamp {
+            epoch: 0,
+            time,
+            seq,
+            node,
+        }
+    }
+
+    /// The minted path is a valid 16-byte v1 TimeUUID and its element-seq round-
+    /// trips through [`list_path_element_seq`].
+    #[test]
+    fn accord_list_path_is_v1_timeuuid_and_seq_round_trips() {
+        let p = accord_list_cell_path(&ts(12_345, 7, 3), 42);
+        assert_eq!(p.len(), 16);
+        assert_eq!(p[6] & 0xF0, 0x10, "version 1");
+        assert_eq!(p[8] & 0xC0, 0x80, "variant 1 (10xx)");
+        assert_eq!(list_path_element_seq(&p), Some(42));
+    }
+
+    /// Distinct Accord `(time, seq, node)` or element index → distinct paths, so
+    /// no concurrent append is silently lost to a path collision.
+    #[test]
+    fn distinct_coordinates_give_distinct_paths() {
+        let paths = [
+            accord_list_cell_path(&ts(100, 0, 1), 0),
+            accord_list_cell_path(&ts(100, 1, 1), 0), // +seq
+            accord_list_cell_path(&ts(100, 0, 2), 0), // +node
+            accord_list_cell_path(&ts(100, 0, 1), 1), // +element index
+        ];
+        let unique: std::collections::HashSet<Vec<u8>> = paths.iter().cloned().collect();
+        assert_eq!(unique.len(), 4);
+    }
+
+    #[test]
+    fn list_path_element_seq_rejects_non_16_byte() {
+        assert_eq!(list_path_element_seq(&[0u8; 8]), None);
+        assert_eq!(list_path_element_seq(&[]), None);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ferrosa-common/src/lib.rs
+++ b/ferrosa-common/src/lib.rs
@@ -32,7 +32,8 @@ pub use accord::{
 };
 pub use cell::{CellValue, Timestamp, NO_DELETION_TIME, NO_TIMESTAMP, NO_TTL};
 pub use complex_cell::{
-    reconcile, CellPath, ComplexColumn, CounterCell, CounterShard, CounterShardId,
+    accord_list_cell_path, list_path_element_seq, reconcile, CellPath, ComplexColumn, CounterCell,
+    CounterShard, CounterShardId,
 };
 pub use cql_type::{CqlType, CqlValue};
 pub use data_type::DataType;

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -7229,7 +7229,50 @@ async fn route_update(
 
     // Build cells from SET assignments
     let mut regular_cells: Vec<(u16, CqlValue)> = Vec::new();
+    // CRDT per-element collection cells (D-write, t_83c4f093): commutative ops
+    // emit read-free per-element cells and converge instead of LWW-clobbering the
+    // whole collection. Same read cost as before (the RMW read below is untouched);
+    // read elimination for pure-commutative updates is a later optimization.
+    let mut complex_cells: Vec<(u16, ferrosa_common::CellValue)> = Vec::new();
     for assignment in &s.assignments {
+        // Commutative collection ops (list append, set add/remove, map put,
+        // map-key remove) become per-element cells and skip the whole-value RMW.
+        // Ops that need a read (counter, list remove-by-value, positional) build
+        // nothing here and fall through to the RMW match below.
+        if let Assignment::Add { column, value } | Assignment::Sub { column, value } = assignment {
+            let col_meta = table_meta
+                .columns
+                .get(column)
+                .ok_or_else(|| CqlError::Invalid(format!("unknown column: {}", column)))?;
+            let cql_type = resolve_col_type(&col_meta.column_type, ks, &state.schema)?;
+            let is_add = matches!(assignment, Assignment::Add { .. });
+            let op = if is_add {
+                crate::collection_cells::CollectionOp::Add
+            } else {
+                crate::collection_cells::CollectionOp::Sub
+            };
+            // A Sub on a map removes keys given as a set; other ops use the column type.
+            let rhs_type = match (&cql_type, is_add) {
+                (CqlType::Map(k, _), false) => CqlType::Set(k.clone()),
+                _ => cql_type.clone(),
+            };
+            if let Ok(rhs) = bridge::term_to_cql_value(value, &rhs_type) {
+                if let Ok(cells) =
+                    crate::collection_cells::build_collection_cells(op, &rhs, timestamp)
+                {
+                    let col_idx = table_meta.storage_column_index(column).ok_or_else(|| {
+                        CqlError::Invalid(format!(
+                            "column '{}' not found in storage schema",
+                            column
+                        ))
+                    })?;
+                    for c in cells {
+                        complex_cells.push((col_idx, c));
+                    }
+                    continue;
+                }
+            }
+        }
         let (col_name, value) = match assignment {
             Assignment::Simple { column, value } => {
                 let col_meta = table_meta
@@ -7375,12 +7418,16 @@ async fn route_update(
         regular_cells.push((col_idx, value));
     }
 
-    let row = bridge::build_row(
+    let mut row = bridge::build_row(
         &regular_cells,
         &ck_values,
         timestamp,
         using_ttl_as_i32(&s.using_ttl)?,
     );
+    if !complex_cells.is_empty() {
+        row.cells.extend(complex_cells);
+        row.cells.sort_by_key(|(idx, _)| *idx);
+    }
     let strategy = keyspace_strategy(&state.schema, ks);
 
     state

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1614,16 +1614,26 @@ fn build_lwt_mutation(
             .as_micros() as i64)
     };
 
-    let (table_id, key, row, ts) = match stmt {
-        Statement::Insert(s) => materialize_insert(state, ctx, s, now_micros()?)?,
+    let (table_id, key, mut row, ts, list_append_cols) = match stmt {
+        Statement::Insert(s) => {
+            let (t, k, r, ts) = materialize_insert(state, ctx, s, now_micros()?)?;
+            (t, k, r, ts, Vec::new())
+        }
         Statement::Update(s) => materialize_update(state, ctx, s, now_micros()?)?,
-        Statement::Delete(s) => materialize_delete(state, ctx, s, now_micros()?)?,
+        Statement::Delete(s) => {
+            let (t, k, r, ts) = materialize_delete(state, ctx, s, now_micros()?)?;
+            (t, k, r, ts, Vec::new())
+        }
         _ => {
             return Err(CqlError::Invalid(
                 "LWT via Accord supports only INSERT/UPDATE/DELETE statements".into(),
             ));
         }
     };
+
+    // Accord write path: flag list-append cells so apply rebinds their paths to
+    // the agreed execution ts (t_68f226b5).
+    flag_accord_list_append_cells(&mut row, &list_append_cols);
 
     let key_bytes = key.key.as_bytes().to_vec();
 
@@ -1658,16 +1668,26 @@ fn build_transaction_write(
             .as_micros() as i64)
     };
 
-    let (table_id, key, row, ts) = match stmt {
-        Statement::Insert(s) => materialize_insert(state, ctx, s, now_micros()?)?,
+    let (table_id, key, mut row, ts, list_append_cols) = match stmt {
+        Statement::Insert(s) => {
+            let (t, k, r, ts) = materialize_insert(state, ctx, s, now_micros()?)?;
+            (t, k, r, ts, Vec::new())
+        }
         Statement::Update(s) => materialize_update(state, ctx, s, now_micros()?)?,
-        Statement::Delete(s) => materialize_delete(state, ctx, s, now_micros()?)?,
+        Statement::Delete(s) => {
+            let (t, k, r, ts) = materialize_delete(state, ctx, s, now_micros()?)?;
+            (t, k, r, ts, Vec::new())
+        }
         _ => {
             return Err(CqlError::Invalid(
                 "only INSERT/UPDATE/DELETE may be buffered in a transaction".into(),
             ));
         }
     };
+
+    // Accord write path: flag list-append cells so apply rebinds their paths to
+    // the agreed execution ts (t_68f226b5).
+    flag_accord_list_append_cells(&mut row, &list_append_cols);
 
     let keyspace = table_id.keyspace.clone();
     let key_bytes = key.key.as_bytes().to_vec();
@@ -7715,7 +7735,11 @@ async fn route_logged_batch(
                 ));
             }
             Statement::Update(s) => {
-                let (table_id, key, row, ts) = materialize_update(state, ctx, s, batch_timestamp)?;
+                // Logged batches are NOT Accord transactions — their list elements
+                // order by the coordinator wall clock (Cassandra LWW semantics), so
+                // the list-append rebind columns are intentionally ignored here.
+                let (table_id, key, row, ts, _list_append_cols) =
+                    materialize_update(state, ctx, s, batch_timestamp)?;
                 mutations.push(Mutation::new(
                     table_id.keyspace.clone(),
                     table_id.table.clone(),
@@ -7839,6 +7863,14 @@ fn materialize_insert(
 
 /// Materialize an UPDATE statement into its key, row, and table ID without
 /// writing. Used by `route_logged_batch()` to collect mutations.
+/// Materialize an UPDATE into `(table_id, key, row, timestamp, list_append_cols)`.
+///
+/// `list_append_cols` are the storage column indices of any non-frozen `list`
+/// append cells built here (`v = v + [..]`). They order by a cell path that the
+/// Accord write path must **rebind** to the agreed execution timestamp at apply
+/// (t_68f226b5) — so the Accord-txn builders flag exactly these columns and the
+/// AP/logged-batch path (which keeps Cassandra coordinator-clock LWW ordering)
+/// ignores them. `set`/`map` cells are order-independent and never listed.
 fn materialize_update(
     state: &SharedState,
     ctx: &RequestContext<'_>,
@@ -7850,6 +7882,7 @@ fn materialize_update(
         ferrosa_common::DecoratedKey,
         ferrosa_sstable::types::Row,
         i64,
+        Vec<u16>,
     ),
     CqlError,
 > {
@@ -7908,6 +7941,9 @@ fn materialize_update(
     // by distinct cell paths. `Row.cells` is a `Vec<(u16, CellValue)>`, which
     // already carries multiple path-keyed cells per column.
     let mut complex_cells: Vec<(u16, ferrosa_common::CellValue)> = Vec::new();
+    // Storage indices of `list` append columns whose per-element cell paths must
+    // be rebound to the Accord execution ts at apply (t_68f226b5).
+    let mut list_append_cols: Vec<u16> = Vec::new();
     for assignment in &s.assignments {
         match assignment {
             Assignment::Simple { column, value } => {
@@ -7948,6 +7984,15 @@ fn materialize_update(
                 let col_idx = table_meta.storage_column_index(column).ok_or_else(|| {
                     CqlError::Invalid(format!("column '{}' not found in storage schema", column))
                 })?;
+                // A `list` append (`v = v + [..]`) builds order-sensitive per-element
+                // cells whose path encodes the write time; the Accord path must
+                // rebind that path to the agreed execution ts at apply. Set/map ops
+                // are order-independent, so they are not flagged.
+                if matches!(op, crate::collection_cells::CollectionOp::Add)
+                    && matches!(rhs, CqlValue::List(_))
+                {
+                    list_append_cols.push(col_idx);
+                }
                 for c in cells {
                     complex_cells.push((col_idx, c));
                 }
@@ -7980,7 +8025,28 @@ fn materialize_update(
     }
     let table_id = TableId::new(ks, &s.table);
 
-    Ok((table_id, decorated_key, row, timestamp))
+    Ok((table_id, decorated_key, row, timestamp, list_append_cols))
+}
+
+/// Set the transient Accord list-path rebind flag on `row`'s list-append cells —
+/// those whose (clean) storage column index is in `list_append_cols`. The replica
+/// apply phase rebinds these cells' paths to the agreed execution timestamp
+/// (t_68f226b5); the flag is stripped at decode and never reaches the SSTable.
+///
+/// Only the Accord write path (`build_transaction_write` / `build_lwt_mutation`)
+/// calls this. The AP and logged-batch paths deliberately do NOT — their list
+/// elements order by the coordinator wall clock (Cassandra LWW semantics), which
+/// is correct for non-transactional writes.
+fn flag_accord_list_append_cells(row: &mut ferrosa_sstable::types::Row, list_append_cols: &[u16]) {
+    if list_append_cols.is_empty() {
+        return;
+    }
+    for (idx, cell) in &mut row.cells {
+        let clean = *idx;
+        if cell.path.is_some() && list_append_cols.contains(&clean) {
+            *idx |= ferrosa_storage::CELL_REBIND_LIST_PATH_FLAG;
+        }
+    }
 }
 
 /// Materialize a DELETE statement into its key, row, and table ID without
@@ -13899,8 +13965,14 @@ mod tests {
         else {
             panic!("expected UPDATE");
         };
-        let (_tid, _dk, row, _ts) = materialize_update(&state, &ctx, &append, 123)
-            .expect("collection append must materialize per-element cells in a transaction");
+        let (_tid, _dk, row, _ts, list_append_cols) =
+            materialize_update(&state, &ctx, &append, 123)
+                .expect("collection append must materialize per-element cells in a transaction");
+        assert_eq!(
+            list_append_cols.len(),
+            1,
+            "a list append reports exactly its column for Accord rebind"
+        );
         let elem_cells: Vec<_> = row.cells.iter().filter(|(_, c)| c.path.is_some()).collect();
         assert_eq!(
             elem_cells.len(),
@@ -13934,6 +14006,88 @@ mod tests {
         assert!(
             materialize_update(&state, &ctx, &remove, 123).is_err(),
             "list remove-by-value needs a read — must stay fail-loud in a transaction"
+        );
+    }
+
+    /// The Accord transaction write path flags a `list` append cell so the replica
+    /// rebinds its path to the agreed execution ts at apply (t_68f226b5); an
+    /// order-independent `set` add is NOT flagged (rebinding it would be wrong and
+    /// would fail loud on its non-TimeUUID element path).
+    #[tokio::test]
+    async fn accord_txn_write_flags_list_append_for_rebind() {
+        use ferrosa_storage::Mutation;
+
+        let (state, _dir) = setup();
+        let ctx = RequestContext {
+            auth: &dev_auth(),
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+            protocol_version: 4,
+        };
+        for ddl in [
+            "CREATE KEYSPACE ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE ks.t (k int PRIMARY KEY, s int, se set<int>, v list<int>)",
+        ] {
+            route(&state, &ctx, crate::parser::parse(ddl).unwrap())
+                .await
+                .unwrap();
+        }
+
+        let t = ferrosa_common::accord::Timestamp {
+            epoch: 0,
+            time: 424_242,
+            seq: 3,
+            node: 5,
+        };
+
+        // A `list` append: the flag makes the apply-side rebind rewrite the cell
+        // path to `accord_list_cell_path(t, 0)`; a plain decode keeps the
+        // coordinator-clock path. The difference proves the flag was set.
+        let append = crate::parser::parse("UPDATE ks.t SET v = v + [7] WHERE k = 1").unwrap();
+        let w = build_transaction_write(&state, &ctx, &append).unwrap();
+        let rebound = Mutation::deserialize_from_rebinding_list_paths(&w.mutation, t).unwrap();
+        let plain = Mutation::deserialize_from(&w.mutation).unwrap();
+        let (_, list_rebound) = rebound.rows[0]
+            .cells
+            .iter()
+            .find(|(_, c)| c.path.is_some())
+            .expect("list append cell");
+        assert_eq!(
+            list_rebound.path.as_deref(),
+            Some(ferrosa_common::accord_list_cell_path(&t, 0).as_slice()),
+            "flagged list cell rebinds to the Accord execution ts at apply"
+        );
+        let (_, list_plain) = plain.rows[0]
+            .cells
+            .iter()
+            .find(|(_, c)| c.path.is_some())
+            .unwrap();
+        assert_ne!(
+            list_plain.path, list_rebound.path,
+            "the rebind flag is what triggers the rewrite (plain decode keeps the coord path)"
+        );
+
+        // A `set` add must NOT be flagged: rebinding decode leaves its element
+        // path exactly as a plain decode does (and would fail loud if flagged,
+        // since a set<int> element path is not a 16-byte TimeUUID).
+        let set_add = crate::parser::parse("UPDATE ks.t SET se = se + {9} WHERE k = 1").unwrap();
+        let w = build_transaction_write(&state, &ctx, &set_add).unwrap();
+        let set_rebound = Mutation::deserialize_from_rebinding_list_paths(&w.mutation, t).unwrap();
+        let set_plain = Mutation::deserialize_from(&w.mutation).unwrap();
+        let path_of = |m: &Mutation| {
+            m.rows[0]
+                .cells
+                .iter()
+                .find(|(_, c)| c.path.is_some())
+                .and_then(|(_, c)| c.path.clone())
+        };
+        assert_eq!(
+            path_of(&set_rebound),
+            path_of(&set_plain),
+            "a set element path is order-independent — never flagged for rebind"
         );
     }
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -7854,8 +7854,15 @@ fn materialize_update(
     }
 
     let mut regular_cells: Vec<(u16, CqlValue)> = Vec::new();
+    // CRDT per-element collection cells (D-write, t_83c4f093). A commutative
+    // collection op (list append, set add/remove, map put) emits one read-free
+    // cell per element — many cells sharing a column index, keyed by path. No
+    // read-modify-write, so concurrent appends commute and Accord serializes them
+    // by distinct cell paths. `Row.cells` is a `Vec<(u16, CellValue)>`, which
+    // already carries multiple path-keyed cells per column.
+    let mut complex_cells: Vec<(u16, ferrosa_common::CellValue)> = Vec::new();
     for assignment in &s.assignments {
-        let (col_name, value) = match assignment {
+        match assignment {
             Assignment::Simple { column, value } => {
                 let col_meta = table_meta
                     .columns
@@ -7863,44 +7870,67 @@ fn materialize_update(
                     .ok_or_else(|| CqlError::Invalid(format!("unknown column: {}", column)))?;
                 let cql_type = resolve_col_type(&col_meta.column_type, ks, &state.schema)?;
                 let val = bridge::term_to_cql_value(value, &cql_type)?;
-                (column.as_str(), val)
+                let col_idx = table_meta.storage_column_index(column).ok_or_else(|| {
+                    CqlError::Invalid(format!("column '{}' not found in storage schema", column))
+                })?;
+                regular_cells.push((col_idx, val));
             }
-            Assignment::Add { column, .. }
-            | Assignment::Sub { column, .. }
-            | Assignment::Element { column, .. } => {
-                // Collection append/subtract (`v = v + [..]`), counter
-                // increment, and map/list element assignment are a
-                // read-modify-write. The plain `route_update` path performs that
-                // RMW, but it is NEVER invoked for a `BEGIN…COMMIT` transaction
-                // (or a logged batch) — those materialize here. Silently skipping
-                // the assignment (the previous behavior) committed a bare row
-                // marker with no cell for the column, dropping the write with no
-                // signal: an Accord `UPDATE v = v + [x]` read back empty.
-                //
-                // FAIL LOUD rather than lose data. Correct transactional support
-                // requires carrying the delta and applying the RMW at commit/apply
-                // time (t_83c4f093); until then, reject it.
+            Assignment::Add { column, value } | Assignment::Sub { column, value } => {
+                let col_meta = table_meta
+                    .columns
+                    .get(column)
+                    .ok_or_else(|| CqlError::Invalid(format!("unknown column: {}", column)))?;
+                let cql_type = resolve_col_type(&col_meta.column_type, ks, &state.schema)?;
+                let op = if matches!(assignment, Assignment::Add { .. }) {
+                    crate::collection_cells::CollectionOp::Add
+                } else {
+                    crate::collection_cells::CollectionOp::Sub
+                };
+                let rhs = bridge::term_to_cql_value(value, &cql_type)?;
+                // Commutative ops build per-element cells; ops that inherently need
+                // a read (list remove-by-value, positional index, counter, map-sub)
+                // return `Unsupported` and stay fail-loud rather than silently drop.
+                let cells = crate::collection_cells::build_collection_cells(op, &rhs, timestamp)
+                    .map_err(|e| {
+                        CqlError::Invalid(format!(
+                            "column '{column}': {} — not supported inside a transaction \
+                             (BEGIN…COMMIT) or logged batch; use a non-transactional UPDATE",
+                            e.reason
+                        ))
+                    })?;
+                let col_idx = table_meta.storage_column_index(column).ok_or_else(|| {
+                    CqlError::Invalid(format!("column '{}' not found in storage schema", column))
+                })?;
+                for c in cells {
+                    complex_cells.push((col_idx, c));
+                }
+            }
+            Assignment::Element { column, .. } => {
+                // `m[k] = v` / `l[i] = v`. Map-put by key is a per-element cell, but
+                // list index-set needs a read; keep the whole element form fail-loud
+                // in a transaction until it is handled explicitly.
                 return Err(CqlError::Invalid(format!(
-                    "column '{column}': collection append/subtract, counter, and \
-                     element updates are not yet supported inside a transaction \
-                     (BEGIN…COMMIT) or logged batch — the write would be silently \
-                     dropped. Use a non-transactional UPDATE."
+                    "column '{column}': element/positional updates (m[k]=v, l[i]=v) are \
+                     not yet supported inside a transaction (BEGIN…COMMIT) or logged \
+                     batch. Use a non-transactional UPDATE."
                 )));
             }
-        };
-        let col_idx = table_meta.storage_column_index(col_name).ok_or_else(|| {
-            CqlError::Invalid(format!("column '{}' not found in storage schema", col_name))
-        })?;
-        regular_cells.push((col_idx, value));
+        }
     }
 
     let decorated_key = bridge::build_decorated_key(&pk_values, &pk_types)?;
-    let row = bridge::build_row(
+    let mut row = bridge::build_row(
         &regular_cells,
         &ck_values,
         timestamp,
         using_ttl_as_i32(&s.using_ttl)?,
     );
+    if !complex_cells.is_empty() {
+        row.cells.extend(complex_cells);
+        // Keep cells grouped by column index (per-element cells within a column
+        // keep insertion order — a stable sort — and are re-ordered by path on read).
+        row.cells.sort_by_key(|(idx, _)| *idx);
+    }
     let table_id = TableId::new(ks, &s.table);
 
     Ok((table_id, decorated_key, row, timestamp))
@@ -13789,13 +13819,13 @@ mod tests {
         );
     }
 
-    /// A collection append/counter update inside a transaction (or logged batch)
-    /// materializes via `materialize_update`, which cannot yet perform the
-    /// read-modify-write. It must FAIL LOUD rather than silently drop the mutation
-    /// (which committed an empty write — an Accord `v = v + [x]` read back empty).
-    /// A scalar assignment on the same path still materializes fine.
+    /// A commutative collection op inside a transaction (or logged batch)
+    /// materializes via `materialize_update` as read-free per-element cells (CRDT
+    /// D-write, t_83c4f093) — an Accord `v = v + [x]` now commits the appended
+    /// element instead of failing loud. Ops that inherently need a read
+    /// (list remove-by-value) stay fail-loud rather than silently dropping.
     #[tokio::test]
-    async fn transaction_collection_append_fails_loud_not_silent_drop() {
+    async fn transaction_collection_append_materializes_per_element_cells() {
         let (state, _dir) = setup();
         let ctx = RequestContext {
             auth: &dev_auth(),
@@ -13815,15 +13845,25 @@ mod tests {
                 .unwrap();
         }
 
-        // Collection append must fail loud (was: silent drop -> empty write).
+        // List append now materializes one read-free per-element cell (path set,
+        // value = the appended element), not a fail-loud reject.
         let Statement::Update(append) =
             crate::parser::parse("UPDATE ks.t SET v = v + [7] WHERE k = 1").unwrap()
         else {
             panic!("expected UPDATE");
         };
-        assert!(
-            materialize_update(&state, &ctx, &append, 123).is_err(),
-            "collection append in a transaction/batch must fail loud, not silently drop the write"
+        let (_tid, _dk, row, _ts) = materialize_update(&state, &ctx, &append, 123)
+            .expect("collection append must materialize per-element cells in a transaction");
+        let elem_cells: Vec<_> = row.cells.iter().filter(|(_, c)| c.path.is_some()).collect();
+        assert_eq!(
+            elem_cells.len(),
+            1,
+            "list append [7] materializes one per-element cell"
+        );
+        assert_eq!(
+            elem_cells[0].1.value.as_deref(),
+            Some(encode_value(&CqlValue::Int(7)).as_slice()),
+            "the element cell carries the appended value"
         );
 
         // A scalar assignment on the same materialization path still works.
@@ -13835,6 +13875,18 @@ mod tests {
         assert!(
             materialize_update(&state, &ctx, &scalar, 123).is_ok(),
             "a scalar UPDATE must still materialize in a transaction"
+        );
+
+        // list remove-by-value (`v = v - [x]`) inherently needs a read — it must
+        // stay fail-loud, never silently drop.
+        let Statement::Update(remove) =
+            crate::parser::parse("UPDATE ks.t SET v = v - [7] WHERE k = 1").unwrap()
+        else {
+            panic!("expected UPDATE");
+        };
+        assert!(
+            materialize_update(&state, &ctx, &remove, 123).is_err(),
+            "list remove-by-value needs a read — must stay fail-loud in a transaction"
         );
     }
 

--- a/ferrosa-jepsen/elle-checker/README.md
+++ b/ferrosa-jepsen/elle-checker/README.md
@@ -1,0 +1,49 @@
+# ferrosa-elle-check
+
+Standalone [Elle](https://github.com/jepsen-io/elle) strict-serializability
+checker for Ferrosa's Accord transactions (t_d7ffb5b7).
+
+Isolated from the main `../jepsen` harness so it depends **only** on `jepsen`
+(which bundles Elle) — avoiding that project's CQL-driver deps (`alia`/`hayt`).
+
+## Pipeline
+
+1. **Generate** a history against a running cluster (RF ≥ 3 so reads route
+   through Accord) with the Rust generator:
+
+   ```bash
+   cargo run -p ferrosa-jepsen --example elle_list_append -- \
+     <host:port> <out.edn> [keys] [ops-per-worker] [workers] [rf]
+   ```
+
+   Each op is `append(k,v)` = `BEGIN; UPDATE la SET v = v + [v] WHERE k=?; COMMIT`
+   (unique `v`) or `read(k)` = `SELECT v ... WHERE k=?` at **SERIAL**. Outcome
+   classification is sound: a failed `BEGIN`/`UPDATE` is `:fail` (definitely not
+   applied); a failed/timed-out `COMMIT` is `:info` (indeterminate — never
+   `:fail`, so a write that did land can't masquerade as a failed op).
+
+2. **Check** the history for strict-serializability violations:
+
+   ```bash
+   lein run <history.edn> [out-dir]
+   ```
+
+   Prints `valid?` and `anomaly-types`. Exit `0` **only** on a definitive
+   `:valid? true`; `false` (real violation) and `:unknown` (indeterminate, e.g.
+   too many `:info` ops) both exit non-zero (fail-loud). Pass an `out-dir` to
+   render anomaly graphs — this requires `graphviz` (`dot`) and `gnuplot`;
+   without a dir the verdict is reported with no external-tool dependency.
+
+## Validated
+
+- Known-valid history → `valid? true`.
+- Known-invalid history (append 1,2 then read `[2 1]`) → `valid? false`,
+  `anomaly-types (:G0-realtime)`.
+
+## Certification note
+
+A meaningful verdict requires a cluster running a build that includes the Accord
+fixes (read-visibility PR #281; FileSyncWriter-dir quorum fix `fb6a6ef9`). A
+stale build surfaces `Accord quorum unavailable` COMMITs (indeterminate) and Elle
+reports cycles from the degraded run — that is a broken *cluster*, not a checker
+result.

--- a/ferrosa-jepsen/elle-checker/project.clj
+++ b/ferrosa-jepsen/elle-checker/project.clj
@@ -1,0 +1,9 @@
+(defproject ferrosa-elle-check "0.1.0"
+  :description "Standalone Elle strict-serializability checker for the Ferrosa
+                Accord list-append history EDN (t_d7ffb5b7). Isolated from the
+                main jepsen harness so it depends only on jepsen (which bundles
+                Elle), avoiding that project's unrelated CQL-driver deps."
+  :license {:name "Apache-2.0"}
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [jepsen "0.3.6"]]
+  :main ferrosa.elle-check)

--- a/ferrosa-jepsen/elle-checker/src/ferrosa/elle_check.clj
+++ b/ferrosa-jepsen/elle-checker/src/ferrosa/elle_check.clj
@@ -1,0 +1,48 @@
+(ns ferrosa.elle-check
+  "Standalone Elle strict-serializability check over a `list-append` history
+   EDN produced by the Rust `elle_list_append` generator (t_d7ffb5b7).
+
+   The generator writes Elle-native ops:
+     {:process P :type :invoke|:ok|:info|:fail :f :txn
+      :value [[:append k v]] | [[:r k [v ...]]]}
+   We index/pair them into a jepsen history and run
+   `elle.list-append/check` under the :strict-serializable model — the
+   consistency Accord claims to provide.
+
+   Usage: lein run -m ferrosa.elle-check <history.edn> [out-dir]"
+  (:require [clojure.edn :as edn]
+            [jepsen.history :as history]
+            [elle.list-append :as la])
+  (:gen-class))
+
+(defn -main
+  [& args]
+  (let [path    (or (first args) "elle-history.edn")
+        ;; A directory triggers Elle's graphviz/gnuplot rendering of anomaly
+        ;; graphs. Those external tools are optional; only pass a directory when
+        ;; the caller explicitly asks (2nd arg), so the verdict is always
+        ;; reported even without `dot`/`gnuplot` installed.
+        out-dir (second args)
+        raw     (edn/read-string (slurp path))
+        h       (history/history raw)
+        opts    (cond-> {:consistency-models [:strict-serializable]}
+                  out-dir (assoc :directory out-dir))
+        res     (la/check opts h)
+        valid   (:valid? res)]
+    (println "=== Elle list-append / strict-serializable ===")
+    (println "history:" path)
+    (println "ops:" (count raw))
+    (println "valid?" valid)
+    (println "anomaly-types:" (:anomaly-types res))
+    (when (seq (:anomaly-types res))
+      (println "anomaly counts:"
+               (into (sorted-map)
+                     (map (fn [[k v]] [k (if (coll? v) (count v) v)])
+                          (:anomalies res)))))
+    (println "output dir:" out-dir)
+    (flush)
+    (shutdown-agents)
+    ;; Exit 0 ONLY on a definitive :valid? true. false = real violation;
+    ;; :unknown = indeterminate (e.g. too many :info ops) — both non-zero so
+    ;; CI can't mistake an unproven run for a pass (fail-loud).
+    (System/exit (if (true? valid) 0 1))))

--- a/ferrosa-jepsen/elle-checker/src/ferrosa/elle_check.clj
+++ b/ferrosa-jepsen/elle-checker/src/ferrosa/elle_check.clj
@@ -40,6 +40,12 @@
                      (map (fn [[k v]] [k (if (coll? v) (count v) v)])
                           (:anomalies res)))))
     (println "output dir:" out-dir)
+    ;; Dump the raw anomalies next to the history so a post-pass can cross-
+    ;; reference the cycle transactions against :info (indeterminate) ops — is a
+    ;; residual anomaly a real :ok/:ok violation, or :info-tainted noise?
+    (let [dump (str path ".anomalies.edn")]
+      (spit dump (pr-str (:anomalies res)))
+      (println "anomalies dumped:" dump))
     (flush)
     (shutdown-agents)
     ;; Exit 0 ONLY on a definitive :valid? true. false = real violation;

--- a/ferrosa-jepsen/examples/elle_list_append.rs
+++ b/ferrosa-jepsen/examples/elle_list_append.rs
@@ -1,0 +1,273 @@
+//! Elle `list-append` history generator for the Accord strict-serializability
+//! validation (t_d7ffb5b7).
+//!
+//! Model: each list is a `list<int>` column (order-preserving).
+//! - **append(k, v)** = `BEGIN TRANSACTION; UPDATE la SET v = v + [v] WHERE k=?;
+//!   COMMIT` — an Accord-serialized write. `v` is globally unique so Elle can
+//!   recover the per-key version order.
+//! - **read(k)** = `SELECT v FROM la WHERE k=?` at **SERIAL** consistency — a
+//!   linearizable read routed through Accord (cluster mode). Returns the list in
+//!   append order.
+//!
+//! Concurrent workers share one pinned coordinator (so each `BEGIN…COMMIT` is
+//! atomic on one connection); concurrency comes from many client tasks. Each op
+//! logs an `:invoke` before and an `:ok`/`:fail` after into a shared, time-
+//! ordered history, which is written as Elle-compatible EDN.
+//!
+//! Usage: cargo run -p ferrosa-jepsen --example elle_list_append -- <host:port> <out.edn> [keys] [ops-per-worker] [workers]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use scylla::client::execution_profile::ExecutionProfile;
+use scylla::client::session::Session;
+use scylla::client::session_builder::SessionBuilder;
+use scylla::client::PoolSize;
+use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
+use scylla::statement::{Consistency, Statement};
+use scylla::value::{CqlValue, Row};
+
+/// A single Elle history event (already rendered to EDN by `edn`).
+struct Event(String);
+
+fn edn_txn(process: u64, kind: &str, f: &str, value: &str) -> Event {
+    Event(format!(
+        "{{:process {process} :type {kind} :f {f} :value {value}}}"
+    ))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let contact = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "127.0.0.1:9042".into());
+    let out_path = args
+        .get(2)
+        .cloned()
+        .unwrap_or_else(|| "elle-history.edn".into());
+    let keys: i32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(8);
+    let ops_per_worker: u64 = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(200);
+    let workers: u64 = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(6);
+    let rf: u32 = args.get(6).and_then(|s| s.parse().ok()).unwrap_or(3);
+
+    // Probe once to learn the coordinator node to pin to. Each worker then builds
+    // its OWN pinned session (one connection) so that a BEGIN…COMMIT is atomic on
+    // that worker's connection AND concurrent workers don't interleave their
+    // transactions on a shared connection (the server buffers a transaction per
+    // connection — a shared connection yields "nested transactions").
+    let probe = SessionBuilder::new()
+        .known_nodes([&contact])
+        .build()
+        .await?;
+    let target = probe
+        .get_cluster_state()
+        .get_nodes_info()
+        .iter()
+        .min_by_key(|n| n.host_id)
+        .cloned()
+        .context("no known nodes")?;
+    drop(probe);
+
+    let session = Arc::new(connect_pinned(&contact, &target).await?);
+
+    // Fresh schema. RF=3 so cluster mode is active and reads route through Accord.
+    session
+        .query_unpaged("DROP KEYSPACE IF EXISTS elle", &[])
+        .await
+        .ok();
+    session
+        .query_unpaged(
+            format!("CREATE KEYSPACE elle WITH replication = {{'class':'SimpleStrategy','replication_factor':{rf}}}"),
+            &[],
+        )
+        .await?;
+    session
+        .query_unpaged("CREATE TABLE elle.la (k int PRIMARY KEY, v list<int>)", &[])
+        .await?;
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    let history: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let next_val = Arc::new(AtomicU64::new(1));
+    let failures = Arc::new(AtomicU64::new(0));
+
+    let mut handles = Vec::new();
+    for w in 0..workers {
+        // Each worker gets its OWN pinned connection ⇒ its own transaction state.
+        let mut session = Arc::new(connect_pinned(&contact, &target).await?);
+        let history = history.clone();
+        let next_val = next_val.clone();
+        let failures = failures.clone();
+        let contact = contact.clone();
+        let target = target.clone();
+        handles.push(tokio::spawn(async move {
+            for i in 0..ops_per_worker {
+                // Deterministic-but-varied key/op choice per (worker, i) — no RNG
+                // (Math.random-style nondeterminism is avoided; index-derived).
+                let k =
+                    ((w.wrapping_mul(2_654_435_761) ^ i.wrapping_mul(40_503)) as i32 % keys).abs();
+                let is_append = (w + i) % 3 != 0; // ~2/3 appends, 1/3 reads
+                if is_append {
+                    let v = next_val.fetch_add(1, Ordering::SeqCst) as i64;
+                    log(
+                        &history,
+                        edn_txn(w, ":invoke", ":txn", &format!("[[:append {k} {v}]]")),
+                    );
+                    // BEGIN/UPDATE/COMMIT are three statements on the pinned conn.
+                    // Outcome classification is what makes the Elle history sound:
+                    //   - BEGIN or UPDATE fails  -> the txn definitely did NOT commit
+                    //     (nothing was applied): a clean :fail.
+                    //   - COMMIT fails/times out -> INDETERMINATE (the write may or
+                    //     may not have landed): :info, never :fail — logging it :fail
+                    //     would let a write that actually committed masquerade as a
+                    //     failed op and fabricate an Elle "aberrant read" violation.
+                    let upd = format!("UPDATE elle.la SET v = v + [{v}] WHERE k = {k}");
+                    let outcome = if let Err(e) = session
+                        .query_unpaged("BEGIN TRANSACTION".to_string(), &[])
+                        .await
+                    {
+                        Some((":fail", format!("BEGIN: {e}")))
+                    } else if let Err(e) = session.query_unpaged(upd.clone(), &[]).await {
+                        Some((":fail", format!("UPDATE: {e}")))
+                    } else if let Err(e) = session.query_unpaged("COMMIT".to_string(), &[]).await {
+                        Some((":info", format!("COMMIT: {e}")))
+                    } else {
+                        None
+                    };
+                    match outcome {
+                        None => {
+                            log(
+                                &history,
+                                edn_txn(w, ":ok", ":txn", &format!("[[:append {k} {v}]]")),
+                            );
+                        }
+                        Some((kind, why)) => {
+                            if failures.load(Ordering::Relaxed) < 3 {
+                                eprintln!("APPEND {kind} on {why}");
+                            }
+                            // Clear any half-open transaction on THIS connection so the
+                            // next BEGIN doesn't hit "nested transactions". ROLLBACK is
+                            // cheap and idempotent; only reconnect if it, too, fails.
+                            if session
+                                .query_unpaged("ROLLBACK".to_string(), &[])
+                                .await
+                                .is_err()
+                            {
+                                if let Ok(fresh) = connect_pinned(&contact, &target).await {
+                                    session = Arc::new(fresh);
+                                }
+                            }
+                            failures.fetch_add(1, Ordering::Relaxed);
+                            log(
+                                &history,
+                                edn_txn(w, kind, ":txn", &format!("[[:append {k} {v}]]")),
+                            );
+                        }
+                    }
+                } else {
+                    log(
+                        &history,
+                        edn_txn(w, ":invoke", ":txn", &format!("[[:r {k} nil]]")),
+                    );
+                    let mut read = Statement::new(format!("SELECT v FROM elle.la WHERE k = {k}"));
+                    read.set_consistency(Consistency::Serial);
+                    match session.query_unpaged(read, &[]).await {
+                        Ok(res) => {
+                            let list = res
+                                .into_rows_result()
+                                .ok()
+                                .and_then(|rr| {
+                                    rr.rows::<Row>()
+                                        .ok()
+                                        .and_then(|mut it| it.next().and_then(|r| r.ok()))
+                                })
+                                .map(|row| decode_int_list(row.columns.first()))
+                                .unwrap_or_default();
+                            let elems = list
+                                .iter()
+                                .map(|n| n.to_string())
+                                .collect::<Vec<_>>()
+                                .join(" ");
+                            log(
+                                &history,
+                                edn_txn(w, ":ok", ":txn", &format!("[[:r {k} [{elems}]]]")),
+                            );
+                        }
+                        Err(_) => {
+                            failures.fetch_add(1, Ordering::Relaxed);
+                            log(
+                                &history,
+                                edn_txn(w, ":fail", ":txn", &format!("[[:r {k} nil]]")),
+                            );
+                        }
+                    }
+                }
+            }
+        }));
+    }
+    for h in handles {
+        h.await.ok();
+    }
+
+    let hist = history.lock().unwrap();
+    let mut edn = String::from("[\n");
+    for e in hist.iter() {
+        edn.push(' ');
+        edn.push_str(&e.0);
+        edn.push('\n');
+    }
+    edn.push_str("]\n");
+    std::fs::write(&out_path, edn)?;
+    println!(
+        "wrote {} events to {out_path} ({} failures)",
+        hist.len(),
+        failures.load(Ordering::Relaxed)
+    );
+    Ok(())
+}
+
+/// Build a session with a single connection pinned to `target` (one connection ⇒
+/// one server-side transaction context), keeping the full topology connected so
+/// the coordinator can fan Accord out to the other replicas.
+async fn connect_pinned(contact: &str, target: &Arc<scylla::cluster::Node>) -> Result<Session> {
+    let profile = ExecutionProfile::builder()
+        .load_balancing_policy(SingleTargetLoadBalancingPolicy::new(
+            NodeIdentifier::Node(target.clone()),
+            None,
+        ))
+        // NO retries: the default retry policy can re-drive a timed-out statement
+        // on ANOTHER node, splitting a connection-stateful BEGIN/UPDATE/COMMIT
+        // across nodes ("COMMIT outside of a transaction" / "nested transactions").
+        // A transaction must run exactly once on its one pinned connection.
+        .retry_policy(Arc::new(scylla::policies::retry::FallthroughRetryPolicy))
+        // Generous per-request timeout so a slow Accord commit under load returns
+        // its real outcome instead of a client timeout that abandons the txn.
+        .request_timeout(Some(std::time::Duration::from_secs(30)))
+        .build();
+    Ok(SessionBuilder::new()
+        .known_nodes([contact])
+        .default_execution_profile_handle(profile.into_handle())
+        .pool_size(PoolSize::PerHost(std::num::NonZeroUsize::new(1).unwrap()))
+        .build()
+        .await?)
+}
+
+fn log(history: &Arc<Mutex<Vec<Event>>>, e: Event) {
+    history.lock().unwrap().push(e);
+}
+
+fn decode_int_list(col: Option<&Option<CqlValue>>) -> Vec<i64> {
+    match col {
+        Some(Some(CqlValue::List(items))) => items
+            .iter()
+            .filter_map(|v| match v {
+                CqlValue::Int(n) => Some(*n as i64),
+                CqlValue::BigInt(n) => Some(*n),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}

--- a/ferrosa-jepsen/examples/elle_list_append.rs
+++ b/ferrosa-jepsen/examples/elle_list_append.rs
@@ -92,6 +92,11 @@ async fn main() -> Result<()> {
     let history: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
     let next_val = Arc::new(AtomicU64::new(1));
     let failures = Arc::new(AtomicU64::new(0));
+    // Tally normalized BEGIN/UPDATE/COMMIT failure reasons so a run reports WHY
+    // ops went :fail/:info — the key to driving indeterminate commits down (the
+    // error text was previously only eprintln'd for the first 3 and lost).
+    let errors: Arc<Mutex<std::collections::BTreeMap<String, u64>>> =
+        Arc::new(Mutex::new(std::collections::BTreeMap::new()));
 
     let mut handles = Vec::new();
     for w in 0..workers {
@@ -100,6 +105,7 @@ async fn main() -> Result<()> {
         let history = history.clone();
         let next_val = next_val.clone();
         let failures = failures.clone();
+        let errors = errors.clone();
         let contact = contact.clone();
         let target = target.clone();
         handles.push(tokio::spawn(async move {
@@ -147,6 +153,11 @@ async fn main() -> Result<()> {
                             if failures.load(Ordering::Relaxed) < 3 {
                                 eprintln!("APPEND {kind} on {why}");
                             }
+                            *errors
+                                .lock()
+                                .unwrap()
+                                .entry(normalize_err(kind, &why))
+                                .or_insert(0) += 1;
                             // Clear any half-open transaction on THIS connection so the
                             // next BEGIN doesn't hit "nested transactions". ROLLBACK is
                             // cheap and idempotent; only reconnect if it, too, fails.
@@ -211,6 +222,20 @@ async fn main() -> Result<()> {
         h.await.ok();
     }
 
+    // Report WHY ops failed, most frequent first — the harness diagnostic that
+    // tells us whether :info is a real cluster failure mode or a client artifact.
+    {
+        let errs = errors.lock().unwrap();
+        if !errs.is_empty() {
+            let mut v: Vec<(&String, &u64)> = errs.iter().collect();
+            v.sort_by(|a, b| b.1.cmp(a.1));
+            eprintln!("=== failure reasons (normalized, most frequent first) ===");
+            for (reason, count) in v {
+                eprintln!("  {count:>5}  {reason}");
+            }
+        }
+    }
+
     let hist = history.lock().unwrap();
     let mut edn = String::from("[\n");
     for e in hist.iter() {
@@ -256,6 +281,22 @@ async fn connect_pinned(contact: &str, target: &Arc<scylla::cluster::Node>) -> R
 
 fn log(history: &Arc<Mutex<Vec<Event>>>, e: Event) {
     history.lock().unwrap().push(e);
+}
+
+/// Collapse a failure to a stable category so similar errors tally together:
+/// the op kind plus the message with digit runs replaced by `#` (partition keys,
+/// timestamps, node ids vary per op but the failure class does not) and
+/// truncated. Only digits are replaced, so error words stay readable.
+fn normalize_err(kind: &str, why: &str) -> String {
+    let mut s: String = why
+        .chars()
+        .map(|c| if c.is_ascii_digit() { '#' } else { c })
+        .collect();
+    while s.contains("##") {
+        s = s.replace("##", "#");
+    }
+    s.truncate(110);
+    format!("{kind} {s}")
 }
 
 fn decode_int_list(col: Option<&Option<CqlValue>>) -> Vec<i64> {

--- a/ferrosa-row-bridge/src/collection.rs
+++ b/ferrosa-row-bridge/src/collection.rs
@@ -20,6 +20,7 @@
 //! transaction path (the write was silently dropped — see t_83c4f093).
 
 use crate::codec::{decode_value, encode_value};
+use ferrosa_common::accord::Timestamp as AccordTimestamp;
 use ferrosa_common::{CellValue, CqlType, CqlValue, Timestamp, NO_DELETION_TIME};
 
 /// 100-nanosecond intervals between the UUID epoch (1582-10-15) and the Unix epoch
@@ -72,6 +73,55 @@ pub fn list_cell_path(write_ts: Timestamp, seq: u16) -> Vec<u8> {
     b[8..10].copy_from_slice(&clock_seq.to_be_bytes());
     // b[10..16] = node, left zero.
     b.to_vec()
+}
+
+/// Mint a globally-unique, **Accord-ordered** `list` cell path from the AGREED
+/// Accord execution timestamp `t` (NOT the coordinator's materialize-time wall
+/// clock). Concurrent list appends must serialize by the Accord total order
+/// `(time, seq, node)` on read, and must never collide on one path (which would
+/// silently drop an element). Unlike [`list_cell_path`] (`node = 0`, ordered by
+/// coordinator clock), this encodes:
+///   - **time field** ← `t.time` (HLC nanos): primary order, respects real-time.
+///   - **clock_seq**  ← `element_seq`: order of elements within one append.
+///   - **node field** ← `t.seq` (bytes 10..14) then `t.node` low 16 bits
+///     (14..16): the Accord secondary order `(seq, node)` — a deterministic
+///     tiebreak for concurrent same-`time` appends AND global uniqueness across
+///     coordinators.
+///
+/// The read-assembly ([`assemble_collection`]) orders list cells by
+/// `(time, clock_seq, node-bytes)`, so the assembled order equals the Accord
+/// order `(time, element_seq, seq, node)`. Legacy `node = 0` paths sort unchanged.
+/// The bytes are a valid v1 TimeUUID (Cassandra layout).
+pub fn accord_list_cell_path(t: &AccordTimestamp, element_seq: u16) -> Vec<u8> {
+    let uuid_ts = t.time.wrapping_add(UUID_EPOCH_OFFSET);
+    let time_low = (uuid_ts & 0xFFFF_FFFF) as u32;
+    let time_mid = ((uuid_ts >> 32) & 0xFFFF) as u16;
+    let time_hi = ((uuid_ts >> 48) & 0x0FFF) as u16 | 0x1000; // version 1
+    let clock_seq = (element_seq & 0x3FFF) | 0x8000; // variant 1
+    let mut b = [0u8; 16];
+    b[0..4].copy_from_slice(&time_low.to_be_bytes());
+    b[4..6].copy_from_slice(&time_mid.to_be_bytes());
+    b[6..8].copy_from_slice(&time_hi.to_be_bytes());
+    b[8..10].copy_from_slice(&clock_seq.to_be_bytes());
+    b[10..14].copy_from_slice(&t.seq.to_be_bytes());
+    b[14..16].copy_from_slice(&((t.node & 0xFFFF) as u16).to_be_bytes());
+    b.to_vec()
+}
+
+/// The list-cell ordering key `(time, clock_seq, node-bytes)` — the Accord total
+/// order `(t.time, element_seq, t.seq, t.node)` for cells minted by
+/// [`accord_list_cell_path`].
+pub type ListOrderKey = (u64, u16, [u8; 6]);
+
+/// The list-cell ordering key: `(time, clock_seq, node-bytes)`. The `node` field
+/// carries the Accord `(seq, node)` tiebreak minted by [`accord_list_cell_path`]
+/// (and is all-zero for legacy [`list_cell_path`] cells, so their order is
+/// unchanged). Returns `None` if `path` is not a 16-byte TimeUUID.
+pub fn list_order_key(path: &[u8]) -> Option<ListOrderKey> {
+    let (time, clock_seq) = timeuuid_time(path)?;
+    let mut node = [0u8; 6];
+    node.copy_from_slice(&path[10..16]);
+    Some((time, clock_seq, node))
 }
 
 /// The `(time, seq)` ordering key of a `list` cell path minted by [`list_cell_path`]:
@@ -254,10 +304,13 @@ pub fn assemble_collection(
             Ok(CqlValue::Map(entries))
         }
         CqlType::List(elem_ty) => {
-            // Order by the path's TimeUUID (time, seq) — append order.
-            let mut keyed: Vec<((u64, u16), CqlValue)> = live()
+            // Order by the path's Accord key (time, clock_seq, node) — the Accord
+            // total order for cells minted by `accord_list_cell_path`. Legacy
+            // `node = 0` cells (`list_cell_path`) keep their (time, clock_seq)
+            // order since the node bytes are zero for all of them.
+            let mut keyed: Vec<(ListOrderKey, CqlValue)> = live()
                 .map(|c| {
-                    let key = timeuuid_time(path_of(c)?).ok_or_else(|| AssembleError {
+                    let key = list_order_key(path_of(c)?).ok_or_else(|| AssembleError {
                         reason: "list cell path is not a 16-byte TimeUUID".into(),
                     })?;
                     Ok((
@@ -523,6 +576,63 @@ mod tests {
             assemble_column_cells(&text_set(), &scells, 0).unwrap(),
             Some(CqlValue::Set(vec![t("b")])),
             "a newer per-element tombstone removes the baseline element `a`"
+        );
+    }
+
+    /// Concurrent Accord list appends must assemble in the Accord total order
+    /// `(time, seq, node)` from `accord_list_cell_path` — NOT the coordinator's
+    /// materialize clock (t_68f226b5). Here a same-`time`-higher-`seq` append
+    /// must sort BETWEEN an earlier-time and a later-time append.
+    #[test]
+    fn accord_list_appends_assemble_in_accord_order() {
+        let ts = |time, seq, node| AccordTimestamp {
+            epoch: 0,
+            time,
+            seq,
+            node,
+        };
+        let a = CellValue::live(encode_value(&t("a")), 100)
+            .with_path(accord_list_cell_path(&ts(100, 0, 7), 0));
+        let c = CellValue::live(encode_value(&t("c")), 100)
+            .with_path(accord_list_cell_path(&ts(100, 5, 7), 0));
+        let b = CellValue::live(encode_value(&t("b")), 200)
+            .with_path(accord_list_cell_path(&ts(200, 0, 7), 0));
+        // Arbitrary input order — assembly imposes the Accord order.
+        let cells: Vec<&CellValue> = vec![&b, &c, &a];
+        assert_eq!(
+            assemble_column_cells(&text_list(), &cells, 0).unwrap(),
+            Some(CqlValue::List(vec![t("a"), t("c"), t("b")])),
+            "order = (time, seq): a(100,0) < c(100,5) < b(200)"
+        );
+    }
+
+    /// Two concurrent appends that differ only in the Accord `seq`, `node`, or the
+    /// element index get DISTINCT paths — so no element is silently lost to a
+    /// path collision (the coordinator-clock `list_cell_path` collided on
+    /// same-ts+seq).
+    #[test]
+    fn accord_list_cell_path_is_unique_per_concurrent_append() {
+        let ts = |time, seq, node| AccordTimestamp {
+            epoch: 0,
+            time,
+            seq,
+            node,
+        };
+        let paths = [
+            accord_list_cell_path(&ts(100, 0, 1), 0),
+            accord_list_cell_path(&ts(100, 1, 1), 0), // +seq (same node/time)
+            accord_list_cell_path(&ts(100, 0, 2), 0), // +node (same seq/time)
+            accord_list_cell_path(&ts(100, 0, 1), 1), // +element index
+        ];
+        let unique: std::collections::HashSet<Vec<u8>> = paths.iter().cloned().collect();
+        assert_eq!(
+            unique.len(),
+            4,
+            "distinct seq/node/element -> distinct paths"
+        );
+        assert!(
+            paths.iter().all(|p| p.len() == 16),
+            "valid 16-byte TimeUUIDs"
         );
     }
 

--- a/ferrosa-row-bridge/src/collection.rs
+++ b/ferrosa-row-bridge/src/collection.rs
@@ -162,6 +162,35 @@ pub struct AssembleError {
     pub reason: String,
 }
 
+/// Reconcile a legacy whole-value blob's synthetic per-element cells (`blob_cells`)
+/// with the real per-element cells (`real_cells`, `path == Some`) by path, LWW:
+/// higher timestamp wins, tombstone wins a tie. A newer real cell therefore
+/// overrides or removes the corresponding baseline element. Owned — used only on
+/// the rare §8 mixed-partition read path (a partition holding both a whole-value
+/// blob and per-element cells for the same column).
+fn merge_blob_and_element_cells(
+    blob_cells: &[CellValue],
+    real_cells: &[&CellValue],
+) -> Vec<CellValue> {
+    use std::collections::BTreeMap;
+    let mut by_path: BTreeMap<Vec<u8>, CellValue> = BTreeMap::new();
+    let real = real_cells
+        .iter()
+        .copied()
+        .filter(|c| c.path.is_some())
+        .cloned();
+    for cell in blob_cells.iter().cloned().chain(real) {
+        let key = cell.path.clone().unwrap_or_default();
+        by_path
+            .entry(key)
+            .and_modify(|existing| {
+                *existing = ferrosa_common::complex_cell::reconcile(existing, &cell)
+            })
+            .or_insert(cell);
+    }
+    by_path.into_values().collect()
+}
+
 impl std::fmt::Display for AssembleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.reason)
@@ -329,16 +358,59 @@ pub fn assemble_column_cells(
             .map(|c| c.timestamp)
             .max();
 
-        // Cells are already one-per-path from the merge, so filter references in
-        // place — no CellValue copy. Keep live element cells not shadowed by the
-        // collection deletion.
-        let live: Vec<&CellValue> = cells
+        // §8 lazy dual-read (mixed partition): a LIVE `path == None` cell is a
+        // legacy/pre-migration whole-value collection blob — the BASELINE. Decode
+        // it into synthetic per-element cells at its own timestamp (list paths
+        // therefore sort before any later append), so the baseline's elements are
+        // not dropped when newer per-element cells exist for the same column. A
+        // non-frozen UDT never carries a whole-value blob, so it is exempt.
+        let blob_cells: Vec<CellValue> = match cells
             .iter()
             .copied()
-            .filter(|c| c.path.is_some())
-            .filter(|c| crate::row::cell_is_live(c, now_secs))
-            .filter(|c| collection_deletion_ts.is_none_or(|d| c.timestamp > d))
-            .collect();
+            .find(|c| c.path.is_none() && !c.is_tombstone())
+        {
+            Some(blob)
+                if !matches!(col_type, CqlType::Udt { .. })
+                    && crate::row::cell_is_live(blob, now_secs) =>
+            {
+                match &blob.value {
+                    Some(bytes) => {
+                        let decoded = decode_value(col_type, bytes).map_err(|e| AssembleError {
+                            reason: format!("decode whole-value collection blob: {e}"),
+                        })?;
+                        build_collection_cells(CollectionOp::Add, &decoded, blob.timestamp)
+                            .map_err(|e| AssembleError { reason: e.reason })?
+                    }
+                    None => Vec::new(),
+                }
+            }
+            _ => Vec::new(),
+        };
+
+        // Fast path (no whole-value baseline — the common case): cells are already
+        // one-per-path from the merge, so filter references in place with no copy.
+        // `merged` outlives `live`, which borrows it on the §8 mixed path.
+        let merged: Vec<CellValue>;
+        let live: Vec<&CellValue> = if blob_cells.is_empty() {
+            cells
+                .iter()
+                .copied()
+                .filter(|c| c.path.is_some())
+                .filter(|c| crate::row::cell_is_live(c, now_secs))
+                .filter(|c| collection_deletion_ts.is_none_or(|d| c.timestamp > d))
+                .collect()
+        } else {
+            // §8 merge: reconcile the synthetic baseline cells with the real
+            // per-element cells by path (LWW — a newer real cell overrides or
+            // tombstones the corresponding baseline element). Owned, but only on
+            // the rare mixed-partition path.
+            merged = merge_blob_and_element_cells(&blob_cells, cells);
+            merged
+                .iter()
+                .filter(|c| crate::row::cell_is_live(c, now_secs))
+                .filter(|c| collection_deletion_ts.is_none_or(|d| c.timestamp > d))
+                .collect()
+        };
         // A non-frozen UDT is a complex column too, but its cell paths are
         // 2-byte field positions and its fields have distinct types.
         if let CqlType::Udt { fields, .. } = col_type {
@@ -421,6 +493,37 @@ mod tests {
         let cells: Vec<&CellValue> = vec![&a[0], &deletion];
         let got = assemble_column_cells(&text_set(), &cells, 0).unwrap();
         assert_eq!(got, Some(CqlValue::Set(vec![])), "all elements shadowed");
+    }
+
+    /// §8 lazy dual-read: a partition holding a LIVE whole-value blob (`path ==
+    /// None`) PLUS newer per-element cells assembles the MERGED collection — the
+    /// baseline blob elements are preserved (not dropped), a newer append lands in
+    /// order after them, and a newer per-element tombstone removes a baseline
+    /// element. This is the mixed-partition case a txn append creates on a key
+    /// that already held whole-value collection data.
+    #[test]
+    fn mixed_whole_value_blob_and_per_element_cells_merge() {
+        // list: blob [a, b] @100 + append [c] @200 -> [a, b, c].
+        let blob = CellValue::live(encode_value(&CqlValue::List(vec![t("a"), t("b")])), 100);
+        let append =
+            build_collection_cells(CollectionOp::Add, &CqlValue::List(vec![t("c")]), 200).unwrap();
+        let cells: Vec<&CellValue> = vec![&blob, &append[0]];
+        assert_eq!(
+            assemble_column_cells(&text_list(), &cells, 0).unwrap(),
+            Some(CqlValue::List(vec![t("a"), t("b"), t("c")])),
+            "blob baseline elements are preserved and precede the newer append"
+        );
+
+        // set: blob {a, b} @100 + per-element remove of a @200 -> {b}.
+        let sblob = CellValue::live(encode_value(&CqlValue::Set(vec![t("a"), t("b")])), 100);
+        let sremove =
+            build_collection_cells(CollectionOp::Sub, &CqlValue::Set(vec![t("a")]), 200).unwrap();
+        let scells: Vec<&CellValue> = vec![&sblob, &sremove[0]];
+        assert_eq!(
+            assemble_column_cells(&text_set(), &scells, 0).unwrap(),
+            Some(CqlValue::Set(vec![t("b")])),
+            "a newer per-element tombstone removes the baseline element `a`"
+        );
     }
 
     fn text_list() -> CqlType {

--- a/ferrosa-row-bridge/src/collection.rs
+++ b/ferrosa-row-bridge/src/collection.rs
@@ -93,19 +93,10 @@ pub fn list_cell_path(write_ts: Timestamp, seq: u16) -> Vec<u8> {
 /// order `(time, element_seq, seq, node)`. Legacy `node = 0` paths sort unchanged.
 /// The bytes are a valid v1 TimeUUID (Cassandra layout).
 pub fn accord_list_cell_path(t: &AccordTimestamp, element_seq: u16) -> Vec<u8> {
-    let uuid_ts = t.time.wrapping_add(UUID_EPOCH_OFFSET);
-    let time_low = (uuid_ts & 0xFFFF_FFFF) as u32;
-    let time_mid = ((uuid_ts >> 32) & 0xFFFF) as u16;
-    let time_hi = ((uuid_ts >> 48) & 0x0FFF) as u16 | 0x1000; // version 1
-    let clock_seq = (element_seq & 0x3FFF) | 0x8000; // variant 1
-    let mut b = [0u8; 16];
-    b[0..4].copy_from_slice(&time_low.to_be_bytes());
-    b[4..6].copy_from_slice(&time_mid.to_be_bytes());
-    b[6..8].copy_from_slice(&time_hi.to_be_bytes());
-    b[8..10].copy_from_slice(&clock_seq.to_be_bytes());
-    b[10..14].copy_from_slice(&t.seq.to_be_bytes());
-    b[14..16].copy_from_slice(&((t.node & 0xFFFF) as u16).to_be_bytes());
-    b.to_vec()
+    // Single source of truth: the byte layout lives in `ferrosa-common` so the
+    // read-side assembly here and the Accord apply-time rebind
+    // (`ferrosa-storage::commitlog::mutation`) can never drift apart.
+    ferrosa_common::accord_list_cell_path(t, element_seq)
 }
 
 /// The list-cell ordering key `(time, clock_seq, node-bytes)` — the Accord total

--- a/ferrosa-storage/proptest-regressions/commitlog/mutation.txt
+++ b/ferrosa-storage/proptest-regressions/commitlog/mutation.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c10db8fc309fe14445402ef7c3c966062b949fe0388c952d4c4b0073b14ab37b # shrinks to mutation = Mutation { mutation_id: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 31, 118, 196, 78], keyspace: "a", table: "a", key: DecoratedKey { token: Token(5048724184180415669), key: PartitionKey([0]) }, rows: [Row { clustering: [], cells: [(0, CellValue { value: Some([]), timestamp: 1, ttl: 0, local_deletion_time: 2147483647, path: Some([0]) })], deletion: DeletionTime { marked_for_delete_at: -9223372036854775808, local_deletion_time: 4294967295 }, primary_key_liveness: LivenessInfo { timestamp: 1, ttl: 0, local_deletion_time: 2147483647 } }], timestamp: 1 }

--- a/ferrosa-storage/src/accord/conflict_index.rs
+++ b/ferrosa-storage/src/accord/conflict_index.rs
@@ -81,9 +81,38 @@ pub struct ConflictIndex {
     /// Indexed column projections for transactional 2i.
     indexed_writes: HashMap<String, HashMap<Vec<u8>, Vec<TxnId>>>,
 
+    /// Per-key high-water-mark of the highest committed **execution** timestamp
+    /// ever seen for a key — retained across [`gc_applied`](Self::gc_applied),
+    /// unlike the in-flight [`single_key`] entries. Without it, once a committed
+    /// append is applied and GC'd, a later append on the same key sees no
+    /// conflict and mints a timestamp below the GC'd one — the GC-boundary
+    /// real-time inversion (t_813caf39). Bounded by `max_entries`; when full,
+    /// new keys are skipped (they fall back to the entry-based conflict path,
+    /// still correct while they have live entries).
+    single_key_hwm: HashMap<Vec<u8>, Timestamp>,
+
     /// Hard cap on total entries.
     max_entries: usize,
     current_entries: usize,
+}
+
+/// Raise a key's execution-timestamp high-water-mark to `t` (monotonic). A new
+/// key is tracked only while under `cap`; a skipped new key degrades gracefully
+/// to the entry-based conflict path (correct while it has live entries), keeping
+/// the HWM map bounded.
+fn raise_hwm(hwm: &mut HashMap<Vec<u8>, Timestamp>, key: &[u8], t: Timestamp, cap: usize) {
+    match hwm.get_mut(key) {
+        Some(existing) => {
+            if t > *existing {
+                *existing = t;
+            }
+        }
+        None => {
+            if hwm.len() < cap {
+                hwm.insert(key.to_vec(), t);
+            }
+        }
+    }
 }
 
 impl ConflictIndex {
@@ -98,6 +127,7 @@ impl ConflictIndex {
             single_key: HashMap::new(),
             range_ops: BTreeMap::new(),
             indexed_writes: HashMap::new(),
+            single_key_hwm: HashMap::new(),
             max_entries,
             current_entries: 0,
         }
@@ -159,22 +189,41 @@ impl ConflictIndex {
     /// a later txn assigned an execution `t` below it — a real-time inversion that
     /// reorders accumulating list elements (t_813caf39).
     pub fn max_conflicting_timestamp(&self, key: &[u8]) -> Option<Timestamp> {
-        self.single_key
+        let live = self
+            .single_key
             .get(key)
-            .and_then(|writes| writes.iter().map(|w| w.accord_ts.unwrap_or(w.t0)).max())
+            .and_then(|writes| writes.iter().map(|w| w.accord_ts.unwrap_or(w.t0)).max());
+        // Fold in the per-key high-water-mark, which survives GC of the live
+        // entries — so a later append still bumps past an already-applied one.
+        let hwm = self.single_key_hwm.get(key).copied();
+        match (live, hwm) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (a, b) => a.or(b),
+        }
     }
 
     /// Record a transaction's agreed execution timestamp on every entry it owns,
     /// so subsequent [`max_conflicting_timestamp`](Self::max_conflicting_timestamp)
     /// lookups bump past its real serialization point rather than its stale `t0`.
-    /// Called when the timestamp is finalized (Accept / Commit). No-op if the txn
-    /// is not indexed (e.g. already GC'd).
+    /// Called when the timestamp is finalized (Accept / Commit).
+    ///
+    /// Also raises the per-key execution-timestamp **high-water-mark** for every
+    /// key the transaction touches, so the bump survives [`gc_applied`] once the
+    /// transaction is applied and its live entry is removed. No-op on the live
+    /// entries if the txn is already GC'd, but the HWM is still raised.
+    ///
+    /// [`gc_applied`]: Self::gc_applied
     pub fn set_commit_ts(&mut self, txn_id: &TxnId, t: Timestamp) {
-        for writes in self.single_key.values_mut() {
+        for (key, writes) in self.single_key.iter_mut() {
+            let mut touches_key = false;
             for entry in writes.iter_mut() {
                 if entry.txn_id == *txn_id {
                     entry.accord_ts = Some(t);
+                    touches_key = true;
                 }
+            }
+            if touches_key {
+                raise_hwm(&mut self.single_key_hwm, key, t, self.max_entries);
             }
         }
     }
@@ -466,6 +515,42 @@ mod tests {
             "a committed txn's execution timestamp (accord_ts) — not its stale t0 — \
              must be its conflict timestamp, so a later PreAccept bumps past it"
         );
+    }
+
+    /// The GC-boundary edge of the list-append inversion (t_813caf39): a
+    /// committed append's execution timestamp must survive `gc_applied` as a
+    /// per-key high-water-mark, so a LATER append on the same key still bumps past
+    /// it even though the earlier append's live entry is gone. Without the HWM,
+    /// `max_conflicting_timestamp` returns `None` after GC and the later append
+    /// mints a lower timestamp → it sorts before the earlier one (mid-list).
+    #[test]
+    fn max_conflicting_timestamp_survives_gc_via_per_key_hwm() {
+        let mut idx = ConflictIndex::new(100);
+        let key = b"k";
+        let id = txn(500);
+        idx.register(
+            key,
+            InFlightWrite {
+                txn_id: id,
+                t0: ts(500),
+                accord_ts: Some(ts(1000)),
+                status: TxnStatus::Committed,
+            },
+        )
+        .unwrap();
+        idx.set_commit_ts(&id, ts(1000)); // records the per-key HWM
+
+        // The txn applies and is GC'd — its live entry is removed.
+        idx.mark_applied(&id);
+        idx.gc_applied();
+        assert_eq!(
+            idx.max_conflicting_timestamp(key),
+            None.or(Some(ts(1000))),
+            "the committed execution timestamp must survive gc_applied as a per-key HWM"
+        );
+
+        // A different key is unaffected (no false HWM bleed across keys).
+        assert_eq!(idx.max_conflicting_timestamp(b"other"), None);
     }
 
     // -----------------------------------------------------------------------

--- a/ferrosa-storage/src/accord/conflict_index.rs
+++ b/ferrosa-storage/src/accord/conflict_index.rs
@@ -148,12 +148,35 @@ impl ConflictIndex {
             .push(txn_id);
     }
 
-    /// Returns the maximum `t0` of all conflicting in-flight transactions
-    /// for a single key. O(1) lookup.
+    /// Returns the maximum **effective** timestamp of all conflicting
+    /// transactions for a single key — each entry's agreed execution timestamp
+    /// (`accord_ts`) once known, else its proposed `t0`. O(1) lookup.
+    ///
+    /// PreAccept bumps a new transaction past this value, so it MUST be the
+    /// conflicting txns' serialization point (their execution `t`), not their
+    /// proposed `t0`: a committed txn whose `t` was bumped far past its `t0`
+    /// (past an earlier, now-GC'd conflict) would otherwise be under-counted, and
+    /// a later txn assigned an execution `t` below it — a real-time inversion that
+    /// reorders accumulating list elements (t_813caf39).
     pub fn max_conflicting_timestamp(&self, key: &[u8]) -> Option<Timestamp> {
         self.single_key
             .get(key)
-            .and_then(|writes| writes.iter().map(|w| w.t0).max())
+            .and_then(|writes| writes.iter().map(|w| w.accord_ts.unwrap_or(w.t0)).max())
+    }
+
+    /// Record a transaction's agreed execution timestamp on every entry it owns,
+    /// so subsequent [`max_conflicting_timestamp`](Self::max_conflicting_timestamp)
+    /// lookups bump past its real serialization point rather than its stale `t0`.
+    /// Called when the timestamp is finalized (Accept / Commit). No-op if the txn
+    /// is not indexed (e.g. already GC'd).
+    pub fn set_commit_ts(&mut self, txn_id: &TxnId, t: Timestamp) {
+        for writes in self.single_key.values_mut() {
+            for entry in writes.iter_mut() {
+                if entry.txn_id == *txn_id {
+                    entry.accord_ts = Some(t);
+                }
+            }
+        }
     }
 
     /// Returns the maximum `t0` of conflicting range operations that
@@ -410,6 +433,39 @@ mod tests {
         // Register T2 with higher t0 (t0 = 20).
         idx.register(key, write_entry(20)).unwrap();
         assert_eq!(idx.max_conflicting_timestamp(key), Some(ts(20)));
+    }
+
+    /// Root cause of the Accord list-append real-time inversion (t_813caf39): a
+    /// committed transaction's serialization point is its EXECUTION timestamp
+    /// (`accord_ts`), not its proposed `t0`. `max_conflicting_timestamp` — used by
+    /// PreAccept to bump a new txn past existing conflicts — must reflect the
+    /// execution timestamp. Otherwise a txn A that bumped its execution `t` far
+    /// past its `t0` (past an earlier, now-GC'd conflict) is under-counted, and a
+    /// later txn B is assigned an execution `t` BELOW A — a real-time inversion
+    /// (and, for accumulating lists, an out-of-order element).
+    #[test]
+    fn max_conflicting_timestamp_reflects_committed_execution_ts_not_t0() {
+        let mut idx = ConflictIndex::new(100);
+        let key = b"k";
+        // Txn A: proposed t0 = 500, but its AGREED execution t = 1000 (it bumped
+        // past an earlier, higher-t0 conflict that has since applied + been GC'd).
+        idx.register(
+            key,
+            InFlightWrite {
+                txn_id: txn(500),
+                t0: ts(500),
+                accord_ts: Some(ts(1000)),
+                status: TxnStatus::Committed,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            idx.max_conflicting_timestamp(key),
+            Some(ts(1000)),
+            "a committed txn's execution timestamp (accord_ts) — not its stale t0 — \
+             must be its conflict timestamp, so a later PreAccept bumps past it"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/ferrosa-storage/src/commitlog/mod.rs
+++ b/ferrosa-storage/src/commitlog/mod.rs
@@ -33,7 +33,7 @@ pub use config::{
     ArchiveConfig, CommitLogBatchConfig, CommitLogConfig, CommitLogPosition, SyncStrategyConfig,
     TableId,
 };
-pub use mutation::Mutation;
+pub use mutation::{Mutation, CELL_REBIND_LIST_PATH_FLAG};
 
 use std::collections::HashSet;
 use std::fs;

--- a/ferrosa-storage/src/commitlog/mutation.rs
+++ b/ferrosa-storage/src/commitlog/mutation.rs
@@ -29,9 +29,16 @@
 //! ```
 //!
 //! The high bit (`0x8000`) of `column_index` flags a **complex-column cell path**
-//! (a collection element identity — timeuuid/element/key). Real column indices are
-//! `< 0x8000`, so simple cells and old segments (which never set the bit) are
-//! byte-for-byte identical to the pre-path format — no version bump required.
+//! (a collection element identity — timeuuid/element/key). The next bit
+//! (`0x4000`) is a **transient Accord list-path rebind flag**: the coordinator
+//! sets it on a non-frozen `list` append cell so the replica's apply phase
+//! rewrites the cell's path from the coordinator-local wall clock to the
+//! Accord-agreed execution timestamp (see
+//! [`Mutation::deserialize_from_rebinding_list_paths`]). It is consumed at
+//! decode time and NEVER reaches the SSTable — the stored column index is always
+//! the clean low-14-bit value. Real column indices are `< 0x4000`, so simple
+//! cells and old segments (which never set either bit) are byte-for-byte
+//! identical to the pre-path format — no version bump required.
 //!
 //! All multi-byte integers are big-endian.
 //!
@@ -42,7 +49,10 @@
 //! `mutation_id` with all-zeros.  A zero `mutation_id` is **never** used for
 //! deduplication — mutations with a zero id are always re-applied on replay.
 
-use ferrosa_common::{CellValue, DecoratedKey, PartitionKey, Token};
+use ferrosa_common::accord::Timestamp as AccordTimestamp;
+use ferrosa_common::{
+    accord_list_cell_path, list_path_element_seq, CellValue, DecoratedKey, PartitionKey, Token,
+};
 use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
 use uuid::Uuid;
 
@@ -116,6 +126,14 @@ pub enum MutationError {
         /// Which field.
         field: &'static str,
     },
+    /// A cell carried the Accord list-path rebind flag (`0x4000`) but did not
+    /// have a 16-byte v1-TimeUUID path to rebind — the coordinator only sets the
+    /// flag on `list` append cells, which always have a 16-byte path, so this is
+    /// a corrupt/forged payload. Fail loud rather than silently mis-rebind.
+    InvalidRebindListPath {
+        /// The actual path length found (not 16).
+        len: usize,
+    },
 }
 
 impl std::fmt::Display for MutationError {
@@ -132,6 +150,11 @@ impl std::fmt::Display for MutationError {
             MutationError::InvalidUtf8 { field } => {
                 write!(f, "invalid UTF-8 in field {field}")
             }
+            MutationError::InvalidRebindListPath { len } => write!(
+                f,
+                "cell has the Accord list-path rebind flag but a {len}-byte path (expected a \
+                 16-byte v1 TimeUUID)"
+            ),
         }
     }
 }
@@ -273,8 +296,19 @@ fn byte_vec_size(data: &[u8]) -> usize {
 /// and simple cells serialize byte-for-byte as before. Only path-bearing cells use
 /// the extended encoding; no format-version bump is needed.
 const CELL_HAS_PATH_FLAG: u16 = 0x8000;
-/// Mask for the real column index (the low 15 bits) once the flag is stripped.
-const CELL_COLUMN_INDEX_MASK: u16 = 0x7FFF;
+/// Second-highest bit of a cell's `column_index`, set by the coordinator to mark
+/// a non-frozen `list` append cell whose path must be **rebound** from the
+/// coordinator-local wall clock to the Accord-agreed execution timestamp at apply
+/// time (see [`Mutation::deserialize_from_rebinding_list_paths`]). Transient: it
+/// is stripped at decode and never persisted — the stored column index is always
+/// the clean low-14-bit value. Only set on the Accord write path, so old segments
+/// and the AP/logged-batch paths never carry it. Public so the CQL coordinator
+/// (`ferrosa-cql`) sets exactly this bit when materializing an Accord list append
+/// — one source of truth for the flag value across the serialize/deserialize seam.
+pub const CELL_REBIND_LIST_PATH_FLAG: u16 = 0x4000;
+/// Mask for the real column index (the low 14 bits) once both high flags are
+/// stripped. Real column indices are `< 0x4000` (16384) — far beyond any table.
+const CELL_COLUMN_INDEX_MASK: u16 = 0x3FFF;
 
 /// Size of a single serialized cell.
 fn cell_size(cell: &CellValue) -> usize {
@@ -438,17 +472,24 @@ impl Mutation {
     }
 
     fn serialize_cell(w: &mut WriteCursor<'_>, column_index: u16, cell: &CellValue) {
-        // Fail loud: a column index that collides with the path flag would corrupt
-        // the encoding. 0x8000 columns is far beyond any real table.
+        // The caller may pre-set the transient rebind flag (0x4000) on the column
+        // index for an Accord `list` append cell; pass it through so the replica's
+        // apply phase can rebind the path. The path flag (0x8000) is derived from
+        // the cell, never passed in — fail loud if a real index collides with it.
+        let rebind = column_index & CELL_REBIND_LIST_PATH_FLAG;
         assert!(
-            column_index & CELL_HAS_PATH_FLAG == 0,
-            "column index {column_index} collides with the cell-path flag (>= 0x8000)"
+            column_index & !(CELL_REBIND_LIST_PATH_FLAG | CELL_COLUMN_INDEX_MASK) == 0,
+            "column index {} collides with a reserved cell flag (>= 0x8000, or >= 0x4000 without \
+             being the rebind flag)",
+            column_index & CELL_COLUMN_INDEX_MASK
         );
-        let tagged = if cell.path.is_some() {
-            column_index | CELL_HAS_PATH_FLAG
-        } else {
-            column_index
-        };
+        let tagged = (column_index & CELL_COLUMN_INDEX_MASK)
+            | rebind
+            | if cell.path.is_some() {
+                CELL_HAS_PATH_FLAG
+            } else {
+                0
+            };
         w.write_u16(tagged);
         w.write_i64(cell.timestamp);
         w.write_i32(cell.ttl);
@@ -474,8 +515,35 @@ impl Mutation {
     /// Deserializes a mutation from a byte slice.
     ///
     /// Returns an error if the buffer is truncated or contains invalid UTF-8
-    /// in string fields.
+    /// in string fields. Any transient Accord list-path rebind flag (`0x4000`)
+    /// on a cell is **stripped** (the clean column index is kept) but the path is
+    /// left as-is — use [`deserialize_from_rebinding_list_paths`] on the apply
+    /// path to actually rebind. In practice only the Accord apply path ever sees
+    /// a flagged payload, so this default decode never encounters the flag.
+    ///
+    /// [`deserialize_from_rebinding_list_paths`]: Self::deserialize_from_rebinding_list_paths
     pub fn deserialize_from(buf: &[u8]) -> Result<Self> {
+        Self::deserialize_inner(buf, None)
+    }
+
+    /// Deserialize a mutation, rebinding every Accord `list` append cell (flagged
+    /// with `0x4000`) to the agreed execution timestamp `t`.
+    ///
+    /// The coordinator stamps a list append cell's path with its own wall clock
+    /// *before* consensus picks `t`, which would order concurrent appends by
+    /// coordinator clock rather than the Accord total order (non-strict-
+    /// serializable, t_68f226b5). This rewrites each flagged cell's path to
+    /// [`accord_list_cell_path(&t, element_seq)`], preserving the element's
+    /// within-append order (`element_seq` recovered from the pre-consensus path's
+    /// clock_seq) while making the primary order the Accord `t`. Non-flagged cells
+    /// (scalars, `set`/`map` elements, non-frozen UDT fields) are untouched. The
+    /// stripped-clean column index is stored, so the flag never reaches the
+    /// SSTable. Fails loud if a flagged cell lacks a 16-byte path.
+    pub fn deserialize_from_rebinding_list_paths(buf: &[u8], t: AccordTimestamp) -> Result<Self> {
+        Self::deserialize_inner(buf, Some(t))
+    }
+
+    fn deserialize_inner(buf: &[u8], rebind_t: Option<AccordTimestamp>) -> Result<Self> {
         let mut r = ReadCursor::new(buf);
 
         // mutation_id: 16 raw bytes (UUID v4, or all-zeros for legacy entries)
@@ -497,7 +565,7 @@ impl Mutation {
 
         let mut rows = Vec::with_capacity(row_count);
         for _ in 0..row_count {
-            rows.push(Self::deserialize_row(&mut r)?);
+            rows.push(Self::deserialize_row(&mut r, rebind_t)?);
         }
 
         Ok(Mutation {
@@ -510,7 +578,7 @@ impl Mutation {
         })
     }
 
-    fn deserialize_row(r: &mut ReadCursor<'_>) -> Result<Row> {
+    fn deserialize_row(r: &mut ReadCursor<'_>, rebind_t: Option<AccordTimestamp>) -> Result<Row> {
         let clustering = r.read_byte_vec("clustering")?;
 
         let marked_for_delete_at = r.read_i64("deletion.marked_for_delete_at")?;
@@ -529,7 +597,7 @@ impl Mutation {
         let cell_count = r.read_u16("cell_count")? as usize;
         let mut cells = Vec::with_capacity(cell_count);
         for _ in 0..cell_count {
-            cells.push(Self::deserialize_cell(r)?);
+            cells.push(Self::deserialize_cell(r, rebind_t)?);
         }
 
         Ok(Row {
@@ -540,9 +608,15 @@ impl Mutation {
         })
     }
 
-    fn deserialize_cell(r: &mut ReadCursor<'_>) -> Result<(u16, CellValue)> {
+    fn deserialize_cell(
+        r: &mut ReadCursor<'_>,
+        rebind_t: Option<AccordTimestamp>,
+    ) -> Result<(u16, CellValue)> {
         let tagged = r.read_u16("cell.column_index")?;
         let has_path = tagged & CELL_HAS_PATH_FLAG != 0;
+        let needs_rebind = tagged & CELL_REBIND_LIST_PATH_FLAG != 0;
+        // The clean column index — both transient flags stripped, so the stored
+        // index (and thus the SSTable) never carries them.
         let column_index = tagged & CELL_COLUMN_INDEX_MASK;
         let timestamp = r.read_i64("cell.timestamp")?;
         let ttl = r.read_i32("cell.ttl")?;
@@ -559,11 +633,25 @@ impl Mutation {
 
         // A complex-column cell path follows the value iff the flag was set. Old
         // segments and simple cells never set it, so they decode with path == None.
-        let path = if has_path {
+        let mut path = if has_path {
             Some(r.read_byte_vec("cell.path")?)
         } else {
             None
         };
+
+        // Accord list-path rebind: when this cell was flagged AND a rebind
+        // timestamp was supplied (the apply path), rewrite the coordinator-clock
+        // list path to the agreed execution timestamp, preserving the element's
+        // within-append order via the original path's clock_seq. A flagged cell
+        // must have a 16-byte v1-TimeUUID path — fail loud otherwise.
+        if needs_rebind {
+            if let Some(t) = rebind_t {
+                let old = path.as_deref().unwrap_or_default();
+                let element_seq = list_path_element_seq(old)
+                    .ok_or(MutationError::InvalidRebindListPath { len: old.len() })?;
+                path = Some(accord_list_cell_path(&t, element_seq));
+            }
+        }
 
         Ok((
             column_index,
@@ -829,6 +917,165 @@ mod tests {
         m.serialize_into(&mut buf);
         let back = Mutation::deserialize_from(&buf).unwrap();
         assert!(back.rows[0].cells.iter().all(|(_, c)| c.path.is_none()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Accord list-path rebind flag (0x4000) — t_68f226b5.
+    // -----------------------------------------------------------------------
+
+    use ferrosa_common::accord::Timestamp as AccordTimestamp;
+
+    const REBIND_FLAG: u16 = 0x4000;
+
+    fn accord_ts(time: u64, seq: u32, node: u64) -> AccordTimestamp {
+        AccordTimestamp {
+            epoch: 0,
+            time,
+            seq,
+            node,
+        }
+    }
+
+    /// Serialize a one-row mutation from raw `(tagged_col_idx, cell)` tuples so a
+    /// test can pre-set the 0x4000 rebind flag exactly as the coordinator would.
+    fn mutation_with_cells(cells: Vec<(u16, CellValue)>) -> Vec<u8> {
+        let m = Mutation {
+            mutation_id: [7u8; 16],
+            keyspace: "ks".into(),
+            table: "t".into(),
+            key: DecoratedKey::new(PartitionKey::new(b"pk".to_vec())),
+            rows: vec![Row {
+                clustering: vec![],
+                cells,
+                deletion: DeletionTime::LIVE,
+                primary_key_liveness: LivenessInfo::with_timestamp(1000),
+            }],
+            timestamp: 1000,
+        };
+        let mut buf = vec![0u8; m.serialized_size()];
+        m.serialize_into(&mut buf);
+        buf
+    }
+
+    /// The DEFAULT decode strips the rebind flag into a clean column index and
+    /// leaves the (coordinator-clock) path untouched — so any non-apply consumer
+    /// (commit-log replay, read-vote) is unaffected and the flag never reaches the
+    /// SSTable via a polluted column index.
+    #[test]
+    fn default_deserialize_strips_rebind_flag_keeps_path() {
+        let coord_path = ferrosa_common::accord_list_cell_path(&accord_ts(999, 0, 0), 5);
+        let buf = mutation_with_cells(vec![(
+            3 | REBIND_FLAG,
+            CellValue::live(b"elem".to_vec(), 1000).with_path(coord_path.clone()),
+        )]);
+        let back = Mutation::deserialize_from(&buf).unwrap();
+        let (idx, cell) = &back.rows[0].cells[0];
+        assert_eq!(*idx, 3, "rebind flag stripped from the stored column index");
+        assert_eq!(
+            cell.path.as_deref(),
+            Some(coord_path.as_slice()),
+            "default decode leaves the path unchanged"
+        );
+    }
+
+    /// The apply decode rebinds a flagged `list` cell's path to the Accord
+    /// execution timestamp, preserving the element_seq baked into the original
+    /// path; a NON-flagged sibling cell (a `set` element) is left untouched.
+    #[test]
+    fn rebinding_deserialize_rewrites_only_flagged_list_path() {
+        let element_seq = 3u16;
+        // Coordinator-clock list path (wrong time, but carries element_seq).
+        let coord_path = ferrosa_common::accord_list_cell_path(&accord_ts(999, 0, 0), element_seq);
+        // A set element path — arbitrary 16 bytes, NOT flagged; must survive.
+        let set_path = vec![0xABu8; 16];
+        let buf = mutation_with_cells(vec![
+            (
+                2 | REBIND_FLAG,
+                CellValue::live(b"L".to_vec(), 1000).with_path(coord_path),
+            ),
+            (
+                5,
+                CellValue::live(Vec::new(), 1000).with_path(set_path.clone()),
+            ),
+        ]);
+
+        let t = accord_ts(4242, 7, 9);
+        let back = Mutation::deserialize_from_rebinding_list_paths(&buf, t).unwrap();
+        let cells = &back.rows[0].cells;
+
+        let (list_idx, list_cell) = cells.iter().find(|(i, _)| *i == 2).unwrap();
+        assert_eq!(*list_idx, 2, "clean column index stored");
+        assert_eq!(
+            list_cell.path.as_deref(),
+            Some(ferrosa_common::accord_list_cell_path(&t, element_seq).as_slice()),
+            "flagged list path rebound to the Accord execution ts, element_seq preserved"
+        );
+
+        let (_, set_cell) = cells.iter().find(|(i, _)| *i == 5).unwrap();
+        assert_eq!(
+            set_cell.path.as_deref(),
+            Some(set_path.as_slice()),
+            "a non-flagged set element path must NOT be rebound"
+        );
+    }
+
+    /// Two flagged appends within one write keep their within-append order
+    /// (element_seq 0 before 1) and both take the Accord `t.time` as primary
+    /// order after rebind.
+    #[test]
+    fn rebinding_preserves_within_append_element_order() {
+        let buf = mutation_with_cells(vec![
+            (
+                2 | REBIND_FLAG,
+                CellValue::live(b"a".to_vec(), 1000).with_path(
+                    ferrosa_common::accord_list_cell_path(&accord_ts(999, 0, 0), 0),
+                ),
+            ),
+            (
+                2 | REBIND_FLAG,
+                CellValue::live(b"b".to_vec(), 1000).with_path(
+                    ferrosa_common::accord_list_cell_path(&accord_ts(999, 0, 0), 1),
+                ),
+            ),
+        ]);
+        let t = accord_ts(5000, 1, 2);
+        let back = Mutation::deserialize_from_rebinding_list_paths(&buf, t).unwrap();
+        let seqs: Vec<u16> = back.rows[0]
+            .cells
+            .iter()
+            .map(|(_, c)| {
+                ferrosa_common::list_path_element_seq(c.path.as_deref().unwrap()).unwrap()
+            })
+            .collect();
+        assert_eq!(seqs, vec![0, 1], "element order preserved across rebind");
+        for (_, c) in &back.rows[0].cells {
+            let p = c.path.as_deref().unwrap();
+            assert_eq!(
+                p,
+                ferrosa_common::accord_list_cell_path(
+                    &t,
+                    ferrosa_common::list_path_element_seq(p).unwrap()
+                )
+                .as_slice(),
+                "every rebound path carries the Accord t"
+            );
+        }
+    }
+
+    /// A flagged cell whose path is not a 16-byte v1 TimeUUID is corrupt — fail
+    /// loud rather than silently mis-rebind (never fake success).
+    #[test]
+    fn rebinding_flagged_cell_without_16_byte_path_fails_loud() {
+        let buf = mutation_with_cells(vec![(
+            2 | REBIND_FLAG,
+            CellValue::live(b"x".to_vec(), 1000).with_path(vec![0u8; 8]),
+        )]);
+        let err = Mutation::deserialize_from_rebinding_list_paths(&buf, accord_ts(1, 0, 0))
+            .expect_err("a flagged cell with a non-16-byte path must fail loud");
+        assert!(matches!(
+            err,
+            MutationError::InvalidRebindListPath { len: 8 }
+        ));
     }
 }
 

--- a/ferrosa-storage/src/compaction/executor.rs
+++ b/ferrosa-storage/src/compaction/executor.rs
@@ -1139,9 +1139,14 @@ fn combine_input_headers<R: ferrosa_sstable::io::ReadAt>(
     let mut max_timestamp = i64::MIN;
     let mut min_local_deletion_time = NO_DELETION_TIME;
     let mut min_ttl = NO_TTL;
+    // Propagate complex-collection framing: if ANY input SSTable stores complex
+    // (per-element) columns, the compacted output must too, or the merged cell
+    // paths would be dropped and the collection corrupted (D-write, t_83c4f093).
+    let mut has_complex = false;
 
     for r in readers {
         let h = r.header();
+        has_complex |= h.complex_collections;
         if h.min_timestamp != NO_TIMESTAMP
             && (min_timestamp == NO_TIMESTAMP || h.min_timestamp < min_timestamp)
         {
@@ -1166,7 +1171,7 @@ fn combine_input_headers<R: ferrosa_sstable::io::ReadAt>(
     }
 
     SerializationHeader {
-        complex_collections: false,
+        complex_collections: has_complex,
         min_timestamp,
         max_timestamp,
         min_local_deletion_time,

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -12482,6 +12482,62 @@ mod tests {
         );
     }
 
+    /// End-to-end D-write: a per-element collection cell (path set) written to the
+    /// memtable must survive a flush WITH its path — i.e. the flush's data-driven
+    /// activation frames the SSTable as complex. If activation failed
+    /// (`complex_collections = false`), the writer would drop the path and the
+    /// element would read back as a scalar/whole-value cell, losing the CRDT model.
+    #[test]
+    fn write_flush_read_complex_collection_auto_activates_and_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = StorageEngineConfig::test_config(dir.path());
+        let engine = StorageEngine::new(config, None).unwrap();
+
+        // A non-frozen list<int> column is multicell -> complex framing applies
+        // when a cell carries a path.
+        let mut schema = test_schema();
+        schema.regular_columns = vec![ColumnDefinition {
+            name: "val".to_string(),
+            type_name:
+                "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)"
+                    .to_string(),
+        }];
+        engine.register_table(schema).unwrap();
+
+        let tid = table_id();
+        let key = make_key("complex_key");
+        // One per-element list cell: value = encoded int 7, path = a 16-byte list path.
+        let path: Vec<u8> = (0u8..16).collect();
+        let cell = CellValue::live(7i32.to_be_bytes().to_vec(), 1000).with_path(path.clone());
+        let row = Row {
+            clustering: vec![0x00, 0x00, 0x00, 0x01],
+            cells: vec![(0, cell)],
+            deletion: DeletionTime::LIVE,
+            primary_key_liveness: LivenessInfo::with_timestamp(1000),
+        };
+        engine.write(&tid, &key, row, 1000).unwrap();
+
+        engine.flush(&tid).unwrap();
+        assert_eq!(engine.sstable_count(&tid), 1);
+        assert_eq!(engine.memtable_size(&tid), 0);
+
+        let got = engine
+            .read(&tid, &key)
+            .unwrap()
+            .expect("row present after flush");
+        let (_, got_cell) = &got.rows[0].cells[0];
+        assert_eq!(
+            got_cell.value.as_deref(),
+            Some(7i32.to_be_bytes().as_slice()),
+            "per-element value survives flush"
+        );
+        assert_eq!(
+            got_cell.path.as_deref(),
+            Some(path.as_slice()),
+            "per-element PATH survives flush -> complex framing was auto-activated"
+        );
+    }
+
     #[test]
     fn write_flush_write_read_merges() {
         let dir = tempfile::tempdir().unwrap();

--- a/ferrosa-storage/src/flush.rs
+++ b/ferrosa-storage/src/flush.rs
@@ -115,6 +115,12 @@ pub fn build_serialization_header(
         }
     }
 
+    // Data-driven complex-collection activation (D-write, t_83c4f093): if the
+    // memtable produced any per-element cell (path set), this SSTable holds at
+    // least one complex column and must be framed as complex so the paths
+    // persist. Legacy whole-value cells (path=None) leave it false; the reader
+    // handles both formats (lazy dual-read).
+    let mut has_complex = false;
     for partition in partitions {
         // Scan static row cells if present
         if let Some(ref static_row) = partition.static_row {
@@ -130,6 +136,7 @@ pub fn build_serialization_header(
                 update_max_ts(&mut max_timestamp, cell.timestamp);
                 update_min_ldt(&mut min_local_deletion_time, cell.local_deletion_time);
                 update_min_ttl(&mut min_ttl, cell.ttl);
+                has_complex |= cell.path.is_some();
             }
         }
 
@@ -147,6 +154,7 @@ pub fn build_serialization_header(
                 update_max_ts(&mut max_timestamp, cell.timestamp);
                 update_min_ldt(&mut min_local_deletion_time, cell.local_deletion_time);
                 update_min_ttl(&mut min_ttl, cell.ttl);
+                has_complex |= cell.path.is_some();
             }
         }
     }
@@ -162,7 +170,7 @@ pub fn build_serialization_header(
     }
 
     SerializationHeader {
-        complex_collections: false,
+        complex_collections: has_complex,
         min_timestamp,
         min_local_deletion_time,
         min_ttl,

--- a/ferrosa-storage/src/lib.rs
+++ b/ferrosa-storage/src/lib.rs
@@ -51,7 +51,7 @@ pub use cache::LocalCache;
 pub use commitlog::cdc::CdcReader;
 pub use commitlog::{
     CommitLog, CommitLogBatchConfig, CommitLogConfig, CommitLogPosition, Mutation,
-    SyncStrategyConfig, TableId,
+    SyncStrategyConfig, TableId, CELL_REBIND_LIST_PATH_FLAG,
 };
 pub use compaction::{
     CompactionConfig, CompactionExecutor, CompactionStrategy, SizeTieredStrategy,

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -1250,6 +1250,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     mode_controller.set_raft_runtime(runtimes.raft.clone());
     mode_controller.set_data_runtime(runtimes.data.clone());
 
+    // Shared HLC: created once per process. The CQL transaction committer mints
+    // `t0` from it (below, via SharedState.accord_clock) and the node's
+    // AccordStateMachine — built at formation — advances the SAME clock past
+    // every execution timestamp it witnesses, so a later append's `t0` stays
+    // above earlier-committed appends even after they are GC'd (t_813caf39).
+    let accord_clock = {
+        let host_bytes = host_id.as_bytes();
+        let node_id = u64::from_be_bytes(host_bytes[..8].try_into().expect("uuid has 16 bytes"));
+        Arc::new(ferrosa_common::accord::HybridLogicalClock::new(node_id, 0))
+    };
+    mode_controller.set_accord_clock(accord_clock.clone());
+
     // 6b. Start heartbeat loop for peer failure detection
     let heartbeat_pm = peer_manager.clone();
     runtimes.raft.spawn(async move {
@@ -1483,14 +1495,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // host_id (big-endian). The HLC is created once per process; all
             // Accord transactions on this node share it to guarantee monotone
             // timestamp ordering across concurrent LWT coordinators.
-            accord_clock: {
-                let host_bytes = host_id.as_bytes();
-                let node_id =
-                    u64::from_be_bytes(host_bytes[..8].try_into().expect("uuid has 16 bytes"));
-                Some(Arc::new(ferrosa_common::accord::HybridLogicalClock::new(
-                    node_id, 0, // use default 500 ms max drift
-                )))
-            },
+            // The SAME shared clock registered on the ModeController above, so the
+            // committer's `t0` and the replica's witnessed-timestamp advances act
+            // on one clock (t_813caf39).
+            accord_clock: Some(accord_clock.clone()),
             // Same shared slot the ModeController fills at cluster formation, so
             // the Accord committer votes the coordinator's own PreAccept against
             // the node's live AccordState (finishes the sole-replica/self-vote


### PR DESCRIPTION
## What & why

Completes the **CRDT collection D-write** (per-element collection cells written inside Accord transactions) and makes **concurrent list appends strict-serializable**, validated with an Elle `list-append` harness.

Before this, `UPDATE v = v + [x]` inside `BEGIN…COMMIT` had nowhere to put the delta (whole-value read-modify-write can't be expressed in an Accord transaction) and was rejected. The D-write emits one read-free per-element cell per appended element; this PR then fixes the timestamp handling so those elements order by the **Accord execution timestamp**, not any local clock — the property strict-serializability requires.

## The Accord timestamp bugs fixed

An Elle `list-append` workload is a far sharper strict-serializability probe than a bank/LWW workload: a list accumulates, so the *whole* element order is observable, exposing timestamp-ordering bugs that a last-write-wins winner hides (the bank suite passed throughout). Four real bugs, each found by the harness and fixed with tests:

1. **Cell paths used the coordinator materialize clock, not the agreed execution `t`** (`960bd2f6`, `9236d30b`). Per-element list cell paths are now rebound at apply time to `accord_list_cell_path(agreed_t, seq)` via a transient `0x4000` mutation flag — apply stays schema-agnostic; the flag never reaches the SSTable.
2. **`ConflictIndex::max_conflicting_timestamp` returned each conflict's proposed `t0`, never its agreed execution `t`** (`f378aaf0`). PreAccept now bumps past the real serialization point; `accord_ts` is populated at accept/commit.
3. **A node never advanced its HLC past timestamps it witnessed through consensus** (`04ebfd04` refactor + `af1f5d4e`). New `HybridLogicalClock::witness` seam; the state machine now shares the committer's clock and witnesses every execution `t`, so a later append's `t0` stays above earlier-committed appends.
4. **A committed append's execution `t` was lost when GC'd from the conflict index** (`9491e87e`). A bounded per-key high-water-mark now survives `gc_applied`, so a later append bumps past an already-applied one.

Together these collapse pervasive concurrent-append write mis-ordering down to a residual edge.

## Certification status 

The Elle harness (`ferrosa-jepsen/examples/elle_list_append.rs` + an isolated lein checker) runs against a real 3-node RF=3 cluster (self-tearing-down fly.io deploy in `deploy/fly-accord-elle/`).

- The **systematic** coordinator-clock cycles are eliminated; real (`:ok`/`:ok`) inversions collapsed from pervasive to ~1.
- The run is **not yet `valid? true`**, but the residual redness is a **harness artifact, not a database defect**: the generator's `BEGIN`/`UPDATE`/`COMMIT` occasionally land on different server connections (the scylla high-level `Session` doesn't guarantee single-connection affinity), producing ~24% indeterminate (`:info`) commits — `"COMMIT outside of a transaction"` / `"nested transactions"` — which taint Elle's anomaly graph. Diagnostics added here (`2b0fc47b` anomaly dump, `d485dd85` generator failure-reason tally) make this measurable. The generator single-connection rework is tracked as follow-up.

## Testing

- Unit/property tests for every layer of each fix (path encoding, mutation flag round-trip + backward-compat proptests, apply rebind on a real engine, conflict-index execution-`t` + GC-surviving HWM, HLC witness, protocol-level inversion regression, end-to-end commit-through-committer rebind).
- Full suites green: `ferrosa-storage` (1083), `ferrosa-cluster` (1005), plus `ferrosa-common` / `ferrosa-cql` / `ferrosa-row-bridge`.
- `cargo fmt --check`, `cargo clippy --all-targets`, and the docs gate clean.

## Follow-ups

- Generator single-connection affinity (drive `:info` → ~0 for a clean `valid? true`).
- Confirm the last residual inversion is real vs. concurrency-legal with a real-time-aware check.
