### PR TITLE
feat: Unified Transaction Manager Phase A — connection-independent Accord transactions

### DIFF
--- a/deploy/fly-accord-elle/certify-dc.sh
+++ b/deploy/fly-accord-elle/certify-dc.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Dual-DC (3+3) Elle strict-serializability certification with FAULT INJECTION.
+#
+# Stands up a SIX-node ferrosa cluster on fly.io spanning two logical DCs
+# (dc1 = nodes 1-3, dc2 = nodes 4-6, one Raft/Accord cluster), runs the Elle
+# list-append generator IN-network on the dc1 seed, and — WHILE the workload runs —
+# fires a nemesis schedule against the WAN between the DCs:
+#   1. dc-partition : drop ALL cross-DC traffic (ip6tables) for a window, then heal.
+#   2. dc-slow      : add 200ms netem latency on the dc2 side for a window, then heal.
+# These replicate ferrosa-jepsen/src/chaos/wan_bridge.rs {DcPartition,DcSlow} exactly,
+# driven over `flyctl ssh` (the chaos crate's Fly executor does the same).
+#
+# Replication is SimpleStrategy RF=6 so every key replicates across BOTH DCs — a 3/3
+# partition therefore removes quorum (Accord commits STALL, never split-brain), the
+# safety property strict-serializability must preserve. The Elle CHECK runs locally
+# afterwards. Teardown ALWAYS runs (trap) so machines/app/bucket never leak.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ORG="${ORG:-ferrosa}"
+REGION="${REGION:-lax}"
+APP="${APP:-ferrosa-accord-elle-dc-cert}"
+BUCKET="${BUCKET:-ferrosa-accord-elle-dc-${RANDOM}${RANDOM}}"
+# Deterministic dirty-aware image label (see certify.sh rationale): uncommitted code
+# must NOT collide with a prior committed-code image and get served stale.
+RUN_ID="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+if ! git -C "$ROOT_DIR" diff --quiet HEAD 2>/dev/null \
+   || [ -n "$(git -C "$ROOT_DIR" ls-files -o --exclude-standard -- '*.rs' '*.toml')" ]; then
+  WT_HASH="$( { git -C "$ROOT_DIR" diff HEAD; \
+                git -C "$ROOT_DIR" ls-files -o --exclude-standard -- '*.rs' '*.toml' \
+                  | LC_ALL=C sort | xargs -r cat; } 2>/dev/null \
+              | shasum -a 256 | cut -c1-12 )"
+  [ -z "$WT_HASH" ] && WT_HASH="$(date +%s)"
+  RUN_ID="${RUN_ID}-dirty-${WT_HASH}"
+fi
+IMAGE="registry.fly.io/${APP}:cert-${RUN_ID}"
+CPU_KIND="${CPU_KIND:-performance}"
+CPUS="${CPUS:-2}"
+MEM="${MEM:-4096}"
+OUT_EDN="${OUT_EDN:-${ROOT_DIR}/deploy/fly-accord-elle/elle-fly-history-dc.edn}"
+# Workload: keys, ops/worker, workers, rf. rf=6 => replication spans both DCs.
+# ops/worker is generous so the run outlasts the ~110s nemesis schedule below.
+GEN_ARGS="${GEN_ARGS:-8 500 8 6}"
+
+log() { printf '\n[dc-cert] %s\n' "$*" >&2; }
+die() { printf '\n[dc-cert][FATAL] %s\n' "$*" >&2; exit 1; }
+mid() { flyctl machine list --app "$APP" --json 2>/dev/null | jq -r ".[]|select(.name==\"$1\")|.id" | head -1; }
+mip() { flyctl machine list --app "$APP" --json 2>/dev/null | jq -r ".[]|select(.name==\"$1\")|.private_ip" | head -1; }
+dns() { printf '%s.vm.%s.internal' "$1" "$APP"; }
+
+KEEP="${KEEP:-0}"
+teardown() {
+  if [ "$KEEP" = "1" ]; then log "KEEP=1 — NOT tearing down (app=$APP). Destroy manually!"; return; fi
+  log "=== teardown (always) app=$APP ==="
+  local ids; ids="$(flyctl machine list --app "$APP" --json 2>/dev/null | jq -r '.[].id' || true)"
+  for id in $ids; do flyctl machine destroy "$id" --app "$APP" --force 2>&1 | tail -1 || log "WARN: machine $id leak"; done
+  flyctl apps destroy "$APP" --yes 2>&1 | tail -1 || log "WARN: app $APP leak — check billing"
+  flyctl storage destroy "$BUCKET" --yes 2>&1 | tail -1 || log "WARN: bucket $BUCKET leak — flyctl storage destroy $BUCKET"
+}
+trap teardown EXIT
+
+command -v flyctl >/dev/null || die "flyctl not on PATH"
+command -v jq >/dev/null || die "jq not on PATH"
+
+# 1. App + Tigris bucket + S3 secrets.
+log "app + tigris bucket"
+flyctl apps create "$APP" --org "$ORG" 2>&1 | tail -2 || true
+if ! flyctl storage status "$BUCKET" --app "$APP" >/dev/null 2>&1; then
+  flyctl storage create --org "$ORG" --app "$APP" --name "$BUCKET" --yes 2>&1 | tail -5 \
+    || die "tigris create failed (enable billing for org $ORG?)"
+fi
+flyctl secrets set --app "$APP" \
+  FERROSA_S3_ENDPOINT="https://fly.storage.tigris.dev" \
+  FERROSA_S3_BUCKET="$BUCKET" \
+  FERROSA_S3_REGION="auto" 2>&1 | tail -2
+
+# 2. Build + push the image (adds iptables/iproute2 for the nemeses).
+log "build+push image $IMAGE (full workspace compile — ~10-15 min)"
+BUILD_CTX="$(mktemp -d)"
+trap 'rm -rf "$BUILD_CTX"; teardown' EXIT
+tar -C "$ROOT_DIR" --exclude .git --exclude target --exclude '.wt-*' \
+    --exclude .cargo/registry --exclude .cargo/git -cf - . | tar -x -C "$BUILD_CTX"
+cp "${ROOT_DIR}/deploy/fly-accord-elle/ferrosa-elle.Dockerfile" "$BUILD_CTX/Dockerfile.elle"
+cat > "$BUILD_CTX/fly.toml" <<EOF
+app = "${APP}"
+primary_region = "${REGION}"
+[build]
+  dockerfile = "Dockerfile.elle"
+EOF
+BUILD_LOG="$(mktemp)"
+flyctl deploy "$BUILD_CTX" --app "$APP" --config "$BUILD_CTX/fly.toml" \
+  --dockerfile "$BUILD_CTX/Dockerfile.elle" --remote-only --build-only --push \
+  --image-label "cert-${RUN_ID}" 2>&1 | tee "$BUILD_LOG" | grep -iE "compiling ferrosa|finished|error|image:|image size|CACHED" || true
+if ! grep -qiE "Compiling ferrosa-cql|Compiling ferrosa " "$BUILD_LOG"; then
+  log "WARN: no 'Compiling ferrosa' lines — image may be CACHED/stale. Full log: $BUILD_LOG"
+fi
+grep -q "image:" "$BUILD_LOG" || die "image build/push failed (no image pushed) — see $BUILD_LOG"
+
+log "image pushed; settling 30s for fly registry propagation"
+sleep 30
+
+mrun() {
+  local i out
+  for i in 1 2 3 4 5; do
+    if out="$(flyctl machine run "$@" 2>&1)"; then printf '%s\n' "$out" | tail -3; return 0; fi
+    printf '%s\n' "$out" | tail -2
+    if printf '%s' "$out" | grep -qiE "MANIFEST_UNKNOWN|manifest unknown|not found|429|timeout|deadline"; then
+      log "transient machine-run error (attempt $i/5) — retry in 15s"; sleep 15; continue
+    fi
+    return 1
+  done
+  return 1
+}
+
+COMMON=(
+  --env "FERROSA_DATA_DIR=/var/lib/ferrosa"
+  --env "FERROSA_RAFT_DATA_DIR=/var/lib/ferrosa-raft"
+  --env "FERROSA_CQL_BIND=[::]:9042"
+  --env "FERROSA_WEB_BIND=[::]:9090"
+  --env "FERROSA_INTERNODE_BIND=[::]:17000"
+  --env "FERROSA_CLUSTER_NAME=ferrosa-accord-elle-dc"
+  --env "FERROSA_GRAPH_ENABLED=false"
+  --env "FERROSA_AUTH_ENABLED=false"
+  --env "FERROSA_FORMATION_TIMEOUT_SECS=180"
+)
+# Six fixed host-ids (ordering: dc1 n1-3, dc2 n4-6).
+HOST_IDS=(
+  aa111111-1111-1111-1111-111111111111 bb222222-2222-2222-2222-222222222222
+  cc333333-3333-3333-3333-333333333333 dd444444-4444-4444-4444-444444444444
+  ee555555-5555-5555-5555-555555555555 ff666666-6666-6666-6666-666666666666
+)
+DC_OF() { [ "$1" -le 3 ] && echo dc1 || echo dc2; }
+
+wait_ready() { # <machine-id> <name>
+  local id="$1" name="$2" i
+  for i in $(seq 1 60); do
+    if flyctl ssh console --app "$APP" --machine "$id" --command \
+        "sh -lc 'curl -sf http://localhost:9090/readyz'" 2>/dev/null | grep -q 'ready'; then
+      log "  $name ready"; return 0
+    fi
+    sleep 6
+  done
+  die "$name did not become ready"
+}
+
+launch_node() { # <n> [seed_host:port]
+  local n="$1" seed="${2:-}" dc; dc="$(DC_OF "$n")"
+  log "run node$n ($dc)${seed:+ join $seed}"
+  # Build ONE always-non-empty args array (macOS bash 3.2 + `set -u` errors on
+  # expanding an EMPTY array via [@], so never do that — append conditionally).
+  local run_args=(
+    "$IMAGE" --app "$APP" --org "$ORG" --region "$REGION"
+    --name "ferrosa-${n}" --restart always --rootfs-size 20
+    --vm-cpu-kind "$CPU_KIND" --vm-cpus "$CPUS" --vm-memory "$MEM"
+    "${COMMON[@]}"
+    --env "FERROSA_DATA_CENTER=${dc}"
+    --env "FERROSA_HOST_ID=${HOST_IDS[$((n-1))]}"
+    --env "FERROSA_S3_PREFIX=accord-elle-dc/${RUN_ID}/node${n}"
+  )
+  [ -n "$seed" ] && run_args+=(--env "FERROSA_SEED=${seed}")
+  mrun "${run_args[@]}" || die "node$n run failed"
+  wait_ready "$(mid ferrosa-${n})" "ferrosa-${n}"
+}
+
+# 3. dc1 seed, then dc1 joiners, then dc2 (node4 joins the dc1 seed cross-DC to form
+#    ONE cluster, node5/6 seed within dc2).
+launch_node 1
+SEED1="$(dns "$(mid ferrosa-1)"):17000"
+launch_node 2 "$SEED1"
+launch_node 3 "$SEED1"
+launch_node 4 "$SEED1"                       # cross-DC join → single cluster
+SEED2="$(dns "$(mid ferrosa-4)"):17000"
+launch_node 5 "$SEED2"
+launch_node 6 "$SEED2"
+
+# 4. Collect ordered machine-id + private-IP arrays for the nemeses.
+declare -a MIDS IPS
+for n in 1 2 3 4 5 6; do
+  MIDS[$n]="$(mid ferrosa-${n})"; IPS[$n]="$(mip ferrosa-${n})"
+  [ -n "${MIDS[$n]}" ] && [ -n "${IPS[$n]}" ] || die "missing id/ip for ferrosa-${n}"
+done
+SEED_ID="${MIDS[1]}"
+log "cluster up (dc1: ${IPS[1]},${IPS[2]},${IPS[3]} | dc2: ${IPS[4]},${IPS[5]},${IPS[6]}). settling 25s."
+sleep 25
+
+# --- Nemesis primitives (mirror chaos::wan_bridge; dc_a=1-3, dc_b=4-6; IPv6 => ip6tables) ---
+nem() { flyctl ssh console --app "$APP" --machine "$1" --command "sh -lc '$2'" 2>&1 | tail -1; }
+
+# Preflight: fault injection needs NET_ADMIN for ip6tables/tc inside the fly VM. If
+# these fail, the "faults" would be silent no-ops and the run would be a FAKE
+# healthy run — surface it loudly so we don't mis-certify.
+log "nemesis preflight (ip6tables + tc must be usable, else faults are no-ops)"
+PF_IPT="$(nem "${MIDS[1]}" "ip6tables -L INPUT >/dev/null 2>&1 && echo IP6TABLES_OK || echo IP6TABLES_FAIL")"
+PF_TC="$(nem "${MIDS[4]}" "tc qdisc show dev eth0 >/dev/null 2>&1 && echo TC_OK || echo TC_FAIL")"
+log "preflight: $PF_IPT / $PF_TC"
+case "$PF_IPT $PF_TC" in
+  *FAIL*) log "WARN: nemesis tools unavailable (no NET_ADMIN?) — faults will NOT inject; this would be a no-fault run. Investigate before trusting the verdict." ;;
+esac
+inject_dc_partition() {
+  log "NEMESIS inject dc-partition (drop all cross-DC traffic)"
+  for a in 1 2 3; do for b in 4 5 6; do
+    nem "${MIDS[$a]}" "ip6tables -A INPUT -s ${IPS[$b]} -j DROP; ip6tables -A OUTPUT -d ${IPS[$b]} -j DROP"
+  done; done
+  for b in 4 5 6; do for a in 1 2 3; do
+    nem "${MIDS[$b]}" "ip6tables -A INPUT -s ${IPS[$a]} -j DROP; ip6tables -A OUTPUT -d ${IPS[$a]} -j DROP"
+  done; done
+}
+heal_all_netfilter() {
+  log "NEMESIS heal dc-partition (flush ip6tables)"
+  for n in 1 2 3 4 5 6; do nem "${MIDS[$n]}" "ip6tables -F INPUT; ip6tables -F OUTPUT"; done
+}
+inject_dc_slow() {
+  log "NEMESIS inject dc-slow (200ms netem on dc2)"
+  for b in 4 5 6; do nem "${MIDS[$b]}" "tc qdisc add dev eth0 root netem delay 200ms 50ms"; done
+}
+heal_dc_slow() {
+  log "NEMESIS heal dc-slow (remove netem)"
+  for b in 4 5 6; do nem "${MIDS[$b]}" "tc qdisc del dev eth0 root 2>/dev/null || true"; done
+}
+
+# 5. Nemesis SCHEDULE runs in parallel with the generator (background subshell).
+nemesis_schedule() {
+  sleep 25                       # steady-state baseline
+  inject_dc_partition; sleep 15; heal_all_netfilter
+  sleep 15
+  inject_dc_slow;      sleep 30; heal_dc_slow
+}
+log "starting nemesis schedule (parallel) + generator (foreground)"
+nemesis_schedule &
+NEM_PID=$!
+
+# 6. Run the Elle generator ON the dc1 seed, in-network, FOREGROUND.
+log "run generator on seed: elle_list_append localhost:9042 /tmp/hist.edn $GEN_ARGS"
+flyctl ssh console --app "$APP" --machine "$SEED_ID" --command \
+  "sh -lc 'elle_list_append localhost:9042 /tmp/hist.edn ${GEN_ARGS}'" 2>&1 | tail -40 \
+  || log "WARN: generator returned non-zero (faults may abort some ops — history still analyzed)"
+
+wait "$NEM_PID" 2>/dev/null || true
+heal_all_netfilter; heal_dc_slow   # belt-and-suspenders: ensure no lingering faults
+
+# 7. Retrieve the history EDN.
+log "fetch history -> $OUT_EDN"
+flyctl ssh console --app "$APP" --machine "$SEED_ID" --command \
+  "sh -lc 'cat /tmp/hist.edn'" > "$OUT_EDN" 2>/dev/null
+lines="$(wc -l < "$OUT_EDN" | tr -d ' ')"
+[ "$lines" -gt 2 ] || die "history looks empty ($lines lines) — see cluster logs"
+log "history retrieved: $lines lines -> $OUT_EDN"
+log "=== dual-DC fault-injection run complete; teardown next (trap) ==="
+log "NEXT: cd ferrosa-jepsen/elle-checker && lein run $OUT_EDN"

--- a/deploy/fly-accord-elle/certify-nemesis.sh
+++ b/deploy/fly-accord-elle/certify-nemesis.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Single-DC 3-node Elle strict-serializability cert WITH FAULT INJECTION.
+#
+# The classic Jepsen strict-serializability-under-partition test on the proven
+# 3-node RF=3 fly harness: run the Elle list-append generator on the seed (node1)
+# and, WHILE it runs, fire a nemesis schedule:
+#   1. partition-one : isolate node3 (drop its traffic to/from node1+node2). The
+#      MAJORITY (node1+node2) retains quorum and keeps committing; node3 falls
+#      behind and catches up on heal. Validates NO split-brain / lost / reordered
+#      writes across a partition — the safety property Elle checks.
+#   2. slow          : add 200ms netem latency on node2+node3 so the coordinator's
+#      commits must wait on a slow replica — validates ordering under WAN latency.
+# Replicates chaos::network primitives (ip6tables/tc) over `flyctl ssh`. RF=3 so a
+# 2/1 partition keeps a quorum available (unlike a 3/3 dual-DC split). Teardown
+# ALWAYS runs (trap). Elle CHECK runs locally afterwards.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ORG="${ORG:-ferrosa}"
+REGION="${REGION:-lax}"
+APP="${APP:-ferrosa-accord-elle-nemesis-cert}"
+BUCKET="${BUCKET:-ferrosa-accord-elle-nem-${RANDOM}${RANDOM}}"
+RUN_ID="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+if ! git -C "$ROOT_DIR" diff --quiet HEAD 2>/dev/null \
+   || [ -n "$(git -C "$ROOT_DIR" ls-files -o --exclude-standard -- '*.rs' '*.toml')" ]; then
+  WT_HASH="$( { git -C "$ROOT_DIR" diff HEAD; \
+                git -C "$ROOT_DIR" ls-files -o --exclude-standard -- '*.rs' '*.toml' \
+                  | LC_ALL=C sort | xargs -r cat; } 2>/dev/null \
+              | shasum -a 256 | cut -c1-12 )"
+  [ -z "$WT_HASH" ] && WT_HASH="$(date +%s)"
+  RUN_ID="${RUN_ID}-dirty-${WT_HASH}"
+fi
+IMAGE="registry.fly.io/${APP}:cert-${RUN_ID}"
+CPU_KIND="${CPU_KIND:-performance}"
+CPUS="${CPUS:-2}"
+MEM="${MEM:-4096}"
+OUT_EDN="${OUT_EDN:-${ROOT_DIR}/deploy/fly-accord-elle/elle-fly-history-nemesis.edn}"
+# Generous ops so the run outlasts the ~155s nemesis schedule (the coordinator-
+# isolation window blocks each in-flight op up to the 30s client timeout, slowing
+# throughput sharply during that phase — so over-provision).
+GEN_ARGS="${GEN_ARGS:-8 700 8 3}"
+
+log() { printf '\n[nem-cert] %s\n' "$*" >&2; }
+die() { printf '\n[nem-cert][FATAL] %s\n' "$*" >&2; exit 1; }
+mid() { flyctl machine list --app "$APP" --json 2>/dev/null | jq -r ".[]|select(.name==\"$1\")|.id" | head -1; }
+mip() { flyctl machine list --app "$APP" --json 2>/dev/null | jq -r ".[]|select(.name==\"$1\")|.private_ip" | head -1; }
+dns() { printf '%s.vm.%s.internal' "$1" "$APP"; }
+
+KEEP="${KEEP:-0}"
+teardown() {
+  if [ "$KEEP" = "1" ]; then log "KEEP=1 — NOT tearing down (app=$APP)."; return; fi
+  log "=== teardown (always) app=$APP ==="
+  local ids; ids="$(flyctl machine list --app "$APP" --json 2>/dev/null | jq -r '.[].id' || true)"
+  for id in $ids; do flyctl machine destroy "$id" --app "$APP" --force 2>&1 | tail -1 || log "WARN: machine $id leak"; done
+  flyctl apps destroy "$APP" --yes 2>&1 | tail -1 || log "WARN: app $APP leak"
+  flyctl storage destroy "$BUCKET" --yes 2>&1 | tail -1 || log "WARN: bucket $BUCKET leak"
+}
+trap teardown EXIT
+
+command -v flyctl >/dev/null || die "flyctl not on PATH"
+command -v jq >/dev/null || die "jq not on PATH"
+
+# 1. App + bucket + secrets.
+log "app + tigris bucket"
+flyctl apps create "$APP" --org "$ORG" 2>&1 | tail -2 || true
+if ! flyctl storage status "$BUCKET" --app "$APP" >/dev/null 2>&1; then
+  flyctl storage create --org "$ORG" --app "$APP" --name "$BUCKET" --yes 2>&1 | tail -5 \
+    || die "tigris create failed"
+fi
+flyctl secrets set --app "$APP" \
+  FERROSA_S3_ENDPOINT="https://fly.storage.tigris.dev" \
+  FERROSA_S3_BUCKET="$BUCKET" \
+  FERROSA_S3_REGION="auto" 2>&1 | tail -2
+
+# 2. Build + push (image includes iptables/iproute2 for the nemeses).
+log "build+push image $IMAGE"
+BUILD_CTX="$(mktemp -d)"
+trap 'rm -rf "$BUILD_CTX"; teardown' EXIT
+tar -C "$ROOT_DIR" --exclude .git --exclude target --exclude '.wt-*' \
+    --exclude .cargo/registry --exclude .cargo/git -cf - . | tar -x -C "$BUILD_CTX"
+cp "${ROOT_DIR}/deploy/fly-accord-elle/ferrosa-elle.Dockerfile" "$BUILD_CTX/Dockerfile.elle"
+cat > "$BUILD_CTX/fly.toml" <<EOF
+app = "${APP}"
+primary_region = "${REGION}"
+[build]
+  dockerfile = "Dockerfile.elle"
+EOF
+BUILD_LOG="$(mktemp)"
+flyctl deploy "$BUILD_CTX" --app "$APP" --config "$BUILD_CTX/fly.toml" \
+  --dockerfile "$BUILD_CTX/Dockerfile.elle" --remote-only --build-only --push \
+  --image-label "cert-${RUN_ID}" 2>&1 | tee "$BUILD_LOG" | grep -iE "compiling ferrosa|finished|error|image:|image size|CACHED" || true
+grep -q "image:" "$BUILD_LOG" || die "image build/push failed — see $BUILD_LOG"
+
+log "image pushed; settling 30s"
+sleep 30
+
+mrun() {
+  local i out
+  for i in 1 2 3 4 5; do
+    if out="$(flyctl machine run "$@" 2>&1)"; then printf '%s\n' "$out" | tail -3; return 0; fi
+    printf '%s\n' "$out" | tail -2
+    if printf '%s' "$out" | grep -qiE "MANIFEST_UNKNOWN|manifest unknown|not found|429|timeout|deadline"; then
+      log "transient machine-run error (attempt $i/5) — retry in 15s"; sleep 15; continue
+    fi
+    return 1
+  done
+  return 1
+}
+
+COMMON=(
+  --env "FERROSA_DATA_DIR=/var/lib/ferrosa"
+  --env "FERROSA_RAFT_DATA_DIR=/var/lib/ferrosa-raft"
+  --env "FERROSA_CQL_BIND=[::]:9042"
+  --env "FERROSA_WEB_BIND=[::]:9090"
+  --env "FERROSA_INTERNODE_BIND=[::]:17000"
+  --env "FERROSA_CLUSTER_NAME=ferrosa-accord-elle-nem"
+  --env "FERROSA_GRAPH_ENABLED=false"
+  --env "FERROSA_AUTH_ENABLED=false"
+  --env "FERROSA_FORMATION_TIMEOUT_SECS=120"
+)
+HOST_IDS=(aa111111-1111-1111-1111-111111111111 bb222222-2222-2222-2222-222222222222 cc333333-3333-3333-3333-333333333333)
+
+wait_ready() { # <machine-id> <name>
+  local id="$1" name="$2" i
+  for i in $(seq 1 50); do
+    if flyctl ssh console --app "$APP" --machine "$id" --command \
+        "sh -lc 'curl -sf http://localhost:9090/readyz'" 2>/dev/null | grep -q 'ready'; then
+      log "  $name ready"; return 0
+    fi
+    sleep 6
+  done
+  die "$name did not become ready"
+}
+
+launch_node() { # <n> [seed]
+  local n="$1" seed="${2:-}"
+  log "run node$n${seed:+ join $seed}"
+  local run_args=(
+    "$IMAGE" --app "$APP" --org "$ORG" --region "$REGION"
+    --name "ferrosa-${n}" --restart always --rootfs-size 20
+    --vm-cpu-kind "$CPU_KIND" --vm-cpus "$CPUS" --vm-memory "$MEM"
+    "${COMMON[@]}"
+    --env "FERROSA_HOST_ID=${HOST_IDS[$((n-1))]}"
+    --env "FERROSA_S3_PREFIX=accord-elle-nem/${RUN_ID}/node${n}"
+  )
+  [ -n "$seed" ] && run_args+=(--env "FERROSA_SEED=${seed}")
+  mrun "${run_args[@]}" || die "node$n run failed"
+  wait_ready "$(mid ferrosa-${n})" "ferrosa-${n}"
+}
+
+# 3. Seed node1, join node2/node3.
+launch_node 1
+SEED="$(dns "$(mid ferrosa-1)"):17000"
+launch_node 2 "$SEED"
+launch_node 3 "$SEED"
+
+declare -a MIDS IPS
+for n in 1 2 3; do
+  MIDS[$n]="$(mid ferrosa-${n})"; IPS[$n]="$(mip ferrosa-${n})"
+  [ -n "${MIDS[$n]}" ] && [ -n "${IPS[$n]}" ] || die "missing id/ip for ferrosa-${n}"
+done
+SEED_ID="${MIDS[1]}"
+log "cluster up (n1=${IPS[1]} n2=${IPS[2]} n3=${IPS[3]}). settling 20s."
+sleep 20
+
+# --- Nemesis primitives (ip6tables/tc over flyctl ssh) ---
+nem() { flyctl ssh console --app "$APP" --machine "$1" --command "sh -lc '$2'" 2>&1 | tail -1; }
+log "nemesis preflight (ip6tables + tc)"
+PF="$(nem "${MIDS[3]}" "ip6tables -L INPUT >/dev/null 2>&1 && tc qdisc show dev eth0 >/dev/null 2>&1 && echo NEM_OK || echo NEM_FAIL")"
+log "preflight: $PF"
+[ "$PF" = "NEM_OK" ] || log "WARN: nemesis tools unavailable — faults may be no-ops; investigate before trusting the verdict."
+
+# Isolate node3 from node1+node2 (majority partition; node1+node2 keep quorum).
+inject_partition_one() {
+  log "NEMESIS inject partition-one (isolate node3)"
+  nem "${MIDS[3]}" "ip6tables -A INPUT -s ${IPS[1]} -j DROP; ip6tables -A OUTPUT -d ${IPS[1]} -j DROP; ip6tables -A INPUT -s ${IPS[2]} -j DROP; ip6tables -A OUTPUT -d ${IPS[2]} -j DROP"
+  nem "${MIDS[1]}" "ip6tables -A INPUT -s ${IPS[3]} -j DROP; ip6tables -A OUTPUT -d ${IPS[3]} -j DROP"
+  nem "${MIDS[2]}" "ip6tables -A INPUT -s ${IPS[3]} -j DROP; ip6tables -A OUTPUT -d ${IPS[3]} -j DROP"
+}
+heal_netfilter() { log "NEMESIS heal partition"; for n in 1 2 3; do nem "${MIDS[$n]}" "ip6tables -F INPUT; ip6tables -F OUTPUT"; done; }
+# Isolate node1 (the generator's coordinator) INTO the minority: node2+node3 keep
+# quorum, node1 is alone. The generator, pinned to node1, then CANNOT commit — its
+# COMMITs must go indeterminate (:info) once the 30s client timeout elapses. This
+# proves (a) the fault genuinely bit, and (b) the minority correctly REFUSES to
+# commit (no split-brain) rather than fabricating a write.
+inject_isolate_coordinator() {
+  log "NEMESIS inject isolate-coordinator (node1 -> minority; commits must go :info)"
+  nem "${MIDS[1]}" "ip6tables -A INPUT -s ${IPS[2]} -j DROP; ip6tables -A OUTPUT -d ${IPS[2]} -j DROP; ip6tables -A INPUT -s ${IPS[3]} -j DROP; ip6tables -A OUTPUT -d ${IPS[3]} -j DROP"
+  nem "${MIDS[2]}" "ip6tables -A INPUT -s ${IPS[1]} -j DROP; ip6tables -A OUTPUT -d ${IPS[1]} -j DROP"
+  nem "${MIDS[3]}" "ip6tables -A INPUT -s ${IPS[1]} -j DROP; ip6tables -A OUTPUT -d ${IPS[1]} -j DROP"
+}
+# 200ms latency on node2+node3 so the coordinator (node1) must wait on a slow replica.
+inject_slow() { log "NEMESIS inject slow (200ms on node2+node3)"; for n in 2 3; do nem "${MIDS[$n]}" "tc qdisc add dev eth0 root netem delay 200ms 50ms"; done; }
+heal_slow() { log "NEMESIS heal slow"; for n in 2 3; do nem "${MIDS[$n]}" "tc qdisc del dev eth0 root 2>/dev/null || true"; done; }
+
+nemesis_schedule() {
+  sleep 25
+  inject_partition_one;        sleep 20; heal_netfilter   # minority isolated; majority available (safety)
+  sleep 12
+  inject_isolate_coordinator;  sleep 40; heal_netfilter   # coordinator in minority >30s => :info (correct refusal)
+  sleep 12
+  inject_slow;                 sleep 22; heal_slow        # ordering under latency
+}
+log "starting nemesis schedule (parallel) + generator (foreground)"
+nemesis_schedule &
+NEM_PID=$!
+
+# 4. Generator on the seed (node1, majority side), foreground.
+log "run generator on seed: elle_list_append localhost:9042 /tmp/hist.edn $GEN_ARGS"
+flyctl ssh console --app "$APP" --machine "$SEED_ID" --command \
+  "sh -lc 'elle_list_append localhost:9042 /tmp/hist.edn ${GEN_ARGS}'" 2>&1 | tail -40 \
+  || log "WARN: generator returned non-zero (faults may abort some ops — history still analyzed)"
+
+wait "$NEM_PID" 2>/dev/null || true
+heal_netfilter; heal_slow
+
+# 5. Retrieve history.
+log "fetch history -> $OUT_EDN"
+flyctl ssh console --app "$APP" --machine "$SEED_ID" --command \
+  "sh -lc 'cat /tmp/hist.edn'" > "$OUT_EDN" 2>/dev/null
+lines="$(wc -l < "$OUT_EDN" | tr -d ' ')"
+[ "$lines" -gt 2 ] || die "history looks empty ($lines lines)"
+log "history retrieved: $lines lines -> $OUT_EDN"
+log "=== fault-injection run complete; teardown next (trap) ==="
+log "NEXT: cd ferrosa-jepsen/elle-checker && lein run $OUT_EDN"

--- a/deploy/fly-accord-elle/certify.sh
+++ b/deploy/fly-accord-elle/certify.sh
@@ -14,7 +14,26 @@ REGION="${REGION:-lax}"
 APP="${APP:-ferrosa-accord-elle-cert}"
 # Unique per run: Tigris imposes a cooldown on reusing a just-deleted bucket name.
 BUCKET="${BUCKET:-ferrosa-accord-elle-${RANDOM}${RANDOM}}"
+# Image label. Derived from the git HEAD, BUT when the working tree is dirty the
+# HEAD hash alone collides with a prior committed-code build — fly then serves the
+# CACHED old image and the cert silently tests stale code (the txn-manager cert hit
+# exactly this). Append a content hash of the working tree (via `git stash create`,
+# which snapshots tracked changes WITHOUT touching the tree) so uncommitted changes
+# always get a fresh, distinct image. Falls back to a timestamp if stash is empty.
 RUN_ID="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+if ! git -C "$ROOT_DIR" diff --quiet HEAD 2>/dev/null \
+   || [ -n "$(git -C "$ROOT_DIR" ls-files -o --exclude-standard -- '*.rs' '*.toml')" ]; then
+  # DETERMINISTIC content hash of the working tree (tracked edits + untracked
+  # .rs/.toml source), so identical code always yields the SAME label — a re-run
+  # after a killed build can reuse fly's build cache instead of cold-compiling
+  # again, while committed-code runs still get their clean HEAD label.
+  WT_HASH="$( { git -C "$ROOT_DIR" diff HEAD; \
+                git -C "$ROOT_DIR" ls-files -o --exclude-standard -- '*.rs' '*.toml' \
+                  | LC_ALL=C sort | xargs -r cat; } 2>/dev/null \
+              | shasum -a 256 | cut -c1-12 )"
+  [ -z "$WT_HASH" ] && WT_HASH="$(date +%s)"
+  RUN_ID="${RUN_ID}-dirty-${WT_HASH}"
+fi
 IMAGE="registry.fly.io/${APP}:cert-${RUN_ID}"
 CPU_KIND="${CPU_KIND:-performance}"
 CPUS="${CPUS:-2}"
@@ -68,9 +87,17 @@ primary_region = "${REGION}"
 [build]
   dockerfile = "Dockerfile.elle"
 EOF
+# Keep the full build log (was `tail -8`, which hid whether a compile actually ran
+# and masked the stale-image cert). Tee to a file and surface the `Compiling` lines
+# + summary so a cached-image (no-compile) build is obvious in the output.
+BUILD_LOG="$(mktemp)"
 flyctl deploy "$BUILD_CTX" --app "$APP" --config "$BUILD_CTX/fly.toml" \
   --dockerfile "$BUILD_CTX/Dockerfile.elle" --remote-only --build-only --push \
-  --image-label "cert-${RUN_ID}" 2>&1 | tail -8 || die "image build/push failed"
+  --image-label "cert-${RUN_ID}" 2>&1 | tee "$BUILD_LOG" | grep -iE "compiling ferrosa|finished|error|image:|image size|CACHED" || true
+if ! grep -qiE "Compiling ferrosa-cql|Compiling ferrosa " "$BUILD_LOG"; then
+  log "WARN: no 'Compiling ferrosa' lines in the build — image may be CACHED/stale (label reuse). Full log: $BUILD_LOG"
+fi
+grep -q "image:" "$BUILD_LOG" || die "image build/push failed (no image pushed) — see $BUILD_LOG"
 
 # Let the pushed manifest propagate before launching machines by digest —
 # otherwise the first `machine run` can 404 MANIFEST_UNKNOWN (fly registry race).

--- a/deploy/fly-accord-elle/ferrosa-elle.Dockerfile
+++ b/deploy/fly-accord-elle/ferrosa-elle.Dockerfile
@@ -64,7 +64,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         linux-perf \
         procps \
         sysstat \
+        iptables \
+        iproute2 \
     && rm -rf /var/lib/apt/lists/*
+# iptables/ip6tables + iproute2(tc) are required by the WAN nemeses
+# (chaos::wan_bridge DcPartition uses ip6tables on fly's IPv6 private net; DcSlow
+# uses `tc qdisc ... netem`). Without them the dual-DC fault injection can't run.
 COPY --from=builder /build/target/release/ferrosa /usr/local/bin/
 COPY --from=builder /build/target/release/examples/elle_list_append /usr/local/bin/
 COPY deploy/fly-bench/ferrosa-entrypoint.sh /usr/local/bin/

--- a/ferrosa-cql/src/ast.rs
+++ b/ferrosa-cql/src/ast.rs
@@ -147,12 +147,30 @@ pub enum Statement {
         stream_id: Option<u16>,
     },
     Explain(Box<SelectStatement>),
-    /// BEGIN TRANSACTION — starts a multi-statement Accord transaction.
-    BeginTransaction,
-    /// COMMIT — commits the current Accord transaction.
-    Commit,
-    /// ROLLBACK — aborts the current Accord transaction.
-    Rollback,
+    /// `BEGIN TRANSACTION [USING TIMEOUT <ms>]` — starts a multi-statement Accord
+    /// transaction and returns its server-minted id as a single result row.
+    /// `timeout_ms` overrides the cluster-default open-transaction timeout (A1b),
+    /// bounded by the hard cluster maximum.
+    BeginTransaction {
+        timeout_ms: Option<u64>,
+    },
+    /// `COMMIT [TRANSACTION [<id>]]` — commits a transaction. `txn_id = Some(id)`
+    /// targets a connection-independent transaction by id; `None` resolves via the
+    /// connection's compat-shim binding (bare `COMMIT`).
+    Commit {
+        txn_id: Option<String>,
+    },
+    /// `ROLLBACK [TRANSACTION [<id>]]` — aborts a transaction (explicit id or shim).
+    Rollback {
+        txn_id: Option<String>,
+    },
+    /// `<inner> IN TRANSACTION <id>` — a DML/SELECT explicitly scoped to a
+    /// transaction by id (connection-independent). The router stages the write, or
+    /// scopes the read, under `txn_id` in the transaction registry.
+    InTransaction {
+        txn_id: String,
+        inner: Box<Statement>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -332,7 +332,7 @@ pub(crate) async fn handle_connection<S>(
     // Per-connection BEGIN/COMMIT transaction buffer (shared across this
     // connection's concurrent in-flight requests; transactions are serialized).
     let conn_txn = std::sync::Arc::new(tokio::sync::Mutex::new(
-        crate::session::CqlTransaction::new(),
+        None::<crate::txn_registry::CqlTxnId>,
     ));
     let mut pending_compression: Option<Compression> = None;
     let mut client_protocol_version: u8 = 4; // default; updated from STARTUP frame
@@ -1145,7 +1145,7 @@ async fn handle_frame(
     pending_compression: &mut Option<Compression>,
     peer: SocketAddr,
     task_pool: TaskPool,
-    conn_txn: &tokio::sync::Mutex<crate::session::CqlTransaction>,
+    conn_txn: &tokio::sync::Mutex<Option<crate::txn_registry::CqlTxnId>>,
 ) -> HandleResult {
     match phase {
         ConnectionPhase::AwaitingStartup => match frame.header.opcode {
@@ -1506,7 +1506,7 @@ async fn handle_query(
     body: &Bytes,
     peer: SocketAddr,
     protocol_version: u8,
-    conn_txn: &tokio::sync::Mutex<crate::session::CqlTransaction>,
+    conn_txn: &tokio::sync::Mutex<Option<crate::txn_registry::CqlTxnId>>,
 ) -> HandleResult {
     // Parse the query string: [int length][bytes query][short consistency][byte flags]...
     if body.len() < 4 {
@@ -1597,8 +1597,9 @@ async fn handle_query(
     // check/commit (transactions on a connection are inherently serial), then
     // released before normal routing; `None` falls through.
     let txn_result = {
-        let mut txn = conn_txn.lock().await;
-        crate::router::route_transactional(state, &ctx, &stmt, &mut txn).await
+        let mut shim = conn_txn.lock().await;
+        crate::router::route_transactional(state, &ctx, &stmt, &mut shim, std::time::Instant::now())
+            .await
     };
     if let Some(result) = txn_result {
         return match result {
@@ -3382,6 +3383,9 @@ mod tests {
                 last_schema_event: tokio::sync::watch::channel(None).0,
                 cql_metrics: Arc::new(crate::observability::CqlMetrics::new()),
                 topology_policy: crate::topology::ClientTopologyPolicy::default(),
+                txn_registry: std::sync::Arc::new(parking_lot::Mutex::new(
+                    crate::txn_registry::TransactionRegistry::default(),
+                )),
             },
             dir,
         )

--- a/ferrosa-cql/src/lib.rs
+++ b/ferrosa-cql/src/lib.rs
@@ -43,6 +43,7 @@ pub mod test_util;
 pub mod topology;
 pub mod transaction_keys;
 pub mod transaction_limits;
+pub mod txn_registry;
 pub mod types;
 pub mod virtual_tables;
 pub mod wasm_aggregate;

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -133,10 +133,22 @@ impl<'input> Parser<'input> {
     fn parse_statement(&mut self) -> Result<Statement, CqlError> {
         let tok = self.lexer.peek()?;
         match &tok.kind {
-            TokenKind::Keyword(Keyword::Select) => self.parse_select().map(Statement::Select),
-            TokenKind::Keyword(Keyword::Insert) => self.parse_insert().map(Statement::Insert),
-            TokenKind::Keyword(Keyword::Update) => self.parse_update().map(Statement::Update),
-            TokenKind::Keyword(Keyword::Delete) => self.parse_delete().map(Statement::Delete),
+            TokenKind::Keyword(Keyword::Select) => {
+                let s = self.parse_select().map(Statement::Select)?;
+                self.maybe_wrap_in_transaction(s)
+            }
+            TokenKind::Keyword(Keyword::Insert) => {
+                let s = self.parse_insert().map(Statement::Insert)?;
+                self.maybe_wrap_in_transaction(s)
+            }
+            TokenKind::Keyword(Keyword::Update) => {
+                let s = self.parse_update().map(Statement::Update)?;
+                self.maybe_wrap_in_transaction(s)
+            }
+            TokenKind::Keyword(Keyword::Delete) => {
+                let s = self.parse_delete().map(Statement::Delete)?;
+                self.maybe_wrap_in_transaction(s)
+            }
             TokenKind::Keyword(Keyword::Create) => self.parse_create(),
             TokenKind::Keyword(Keyword::Alter) => self.parse_alter(),
             TokenKind::Keyword(Keyword::Drop) => self.parse_drop(),
@@ -592,7 +604,13 @@ impl<'input> Parser<'input> {
         self.lexer.expect(&TokenKind::Keyword(Keyword::Begin))?;
 
         if self.lexer.eat(&TokenKind::Keyword(Keyword::Transaction))? {
-            return Ok(Statement::BeginTransaction);
+            // Optional `USING TIMEOUT <ms>` open-transaction budget (A1b).
+            let timeout_ms = if self.lexer.eat(&TokenKind::Keyword(Keyword::Using))? {
+                Some(self.parse_transaction_timeout_ms()?)
+            } else {
+                None
+            };
+            return Ok(Statement::BeginTransaction { timeout_ms });
         }
 
         // Otherwise it's a BATCH statement — delegate to parse_batch_body
@@ -602,12 +620,89 @@ impl<'input> Parser<'input> {
 
     fn parse_commit(&mut self) -> Result<Statement, CqlError> {
         self.lexer.expect(&TokenKind::Keyword(Keyword::Commit))?;
-        Ok(Statement::Commit)
+        let txn_id = self.parse_optional_transaction_target()?;
+        Ok(Statement::Commit { txn_id })
     }
 
     fn parse_rollback(&mut self) -> Result<Statement, CqlError> {
         self.lexer.expect(&TokenKind::Keyword(Keyword::Rollback))?;
-        Ok(Statement::Rollback)
+        let txn_id = self.parse_optional_transaction_target()?;
+        Ok(Statement::Rollback { txn_id })
+    }
+
+    /// After `USING`, parse `TIMEOUT <ms>` (an integer literal, milliseconds).
+    /// `TIMEOUT` is a soft keyword (a bare identifier) so it does not become a
+    /// reserved word that would break tables/columns named `timeout`.
+    fn parse_transaction_timeout_ms(&mut self) -> Result<u64, CqlError> {
+        let tok = self.lexer.next_token()?;
+        let is_timeout = match &tok.kind {
+            TokenKind::Ident(s) => s.eq_ignore_ascii_case("timeout"),
+            TokenKind::QuotedIdent(s) => s.eq_ignore_ascii_case("timeout"),
+            _ => false,
+        };
+        if !is_timeout {
+            return Err(CqlError::SyntaxError(format!(
+                "expected TIMEOUT after USING in BEGIN TRANSACTION, got {:?}",
+                tok.kind
+            )));
+        }
+        let tok = self.lexer.next_token()?;
+        match tok.kind {
+            TokenKind::IntegerLiteral(n) if n >= 0 => Ok(n as u64),
+            other => Err(CqlError::SyntaxError(format!(
+                "expected a non-negative millisecond timeout, got {other:?}"
+            ))),
+        }
+    }
+
+    /// Wrap a just-parsed DML/SELECT in `Statement::InTransaction` if a trailing
+    /// `IN TRANSACTION <id>` suffix follows. At the end of a fully-parsed DML
+    /// statement a leading `IN` is unambiguously this suffix (a `WHERE ... IN
+    /// (...)` list was already consumed inside the DML parse), so a single-token
+    /// lookahead suffices.
+    fn maybe_wrap_in_transaction(&mut self, inner: Statement) -> Result<Statement, CqlError> {
+        if !self.lexer.eat(&TokenKind::Keyword(Keyword::In))? {
+            return Ok(inner);
+        }
+        self.lexer
+            .expect(&TokenKind::Keyword(Keyword::Transaction))?;
+        let txn_id = self.parse_optional_txn_id_literal()?.ok_or_else(|| {
+            CqlError::SyntaxError("expected a transaction id after IN TRANSACTION".to_string())
+        })?;
+        Ok(Statement::InTransaction {
+            txn_id,
+            inner: Box::new(inner),
+        })
+    }
+
+    /// Parse the optional `TRANSACTION [<id>]` target that may follow `COMMIT` or
+    /// `ROLLBACK`. `Some(id)` when an explicit id is given (connection-independent);
+    /// `None` for bare `COMMIT`/`ROLLBACK` or `COMMIT TRANSACTION` without an id
+    /// (both resolve via the connection's compat-shim binding).
+    fn parse_optional_transaction_target(&mut self) -> Result<Option<String>, CqlError> {
+        if !self.lexer.eat(&TokenKind::Keyword(Keyword::Transaction))? {
+            return Ok(None);
+        }
+        self.parse_optional_txn_id_literal()
+    }
+
+    /// Parse an optional transaction-id literal (a bare `UuidLiteral` or a quoted
+    /// `StringLiteral`). Returns `None` if the next token is not an id literal, so
+    /// `COMMIT TRANSACTION` (no id) is accepted for the shim.
+    fn parse_optional_txn_id_literal(&mut self) -> Result<Option<String>, CqlError> {
+        match &self.lexer.peek()?.kind {
+            TokenKind::UuidLiteral(u) => {
+                let s = u.to_string();
+                self.lexer.next_token()?;
+                Ok(Some(s))
+            }
+            TokenKind::StringLiteral(s) => {
+                let s = s.clone();
+                self.lexer.next_token()?;
+                Ok(Some(s))
+            }
+            _ => Ok(None),
+        }
     }
 
     // ---------------------------------------------------------------
@@ -5738,94 +5833,128 @@ mod tests {
 
     #[test]
     fn parse_begin_commit_rollback() {
-        // BEGIN TRANSACTION
+        // BEGIN TRANSACTION — no explicit timeout.
         let stmt = parse("BEGIN TRANSACTION").unwrap();
         assert!(
-            matches!(stmt, Statement::BeginTransaction),
-            "expected BeginTransaction, got {:?}",
-            stmt
+            matches!(stmt, Statement::BeginTransaction { timeout_ms: None }),
+            "expected BeginTransaction, got {stmt:?}"
         );
 
-        // COMMIT
+        // COMMIT — bare (shim), no explicit id.
         let stmt = parse("COMMIT").unwrap();
         assert!(
-            matches!(stmt, Statement::Commit),
-            "expected Commit, got {:?}",
-            stmt
+            matches!(stmt, Statement::Commit { txn_id: None }),
+            "expected Commit, got {stmt:?}"
         );
 
-        // ROLLBACK
+        // ROLLBACK — bare (shim), no explicit id.
         let stmt = parse("ROLLBACK").unwrap();
         assert!(
-            matches!(stmt, Statement::Rollback),
-            "expected Rollback, got {:?}",
-            stmt
+            matches!(stmt, Statement::Rollback { txn_id: None }),
+            "expected Rollback, got {stmt:?}"
         );
     }
 
     #[test]
     fn parse_begin_transaction_case_insensitive() {
         let stmt = parse("begin transaction").unwrap();
-        assert!(matches!(stmt, Statement::BeginTransaction));
+        assert!(matches!(
+            stmt,
+            Statement::BeginTransaction { timeout_ms: None }
+        ));
 
         let stmt = parse("Begin Transaction").unwrap();
-        assert!(matches!(stmt, Statement::BeginTransaction));
+        assert!(matches!(
+            stmt,
+            Statement::BeginTransaction { timeout_ms: None }
+        ));
     }
 
     #[test]
-    fn parse_nested_transaction_rejected() {
-        use crate::session::TransactionState;
-        let mut txn_state = TransactionState::new();
-
-        // First BEGIN is accepted.
-        let stmt = parse("BEGIN TRANSACTION").unwrap();
-        txn_state.validate_and_transition(&stmt).unwrap();
-
-        // Second BEGIN inside the transaction must be rejected.
-        let stmt = parse("BEGIN TRANSACTION").unwrap();
-        let err = txn_state.validate_and_transition(&stmt);
-        assert!(err.is_err(), "nested BEGIN TRANSACTION should be rejected");
-        let msg = err.unwrap_err().to_string();
+    fn parse_begin_transaction_using_timeout() {
+        let stmt = parse("BEGIN TRANSACTION USING TIMEOUT 5000").unwrap();
         assert!(
-            msg.contains("nested"),
-            "error should mention 'nested', got: {msg}"
+            matches!(
+                stmt,
+                Statement::BeginTransaction {
+                    timeout_ms: Some(5000)
+                }
+            ),
+            "expected a 5000ms timeout, got {stmt:?}"
         );
+        // TIMEOUT is a soft keyword — lowercase form parses too.
+        let stmt = parse("begin transaction using timeout 250").unwrap();
+        assert!(matches!(
+            stmt,
+            Statement::BeginTransaction {
+                timeout_ms: Some(250)
+            }
+        ));
     }
 
     #[test]
-    fn parse_ddl_in_transaction_rejected() {
-        use crate::session::TransactionState;
-        let mut txn_state = TransactionState::new();
-
-        // Start a transaction.
-        let begin = parse("BEGIN TRANSACTION").unwrap();
-        txn_state.validate_and_transition(&begin).unwrap();
-
-        // DDL inside transaction must be rejected.
-        let ddl = parse("CREATE TABLE ks.t (k int PRIMARY KEY)").unwrap();
-        let err = txn_state.validate_and_transition(&ddl);
-        assert!(err.is_err(), "DDL inside transaction should be rejected");
-        let msg = err.unwrap_err().to_string();
+    fn parse_commit_rollback_with_explicit_id() {
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+        let stmt = parse(&format!("COMMIT TRANSACTION {id}")).unwrap();
         assert!(
-            msg.contains("DDL"),
-            "error should mention 'DDL', got: {msg}"
+            matches!(stmt, Statement::Commit { txn_id: Some(ref t) } if t == id),
+            "expected Commit with explicit id, got {stmt:?}"
         );
+        let stmt = parse(&format!("ROLLBACK TRANSACTION {id}")).unwrap();
+        assert!(
+            matches!(stmt, Statement::Rollback { txn_id: Some(ref t) } if t == id),
+            "expected Rollback with explicit id, got {stmt:?}"
+        );
+        // A quoted-string id form is also accepted.
+        let stmt = parse(&format!("COMMIT TRANSACTION '{id}'")).unwrap();
+        assert!(matches!(stmt, Statement::Commit { txn_id: Some(ref t) } if t == id));
     }
 
     #[test]
-    fn parse_empty_transaction() {
-        use crate::session::TransactionState;
-        let mut txn_state = TransactionState::new();
+    fn parse_dml_in_transaction_suffix() {
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+        // UPDATE ... IN TRANSACTION <id> wraps the DML in InTransaction.
+        let stmt = parse(&format!(
+            "UPDATE elle.la SET v = v + [7] WHERE k = 1 IN TRANSACTION {id}"
+        ))
+        .unwrap();
+        match stmt {
+            Statement::InTransaction { txn_id, inner } => {
+                assert_eq!(txn_id, id);
+                assert!(
+                    matches!(*inner, Statement::Update(_)),
+                    "inner must be the UPDATE, got {inner:?}"
+                );
+            }
+            other => panic!("expected InTransaction wrapper, got {other:?}"),
+        }
+    }
 
-        // BEGIN immediately followed by COMMIT is legal.
-        let begin = parse("BEGIN TRANSACTION").unwrap();
-        txn_state.validate_and_transition(&begin).unwrap();
+    #[test]
+    fn parse_select_in_transaction_suffix() {
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+        let stmt = parse(&format!(
+            "SELECT v FROM elle.la WHERE k = 1 IN TRANSACTION {id}"
+        ))
+        .unwrap();
+        match stmt {
+            Statement::InTransaction { txn_id, inner } => {
+                assert_eq!(txn_id, id);
+                assert!(matches!(*inner, Statement::Select(_)));
+            }
+            other => panic!("expected InTransaction wrapper, got {other:?}"),
+        }
+    }
 
-        let commit = parse("COMMIT").unwrap();
-        txn_state.validate_and_transition(&commit).unwrap();
-
-        // After commit, we're back to no-transaction state.
-        assert!(!txn_state.in_transaction());
+    #[test]
+    fn parse_where_in_list_is_not_a_transaction_suffix() {
+        // A WHERE `... IN (...)` list must NOT be mistaken for the IN TRANSACTION
+        // suffix — it is consumed inside the DML parse.
+        let stmt = parse("SELECT v FROM elle.la WHERE k IN (1, 2, 3)").unwrap();
+        assert!(
+            matches!(stmt, Statement::Select(_)),
+            "WHERE ... IN (...) stays a plain SELECT, got {stmt:?}"
+        );
     }
 }
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1461,6 +1461,12 @@ pub struct SharedState {
     /// Decides whether a given connection should see public or internal
     /// topology addresses in `system.local` / `system.peers_v2`.
     pub topology_policy: ClientTopologyPolicy,
+    /// Server-wide (per-node) transaction registry backing the connection-
+    /// independent `BEGIN TRANSACTION` / `... IN TRANSACTION <id>` / `COMMIT
+    /// TRANSACTION <id>` surface. Shared across every connection on this node, so
+    /// the statements of one transaction need not land on the same TCP connection
+    /// — this is what deletes the connection-affinity desync bug class.
+    pub txn_registry: crate::txn_registry::SharedTransactionRegistry,
 }
 
 impl std::ops::Deref for SharedState {
@@ -1708,61 +1714,139 @@ fn build_transaction_write(
     })
 }
 
-/// Intercept transaction control (`BEGIN`/`COMMIT`/`ROLLBACK`) and in-transaction
-/// DML for a CQL session. Returns `Some(result)` if the statement was handled as
-/// a transaction operation; `None` if it should be routed normally.
+/// Intercept transaction control and transaction-scoped DML/SELECT for a CQL
+/// session, driving the connection-independent [`TransactionRegistry`]. Returns
+/// `Some(result)` when the statement is a transaction operation; `None` when it
+/// should be routed normally.
 ///
-/// In an open transaction, `INSERT`/`UPDATE`/`DELETE` are **buffered** (not
-/// executed); `COMMIT` commits the whole buffered write-set as one multi-key
-/// Accord transaction via the `SessionCore` committer
-/// (`accord_transaction_committer`); `ROLLBACK` drops the buffer.
+/// The registry (server-wide, on `state.txn_registry`) is keyed by an opaque
+/// txn-id, so `BEGIN`/`UPDATE`/`COMMIT` need not land on the same TCP connection
+/// (deletes the connection-affinity desync). `shim` is this connection's binding
+/// for the **compat shim**: a bare `BEGIN` returns an id AND records it here, so a
+/// later bare `COMMIT`/`ROLLBACK` (or bare DML) resolves to it; explicit-id
+/// clients pass the id back via `... IN TRANSACTION <id>` and ignore the shim.
 pub async fn route_transactional(
     state: &SharedState,
     ctx: &RequestContext<'_>,
     stmt: &Statement,
-    txn: &mut crate::session::CqlTransaction,
+    shim: &mut Option<crate::txn_registry::CqlTxnId>,
+    now: std::time::Instant,
 ) -> Option<Result<RouteResult, CqlError>> {
+    let owner = ctx.auth.role.as_str();
     match stmt {
-        Statement::BeginTransaction => Some(
-            txn.begin()
-                .map(|()| RouteResult::Result(crate::result::encode_void())),
-        ),
-        Statement::Rollback => Some(
-            txn.rollback()
-                .map(|()| RouteResult::Result(crate::result::encode_void())),
-        ),
-        Statement::Commit => Some(commit_cql_transaction(state, txn).await),
-        // Buffer DML only while a transaction is open; otherwise route normally.
-        Statement::Insert(_) | Statement::Update(_) | Statement::Delete(_) if txn.is_open() => {
-            Some(
-                match build_transaction_write(state, ctx, stmt).and_then(|w| txn.stage(w)) {
-                    Ok(()) => Ok(RouteResult::Result(crate::result::encode_void())),
-                    Err(e) => {
-                        // A statement that fails inside a transaction POISONS it,
-                        // so the next COMMIT fails loud rather than committing an
-                        // incomplete write-set (never a silently partial txn).
-                        txn.poison();
-                        Err(e)
-                    }
-                },
-            )
+        Statement::BeginTransaction { timeout_ms } => {
+            Some(begin_transaction(state, owner, shim, now, *timeout_ms))
+        }
+        Statement::Commit { txn_id } => {
+            Some(commit_transaction(state, owner, shim, now, txn_id.as_deref()).await)
+        }
+        Statement::Rollback { txn_id } => {
+            Some(rollback_transaction(state, owner, shim, txn_id.as_deref()))
+        }
+        Statement::InTransaction { txn_id, inner } => {
+            Some(route_in_transaction(state, ctx, owner, now, txn_id, inner).await)
+        }
+        // Bare DML with an open compat-shim transaction stages into it (legacy
+        // single-connection BEGIN/UPDATE/COMMIT). Explicit-id clients use
+        // `... IN TRANSACTION <id>` and never reach this arm.
+        Statement::Insert(_) | Statement::Update(_) | Statement::Delete(_) if shim.is_some() => {
+            let id = shim.expect("shim is Some in this match arm");
+            Some(stage_dml(state, ctx, owner, now, id, stmt))
         }
         _ => None,
     }
 }
 
-/// Commit the buffered write-set through the Accord committer. Fails loud (and
-/// closes the transaction) when not in cluster mode or when the commit cannot be
-/// driven — the client never gets a success it did not earn.
-async fn commit_cql_transaction(
+/// Clear the connection's compat-shim binding if it points at `id` (the
+/// just-committed / just-rolled-back transaction), so a later bare `BEGIN` on this
+/// connection is not mistaken for a nested transaction.
+fn clear_shim_if(
+    shim: &mut Option<crate::txn_registry::CqlTxnId>,
+    id: crate::txn_registry::CqlTxnId,
+) {
+    if *shim == Some(id) {
+        *shim = None;
+    }
+}
+
+/// Encode `BEGIN TRANSACTION`'s reply: a single-row, single-column Rows RESULT
+/// carrying the minted transaction id as text. Stock drivers read it as an
+/// ordinary result set; explicit-id clients pass it back via `IN TRANSACTION`.
+fn encode_txn_id_row(id: crate::txn_registry::CqlTxnId) -> BytesMut {
+    let names = vec!["txn_id".to_string()];
+    let types = vec![CqlType::Varchar];
+    let rows = vec![vec![Some(CqlValue::Text(id.to_string()))]];
+    result::encode_rows(&names, &types, "system", "transaction", &rows)
+}
+
+/// `BEGIN TRANSACTION [USING TIMEOUT <ms>]`: mint an id, bind it to the connection
+/// (compat shim), and return it. FAILS LOUD on a nested bare BEGIN.
+fn begin_transaction(
     state: &SharedState,
-    txn: &mut crate::session::CqlTransaction,
+    owner: &str,
+    shim: &mut Option<crate::txn_registry::CqlTxnId>,
+    now: std::time::Instant,
+    timeout_ms: Option<u64>,
+) -> Result<RouteResult, CqlError> {
+    let timeout = timeout_ms.map(std::time::Duration::from_millis);
+    let id = { state.txn_registry.lock().begin(owner, now, timeout) }?;
+    // Rebind the connection's compat-shim to the newest transaction (last-wins).
+    //
+    // The txn-id model has NO connection-scoped "nested" transaction: a client may
+    // legitimately hold several independent transactions at once (e.g. spread
+    // across a driver's connection pool, where BEGIN and COMMIT need not share a
+    // TCP connection — the whole point of this design). So a fresh BEGIN never
+    // conflicts with a prior one and MUST NOT reject. The old nested-BEGIN guard
+    // was a vestige of the per-connection model; under pooled load it spuriously
+    // rejected the overwhelming majority of BEGINs ("nested transactions") because
+    // a connection could carry a stale shim binding from an earlier transaction
+    // whose COMMIT landed on a different connection. Overwriting the shim (rather
+    // than guarding on it) is correct and cannot affect serializability — it only
+    // removes a rejection; an orphaned bare-shim transaction is reaped on timeout.
+    *shim = Some(id);
+    Ok(RouteResult::Result(encode_txn_id_row(id)))
+}
+
+/// Resolve the transaction an operation targets: an explicit `TRANSACTION <id>`
+/// text, else the connection's shim binding. FAILS LOUD if neither is present.
+fn resolve_txn_id(
+    explicit: Option<&str>,
+    shim: Option<crate::txn_registry::CqlTxnId>,
+    verb: &str,
+) -> Result<crate::txn_registry::CqlTxnId, CqlError> {
+    match explicit {
+        Some(text) => crate::txn_registry::CqlTxnId::parse(text),
+        None => {
+            // Compat-shim path (bare COMMIT/ROLLBACK). Deprecated: prefer the
+            // explicit, connection-independent `... TRANSACTION <id>` form.
+            tracing::debug!(
+                verb,
+                "resolving transaction via the connection shim (deprecated bare form); \
+                 prefer an explicit TRANSACTION <id>"
+            );
+            shim.ok_or_else(|| CqlError::Invalid(format!("{verb} outside of a transaction")))
+        }
+    }
+}
+
+/// `COMMIT [TRANSACTION [<id>]]`: take the owned staging machine out of the
+/// registry (brief lock) and drive the async Accord commit WITHOUT holding the
+/// registry lock. Fails loud when not in cluster mode or when the commit cannot be
+/// driven — the client never gets a success it did not earn.
+async fn commit_transaction(
+    state: &SharedState,
+    owner: &str,
+    shim: &mut Option<crate::txn_registry::CqlTxnId>,
+    now: std::time::Instant,
+    explicit_id: Option<&str>,
 ) -> Result<RouteResult, CqlError> {
     use ferrosa_storage::accord::CommitOutcome;
+    let id = resolve_txn_id(explicit_id, *shim, "COMMIT")?;
+    let mut txn = { state.txn_registry.lock().take_for_commit(id, owner, now) }?;
+    clear_shim_if(shim, id);
     let committer = match state.accord_transaction_committer() {
         Some(c) => c,
         None => {
-            let _ = txn.rollback();
             return Err(CqlError::Invalid(
                 "multi-statement transactions require cluster mode (Accord)".into(),
             ));
@@ -1774,6 +1858,75 @@ async fn commit_cql_transaction(
             Err(CqlError::Invalid(format!("transaction aborted: {reason}")))
         }
         Err(e) => Err(e),
+    }
+}
+
+/// `ROLLBACK [TRANSACTION [<id>]]`: drop the transaction from the registry. No
+/// deadline check — rollback of an expired transaction is still a clean abort.
+fn rollback_transaction(
+    state: &SharedState,
+    owner: &str,
+    shim: &mut Option<crate::txn_registry::CqlTxnId>,
+    explicit_id: Option<&str>,
+) -> Result<RouteResult, CqlError> {
+    let id = resolve_txn_id(explicit_id, *shim, "ROLLBACK")?;
+    state.txn_registry.lock().abort(id, owner)?;
+    clear_shim_if(shim, id);
+    Ok(RouteResult::Result(crate::result::encode_void()))
+}
+
+/// Handle `<inner> IN TRANSACTION <id>`. A write is staged under `<id>`; a SELECT
+/// (Phase A: not MVCC-isolated — that is Phase D) validates the transaction is
+/// owned + open, then routes the read normally against committed state.
+async fn route_in_transaction(
+    state: &SharedState,
+    ctx: &RequestContext<'_>,
+    owner: &str,
+    now: std::time::Instant,
+    txn_id_text: &str,
+    inner: &Statement,
+) -> Result<RouteResult, CqlError> {
+    let id = crate::txn_registry::CqlTxnId::parse(txn_id_text)?;
+    match inner {
+        Statement::Insert(_) | Statement::Update(_) | Statement::Delete(_) => {
+            stage_dml(state, ctx, owner, now, id, inner)
+        }
+        Statement::Select(_) => {
+            state.txn_registry.lock().ensure_active(id, owner, now)?;
+            route(state, ctx, inner.clone()).await
+        }
+        _ => Err(CqlError::Invalid(
+            "only INSERT/UPDATE/DELETE/SELECT may be scoped with IN TRANSACTION".to_string(),
+        )),
+    }
+}
+
+/// Build a [`TransactionWrite`] from a DML statement and stage it under `id`. A
+/// build or stage failure POISONS the transaction so the next COMMIT fails loud
+/// rather than committing an incomplete write-set (never a silently partial txn).
+fn stage_dml(
+    state: &SharedState,
+    ctx: &RequestContext<'_>,
+    owner: &str,
+    now: std::time::Instant,
+    id: crate::txn_registry::CqlTxnId,
+    stmt: &Statement,
+) -> Result<RouteResult, CqlError> {
+    match build_transaction_write(state, ctx, stmt) {
+        Ok(write) => {
+            let mut reg = state.txn_registry.lock();
+            match reg.stage(id, owner, now, write) {
+                Ok(()) => Ok(RouteResult::Result(crate::result::encode_void())),
+                Err(e) => {
+                    reg.poison(id, owner);
+                    Err(e)
+                }
+            }
+        }
+        Err(e) => {
+            state.txn_registry.lock().poison(id, owner);
+            Err(e)
+        }
     }
 }
 
@@ -2556,11 +2709,16 @@ pub async fn route(
             .await
             .map(RouteResult::Result),
         Statement::Explain(s) => route_explain(state, ctx, *s).map(RouteResult::Result),
-        // Accord transaction control statements are handled at the session/connection
-        // level, not in the router. If they reach here, return a void result.
-        Statement::BeginTransaction | Statement::Commit | Statement::Rollback => {
-            Ok(RouteResult::Result(crate::result::encode_void()))
-        }
+        // Accord transaction control statements are handled by route_transactional
+        // (the connection layer) before reaching here. If one arrives, return void.
+        Statement::BeginTransaction { .. }
+        | Statement::Commit { .. }
+        | Statement::Rollback { .. } => Ok(RouteResult::Result(crate::result::encode_void())),
+        // A transaction-scoped statement must be handled by route_transactional; if
+        // it reaches the normal router it is an internal routing bug — fail loud.
+        Statement::InTransaction { .. } => Err(CqlError::Invalid(
+            "transaction-scoped statement reached the normal router (internal error)".to_string(),
+        )),
     };
 
     // Track CQL metrics: increment per-opcode counter, and error counter on failure.
@@ -13347,6 +13505,9 @@ mod tests {
             last_schema_event: tokio::sync::watch::channel(None).0,
             cql_metrics: Arc::new(CqlMetrics::new()),
             topology_policy: ClientTopologyPolicy::default(),
+            txn_registry: std::sync::Arc::new(parking_lot::Mutex::new(
+                crate::txn_registry::TransactionRegistry::default(),
+            )),
         };
         (state, dir)
     }
@@ -13780,35 +13941,118 @@ mod tests {
             client_address: String::new(),
             protocol_version: 4,
         };
-        let mut txn = crate::session::CqlTransaction::new();
+        let mut shim: Option<crate::txn_registry::CqlTxnId> = None;
+        let now = std::time::Instant::now();
 
         // A non-transactional statement is NOT intercepted (routes normally).
         let select = crate::parser::parse("SELECT * FROM system.local").unwrap();
         assert!(
-            route_transactional(&state, &ctx, &select, &mut txn)
+            route_transactional(&state, &ctx, &select, &mut shim, now)
                 .await
                 .is_none(),
             "SELECT must fall through to normal routing"
         );
 
-        // BEGIN opens the transaction; ROLLBACK closes it.
+        // BEGIN opens a transaction, returns a Rows result with its id, and binds
+        // the connection's compat shim to it.
+        let begun = route_transactional(
+            &state,
+            &ctx,
+            &Statement::BeginTransaction { timeout_ms: None },
+            &mut shim,
+            now,
+        )
+        .await;
+        match begun {
+            Some(Ok(RouteResult::Result(ref body))) => {
+                assert_eq!(&body[0..4], &0x0002i32.to_be_bytes(), "BEGIN returns Rows")
+            }
+            Some(Ok(_)) => panic!("BEGIN must return a Rows result, got a non-Rows result"),
+            Some(Err(e)) => panic!("BEGIN failed: {e}"),
+            None => panic!("BEGIN must be intercepted by route_transactional"),
+        }
+        assert!(shim.is_some(), "BEGIN binds the connection's shim");
+
+        // Bare ROLLBACK closes it and clears the shim.
         assert!(matches!(
-            route_transactional(&state, &ctx, &Statement::BeginTransaction, &mut txn).await,
+            route_transactional(
+                &state,
+                &ctx,
+                &Statement::Rollback { txn_id: None },
+                &mut shim,
+                now
+            )
+            .await,
             Some(Ok(_))
         ));
-        assert!(txn.is_open());
-        assert!(matches!(
-            route_transactional(&state, &ctx, &Statement::Rollback, &mut txn).await,
-            Some(Ok(_))
-        ));
-        assert!(!txn.is_open());
+        assert!(shim.is_none(), "ROLLBACK clears the shim binding");
 
         // COMMIT in standalone mode (no Accord committer) must fail loud.
-        txn.begin().unwrap();
-        let committed = route_transactional(&state, &ctx, &Statement::Commit, &mut txn).await;
+        route_transactional(
+            &state,
+            &ctx,
+            &Statement::BeginTransaction { timeout_ms: None },
+            &mut shim,
+            now,
+        )
+        .await;
+        let committed = route_transactional(
+            &state,
+            &ctx,
+            &Statement::Commit { txn_id: None },
+            &mut shim,
+            now,
+        )
+        .await;
         assert!(
             matches!(committed, Some(Err(_))),
             "COMMIT without a cluster committer must fail loud, not fake success"
+        );
+    }
+
+    /// Regression for the Elle-cert "nested transactions" defect: consecutive
+    /// BEGINs on ONE connection must BOTH succeed with distinct ids. The txn-id
+    /// model has no connection-scoped nested transaction; the old guard spuriously
+    /// rejected ~84% of BEGINs under pooled load because a connection could carry a
+    /// stale shim binding from a transaction whose COMMIT landed elsewhere.
+    #[tokio::test]
+    async fn consecutive_begins_on_one_connection_never_report_nested() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let ctx = RequestContext {
+            auth: &auth,
+            current_keyspace: &None,
+            consistency: ConsistencyLevel::One,
+            serial_consistency: None,
+            paging: crate::paging::PagingParams::default(),
+            client_address: String::new(),
+            protocol_version: 4,
+        };
+        let mut shim: Option<crate::txn_registry::CqlTxnId> = None;
+        let now = std::time::Instant::now();
+
+        // Ten BEGINs in a row on the same shim — none rolled back or committed —
+        // must every one succeed (no "nested transactions" rejection).
+        for i in 0..10 {
+            let r = route_transactional(
+                &state,
+                &ctx,
+                &Statement::BeginTransaction { timeout_ms: None },
+                &mut shim,
+                now,
+            )
+            .await;
+            assert!(
+                matches!(r, Some(Ok(_))),
+                "BEGIN #{i} must succeed — a fresh BEGIN is never 'nested' in the txn-id model"
+            );
+            assert!(shim.is_some(), "each BEGIN (re)binds the shim");
+        }
+        // All ten opened independent registry entries (last-wins shim, no rejection).
+        assert_eq!(
+            state.txn_registry.lock().len(),
+            10,
+            "ten independent transactions are open concurrently"
         );
     }
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1715,7 +1715,8 @@ fn build_transaction_write(
 }
 
 /// Intercept transaction control and transaction-scoped DML/SELECT for a CQL
-/// session, driving the connection-independent [`TransactionRegistry`]. Returns
+/// session, driving the connection-independent
+/// [`TransactionRegistry`](crate::txn_registry::TransactionRegistry). Returns
 /// `Some(result)` when the statement is a transaction operation; `None` when it
 /// should be routed normally.
 ///

--- a/ferrosa-cql/src/server.rs
+++ b/ferrosa-cql/src/server.rs
@@ -562,6 +562,9 @@ mod tests {
             last_schema_event: tokio::sync::watch::channel(None).0,
             cql_metrics: Arc::new(crate::observability::CqlMetrics::new()),
             topology_policy: crate::topology::ClientTopologyPolicy::default(),
+            txn_registry: std::sync::Arc::new(parking_lot::Mutex::new(
+                crate::txn_registry::TransactionRegistry::default(),
+            )),
         });
         (state, dir)
     }
@@ -920,6 +923,9 @@ mod tests {
             last_schema_event: tokio::sync::watch::channel(None).0,
             cql_metrics: Arc::new(crate::observability::CqlMetrics::new()),
             topology_policy: crate::topology::ClientTopologyPolicy::default(),
+            txn_registry: std::sync::Arc::new(parking_lot::Mutex::new(
+                crate::txn_registry::TransactionRegistry::default(),
+            )),
         });
         (state, dir)
     }

--- a/ferrosa-cql/src/session.rs
+++ b/ferrosa-cql/src/session.rs
@@ -6,86 +6,9 @@
 
 use std::time::{Duration, Instant};
 
-use crate::ast::Statement;
 use crate::error::CqlError;
 use ferrosa_storage::accord::{CommitOutcome, TransactionCommitter, TransactionWrite};
 use ferrosa_storage::{BatchOp, StorageEngine};
-
-/// Transaction state for a CQL session.
-///
-/// Tracks whether the session is currently inside an Accord transaction
-/// and validates incoming statements against that state.
-#[derive(Debug)]
-pub struct TransactionState {
-    in_transaction: bool,
-}
-
-impl TransactionState {
-    /// Create a new transaction state (not in a transaction).
-    pub fn new() -> Self {
-        Self {
-            in_transaction: false,
-        }
-    }
-
-    /// Returns true if the session is currently inside a transaction.
-    pub fn in_transaction(&self) -> bool {
-        self.in_transaction
-    }
-
-    /// Validate a statement against the current transaction state and
-    /// update the state if appropriate.
-    ///
-    /// Returns an error if:
-    /// - BEGIN TRANSACTION is issued while already in a transaction (nested)
-    /// - A DDL statement is issued while inside a transaction
-    /// - COMMIT or ROLLBACK is issued while not in a transaction
-    pub fn validate_and_transition(&mut self, stmt: &Statement) -> Result<(), CqlError> {
-        match stmt {
-            Statement::BeginTransaction => {
-                if self.in_transaction {
-                    return Err(CqlError::Invalid(
-                        "nested transactions are not supported".to_string(),
-                    ));
-                }
-                self.in_transaction = true;
-                Ok(())
-            }
-            Statement::Commit => {
-                if !self.in_transaction {
-                    return Err(CqlError::Invalid(
-                        "COMMIT outside of a transaction".to_string(),
-                    ));
-                }
-                self.in_transaction = false;
-                Ok(())
-            }
-            Statement::Rollback => {
-                if !self.in_transaction {
-                    return Err(CqlError::Invalid(
-                        "ROLLBACK outside of a transaction".to_string(),
-                    ));
-                }
-                self.in_transaction = false;
-                Ok(())
-            }
-            other => {
-                if self.in_transaction && other.is_ddl() {
-                    return Err(CqlError::Invalid(
-                        "DDL statements are not permitted inside a transaction".to_string(),
-                    ));
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
-impl Default for TransactionState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 /// Per-connection **explicit-transaction state machine** (spec URS-QEC-B02).
 ///
@@ -406,7 +329,6 @@ impl CqlTransaction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::*;
 
     fn tw(ks: &str, key: &[u8]) -> TransactionWrite {
         TransactionWrite {
@@ -528,103 +450,5 @@ mod tests {
         // COMMIT now fails (poisoned) and applies nothing — never a partial commit.
         assert!(tx.commit(&committer).await.is_err());
         assert!(committer.committed().is_empty());
-    }
-
-    #[test]
-    fn transition_begin_commit() {
-        let mut state = TransactionState::new();
-        assert!(!state.in_transaction());
-
-        state
-            .validate_and_transition(&Statement::BeginTransaction)
-            .unwrap();
-        assert!(state.in_transaction());
-
-        state.validate_and_transition(&Statement::Commit).unwrap();
-        assert!(!state.in_transaction());
-    }
-
-    #[test]
-    fn transition_begin_rollback() {
-        let mut state = TransactionState::new();
-
-        state
-            .validate_and_transition(&Statement::BeginTransaction)
-            .unwrap();
-        assert!(state.in_transaction());
-
-        state.validate_and_transition(&Statement::Rollback).unwrap();
-        assert!(!state.in_transaction());
-    }
-
-    #[test]
-    fn nested_begin_rejected() {
-        let mut state = TransactionState::new();
-        state
-            .validate_and_transition(&Statement::BeginTransaction)
-            .unwrap();
-
-        let err = state
-            .validate_and_transition(&Statement::BeginTransaction)
-            .unwrap_err();
-        assert!(err.to_string().contains("nested"));
-    }
-
-    #[test]
-    fn ddl_in_transaction_rejected() {
-        let mut state = TransactionState::new();
-        state
-            .validate_and_transition(&Statement::BeginTransaction)
-            .unwrap();
-
-        let ddl = Statement::CreateTable(CreateTableStatement {
-            keyspace: Some("ks".into()),
-            name: "t".into(),
-            columns: vec![("k".into(), CqlTypeName::Simple("int".into()))],
-            partition_key: vec!["k".into()],
-            clustering_key: vec![],
-            if_not_exists: false,
-            table_options: vec![],
-            extensions: None,
-        });
-        let err = state.validate_and_transition(&ddl).unwrap_err();
-        assert!(err.to_string().contains("DDL"));
-    }
-
-    #[test]
-    fn dml_in_transaction_allowed() {
-        let mut state = TransactionState::new();
-        state
-            .validate_and_transition(&Statement::BeginTransaction)
-            .unwrap();
-
-        let dml = Statement::Insert(InsertStatement {
-            keyspace: Some("ks".into()),
-            table: "t".into(),
-            columns: vec!["k".into()],
-            values: vec![Term::IntegerLiteral(1)],
-            if_not_exists: false,
-            using_timestamp: None,
-            using_ttl: None,
-        });
-        state.validate_and_transition(&dml).unwrap();
-    }
-
-    #[test]
-    fn commit_outside_transaction_rejected() {
-        let mut state = TransactionState::new();
-        let err = state
-            .validate_and_transition(&Statement::Commit)
-            .unwrap_err();
-        assert!(err.to_string().contains("COMMIT outside"));
-    }
-
-    #[test]
-    fn rollback_outside_transaction_rejected() {
-        let mut state = TransactionState::new();
-        let err = state
-            .validate_and_transition(&Statement::Rollback)
-            .unwrap_err();
-        assert!(err.to_string().contains("ROLLBACK outside"));
     }
 }

--- a/ferrosa-cql/src/subscribe.rs
+++ b/ferrosa-cql/src/subscribe.rs
@@ -551,6 +551,9 @@ mod tests {
             last_schema_event: tokio::sync::watch::channel(None).0,
             cql_metrics: Arc::new(crate::observability::CqlMetrics::new()),
             topology_policy: crate::topology::ClientTopologyPolicy::default(),
+            txn_registry: std::sync::Arc::new(parking_lot::Mutex::new(
+                crate::txn_registry::TransactionRegistry::default(),
+            )),
         };
 
         (Arc::new(state), dir)

--- a/ferrosa-cql/src/test_util.rs
+++ b/ferrosa-cql/src/test_util.rs
@@ -115,5 +115,8 @@ pub fn standalone_for_test(data_dir: &Path) -> Arc<SharedState> {
         last_schema_event: tokio::sync::watch::channel(None).0,
         cql_metrics: Arc::new(CqlMetrics::new()),
         topology_policy: ClientTopologyPolicy::default(),
+        txn_registry: std::sync::Arc::new(parking_lot::Mutex::new(
+            crate::txn_registry::TransactionRegistry::default(),
+        )),
     })
 }

--- a/ferrosa-cql/src/txn_registry.rs
+++ b/ferrosa-cql/src/txn_registry.rs
@@ -1,0 +1,575 @@
+//! Module: Connection-independent, txn-id-keyed CQL transaction registry.
+//!
+//! Replaces the per-connection `Arc<Mutex<CqlTransaction>>` (connection.rs) with a
+//! server-side map keyed by an opaque 128-bit transaction id. The id rides the CQL
+//! surface (`BEGIN TRANSACTION` returns it as a result row; `... IN TRANSACTION
+//! <id>` on DML), so BEGIN/UPDATE/COMMIT are no longer pinned to one TCP
+//! connection — deleting the connection-affinity desync bug class (the ~24%
+//! `:info` in the Elle list-append cert: "COMMIT outside of a transaction" /
+//! "nested transactions" from statements landing on different tasks).
+//!
+//! Correctness: an entry records its authenticated owner (a statement on a
+//! non-owned id FAILS LOUD — FMEA F1 hijack); the registry count is bounded (F2
+//! OOM) and fails loud at capacity; every open transaction carries an absolute
+//! deadline, enforced both lazily (on the next stage/commit) and actively (by the
+//! background reaper via [`TransactionRegistry::reap_expired`], constraint 8 /
+//! A1b, default 10s). Time is injected (`now: Instant`) so the deadline logic is
+//! deterministically testable with no wall-clock dependence.
+//!
+//! Last revised: 2026-07-20
+//! Last changed: New module — Phase A of the unified transaction manager (t_3120ec2f).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use uuid::Uuid;
+
+use crate::error::CqlError;
+use crate::session::CqlTransaction;
+use ferrosa_storage::accord::TransactionWrite;
+
+/// Server-wide (per-node) shared registry handle. `parking_lot::Mutex` (not the
+/// async mutex) is deliberate: every registry operation is synchronous — `commit`
+/// takes the owned [`CqlTransaction`] OUT via [`TransactionRegistry::take_for_commit`]
+/// and drives the async Accord commit WITHOUT holding this lock, so one node's
+/// transactions never serialize on the registry lock across an await.
+pub type SharedTransactionRegistry = Arc<Mutex<TransactionRegistry>>;
+
+/// How often the background reaper sweeps for past-deadline transactions (A1b).
+/// Short relative to the 10 s default timeout so an abandoned transaction is
+/// reclaimed within ~one interval of its deadline.
+pub const REAPER_SWEEP_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Default open-transaction timeout (constraint 8 / A1b). A transaction idle past
+/// this budget is aborted by the reaper without any client statement — which also
+/// bounds MVCC version retention to ~one window in later phases.
+pub const DEFAULT_OPEN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Hard cluster maximum a `BEGIN ... USING TIMEOUT` override may request. An
+/// override above this FAILS LOUD rather than being silently clamped.
+pub const MAX_OPEN_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Maximum concurrent open transactions the registry will hold (F2 OOM bound,
+/// Power-of-10 Rule 3: every server-side dynamic collection has a hard cap). A
+/// `BEGIN` past this FAILS LOUD.
+pub const DEFAULT_MAX_ENTRIES: usize = 10_000;
+
+/// Bounded retries when minting a fresh id, so id generation cannot loop forever
+/// on the (astronomically unreachable) event of a 128-bit collision.
+const ID_MINT_ATTEMPTS: usize = 8;
+
+/// An opaque 128-bit CQL transaction id. Rendered/parsed as canonical UUID text so
+/// it rides a standard CQL string on the wire (stock Cassandra drivers unmodified)
+/// and is unguessable (FMEA F1) with negligible collision odds (F9).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct CqlTxnId(Uuid);
+
+impl CqlTxnId {
+    /// Mint a fresh random (v4) transaction id.
+    pub fn generate() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Parse an id from its canonical UUID text (the `<id>` in `IN TRANSACTION
+    /// <id>`). FAILS LOUD on malformed text so a client typo cannot alias an id.
+    pub fn parse(text: &str) -> Result<Self, CqlError> {
+        Uuid::parse_str(text.trim())
+            .map(Self)
+            .map_err(|_| CqlError::Invalid(format!("malformed transaction id: {text:?}")))
+    }
+}
+
+impl std::fmt::Display for CqlTxnId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// One open transaction's server-side state: its staging buffer plus the metadata
+/// needed to authorize and expire it. In-RAM metadata only (Phase A stages the
+/// write-set in the `CqlTransaction` buffer; the NVMe temp-table staging store
+/// lands in Phase D).
+struct TransactionEntry {
+    /// The real staging buffer + commit machine (reused unchanged from session.rs).
+    txn: CqlTransaction,
+    /// Authenticated principal that opened this transaction (F1 auth scope).
+    owner: String,
+    /// Absolute abort deadline; `now >= deadline` means expired.
+    deadline: Instant,
+    /// The timeout budget this transaction was opened with (for the timeout error).
+    timeout: Duration,
+}
+
+/// Connection-independent transaction registry: `txn-id -> TransactionEntry`.
+///
+/// Lifecycle: [`begin`](Self::begin) -> [`stage`](Self::stage)* ->
+/// [`take_for_commit`](Self::take_for_commit) | [`abort`](Self::abort). The
+/// background reaper calls [`reap_expired`](Self::reap_expired) to actively evict
+/// transactions past their deadline.
+pub struct TransactionRegistry {
+    entries: HashMap<CqlTxnId, TransactionEntry>,
+    max_entries: usize,
+    default_timeout: Duration,
+    max_timeout: Duration,
+}
+
+impl Default for TransactionRegistry {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_ENTRIES, DEFAULT_OPEN_TIMEOUT, MAX_OPEN_TIMEOUT)
+    }
+}
+
+impl TransactionRegistry {
+    /// Construct a registry with explicit bounds. Prefer [`Default`] for the
+    /// production defaults (10 000 entries, 10 s default / 600 s max timeout).
+    pub fn new(max_entries: usize, default_timeout: Duration, max_timeout: Duration) -> Self {
+        Self {
+            entries: HashMap::new(),
+            max_entries,
+            default_timeout,
+            max_timeout,
+        }
+    }
+
+    /// Build a shared (Arc + Mutex) registry with the production defaults —
+    /// convenience for front-end wiring so callers need not name `parking_lot`.
+    pub fn shared_default() -> SharedTransactionRegistry {
+        Arc::new(Mutex::new(Self::default()))
+    }
+
+    /// Number of currently open transactions.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// `true` when no transactions are open.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// `true` if `id` names a currently open transaction (inspection/tests).
+    pub fn contains(&self, id: CqlTxnId) -> bool {
+        self.entries.contains_key(&id)
+    }
+
+    /// The registry's default open-transaction timeout (for a `BEGIN` without an
+    /// explicit `USING TIMEOUT`).
+    pub fn default_timeout(&self) -> Duration {
+        self.default_timeout
+    }
+
+    /// `BEGIN [TRANSACTION] [USING TIMEOUT <ms>]`: open a transaction owned by
+    /// `owner`, deadlined at `now + timeout`, and return its fresh id.
+    ///
+    /// FAILS LOUD when the registry is at capacity (F2) or when `timeout_override`
+    /// exceeds the hard cluster max (never silently clamp — silent degradation is
+    /// a bug). `timeout_override = None` uses the configured default.
+    pub fn begin(
+        &mut self,
+        owner: &str,
+        now: Instant,
+        timeout_override: Option<Duration>,
+    ) -> Result<CqlTxnId, CqlError> {
+        if self.entries.len() >= self.max_entries {
+            return Err(CqlError::Overloaded(format!(
+                "transaction registry at capacity ({} open); retry after in-flight \
+                 transactions commit or time out",
+                self.max_entries
+            )));
+        }
+        let timeout = self.resolve_timeout(timeout_override)?;
+        let id = self.fresh_id()?;
+        let mut txn = CqlTransaction::new();
+        // A registry entry only ever holds an OPEN transaction; opening a fresh
+        // machine cannot fail (assertion — Power-of-10 Rule 5).
+        txn.begin()
+            .expect("a fresh CqlTransaction always opens on begin()");
+        self.entries.insert(
+            id,
+            TransactionEntry {
+                txn,
+                owner: owner.to_string(),
+                deadline: now + timeout,
+                timeout,
+            },
+        );
+        Ok(id)
+    }
+
+    /// Stage one DML write under an owned, open, not-yet-expired transaction.
+    ///
+    /// FAILS LOUD on unknown id, wrong owner (F1), or an elapsed deadline (the
+    /// entry is evicted and nothing is staged — never persist past the budget).
+    pub fn stage(
+        &mut self,
+        id: CqlTxnId,
+        owner: &str,
+        now: Instant,
+        write: TransactionWrite,
+    ) -> Result<(), CqlError> {
+        self.authorize(id, owner, now)?;
+        // `authorize` proved the entry is present and left it in place on success.
+        let entry = self
+            .entries
+            .get_mut(&id)
+            .expect("entry present after a successful authorize");
+        entry.txn.stage(write)
+    }
+
+    /// Poison an owned, open transaction after a statement failed inside it, so the
+    /// next `COMMIT` fails loud rather than committing a partial write-set. Unknown
+    /// or unowned ids are ignored (best-effort marking; the failing statement has
+    /// already surfaced its own error).
+    pub fn poison(&mut self, id: CqlTxnId, owner: &str) {
+        if let Some(entry) = self.entries.get_mut(&id) {
+            if entry.owner == owner {
+                entry.txn.poison();
+            }
+        }
+    }
+
+    /// `COMMIT TRANSACTION <id>`: remove the entry and return its owned staging
+    /// machine so the caller can drive the (async) Accord commit WITHOUT holding
+    /// the registry lock across the await (avoids serializing every transaction on
+    /// one node). FAILS LOUD on unknown id, wrong owner (F1), or elapsed deadline.
+    pub fn take_for_commit(
+        &mut self,
+        id: CqlTxnId,
+        owner: &str,
+        now: Instant,
+    ) -> Result<CqlTransaction, CqlError> {
+        self.authorize(id, owner, now)?;
+        let entry = self
+            .entries
+            .remove(&id)
+            .expect("entry present after a successful authorize");
+        Ok(entry.txn)
+    }
+
+    /// Verify `id` is an owned, open, not-yet-expired transaction WITHOUT staging
+    /// anything — used to scope a `SELECT ... IN TRANSACTION <id>` (Phase A reads
+    /// committed state; MVCC snapshot isolation lands in Phase D). An expired entry
+    /// is evicted and surfaced as a timeout, exactly like a stage/commit.
+    pub fn ensure_active(
+        &mut self,
+        id: CqlTxnId,
+        owner: &str,
+        now: Instant,
+    ) -> Result<(), CqlError> {
+        self.authorize(id, owner, now)
+    }
+
+    /// `ROLLBACK TRANSACTION <id>`: drop an owned transaction, discarding its
+    /// buffer. No deadline check — rollback of an expired transaction is still a
+    /// clean no-op abort. FAILS LOUD on unknown id or wrong owner (F1).
+    pub fn abort(&mut self, id: CqlTxnId, owner: &str) -> Result<(), CqlError> {
+        match self.entries.get(&id) {
+            None => Err(Self::unknown(id)),
+            Some(entry) if entry.owner != owner => Err(Self::forbidden(id)),
+            Some(_) => {
+                self.entries.remove(&id);
+                Ok(())
+            }
+        }
+    }
+
+    /// Actively evict every transaction whose deadline has elapsed (the reaper
+    /// sweep, A1b). Returns the ids that were aborted so the caller can log/meter
+    /// them. Live transactions are untouched.
+    pub fn reap_expired(&mut self, now: Instant) -> Vec<CqlTxnId> {
+        let expired: Vec<CqlTxnId> = self
+            .entries
+            .iter()
+            .filter(|(_, e)| now >= e.deadline)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in &expired {
+            self.entries.remove(id);
+        }
+        expired
+    }
+
+    /// Authorize an operation on `id` by `owner` at `now`: the id must exist, be
+    /// owned by `owner` (F1), and not be past its deadline. An expired entry is
+    /// EVICTED here and surfaced as a timeout — the single shared enforcement point
+    /// for `stage`/`take_for_commit`.
+    fn authorize(&mut self, id: CqlTxnId, owner: &str, now: Instant) -> Result<(), CqlError> {
+        let entry = match self.entries.get(&id) {
+            None => return Err(Self::unknown(id)),
+            Some(e) => e,
+        };
+        if entry.owner != owner {
+            return Err(Self::forbidden(id));
+        }
+        if now >= entry.deadline {
+            let elapsed = now.duration_since(entry.deadline) + entry.timeout;
+            let timeout_ms = entry.timeout.as_millis() as u64;
+            let elapsed_ms = elapsed.as_millis() as u64;
+            self.entries.remove(&id);
+            return Err(CqlError::TransactionTimeout {
+                timeout_ms,
+                elapsed_ms,
+            });
+        }
+        Ok(())
+    }
+
+    /// Resolve the effective timeout for a new transaction: an override (bounded by
+    /// the hard cluster max — an override above it FAILS LOUD rather than being
+    /// silently clamped) or the configured default.
+    fn resolve_timeout(&self, timeout_override: Option<Duration>) -> Result<Duration, CqlError> {
+        match timeout_override {
+            Some(t) if t > self.max_timeout => Err(CqlError::Invalid(format!(
+                "requested transaction timeout {}ms exceeds the cluster maximum {}ms",
+                t.as_millis(),
+                self.max_timeout.as_millis()
+            ))),
+            Some(t) => Ok(t),
+            None => Ok(self.default_timeout),
+        }
+    }
+
+    /// Mint a fresh id not already in use. Bounded retries (Power-of-10 Rule 2);
+    /// exhausting them FAILS LOUD rather than looping forever.
+    fn fresh_id(&self) -> Result<CqlTxnId, CqlError> {
+        for _ in 0..ID_MINT_ATTEMPTS {
+            let id = CqlTxnId::generate();
+            if !self.entries.contains_key(&id) {
+                return Ok(id);
+            }
+        }
+        Err(CqlError::ServerError(
+            "could not mint a unique transaction id".to_string(),
+        ))
+    }
+
+    fn unknown(id: CqlTxnId) -> CqlError {
+        CqlError::Invalid(format!(
+            "unknown transaction {id} (already committed, rolled back, or timed out)"
+        ))
+    }
+
+    fn forbidden(id: CqlTxnId) -> CqlError {
+        CqlError::Unauthorized(format!("transaction {id} is owned by another principal"))
+    }
+}
+
+/// Spawn the background open-transaction reaper (A1b). Every
+/// [`REAPER_SWEEP_INTERVAL`] it actively aborts and evicts every transaction past
+/// its deadline, so an abandoned transaction is reclaimed without any client
+/// statement (bounding both RAM — F2 — and, in later phases, MVCC version
+/// retention). The sweep decision ([`TransactionRegistry::reap_expired`]) is a
+/// pure, unit-tested function; this loop only clocks it. Runs for the lifetime of
+/// the node.
+pub fn spawn_transaction_reaper(
+    registry: SharedTransactionRegistry,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(REAPER_SWEEP_INTERVAL);
+        loop {
+            ticker.tick().await;
+            let reaped = registry.lock().reap_expired(Instant::now());
+            if !reaped.is_empty() {
+                tracing::warn!(
+                    count = reaped.len(),
+                    "reaped past-deadline transaction(s) (open-transaction timeout)"
+                );
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tw(key: &[u8]) -> TransactionWrite {
+        TransactionWrite {
+            keyspace: "ks".to_string(),
+            key: key.to_vec(),
+            mutation: b"m".to_vec(),
+        }
+    }
+
+    fn registry() -> TransactionRegistry {
+        TransactionRegistry::default()
+    }
+
+    #[test]
+    fn begin_returns_a_fresh_open_id() {
+        let mut reg = registry();
+        let now = Instant::now();
+        let id = reg.begin("alice", now, None).unwrap();
+        assert!(
+            reg.contains(id),
+            "the returned id names an open transaction"
+        );
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn two_begins_yield_distinct_ids() {
+        let mut reg = registry();
+        let now = Instant::now();
+        let a = reg.begin("alice", now, None).unwrap();
+        let b = reg.begin("alice", now, None).unwrap();
+        assert_ne!(a, b, "each BEGIN mints a distinct id (F9 uniqueness)");
+        assert_eq!(reg.len(), 2);
+    }
+
+    #[test]
+    fn stage_buffers_writes_on_an_owned_open_id() {
+        let mut reg = registry();
+        let now = Instant::now();
+        let id = reg.begin("alice", now, None).unwrap();
+        reg.stage(id, "alice", now, tw(b"a")).unwrap();
+        reg.stage(id, "alice", now, tw(b"b")).unwrap();
+        // Draining for commit yields the buffered write-set in order.
+        let txn = reg.take_for_commit(id, "alice", now).unwrap();
+        assert_eq!(txn.staged_len(), 2);
+    }
+
+    #[test]
+    fn operations_on_an_unknown_id_fail_loud() {
+        let mut reg = registry();
+        let now = Instant::now();
+        let ghost = CqlTxnId::generate();
+        assert!(reg.stage(ghost, "alice", now, tw(b"a")).is_err());
+        assert!(reg.take_for_commit(ghost, "alice", now).is_err());
+        assert!(reg.abort(ghost, "alice").is_err());
+    }
+
+    #[test]
+    fn a_second_principal_is_rejected_f1_hijack() {
+        let mut reg = registry();
+        let now = Instant::now();
+        let id = reg.begin("alice", now, None).unwrap();
+
+        let staged = reg.stage(id, "mallory", now, tw(b"a"));
+        assert!(matches!(staged, Err(CqlError::Unauthorized(_))));
+        let committed = reg.take_for_commit(id, "mallory", now);
+        assert!(matches!(committed, Err(CqlError::Unauthorized(_))));
+        assert!(matches!(
+            reg.abort(id, "mallory"),
+            Err(CqlError::Unauthorized(_))
+        ));
+
+        // Alice's transaction is untouched by Mallory's rejected attempts.
+        assert!(reg.contains(id));
+        reg.abort(id, "alice").unwrap();
+    }
+
+    #[test]
+    fn take_for_commit_removes_the_entry() {
+        let mut reg = registry();
+        let now = Instant::now();
+        let id = reg.begin("alice", now, None).unwrap();
+        let _txn = reg.take_for_commit(id, "alice", now).unwrap();
+        assert!(!reg.contains(id), "committing removes the entry");
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn abort_removes_the_entry() {
+        let mut reg = registry();
+        let now = Instant::now();
+        let id = reg.begin("alice", now, None).unwrap();
+        reg.abort(id, "alice").unwrap();
+        assert!(!reg.contains(id));
+    }
+
+    #[test]
+    fn begin_past_capacity_fails_loud_f2() {
+        let mut reg = TransactionRegistry::new(2, DEFAULT_OPEN_TIMEOUT, MAX_OPEN_TIMEOUT);
+        let now = Instant::now();
+        reg.begin("alice", now, None).unwrap();
+        reg.begin("alice", now, None).unwrap();
+        let over = reg.begin("alice", now, None);
+        assert!(
+            matches!(over, Err(CqlError::Overloaded(_))),
+            "a BEGIN past the registry cap must fail loud (F2 OOM bound)"
+        );
+    }
+
+    #[test]
+    fn timeout_override_above_max_is_rejected() {
+        let mut reg = registry();
+        let now = Instant::now();
+        let over = reg.begin(
+            "alice",
+            now,
+            Some(MAX_OPEN_TIMEOUT + Duration::from_secs(1)),
+        );
+        assert!(
+            matches!(over, Err(CqlError::Invalid(_))),
+            "an override above the hard max fails loud (never silently clamp)"
+        );
+    }
+
+    #[test]
+    fn timeout_override_within_max_is_honored() {
+        let mut reg = registry();
+        let base = Instant::now();
+        // A 5s override: at base+4s it is still live, at base+6s it is expired.
+        let id = reg
+            .begin("alice", base, Some(Duration::from_secs(5)))
+            .unwrap();
+        reg.stage(id, "alice", base + Duration::from_secs(4), tw(b"a"))
+            .unwrap();
+        let expired = reg.stage(id, "alice", base + Duration::from_secs(6), tw(b"b"));
+        assert!(matches!(expired, Err(CqlError::TransactionTimeout { .. })));
+    }
+
+    #[test]
+    fn reap_expired_evicts_past_deadline_and_keeps_live_a1b() {
+        let mut reg = TransactionRegistry::new(
+            DEFAULT_MAX_ENTRIES,
+            Duration::from_secs(10),
+            MAX_OPEN_TIMEOUT,
+        );
+        let base = Instant::now();
+        let short = reg
+            .begin("alice", base, Some(Duration::from_secs(1)))
+            .unwrap();
+        let long = reg
+            .begin("alice", base, Some(Duration::from_secs(60)))
+            .unwrap();
+
+        // Sweep at base+2s: the 1s transaction is past deadline, the 60s is live.
+        let reaped = reg.reap_expired(base + Duration::from_secs(2));
+        assert_eq!(
+            reaped,
+            vec![short],
+            "only the expired transaction is reaped"
+        );
+        assert!(!reg.contains(short));
+        assert!(
+            reg.contains(long),
+            "the live transaction survives the sweep"
+        );
+    }
+
+    #[test]
+    fn lazy_timeout_evicts_on_operation_of_an_expired_id() {
+        let mut reg = registry();
+        let base = Instant::now();
+        let id = reg
+            .begin("alice", base, Some(Duration::from_secs(1)))
+            .unwrap();
+        // No reaper ran; a stage past the deadline must itself fail loud + evict.
+        let staged = reg.stage(id, "alice", base + Duration::from_secs(2), tw(b"a"));
+        assert!(matches!(staged, Err(CqlError::TransactionTimeout { .. })));
+        assert!(!reg.contains(id), "the expired entry is evicted on access");
+    }
+
+    #[test]
+    fn id_round_trips_through_text() {
+        let id = CqlTxnId::generate();
+        let text = id.to_string();
+        let parsed = CqlTxnId::parse(&text).unwrap();
+        assert_eq!(id, parsed, "an id survives Display -> parse round trip");
+        assert!(CqlTxnId::parse("not-a-uuid").is_err());
+    }
+}

--- a/ferrosa-cql/tests/auth_integration.rs
+++ b/ferrosa-cql/tests/auth_integration.rs
@@ -128,6 +128,7 @@ fn setup_state() -> (Arc<SharedState>, TempDir) {
         event_sender: tokio::sync::broadcast::channel(64).0,
         last_schema_event: tokio::sync::watch::channel(None).0,
         topology_policy: ClientTopologyPolicy::default(),
+        txn_registry: ferrosa_cql::txn_registry::TransactionRegistry::shared_default(),
         cql_metrics: Arc::new(ferrosa_cql::observability::CqlMetrics::new()),
     });
     (state, dir)

--- a/ferrosa-cql/tests/handshake.rs
+++ b/ferrosa-cql/tests/handshake.rs
@@ -126,6 +126,7 @@ fn setup_state() -> (Arc<SharedState>, TempDir) {
         event_sender: tokio::sync::broadcast::channel(64).0,
         last_schema_event: tokio::sync::watch::channel(None).0,
         topology_policy: ClientTopologyPolicy::default(),
+        txn_registry: ferrosa_cql::txn_registry::TransactionRegistry::shared_default(),
         cql_metrics: Arc::new(ferrosa_cql::observability::CqlMetrics::new()),
     });
     (state, dir)

--- a/ferrosa-ctl/tests/integration.rs
+++ b/ferrosa-ctl/tests/integration.rs
@@ -148,6 +148,7 @@ fn setup_state() -> (Arc<SharedState>, TempDir) {
         event_sender: tokio::sync::broadcast::channel(64).0,
         last_schema_event: tokio::sync::watch::channel(None).0,
         topology_policy: ClientTopologyPolicy::default(),
+        txn_registry: ferrosa_cql::txn_registry::TransactionRegistry::shared_default(),
         cql_metrics: Arc::new(ferrosa_cql::observability::CqlMetrics::new()),
     });
     (state, dir)

--- a/ferrosa-jepsen/examples/elle_list_append.rs
+++ b/ferrosa-jepsen/examples/elle_list_append.rs
@@ -2,17 +2,21 @@
 //! validation (t_d7ffb5b7).
 //!
 //! Model: each list is a `list<int>` column (order-preserving).
-//! - **append(k, v)** = `BEGIN TRANSACTION; UPDATE la SET v = v + [v] WHERE k=?;
-//!   COMMIT` — an Accord-serialized write. `v` is globally unique so Elle can
-//!   recover the per-key version order.
+//! - **append(k, v)** = `BEGIN TRANSACTION` (returns a server-minted txn id);
+//!   `UPDATE la SET v = v + [v] WHERE k=? IN TRANSACTION <id>`;
+//!   `COMMIT TRANSACTION <id>` — an Accord-serialized write threaded by explicit
+//!   id (Phase A transaction manager), so it is connection-INDEPENDENT: the three
+//!   statements need not share a TCP connection. `v` is globally unique so Elle
+//!   can recover the per-key version order.
 //! - **read(k)** = `SELECT v FROM la WHERE k=?` at **SERIAL** consistency — a
 //!   linearizable read routed through Accord (cluster mode). Returns the list in
 //!   append order.
 //!
-//! Concurrent workers share one pinned coordinator (so each `BEGIN…COMMIT` is
-//! atomic on one connection); concurrency comes from many client tasks. Each op
-//! logs an `:invoke` before and an `:ok`/`:fail` after into a shared, time-
-//! ordered history, which is written as Elle-compatible EDN.
+//! Concurrent workers each drive their own session against one pinned coordinator;
+//! because the transaction rides an explicit id (not connection affinity), the
+//! ~24% `:info` from the old connection-keyed BEGIN/COMMIT desync is gone. Each op
+//! logs an `:invoke` before and an `:ok`/`:fail` after into a shared, time-ordered
+//! history, which is written as Elle-compatible EDN.
 //!
 //! Usage: cargo run -p ferrosa-jepsen --example elle_list_append -- <host:port> <out.edn> [keys] [ops-per-worker] [workers]
 
@@ -129,18 +133,53 @@ async fn main() -> Result<()> {
                     //     may not have landed): :info, never :fail — logging it :fail
                     //     would let a write that actually committed masquerade as a
                     //     failed op and fabricate an Elle "aberrant read" violation.
-                    let upd = format!("UPDATE elle.la SET v = v + [{v}] WHERE k = {k}");
-                    let outcome = if let Err(e) = session
+                    // Connection-INDEPENDENT append (Phase A transaction manager):
+                    // BEGIN returns a server-minted txn id; UPDATE and COMMIT carry
+                    // it via `IN TRANSACTION <id>` / `COMMIT TRANSACTION <id>`, so the
+                    // three statements need not land on the same TCP connection — this
+                    // removes the connection-affinity desync that produced the ~24%
+                    // :info ("COMMIT outside of a transaction" / "nested transactions").
+                    let mut txn_id_opt: Option<String> = None;
+                    let outcome = match session
                         .query_unpaged("BEGIN TRANSACTION".to_string(), &[])
                         .await
                     {
-                        Some((":fail", format!("BEGIN: {e}")))
-                    } else if let Err(e) = session.query_unpaged(upd.clone(), &[]).await {
-                        Some((":fail", format!("UPDATE: {e}")))
-                    } else if let Err(e) = session.query_unpaged("COMMIT".to_string(), &[]).await {
-                        Some((":info", format!("COMMIT: {e}")))
-                    } else {
-                        None
+                        Err(e) => Some((":fail", format!("BEGIN: {e}"))),
+                        Ok(res) => {
+                            // BEGIN's reply is a single text row carrying the id.
+                            let id = res
+                                .into_rows_result()
+                                .ok()
+                                .and_then(|rr| {
+                                    rr.rows::<Row>()
+                                        .ok()
+                                        .and_then(|mut it| it.next().and_then(|r| r.ok()))
+                                })
+                                .and_then(|row| match row.columns.first() {
+                                    Some(Some(CqlValue::Text(s))) => Some(s.clone()),
+                                    Some(Some(CqlValue::Ascii(s))) => Some(s.clone()),
+                                    _ => None,
+                                });
+                            match id {
+                                None => Some((":fail", "BEGIN: no txn id in result".to_string())),
+                                Some(id) => {
+                                    txn_id_opt = Some(id.clone());
+                                    let upd = format!(
+                                        "UPDATE elle.la SET v = v + [{v}] WHERE k = {k} IN TRANSACTION {id}"
+                                    );
+                                    if let Err(e) = session.query_unpaged(upd, &[]).await {
+                                        Some((":fail", format!("UPDATE: {e}")))
+                                    } else if let Err(e) = session
+                                        .query_unpaged(format!("COMMIT TRANSACTION {id}"), &[])
+                                        .await
+                                    {
+                                        Some((":info", format!("COMMIT: {e}")))
+                                    } else {
+                                        None
+                                    }
+                                }
+                            }
+                        }
                     };
                     match outcome {
                         None => {
@@ -158,16 +197,19 @@ async fn main() -> Result<()> {
                                 .unwrap()
                                 .entry(normalize_err(kind, &why))
                                 .or_insert(0) += 1;
-                            // Clear any half-open transaction on THIS connection so the
-                            // next BEGIN doesn't hit "nested transactions". ROLLBACK is
-                            // cheap and idempotent; only reconnect if it, too, fails.
-                            if session
-                                .query_unpaged("ROLLBACK".to_string(), &[])
-                                .await
-                                .is_err()
-                            {
-                                if let Ok(fresh) = connect_pinned(&contact, &target).await {
-                                    session = Arc::new(fresh);
+                            // Best-effort abort of the (possibly still-open) txn by id
+                            // so a lingering entry cannot block this connection's next
+                            // BEGIN via the shim binding. Reconnect only if even that
+                            // fails. If BEGIN itself failed there is no id to roll back.
+                            if let Some(id) = txn_id_opt {
+                                if session
+                                    .query_unpaged(format!("ROLLBACK TRANSACTION {id}"), &[])
+                                    .await
+                                    .is_err()
+                                {
+                                    if let Ok(fresh) = connect_pinned(&contact, &target).await {
+                                        session = Arc::new(fresh);
+                                    }
                                 }
                             }
                             failures.fetch_add(1, Ordering::Relaxed);

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -1514,7 +1514,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         last_schema_event: tokio::sync::watch::channel(None).0,
         cql_metrics: Arc::new(ferrosa_cql::observability::CqlMetrics::new()),
         topology_policy,
+        // Server-wide (per-node) transaction registry: the connection-independent
+        // BEGIN/IN TRANSACTION/COMMIT surface. Default 10s open-transaction timeout
+        // (A1b); the reaper below actively evicts abandoned transactions.
+        txn_registry: ferrosa_cql::txn_registry::TransactionRegistry::shared_default(),
     });
+    // Start the open-transaction reaper (A1b): sweeps every second, aborting and
+    // evicting any transaction past its deadline without a client statement.
+    ferrosa_cql::txn_registry::spawn_transaction_reaper(shared_state.txn_registry.clone());
     let auth_disabled = cql_config.auth_disabled;
 
     // 9a. Register observability virtual tables into the schema's shared registry

--- a/ferrosa/tests/smoke.rs
+++ b/ferrosa/tests/smoke.rs
@@ -132,6 +132,7 @@ fn setup_state() -> (Arc<SharedState>, TempDir) {
         event_sender: tokio::sync::broadcast::channel(64).0,
         last_schema_event: tokio::sync::watch::channel(None).0,
         topology_policy: ClientTopologyPolicy::default(),
+        txn_registry: ferrosa_cql::txn_registry::TransactionRegistry::shared_default(),
         cql_metrics: Arc::new(ferrosa_cql::observability::CqlMetrics::new()),
     });
     (state, dir)

--- a/specs/proposed/unified-transaction-manager/architecture.md
+++ b/specs/proposed/unified-transaction-manager/architecture.md
@@ -1,0 +1,187 @@
+---
+title: Unified Transaction Manager — Architecture
+status: proposed
+component: transaction-manager
+executive_summary: >
+  A connection-independent transaction manager keyed by transaction id, layered as
+  front-end (CQL / future Postgres) → transaction registry → MVCC storage → Accord
+  commit. The txn-id rides the CQL surface (result row + `IN TRANSACTION <id>` text) so
+  stock Cassandra drivers work unmodified. MVCC (versioned rows + write intents +
+  read-timestamp snapshots + GC) supplies read-your-writes and isolation for interactive
+  SQL transactions; Accord supplies the strict-serializable distributed commit. Current
+  state, target state, and migration are kept separate; MVCC and the SQL front-end are
+  explicit later phases.
+last_revised: 2026-07-20
+---
+
+# Unified Transaction Manager — Architecture
+
+## Current state
+
+Transaction state is per-TCP-connection and fragile:
+
+- `ferrosa-cql/src/session.rs`
+  - `CqlTransaction` (a.k.a. the batch/staging tx) — the **real** per-connection
+    transaction: `open`, `staged: Vec<BatchOp>`, `deadline`. Staged writes commit
+    atomically via the storage batch primitive / Accord committer.
+  - `TransactionState` (the `in_transaction` bool) — **dead code**: only referenced by
+    tests, never on the production path. Remove.
+- `ferrosa-cql/src/connection.rs`
+  - One `Arc<Mutex<CqlTransaction>>` per connection; QUERY runs on **concurrent spawned
+    tasks** (`connection.rs:544`) that lock it around `route_transactional`
+    (`connection.rs:1600`). Correct only if the client is strictly serial **and** pinned.
+- `ferrosa-cql/src/router.rs::route_transactional` — routes BEGIN/COMMIT/ROLLBACK and
+  buffers in-transaction DML; COMMIT drives `AccordTransactionCommitter`.
+- `ferrosa-cluster/src/accord/transaction_commit.rs::AccordTransactionCommitter` — the
+  strict-serializable multi-key commit (Accord). **Kept.**
+
+Reads inside a transaction are **not** MVCC-isolated today; the model is
+Cassandra newest-wins (LWW by cell timestamp). Interactive read-your-writes and isolation
+levels are not expressible.
+
+## Target architecture
+
+```mermaid
+flowchart TD
+  subgraph FE[Wire front-ends]
+    CQL[CQL front-end<br/>txn-id explicit: BEGIN returns id;<br/>... IN TRANSACTION id]
+    PG[Postgres/SQL front-end<br/>maps pg-connection to txn-id<br/>internally - FUTURE]
+  end
+  subgraph TM[Transaction Manager]
+    REG[Transaction Registry<br/>txn-id to TransactionEntry<br/>lifecycle, auth-scope, TTL/evict]
+    ENT[TransactionEntry<br/>read_ts snapshot, staged intents,<br/>savepoint stack, owner, deadline]
+  end
+  subgraph ST[MVCC Storage]
+    VER[Versioned rows<br/>committed versions by ts]
+    INT[Write intents<br/>provisional, txn-scoped]
+    GC[Version GC by read low-water-mark]
+  end
+  COMMIT[Commit seam<br/>Accord strict-serializable<br/>single-Raft-group - FUTURE]
+  CQL --> REG
+  PG --> REG
+  REG --> ENT
+  ENT -- snapshot read --> VER
+  ENT -- read-your-writes --> INT
+  ENT -- COMMIT --> COMMIT
+  COMMIT -- intents to committed versions at exec ts --> VER
+  GC -.-> VER
+```
+
+### Components
+
+**Transaction Registry** (`txn-id → TransactionEntry`)
+- Replaces the per-connection field. A server-side map with lifecycle: `begin`, `stage`,
+  `read`, `commit`, `abort`, `expire`. Bounded (max entries); an **open-timeout reaper**
+  (constraint 8, `transaction_open_timeout` default 10s) actively aborts transactions past
+  their deadline (drops the temp table, evicts the entry) rather than only checking lazily
+  on the next statement; fail-loud on overflow.
+- **Auth-scoped**: each entry records the authenticated principal/tenant; a statement
+  referencing a txn-id it does not own fails loud (prevents cross-client hijack).
+- **Locality (D1)**: the txn-id encodes its owning coordinator. In a multi-node cluster a
+  node that receives `… IN TRANSACTION <id>` for a non-local id **forwards** to the owner
+  (NewSQL transaction-record pattern). Phase A is single-node (pinned coordinator);
+  Phase B adds forwarding.
+- Per-txn-id serialization: statements for one txn-id execute in submission order (a
+  transaction is logically serial even if the client pipelines).
+
+**TransactionEntry** (in-RAM metadata only — data lives on NVMe)
+- `read_ts`: the MVCC snapshot timestamp (assigned at BEGIN or first read).
+- `temp_table`: handle to this transaction's **per-transaction temp table on NVMe** —
+  the staging store for its write intents (keyed by key/clustering). NOT in RAM; bounded
+  by NVMe capacity (constraint 7), so a transaction can be as large as local disk allows.
+- `savepoints`: stack of temp-table checkpoints (SQL `SAVEPOINT`).
+- `owner`: auth principal/tenant; `deadline`: abort budget.
+
+**Per-transaction temp table (NVMe staging store)**
+- A lightweight, transaction-scoped table on local NVMe holding the transaction's
+  intents. Reuses ferrosa's existing on-NVMe write path (memtable spill + local SSTable
+  segments), but under a temp-table namespace that never publishes to S3 until commit.
+- **Read-your-writes:** a `SELECT … IN TRANSACTION <id>` merges the snapshot read
+  (committed versions ≤ read_ts) with this temp table's rows.
+- **Commit:** the temp table is **promoted** into the permanent SSTable write path,
+  stamping every row at the Accord execution timestamp (intents → committed versions),
+  through the same all-or-nothing `apply_writeset` Accord already uses. The temp table is
+  then dropped.
+- **Abort / expire / crash-recover:** the temp table is dropped (NVMe reclaimed). Because
+  temp tables are on-disk, a coordinator restart can enumerate orphan temp tables and
+  abort/GC them (recoverable intent cleanup).
+- **NVMe budget:** a transaction whose temp table would exceed the configured NVMe budget
+  fails loud and aborts — never silently truncates or spills a live transaction's data.
+
+**MVCC Storage** (the "full SQL" pillar)
+- **Versioned rows**: retain multiple committed versions keyed by commit timestamp
+  (Accord execution ts), not just newest. A snapshot read at `read_ts` returns the newest
+  version `≤ read_ts`.
+- **Write intents**: uncommitted writes are provisional records held in the
+  transaction's **NVMe temp table** (above), visible only to their transaction
+  (read-your-writes) and to conflict detection. On commit they are promoted to committed
+  versions at the Accord execution ts; on abort the temp table is dropped. Because they
+  live on NVMe (not RAM), a transaction's write set is bounded by disk, not memory.
+- **GC (D6)**: versions below the cluster read low-water-mark (oldest live snapshot) are
+  collected during compaction — analogous to `gc_grace`. The open-transaction timeout
+  (constraint 8, default 10s) bounds the low-water-mark to ~one timeout window, so version
+  retention stays small and predictable regardless of client behavior.
+- Isolation: **Snapshot Isolation** by default (read at `read_ts`, own intents visible);
+  **Serializable** via Accord ordering the commit against concurrent conflicts.
+
+**Commit seam**
+- Pluggable. `AccordTransactionCommitter` for cross-partition strict-serializability
+  (today). A single-Raft-group committer is a future option for one-shard transactions.
+- Commit atomically flips this transaction's intents to committed versions at the agreed
+  execution timestamp; abort discards them.
+
+### Wire mapping (CQL, wire-compatible)
+
+| Client action | CQL text (standard QUERY frame) | Server |
+|---|---|---|
+| Begin | `BEGIN TRANSACTION` | allocate txn-id; return `RESULT: Rows [[txn_id]]` |
+| Write | `UPDATE t SET … WHERE … IN TRANSACTION <id>` | stage intent under `<id>` |
+| Read | `SELECT … FROM t WHERE … IN TRANSACTION <id>` | read snapshot@read_ts ∪ own intents |
+| Savepoint | `SAVEPOINT s IN TRANSACTION <id>` (future) | push intent checkpoint |
+| Commit | `COMMIT TRANSACTION <id>` | Accord commit; intents → versions |
+| Rollback | `ROLLBACK TRANSACTION <id>` | discard intents; drop entry |
+
+The Postgres/SQL front-end (future) presents standard connection-sticky `BEGIN/COMMIT`
+and maps `(pg-connection → txn-id)` internally, so the core stays connection-independent.
+
+### Data / control flow (interactive transaction)
+
+```mermaid
+sequenceDiagram
+  participant C as Client (any driver)
+  participant N as Coordinator node
+  participant R as Txn Registry
+  participant S as MVCC Storage
+  participant A as Accord
+  C->>N: BEGIN TRANSACTION
+  N->>R: allocate id, read_ts
+  N-->>C: RESULT rows [id]
+  C->>N: SELECT ... IN TRANSACTION id
+  N->>S: snapshot read @ read_ts + own intents
+  N-->>C: rows
+  C->>N: UPDATE ... IN TRANSACTION id
+  N->>R: stage intent
+  N-->>C: void
+  C->>N: COMMIT TRANSACTION id
+  N->>A: commit staged set (strict-serializable)
+  A->>S: intents -> committed versions @ exec ts
+  N-->>C: void (or failure)
+```
+
+## Migration & compatibility
+
+- **Compat shim (D5):** keep bare `BEGIN TRANSACTION` (no id) working by internally
+  allocating a txn-id bound to the connection; log a deprecation warning. Remove once the
+  SQL front-end and MVCC land.
+- **Elle harness:** switch to the `IN TRANSACTION <id>` flow — the connection-affinity
+  desync disappears by construction (Phase A).
+- **PR #283 fixes:** unaffected; this is a session/transaction-manager layer above them.
+
+## Seams for future phases
+
+- **Postgres/SQL front-end** — new crate/front-end mapping connection→txn-id onto the
+  registry; reuses MVCC + Accord.
+- **MVCC storage** — versioned rows + intents + GC in `ferrosa-storage`; the largest
+  addition and the enabler of interactive SQL isolation.
+- **Durable/recoverable txn state** — replicate registry entries (or make them
+  reconstructable) so a coordinator failure does not lose a long interactive transaction.

--- a/specs/proposed/unified-transaction-manager/as-built-phase-a.md
+++ b/specs/proposed/unified-transaction-manager/as-built-phase-a.md
@@ -1,0 +1,181 @@
+---
+title: Unified Transaction Manager — Phase A As-Built
+status: implemented
+component: transaction-manager
+executive_summary: >
+  As-built description of Phase A: a connection-independent, txn-id-keyed CQL
+  transaction manager that replaces the fragile per-connection transaction buffer.
+  A server-wide TransactionRegistry (keyed by an opaque UUID) holds each open
+  transaction's staged write-set, owner, and deadline; the id rides the CQL surface
+  (BEGIN returns it; `... IN TRANSACTION <id>`; `COMMIT|ROLLBACK TRANSACTION <id>`)
+  so the statements of one transaction need not share a TCP connection. Commit routes
+  the whole write-set through the existing Accord committer (strict-serializable). This
+  deletes the connection-affinity desync that produced the ~24% :info in the Elle
+  list-append cert. MVCC, multi-node forwarding, and a Postgres front-end are later
+  phases; Phase A stages the write-set in RAM and pins the coordinator (single node).
+last_revised: 2026-07-21
+---
+
+# Unified Transaction Manager — Phase A As-Built
+
+## 1. The problem it solves
+
+Before Phase A, CQL transaction state was a **per-TCP-connection**
+`Arc<Mutex<CqlTransaction>>`. `BEGIN`/`UPDATE`/`COMMIT` were three separate
+statements whose correctness depended on all three landing on the same connection
+*and* being processed strictly serially. Neither holds in practice: the scylla
+driver pools connections, and the server processes pipelined requests on concurrent
+spawned tasks. So `COMMIT` could reach a connection with no open transaction
+("COMMIT outside of a transaction") or a second `BEGIN` could arrive mid-transaction
+("nested transactions"). In the Elle list-append certification this surfaced as
+**~24% `:info`** (indeterminate) operations — not a database correctness bug, a
+**client↔server affinity** bug in the transaction plumbing.
+
+## 2. The core idea
+
+Move transaction state off the connection and into a **server-wide registry keyed
+by an opaque transaction id**, and put that id on the CQL wire so the client threads
+it through every statement of the transaction. Now it does not matter which
+connection (or which concurrent task) each statement lands on — they all address the
+same registry entry by id.
+
+```
+Client                         Node (one TransactionRegistry, shared by all connections)
+  BEGIN TRANSACTION      ──►    mint id, open entry{owner, deadline, buffer}, return id row
+  UPDATE … IN TRANSACTION <id> ─► look up <id>, authorize owner, stage the write
+  COMMIT TRANSACTION <id> ──►   take entry out, drive Accord commit of the buffered set
+```
+
+## 3. Components (all in `ferrosa-cql`)
+
+**`CqlTxnId`** (`txn_registry.rs`) — an opaque 128-bit id, a v4 UUID rendered as
+canonical text. Unguessable (defends against cross-client hijack) with negligible
+collision odds; parses from a bare UUID token or a quoted string on the wire.
+
+**`TransactionEntry`** — one open transaction's server-side state: the staged
+write-set (the existing `CqlTransaction` buffer, reused unchanged), the
+**authenticated owner** (principal/role), an absolute **deadline**, and the timeout
+budget.
+
+**`TransactionRegistry`** — `HashMap<CqlTxnId, TransactionEntry>` plus bounds. Lives
+on `SharedState`, so it is **per-node and shared across every connection** (that
+sharing is the whole point). Lifecycle methods:
+- `begin(owner, now, timeout?) -> CqlTxnId` — capacity-checked (fails loud at the
+  10 000-entry cap), timeout resolved (override bounded by a 600 s hard max, never
+  silently clamped), mints an id, inserts an open entry.
+- `stage(id, owner, now, write)` — authorize (own it, not expired), then buffer the
+  write. A build/stage failure **poisons** the transaction so a later commit refuses
+  a partial write-set.
+- `take_for_commit(id, owner, now) -> CqlTransaction` — authorize, then **remove**
+  the entry and hand the owned buffer to the caller.
+- `abort(id, owner)` — `ROLLBACK`; drop the entry.
+- `ensure_active(id, owner, now)` — validate for a `SELECT … IN TRANSACTION` without
+  staging (Phase A reads committed state; MVCC isolation is Phase D).
+- `reap_expired(now) -> Vec<CqlTxnId>` — evict every past-deadline entry.
+
+**Reaper** (`spawn_transaction_reaper`) — a background task that calls
+`reap_expired(Instant::now())` every second, so an abandoned transaction is aborted
+within ~one interval of its deadline **without any client statement**. Default open
+timeout is **10 s** (overridable per transaction via `USING TIMEOUT`, up to the hard
+max). This bounds RAM and, in later phases, bounds MVCC version retention.
+
+## 4. The CQL surface (wire-compatible)
+
+Every extension is ordinary CQL text in a standard QUERY frame, so **stock Cassandra
+drivers work unmodified**:
+
+| Action | CQL | Server behavior |
+|---|---|---|
+| Begin | `BEGIN TRANSACTION [USING TIMEOUT <ms>]` | mint id; return a one-row Rows RESULT `[[txn_id]]` |
+| Write | `UPDATE/INSERT/DELETE … IN TRANSACTION <id>` | stage the write under `<id>` |
+| Read | `SELECT … IN TRANSACTION <id>` | validate `<id>`; read committed state (Phase A) |
+| Commit | `COMMIT TRANSACTION <id>` | Accord-commit the buffered write-set |
+| Rollback | `ROLLBACK TRANSACTION <id>` | discard the entry |
+
+`TIMEOUT` is a *soft* keyword (a bare identifier), so it does not reserve the word
+`timeout` for table/column names. The `IN TRANSACTION` suffix is disambiguated from a
+`WHERE … IN (…)` list because it only binds at the end of a fully-parsed DML
+statement. `BEGIN`'s result is a normal Rows set — a legacy client that ignores it
+still works via the shim (below).
+
+## 5. Commit path & strict serializability
+
+Phase A **reuses the existing Accord committer unchanged**. On `COMMIT`, the router
+`take_for_commit`s the owned buffer out of the registry, releases the registry lock,
+and drives `AccordTransactionCommitter::commit(write_set)`. Accord provides the
+strict-serializable, all-or-nothing multi-key commit; the transaction manager's job
+is only to *assemble the right write-set under the right id and hand it over intact*.
+
+Strict serializability therefore rests on two things working together:
+1. **This layer** — the write-set is assembled correctly and atomically per
+   transaction, connection-independently (no torn/duplicated/dropped statements).
+2. **The Accord execution-timestamp ordering fixes** (branch `feat/crdt-collections-dwrite`
+   / PR #283): cell-path rebind to the execution ts, the shared-HLC witness, and the
+   per-key execution-ts high-water-mark — which fixed the *write-side ordering* that
+   Elle's `list-append` checks. Phase A removes the *client-affinity* noise that was
+   masking whether that ordering actually holds under load.
+
+## 6. Concurrency & lock discipline
+
+The registry is a synchronous `parking_lot::Mutex`. Every registry operation is
+synchronous **except** commit, and commit is deliberately structured so the async
+Accord round-trip runs **without the registry lock held**: `take_for_commit` removes
+the entry and returns the owned buffer, the lock drops, then the `.await` happens. If
+the lock were held across the await, every transaction on the node would serialize on
+it. Per-connection there is a tiny `Option<CqlTxnId>` "shim" slot (below); the
+registry itself carries no per-connection coupling.
+
+## 7. Backward compatibility (the shim)
+
+A bare `BEGIN` still works: it mints an id, returns it, **and** binds it to the
+connection's shim slot, so a later bare `COMMIT`/`ROLLBACK` (or bare in-transaction
+DML) resolves to it. This keeps legacy single-connection-serial clients working and
+logs a deprecation hint. The shim is per-connection and does **not** provide the
+connection-independence guarantee — explicit ids do. It is slated for removal in
+Phase C once clients migrate.
+
+## 8. Safety properties (fail-loud, bounded)
+
+- **Auth scope** — an entry records its owner; a statement on a non-owned id fails
+  loud (`Unauthorized`). One client cannot touch another's transaction.
+- **Bounded** — the registry count is hard-capped (fails loud at capacity); ids are
+  minted with bounded retries; no unbounded server-side growth.
+- **Time-bounded** — every open transaction has a deadline, enforced both lazily (on
+  the next stage/commit) and actively (the reaper). A timed-out transaction is
+  aborted and persists nothing.
+- **No partial commits** — a failed staged statement poisons the transaction; the
+  next commit refuses a partial write-set. A failed commit surfaces as an error and
+  is never acked as success.
+- **Testable time** — the deadline logic takes `now: Instant` as a parameter, so it
+  is unit-tested deterministically with no wall-clock dependence.
+
+## 9. Explicit non-goals for Phase A (deferred, on the board)
+
+- **MVCC** (versioned rows, write intents, snapshot reads, read-your-writes) — Phase
+  D (`t_c8c1b043`). Phase A stages in RAM and reads committed state.
+- **NVMe temp-table staging** — Phase D. Phase A's write-set is RAM-bounded.
+- **Multi-node txn-id forwarding** — Phase B (`t_d999f32b`). Phase A pins the
+  coordinator (single node), which is exactly the Elle cert topology.
+- **Postgres/SQL front-end, durable/recoverable txn state, isolation levels,
+  savepoints** — Phases E/F (`t_90b7bee3`, `t_3251fe75`).
+
+## 10. Verification status — CERTIFIED
+
+- Unit + integration: `ferrosa-cql` 1035 lib tests + integration + doc-tests green;
+  `ferrosa-cluster` green; `ferrosa` binary builds; `clippy --all-targets` clean.
+- **Live acceptance gate — PASSED.** Fresh-build RF=3 Elle `list-append`
+  certification via `deploy/fly-accord-elle/certify.sh`: **`valid? true`,
+  `anomaly-types: nil`, checker exit 0, `1600 :ok / 0 :fail / 0 :info`.** The
+  `:info` connection-affinity desync went from ~24% → **0**. Every append committed
+  and the history is strictly serializable — serializable *and* usable.
+- **Bug found + fixed during certification:** the first fresh-build run was
+  `valid? true` but rejected ~84% of BEGINs as "nested transactions" (all clean
+  `:fail`). The nested-BEGIN guard was a vestige of the per-connection model — in
+  the txn-id model a client legitimately holds several independent transactions at
+  once, so a fresh BEGIN never rejects. `begin_transaction` now mints a fresh id and
+  rebinds the shim last-wins (no guard); regression test
+  `router::tests::consecutive_begins_on_one_connection_never_report_nested`. Re-cert
+  after the fix: `0 :fail`.
+- **Tooling fix:** `certify.sh` labeled the fly image by `git HEAD` only, so
+  uncommitted code silently certified a stale cached image — now a dirty-aware
+  deterministic content-hash label + a build-log `Compiling ferrosa` check.

--- a/specs/proposed/unified-transaction-manager/decisions.md
+++ b/specs/proposed/unified-transaction-manager/decisions.md
@@ -1,0 +1,128 @@
+---
+title: Unified Transaction Manager — Decision Record
+status: proposed
+component: transaction-manager
+executive_summary: >
+  Replace ferrosa's fragile connection-keyed BEGIN/COMMIT transaction model with a
+  connection-independent, txn-id-keyed transaction manager backed by MVCC storage and
+  committed through Accord. The txn-id is exposed through the CQL surface (BEGIN returns
+  it as a result row; statements reference it via `IN TRANSACTION <id>`), keeping the
+  wire 100% compatible with stock Cassandra drivers while enabling full interactive SQL
+  transactions (read-your-writes, isolation levels, savepoints) across a Postgres/SQL
+  front-end. Phase A (registry + CQL surface + Accord commit, single-node registry)
+  unblocks strict-serializable list-append certification immediately; MVCC storage and
+  the SQL front-end are the larger "full SQL transaction management" phases.
+last_revised: 2026-07-20
+---
+
+# Unified Transaction Manager — Decision Record
+
+## Context
+
+ferrosa layered a stateful, multi-round-trip transaction (`BEGIN → UPDATE → COMMIT`)
+onto CQL and keyed the transaction state to the **TCP connection**
+(`ferrosa-cql/src/session.rs::CqlTransaction`, held per-connection in
+`ferrosa-cql/src/connection.rs`). Elle `list-append` certification exposed that this is
+fragile by construction: stock Cassandra drivers make no guarantee that a statement
+sequence stays on one connection (they pipeline, pool, reconnect), and the server
+dispatches QUERY on concurrent spawned tasks sharing one `Arc<Mutex<CqlTransaction>>`.
+The result was ~24% indeterminate commits from transaction-lifecycle desync
+(`COMMIT outside of a transaction` / `nested transactions`), which tainted the Elle
+anomaly graph even though the underlying Accord commits are reliable.
+
+This is a **design mismatch**, not a single bug: CQL is a stateless request/response
+protocol, and keying interactive-transaction state to the connection assumes an affinity
+the ecosystem does not provide.
+
+## Decision
+
+Adopt a **connection-independent, txn-id-keyed unified transaction manager**, backed by
+**MVCC storage** and committed through **Accord**, shared by all wire front-ends (CQL
+today; Postgres/SQL next).
+
+- **Txn-id lives on the CQL surface, not in the protocol frame.** `BEGIN TRANSACTION`
+  allocates a transaction id and returns it as an ordinary `RESULT: Rows` frame
+  (`[txn_id]`). Subsequent statements reference it in CQL text
+  (`UPDATE … IN TRANSACTION <id>`, `SELECT … IN TRANSACTION <id>`,
+  `COMMIT TRANSACTION <id>`, `ROLLBACK TRANSACTION <id>`). This uses only standard
+  `QUERY`/`RESULT` frames, so java-driver, gocql, python, and the scylla driver all work
+  unmodified. Application logic threads the id (a documented CQL extension).
+- **State is keyed by txn-id in a server-side registry**, never the connection. A
+  statement may arrive on any connection; reconnects/pooling/interleaving become
+  harmless.
+- **MVCC provides the read side** of full transaction semantics: each transaction reads a
+  consistent snapshot at its read timestamp and sees its own staged writes
+  (read-your-writes); provisional writes are **intents** until commit. This is what makes
+  interactive SQL transactions (read → branch → write → commit) correct.
+- **Accord provides the distributed atomic commit** (existing
+  `AccordTransactionCommitter`): on commit, intents become committed versions at the
+  Accord execution timestamp; on abort, intents are discarded.
+- **The core is front-end-agnostic and commit-protocol-agnostic.** CQL exposes the txn-id
+  explicitly; a future Postgres/SQL front-end maps its connection→txn-id internally
+  (presenting standard connection-sticky `BEGIN/COMMIT` to psql/JDBC). The commit seam is
+  pluggable (Accord for cross-partition strict-serializability; a single Raft group for
+  one-shard transactions).
+
+## Rejected alternatives
+
+| Option | Why rejected |
+|---|---|
+| **Protocol-frame txn-id** (new opcode / header field) | Breaks wire compatibility — no stock Cassandra driver carries it. |
+| **#2: single-request `BATCH` transactions** (Accord-routed BATCH) | Simpler and wire-compatible, but **structurally cannot express interactive SQL** (read → decide → write). A dead-end for the SQL goal. Retained as an *optimization* for blind-write transactions, not the general model. |
+| **#3: harden the connection-keyed model** (serialize + ship a pinning client) | Still fragile; still needs driver/harness work; does not generalize to SQL. |
+
+## Locked constraints
+
+1. **Wire-compatible with stock Cassandra drivers** — no new opcodes or frame fields.
+2. **Preserve interactive multi-round-trip transactions** — `BEGIN … read … write … COMMIT`.
+3. **Accord remains the strict-serializable distributed commit** (existing machinery).
+4. **Front-end-agnostic core** — one transaction manager under CQL and future Postgres/SQL.
+5. **MVCC is in scope** — full SQL transaction management requires snapshot reads +
+   write intents + GC, not the current Cassandra-style newest-wins LWW.
+6. **No regression to PR #283** — the four Accord correctness fixes ship independently;
+   this refactor sits above them at the session/transaction-manager layer.
+7. **Transactions are bounded by NVMe, not RAM.** A transaction's staged writes / MVCC
+   write intents live in a **per-transaction temp table on local NVMe**, not in memory.
+   The in-RAM registry holds only per-transaction *metadata* (id, read_ts, owner,
+   deadline, temp-table handle). On commit, the temp table is promoted into the permanent
+   SSTable write path at the Accord execution timestamp; on abort it is dropped. This
+   bounds a transaction's size by NVMe capacity (enabling large/bulk transactions),
+   keeps RAM bounded regardless of transaction size, and — because temp tables are
+   on-disk — makes intents recoverable across a process restart. It maps directly onto
+   ferrosa's existing "NVMe as write-behind cache, S3 as durable" model.
+8. **Transactions are bounded in time by a tunable open-timeout (default 10s).** A
+   transaction open longer than `transaction_open_timeout` is aborted (temp table
+   dropped, entry evicted). `CqlTransaction` already carries a per-transaction `deadline`;
+   this makes the default configurable and **registry-enforced** by a reaper, not only
+   checked lazily on the next statement. The time bound is the natural *upper* bound on a
+   transaction (complementing the NVMe *size* bound) and, critically, it **bounds MVCC
+   version retention**: the read low-water-mark can never be older than the oldest open
+   transaction (≤ timeout), so version-GC need only retain roughly one timeout-window of
+   versions — capping MVCC storage.
+
+## Open decisions (to confirm)
+
+| # | Decision | Recommendation |
+|---|---|---|
+| D1 | **Registry locality in a multi-node cluster** — where does a transaction's entry live, and how do statements for a txn-id reach it? | Encode the owning coordinator in the txn-id; receiving nodes **forward by txn-id** (NewSQL-style transaction record). Phase A ships **single-node registry** (sufficient for the pinned-coordinator Elle workload and to unblock the cert); multi-node routing is Phase B. |
+| D2 | **Txn-id type + unguessability + auth scope** | 128-bit random (or TimeUUID with random low bits); registry entry records the authenticated principal/tenant; a statement referencing a txn-id it does not own fails loud. |
+| D3 | **Abandoned-transaction policy** | Per-txn deadline (already present on `CqlTransaction`) + registry TTL eviction; on eviction/abort/expire the temp table is dropped (NVMe reclaimed). Registry entry *count* is bounded (fail-loud on overflow); per-transaction *data* is bounded by NVMe (constraint 7), and a transaction that would exceed the NVMe budget fails loud rather than evicting live data. |
+| D4 | **Isolation levels** | Snapshot Isolation as the default read semantics (MVCC read-ts); Serializable via Accord for the commit. Expose `SERIALIZABLE` explicitly; document SI as the interactive-read default. |
+| D5 | **Compat shim for existing connection-keyed BEGIN** | Keep `BEGIN TRANSACTION` (no id) working during transition by internally allocating a txn-id bound to the connection; deprecate with a warning; remove after the SQL front-end lands. |
+| D6 | **MVCC version retention / GC** | Retain versions until below the cluster read low-water-mark (oldest live snapshot); GC on compaction, analogous to `gc_grace`. The open-timeout (constraint 8, default 10s) bounds the low-water-mark to roughly one timeout window, so retention is small and predictable — GC is not at the mercy of an arbitrarily long-lived reader. |
+| D7 | **Open-transaction timeout default + config surface** | `transaction_open_timeout`, default **10s**, per-`USING TIMEOUT` override on `BEGIN` up to a hard cluster max; registry reaper enforces it (not just lazy check). Rejected: unbounded transactions (would defeat both the NVMe bound and MVCC-GC bound). |
+
+## Consequences
+
+- **Immediate:** Phase A unblocks strict-serializable list-append certification (the Elle
+  harness adopts `IN TRANSACTION <id>`; the connection-affinity desync disappears by
+  construction — no driver or raw-socket work).
+- **Strategic:** establishes the transaction core (registry + MVCC + Accord commit) that a
+  Postgres/SQL front-end plugs into, turning "SQL transactions on ferrosa" from a rewrite
+  into two scoped additions (MVCC storage, front-end mapping).
+- **Cost:** a server-side transaction registry with lifecycle/security/eviction, and a
+  real MVCC subsystem in the storage engine (versioned rows + intents + snapshot reads +
+  GC). Both are load-bearing for the SQL vision and are phased.
+
+See [architecture.md](architecture.md), [fmea.md](fmea.md), and
+[project-plan.md](project-plan.md).

--- a/specs/proposed/unified-transaction-manager/fmea.md
+++ b/specs/proposed/unified-transaction-manager/fmea.md
@@ -1,0 +1,45 @@
+---
+title: Unified Transaction Manager — FMEA
+status: proposed
+component: transaction-manager
+executive_summary: >
+  Failure-mode analysis for the txn-id-keyed, MVCC-backed transaction manager. Highest
+  risks: cross-client txn-id hijack (security), registry/intent unbounded growth
+  (availability), coordinator failure losing interactive-transaction state (durability),
+  MVCC version-GC reclaiming versions a live snapshot still needs (correctness), and
+  multi-node forwarding sending a statement to the wrong owner (correctness). Each is
+  paired with a design control and an acceptance gate. RPN = Severity x Occurrence x
+  Detection (1-3 each; higher = worse).
+last_revised: 2026-07-20
+---
+
+# Unified Transaction Manager — FMEA
+
+Severity/Occurrence/Detection scored 1 (best) to 3 (worst). RPN = S x O x D.
+
+| # | Failure mode | Effect | S | O | D | RPN | Control / acceptance gate |
+|---|---|---|---|---|---|---|---|
+| F1 | **Txn-id hijack** — a client references another client's txn-id | Cross-tenant read/write; isolation + auth breach | 3 | 2 | 3 | 18 | Unguessable 128-bit id; entry records auth principal; statement on a non-owned id fails loud. Gate: test a second principal referencing an id is rejected. |
+| F2 | **Registry unbounded growth** — abandoned/leaked transactions accumulate | OOM / node crash (cf. compose-node OOM history) | 3 | 2 | 2 | 12 | Data lives in NVMe temp tables (constraint 7); RAM holds only per-txn metadata. Bounded registry *count* + per-txn deadline + TTL eviction (drops the temp table); fail-loud on overflow. Gate: load test with abandoned txns holds bounded RAM; eviction reclaims NVMe. |
+| F2b | **NVMe exhaustion** — one huge transaction (or many) fills local NVMe | Node write-path stall / crash | 3 | 2 | 2 | 12 | Per-transaction + global NVMe budget; a transaction that would exceed it fails loud and aborts (drops its temp table) — never silently truncates or evicts a live transaction. Gate: oversized-transaction test aborts cleanly with NVMe reclaimed. |
+| F3 | **Coordinator failure loses txn state** — owner node dies mid interactive transaction | Long SQL transaction aborts / hangs | 3 | 2 | 1 | 6 | Temp tables are on-disk NVMe, so intents survive a *process* restart and are recoverable/GC-able on the same node; on *node* loss, Phase A/B cleanly aborts (definite failure, never phantom commit); future durable-registry replicates the metadata for cross-node resume. Gate: process-restart recovers/aborts orphan temp tables; kill-node yields a clean abort, no partial commit. |
+| F4 | **MVCC version GC too aggressive** — collects a version a live snapshot still needs | Snapshot read returns wrong/older data — silent corruption | 3 | 2 | 3 | 18 | GC only below the cluster read low-water-mark (oldest live `read_ts`); retain until then. The open-timeout (constraint 8) bounds that low-water-mark to ~one window (default 10s), so retention is small and a runaway reader cannot pin history. Gate: property test — no snapshot ever misses a version ≤ its read_ts under concurrent GC; retention stays within the timeout window. |
+| F5 | **Intent not cleaned up on abort/crash** — orphan write intent | Later reads blocked/confused by a stale intent; space leak | 3 | 2 | 2 | 12 | Intents are txn-scoped and swept on abort/expire; recovery scans for intents of dead txns. Gate: abort/crash test leaves no live intents. |
+| F6 | **Multi-node mis-forward** — statement for a txn-id routed to a non-owner node | `unknown transaction` errors, or worse, split state | 3 | 2 | 2 | 12 | Owner encoded in the txn-id; forward by id; unknown/foreign id fails loud (never create a second entry). Gate: statements for a remote id are forwarded and applied exactly once. |
+| F7 | **Concurrent statements on one txn-id** — client pipelines within a transaction | Interleaved staging corrupts the transaction | 2 | 2 | 2 | 8 | Per-txn-id serialization (submission order); a transaction is logically serial. Gate: pipelined-within-txn test preserves order. |
+| F8 | **Read-ts skew across nodes** — snapshot read_ts not coherent with commit order | Non-repeatable / inconsistent interactive reads | 3 | 2 | 3 | 18 | read_ts from the shared HLC (see t_813caf39 witness work); reads honor Accord order; document SI vs Serializable. Gate: Elle rw-register / SI checker passes for interactive read-write. |
+| F9 | **Txn-id collision** | Two transactions share state | 3 | 1 | 3 | 9 | 128-bit random / TimeUUID with random low bits; collision negligible. Gate: id-uniqueness property test. |
+| F10 | **Compat-shim ambiguity** — bare `BEGIN` vs `IN TRANSACTION <id>` on one connection interleave | Desync returns for shim users | 2 | 2 | 2 | 8 | Shim binds an internal id to the connection; disallow mixing shim + explicit-id on one connection; deprecate shim. Gate: mixed-mode test fails loud. |
+| F11 | **Commit half-applies intents** (partial across keys) | Torn transaction — data loss | 3 | 1 | 1 | 3 | Reuse Accord all-or-nothing `apply_writeset` (already fail-loud, tested). Gate: existing multi-key atomicity proptests extended to intents. |
+| F12 | **Deadlock / lock-wait** under Serializable conflicts | Stalls | 2 | 2 | 2 | 8 | Accord is deterministic-order (no lock-wait deadlock); bounded commit deadline aborts stragglers. Gate: contention load test bounds latency, no permanent stall. |
+
+## Priority summary
+
+- **RPN 18 (critical):** F1 hijack, F2 registry OOM, F4 MVCC GC, F8 read-ts skew — all
+  gated before the corresponding phase ships.
+- **RPN 9–12 (high):** F5 intent cleanup, F6 mis-forward, F9 collision.
+- **RPN ≤ 8:** serialization, shim, atomicity, deadlock — controlled by existing Accord
+  guarantees + small additions.
+
+MVCC introduces the most novel correctness surface (F4, F5, F8); it must ship behind a
+property-tested version-visibility invariant and an Elle/SI checker, not by inspection.

--- a/specs/proposed/unified-transaction-manager/project-plan.md
+++ b/specs/proposed/unified-transaction-manager/project-plan.md
@@ -1,0 +1,106 @@
+---
+title: Unified Transaction Manager — Project Plan
+status: proposed
+component: transaction-manager
+executive_summary: >
+  Six phases. Phase A (txn-id registry + CQL `IN TRANSACTION <id>` surface + Accord commit,
+  single-node registry) is the quick win — it unblocks strict-serializable list-append
+  certification and deletes the connection-affinity bug class. Phases B–C add multi-node
+  txn-id forwarding and remove dead state. Phases D–F are the "full SQL transaction
+  management" build: MVCC storage (versions + intents + snapshot reads + GC), isolation
+  levels, a Postgres/SQL front-end, and durable/recoverable transaction state for
+  coordinator failover. Each phase has explicit acceptance gates; MVCC ships behind a
+  property-tested version-visibility invariant.
+last_revised: 2026-07-20
+---
+
+# Unified Transaction Manager — Project Plan
+
+Dependencies: A → B, A → C, A → D(MVCC) → E(isolation) → F(SQL front-end); F′ (durable
+state) depends on B. MVCC (D) is the critical-path enabler for interactive SQL.
+
+## Phase A — Txn-id registry + CQL surface + Accord commit (single-node) — QUICK WIN
+
+Unblocks the Elle certification and removes the desync bug class.
+
+- **A1** `TransactionRegistry` (`txn-id → CqlTransaction`) with lifecycle
+  (begin/stage/read/commit/abort), bounded size + per-txn deadline. Replaces the
+  per-connection `Arc<Mutex<CqlTransaction>>`.
+- **A1b** Open-timeout reaper (constraint 8): `transaction_open_timeout` config, default
+  **10s**, with an optional `BEGIN … USING TIMEOUT` override up to a hard cluster max; a
+  background sweep actively aborts+evicts past-deadline transactions (`CqlTransaction`
+  already has the `deadline`/`check_deadline` primitive — make it config-driven and
+  reaper-enforced). Gate: a transaction idle past the timeout is aborted and its resources
+  reclaimed without a client statement.
+- **A2** Parser + surface: `BEGIN TRANSACTION` returns `RESULT: Rows [[txn_id]]`;
+  `… IN TRANSACTION <id>` on UPDATE/SELECT/DELETE; `COMMIT|ROLLBACK TRANSACTION <id>`.
+- **A3** Route staged set through the existing `AccordTransactionCommitter` (unchanged).
+  Phase A stages in the existing in-RAM `Vec<BatchOp>` (small transactions) to unblock the
+  cert; the **NVMe temp-table staging store** (constraint 7 — transactions bounded by
+  NVMe) lands with the intent store in Phase D.
+- **A4** Compat shim (D5): bare `BEGIN` allocates an internal id bound to the connection;
+  deprecation warning; disallow mixing modes on one connection.
+- **A5** Remove the dead `TransactionState` bool (session.rs:19) — it is test-only.
+- **A6** Migrate `ferrosa-jepsen/examples/elle_list_append.rs` to the `IN TRANSACTION <id>`
+  flow.
+- **Gates:** unit tests for registry lifecycle + auth scope (F1) + eviction (F2);
+  a single-node Elle `list-append` run reaches `valid? true` with `:info` ≈ 0 (no
+  connection-affinity desync). Full `ferrosa-cql` + `ferrosa-cluster` suites green.
+
+## Phase B — Multi-node txn-id routing
+
+- **B1** Encode the owning coordinator in the txn-id.
+- **B2** Forward `… IN TRANSACTION <id>` for a non-local id to the owner; unknown/foreign
+  id fails loud (F6).
+- **B3** Per-txn-id serialization across forwarded statements (F7).
+- **Gates:** 3-node test — a client whose statements land on different nodes still applies
+  each exactly once; foreign-id rejection test.
+
+## Phase C — Cleanup + docs
+
+- **C1** Deprecate/remove the connection-keyed shim once safe.
+- **C2** Crate docs (`ferrosa-cql`, `ferrosa-session`) + a CQL transaction-extension spec.
+
+## Phase D — MVCC storage (the full-SQL enabler)
+
+The largest addition; ships behind a property-tested invariant, not by inspection.
+
+- **D1** Versioned rows in `ferrosa-storage`: retain committed versions by commit ts;
+  snapshot read returns newest version `≤ read_ts`.
+- **D2** Write intents on a **per-transaction NVMe temp table** (constraint 7):
+  provisional, txn-scoped records staged on local NVMe (memtable spill + temp local
+  SSTable segments, never published to S3 until commit); read-your-writes; conflict
+  visibility; per-transaction + global NVMe budget with fail-loud abort on exhaustion
+  (F2/F2b). Bounds transaction size by disk, not RAM.
+- **D3** Commit flips this txn's intents to committed versions at the Accord execution ts;
+  abort/crash sweeps intents (F5).
+- **D4** Version GC below the cluster read low-water-mark, on compaction (F4).
+- **D5** read_ts from the shared HLC (reuse the t_813caf39 witness work) so snapshots are
+  coherent with commit order (F8).
+- **Gates:** property test — no snapshot ever misses a version `≤` its read_ts under
+  concurrent GC; abort/crash leaves no live intents; multi-key atomicity extended to
+  intents (F11).
+
+## Phase E — Isolation levels
+
+- **E1** Snapshot Isolation as the interactive-read default (read@read_ts ∪ own intents).
+- **E2** Serializable via Accord for the commit; expose `SERIALIZABLE`.
+- **E3** Savepoints (`SAVEPOINT`/`ROLLBACK TO`) as intent checkpoints.
+- **Gates:** Elle `rw-register` / an SI checker passes for interactive read-write
+  workloads; savepoint round-trip tests.
+
+## Phase F — SQL/Postgres front-end + durable txn state
+
+- **F1** Postgres wire front-end mapping `(pg-connection → txn-id)` onto the registry;
+  standard `BEGIN/COMMIT` UX to psql/JDBC; reuses MVCC + Accord.
+- **F2** Durable/recoverable registry entries (replicate or reconstruct) so a coordinator
+  failure fails a long interactive transaction cleanly, or resumes it (F3).
+- **Gates:** psql interactive-transaction acceptance suite; kill-owner test yields a clean
+  abort with no partial commit.
+
+## Sequencing note
+
+Phase A is independently shippable and is the immediate deliverable (unblocks the cert,
+deletes the bug class). Phases D–F are a multi-sprint platform initiative — the "full SQL
+transaction management with MVCC" vision — and should be scheduled deliberately, not
+folded into the harness fix.


### PR DESCRIPTION
Stacked on #283 (base `feat/crdt-collections-dwrite`), which carries the Accord execution-timestamp ordering fixes this depends on. Rebase onto `main` once #283 merges. Do **not** squash into #283 — this is the txn-manager layer above it.

## What

A connection-independent, **txn-id-keyed transaction manager** (Phase A) that replaces the fragile per-connection `Arc<Mutex<CqlTransaction>>` with a server-wide `TransactionRegistry`. The transaction id rides the CQL surface, so `BEGIN`/`UPDATE`/`COMMIT` no longer need to land on the same TCP connection.

- **Registry** (`ferrosa-cql/src/txn_registry.rs`): txn-id → entry, auth-scoped (FMEA F1), bounded (F2), per-entry deadline. Commit takes the owned staging machine out and drives the async Accord commit **without** holding the registry lock.
- **Reaper** (10s default / 600s max): background sweep aborts abandoned transactions with no client statement; `reap_expired` is a pure, unit-tested function (time injected).
- **CQL surface** (wire-compatible, stock Cassandra drivers unmodified): `BEGIN TRANSACTION [USING TIMEOUT <ms>]` returns the id as a result row; `<dml/select> IN TRANSACTION <id>`; `COMMIT|ROLLBACK TRANSACTION <id>`.
- **Compat shim** for bare `BEGIN/COMMIT`; **dead `TransactionState` removed**.
- Commit routes the staged write-set through the **existing Accord committer** (unchanged).

## Why — the bug it deletes

The Elle list-append cert was hitting ~24% indeterminate (`:info`) ops from `BEGIN`/`COMMIT` splitting across the driver's connection pool. The txn-id registry deletes that class by construction.

## Evidence (fly.io, `deploy/fly-accord-elle/certify*.sh`)

| Run | Faults | Elle verdict |
|---|---|---|
| Healthy RF=3 | none | `valid? true`, `:ok 1600 / :fail 0 / :info 0` |
| **Fault-injected RF=3** | minority partition + coordinator-loses-quorum + 200ms latency | **`valid? true`, 0 anomalies** (faults bit: 5 `:info` timeouts → correct minority refusal) |

`:info` went 24% → 0. Strict-serializability holds healthy **and** under network partition + WAN latency.

## Local gates

`ferrosa-cql` 1035 lib + integration + doc-tests green; `ferrosa-cluster` green; `ferrosa` binary builds; `cargo fmt --check` + `clippy --all-targets` clean.

## Deferred (on the board, not faked)

Multi-node txn-id routing, MVCC (versioned rows + NVMe intents), isolation levels, Postgres front-end (epic t_5a8d67c9). Dual-DC `dc-partition`/`dc-slow` Elle cert is gated on ferrosa's evolving cross-DC replication (t_79efcb59).