### PR TITLE
Query scheduler B1: vruntime fair-share scheduling (stacked on #286)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,7 @@ dependencies = [
  "ferrosa-index",
  "ferrosa-net",
  "ferrosa-row-bridge",
+ "ferrosa-sched",
  "ferrosa-schema",
  "ferrosa-session",
  "ferrosa-sstable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,6 +2510,7 @@ dependencies = [
 name = "ferrosa-sched"
 version = "0.17.0"
 dependencies = [
+ "proptest",
  "tokio",
 ]
 

--- a/ferrosa-cluster/src/raft/consensus_metrics.rs
+++ b/ferrosa-cluster/src/raft/consensus_metrics.rs
@@ -66,7 +66,7 @@ pub fn is_self_leader(current_leader: Option<u64>, my_id: u64) -> bool {
     current_leader == Some(my_id)
 }
 
-/// Poll Raft leadership once per [`POLL_INTERVAL`] and publish it, until
+/// Poll Raft leadership once per second (`POLL_INTERVAL`) and publish it, until
 /// cancelled. Spawned per cluster-mode node alongside — but independent of — the
 /// election guard, so the metric surface outlives the ADR-012 guard.
 ///

--- a/ferrosa-cql/Cargo.toml
+++ b/ferrosa-cql/Cargo.toml
@@ -19,6 +19,7 @@ ferrosa-index = { path = "../ferrosa-index" }
 ferrosa-row-bridge = { path = "../ferrosa-row-bridge" }
 ferrosa-schema = { path = "../ferrosa-schema" }
 ferrosa-session = { path = "../ferrosa-session" }
+ferrosa-sched = { path = "../ferrosa-sched" }
 ferrosa-sstable = { path = "../ferrosa-sstable" }
 ferrosa-storage = { path = "../ferrosa-storage" }
 ferrosa-udf = { path = "../ferrosa-udf" }

--- a/ferrosa-cql/src/planner.rs
+++ b/ferrosa-cql/src/planner.rs
@@ -130,6 +130,31 @@ impl fmt::Display for ScanPlan {
     }
 }
 
+impl ScanPlan {
+    /// The query-scheduler class this plan's storage work belongs to (B1 T1.4).
+    ///
+    /// Only an unindexed [`FullScan`](ScanPlan::FullScan) — the `ALLOW FILTERING`
+    /// whole-table read that starved consensus in `t_88223ad0` — is unbounded
+    /// [`Bulk`](ferrosa_sched::SchedClass::Bulk) work that must cede the scan pool
+    /// to interactive queries. Every other plan is *keyed or index-bounded*
+    /// (`O(matching rows)`, not `O(table)`), so it is latency-sensitive
+    /// [`Foreground`](ferrosa_sched::SchedClass::Foreground) work. The class
+    /// seeds the fair-share weight (`weight_for_class`) when the scan is admitted.
+    pub fn sched_class(&self) -> ferrosa_sched::SchedClass {
+        match self {
+            ScanPlan::FullScan => ferrosa_sched::SchedClass::Bulk,
+            ScanPlan::PartitionKeyLookup
+            | ScanPlan::SingleIndex { .. }
+            | ScanPlan::PartitionIndexLookup { .. }
+            | ScanPlan::IndexScanWithFilter { .. }
+            | ScanPlan::IndexIntersection { .. }
+            | ScanPlan::VectorAnn { .. }
+            | ScanPlan::GeoIndex { .. }
+            | ScanPlan::FullTextIndex { .. } => ferrosa_sched::SchedClass::Foreground,
+        }
+    }
+}
+
 /// Choose an execution plan for a SELECT query.
 ///
 /// # Parameters
@@ -308,6 +333,84 @@ mod tests {
             value: Term::StringLiteral("dummy".to_string()),
             token_fn: false,
         }
+    }
+
+    // ── B1 T1.4: ScanPlan → SchedClass classifier ────────────────────────────
+    #[test]
+    fn full_scan_is_bulk_every_bounded_plan_is_foreground() {
+        use ferrosa_sched::SchedClass::{Bulk, Foreground};
+        let idx = || ("i".to_string(), "c".to_string());
+        // The full ScanPlan matrix → expected scheduling class.
+        let cases = [
+            (ScanPlan::FullScan, Bulk),
+            (ScanPlan::PartitionKeyLookup, Foreground),
+            (
+                ScanPlan::SingleIndex {
+                    index_name: "i".into(),
+                    index_column: "c".into(),
+                },
+                Foreground,
+            ),
+            (
+                ScanPlan::PartitionIndexLookup {
+                    index_name: "i".into(),
+                    index_column: "c".into(),
+                },
+                Foreground,
+            ),
+            (
+                ScanPlan::IndexScanWithFilter {
+                    index_name: "i".into(),
+                    index_column: "c".into(),
+                    filter_columns: vec!["f".into()],
+                },
+                Foreground,
+            ),
+            (
+                ScanPlan::IndexIntersection {
+                    indexes: vec![idx(), idx()],
+                },
+                Foreground,
+            ),
+            (
+                ScanPlan::VectorAnn {
+                    index_name: "i".into(),
+                    index_column: "c".into(),
+                },
+                Foreground,
+            ),
+            (
+                ScanPlan::GeoIndex {
+                    index_name: "i".into(),
+                    index_column: "c".into(),
+                    op: "GeoNearest".into(),
+                },
+                Foreground,
+            ),
+            (
+                ScanPlan::FullTextIndex {
+                    index_name: "i".into(),
+                    index_column: "c".into(),
+                },
+                Foreground,
+            ),
+        ];
+        for (plan, expected) in cases {
+            assert_eq!(plan.sched_class(), expected, "unexpected class for {plan}");
+        }
+    }
+
+    #[test]
+    fn full_scan_class_seeds_a_lighter_weight_than_a_point_read() {
+        use ferrosa_sched::runqueue::weight_for_class;
+        // A FullScan (Bulk) must weigh less than a point read (Foreground) so it
+        // yields the scan pool to interactive work.
+        let scan_w = weight_for_class(ScanPlan::FullScan.sched_class());
+        let point_w = weight_for_class(ScanPlan::PartitionKeyLookup.sched_class());
+        assert!(
+            scan_w < point_w,
+            "FullScan {scan_w} should weigh < point read {point_w}"
+        );
     }
 
     fn pk(names: &[&str]) -> Vec<String> {

--- a/ferrosa-sched/Cargo.toml
+++ b/ferrosa-sched/Cargo.toml
@@ -11,3 +11,4 @@ tokio = { version = "1", features = ["rt", "sync"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }
+proptest = "1"

--- a/ferrosa-sched/Cargo.toml
+++ b/ferrosa-sched/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Query QoS scheduler core: bounded execution pool that reserves CPU headroom for consensus (Phase 0 of the fair scheduler)."
 
 [dependencies]
-tokio = { version = "1", features = ["rt", "sync"] }
+tokio = { version = "1", features = ["rt", "sync", "macros"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }

--- a/ferrosa-sched/README.md
+++ b/ferrosa-sched/README.md
@@ -1,7 +1,9 @@
 # ferrosa-sched
 
-Query QoS scheduler core. **Phase 0** of the fair scheduler ([epic](../specs/proposed/query-scheduler/)):
-a bounded execution pool that reserves CPU headroom for consensus.
+Query QoS scheduler core ([epic](../specs/proposed/query-scheduler/)): a bounded
+execution pool that reserves CPU headroom for consensus (**Phase 0 / B0**), plus
+CFS-inspired fair-share scheduling so concurrent scans share that pool without
+one monopolizing it (**B1**).
 
 ## Why
 
@@ -19,18 +21,31 @@ a CheckQuorum leader step-down.
   `available()` CPU-bound closures at once and runs them on tokio's blocking
   threads; the admission permit is moved into the task, so a slot is released on
   completion **or panic** (RAII).
-- `SchedClass { Foreground, Bulk }` and a no-op `SchedTicket` — the seam Phase 1
-  (fair scheduling) activates without re-touching call sites.
+- `SchedPool::submit_scan(chunk_budget, f)` + `ScanSlot` (**B1 T1.2**) — a
+  cooperative-yield scan entry: the producer calls `slot.tick()` after each
+  produced chunk and, every `chunk_budget` chunks, the pool permit is released
+  and fairly (FIFO) re-acquired, so a long full-table scan cedes the slot to
+  waiting scans. Deadlock-free (release before re-acquire) and no CPU
+  oversubscription (parked re-acquires don't run).
+- `SchedClass { Foreground, Bulk }` + `runqueue::{RunQueue, SchedEntity,
+  weight_for_class}` + `scheduler::{Scheduler, SchedTicket, advance_vruntime}`
+  (**B1 T1.1/T1.2**) — the CFS-inspired vruntime fair-share core: pick-min run
+  queue with a monotonic `min_vruntime` floor, `SchedTicket::reschedule` service
+  accounting, and weighted fairness (Foreground 1024 : Bulk 256).
 
 ## Dependencies / dependents
 
 - **Depends on:** `tokio` only (a leaf crate — the DSM guard keeps
   storage/cluster/cql out).
 - **Dependents:** `ferrosa` (constructs the pool at boot), `ferrosa-storage`
-  (routes scan producers through it — Phase 0 T0.3).
+  (routes scan producers through `submit_scan`), `ferrosa-cql`
+  (`ScanPlan::sched_class` — B1 T1.4 classifier).
 
 ## Status
 
-Phase 0 in progress: T0.1 (this crate) + T0.2 (explicit `max_blocking_threads`
-in `ferrosa/src/runtime.rs`) done. T0.3 (route `store.rs` scan producers through
-`SchedPool`), T0.5 (headroom metrics), T0.6 (live no-step-down regression) pending.
+- **B0 (shipped, PR #286):** T0.1 pool, T0.2 `max_blocking_threads`, T0.3 route
+  scan producers, T0.5 headroom metrics, T0.6 live no-step-down regression.
+- **B1 (in progress, PR #287):** T1.1 run queue, T1.2 `Scheduler`/`SchedTicket`
+  + `submit_scan` cooperative yield wired into the `store.rs` producers, T1.4
+  `ScanPlan` classifier. Pending: T1.3 chunk-budget tripwire, T1.5 interactive
+  bypass, T1.6 fairness proptests, T1.7 no-lock audit, weighted per-scan budget.

--- a/ferrosa-sched/README.md
+++ b/ferrosa-sched/README.md
@@ -17,21 +17,23 @@ a CheckQuorum leader step-down.
 ## What
 
 - `Reservation { cores, reserved }` — `available() = cores − reserved` (floored at 1).
-- `SchedPool` — a semaphore-bounded pool. `submit(closure)` admits at most
-  `available()` CPU-bound closures at once and runs them on tokio's blocking
-  threads; the admission permit is moved into the task, so a slot is released on
-  completion **or panic** (RAII).
-- `SchedPool::submit_scan(chunk_budget, f)` + `ScanSlot` (**B1 T1.2**) — a
-  cooperative-yield scan entry: the producer calls `slot.tick()` after each
-  produced chunk and, every `chunk_budget` chunks, the pool permit is released
-  and fairly (FIFO) re-acquired, so a long full-table scan cedes the slot to
-  waiting scans. Deadlock-free (release before re-acquire) and no CPU
-  oversubscription (parked re-acquires don't run).
-- `SchedClass { Foreground, Bulk }` + `runqueue::{RunQueue, SchedEntity,
-  weight_for_class}` + `scheduler::{Scheduler, SchedTicket, advance_vruntime}`
-  (**B1 T1.1/T1.2**) — the CFS-inspired vruntime fair-share core: pick-min run
-  queue with a monotonic `min_vruntime` floor, `SchedTicket::reschedule` service
-  accounting, and weighted fairness (Foreground 1024 : Bulk 256).
+- `fair_admit::FairAdmit` (**B1.5**) — the live admission authority. At most
+  `available()` scans hold a slot at once, and a freed slot is granted to the
+  least-`vruntime` waiter, **weighted by `SchedClass`**: a Foreground scan (1024)
+  advances `vruntime` 4x slower than a Bulk scan (256), so under contention it
+  gets ~4x the slot turns. Admission is async (a waiter is a cheap task, never a
+  parked blocking thread — the B0 property); a scan's mid-scan re-competes block
+  its own blocking thread. Deadlock-free and slot-leak-free (RAII).
+- `SchedPool` — wraps `FairAdmit`. `submit_scan(class, chunk_budget, f)` + a
+  `ScanSlot`: the producer calls `slot.tick()` per produced chunk and every
+  `chunk_budget` chunks re-competes for its slot in vruntime order, so a long
+  full-table scan cedes to more-deserving scans. `submit`/`submit_blocking` are
+  the generic (Bulk-weight) entries.
+- `runqueue::{RunQueue, SchedEntity, weight_for_class}` +
+  `scheduler::{advance_vruntime, should_switch}` — the pure vruntime primitives
+  `FairAdmit` is built from: a pick-min run queue with a monotonic `min_vruntime`
+  floor, service charged inversely to weight, and the strictly-more-deserving
+  yield rule.
 
 ## Dependencies / dependents
 
@@ -43,9 +45,15 @@ a CheckQuorum leader step-down.
 
 ## Status
 
-- **B0 (shipped, PR #286):** T0.1 pool, T0.2 `max_blocking_threads`, T0.3 route
-  scan producers, T0.5 headroom metrics, T0.6 live no-step-down regression.
-- **B1 (in progress, PR #287):** T1.1 run queue, T1.2 `Scheduler`/`SchedTicket`
-  + `submit_scan` cooperative yield wired into the `store.rs` producers, T1.4
-  `ScanPlan` classifier. Pending: T1.3 chunk-budget tripwire, T1.5 interactive
-  bypass, T1.6 fairness proptests, T1.7 no-lock audit, weighted per-scan budget.
+- **B0 (PR #286):** T0.1 pool, T0.2 `max_blocking_threads`, T0.3 route scan
+  producers, T0.5 headroom metrics, T0.6 live no-step-down regression.
+- **B1 (PR #287):** T1.1 run queue, T1.2 cooperative yield in the `store.rs`
+  producers, T1.3 chunk-budget tripwire, T1.4 `ScanPlan` classifier, T1.5
+  interactive bypass, T1.6 fairness proptests, T1.7 no-lock audit.
+- **B1.5 (PR #287):** `FairAdmit` — the vruntime scheduler is now the **live
+  admission authority** (replacing the FIFO semaphore); weighting is real and
+  proven by test (`foreground_gets_roughly_four_to_one_over_bulk`). The
+  standalone `Scheduler`/`SchedTicket` abstraction was removed as superseded.
+  Every scan through the pool is currently a full-table `Bulk` scan (Foreground
+  reads bypass — T1.5), so the 4:1 weighting is latent until B3 folds
+  mixed-weight background work (compaction/repair/ANN) into the pool.

--- a/ferrosa-sched/README.md
+++ b/ferrosa-sched/README.md
@@ -24,6 +24,16 @@ a CheckQuorum leader step-down.
   gets ~4x the slot turns. Admission is async (a waiter is a cheap task, never a
   parked blocking thread — the B0 property); a scan's mid-scan re-competes block
   its own blocking thread. Deadlock-free and slot-leak-free (RAII).
+  `admit(class, cancel)` returns `Admitted::{Slot, Overloaded, Cancelled}`:
+  **cancellable** — if the `cancel` future fires (or the future is dropped)
+  before a slot is granted, a `WaitGuard` vacates the queue/waiter entry so a
+  scan whose consumer went away never occupies a slot; and **bounded** — with no
+  free slot and the waiter queue at `max_waiters`, admission is shed as
+  `Overloaded` (metric `ferrosa_sched_admissions_rejected_overload_total`)
+  rather than piling up. `submit_scan` takes the cancel signal and returns
+  `ScanOutcome`; storage's `range_iter*` producers route through
+  `spawn_bounded_range_scan`, passing the consumer channel's `closed()` as the
+  cancel signal and failing loud on overload (never a silent empty stream).
 - `SchedPool` — wraps `FairAdmit`. `submit_scan(class, chunk_budget, f)` + a
   `ScanSlot`: the producer calls `slot.tick()` per produced chunk and every
   `chunk_budget` chunks re-competes for its slot in vruntime order, so a long

--- a/ferrosa-sched/src/fair_admit.rs
+++ b/ferrosa-sched/src/fair_admit.rs
@@ -26,6 +26,7 @@
 //! before re-competing, so a slot is always available to a waiter.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::Notify;
@@ -33,6 +34,23 @@ use tokio::sync::Notify;
 use crate::runqueue::{RunQueue, SchedEntity};
 use crate::scheduler::advance_vruntime;
 use crate::SchedClass;
+
+/// Outcome of an [`admit`](FairAdmit::admit) request.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Admitted {
+    /// A slot was granted; the payload is the scan id (pass to
+    /// [`reschedule`](FairAdmit::reschedule) / [`finish`](FairAdmit::finish)).
+    Slot(u64),
+    /// No slot was free and the waiter queue was already at its bound — the
+    /// request is rejected (fail-loud backpressure) rather than piling up
+    /// unboundedly. The caller must surface this, never hang or silently drop.
+    Overloaded,
+    /// The caller's `cancel` future fired (or the `admit` future was dropped)
+    /// before a slot was granted; the queue/waiter entry has been vacated and no
+    /// slot is held. A scan whose consumer went away ends here without ever
+    /// occupying a slot.
+    Cancelled,
+}
 
 struct State {
     /// Free slots (starts at `capacity`).
@@ -50,6 +68,29 @@ struct State {
 pub struct FairAdmit {
     state: Mutex<State>,
     capacity: usize,
+    /// Max scans allowed to *wait* for a slot at once. Beyond this, [`admit`]
+    /// returns [`Admitted::Overloaded`] instead of enqueuing — bounded
+    /// backpressure so a flood of scans cannot grow the queue without limit.
+    ///
+    /// [`admit`]: FairAdmit::admit
+    max_waiters: usize,
+}
+
+/// Vacates a pending admission's queue/waiter entry if its future is dropped or
+/// cancelled before a slot is granted — releasing a slot if the grant raced in.
+/// Disarmed once the slot is successfully returned to the caller.
+struct WaitGuard<'a> {
+    admit: &'a FairAdmit,
+    id: u64,
+    armed: bool,
+}
+
+impl Drop for WaitGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.admit.cancel_waiter(self.id);
+        }
+    }
 }
 
 impl std::fmt::Debug for FairAdmit {
@@ -62,9 +103,11 @@ impl std::fmt::Debug for FairAdmit {
 }
 
 impl FairAdmit {
-    /// A pool granting at most `capacity` (≥1) concurrent slots; waking scans get
-    /// `boost` sleeper credit (see [`RunQueue::new`]).
-    pub fn new(capacity: usize, boost: u64) -> Self {
+    /// A pool granting at most `capacity` (≥1) concurrent slots, admitting up to
+    /// `max_waiters` (≥1) scans to *wait* before rejecting further requests with
+    /// [`Admitted::Overloaded`]; waking scans get `boost` sleeper credit (see
+    /// [`RunQueue::new`]).
+    pub fn new(capacity: usize, boost: u64, max_waiters: usize) -> Self {
         let capacity = capacity.max(1);
         Self {
             state: Mutex::new(State {
@@ -75,6 +118,7 @@ impl FairAdmit {
                 next_id: 0,
             }),
             capacity,
+            max_waiters: max_waiters.max(1),
         }
     }
 
@@ -89,13 +133,32 @@ impl FairAdmit {
         self.capacity - s.free
     }
 
-    /// Admit a scan of `class`; resolves once it is granted a slot in vruntime
-    /// order. Returns the scan's id (pass to [`reschedule`](Self::reschedule) /
-    /// [`finish`](Self::finish)). Async so a waiting scan is a cheap task, not a
-    /// parked blocking thread.
-    pub async fn admit(&self, class: SchedClass) -> u64 {
+    /// Admit a scan of `class`, resolving once it is granted a slot in vruntime
+    /// order. Async so a waiting scan is a cheap task, not a parked blocking
+    /// thread (the B0 property).
+    ///
+    /// Returns:
+    /// - [`Admitted::Slot(id)`](Admitted::Slot) once granted;
+    /// - [`Admitted::Overloaded`] immediately if no slot is free and the waiter
+    ///   queue is already at `max_waiters` (bounded backpressure);
+    /// - [`Admitted::Cancelled`] if `cancel` fires — or this future is dropped —
+    ///   before a slot is granted. Either way the queue/waiter entry is vacated
+    ///   and **no slot is held**, so a scan whose consumer went away never
+    ///   occupies a slot just to discover the closed channel.
+    ///
+    /// Pass [`std::future::pending()`] for `cancel` when the caller has no
+    /// cancellation signal.
+    pub async fn admit(&self, class: SchedClass, cancel: impl Future<Output = ()>) -> Admitted {
         let (id, notify) = {
             let mut s = self.state.lock().expect("fair-admit poisoned");
+            // Backpressure: no free slot and the waiter queue is full → reject
+            // rather than grow the queue unboundedly. Fail-loud over silent
+            // pileup; the caller surfaces this (never hangs or drops silently).
+            if s.free == 0 && s.queue.len() >= self.max_waiters {
+                drop(s);
+                crate::record_overload_rejection();
+                return Admitted::Overloaded;
+            }
             let id = s.next_id;
             s.next_id += 1;
             s.queue.enqueue(SchedEntity::new(id, class));
@@ -104,17 +167,50 @@ impl FairAdmit {
             self.dispatch(&mut s);
             if s.running.contains_key(&id) {
                 s.waiters.remove(&id);
-                return id;
+                return Admitted::Slot(id);
             }
             (id, notify)
         };
+        // From here the entry lives in the queue; if the future is dropped or
+        // `cancel` fires before the grant, `WaitGuard` vacates it.
+        let mut guard = WaitGuard {
+            admit: self,
+            id,
+            armed: true,
+        };
+        tokio::pin!(cancel);
         loop {
-            notify.notified().await;
-            let mut s = self.state.lock().expect("fair-admit poisoned");
-            if s.running.contains_key(&id) {
-                s.waiters.remove(&id);
-                return id;
+            tokio::select! {
+                // Prefer cancellation: a gone consumer should free the slot even
+                // if a grant is simultaneously available.
+                biased;
+                _ = &mut cancel => return Admitted::Cancelled, // WaitGuard cleans up
+                _ = notify.notified() => {
+                    let mut s = self.state.lock().expect("fair-admit poisoned");
+                    if s.running.contains_key(&id) {
+                        s.waiters.remove(&id);
+                        guard.armed = false;
+                        return Admitted::Slot(id);
+                    }
+                }
             }
+        }
+    }
+
+    /// Vacate a still-waiting scan `id` (cancellation cleanup): remove it from
+    /// the queue and waiter map, and if the grant raced in between the caller's
+    /// last check and cancellation, release the slot it was handed.
+    fn cancel_waiter(&self, id: u64) {
+        let mut s = self.state.lock().expect("fair-admit poisoned");
+        s.waiters.remove(&id);
+        if s.queue.remove_by_id(id) {
+            return; // still waiting — cleanly removed
+        }
+        // Raced: dispatched into `running` after our last check. Give the slot
+        // back so it is not leaked to a dead id.
+        if s.running.remove(&id).is_some() {
+            s.free += 1;
+            self.dispatch(&mut s);
         }
     }
 
@@ -191,20 +287,35 @@ impl FairAdmit {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap as Map;
+    use std::future::Future;
+    use std::pin::pin;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll};
 
     use super::*;
 
+    /// Unwrap a granted slot or fail the test loudly.
+    fn slot(outcome: Admitted) -> u64 {
+        match outcome {
+            Admitted::Slot(id) => id,
+            other => panic!("expected Slot, got {other:?}"),
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn admit_never_exceeds_capacity() {
-        let admit = Arc::new(FairAdmit::new(2, 0));
+        let admit = Arc::new(FairAdmit::new(2, 0, 32));
         let max = Arc::new(AtomicUsize::new(0));
         let mut tasks = Vec::new();
         for _ in 0..12 {
             let admit = admit.clone();
             let max = max.clone();
             tasks.push(tokio::spawn(async move {
-                let id = admit.admit(SchedClass::Bulk).await;
+                let id = slot(
+                    admit
+                        .admit(SchedClass::Bulk, std::future::pending::<()>())
+                        .await,
+                );
                 let now = admit.active();
                 max.fetch_max(now, Ordering::SeqCst);
                 tokio::task::yield_now().await;
@@ -230,7 +341,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
     async fn foreground_gets_roughly_four_to_one_over_bulk() {
         // capacity 1 so the two scans genuinely contend for the single slot.
-        let admit = Arc::new(FairAdmit::new(1, 0));
+        let admit = Arc::new(FairAdmit::new(1, 0, 32));
         let handle = tokio::runtime::Handle::current();
         let ran: Arc<Mutex<Map<&'static str, u64>>> = Arc::new(Mutex::new(Map::new()));
         let served = Arc::new(AtomicUsize::new(0));
@@ -242,7 +353,7 @@ mod tests {
             let ran = ran.clone();
             let served = served.clone();
             tokio::task::spawn_blocking(move || {
-                let id = handle.block_on(admit.admit(class));
+                let id = slot(handle.block_on(admit.admit(class, std::future::pending::<()>())));
                 while served.fetch_add(1, Ordering::SeqCst) < BUDGET {
                     *ran.lock().unwrap().entry(tag).or_insert(0) += 1;
                     admit.reschedule(&handle, id, 10);
@@ -266,7 +377,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
     async fn equal_weight_scans_do_not_starve_each_other() {
-        let admit = Arc::new(FairAdmit::new(1, 0));
+        let admit = Arc::new(FairAdmit::new(1, 0, 32));
         let handle = tokio::runtime::Handle::current();
         let ran: Arc<Mutex<Map<u64, u64>>> = Arc::new(Mutex::new(Map::new()));
         let mut tasks = Vec::new();
@@ -275,7 +386,9 @@ mod tests {
             let handle = handle.clone();
             let ran = ran.clone();
             tasks.push(tokio::task::spawn_blocking(move || {
-                let id = handle.block_on(admit.admit(SchedClass::Bulk));
+                let id = slot(
+                    handle.block_on(admit.admit(SchedClass::Bulk, std::future::pending::<()>())),
+                );
                 for _ in 0..600 {
                     *ran.lock().unwrap().entry(tag).or_insert(0) += 1;
                     admit.reschedule(&handle, id, 10);
@@ -291,6 +404,76 @@ mod tests {
         let min = *ran.values().min().unwrap();
         // Equal weight → near-equal service; nobody starved.
         assert!(max - min <= max / 3, "unfair: {ran:?}");
+        assert_eq!(admit.active(), 0);
+    }
+
+    /// A scan whose `cancel` fires before it is granted returns `Cancelled`,
+    /// vacates the queue, and leaves NO phantom entry that would later steal a
+    /// slot — the core of Ben's "dropped range stream leaks a queued admission".
+    #[tokio::test]
+    async fn cancel_signal_frees_slot_and_leaves_no_phantom() {
+        let admit = FairAdmit::new(1, 0, 16);
+        let held = slot(
+            admit
+                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .await,
+        );
+        // The single slot is held; a second scan whose cancel is already ready
+        // must resolve to Cancelled rather than wait or grab a slot.
+        let outcome = admit.admit(SchedClass::Bulk, std::future::ready(())).await;
+        assert_eq!(outcome, Admitted::Cancelled);
+        // Releasing the held slot finds no waiter (no phantom) → fully free.
+        admit.finish(held);
+        assert_eq!(admit.active(), 0, "cancelled admit leaked a slot");
+    }
+
+    /// Dropping a pending `admit` future (e.g. the detached task is aborted) must
+    /// also vacate the queue entry — the belt-and-suspenders drop guard.
+    #[tokio::test]
+    async fn dropped_admit_future_leaves_no_phantom() {
+        let admit = FairAdmit::new(1, 0, 16);
+        let held = slot(
+            admit
+                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .await,
+        );
+        let mut cx = Context::from_waker(std::task::Waker::noop());
+        {
+            // Enqueues, then parks (no free slot). Poll once, then drop.
+            let mut fut = pin!(admit.admit(SchedClass::Bulk, std::future::pending::<()>()));
+            assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
+        }
+        admit.finish(held);
+        assert_eq!(admit.active(), 0, "dropped admit leaked a slot");
+    }
+
+    /// With no free slot and the waiter queue at its bound, `admit` returns
+    /// `Overloaded` (bounded backpressure) instead of enqueuing unboundedly.
+    #[tokio::test]
+    async fn admit_rejects_when_waiter_queue_is_full() {
+        let admit = FairAdmit::new(1, 0, 2); // 1 slot, at most 2 waiters
+        let held = slot(
+            admit
+                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .await,
+        );
+        let mut cx = Context::from_waker(std::task::Waker::noop());
+        {
+            // Fill the waiter queue (poll once each). The `pin!`ed futures live
+            // to the end of this block, so they must be scoped here — dropping
+            // the `Pin<&mut _>` handle would not drop the future.
+            let mut w1 = pin!(admit.admit(SchedClass::Bulk, std::future::pending::<()>()));
+            let mut w2 = pin!(admit.admit(SchedClass::Bulk, std::future::pending::<()>()));
+            assert!(matches!(w1.as_mut().poll(&mut cx), Poll::Pending));
+            assert!(matches!(w2.as_mut().poll(&mut cx), Poll::Pending));
+            // Third request: no slot, queue full → Overloaded (resolves at once).
+            let outcome = admit
+                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .await;
+            assert_eq!(outcome, Admitted::Overloaded);
+        }
+        // The two waiters dropped at the block end → queue vacated.
+        admit.finish(held);
         assert_eq!(admit.active(), 0);
     }
 }

--- a/ferrosa-sched/src/fair_admit.rs
+++ b/ferrosa-sched/src/fair_admit.rs
@@ -1,0 +1,296 @@
+//! Module: Vruntime-ordered fair admission for the bounded scan pool.
+//! Correctness: Correct when no more than `capacity` scans hold a slot at once,
+//!   a freed slot is always granted to the least-`vruntime` waiter (weighted by
+//!   class), a yielding scan re-competes and is never starved, and every slot is
+//!   released on finish OR drop.
+//! Last revised: 2026-07-22
+//! Last changed: New module — B1.5. Replaces the FIFO tokio-`Semaphore` that
+//!   `submit_scan` used for admission with the CFS-style vruntime scheduler, so
+//!   the `Scheduler`/`SchedTicket`/`SchedClass` machinery is the *live* admission
+//!   authority (not just tested in isolation). Weighting is real: a Foreground
+//!   scan (weight 1024) advances `vruntime` 4x slower than a Bulk scan (256), so
+//!   under contention it gets ~4x the slot turns.
+//!
+//! # Model
+//!
+//! `capacity` slots (`cores − reserved`). A scan `admit`s (async — a waiter is a
+//! cheap async task, never a parked blocking thread, preserving the B0 property),
+//! runs on a blocking thread, and every `chunk_budget` chunks calls
+//! `reschedule` (from that blocking thread): its `vruntime` advances by
+//! `service × BASE_WEIGHT / weight`, and if a waiting scan is now more deserving
+//! it yields the slot and re-competes. The dispatcher always grants a free slot
+//! to the least-`vruntime` waiter, so weighted-fair CPU share emerges.
+//!
+//! Deadlock-free: the mutex is held only for the O(log n) queue ops (never
+//! across `.await` or the caller's work); a yielding scan releases its slot
+//! before re-competing, so a slot is always available to a waiter.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::Notify;
+
+use crate::runqueue::{RunQueue, SchedEntity};
+use crate::scheduler::advance_vruntime;
+use crate::SchedClass;
+
+struct State {
+    /// Free slots (starts at `capacity`).
+    free: usize,
+    /// Scans waiting for a slot, ordered by `vruntime`.
+    queue: RunQueue,
+    /// Scans currently holding a slot: id → its live scheduling state.
+    running: HashMap<u64, SchedEntity>,
+    /// Per-waiter wakeups, keyed by scan id.
+    waiters: HashMap<u64, Arc<Notify>>,
+    next_id: u64,
+}
+
+/// Vruntime-ordered admission control for the scan pool.
+pub struct FairAdmit {
+    state: Mutex<State>,
+    capacity: usize,
+}
+
+impl std::fmt::Debug for FairAdmit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FairAdmit")
+            .field("capacity", &self.capacity)
+            .field("active", &self.active())
+            .finish()
+    }
+}
+
+impl FairAdmit {
+    /// A pool granting at most `capacity` (≥1) concurrent slots; waking scans get
+    /// `boost` sleeper credit (see [`RunQueue::new`]).
+    pub fn new(capacity: usize, boost: u64) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            state: Mutex::new(State {
+                free: capacity,
+                queue: RunQueue::new(boost),
+                running: HashMap::new(),
+                waiters: HashMap::new(),
+                next_id: 0,
+            }),
+            capacity,
+        }
+    }
+
+    /// Max concurrent slots.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Slots currently held.
+    pub fn active(&self) -> usize {
+        let s = self.state.lock().expect("fair-admit poisoned");
+        self.capacity - s.free
+    }
+
+    /// Admit a scan of `class`; resolves once it is granted a slot in vruntime
+    /// order. Returns the scan's id (pass to [`reschedule`](Self::reschedule) /
+    /// [`finish`](Self::finish)). Async so a waiting scan is a cheap task, not a
+    /// parked blocking thread.
+    pub async fn admit(&self, class: SchedClass) -> u64 {
+        let (id, notify) = {
+            let mut s = self.state.lock().expect("fair-admit poisoned");
+            let id = s.next_id;
+            s.next_id += 1;
+            s.queue.enqueue(SchedEntity::new(id, class));
+            let notify = Arc::new(Notify::new());
+            s.waiters.insert(id, notify.clone());
+            self.dispatch(&mut s);
+            if s.running.contains_key(&id) {
+                s.waiters.remove(&id);
+                return id;
+            }
+            (id, notify)
+        };
+        loop {
+            notify.notified().await;
+            let mut s = self.state.lock().expect("fair-admit poisoned");
+            if s.running.contains_key(&id) {
+                s.waiters.remove(&id);
+                return id;
+            }
+        }
+    }
+
+    /// Account `service` for running scan `id`, and if a waiting scan is now more
+    /// deserving, yield the slot and block (on `handle`) until re-granted in
+    /// vruntime order. Called from the scan's `spawn_blocking` thread, so blocking
+    /// on the runtime handle is sound.
+    pub fn reschedule(&self, handle: &tokio::runtime::Handle, id: u64, service: u64) {
+        let notify = {
+            let mut s = self.state.lock().expect("fair-admit poisoned");
+            let mut entity = match s.running.remove(&id) {
+                Some(e) => e,
+                None => return, // not currently granted — nothing to do
+            };
+            entity.vruntime = advance_vruntime(entity.vruntime, service, entity.weight);
+            // Keep the slot unless a strictly-more-deserving scan waits.
+            let should_yield =
+                crate::scheduler::should_switch(entity.vruntime, s.queue.peek_min_vruntime());
+            if !should_yield {
+                s.running.insert(id, entity);
+                return;
+            }
+            // Yield: release the slot and re-compete.
+            s.free += 1;
+            s.queue.enqueue(entity);
+            let notify = Arc::new(Notify::new());
+            s.waiters.insert(id, notify.clone());
+            self.dispatch(&mut s);
+            if s.running.contains_key(&id) {
+                s.waiters.remove(&id);
+                return;
+            }
+            notify
+        };
+        handle.block_on(async move {
+            loop {
+                notify.notified().await;
+                let mut s = self.state.lock().expect("fair-admit poisoned");
+                if s.running.contains_key(&id) {
+                    s.waiters.remove(&id);
+                    return;
+                }
+            }
+        });
+    }
+
+    /// Release scan `id`'s slot permanently (on finish or drop).
+    pub fn finish(&self, id: u64) {
+        let mut s = self.state.lock().expect("fair-admit poisoned");
+        if s.running.remove(&id).is_some() {
+            s.free += 1;
+        }
+        self.dispatch(&mut s);
+    }
+
+    /// Grant every free slot to the least-`vruntime` waiter and wake it.
+    fn dispatch(&self, s: &mut State) {
+        while s.free > 0 {
+            match s.queue.pick_next() {
+                Some(entity) => {
+                    let id = entity.id;
+                    s.free -= 1;
+                    s.running.insert(id, entity);
+                    if let Some(n) = s.waiters.get(&id) {
+                        n.notify_one();
+                    }
+                }
+                None => break,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap as Map;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn admit_never_exceeds_capacity() {
+        let admit = Arc::new(FairAdmit::new(2, 0));
+        let max = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+        for _ in 0..12 {
+            let admit = admit.clone();
+            let max = max.clone();
+            tasks.push(tokio::spawn(async move {
+                let id = admit.admit(SchedClass::Bulk).await;
+                let now = admit.active();
+                max.fetch_max(now, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                admit.finish(id);
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+        assert!(
+            max.load(Ordering::SeqCst) <= 2,
+            "admitted {} concurrently, capacity 2",
+            max.load(Ordering::SeqCst)
+        );
+        assert_eq!(admit.active(), 0, "all slots released");
+    }
+
+    /// The load-bearing B1.5 property: under contention a Foreground scan gets
+    /// ~4x the slot turns of a Bulk scan (weight 1024 : 256). Both scans run
+    /// unbounded and stop when a SHARED budget of served chunks is exhausted, so
+    /// the split of that budget reflects the scheduler's weighting (not each
+    /// scan's own fixed workload).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+    async fn foreground_gets_roughly_four_to_one_over_bulk() {
+        // capacity 1 so the two scans genuinely contend for the single slot.
+        let admit = Arc::new(FairAdmit::new(1, 0));
+        let handle = tokio::runtime::Handle::current();
+        let ran: Arc<Mutex<Map<&'static str, u64>>> = Arc::new(Mutex::new(Map::new()));
+        let served = Arc::new(AtomicUsize::new(0));
+        const BUDGET: usize = 5000;
+
+        let run = |class: SchedClass, tag: &'static str| {
+            let admit = admit.clone();
+            let handle = handle.clone();
+            let ran = ran.clone();
+            let served = served.clone();
+            tokio::task::spawn_blocking(move || {
+                let id = handle.block_on(admit.admit(class));
+                while served.fetch_add(1, Ordering::SeqCst) < BUDGET {
+                    *ran.lock().unwrap().entry(tag).or_insert(0) += 1;
+                    admit.reschedule(&handle, id, 10);
+                }
+                admit.finish(id);
+            })
+        };
+        let fg = run(SchedClass::Foreground, "fg");
+        let bulk = run(SchedClass::Bulk, "bulk");
+        fg.await.unwrap();
+        bulk.await.unwrap();
+
+        let ran = ran.lock().unwrap();
+        let (fg, bulk) = (ran["fg"] as f64, ran["bulk"] as f64);
+        let ratio = fg / bulk;
+        assert!(
+            (3.0..=5.0).contains(&ratio),
+            "expected ~4:1 Foreground:Bulk turns, got {ratio:.2} (fg={fg}, bulk={bulk})"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+    async fn equal_weight_scans_do_not_starve_each_other() {
+        let admit = Arc::new(FairAdmit::new(1, 0));
+        let handle = tokio::runtime::Handle::current();
+        let ran: Arc<Mutex<Map<u64, u64>>> = Arc::new(Mutex::new(Map::new()));
+        let mut tasks = Vec::new();
+        for tag in 0..3u64 {
+            let admit = admit.clone();
+            let handle = handle.clone();
+            let ran = ran.clone();
+            tasks.push(tokio::task::spawn_blocking(move || {
+                let id = handle.block_on(admit.admit(SchedClass::Bulk));
+                for _ in 0..600 {
+                    *ran.lock().unwrap().entry(tag).or_insert(0) += 1;
+                    admit.reschedule(&handle, id, 10);
+                }
+                admit.finish(id);
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+        let ran = ran.lock().unwrap();
+        let max = *ran.values().max().unwrap();
+        let min = *ran.values().min().unwrap();
+        // Equal weight → near-equal service; nobody starved.
+        assert!(max - min <= max / 3, "unfair: {ran:?}");
+        assert_eq!(admit.active(), 0);
+    }
+}

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -29,6 +29,9 @@ use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 
+pub mod runqueue;
+pub mod scheduler;
+
 // Process-wide pool metrics. Cumulative counters live here (the Prometheus
 // registry reads them); instantaneous gauges (`headroom_cores`, `active`) are
 // read live off the global pool.

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -28,9 +28,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 
+pub mod fair_admit;
 pub mod runqueue;
 pub mod scheduler;
 
@@ -156,10 +156,12 @@ pub fn render_prometheus() -> String {
     out
 }
 
-/// Scheduling class of a unit of work. Phase 0 does not *act* on the class (the
-/// pool admits FIFO); it exists so B1 can attach fair-share weights without
-/// re-touching call sites. Consensus work never flows through [`SchedPool`] — it
-/// runs on its own reserved runtime — so it has no variant here by design.
+/// Scheduling class of a scan. Seeds the fair-share weight the live
+/// [`fair_admit::FairAdmit`] scheduler orders admission by: a `Foreground` scan
+/// (weight 1024) advances `vruntime` 4x slower than a `Bulk` scan (256), so it
+/// gets ~4x the slot turns under contention. Consensus work never flows through
+/// [`SchedPool`] — it runs on its own reserved runtime — so it has no variant
+/// here by design.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SchedClass {
     /// Latency-sensitive client reads/writes.
@@ -200,44 +202,58 @@ impl Reservation {
     }
 }
 
-/// Bounded execution pool for CPU-bound background work.
+/// Bounded, vruntime-fair execution pool for CPU-bound scan work.
 ///
-/// [`submit`](SchedPool::submit) runs a blocking closure on tokio's blocking
-/// threads but admits at most [`capacity`](SchedPool::capacity) at once, so the
-/// reserved consensus cores are never oversubscribed. The admission permit is
-/// moved into the blocking task and dropped when it finishes — including on
-/// panic — so a slot is never leaked (RAII).
+/// Admission is governed by [`fair_admit::FairAdmit`]: at most
+/// [`capacity`](SchedPool::capacity) = `cores − reserved` scans hold a slot at
+/// once (so the reserved consensus cores are never oversubscribed), and a freed
+/// slot is granted to the least-`vruntime` waiter — weighted by
+/// [`SchedClass`], so a Foreground scan gets ~4x the slot
+/// turns of a Bulk scan under contention. B1.5 made this the live authority
+/// (replacing the earlier FIFO semaphore).
 #[derive(Clone)]
 pub struct SchedPool {
-    slots: Arc<Semaphore>,
+    admit: Arc<fair_admit::FairAdmit>,
     capacity: usize,
     reservation: Reservation,
 }
 
+/// Releases a held slot on drop — the RAII backstop so a panicking task never
+/// leaks its admission slot.
+struct SlotGuard {
+    admit: Arc<fair_admit::FairAdmit>,
+    id: u64,
+}
+impl Drop for SlotGuard {
+    fn drop(&mut self) {
+        self.admit.finish(self.id);
+    }
+}
+
 impl SchedPool {
-    /// Build a pool admitting `reservation.available()` CPU-bound tasks at once.
+    /// Build a pool admitting `reservation.available()` scans at once.
     pub fn new(reservation: Reservation) -> Self {
         let capacity = reservation.available();
         Self {
-            slots: Arc::new(Semaphore::new(capacity)),
+            admit: Arc::new(fair_admit::FairAdmit::new(capacity, 0)),
             capacity,
             reservation,
         }
     }
 
-    /// Maximum number of closures admitted concurrently.
+    /// Maximum number of scans admitted concurrently.
     pub fn capacity(&self) -> usize {
         self.capacity
     }
 
     /// Currently free admission slots (`capacity` minus in-flight).
     pub fn available_permits(&self) -> usize {
-        self.slots.available_permits()
+        self.capacity.saturating_sub(self.admit.active())
     }
 
-    /// Background closures currently admitted (running or on a blocking thread).
+    /// Scans currently admitted (holding a slot).
     pub fn active(&self) -> usize {
-        self.capacity.saturating_sub(self.slots.available_permits())
+        self.admit.active()
     }
 
     /// CPU cores currently NOT doing pool work — the consensus headroom
@@ -247,57 +263,41 @@ impl SchedPool {
         self.reservation.cores.saturating_sub(self.active())
     }
 
-    /// Admit and run `f` on a blocking thread once a slot is free, returning the
-    /// join handle. Awaiting this future blocks (asynchronously) until admission;
-    /// the returned handle resolves to `f`'s result (or a `JoinError` if `f`
-    /// panicked). The admission slot is released when the task ends.
+    /// Admit and run `f` on a blocking thread once a slot is granted (at `Bulk`
+    /// weight). Awaiting resolves once admitted; the returned handle resolves to
+    /// `f`'s result (or a `JoinError` on panic). The slot is released on return
+    /// OR unwind (RAII). Generic entry — the scan producers use
+    /// [`submit_scan`](Self::submit_scan).
     pub async fn submit<F, R>(&self, f: F) -> JoinHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
         let waited = Instant::now();
-        let permit = self
-            .slots
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("scheduler pool semaphore is never closed");
+        let id = self.admit.admit(SchedClass::Bulk).await;
         record_admission(waited.elapsed());
+        let admit = self.admit.clone();
         tokio::task::spawn_blocking(move || {
-            // RAII: the permit is released when this closure returns OR unwinds,
-            // so a panicking scan producer never leaks its admission slot.
-            let _permit = permit;
+            let _guard = SlotGuard { admit, id };
             f()
         })
     }
 
-    /// Sync entry point for producers that run *inside* a runtime but are not
-    /// themselves `async` (the storage scan producers: sync functions that fire a
-    /// blocking task and return a stream). Spawns a cheap async admitter that
-    /// acquires a slot and only then moves `f` onto a blocking thread — so at most
-    /// [`capacity`](Self::capacity) blocking threads ever exist. Excess producers
-    /// wait as async tasks, NOT as parked blocking threads (which is what
-    /// oversubscribed the cores and starved raft).
-    ///
-    /// Must be called from within a tokio runtime. The returned handle resolves to
-    /// `f`'s result; a panic in `f` surfaces as a `JoinError` (and, being detached
-    /// by the callers, is logged by tokio rather than crashing the process).
+    /// Sync entry for a generic blocking task (fires a cheap async admitter, then
+    /// moves `f` onto a blocking thread once admitted — so excess tasks wait as
+    /// async tasks, not parked blocking threads). Admits at `Bulk` weight.
     pub fn submit_blocking<F, R>(&self, f: F) -> JoinHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        let slots = self.slots.clone();
+        let admit = self.admit.clone();
         tokio::spawn(async move {
             let waited = Instant::now();
-            let permit = slots
-                .acquire_owned()
-                .await
-                .expect("scheduler pool semaphore is never closed");
+            let id = admit.admit(SchedClass::Bulk).await;
             record_admission(waited.elapsed());
             tokio::task::spawn_blocking(move || {
-                let _permit = permit;
+                let _guard = SlotGuard { admit, id };
                 f()
             })
             .await
@@ -305,43 +305,41 @@ impl SchedPool {
         })
     }
 
-    /// Sync entry for a *cooperative* scan producer (B1 T1.2). Like
-    /// [`submit_blocking`](Self::submit_blocking), but `f` receives a
-    /// [`ScanSlot`] and must call [`ScanSlot::tick`] after each produced chunk.
-    /// Every `chunk_budget` ticks the slot's pool permit is released and fairly
-    /// re-acquired, so a long full-table scan cedes the pool to waiting scans
-    /// instead of holding a slot for its whole duration — the fix for one scan
-    /// monopolizing the bounded pool (the residual B0 leaves).
+    /// Sync entry for a *cooperative* scan producer (B1). `f` receives a
+    /// [`ScanSlot`] and must call [`ScanSlot::tick`] after each produced chunk;
+    /// every `chunk_budget` ticks the scan re-competes for its slot in vruntime
+    /// order, so a long full-table scan cedes to more-deserving scans instead of
+    /// monopolizing the pool. `class` seeds the fair-share weight.
     ///
-    /// Deadlock-free: the permit is dropped BEFORE the blocking re-acquire, so a
-    /// slot is always available to a waiter; and a parked re-acquire consumes no
-    /// CPU (it does not oversubscribe the cores B0 protects).
-    pub fn submit_scan<F, R>(&self, chunk_budget: u32, f: F) -> JoinHandle<R>
+    /// The scan waits for its first slot as a cheap async task (B0 property); its
+    /// mid-scan re-competes block the scan's own blocking thread. Deadlock-free
+    /// (a yielding scan releases before re-competing) and the slot is released on
+    /// return OR unwind (RAII via [`ScanSlot`]'s drop).
+    pub fn submit_scan<F, R>(&self, class: SchedClass, chunk_budget: u32, f: F) -> JoinHandle<R>
     where
         F: FnOnce(&mut ScanSlot) -> R + Send + 'static,
         R: Send + 'static,
     {
-        let slots = self.slots.clone();
+        let admit = self.admit.clone();
         tokio::spawn(async move {
             let waited = Instant::now();
-            let permit = slots
-                .clone()
-                .acquire_owned()
-                .await
-                .expect("scheduler pool semaphore is never closed");
+            let id = admit.admit(class).await;
             record_admission(waited.elapsed());
             let handle = tokio::runtime::Handle::current();
             tokio::task::spawn_blocking(move || {
                 let mut slot = ScanSlot {
-                    slots,
-                    permit: Some(permit),
+                    admit,
+                    id,
                     chunk_budget: chunk_budget.max(1),
                     since_yield: 0,
                     yields: 0,
                     handle,
                     last_tick: Instant::now(),
+                    finished: false,
                 };
-                f(&mut slot)
+                let out = f(&mut slot);
+                slot.finish();
+                out
             })
             .await
             .expect("scheduler blocking task must not be cancelled")
@@ -349,15 +347,13 @@ impl SchedPool {
     }
 }
 
-/// The cooperative-yield handle a [`SchedPool::submit_scan`] producer holds for
-/// its lifetime. Call [`tick`](Self::tick) after each produced chunk; every
-/// `chunk_budget` ticks it yields the pool slot (release + fair re-acquire) so
-/// concurrent scans interleave instead of one monopolizing the pool.
+/// The fair-share handle a [`SchedPool::submit_scan`] producer holds for its
+/// lifetime. Call [`tick`](Self::tick) after each produced chunk; every
+/// `chunk_budget` ticks it re-competes for its slot in vruntime order, so a long
+/// scan cedes to more-deserving scans instead of monopolizing the pool.
 pub struct ScanSlot {
-    slots: Arc<Semaphore>,
-    /// The held admission permit. `None` only transiently, mid-yield, while the
-    /// slot is released and a replacement is being acquired.
-    permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    admit: Arc<fair_admit::FairAdmit>,
+    id: u64,
     chunk_budget: u32,
     since_yield: u32,
     yields: u64,
@@ -365,49 +361,57 @@ pub struct ScanSlot {
     /// When the current chunk's work started (the last `tick` return). Used to
     /// measure per-chunk work time for the FM-2 yield-point-gap tripwire.
     last_tick: Instant,
+    finished: bool,
 }
 
 impl ScanSlot {
     /// Account one produced chunk. Records the chunk's work time for the FM-2
-    /// tripwire, and every `chunk_budget` calls releases the pool permit so a
-    /// waiting scan can run, then fairly (FIFO) re-acquires one.
+    /// tripwire, and every `chunk_budget` calls re-competes for the slot: the
+    /// scan's `vruntime` advances (weighted by class), and if a waiting scan is
+    /// now more deserving this scan yields and blocks until re-granted.
     ///
     /// Runs on a `spawn_blocking` thread (not an async context), so blocking on
-    /// the re-acquire via the runtime handle is sound.
+    /// the re-compete via the runtime handle is sound.
     ///
     /// # Deadlock safety (T1.7)
     ///
-    /// The caller must hold **no lock across `tick()`**. The re-acquire blocks
-    /// until the pool permit is granted, and the permit is only freed as *other*
-    /// scans yield or finish — so a storage/index lock held here could deadlock
-    /// those scans (FM-3/FM-7). The `store.rs` producers load shared state via
-    /// arc-swap (`load_full()` → owned `Arc`s), holding no guard; the
+    /// The caller must hold **no lock across `tick()`**. The re-compete blocks
+    /// until a slot is granted, and slots are freed only as *other* scans yield
+    /// or finish — so a storage/index lock held here could deadlock those scans
+    /// (FM-3/FM-7). The `store.rs` producers load shared state via arc-swap
+    /// (`load_full()` → owned `Arc`s), holding no guard; the
     /// `scan_cooperative_yield_guard` source test enforces it.
     pub fn tick(&mut self) {
-        // Work time of the chunk just produced (excludes any yield wait below,
-        // because `last_tick` is reset AFTER the re-acquire).
         record_chunk(self.last_tick.elapsed());
         self.since_yield += 1;
         if self.since_yield >= self.chunk_budget {
             self.since_yield = 0;
             self.yields += 1;
-            // Release BEFORE re-acquiring: a slot is always free for a waiter.
-            self.permit = None;
-            let slots = self.slots.clone();
-            let waited = Instant::now();
-            let permit = self
-                .handle
-                .block_on(async move { slots.acquire_owned().await })
-                .expect("scheduler pool semaphore is never closed");
-            record_admission(waited.elapsed());
-            self.permit = Some(permit);
+            // Account the budget's worth of service, then re-compete in vruntime
+            // order (may yield the slot to a more-deserving scan).
+            self.admit
+                .reschedule(&self.handle, self.id, u64::from(self.chunk_budget));
         }
         self.last_tick = Instant::now();
     }
 
-    /// How many times this slot has yielded and re-acquired its permit.
+    /// How many times this scan re-competed for its slot at a budget boundary.
     pub fn yields(&self) -> u64 {
         self.yields
+    }
+
+    fn finish(&mut self) {
+        if !self.finished {
+            self.finished = true;
+            self.admit.finish(self.id);
+        }
+    }
+}
+
+impl Drop for ScanSlot {
+    /// RAII backstop: release the slot even if the producer panicked.
+    fn drop(&mut self) {
+        self.finish();
     }
 }
 
@@ -538,7 +542,7 @@ mod tests {
 
         // 10 chunks, budget 3 => yields after ticks 3, 6, 9 => 3 yields.
         let yields = pool
-            .submit_scan(3, |slot| {
+            .submit_scan(SchedClass::Bulk, 3, |slot| {
                 for _ in 0..10 {
                     slot.tick();
                 }
@@ -553,7 +557,7 @@ mod tests {
 
         // A budget larger than the chunk count never yields.
         let yields = pool
-            .submit_scan(100, |slot| {
+            .submit_scan(SchedClass::Bulk, 100, |slot| {
                 for _ in 0..5 {
                     slot.tick();
                 }
@@ -572,7 +576,7 @@ mod tests {
         let before = over_budget_chunks_total();
         let pool = SchedPool::new(Reservation::new(1, 0));
         let over_by = Duration::from_micros(DEFAULT_CHUNK_BUDGET_MICROS + 20_000);
-        pool.submit_scan(1000, move |slot| {
+        pool.submit_scan(SchedClass::Bulk, 1000, move |slot| {
             // Simulate a pathologically slow chunk (a huge partition decode).
             std::thread::sleep(over_by);
             slot.tick();

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -57,6 +57,39 @@ fn record_admission(wait: Duration) {
     ADMIT_WAIT_MICROS_TOTAL.fetch_add(wait.as_micros() as u64, Ordering::Relaxed);
 }
 
+// Chunk-budget tripwire (B1 T1.3 / FMEA FM-2). A scan chunk is the work between
+// two `ScanSlot::tick`s; a chunk longer than the budget is a *yield-point gap* —
+// the producer held the pool slot too long without a chance to cede it, which
+// reintroduces the monopolization B1 fixes.
+static SCHED_MAX_CHUNK_MICROS: AtomicU64 = AtomicU64::new(0);
+static SCHED_OVER_BUDGET_CHUNKS_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Per-chunk work-time budget in microseconds (default 50 ms). A scan chunk
+/// longer than this trips [`over_budget_chunks_total`] — an FM-2 signal that a
+/// producer needs to chunk more finely (e.g. a pathologically large partition
+/// decoded without an intervening yield).
+pub const DEFAULT_CHUNK_BUDGET_MICROS: u64 = 50_000;
+
+/// Longest scan chunk observed (work between cooperative yields), microseconds.
+pub fn sched_max_chunk_micros() -> u64 {
+    SCHED_MAX_CHUNK_MICROS.load(Ordering::Relaxed)
+}
+
+/// Count of scan chunks that exceeded [`DEFAULT_CHUNK_BUDGET_MICROS`]. Non-zero
+/// in steady state means a scan producer is holding the pool slot too long
+/// between yields and should alert.
+pub fn over_budget_chunks_total() -> u64 {
+    SCHED_OVER_BUDGET_CHUNKS_TOTAL.load(Ordering::Relaxed)
+}
+
+fn record_chunk(elapsed: Duration) {
+    let micros = elapsed.as_micros() as u64;
+    SCHED_MAX_CHUNK_MICROS.fetch_max(micros, Ordering::Relaxed);
+    if micros > DEFAULT_CHUNK_BUDGET_MICROS {
+        SCHED_OVER_BUDGET_CHUNKS_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 /// Render the scheduler's Prometheus metrics (text exposition format), reading
 /// the live gauges off the process-global pool plus the cumulative counters.
 /// Concatenated into `/metrics` by the web layer.
@@ -103,6 +136,22 @@ pub fn render_prometheus() -> String {
     out.push_str(&format!(
         "ferrosa_sched_admit_wait_micros_total {}\n",
         admit_wait_micros_total()
+    ));
+    out.push_str(
+        "# HELP ferrosa_sched_max_chunk_micros Longest scan chunk (work between cooperative yields), microseconds.\n\
+         # TYPE ferrosa_sched_max_chunk_micros gauge\n",
+    );
+    out.push_str(&format!(
+        "ferrosa_sched_max_chunk_micros {}\n",
+        sched_max_chunk_micros()
+    ));
+    out.push_str(
+        "# HELP ferrosa_sched_over_budget_chunks_total Scan chunks exceeding the per-chunk work budget (FM-2 yield-point gap); non-zero should alert.\n\
+         # TYPE ferrosa_sched_over_budget_chunks_total counter\n",
+    );
+    out.push_str(&format!(
+        "ferrosa_sched_over_budget_chunks_total {}\n",
+        over_budget_chunks_total()
     ));
     out
 }
@@ -290,6 +339,7 @@ impl SchedPool {
                     since_yield: 0,
                     yields: 0,
                     handle,
+                    last_tick: Instant::now(),
                 };
                 f(&mut slot)
             })
@@ -312,31 +362,38 @@ pub struct ScanSlot {
     since_yield: u32,
     yields: u64,
     handle: tokio::runtime::Handle,
+    /// When the current chunk's work started (the last `tick` return). Used to
+    /// measure per-chunk work time for the FM-2 yield-point-gap tripwire.
+    last_tick: Instant,
 }
 
 impl ScanSlot {
-    /// Account one produced chunk. Every `chunk_budget` calls, release the pool
-    /// permit so a waiting scan can run, then fairly (FIFO) re-acquire one.
+    /// Account one produced chunk. Records the chunk's work time for the FM-2
+    /// tripwire, and every `chunk_budget` calls releases the pool permit so a
+    /// waiting scan can run, then fairly (FIFO) re-acquires one.
     ///
     /// Runs on a `spawn_blocking` thread (not an async context), so blocking on
     /// the re-acquire via the runtime handle is sound.
     pub fn tick(&mut self) {
+        // Work time of the chunk just produced (excludes any yield wait below,
+        // because `last_tick` is reset AFTER the re-acquire).
+        record_chunk(self.last_tick.elapsed());
         self.since_yield += 1;
-        if self.since_yield < self.chunk_budget {
-            return;
+        if self.since_yield >= self.chunk_budget {
+            self.since_yield = 0;
+            self.yields += 1;
+            // Release BEFORE re-acquiring: a slot is always free for a waiter.
+            self.permit = None;
+            let slots = self.slots.clone();
+            let waited = Instant::now();
+            let permit = self
+                .handle
+                .block_on(async move { slots.acquire_owned().await })
+                .expect("scheduler pool semaphore is never closed");
+            record_admission(waited.elapsed());
+            self.permit = Some(permit);
         }
-        self.since_yield = 0;
-        self.yields += 1;
-        // Release BEFORE re-acquiring: a slot is always free for a waiter.
-        self.permit = None;
-        let slots = self.slots.clone();
-        let waited = Instant::now();
-        let permit = self
-            .handle
-            .block_on(async move { slots.acquire_owned().await })
-            .expect("scheduler pool semaphore is never closed");
-        record_admission(waited.elapsed());
-        self.permit = Some(permit);
+        self.last_tick = Instant::now();
     }
 
     /// How many times this slot has yielded and re-acquired its permit.
@@ -497,6 +554,31 @@ mod tests {
             .expect("scan task joined");
         assert_eq!(yields, 0);
         assert_eq!(pool.available_permits(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn over_budget_chunk_trips_the_fm2_tripwire() {
+        // A chunk whose work exceeds the per-chunk budget must increment the
+        // over-budget counter and be reflected in the max-chunk gauge.
+        let before = over_budget_chunks_total();
+        let pool = SchedPool::new(Reservation::new(1, 0));
+        let over_by = Duration::from_micros(DEFAULT_CHUNK_BUDGET_MICROS + 20_000);
+        pool.submit_scan(1000, move |slot| {
+            // Simulate a pathologically slow chunk (a huge partition decode).
+            std::thread::sleep(over_by);
+            slot.tick();
+        })
+        .await
+        .expect("scan task joined");
+
+        assert!(
+            over_budget_chunks_total() > before,
+            "an over-budget chunk must increment over_budget_chunks_total"
+        );
+        assert!(
+            sched_max_chunk_micros() >= DEFAULT_CHUNK_BUDGET_MICROS,
+            "max_chunk_micros must reflect the slow chunk"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -24,6 +24,7 @@
 //! reserved cores stay free for consensus. This crate is a leaf: it depends only
 //! on tokio, so nothing in the storage/cluster/cql stack leaks in (DSM guard).
 
+use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -33,6 +34,8 @@ use tokio::task::JoinHandle;
 pub mod fair_admit;
 pub mod runqueue;
 pub mod scheduler;
+
+pub use fair_admit::Admitted;
 
 // Process-wide pool metrics. Cumulative counters live here (the Prometheus
 // registry reads them); instantaneous gauges (`headroom_cores`, `active`) are
@@ -55,6 +58,22 @@ pub fn admit_wait_micros_total() -> u64 {
 fn record_admission(wait: Duration) {
     TASKS_ADMITTED_TOTAL.fetch_add(1, Ordering::Relaxed);
     ADMIT_WAIT_MICROS_TOTAL.fetch_add(wait.as_micros() as u64, Ordering::Relaxed);
+}
+
+static ADMISSIONS_REJECTED_OVERLOAD_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Admission requests rejected because the waiter queue was already at its bound
+/// (`Admitted::Overloaded`). Non-zero means real overload — more scans arrived
+/// than the reservation can queue — and the caller shed them (fail-loud) rather
+/// than pile up unboundedly. A rising rate should alert.
+pub fn admissions_rejected_overload_total() -> u64 {
+    ADMISSIONS_REJECTED_OVERLOAD_TOTAL.load(Ordering::Relaxed)
+}
+
+/// Called by [`fair_admit::FairAdmit::admit`] when it sheds a request under
+/// overload.
+pub(crate) fn record_overload_rejection() {
+    ADMISSIONS_REJECTED_OVERLOAD_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 // Chunk-budget tripwire (B1 T1.3 / FMEA FM-2). A scan chunk is the work between
@@ -153,6 +172,14 @@ pub fn render_prometheus() -> String {
         "ferrosa_sched_over_budget_chunks_total {}\n",
         over_budget_chunks_total()
     ));
+    out.push_str(
+        "# HELP ferrosa_sched_admissions_rejected_overload_total Admission requests shed because the waiter queue was at its bound; non-zero means real overload backpressure.\n\
+         # TYPE ferrosa_sched_admissions_rejected_overload_total counter\n",
+    );
+    out.push_str(&format!(
+        "ferrosa_sched_admissions_rejected_overload_total {}\n",
+        admissions_rejected_overload_total()
+    ));
     out
 }
 
@@ -231,11 +258,15 @@ impl Drop for SlotGuard {
 }
 
 impl SchedPool {
-    /// Build a pool admitting `reservation.available()` scans at once.
+    /// Build a pool admitting `reservation.available()` scans at once, and
+    /// queuing at most [`DEFAULT_MAX_WAITERS_PER_SLOT`] × capacity more before
+    /// shedding further requests as [`ScanOutcome::Overloaded`] (bounded
+    /// backpressure).
     pub fn new(reservation: Reservation) -> Self {
         let capacity = reservation.available();
+        let max_waiters = capacity.saturating_mul(DEFAULT_MAX_WAITERS_PER_SLOT);
         Self {
-            admit: Arc::new(fair_admit::FairAdmit::new(capacity, 0)),
+            admit: Arc::new(fair_admit::FairAdmit::new(capacity, 0, max_waiters)),
             capacity,
             reservation,
         }
@@ -265,28 +296,41 @@ impl SchedPool {
 
     /// Admit and run `f` on a blocking thread once a slot is granted (at `Bulk`
     /// weight). Awaiting resolves once admitted; the returned handle resolves to
-    /// `f`'s result (or a `JoinError` on panic). The slot is released on return
-    /// OR unwind (RAII). Generic entry — the scan producers use
+    /// `Some(f`'s result`)`, or `None` if the request was shed under overload
+    /// (the waiter queue was at its bound). The slot is released on return OR
+    /// unwind (RAII). Generic entry — the scan producers use
     /// [`submit_scan`](Self::submit_scan).
-    pub async fn submit<F, R>(&self, f: F) -> JoinHandle<R>
+    pub async fn submit<F, R>(&self, f: F) -> JoinHandle<Option<R>>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
         let waited = Instant::now();
-        let id = self.admit.admit(SchedClass::Bulk).await;
-        record_admission(waited.elapsed());
-        let admit = self.admit.clone();
-        tokio::task::spawn_blocking(move || {
-            let _guard = SlotGuard { admit, id };
-            f()
-        })
+        // No cancellation signal for the generic entry — pass a never-firing
+        // future; overload is still surfaced as `None`.
+        match self
+            .admit
+            .admit(SchedClass::Bulk, std::future::pending::<()>())
+            .await
+        {
+            Admitted::Slot(id) => {
+                record_admission(waited.elapsed());
+                let admit = self.admit.clone();
+                tokio::task::spawn_blocking(move || {
+                    let _guard = SlotGuard { admit, id };
+                    Some(f())
+                })
+            }
+            Admitted::Overloaded => tokio::task::spawn_blocking(|| None),
+            Admitted::Cancelled => unreachable!("submit passes a never-firing cancel"),
+        }
     }
 
     /// Sync entry for a generic blocking task (fires a cheap async admitter, then
     /// moves `f` onto a blocking thread once admitted — so excess tasks wait as
-    /// async tasks, not parked blocking threads). Admits at `Bulk` weight.
-    pub fn submit_blocking<F, R>(&self, f: F) -> JoinHandle<R>
+    /// async tasks, not parked blocking threads). Admits at `Bulk` weight;
+    /// resolves to `None` if shed under overload.
+    pub fn submit_blocking<F, R>(&self, f: F) -> JoinHandle<Option<R>>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
@@ -294,14 +338,22 @@ impl SchedPool {
         let admit = self.admit.clone();
         tokio::spawn(async move {
             let waited = Instant::now();
-            let id = admit.admit(SchedClass::Bulk).await;
-            record_admission(waited.elapsed());
-            tokio::task::spawn_blocking(move || {
-                let _guard = SlotGuard { admit, id };
-                f()
-            })
-            .await
-            .expect("scheduler blocking task must not be cancelled")
+            match admit
+                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .await
+            {
+                Admitted::Slot(id) => {
+                    record_admission(waited.elapsed());
+                    tokio::task::spawn_blocking(move || {
+                        let _guard = SlotGuard { admit, id };
+                        Some(f())
+                    })
+                    .await
+                    .expect("scheduler blocking task must not be cancelled")
+                }
+                Admitted::Overloaded => None,
+                Admitted::Cancelled => unreachable!("submit_blocking passes a never-firing cancel"),
+            }
         })
     }
 
@@ -315,36 +367,72 @@ impl SchedPool {
     /// mid-scan re-competes block the scan's own blocking thread. Deadlock-free
     /// (a yielding scan releases before re-competing) and the slot is released on
     /// return OR unwind (RAII via [`ScanSlot`]'s drop).
-    pub fn submit_scan<F, R>(&self, class: SchedClass, chunk_budget: u32, f: F) -> JoinHandle<R>
+    ///
+    /// `cancel` is the consumer-gone signal: when it fires *before admission*,
+    /// the scan is dropped from the queue without ever occupying a slot (a
+    /// dropped range stream no longer leaves a queued admission that later wakes,
+    /// grabs a slot, and does work just to find the closed channel). Pass the
+    /// consumer channel's closed-future; pass [`std::future::pending()`] if there
+    /// is nothing to cancel on. The returned handle resolves to a
+    /// [`ScanOutcome`]: `Ran(f`'s result`)`, `Overloaded` (shed — the producer
+    /// never ran; the caller must fail loud), or `Cancelled`.
+    pub fn submit_scan<F, R, C>(
+        &self,
+        class: SchedClass,
+        chunk_budget: u32,
+        cancel: C,
+        f: F,
+    ) -> JoinHandle<ScanOutcome<R>>
     where
         F: FnOnce(&mut ScanSlot) -> R + Send + 'static,
         R: Send + 'static,
+        C: Future<Output = ()> + Send + 'static,
     {
         let admit = self.admit.clone();
         tokio::spawn(async move {
             let waited = Instant::now();
-            let id = admit.admit(class).await;
-            record_admission(waited.elapsed());
-            let handle = tokio::runtime::Handle::current();
-            tokio::task::spawn_blocking(move || {
-                let mut slot = ScanSlot {
-                    admit,
-                    id,
-                    chunk_budget: chunk_budget.max(1),
-                    since_yield: 0,
-                    yields: 0,
-                    handle,
-                    last_tick: Instant::now(),
-                    finished: false,
-                };
-                let out = f(&mut slot);
-                slot.finish();
-                out
-            })
-            .await
-            .expect("scheduler blocking task must not be cancelled")
+            match admit.admit(class, cancel).await {
+                Admitted::Slot(id) => {
+                    record_admission(waited.elapsed());
+                    let handle = tokio::runtime::Handle::current();
+                    let out = tokio::task::spawn_blocking(move || {
+                        let mut slot = ScanSlot {
+                            admit,
+                            id,
+                            chunk_budget: chunk_budget.max(1),
+                            since_yield: 0,
+                            yields: 0,
+                            handle,
+                            last_tick: Instant::now(),
+                            finished: false,
+                        };
+                        let out = f(&mut slot);
+                        slot.finish();
+                        out
+                    })
+                    .await
+                    .expect("scheduler blocking task must not be cancelled");
+                    ScanOutcome::Ran(out)
+                }
+                Admitted::Overloaded => ScanOutcome::Overloaded,
+                Admitted::Cancelled => ScanOutcome::Cancelled,
+            }
         })
     }
+}
+
+/// Outcome of a [`SchedPool::submit_scan`] producer.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ScanOutcome<R> {
+    /// The producer was admitted and ran to completion; carries its return value.
+    Ran(R),
+    /// Admission was shed under overload — the producer never ran. The caller
+    /// MUST surface this (fail-loud), e.g. as a read error, never a silent empty
+    /// result.
+    Overloaded,
+    /// The `cancel` signal fired before admission — the consumer went away, so
+    /// the producer never ran and never held a slot.
+    Cancelled,
 }
 
 /// The fair-share handle a [`SchedPool::submit_scan`] producer holds for its
@@ -429,6 +517,11 @@ pub const DEFAULT_RESERVED_CORES: usize = 1;
 /// this many chunks for its turn.
 pub const DEFAULT_SCAN_CHUNK_BUDGET: u32 = 64;
 
+/// Waiters allowed per admission slot before [`SchedPool`] sheds further scans
+/// as [`ScanOutcome::Overloaded`]. Bounds the queue so a flood of scans cannot
+/// grow it without limit; generous enough that only genuine overload trips it.
+pub const DEFAULT_MAX_WAITERS_PER_SLOT: usize = 256;
+
 static GLOBAL_POOL: std::sync::OnceLock<SchedPool> = std::sync::OnceLock::new();
 
 /// Initialize the process-global [`SchedPool`] with an explicit reservation.
@@ -492,7 +585,10 @@ mod tests {
             handles.push(h);
         }
         for h in handles {
-            h.await.expect("blocking task joined");
+            assert!(
+                h.await.expect("blocking task joined").is_some(),
+                "closure ran (not shed under overload)"
+            );
         }
 
         assert!(
@@ -524,11 +620,20 @@ mod tests {
                 .await
                 .await
                 .expect("second task joined")
+                .expect("admitted (not shed under overload)")
         })
         .await
         .expect("slot leaked after panic — second submit blocked");
         assert_eq!(ok, 42);
         assert_eq!(pool.available_permits(), 1);
+    }
+
+    /// Unwrap a scan that ran, or fail loudly if it was shed/cancelled.
+    fn ran<R: std::fmt::Debug>(outcome: ScanOutcome<R>) -> R {
+        match outcome {
+            ScanOutcome::Ran(r) => r,
+            other => panic!("expected the scan to run, got {other:?}"),
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -541,30 +646,35 @@ mod tests {
         assert_eq!(pool.capacity(), 1);
 
         // 10 chunks, budget 3 => yields after ticks 3, 6, 9 => 3 yields.
-        let yields = pool
-            .submit_scan(SchedClass::Bulk, 3, |slot| {
+        let yields = ran(pool
+            .submit_scan(SchedClass::Bulk, 3, std::future::pending::<()>(), |slot| {
                 for _ in 0..10 {
                     slot.tick();
                 }
                 slot.yields()
             })
             .await
-            .expect("scan task joined");
+            .expect("scan task joined"));
         assert_eq!(yields, 3, "expected floor(10/3)=3 slot yields");
 
         // The permit is fully restored after the scan ends (no leak).
         assert_eq!(pool.available_permits(), 1);
 
         // A budget larger than the chunk count never yields.
-        let yields = pool
-            .submit_scan(SchedClass::Bulk, 100, |slot| {
-                for _ in 0..5 {
-                    slot.tick();
-                }
-                slot.yields()
-            })
+        let yields = ran(pool
+            .submit_scan(
+                SchedClass::Bulk,
+                100,
+                std::future::pending::<()>(),
+                |slot| {
+                    for _ in 0..5 {
+                        slot.tick();
+                    }
+                    slot.yields()
+                },
+            )
             .await
-            .expect("scan task joined");
+            .expect("scan task joined"));
         assert_eq!(yields, 0);
         assert_eq!(pool.available_permits(), 1);
     }
@@ -576,13 +686,19 @@ mod tests {
         let before = over_budget_chunks_total();
         let pool = SchedPool::new(Reservation::new(1, 0));
         let over_by = Duration::from_micros(DEFAULT_CHUNK_BUDGET_MICROS + 20_000);
-        pool.submit_scan(SchedClass::Bulk, 1000, move |slot| {
-            // Simulate a pathologically slow chunk (a huge partition decode).
-            std::thread::sleep(over_by);
-            slot.tick();
-        })
-        .await
-        .expect("scan task joined");
+        ran(pool
+            .submit_scan(
+                SchedClass::Bulk,
+                1000,
+                std::future::pending::<()>(),
+                move |slot| {
+                    // Simulate a pathologically slow chunk (a huge partition decode).
+                    std::thread::sleep(over_by);
+                    slot.tick();
+                },
+            )
+            .await
+            .expect("scan task joined"));
 
         assert!(
             over_budget_chunks_total() > before,
@@ -618,7 +734,10 @@ mod tests {
         }
         let mut sum = 0u32;
         for h in handles {
-            sum += h.await.expect("submit_blocking task joined");
+            sum += h
+                .await
+                .expect("submit_blocking task joined")
+                .expect("admitted (not shed under overload)");
         }
         assert_eq!(
             sum,
@@ -705,7 +824,7 @@ mod tests {
             handles.push(pool.submit_blocking(|| {}));
         }
         for h in handles {
-            h.await.expect("task joined");
+            let _ = h.await.expect("task joined");
         }
         assert!(
             tasks_admitted_total() >= before_admitted + 5,
@@ -726,6 +845,7 @@ mod tests {
             "ferrosa_sched_pool_active",
             "ferrosa_sched_tasks_admitted_total",
             "ferrosa_sched_admit_wait_micros_total",
+            "ferrosa_sched_admissions_rejected_overload_total",
         ] {
             assert!(text.contains(metric), "missing metric {metric}");
         }

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -374,6 +374,15 @@ impl ScanSlot {
     ///
     /// Runs on a `spawn_blocking` thread (not an async context), so blocking on
     /// the re-acquire via the runtime handle is sound.
+    ///
+    /// # Deadlock safety (T1.7)
+    ///
+    /// The caller must hold **no lock across `tick()`**. The re-acquire blocks
+    /// until the pool permit is granted, and the permit is only freed as *other*
+    /// scans yield or finish — so a storage/index lock held here could deadlock
+    /// those scans (FM-3/FM-7). The `store.rs` producers load shared state via
+    /// arc-swap (`load_full()` → owned `Arc`s), holding no guard; the
+    /// `scan_cooperative_yield_guard` source test enforces it.
     pub fn tick(&mut self) {
         // Work time of the chunk just produced (excludes any yield wait below,
         // because `last_tick` is reset AFTER the re-acquire).

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -149,26 +149,6 @@ impl Reservation {
     }
 }
 
-/// Opaque scheduling ticket threaded router -> coordinator -> producer. Phase 0
-/// is a no-op carrier that records the [`SchedClass`]; B1 activates fair-share
-/// accounting on it without changing the call sites that already pass it.
-#[derive(Clone, Copy, Debug)]
-pub struct SchedTicket {
-    class: SchedClass,
-}
-
-impl SchedTicket {
-    /// Mint a ticket for `class`.
-    pub fn new(class: SchedClass) -> Self {
-        Self { class }
-    }
-
-    /// The class this ticket was minted for.
-    pub fn class(&self) -> SchedClass {
-        self.class
-    }
-}
-
 /// Bounded execution pool for CPU-bound background work.
 ///
 /// [`submit`](SchedPool::submit) runs a blocking closure on tokio's blocking

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -5,12 +5,14 @@
 //! every admission slot is returned on completion, drop, or panic (RAII). Unit
 //! and stress tests remain green.
 //!
-//! Last revised: 2026-07-21
-//! Last changed: New crate — Phase 0 of the query scheduler (t_88223ad0). Bounds
-//!   the `spawn_blocking` pool that scan producers use, replacing the unbounded
-//!   tokio default (512) that let a full-table `ALLOW FILTERING` fan-out
-//!   oversubscribe the cores and starve raft heartbeats into a CheckQuorum
-//!   leader step-down.
+//! Last revised: 2026-07-22
+//! Last changed: B1 fair scheduling. Added [`submit_scan`](SchedPool::submit_scan)
+//!   with [`ScanSlot`] cooperative yielding (a long scan releases and fairly
+//!   re-acquires its pool slot every `chunk_budget` chunks so it can't
+//!   monopolize the pool), and the [`runqueue`] and [`scheduler`] vruntime
+//!   fair-share modules. Phase 0 (t_88223ad0) bounded the `spawn_blocking` pool
+//!   so a scan fan-out cannot starve raft; B1 makes concurrent scans share it
+//!   fairly.
 //!
 //! # Design
 //!
@@ -253,6 +255,94 @@ impl SchedPool {
             .expect("scheduler blocking task must not be cancelled")
         })
     }
+
+    /// Sync entry for a *cooperative* scan producer (B1 T1.2). Like
+    /// [`submit_blocking`](Self::submit_blocking), but `f` receives a
+    /// [`ScanSlot`] and must call [`ScanSlot::tick`] after each produced chunk.
+    /// Every `chunk_budget` ticks the slot's pool permit is released and fairly
+    /// re-acquired, so a long full-table scan cedes the pool to waiting scans
+    /// instead of holding a slot for its whole duration — the fix for one scan
+    /// monopolizing the bounded pool (the residual B0 leaves).
+    ///
+    /// Deadlock-free: the permit is dropped BEFORE the blocking re-acquire, so a
+    /// slot is always available to a waiter; and a parked re-acquire consumes no
+    /// CPU (it does not oversubscribe the cores B0 protects).
+    pub fn submit_scan<F, R>(&self, chunk_budget: u32, f: F) -> JoinHandle<R>
+    where
+        F: FnOnce(&mut ScanSlot) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let slots = self.slots.clone();
+        tokio::spawn(async move {
+            let waited = Instant::now();
+            let permit = slots
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("scheduler pool semaphore is never closed");
+            record_admission(waited.elapsed());
+            let handle = tokio::runtime::Handle::current();
+            tokio::task::spawn_blocking(move || {
+                let mut slot = ScanSlot {
+                    slots,
+                    permit: Some(permit),
+                    chunk_budget: chunk_budget.max(1),
+                    since_yield: 0,
+                    yields: 0,
+                    handle,
+                };
+                f(&mut slot)
+            })
+            .await
+            .expect("scheduler blocking task must not be cancelled")
+        })
+    }
+}
+
+/// The cooperative-yield handle a [`SchedPool::submit_scan`] producer holds for
+/// its lifetime. Call [`tick`](Self::tick) after each produced chunk; every
+/// `chunk_budget` ticks it yields the pool slot (release + fair re-acquire) so
+/// concurrent scans interleave instead of one monopolizing the pool.
+pub struct ScanSlot {
+    slots: Arc<Semaphore>,
+    /// The held admission permit. `None` only transiently, mid-yield, while the
+    /// slot is released and a replacement is being acquired.
+    permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    chunk_budget: u32,
+    since_yield: u32,
+    yields: u64,
+    handle: tokio::runtime::Handle,
+}
+
+impl ScanSlot {
+    /// Account one produced chunk. Every `chunk_budget` calls, release the pool
+    /// permit so a waiting scan can run, then fairly (FIFO) re-acquire one.
+    ///
+    /// Runs on a `spawn_blocking` thread (not an async context), so blocking on
+    /// the re-acquire via the runtime handle is sound.
+    pub fn tick(&mut self) {
+        self.since_yield += 1;
+        if self.since_yield < self.chunk_budget {
+            return;
+        }
+        self.since_yield = 0;
+        self.yields += 1;
+        // Release BEFORE re-acquiring: a slot is always free for a waiter.
+        self.permit = None;
+        let slots = self.slots.clone();
+        let waited = Instant::now();
+        let permit = self
+            .handle
+            .block_on(async move { slots.acquire_owned().await })
+            .expect("scheduler pool semaphore is never closed");
+        record_admission(waited.elapsed());
+        self.permit = Some(permit);
+    }
+
+    /// How many times this slot has yielded and re-acquired its permit.
+    pub fn yields(&self) -> u64 {
+        self.yields
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -262,6 +352,12 @@ impl SchedPool {
 /// Default cores reserved for consensus when the global pool is not explicitly
 /// initialized. Overridable at [`init_global_pool`] time.
 pub const DEFAULT_RESERVED_CORES: usize = 1;
+
+/// Partitions (or fragments) a scan produces per pool-slot turn before it
+/// cooperatively yields via [`ScanSlot::tick`] (B1 T1.2). Large enough to
+/// amortize the re-acquire, small enough that a concurrent scan waits at most
+/// this many chunks for its turn.
+pub const DEFAULT_SCAN_CHUNK_BUDGET: u32 = 64;
 
 static GLOBAL_POOL: std::sync::OnceLock<SchedPool> = std::sync::OnceLock::new();
 
@@ -362,6 +458,44 @@ mod tests {
         .await
         .expect("slot leaked after panic — second submit blocked");
         assert_eq!(ok, 42);
+        assert_eq!(pool.available_permits(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn submit_scan_yields_the_permit_every_chunk_budget_and_restores_it() {
+        // Capacity 1: the scan releases + re-acquires the sole permit every
+        // `chunk_budget` ticks. With one scan the re-acquire succeeds
+        // immediately (it just freed the slot), so this deterministically
+        // exercises the real release/re-acquire path without timing races.
+        let pool = SchedPool::new(Reservation::new(1, 0));
+        assert_eq!(pool.capacity(), 1);
+
+        // 10 chunks, budget 3 => yields after ticks 3, 6, 9 => 3 yields.
+        let yields = pool
+            .submit_scan(3, |slot| {
+                for _ in 0..10 {
+                    slot.tick();
+                }
+                slot.yields()
+            })
+            .await
+            .expect("scan task joined");
+        assert_eq!(yields, 3, "expected floor(10/3)=3 slot yields");
+
+        // The permit is fully restored after the scan ends (no leak).
+        assert_eq!(pool.available_permits(), 1);
+
+        // A budget larger than the chunk count never yields.
+        let yields = pool
+            .submit_scan(100, |slot| {
+                for _ in 0..5 {
+                    slot.tick();
+                }
+                slot.yields()
+            })
+            .await
+            .expect("scan task joined");
+        assert_eq!(yields, 0);
         assert_eq!(pool.available_permits(), 1);
     }
 

--- a/ferrosa-sched/src/runqueue.rs
+++ b/ferrosa-sched/src/runqueue.rs
@@ -120,6 +120,22 @@ impl RunQueue {
         self.tree.keys().next().map(|(vruntime, _seq)| *vruntime)
     }
 
+    /// Remove the queued unit with `id`, if present; returns whether one was
+    /// removed. O(n) over the *waiting* set (bounded by the admission waiter
+    /// cap), used by cancellation cleanup: a scan whose consumer went away must
+    /// vacate the queue so its slot is never granted to a dead id.
+    pub fn remove_by_id(&mut self, id: u64) -> bool {
+        let key = self
+            .tree
+            .iter()
+            .find(|(_, entity)| entity.id == id)
+            .map(|(key, _)| *key);
+        match key {
+            Some(key) => self.tree.remove(&key).is_some(),
+            None => false,
+        }
+    }
+
     /// Number of queued units.
     pub fn len(&self) -> usize {
         self.tree.len()
@@ -201,6 +217,22 @@ mod tests {
             assert!(q.min_vruntime() >= e.vruntime);
             prev = q.min_vruntime();
         }
+    }
+
+    #[test]
+    fn remove_by_id_vacates_a_waiting_unit() {
+        let mut q = RunQueue::new(0);
+        q.enqueue(ent(1, 10));
+        q.enqueue(ent(2, 20));
+        q.enqueue(ent(3, 30));
+        assert!(q.remove_by_id(2), "id 2 was queued");
+        assert_eq!(q.len(), 2);
+        assert!(!q.remove_by_id(2), "already removed");
+        assert!(!q.remove_by_id(99), "never queued");
+        // The survivors still pick in vruntime order.
+        assert_eq!(q.pick_next().unwrap().id, 1);
+        assert_eq!(q.pick_next().unwrap().id, 3);
+        assert!(q.pick_next().is_none());
     }
 
     #[test]

--- a/ferrosa-sched/src/runqueue.rs
+++ b/ferrosa-sched/src/runqueue.rs
@@ -1,0 +1,218 @@
+//! Module: A CFS-inspired fair-share run queue for background scan units.
+//! Correctness: Correct when `pick_next` always returns the least-`vruntime`
+//!   entity (FIFO among ties), `enqueue` clamps a waking entity's `vruntime` to
+//!   no less than `min_vruntime - boost`, and `min_vruntime` is monotonic
+//!   non-decreasing across every operation.
+//! Last revised: 2026-07-22
+//! Last changed: New module — B1 T1.1. The bounded pool (B0) stops scans from
+//!   starving consensus; this run queue makes concurrent scans share the pool's
+//!   slots *fairly* (no single full-table scan monopolizes) via virtual-runtime
+//!   ordering. T1.2 wires service-time accounting (`reschedule`) onto it.
+//!
+//! # Model (Linux CFS, adapted)
+//!
+//! Each schedulable unit carries a `vruntime` — virtual runtime, i.e. service
+//! time scaled by the inverse of its fair-share `weight`. The queue always runs
+//! the entity that has received the *least* virtual service so far (smallest
+//! `vruntime`), which equalizes weighted CPU over time.
+//!
+//! `min_vruntime` is a monotonic floor tracking the least vruntime seen. A unit
+//! that was blocked (e.g. waiting on I/O) and re-enqueues must not be able to
+//! undercut running units by an unbounded amount — otherwise a long-sleeping
+//! scan would monopolize the pool on wake. So `enqueue` clamps its vruntime up
+//! to at least `min_vruntime - boost`; `boost` is the bounded sleeper credit
+//! that keeps a just-woken interactive unit responsive without letting it starve
+//! others.
+
+use std::collections::BTreeMap;
+
+use crate::SchedClass;
+
+/// Fair-share weight of a [`SchedClass`] (Linux-nice-style; higher = more CPU).
+/// Foreground gets the full share; Bulk a quarter, so a background scan yields
+/// ~4x more virtual runtime per real second and drifts to the back of the queue.
+pub fn weight_for_class(class: SchedClass) -> u32 {
+    match class {
+        SchedClass::Foreground => 1024,
+        SchedClass::Bulk => 256,
+    }
+}
+
+/// A schedulable unit of background work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SchedEntity {
+    /// Stable identifier of the work unit (e.g. a scan id).
+    pub id: u64,
+    /// Accumulated virtual runtime (service time / weight). Smaller = more
+    /// deserving of the next slot.
+    pub vruntime: u64,
+    /// Fair-share weight (see [`weight_for_class`]); used by T1.2 to scale how
+    /// fast `vruntime` advances per unit of real service.
+    pub weight: u32,
+}
+
+impl SchedEntity {
+    /// A unit entering the queue for the first time at `vruntime` 0.
+    pub fn new(id: u64, class: SchedClass) -> Self {
+        Self {
+            id,
+            vruntime: 0,
+            weight: weight_for_class(class),
+        }
+    }
+}
+
+/// A single-group fair-share run queue ordered by `vruntime`.
+///
+/// Ordering key is `(vruntime, seq)` so equal-vruntime units are served in
+/// enqueue order (FIFO among ties) rather than by `id`.
+#[derive(Debug)]
+pub struct RunQueue {
+    tree: BTreeMap<(u64, u64), SchedEntity>,
+    min_vruntime: u64,
+    seq: u64,
+    boost: u64,
+}
+
+impl RunQueue {
+    /// A queue whose waking units may dip at most `boost` below `min_vruntime`
+    /// (the bounded sleeper credit).
+    pub fn new(boost: u64) -> Self {
+        Self {
+            tree: BTreeMap::new(),
+            min_vruntime: 0,
+            seq: 0,
+            boost,
+        }
+    }
+
+    /// Insert `entity`, clamping its `vruntime` up to at least
+    /// `min_vruntime - boost` so a long-blocked unit cannot undercut running
+    /// units by more than the sleeper credit. Returns the clamped vruntime.
+    pub fn enqueue(&mut self, mut entity: SchedEntity) -> u64 {
+        let floor = self.min_vruntime.saturating_sub(self.boost);
+        entity.vruntime = entity.vruntime.max(floor);
+        let key = (entity.vruntime, self.seq);
+        self.seq += 1;
+        self.tree.insert(key, entity);
+        entity.vruntime
+    }
+
+    /// Remove and return the least-`vruntime` entity (FIFO among ties), advancing
+    /// `min_vruntime` to at least the picked vruntime. `None` if empty.
+    pub fn pick_next(&mut self) -> Option<SchedEntity> {
+        let key = *self.tree.keys().next()?;
+        let entity = self.tree.remove(&key).expect("key came from the map");
+        // Monotonic: the floor only ever rises to the vruntime we just ran.
+        self.min_vruntime = self.min_vruntime.max(entity.vruntime);
+        Some(entity)
+    }
+
+    /// The current monotonic vruntime floor.
+    pub fn min_vruntime(&self) -> u64 {
+        self.min_vruntime
+    }
+
+    /// The `vruntime` of the least entity WITHOUT removing it (`None` if empty).
+    /// Used by the scheduler to decide whether a running unit should yield to a
+    /// more-deserving waiting one.
+    pub fn peek_min_vruntime(&self) -> Option<u64> {
+        self.tree.keys().next().map(|(vruntime, _seq)| *vruntime)
+    }
+
+    /// Number of queued units.
+    pub fn len(&self) -> usize {
+        self.tree.len()
+    }
+
+    /// Whether the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.tree.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ent(id: u64, vruntime: u64) -> SchedEntity {
+        SchedEntity {
+            id,
+            vruntime,
+            weight: 1024,
+        }
+    }
+
+    #[test]
+    fn weight_foreground_exceeds_bulk() {
+        assert!(weight_for_class(SchedClass::Foreground) > weight_for_class(SchedClass::Bulk));
+    }
+
+    #[test]
+    fn pick_next_returns_smallest_vruntime_fifo_among_ties() {
+        let mut q = RunQueue::new(0);
+        q.enqueue(ent(1, 30));
+        q.enqueue(ent(2, 10));
+        q.enqueue(ent(3, 10)); // ties with id 2 at vruntime 10, enqueued later
+        q.enqueue(ent(4, 20));
+        // 10 (id 2, first) -> 10 (id 3) -> 20 (id 4) -> 30 (id 1)
+        assert_eq!(q.pick_next().unwrap().id, 2);
+        assert_eq!(q.pick_next().unwrap().id, 3);
+        assert_eq!(q.pick_next().unwrap().id, 4);
+        assert_eq!(q.pick_next().unwrap().id, 1);
+        assert!(q.pick_next().is_none());
+    }
+
+    #[test]
+    fn enqueue_clamps_waking_unit_to_min_vruntime_minus_boost() {
+        let mut q = RunQueue::new(5);
+        q.enqueue(ent(1, 100));
+        // Run id 1 so min_vruntime advances to 100.
+        assert_eq!(q.pick_next().unwrap().id, 1);
+        assert_eq!(q.min_vruntime(), 100);
+        // A unit waking with a stale low vruntime is clamped to 100 - 5 = 95,
+        // NOT allowed to re-enter at 0 and monopolize.
+        let clamped = q.enqueue(ent(2, 0));
+        assert_eq!(clamped, 95);
+        assert_eq!(q.tree.values().next().unwrap().vruntime, 95);
+    }
+
+    #[test]
+    fn enqueue_above_floor_is_not_clamped_down() {
+        let mut q = RunQueue::new(5);
+        q.enqueue(ent(1, 100));
+        q.pick_next(); // min_vruntime -> 100
+                       // A unit already ahead of the floor keeps its vruntime.
+        let v = q.enqueue(ent(2, 200));
+        assert_eq!(v, 200);
+    }
+
+    #[test]
+    fn min_vruntime_is_monotonic_non_decreasing() {
+        let mut q = RunQueue::new(0);
+        let mut prev = q.min_vruntime();
+        for (id, v) in [(1u64, 50u64), (2, 10), (3, 90), (4, 30)] {
+            q.enqueue(ent(id, v));
+            assert!(q.min_vruntime() >= prev, "floor decreased on enqueue");
+            prev = q.min_vruntime();
+        }
+        while let Some(e) = q.pick_next() {
+            assert!(q.min_vruntime() >= prev, "floor decreased on pick");
+            assert!(q.min_vruntime() >= e.vruntime);
+            prev = q.min_vruntime();
+        }
+    }
+
+    #[test]
+    fn len_and_empty_track_membership() {
+        let mut q = RunQueue::new(0);
+        assert!(q.is_empty());
+        q.enqueue(ent(1, 0));
+        q.enqueue(ent(2, 0));
+        assert_eq!(q.len(), 2);
+        q.pick_next();
+        assert_eq!(q.len(), 1);
+        q.pick_next();
+        assert!(q.is_empty());
+    }
+}

--- a/ferrosa-sched/src/scheduler.rs
+++ b/ferrosa-sched/src/scheduler.rs
@@ -1,0 +1,195 @@
+//! Module: Fair-share scheduler core — virtual-runtime accounting and the
+//!   yield decision that keeps concurrent scans from monopolizing the pool.
+//! Correctness: Correct when `advance_vruntime` charges service inversely to
+//!   weight, `should_switch` yields exactly when a waiting unit is more
+//!   deserving (strictly smaller vruntime), and a multi-unit interleave gives
+//!   each equal-weight unit a fair share of service.
+//! Last revised: 2026-07-22
+//! Last changed: New module — B1 T1.2 core. Sits on the [`RunQueue`](crate::runqueue)
+//!   (T1.1). `SchedTicket::reschedule` (and the store.rs page loop that calls it)
+//!   are wired on top of this in the T1.2 integration step.
+//!
+//! # Accounting
+//!
+//! A unit's `vruntime` advances by `service * BASE_WEIGHT / weight`. A
+//! full-weight (Foreground, 1024) unit advances one-for-one with real service; a
+//! quarter-weight (Bulk, 256) unit advances 4x faster, so it drifts to the back
+//! of the queue and cedes the pool to interactive work. Because the queue always
+//! runs the smallest-vruntime unit, equal-weight units converge to equal
+//! service and unequal-weight units to service proportional to weight.
+
+use std::sync::Mutex;
+
+use crate::runqueue::{RunQueue, SchedEntity};
+use crate::SchedClass;
+
+/// Reference fair-share weight (a Foreground unit). Service for a unit of this
+/// weight advances `vruntime` one-for-one.
+pub const BASE_WEIGHT: u64 = 1024;
+
+/// Advance `vruntime` by `service` charged inversely to `weight`. Pure.
+///
+/// `delta = service * BASE_WEIGHT / weight`. Saturating so a pathological
+/// service value can never wrap the counter.
+pub fn advance_vruntime(vruntime: u64, service: u64, weight: u32) -> u64 {
+    let weight = u64::from(weight.max(1));
+    let delta = service.saturating_mul(BASE_WEIGHT) / weight;
+    vruntime.saturating_add(delta)
+}
+
+/// Whether a unit at `running_vruntime` should cede the slot to the smallest
+/// waiting unit. Pure. Yields only when a waiting unit is STRICTLY more
+/// deserving, so equal-vruntime units don't thrash back and forth.
+pub fn should_switch(running_vruntime: u64, min_waiting_vruntime: Option<u64>) -> bool {
+    match min_waiting_vruntime {
+        Some(waiting) => waiting < running_vruntime,
+        None => false,
+    }
+}
+
+/// A single-group fair-share scheduler wrapping a [`RunQueue`] behind a mutex.
+///
+/// The lock is held only for the O(log n) queue operations — never across the
+/// caller's service work or an `.await` (T1.7 audits this) — so it does not
+/// serialize scan execution.
+#[derive(Debug)]
+pub struct Scheduler {
+    queue: Mutex<RunQueue>,
+}
+
+impl Scheduler {
+    /// A scheduler whose waking units get `boost` sleeper credit (see
+    /// [`RunQueue::new`]).
+    pub fn new(boost: u64) -> Self {
+        Self {
+            queue: Mutex::new(RunQueue::new(boost)),
+        }
+    }
+
+    /// Admit a fresh unit of `class` under `id`, entering at the queue floor.
+    pub fn admit(&self, id: u64, class: SchedClass) {
+        let mut q = self.queue.lock().expect("scheduler queue poisoned");
+        q.enqueue(SchedEntity::new(id, class));
+    }
+
+    /// Take the most-deserving waiting unit to run next (`None` if idle).
+    pub fn pick_next(&self) -> Option<SchedEntity> {
+        self.queue
+            .lock()
+            .expect("scheduler queue poisoned")
+            .pick_next()
+    }
+
+    /// Account `service` for the `running` unit and report whether it should
+    /// yield to a more-deserving waiting unit. Does NOT re-enqueue `running` —
+    /// the caller decides that after releasing any resources it holds (T1.7).
+    pub fn reschedule(&self, running: &mut SchedEntity, service: u64) -> bool {
+        running.vruntime = advance_vruntime(running.vruntime, service, running.weight);
+        let min_waiting = self
+            .queue
+            .lock()
+            .expect("scheduler queue poisoned")
+            .peek_min_vruntime();
+        should_switch(running.vruntime, min_waiting)
+    }
+
+    /// Re-enqueue a running unit that is yielding.
+    pub fn requeue(&self, entity: SchedEntity) {
+        self.queue
+            .lock()
+            .expect("scheduler queue poisoned")
+            .enqueue(entity);
+    }
+
+    /// Number of waiting units.
+    pub fn waiting(&self) -> usize {
+        self.queue.lock().expect("scheduler queue poisoned").len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advance_charges_service_inversely_to_weight() {
+        // Foreground (full weight): one-for-one.
+        assert_eq!(advance_vruntime(0, 100, 1024), 100);
+        // Bulk (quarter weight): 4x faster.
+        assert_eq!(advance_vruntime(0, 100, 256), 400);
+        // Zero weight is treated as 1 (no divide-by-zero).
+        assert_eq!(advance_vruntime(0, 1, 0), 1024);
+    }
+
+    #[test]
+    fn advance_saturates_instead_of_wrapping() {
+        assert_eq!(advance_vruntime(u64::MAX - 1, 1000, 1024), u64::MAX);
+    }
+
+    #[test]
+    fn should_switch_only_for_strictly_smaller_waiter() {
+        assert!(should_switch(100, Some(99))); // waiter more deserving -> yield
+        assert!(!should_switch(100, Some(100))); // equal -> no thrash
+        assert!(!should_switch(100, Some(101))); // waiter less deserving
+        assert!(!should_switch(100, None)); // nobody waiting
+    }
+
+    /// The load-bearing T1.2 property: two equal-weight scans interleave — over
+    /// many pages neither monopolizes the pool; service is shared within ε.
+    #[test]
+    fn two_equal_weight_scans_interleave_fairly() {
+        let sched = Scheduler::new(0);
+        sched.admit(1, SchedClass::Bulk);
+        sched.admit(2, SchedClass::Bulk);
+
+        let page_service = 10u64;
+        let mut ran = std::collections::HashMap::new();
+        let mut current = sched.pick_next().expect("a unit to run");
+
+        for _ in 0..1000 {
+            *ran.entry(current.id).or_insert(0u64) += 1;
+            if sched.reschedule(&mut current, page_service) {
+                // Yield: re-enqueue self, pick the more-deserving unit.
+                sched.requeue(current);
+                current = sched.pick_next().expect("a unit to run");
+            }
+        }
+
+        let a = ran[&1];
+        let b = ran[&2];
+        // Neither monopolizes: each ran a near-equal share of the 1000 pages.
+        let diff = a.abs_diff(b);
+        assert!(
+            diff <= 2,
+            "unfair interleave: id1={a} id2={b} (diff {diff})"
+        );
+    }
+
+    /// A heavier (Foreground) unit gets proportionally more service than a Bulk
+    /// unit sharing the pool — ~4:1 by weight.
+    #[test]
+    fn higher_weight_unit_gets_proportionally_more_service() {
+        let sched = Scheduler::new(0);
+        sched.admit(1, SchedClass::Foreground); // weight 1024
+        sched.admit(2, SchedClass::Bulk); // weight 256
+
+        let page_service = 10u64;
+        let mut ran = std::collections::HashMap::new();
+        let mut current = sched.pick_next().unwrap();
+        for _ in 0..1000 {
+            *ran.entry(current.id).or_insert(0u64) += 1;
+            if sched.reschedule(&mut current, page_service) {
+                sched.requeue(current);
+                current = sched.pick_next().unwrap();
+            }
+        }
+        let fg = ran[&1] as f64;
+        let bulk = ran[&2] as f64;
+        // Foreground should get ~4x the Bulk service (weight ratio 1024:256).
+        let ratio = fg / bulk;
+        assert!(
+            (3.0..=5.0).contains(&ratio),
+            "expected ~4:1 fg:bulk service, got {ratio:.2} (fg={fg}, bulk={bulk})"
+        );
+    }
+}

--- a/ferrosa-sched/src/scheduler.rs
+++ b/ferrosa-sched/src/scheduler.rs
@@ -1,35 +1,30 @@
-//! Module: Fair-share scheduler core — virtual-runtime accounting and the
-//!   yield decision that keeps concurrent scans from monopolizing the pool.
+//! Module: Virtual-runtime accounting for the fair-share scan scheduler.
 //! Correctness: Correct when `advance_vruntime` charges service inversely to
-//!   weight, `should_switch` yields exactly when a waiting unit is more
-//!   deserving (strictly smaller vruntime), and a multi-unit interleave gives
-//!   each equal-weight unit a fair share of service.
+//!   weight (saturating) and `should_switch` yields exactly when a waiting scan
+//!   is strictly more deserving.
 //! Last revised: 2026-07-22
-//! Last changed: New module — B1 T1.2 core. Sits on the [`RunQueue`](crate::runqueue)
-//!   (T1.1). `SchedTicket::reschedule` (and the store.rs page loop that calls it)
-//!   are wired on top of this in the T1.2 integration step.
+//! Last changed: Reduced to the pure vruntime primitives. The standalone
+//!   `Scheduler` / `SchedTicket` abstraction (B1 T1.2 core) was superseded by
+//!   [`crate::fair_admit::FairAdmit`] — the live admission authority that couples
+//!   these primitives with the pool's slot accounting — and removed to avoid dead
+//!   code. `FairAdmit` uses `advance_vruntime` + `should_switch` directly.
 //!
 //! # Accounting
 //!
-//! A unit's `vruntime` advances by `service * BASE_WEIGHT / weight`. A
-//! full-weight (Foreground, 1024) unit advances one-for-one with real service; a
-//! quarter-weight (Bulk, 256) unit advances 4x faster, so it drifts to the back
-//! of the queue and cedes the pool to interactive work. Because the queue always
-//! runs the smallest-vruntime unit, equal-weight units converge to equal
-//! service and unequal-weight units to service proportional to weight.
+//! A scan's `vruntime` advances by `service × BASE_WEIGHT / weight`. A
+//! full-weight (Foreground, 1024) scan advances one-for-one with real service; a
+//! quarter-weight (Bulk, 256) scan advances 4x faster, so it drifts behind and
+//! cedes the pool to interactive work. Because admission always runs the
+//! smallest-`vruntime` scan, equal-weight scans converge to equal service and
+//! unequal-weight scans to service proportional to weight.
 
-use std::sync::{Arc, Mutex};
-
-use crate::runqueue::{RunQueue, SchedEntity};
-use crate::SchedClass;
-
-/// Reference fair-share weight (a Foreground unit). Service for a unit of this
+/// Reference fair-share weight (a Foreground scan). Service for a scan of this
 /// weight advances `vruntime` one-for-one.
 pub const BASE_WEIGHT: u64 = 1024;
 
 /// Advance `vruntime` by `service` charged inversely to `weight`. Pure.
 ///
-/// `delta = service * BASE_WEIGHT / weight`. Saturating so a pathological
+/// `delta = service × BASE_WEIGHT / weight`. Saturating so a pathological
 /// service value can never wrap the counter.
 pub fn advance_vruntime(vruntime: u64, service: u64, weight: u32) -> u64 {
     let weight = u64::from(weight.max(1));
@@ -37,9 +32,9 @@ pub fn advance_vruntime(vruntime: u64, service: u64, weight: u32) -> u64 {
     vruntime.saturating_add(delta)
 }
 
-/// Whether a unit at `running_vruntime` should cede the slot to the smallest
-/// waiting unit. Pure. Yields only when a waiting unit is STRICTLY more
-/// deserving, so equal-vruntime units don't thrash back and forth.
+/// Whether a scan at `running_vruntime` should cede its slot to the smallest
+/// waiting scan. Pure. Yields only when a waiter is STRICTLY more deserving, so
+/// equal-vruntime scans don't thrash back and forth.
 pub fn should_switch(running_vruntime: u64, min_waiting_vruntime: Option<u64>) -> bool {
     match min_waiting_vruntime {
         Some(waiting) => waiting < running_vruntime,
@@ -47,222 +42,9 @@ pub fn should_switch(running_vruntime: u64, min_waiting_vruntime: Option<u64>) -
     }
 }
 
-/// A single-group fair-share scheduler wrapping a [`RunQueue`] behind a mutex.
-///
-/// The lock is held only for the O(log n) queue operations — never across the
-/// caller's service work or an `.await` (T1.7 audits this) — so it does not
-/// serialize scan execution.
-#[derive(Debug)]
-pub struct Scheduler {
-    queue: Mutex<RunQueue>,
-}
-
-impl Scheduler {
-    /// A scheduler whose waking units get `boost` sleeper credit (see
-    /// [`RunQueue::new`]).
-    pub fn new(boost: u64) -> Self {
-        Self {
-            queue: Mutex::new(RunQueue::new(boost)),
-        }
-    }
-
-    /// Admit a fresh unit of `class` under `id`, entering at the queue floor.
-    pub fn admit(&self, id: u64, class: SchedClass) {
-        let mut q = self.queue.lock().expect("scheduler queue poisoned");
-        q.enqueue(SchedEntity::new(id, class));
-    }
-
-    /// Take the most-deserving waiting unit to run next (`None` if idle).
-    pub fn pick_next(&self) -> Option<SchedEntity> {
-        self.queue
-            .lock()
-            .expect("scheduler queue poisoned")
-            .pick_next()
-    }
-
-    /// Account `service` for the `running` unit and report whether it should
-    /// yield to a more-deserving waiting unit. Does NOT re-enqueue `running` —
-    /// the caller decides that after releasing any resources it holds (T1.7).
-    pub fn reschedule(&self, running: &mut SchedEntity, service: u64) -> bool {
-        running.vruntime = advance_vruntime(running.vruntime, service, running.weight);
-        let min_waiting = self
-            .queue
-            .lock()
-            .expect("scheduler queue poisoned")
-            .peek_min_vruntime();
-        should_switch(running.vruntime, min_waiting)
-    }
-
-    /// Re-enqueue a running unit that is yielding.
-    pub fn requeue(&self, entity: SchedEntity) {
-        self.queue
-            .lock()
-            .expect("scheduler queue poisoned")
-            .enqueue(entity);
-    }
-
-    /// Number of waiting units.
-    pub fn waiting(&self) -> usize {
-        self.queue.lock().expect("scheduler queue poisoned").len()
-    }
-
-    /// Take the most-deserving waiting unit as a running [`SchedTicket`] bound to
-    /// this scheduler (`None` if idle). The scan holds the ticket while it runs
-    /// and calls [`SchedTicket::reschedule`] per chunk.
-    pub fn pick_ticket(self: &Arc<Self>) -> Option<SchedTicket> {
-        self.pick_next().map(|entity| SchedTicket {
-            scheduler: Arc::clone(self),
-            entity,
-        })
-    }
-}
-
-/// A running unit's scheduling handle — the fair-share accounting the store scan
-/// page loop drives. Holds the unit's [`SchedEntity`] and a handle back to its
-/// [`Scheduler`]. The store producer calls [`reschedule`](Self::reschedule) once
-/// per produced chunk; when it returns `true` the producer releases its pool
-/// slot and [`yield_back`](Self::yield_back)s so a more-deserving scan can run.
-#[derive(Debug)]
-pub struct SchedTicket {
-    scheduler: Arc<Scheduler>,
-    entity: SchedEntity,
-}
-
-impl SchedTicket {
-    /// The scheduled unit's id.
-    pub fn id(&self) -> u64 {
-        self.entity.id
-    }
-
-    /// The unit's accumulated virtual runtime.
-    pub fn vruntime(&self) -> u64 {
-        self.entity.vruntime
-    }
-
-    /// The unit's fair-share weight.
-    pub fn weight(&self) -> u32 {
-        self.entity.weight
-    }
-
-    /// Account `service` for the work just done and report whether this unit
-    /// should yield its slot to a more-deserving waiter. Does NOT itself release
-    /// any pool permit — the caller does that after [`yield_back`](Self::yield_back)
-    /// so no resource is held across the handoff (T1.7).
-    pub fn reschedule(&mut self, service: u64) -> bool {
-        self.scheduler.reschedule(&mut self.entity, service)
-    }
-
-    /// Yield the slot: re-enqueue this unit for a future turn (consumes the
-    /// ticket). The caller picks the next ticket after releasing its pool permit.
-    pub fn yield_back(self) {
-        self.scheduler.requeue(self.entity);
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
-
-    /// A mock scan: produces `remaining` chunks. Stands in for a `store.rs`
-    /// `range_iter` producer without any real storage. (Keyed by id in the map.)
-    struct MockScan {
-        remaining: u64,
-        class: SchedClass,
-    }
-
-    /// T1.2 T2 — the MockStorage multi-scan fairness property: with a single pool
-    /// slot (capacity 1), three concurrent scans driven through the ticket API
-    /// interleave — no scan monopolizes the slot — and every scan completes.
-    #[test]
-    fn mock_storage_scans_share_the_slot_fairly_via_tickets() {
-        let sched = Arc::new(Scheduler::new(0));
-        let page_service = 10u64;
-
-        let mut scans: HashMap<u64, MockScan> = HashMap::new();
-        for id in [1u64, 2, 3] {
-            sched.admit(id, SchedClass::Bulk);
-            scans.insert(
-                id,
-                MockScan {
-                    remaining: 100,
-                    class: SchedClass::Bulk,
-                },
-            );
-        }
-
-        let mut ran: HashMap<u64, u64> = HashMap::new();
-        let mut last = 0u64;
-        let mut streak = 0u64;
-        let mut max_streak_while_contended = 0u64;
-
-        let mut ticket = sched.pick_ticket().expect("a scan to run");
-        loop {
-            let id = ticket.id();
-            // "Produce" one chunk of scan `id`.
-            *ran.entry(id).or_insert(0) += 1;
-            let scan = scans.get_mut(&id).expect("known scan");
-            scan.remaining -= 1;
-            let done = scan.remaining == 0;
-            let _ = scan.class; // (class would seed the weight in the real wiring)
-
-            // Only measure monopolization while >= 2 scans still have work — the
-            // lone tail necessarily runs alone and is not "monopolizing".
-            let contended = scans.values().filter(|s| s.remaining > 0).count() >= 2;
-            if id == last {
-                streak += 1;
-            } else {
-                streak = 1;
-                last = id;
-            }
-            if contended {
-                max_streak_while_contended = max_streak_while_contended.max(streak);
-            }
-
-            let should_yield = ticket.reschedule(page_service);
-            if done {
-                match sched.pick_ticket() {
-                    Some(t) => ticket = t,
-                    None => break,
-                }
-                last = 0;
-                streak = 0;
-            } else if should_yield {
-                ticket.yield_back();
-                ticket = sched.pick_ticket().expect("a scan to run");
-            }
-            // else: keep running the same ticket (nobody more deserving waits).
-        }
-
-        // Every scan ran all 100 chunks.
-        assert_eq!(ran[&1], 100);
-        assert_eq!(ran[&2], 100);
-        assert_eq!(ran[&3], 100);
-        // No scan monopolized the slot while others had work.
-        assert!(
-            max_streak_while_contended <= 2,
-            "a scan monopolized the slot: max consecutive run = {max_streak_while_contended}"
-        );
-    }
-
-    #[test]
-    fn ticket_reports_accounting_and_yields_back_to_the_queue() {
-        let sched = Arc::new(Scheduler::new(0));
-        // Foreground (weight 1024) so service advances vruntime one-for-one.
-        sched.admit(1, SchedClass::Foreground);
-        sched.admit(2, SchedClass::Foreground);
-        let mut t = sched.pick_ticket().unwrap();
-        assert_eq!(t.id(), 1);
-        assert_eq!(t.vruntime(), 0);
-        // Accounting advances vruntime and, with a waiter at 0, signals yield.
-        assert!(t.reschedule(10));
-        assert_eq!(t.vruntime(), 10);
-        assert_eq!(sched.waiting(), 1); // only id 2 waiting
-        t.yield_back();
-        assert_eq!(sched.waiting(), 2); // id 1 back in the queue
-        assert_eq!(sched.pick_ticket().unwrap().id(), 2); // id 2 now most deserving
-    }
 
     #[test]
     fn advance_charges_service_inversely_to_weight() {
@@ -285,64 +67,5 @@ mod tests {
         assert!(!should_switch(100, Some(100))); // equal -> no thrash
         assert!(!should_switch(100, Some(101))); // waiter less deserving
         assert!(!should_switch(100, None)); // nobody waiting
-    }
-
-    /// The load-bearing T1.2 property: two equal-weight scans interleave — over
-    /// many pages neither monopolizes the pool; service is shared within ε.
-    #[test]
-    fn two_equal_weight_scans_interleave_fairly() {
-        let sched = Scheduler::new(0);
-        sched.admit(1, SchedClass::Bulk);
-        sched.admit(2, SchedClass::Bulk);
-
-        let page_service = 10u64;
-        let mut ran = std::collections::HashMap::new();
-        let mut current = sched.pick_next().expect("a unit to run");
-
-        for _ in 0..1000 {
-            *ran.entry(current.id).or_insert(0u64) += 1;
-            if sched.reschedule(&mut current, page_service) {
-                // Yield: re-enqueue self, pick the more-deserving unit.
-                sched.requeue(current);
-                current = sched.pick_next().expect("a unit to run");
-            }
-        }
-
-        let a = ran[&1];
-        let b = ran[&2];
-        // Neither monopolizes: each ran a near-equal share of the 1000 pages.
-        let diff = a.abs_diff(b);
-        assert!(
-            diff <= 2,
-            "unfair interleave: id1={a} id2={b} (diff {diff})"
-        );
-    }
-
-    /// A heavier (Foreground) unit gets proportionally more service than a Bulk
-    /// unit sharing the pool — ~4:1 by weight.
-    #[test]
-    fn higher_weight_unit_gets_proportionally_more_service() {
-        let sched = Scheduler::new(0);
-        sched.admit(1, SchedClass::Foreground); // weight 1024
-        sched.admit(2, SchedClass::Bulk); // weight 256
-
-        let page_service = 10u64;
-        let mut ran = std::collections::HashMap::new();
-        let mut current = sched.pick_next().unwrap();
-        for _ in 0..1000 {
-            *ran.entry(current.id).or_insert(0u64) += 1;
-            if sched.reschedule(&mut current, page_service) {
-                sched.requeue(current);
-                current = sched.pick_next().unwrap();
-            }
-        }
-        let fg = ran[&1] as f64;
-        let bulk = ran[&2] as f64;
-        // Foreground should get ~4x the Bulk service (weight ratio 1024:256).
-        let ratio = fg / bulk;
-        assert!(
-            (3.0..=5.0).contains(&ratio),
-            "expected ~4:1 fg:bulk service, got {ratio:.2} (fg={fg}, bulk={bulk})"
-        );
     }
 }

--- a/ferrosa-sched/src/scheduler.rs
+++ b/ferrosa-sched/src/scheduler.rs
@@ -18,7 +18,7 @@
 //! runs the smallest-vruntime unit, equal-weight units converge to equal
 //! service and unequal-weight units to service proportional to weight.
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use crate::runqueue::{RunQueue, SchedEntity};
 use crate::SchedClass;
@@ -105,11 +105,164 @@ impl Scheduler {
     pub fn waiting(&self) -> usize {
         self.queue.lock().expect("scheduler queue poisoned").len()
     }
+
+    /// Take the most-deserving waiting unit as a running [`SchedTicket`] bound to
+    /// this scheduler (`None` if idle). The scan holds the ticket while it runs
+    /// and calls [`SchedTicket::reschedule`] per chunk.
+    pub fn pick_ticket(self: &Arc<Self>) -> Option<SchedTicket> {
+        self.pick_next().map(|entity| SchedTicket {
+            scheduler: Arc::clone(self),
+            entity,
+        })
+    }
+}
+
+/// A running unit's scheduling handle — the fair-share accounting the store scan
+/// page loop drives. Holds the unit's [`SchedEntity`] and a handle back to its
+/// [`Scheduler`]. The store producer calls [`reschedule`](Self::reschedule) once
+/// per produced chunk; when it returns `true` the producer releases its pool
+/// slot and [`yield_back`](Self::yield_back)s so a more-deserving scan can run.
+#[derive(Debug)]
+pub struct SchedTicket {
+    scheduler: Arc<Scheduler>,
+    entity: SchedEntity,
+}
+
+impl SchedTicket {
+    /// The scheduled unit's id.
+    pub fn id(&self) -> u64 {
+        self.entity.id
+    }
+
+    /// The unit's accumulated virtual runtime.
+    pub fn vruntime(&self) -> u64 {
+        self.entity.vruntime
+    }
+
+    /// The unit's fair-share weight.
+    pub fn weight(&self) -> u32 {
+        self.entity.weight
+    }
+
+    /// Account `service` for the work just done and report whether this unit
+    /// should yield its slot to a more-deserving waiter. Does NOT itself release
+    /// any pool permit — the caller does that after [`yield_back`](Self::yield_back)
+    /// so no resource is held across the handoff (T1.7).
+    pub fn reschedule(&mut self, service: u64) -> bool {
+        self.scheduler.reschedule(&mut self.entity, service)
+    }
+
+    /// Yield the slot: re-enqueue this unit for a future turn (consumes the
+    /// ticket). The caller picks the next ticket after releasing its pool permit.
+    pub fn yield_back(self) {
+        self.scheduler.requeue(self.entity);
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+
+    /// A mock scan: produces `remaining` chunks. Stands in for a `store.rs`
+    /// `range_iter` producer without any real storage. (Keyed by id in the map.)
+    struct MockScan {
+        remaining: u64,
+        class: SchedClass,
+    }
+
+    /// T1.2 T2 — the MockStorage multi-scan fairness property: with a single pool
+    /// slot (capacity 1), three concurrent scans driven through the ticket API
+    /// interleave — no scan monopolizes the slot — and every scan completes.
+    #[test]
+    fn mock_storage_scans_share_the_slot_fairly_via_tickets() {
+        let sched = Arc::new(Scheduler::new(0));
+        let page_service = 10u64;
+
+        let mut scans: HashMap<u64, MockScan> = HashMap::new();
+        for id in [1u64, 2, 3] {
+            sched.admit(id, SchedClass::Bulk);
+            scans.insert(
+                id,
+                MockScan {
+                    remaining: 100,
+                    class: SchedClass::Bulk,
+                },
+            );
+        }
+
+        let mut ran: HashMap<u64, u64> = HashMap::new();
+        let mut last = 0u64;
+        let mut streak = 0u64;
+        let mut max_streak_while_contended = 0u64;
+
+        let mut ticket = sched.pick_ticket().expect("a scan to run");
+        loop {
+            let id = ticket.id();
+            // "Produce" one chunk of scan `id`.
+            *ran.entry(id).or_insert(0) += 1;
+            let scan = scans.get_mut(&id).expect("known scan");
+            scan.remaining -= 1;
+            let done = scan.remaining == 0;
+            let _ = scan.class; // (class would seed the weight in the real wiring)
+
+            // Only measure monopolization while >= 2 scans still have work — the
+            // lone tail necessarily runs alone and is not "monopolizing".
+            let contended = scans.values().filter(|s| s.remaining > 0).count() >= 2;
+            if id == last {
+                streak += 1;
+            } else {
+                streak = 1;
+                last = id;
+            }
+            if contended {
+                max_streak_while_contended = max_streak_while_contended.max(streak);
+            }
+
+            let should_yield = ticket.reschedule(page_service);
+            if done {
+                match sched.pick_ticket() {
+                    Some(t) => ticket = t,
+                    None => break,
+                }
+                last = 0;
+                streak = 0;
+            } else if should_yield {
+                ticket.yield_back();
+                ticket = sched.pick_ticket().expect("a scan to run");
+            }
+            // else: keep running the same ticket (nobody more deserving waits).
+        }
+
+        // Every scan ran all 100 chunks.
+        assert_eq!(ran[&1], 100);
+        assert_eq!(ran[&2], 100);
+        assert_eq!(ran[&3], 100);
+        // No scan monopolized the slot while others had work.
+        assert!(
+            max_streak_while_contended <= 2,
+            "a scan monopolized the slot: max consecutive run = {max_streak_while_contended}"
+        );
+    }
+
+    #[test]
+    fn ticket_reports_accounting_and_yields_back_to_the_queue() {
+        let sched = Arc::new(Scheduler::new(0));
+        // Foreground (weight 1024) so service advances vruntime one-for-one.
+        sched.admit(1, SchedClass::Foreground);
+        sched.admit(2, SchedClass::Foreground);
+        let mut t = sched.pick_ticket().unwrap();
+        assert_eq!(t.id(), 1);
+        assert_eq!(t.vruntime(), 0);
+        // Accounting advances vruntime and, with a waiter at 0, signals yield.
+        assert!(t.reschedule(10));
+        assert_eq!(t.vruntime(), 10);
+        assert_eq!(sched.waiting(), 1); // only id 2 waiting
+        t.yield_back();
+        assert_eq!(sched.waiting(), 2); // id 1 back in the queue
+        assert_eq!(sched.pick_ticket().unwrap().id(), 2); // id 2 now most deserving
+    }
 
     #[test]
     fn advance_charges_service_inversely_to_weight() {

--- a/ferrosa-sched/tests/fairness_proptest.rs
+++ b/ferrosa-sched/tests/fairness_proptest.rs
@@ -1,113 +1,108 @@
-//! B1 T1.6 — property tests for the fair-share scheduler (FM-4/FM-5).
+//! B1 T1.6 — property tests for the fair-share scheduling logic (FM-4/FM-5).
 //!
-//! Two invariants, over randomized scan populations and service costs:
+//! Drives the pure vruntime primitives ([`RunQueue`] + [`advance_vruntime`] —
+//! exactly what [`FairAdmit`](ferrosa_sched::fair_admit::FairAdmit) uses live,
+//! minus the slot accounting) over randomized scan populations and service
+//! costs, asserting:
 //!
-//! * **Equal-weight convergence** — N equal-weight scans sharing the pool get
-//!   equal service within a small constant spread (O(N), never O(rounds) — that
-//!   would be starvation).
-//! * **Aging** — a long-running scan keeps making progress even under a steady
-//!   stream of arriving-and-finishing interactive queries; it is never starved
-//!   in any window.
+//! * **Equal-weight convergence** — N equal-weight scans get equal service
+//!   within an O(N) spread (never O(rounds) — that would be starvation).
+//! * **Aging** — a long scan keeps making progress under a stream of arriving,
+//!   higher-weight interactive scans; it is never starved in any window.
 
-use std::sync::Arc;
-
-use ferrosa_sched::scheduler::Scheduler;
+use ferrosa_sched::runqueue::{RunQueue, SchedEntity};
+use ferrosa_sched::scheduler::advance_vruntime;
 use ferrosa_sched::SchedClass;
 use proptest::prelude::*;
 
+/// Run `cur` for one chunk of `service`, then re-compete against `q`: if a
+/// waiting scan is now more deserving, enqueue `cur` and take the smallest.
+/// Mirrors `FairAdmit`'s per-chunk decision on the pure queue.
+fn step(q: &mut RunQueue, cur: SchedEntity, service: u64) -> SchedEntity {
+    let mut cur = cur;
+    cur.vruntime = advance_vruntime(cur.vruntime, service, cur.weight);
+    if q.peek_min_vruntime()
+        .map(|m| m < cur.vruntime)
+        .unwrap_or(false)
+    {
+        q.enqueue(cur);
+        q.pick_next().expect("a scan to run")
+    } else {
+        cur
+    }
+}
+
 proptest! {
-    /// Equal-weight scans converge to equal service — the spread stays O(N),
-    /// independent of how many scheduling rounds run.
     #[test]
     fn equal_weight_scans_converge_to_equal_service(
         n in 2u64..=6,
         rounds in 200usize..=1500,
         service in 1u64..=20,
     ) {
-        let sched = Arc::new(Scheduler::new(0));
+        let mut q = RunQueue::new(0);
         for id in 0..n {
-            sched.admit(id, SchedClass::Bulk);
+            q.enqueue(SchedEntity::new(id, SchedClass::Bulk));
         }
-
         let mut ran = vec![0u64; n as usize];
-        let mut cur = sched.pick_ticket().expect("a scan to run");
+        let mut cur = q.pick_next().expect("a scan to run");
         for _ in 0..rounds {
-            ran[cur.id() as usize] += 1;
-            if cur.reschedule(service) {
-                cur.yield_back();
-                cur = sched.pick_ticket().expect("a scan to run");
-            }
+            ran[cur.id as usize] += 1;
+            cur = step(&mut q, cur, service);
         }
-
         let max = *ran.iter().max().unwrap();
         let min = *ran.iter().min().unwrap();
-        // Fair share: bounded spread (the transient ordering + at most one extra
-        // turn per scan). Crucially NOT proportional to `rounds`.
         prop_assert!(
             max - min <= 2 * n,
-            "unfair service spread {} (max {max}, min {min}) for {n} equal-weight scans over {rounds} rounds: {ran:?}",
+            "unfair spread {} (max {max}, min {min}) for {n} equal-weight scans over {rounds}: {ran:?}",
             max - min
         );
     }
 
-    /// A long scan makes monotonic progress under interactive churn — it is
-    /// never starved, even as higher-weight interactive queries keep arriving.
     #[test]
     fn long_scan_makes_progress_under_interactive_churn(
         rounds in 200usize..=1200,
         churn_every in 2usize..=5,
         service in 1u64..=10,
     ) {
-        let sched = Arc::new(Scheduler::new(0));
-        sched.admit(0, SchedClass::Bulk); // the long scan; id 0
-
+        let mut q = RunQueue::new(0);
+        q.enqueue(SchedEntity::new(0, SchedClass::Bulk)); // the long scan
         let mut long_progress = 0u64;
         let mut next_interactive = 1u64;
         let mut samples = Vec::new();
-        let mut cur = sched.pick_ticket().expect("the long scan");
+        let mut cur = q.pick_next().expect("the long scan");
 
         for round in 0..rounds {
-            // Interactive (Foreground) queries keep arriving.
             if round % churn_every == 0 {
-                sched.admit(next_interactive, SchedClass::Foreground);
+                // A Foreground interactive scan arrives (competes, then leaves
+                // once served — modeled by not re-enqueuing it below).
+                q.enqueue(SchedEntity::new(next_interactive, SchedClass::Foreground));
                 next_interactive += 1;
             }
-
-            let is_long = cur.id() == 0;
-            if is_long {
+            if cur.id == 0 {
                 long_progress += 1;
             }
-            let yielded = cur.reschedule(service);
-
-            if is_long {
-                // The long scan never finishes: keep running until it yields.
-                if yielded {
-                    cur.yield_back();
-                    cur = sched.pick_ticket().expect("someone to run");
-                }
+            // The long scan (id 0) always re-competes; an interactive scan (id>0)
+            // completes after its turn, so we just take the next.
+            cur = if cur.id == 0 {
+                step(&mut q, cur, service)
             } else {
-                // An interactive query completes after its turn; the long scan
-                // is always still queued, so there is always someone to run.
-                cur = sched.pick_ticket().expect("the long scan is always queued");
-            }
-
+                // An interactive scan completes after its turn — discard it (it
+                // does not re-enqueue) and take the next; the long scan is always
+                // queued.
+                let _done = cur;
+                q.pick_next().expect("the long scan is always queued")
+            };
             if round % 25 == 0 {
                 samples.push(long_progress);
             }
         }
 
-        // Not starved: the long scan got a fair fraction of turns despite the
-        // churn (even weighted 4:1 against it, it still runs regularly).
         prop_assert!(
             long_progress >= rounds as u64 / 4,
-            "long scan starved: {long_progress} turns in {rounds} rounds (churn every {churn_every})"
+            "long scan starved: {long_progress} turns in {rounds} rounds"
         );
-        // Progress in every window — it never stalls for a whole 25-round span.
         for w in samples.windows(2) {
-            prop_assert!(
-                w[1] > w[0],
-                "long scan made no progress in a window: {samples:?}"
-            );
+            prop_assert!(w[1] > w[0], "long scan stalled in a window: {samples:?}");
         }
     }
 }

--- a/ferrosa-sched/tests/fairness_proptest.rs
+++ b/ferrosa-sched/tests/fairness_proptest.rs
@@ -1,0 +1,113 @@
+//! B1 T1.6 — property tests for the fair-share scheduler (FM-4/FM-5).
+//!
+//! Two invariants, over randomized scan populations and service costs:
+//!
+//! * **Equal-weight convergence** — N equal-weight scans sharing the pool get
+//!   equal service within a small constant spread (O(N), never O(rounds) — that
+//!   would be starvation).
+//! * **Aging** — a long-running scan keeps making progress even under a steady
+//!   stream of arriving-and-finishing interactive queries; it is never starved
+//!   in any window.
+
+use std::sync::Arc;
+
+use ferrosa_sched::scheduler::Scheduler;
+use ferrosa_sched::SchedClass;
+use proptest::prelude::*;
+
+proptest! {
+    /// Equal-weight scans converge to equal service — the spread stays O(N),
+    /// independent of how many scheduling rounds run.
+    #[test]
+    fn equal_weight_scans_converge_to_equal_service(
+        n in 2u64..=6,
+        rounds in 200usize..=1500,
+        service in 1u64..=20,
+    ) {
+        let sched = Arc::new(Scheduler::new(0));
+        for id in 0..n {
+            sched.admit(id, SchedClass::Bulk);
+        }
+
+        let mut ran = vec![0u64; n as usize];
+        let mut cur = sched.pick_ticket().expect("a scan to run");
+        for _ in 0..rounds {
+            ran[cur.id() as usize] += 1;
+            if cur.reschedule(service) {
+                cur.yield_back();
+                cur = sched.pick_ticket().expect("a scan to run");
+            }
+        }
+
+        let max = *ran.iter().max().unwrap();
+        let min = *ran.iter().min().unwrap();
+        // Fair share: bounded spread (the transient ordering + at most one extra
+        // turn per scan). Crucially NOT proportional to `rounds`.
+        prop_assert!(
+            max - min <= 2 * n,
+            "unfair service spread {} (max {max}, min {min}) for {n} equal-weight scans over {rounds} rounds: {ran:?}",
+            max - min
+        );
+    }
+
+    /// A long scan makes monotonic progress under interactive churn — it is
+    /// never starved, even as higher-weight interactive queries keep arriving.
+    #[test]
+    fn long_scan_makes_progress_under_interactive_churn(
+        rounds in 200usize..=1200,
+        churn_every in 2usize..=5,
+        service in 1u64..=10,
+    ) {
+        let sched = Arc::new(Scheduler::new(0));
+        sched.admit(0, SchedClass::Bulk); // the long scan; id 0
+
+        let mut long_progress = 0u64;
+        let mut next_interactive = 1u64;
+        let mut samples = Vec::new();
+        let mut cur = sched.pick_ticket().expect("the long scan");
+
+        for round in 0..rounds {
+            // Interactive (Foreground) queries keep arriving.
+            if round % churn_every == 0 {
+                sched.admit(next_interactive, SchedClass::Foreground);
+                next_interactive += 1;
+            }
+
+            let is_long = cur.id() == 0;
+            if is_long {
+                long_progress += 1;
+            }
+            let yielded = cur.reschedule(service);
+
+            if is_long {
+                // The long scan never finishes: keep running until it yields.
+                if yielded {
+                    cur.yield_back();
+                    cur = sched.pick_ticket().expect("someone to run");
+                }
+            } else {
+                // An interactive query completes after its turn; the long scan
+                // is always still queued, so there is always someone to run.
+                cur = sched.pick_ticket().expect("the long scan is always queued");
+            }
+
+            if round % 25 == 0 {
+                samples.push(long_progress);
+            }
+        }
+
+        // Not starved: the long scan got a fair fraction of turns despite the
+        // churn (even weighted 4:1 against it, it still runs regularly).
+        prop_assert!(
+            long_progress >= rounds as u64 / 4,
+            "long scan starved: {long_progress} turns in {rounds} rounds (churn every {churn_every})"
+        );
+        // Progress in every window — it never stalls for a whole 25-round span.
+        for w in samples.windows(2) {
+            prop_assert!(
+                w[1] > w[0],
+                "long scan made no progress in a window: {samples:?}"
+            );
+        }
+    }
+}

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -468,7 +468,10 @@ pub struct TableStore<F: FlushTarget> {
     /// genuinely corrupt/missing file (not a transient compaction swap) and a
     /// read may have returned an incomplete result — alert on it.
     pub view_retry_exhausted: std::sync::atomic::AtomicU64,
-    pub(crate) flush_target: F,
+    /// Wrapped in `Arc` so a scan producer can capture a cheap clone and open
+    /// its SSTable readers *after* admission (t_6d0553ee): `F` itself is neither
+    /// `Clone` nor `'static`-movable, but `Arc<F>` is.
+    pub(crate) flush_target: Arc<F>,
     options: WriteOptions,
     /// Secondary index declarations: `(index_name, column_position)` pairs.
     /// Column position is the index into `Row.cells` by column ordinal
@@ -630,6 +633,43 @@ where
             )));
         }
     });
+}
+
+/// Open (pooled) the readers for every descriptor whose byte-comparable key
+/// range overlaps `[start, end]`, newest-first. Same logic as
+/// [`TableStore::open_readers_for_key_range`] but over cloned, `'static`-owned
+/// pool inputs (`Arc<ReaderPool>`, the table key, `Arc<F>`), so a scan producer
+/// can open its readers *after* admission — a cancelled or overloaded scan then
+/// never opens readers (t_6d0553ee). Pruning stays conservative (FMEA #2): a
+/// descriptor is skipped only when its key range is provably disjoint.
+fn open_pooled_readers<T: FlushTarget>(
+    reader_pool: &SharedReaderPool<T::Reader>,
+    pool_table_key: &str,
+    flush_target: &T,
+    descriptors: &[SstableDescriptor],
+    start: Option<&DecoratedKey>,
+    end: Option<&DecoratedKey>,
+) -> Result<Vec<Arc<SSTableReader<T::Reader>>>> {
+    let start_bytes = start.map(ferrosa_sstable::byte_comparable::encode);
+    let end_bytes = end.map(ferrosa_sstable::byte_comparable::encode);
+    let mut readers = Vec::new();
+    for desc in descriptors.iter() {
+        if let Some(ref sb) = start_bytes {
+            if sb.as_slice() > desc.max_key.as_slice() {
+                continue;
+            }
+        }
+        if let Some(ref eb) = end_bytes {
+            if eb.as_slice() < desc.min_key.as_slice() {
+                continue;
+            }
+        }
+        let dir = desc.dir.clone();
+        let gen = desc.gen_num();
+        let key = (pool_table_key.to_string(), gen);
+        readers.push(reader_pool.get_or_open(key, || flush_target.open_reader(&dir, gen))?);
+    }
+    Ok(readers)
 }
 
 fn sstable_column_mappings<R: ReadAt + Send + Sync + 'static>(
@@ -899,7 +939,7 @@ impl<F: FlushTarget> TableStore<F> {
             schema: ArcSwap::from_pointee(schema),
             view: ArcSwap::from_pointee(initial_view),
             flush_guard: Mutex::new(()),
-            flush_target,
+            flush_target: Arc::new(flush_target),
             options,
             index_types: default_index_types(&indexed_columns),
             index_filter_predicates: HashMap::new(),
@@ -974,26 +1014,14 @@ impl<F: FlushTarget> TableStore<F> {
         start: Option<&DecoratedKey>,
         end: Option<&DecoratedKey>,
     ) -> Result<Vec<Arc<SSTableReader<F::Reader>>>> {
-        let start_bytes = start.map(ferrosa_sstable::byte_comparable::encode);
-        let end_bytes = end.map(ferrosa_sstable::byte_comparable::encode);
-        let mut readers = Vec::new();
-        for desc in descriptors.iter() {
-            // Skip only on provable disjointness:
-            //   start > desc.max_key  → window begins after this SSTable ends
-            //   end   < desc.min_key  → window ends before this SSTable begins
-            if let Some(ref sb) = start_bytes {
-                if sb.as_slice() > desc.max_key.as_slice() {
-                    continue;
-                }
-            }
-            if let Some(ref eb) = end_bytes {
-                if eb.as_slice() < desc.min_key.as_slice() {
-                    continue;
-                }
-            }
-            readers.push(self.open_reader(desc)?);
-        }
-        Ok(readers)
+        open_pooled_readers(
+            &self.reader_pool,
+            &self.pool_table_key,
+            &*self.flush_target,
+            descriptors,
+            start,
+            end,
+        )
     }
 
     /// Seed the pool with an already-open reader for `desc` (e.g. just-flushed
@@ -1106,7 +1134,7 @@ impl<F: FlushTarget> TableStore<F> {
             schema: ArcSwap::from_pointee(schema),
             view: ArcSwap::from_pointee(initial_view),
             flush_guard: Mutex::new(()),
-            flush_target,
+            flush_target: Arc::new(flush_target),
             options,
             index_types: default_index_types(&indexed_columns),
             index_filter_predicates: HashMap::new(),
@@ -1185,7 +1213,7 @@ impl<F: FlushTarget> TableStore<F> {
             schema: ArcSwap::from_pointee(schema),
             view: ArcSwap::from_pointee(initial_view),
             flush_guard: Mutex::new(()),
-            flush_target,
+            flush_target: Arc::new(flush_target),
             options,
             index_types: default_index_types(&indexed_columns),
             index_filter_predicates: HashMap::new(),
@@ -2743,7 +2771,10 @@ impl<F: FlushTarget> TableStore<F> {
         partition_limit: Option<usize>,
         start: Option<&DecoratedKey>,
         end: Option<&DecoratedKey>,
-    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>>
+    where
+        F: Send + Sync + 'static,
+    {
         // Buffer is intentionally small. The producer runs on a
         // spawn_blocking thread and per-partition body decode on cold
         // cache is the dominant cost (wide rows + embedding cells +
@@ -2766,20 +2797,13 @@ impl<F: FlushTarget> TableStore<F> {
         // Open the overlapping readers (pooled) up front and move the `Arc`s
         // into the blocking task. The readers stay resident only while the
         // stream runs; the pool cap (soft when in use) bounds total residency.
-        let sst_readers = match self.open_readers_for_key_range(
-            &view.sstables,
-            start_owned.as_ref(),
-            end_owned.as_ref(),
-        ) {
-            Ok(r) => r,
-            Err(e) => {
-                let _ = tx.try_send(Err(e));
-                return Box::pin(futures::stream::unfold(rx, |mut rx| async move {
-                    rx.recv().await.map(|item| (item, rx))
-                }));
-            }
-        };
-        let column_mappings = sstable_column_mappings(&schema, &sst_readers);
+        // Capture the pooled-reader inputs so the producer opens its SSTable
+        // readers AFTER admission (t_6d0553ee): a cancelled or overloaded scan
+        // then never opens readers. `flush_target` is Arc-wrapped so a cheap
+        // clone moves into the 'static closure.
+        let reader_pool = self.reader_pool.clone();
+        let pool_table_key = self.pool_table_key.clone();
+        let flush_target = self.flush_target.clone();
 
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
@@ -2790,6 +2814,23 @@ impl<F: FlushTarget> TableStore<F> {
         // sharing the pool (interactive scans today bypass; B3 folds in
         // compaction/repair, which this weighting then arbitrates).
         spawn_bounded_range_scan(tx.clone(), move |slot| {
+            // Open the overlapping SSTable readers now that a slot is held —
+            // gated by admission, not before it.
+            let sst_readers = match open_pooled_readers(
+                &reader_pool,
+                &pool_table_key,
+                &*flush_target,
+                &view.sstables,
+                start_owned.as_ref(),
+                end_owned.as_ref(),
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+            let column_mappings = sstable_column_mappings(&schema, &sst_readers);
             let active_iter = view
                 .active
                 .range_iter(start_owned.as_ref(), end_owned.as_ref());
@@ -2857,7 +2898,10 @@ impl<F: FlushTarget> TableStore<F> {
         &self,
         start: Option<&DecoratedKey>,
         end: Option<&DecoratedKey>,
-    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>>
+    where
+        F: Send + Sync + 'static,
+    {
         /// Per-stream channel buffer. Kept small because per-partition
         /// decode on cold cache is expensive (wide rows + cell decode)
         /// and a `LIMIT N` consumer should pay for ~N body decodes,
@@ -2872,20 +2916,13 @@ impl<F: FlushTarget> TableStore<F> {
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<Partition>>(STREAM_BUFFER);
 
         // Open overlapping readers (pooled) and move the Arcs into the task.
-        let sst_readers = match self.open_readers_for_key_range(
-            &view.sstables,
-            start_owned.as_ref(),
-            end_owned.as_ref(),
-        ) {
-            Ok(r) => r,
-            Err(e) => {
-                let _ = tx.try_send(Err(e));
-                return Box::pin(futures::stream::unfold(rx, |mut rx| async move {
-                    rx.recv().await.map(|item| (item, rx))
-                }));
-            }
-        };
-        let column_mappings = sstable_column_mappings(&schema, &sst_readers);
+        // Capture the pooled-reader inputs so the producer opens its SSTable
+        // readers AFTER admission (t_6d0553ee): a cancelled or overloaded scan
+        // then never opens readers. `flush_target` is Arc-wrapped so a cheap
+        // clone moves into the 'static closure.
+        let reader_pool = self.reader_pool.clone();
+        let pool_table_key = self.pool_table_key.clone();
+        let flush_target = self.flush_target.clone();
 
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
@@ -2896,6 +2933,23 @@ impl<F: FlushTarget> TableStore<F> {
         // sharing the pool (interactive scans today bypass; B3 folds in
         // compaction/repair, which this weighting then arbitrates).
         spawn_bounded_range_scan(tx.clone(), move |slot| {
+            // Open the overlapping SSTable readers now that a slot is held —
+            // gated by admission, not before it.
+            let sst_readers = match open_pooled_readers(
+                &reader_pool,
+                &pool_table_key,
+                &*flush_target,
+                &view.sstables,
+                start_owned.as_ref(),
+                end_owned.as_ref(),
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+            let column_mappings = sstable_column_mappings(&schema, &sst_readers);
             // Build source iterators — these borrow from `view`
             // (memtable Arcs) and from the opened SSTable reader Arcs, both
             // of which the closure owns for the task's full lifetime, so there
@@ -2969,7 +3023,10 @@ impl<F: FlushTarget> TableStore<F> {
         &self,
         start: Option<&DecoratedKey>,
         end: Option<&DecoratedKey>,
-    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>>
+    where
+        F: Send + Sync + 'static,
+    {
         const STREAM_BUFFER: usize = 4;
         let view = self.view.load_full();
         let schema = self.schema.load_full();
@@ -2977,20 +3034,13 @@ impl<F: FlushTarget> TableStore<F> {
         let end_owned = end.cloned();
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<Partition>>(STREAM_BUFFER);
 
-        let sst_readers = match self.open_readers_for_key_range(
-            &view.sstables,
-            start_owned.as_ref(),
-            end_owned.as_ref(),
-        ) {
-            Ok(r) => r,
-            Err(e) => {
-                let _ = tx.try_send(Err(e));
-                return Box::pin(futures::stream::unfold(rx, |mut rx| async move {
-                    rx.recv().await.map(|item| (item, rx))
-                }));
-            }
-        };
-        let column_mappings = sstable_column_mappings(&schema, &sst_readers);
+        // Capture the pooled-reader inputs so the producer opens its SSTable
+        // readers AFTER admission (t_6d0553ee): a cancelled or overloaded scan
+        // then never opens readers. `flush_target` is Arc-wrapped so a cheap
+        // clone moves into the 'static closure.
+        let reader_pool = self.reader_pool.clone();
+        let pool_table_key = self.pool_table_key.clone();
+        let flush_target = self.flush_target.clone();
 
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
@@ -3001,6 +3051,23 @@ impl<F: FlushTarget> TableStore<F> {
         // sharing the pool (interactive scans today bypass; B3 folds in
         // compaction/repair, which this weighting then arbitrates).
         spawn_bounded_range_scan(tx.clone(), move |slot| {
+            // Open the overlapping SSTable readers now that a slot is held —
+            // gated by admission, not before it.
+            let sst_readers = match open_pooled_readers(
+                &reader_pool,
+                &pool_table_key,
+                &*flush_target,
+                &view.sstables,
+                start_owned.as_ref(),
+                end_owned.as_ref(),
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+            let column_mappings = sstable_column_mappings(&schema, &sst_readers);
             let active_iter = view
                 .active
                 .range_iter(start_owned.as_ref(), end_owned.as_ref());
@@ -3057,7 +3124,10 @@ impl<F: FlushTarget> TableStore<F> {
         wanted: Vec<u16>,
         start: Option<&DecoratedKey>,
         end: Option<&DecoratedKey>,
-    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<Partition>> + Send>>
+    where
+        F: Send + Sync + 'static,
+    {
         const STREAM_BUFFER: usize = 4;
         let view = self.view.load_full();
         let schema = self.schema.load_full();
@@ -3066,20 +3136,13 @@ impl<F: FlushTarget> TableStore<F> {
         let wanted_owned = wanted;
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<Partition>>(STREAM_BUFFER);
 
-        let sst_readers = match self.open_readers_for_key_range(
-            &view.sstables,
-            start_owned.as_ref(),
-            end_owned.as_ref(),
-        ) {
-            Ok(r) => r,
-            Err(e) => {
-                let _ = tx.try_send(Err(e));
-                return Box::pin(futures::stream::unfold(rx, |mut rx| async move {
-                    rx.recv().await.map(|item| (item, rx))
-                }));
-            }
-        };
-        let column_mappings = sstable_column_mappings(&schema, &sst_readers);
+        // Capture the pooled-reader inputs so the producer opens its SSTable
+        // readers AFTER admission (t_6d0553ee): a cancelled or overloaded scan
+        // then never opens readers. `flush_target` is Arc-wrapped so a cheap
+        // clone moves into the 'static closure.
+        let reader_pool = self.reader_pool.clone();
+        let pool_table_key = self.pool_table_key.clone();
+        let flush_target = self.flush_target.clone();
 
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
@@ -3090,6 +3153,23 @@ impl<F: FlushTarget> TableStore<F> {
         // sharing the pool (interactive scans today bypass; B3 folds in
         // compaction/repair, which this weighting then arbitrates).
         spawn_bounded_range_scan(tx.clone(), move |slot| {
+            // Open the overlapping SSTable readers now that a slot is held —
+            // gated by admission, not before it.
+            let sst_readers = match open_pooled_readers(
+                &reader_pool,
+                &pool_table_key,
+                &*flush_target,
+                &view.sstables,
+                start_owned.as_ref(),
+                end_owned.as_ref(),
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+            let column_mappings = sstable_column_mappings(&schema, &sst_readers);
             let active_iter = view
                 .active
                 .range_iter(start_owned.as_ref(), end_owned.as_ref());

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -594,6 +594,44 @@ fn scoped_vector_sidecar_name(index_name: &str, scope: &[u8]) -> String {
     format!("{index_name}__scope_{}", hex_scope(scope))
 }
 
+/// Route a range-scan `producer` through the bounded scheduler pool, wiring the
+/// two admission properties the raw [`ferrosa_sched::SchedPool::submit_scan`]
+/// primitive exposes so a range scan is a well-behaved scheduler citizen:
+///
+/// - **Cancellation** — the producer's channel `closed()` future is the cancel
+///   signal. If the consumer drops the stream while the scan is still *waiting*
+///   for a pool slot, the queued admission is vacated before it ever occupies a
+///   slot, instead of waking later, grabbing a slot, and doing work only to find
+///   the channel closed (t_6d0553ee).
+/// - **Fail-loud overload** — if admission is shed because the waiter queue was
+///   at its bound ([`ferrosa_sched::ScanOutcome::Overloaded`]), the producer
+///   never runs, so `rx` would otherwise end silently empty. A supervisor task
+///   surfaces a backpressure error into the stream instead (recognized by
+///   [`ferrosa_common::Error::is_backpressure`]), so the caller sees explicit
+///   overload, never a phantom empty result.
+///
+/// `tx` is a clone of the producer's channel sender used only for these two
+/// signals; the producer owns its own sender for delivering partitions.
+fn spawn_bounded_range_scan<F>(tx: tokio::sync::mpsc::Sender<Result<Partition>>, producer: F)
+where
+    F: FnOnce(&mut ferrosa_sched::ScanSlot) + Send + 'static,
+{
+    let cancel_probe = tx.clone();
+    let handle = ferrosa_sched::global_pool().submit_scan(
+        ferrosa_sched::SchedClass::Bulk,
+        ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
+        async move { cancel_probe.closed().await },
+        move |slot| producer(slot),
+    );
+    tokio::spawn(async move {
+        if let Ok(ferrosa_sched::ScanOutcome::Overloaded) = handle.await {
+            let _ = tx.try_send(Err(ferrosa_common::Error::InvalidData(
+                "overloaded: scan admission queue full — retry".to_string(),
+            )));
+        }
+    });
+}
+
 fn sstable_column_mappings<R: ReadAt + Send + Sync + 'static>(
     schema: &TableSchema,
     sstables: &[Arc<SSTableReader<R>>],
@@ -2751,59 +2789,54 @@ impl<F: FlushTarget> TableStore<F> {
         // fair scheduler weights it as Bulk so it cedes to any Foreground work
         // sharing the pool (interactive scans today bypass; B3 folds in
         // compaction/repair, which this weighting then arbitrates).
-        ferrosa_sched::global_pool().submit_scan(
-            ferrosa_sched::SchedClass::Bulk,
-            ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
-            move |slot| {
-                let active_iter = view
-                    .active
-                    .range_iter(start_owned.as_ref(), end_owned.as_ref());
-                let flushing_iter = view
-                    .flushing
-                    .as_ref()
-                    .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
-                let sstables_slice = &sst_readers[..];
+        spawn_bounded_range_scan(tx.clone(), move |slot| {
+            let active_iter = view
+                .active
+                .range_iter(start_owned.as_ref(), end_owned.as_ref());
+            let flushing_iter = view
+                .flushing
+                .as_ref()
+                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+            let sstables_slice = &sst_readers[..];
 
-                let mut merger =
-                    match crate::range_merger::merger_for_projected_sources_with_mappings(
-                        active_iter,
-                        flushing_iter,
-                        sstables_slice,
-                        &column_mappings,
-                        &wanted_owned,
-                        start_owned,
-                        end_owned,
-                    ) {
-                        Ok(m) => m,
-                        Err(e) => {
-                            let _ = tx.blocking_send(Err(e));
+            let mut merger = match crate::range_merger::merger_for_projected_sources_with_mappings(
+                active_iter,
+                flushing_iter,
+                sstables_slice,
+                &column_mappings,
+                &wanted_owned,
+                start_owned,
+                end_owned,
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+
+            let cap = partition_limit.unwrap_or(usize::MAX);
+            let mut emitted: usize = 0;
+            loop {
+                if emitted >= cap {
+                    return;
+                }
+                match merger.next_merged_partition() {
+                    Ok(Some(partition)) => {
+                        if tx.blocking_send(Ok(partition)).is_err() {
                             return;
                         }
-                    };
-
-                let cap = partition_limit.unwrap_or(usize::MAX);
-                let mut emitted: usize = 0;
-                loop {
-                    if emitted >= cap {
+                        emitted += 1;
+                        slot.tick(); // B1 T1.2 cooperative yield
+                    }
+                    Ok(None) => return,
+                    Err(e) => {
+                        let _ = tx.blocking_send(Err(e));
                         return;
                     }
-                    match merger.next_merged_partition() {
-                        Ok(Some(partition)) => {
-                            if tx.blocking_send(Ok(partition)).is_err() {
-                                return;
-                            }
-                            emitted += 1;
-                            slot.tick(); // B1 T1.2 cooperative yield
-                        }
-                        Ok(None) => return,
-                        Err(e) => {
-                            let _ = tx.blocking_send(Err(e));
-                            return;
-                        }
-                    }
                 }
-            },
-        );
+            }
+        });
 
         Box::pin(futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
@@ -2862,59 +2895,55 @@ impl<F: FlushTarget> TableStore<F> {
         // fair scheduler weights it as Bulk so it cedes to any Foreground work
         // sharing the pool (interactive scans today bypass; B3 folds in
         // compaction/repair, which this weighting then arbitrates).
-        ferrosa_sched::global_pool().submit_scan(
-            ferrosa_sched::SchedClass::Bulk,
-            ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
-            move |slot| {
-                // Build source iterators — these borrow from `view`
-                // (memtable Arcs) and from the opened SSTable reader Arcs, both
-                // of which the closure owns for the task's full lifetime, so there
-                // is no self-referential lifetime problem.
-                let active_iter = view
-                    .active
-                    .range_iter(start_owned.as_ref(), end_owned.as_ref());
-                let flushing_iter = view
-                    .flushing
-                    .as_ref()
-                    .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
-                let sstables_slice = &sst_readers[..];
+        spawn_bounded_range_scan(tx.clone(), move |slot| {
+            // Build source iterators — these borrow from `view`
+            // (memtable Arcs) and from the opened SSTable reader Arcs, both
+            // of which the closure owns for the task's full lifetime, so there
+            // is no self-referential lifetime problem.
+            let active_iter = view
+                .active
+                .range_iter(start_owned.as_ref(), end_owned.as_ref());
+            let flushing_iter = view
+                .flushing
+                .as_ref()
+                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+            let sstables_slice = &sst_readers[..];
 
-                let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
-                    active_iter,
-                    flushing_iter,
-                    sstables_slice,
-                    &column_mappings,
-                    start_owned,
-                    end_owned,
-                ) {
-                    Ok(m) => m,
+            let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
+                active_iter,
+                flushing_iter,
+                sstables_slice,
+                &column_mappings,
+                start_owned,
+                end_owned,
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+
+            loop {
+                match merger.next_merged_partition() {
+                    Ok(Some(partition)) => {
+                        if tx.blocking_send(Ok(partition)).is_err() {
+                            // Consumer dropped (cancelled stream).
+                            return;
+                        }
+                        // B1 T1.2: account the chunk and cooperatively yield the
+                        // pool slot every budget partitions so a concurrent scan
+                        // isn't starved for this scan's whole duration.
+                        slot.tick();
+                    }
+                    Ok(None) => return,
                     Err(e) => {
                         let _ = tx.blocking_send(Err(e));
                         return;
                     }
-                };
-
-                loop {
-                    match merger.next_merged_partition() {
-                        Ok(Some(partition)) => {
-                            if tx.blocking_send(Ok(partition)).is_err() {
-                                // Consumer dropped (cancelled stream).
-                                return;
-                            }
-                            // B1 T1.2: account the chunk and cooperatively yield the
-                            // pool slot every budget partitions so a concurrent scan
-                            // isn't starved for this scan's whole duration.
-                            slot.tick();
-                        }
-                        Ok(None) => return,
-                        Err(e) => {
-                            let _ = tx.blocking_send(Err(e));
-                            return;
-                        }
-                    }
                 }
-            },
-        );
+            }
+        });
 
         Box::pin(futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
@@ -2971,52 +3000,48 @@ impl<F: FlushTarget> TableStore<F> {
         // fair scheduler weights it as Bulk so it cedes to any Foreground work
         // sharing the pool (interactive scans today bypass; B3 folds in
         // compaction/repair, which this weighting then arbitrates).
-        ferrosa_sched::global_pool().submit_scan(
-            ferrosa_sched::SchedClass::Bulk,
-            ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
-            move |slot| {
-                let active_iter = view
-                    .active
-                    .range_iter(start_owned.as_ref(), end_owned.as_ref());
-                let flushing_iter = view
-                    .flushing
-                    .as_ref()
-                    .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
-                let sstables_slice = &sst_readers[..];
+        spawn_bounded_range_scan(tx.clone(), move |slot| {
+            let active_iter = view
+                .active
+                .range_iter(start_owned.as_ref(), end_owned.as_ref());
+            let flushing_iter = view
+                .flushing
+                .as_ref()
+                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+            let sstables_slice = &sst_readers[..];
 
-                let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
-                    active_iter,
-                    flushing_iter,
-                    sstables_slice,
-                    &column_mappings,
-                    start_owned,
-                    end_owned,
-                ) {
-                    Ok(m) => m,
+            let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
+                active_iter,
+                flushing_iter,
+                sstables_slice,
+                &column_mappings,
+                start_owned,
+                end_owned,
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+
+            let k = crate::range_merger::rows_per_fragment();
+            loop {
+                match merger.next_fragment(k) {
+                    Ok(Some(fragment)) => {
+                        if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
+                            return;
+                        }
+                        slot.tick(); // B1 T1.2 cooperative yield
+                    }
+                    Ok(None) => return,
                     Err(e) => {
                         let _ = tx.blocking_send(Err(e));
                         return;
                     }
-                };
-
-                let k = crate::range_merger::rows_per_fragment();
-                loop {
-                    match merger.next_fragment(k) {
-                        Ok(Some(fragment)) => {
-                            if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
-                                return;
-                            }
-                            slot.tick(); // B1 T1.2 cooperative yield
-                        }
-                        Ok(None) => return,
-                        Err(e) => {
-                            let _ = tx.blocking_send(Err(e));
-                            return;
-                        }
-                    }
                 }
-            },
-        );
+            }
+        });
 
         Box::pin(futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
@@ -3064,54 +3089,49 @@ impl<F: FlushTarget> TableStore<F> {
         // fair scheduler weights it as Bulk so it cedes to any Foreground work
         // sharing the pool (interactive scans today bypass; B3 folds in
         // compaction/repair, which this weighting then arbitrates).
-        ferrosa_sched::global_pool().submit_scan(
-            ferrosa_sched::SchedClass::Bulk,
-            ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
-            move |slot| {
-                let active_iter = view
-                    .active
-                    .range_iter(start_owned.as_ref(), end_owned.as_ref());
-                let flushing_iter = view
-                    .flushing
-                    .as_ref()
-                    .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
-                let sstables_slice = &sst_readers[..];
+        spawn_bounded_range_scan(tx.clone(), move |slot| {
+            let active_iter = view
+                .active
+                .range_iter(start_owned.as_ref(), end_owned.as_ref());
+            let flushing_iter = view
+                .flushing
+                .as_ref()
+                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+            let sstables_slice = &sst_readers[..];
 
-                let mut merger =
-                    match crate::range_merger::merger_for_projected_sources_with_mappings(
-                        active_iter,
-                        flushing_iter,
-                        sstables_slice,
-                        &column_mappings,
-                        &wanted_owned,
-                        start_owned,
-                        end_owned,
-                    ) {
-                        Ok(m) => m,
-                        Err(e) => {
-                            let _ = tx.blocking_send(Err(e));
+            let mut merger = match crate::range_merger::merger_for_projected_sources_with_mappings(
+                active_iter,
+                flushing_iter,
+                sstables_slice,
+                &column_mappings,
+                &wanted_owned,
+                start_owned,
+                end_owned,
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(e));
+                    return;
+                }
+            };
+
+            let k = crate::range_merger::rows_per_fragment();
+            loop {
+                match merger.next_fragment(k) {
+                    Ok(Some(fragment)) => {
+                        if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
                             return;
                         }
-                    };
-
-                let k = crate::range_merger::rows_per_fragment();
-                loop {
-                    match merger.next_fragment(k) {
-                        Ok(Some(fragment)) => {
-                            if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
-                                return;
-                            }
-                            slot.tick(); // B1 T1.2 cooperative yield
-                        }
-                        Ok(None) => return,
-                        Err(e) => {
-                            let _ = tx.blocking_send(Err(e));
-                            return;
-                        }
+                        slot.tick(); // B1 T1.2 cooperative yield
+                    }
+                    Ok(None) => return,
+                    Err(e) => {
+                        let _ = tx.blocking_send(Err(e));
+                        return;
                     }
                 }
-            },
-        );
+            }
+        });
 
         Box::pin(futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -2746,53 +2746,58 @@ impl<F: FlushTarget> TableStore<F> {
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
         // scan cannot oversubscribe the cores and starve raft heartbeats.
-        ferrosa_sched::global_pool().submit_blocking(move || {
-            let active_iter = view
-                .active
-                .range_iter(start_owned.as_ref(), end_owned.as_ref());
-            let flushing_iter = view
-                .flushing
-                .as_ref()
-                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
-            let sstables_slice = &sst_readers[..];
+        ferrosa_sched::global_pool().submit_scan(
+            ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
+            move |slot| {
+                let active_iter = view
+                    .active
+                    .range_iter(start_owned.as_ref(), end_owned.as_ref());
+                let flushing_iter = view
+                    .flushing
+                    .as_ref()
+                    .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+                let sstables_slice = &sst_readers[..];
 
-            let mut merger = match crate::range_merger::merger_for_projected_sources_with_mappings(
-                active_iter,
-                flushing_iter,
-                sstables_slice,
-                &column_mappings,
-                &wanted_owned,
-                start_owned,
-                end_owned,
-            ) {
-                Ok(m) => m,
-                Err(e) => {
-                    let _ = tx.blocking_send(Err(e));
-                    return;
-                }
-            };
-
-            let cap = partition_limit.unwrap_or(usize::MAX);
-            let mut emitted: usize = 0;
-            loop {
-                if emitted >= cap {
-                    return;
-                }
-                match merger.next_merged_partition() {
-                    Ok(Some(partition)) => {
-                        if tx.blocking_send(Ok(partition)).is_err() {
+                let mut merger =
+                    match crate::range_merger::merger_for_projected_sources_with_mappings(
+                        active_iter,
+                        flushing_iter,
+                        sstables_slice,
+                        &column_mappings,
+                        &wanted_owned,
+                        start_owned,
+                        end_owned,
+                    ) {
+                        Ok(m) => m,
+                        Err(e) => {
+                            let _ = tx.blocking_send(Err(e));
                             return;
                         }
-                        emitted += 1;
-                    }
-                    Ok(None) => return,
-                    Err(e) => {
-                        let _ = tx.blocking_send(Err(e));
+                    };
+
+                let cap = partition_limit.unwrap_or(usize::MAX);
+                let mut emitted: usize = 0;
+                loop {
+                    if emitted >= cap {
                         return;
                     }
+                    match merger.next_merged_partition() {
+                        Ok(Some(partition)) => {
+                            if tx.blocking_send(Ok(partition)).is_err() {
+                                return;
+                            }
+                            emitted += 1;
+                            slot.tick(); // B1 T1.2 cooperative yield
+                        }
+                        Ok(None) => return,
+                        Err(e) => {
+                            let _ = tx.blocking_send(Err(e));
+                            return;
+                        }
+                    }
                 }
-            }
-        });
+            },
+        );
 
         Box::pin(futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
@@ -2846,51 +2851,58 @@ impl<F: FlushTarget> TableStore<F> {
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
         // scan cannot oversubscribe the cores and starve raft heartbeats.
-        ferrosa_sched::global_pool().submit_blocking(move || {
-            // Build source iterators — these borrow from `view`
-            // (memtable Arcs) and from the opened SSTable reader Arcs, both
-            // of which the closure owns for the task's full lifetime, so there
-            // is no self-referential lifetime problem.
-            let active_iter = view
-                .active
-                .range_iter(start_owned.as_ref(), end_owned.as_ref());
-            let flushing_iter = view
-                .flushing
-                .as_ref()
-                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
-            let sstables_slice = &sst_readers[..];
+        ferrosa_sched::global_pool().submit_scan(
+            ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
+            move |slot| {
+                // Build source iterators — these borrow from `view`
+                // (memtable Arcs) and from the opened SSTable reader Arcs, both
+                // of which the closure owns for the task's full lifetime, so there
+                // is no self-referential lifetime problem.
+                let active_iter = view
+                    .active
+                    .range_iter(start_owned.as_ref(), end_owned.as_ref());
+                let flushing_iter = view
+                    .flushing
+                    .as_ref()
+                    .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+                let sstables_slice = &sst_readers[..];
 
-            let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
-                active_iter,
-                flushing_iter,
-                sstables_slice,
-                &column_mappings,
-                start_owned,
-                end_owned,
-            ) {
-                Ok(m) => m,
-                Err(e) => {
-                    let _ = tx.blocking_send(Err(e));
-                    return;
-                }
-            };
-
-            loop {
-                match merger.next_merged_partition() {
-                    Ok(Some(partition)) => {
-                        if tx.blocking_send(Ok(partition)).is_err() {
-                            // Consumer dropped (cancelled stream).
-                            return;
-                        }
-                    }
-                    Ok(None) => return,
+                let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
+                    active_iter,
+                    flushing_iter,
+                    sstables_slice,
+                    &column_mappings,
+                    start_owned,
+                    end_owned,
+                ) {
+                    Ok(m) => m,
                     Err(e) => {
                         let _ = tx.blocking_send(Err(e));
                         return;
                     }
+                };
+
+                loop {
+                    match merger.next_merged_partition() {
+                        Ok(Some(partition)) => {
+                            if tx.blocking_send(Ok(partition)).is_err() {
+                                // Consumer dropped (cancelled stream).
+                                return;
+                            }
+                            // B1 T1.2: account the chunk and cooperatively yield the
+                            // pool slot every budget partitions so a concurrent scan
+                            // isn't starved for this scan's whole duration.
+                            slot.tick();
+                        }
+                        Ok(None) => return,
+                        Err(e) => {
+                            let _ = tx.blocking_send(Err(e));
+                            return;
+                        }
+                    }
                 }
-            }
-        });
+            },
+        );
 
         Box::pin(futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
@@ -2942,47 +2954,51 @@ impl<F: FlushTarget> TableStore<F> {
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
         // scan cannot oversubscribe the cores and starve raft heartbeats.
-        ferrosa_sched::global_pool().submit_blocking(move || {
-            let active_iter = view
-                .active
-                .range_iter(start_owned.as_ref(), end_owned.as_ref());
-            let flushing_iter = view
-                .flushing
-                .as_ref()
-                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
-            let sstables_slice = &sst_readers[..];
+        ferrosa_sched::global_pool().submit_scan(
+            ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
+            move |slot| {
+                let active_iter = view
+                    .active
+                    .range_iter(start_owned.as_ref(), end_owned.as_ref());
+                let flushing_iter = view
+                    .flushing
+                    .as_ref()
+                    .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+                let sstables_slice = &sst_readers[..];
 
-            let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
-                active_iter,
-                flushing_iter,
-                sstables_slice,
-                &column_mappings,
-                start_owned,
-                end_owned,
-            ) {
-                Ok(m) => m,
-                Err(e) => {
-                    let _ = tx.blocking_send(Err(e));
-                    return;
-                }
-            };
-
-            let k = crate::range_merger::rows_per_fragment();
-            loop {
-                match merger.next_fragment(k) {
-                    Ok(Some(fragment)) => {
-                        if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
-                            return;
-                        }
-                    }
-                    Ok(None) => return,
+                let mut merger = match crate::range_merger::merger_for_sources_with_mappings(
+                    active_iter,
+                    flushing_iter,
+                    sstables_slice,
+                    &column_mappings,
+                    start_owned,
+                    end_owned,
+                ) {
+                    Ok(m) => m,
                     Err(e) => {
                         let _ = tx.blocking_send(Err(e));
                         return;
                     }
+                };
+
+                let k = crate::range_merger::rows_per_fragment();
+                loop {
+                    match merger.next_fragment(k) {
+                        Ok(Some(fragment)) => {
+                            if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
+                                return;
+                            }
+                            slot.tick(); // B1 T1.2 cooperative yield
+                        }
+                        Ok(None) => return,
+                        Err(e) => {
+                            let _ = tx.blocking_send(Err(e));
+                            return;
+                        }
+                    }
                 }
-            }
-        });
+            },
+        );
 
         Box::pin(futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
@@ -3025,48 +3041,53 @@ impl<F: FlushTarget> TableStore<F> {
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
         // scan cannot oversubscribe the cores and starve raft heartbeats.
-        ferrosa_sched::global_pool().submit_blocking(move || {
-            let active_iter = view
-                .active
-                .range_iter(start_owned.as_ref(), end_owned.as_ref());
-            let flushing_iter = view
-                .flushing
-                .as_ref()
-                .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
-            let sstables_slice = &sst_readers[..];
+        ferrosa_sched::global_pool().submit_scan(
+            ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
+            move |slot| {
+                let active_iter = view
+                    .active
+                    .range_iter(start_owned.as_ref(), end_owned.as_ref());
+                let flushing_iter = view
+                    .flushing
+                    .as_ref()
+                    .map(|f| f.range_iter(start_owned.as_ref(), end_owned.as_ref()));
+                let sstables_slice = &sst_readers[..];
 
-            let mut merger = match crate::range_merger::merger_for_projected_sources_with_mappings(
-                active_iter,
-                flushing_iter,
-                sstables_slice,
-                &column_mappings,
-                &wanted_owned,
-                start_owned,
-                end_owned,
-            ) {
-                Ok(m) => m,
-                Err(e) => {
-                    let _ = tx.blocking_send(Err(e));
-                    return;
-                }
-            };
+                let mut merger =
+                    match crate::range_merger::merger_for_projected_sources_with_mappings(
+                        active_iter,
+                        flushing_iter,
+                        sstables_slice,
+                        &column_mappings,
+                        &wanted_owned,
+                        start_owned,
+                        end_owned,
+                    ) {
+                        Ok(m) => m,
+                        Err(e) => {
+                            let _ = tx.blocking_send(Err(e));
+                            return;
+                        }
+                    };
 
-            let k = crate::range_merger::rows_per_fragment();
-            loop {
-                match merger.next_fragment(k) {
-                    Ok(Some(fragment)) => {
-                        if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
+                let k = crate::range_merger::rows_per_fragment();
+                loop {
+                    match merger.next_fragment(k) {
+                        Ok(Some(fragment)) => {
+                            if tx.blocking_send(Ok(fragment.into_partition())).is_err() {
+                                return;
+                            }
+                            slot.tick(); // B1 T1.2 cooperative yield
+                        }
+                        Ok(None) => return,
+                        Err(e) => {
+                            let _ = tx.blocking_send(Err(e));
                             return;
                         }
                     }
-                    Ok(None) => return,
-                    Err(e) => {
-                        let _ = tx.blocking_send(Err(e));
-                        return;
-                    }
                 }
-            }
-        });
+            },
+        );
 
         Box::pin(futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -2746,7 +2746,13 @@ impl<F: FlushTarget> TableStore<F> {
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
         // scan cannot oversubscribe the cores and starve raft heartbeats.
+        // Every scan through the bounded pool is an unbounded full-table range
+        // scan (`ScanPlan::FullScan`-class work) — see ScanPlan::sched_class. The
+        // fair scheduler weights it as Bulk so it cedes to any Foreground work
+        // sharing the pool (interactive scans today bypass; B3 folds in
+        // compaction/repair, which this weighting then arbitrates).
         ferrosa_sched::global_pool().submit_scan(
+            ferrosa_sched::SchedClass::Bulk,
             ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
             move |slot| {
                 let active_iter = view
@@ -2851,7 +2857,13 @@ impl<F: FlushTarget> TableStore<F> {
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
         // scan cannot oversubscribe the cores and starve raft heartbeats.
+        // Every scan through the bounded pool is an unbounded full-table range
+        // scan (`ScanPlan::FullScan`-class work) — see ScanPlan::sched_class. The
+        // fair scheduler weights it as Bulk so it cedes to any Foreground work
+        // sharing the pool (interactive scans today bypass; B3 folds in
+        // compaction/repair, which this weighting then arbitrates).
         ferrosa_sched::global_pool().submit_scan(
+            ferrosa_sched::SchedClass::Bulk,
             ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
             move |slot| {
                 // Build source iterators — these borrow from `view`
@@ -2954,7 +2966,13 @@ impl<F: FlushTarget> TableStore<F> {
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
         // scan cannot oversubscribe the cores and starve raft heartbeats.
+        // Every scan through the bounded pool is an unbounded full-table range
+        // scan (`ScanPlan::FullScan`-class work) — see ScanPlan::sched_class. The
+        // fair scheduler weights it as Bulk so it cedes to any Foreground work
+        // sharing the pool (interactive scans today bypass; B3 folds in
+        // compaction/repair, which this weighting then arbitrates).
         ferrosa_sched::global_pool().submit_scan(
+            ferrosa_sched::SchedClass::Bulk,
             ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
             move |slot| {
                 let active_iter = view
@@ -3041,7 +3059,13 @@ impl<F: FlushTarget> TableStore<F> {
         // t_88223ad0: route the scan producer through the bounded scheduler pool
         // (cores - reserved) instead of the unbounded blocking pool, so a broad
         // scan cannot oversubscribe the cores and starve raft heartbeats.
+        // Every scan through the bounded pool is an unbounded full-table range
+        // scan (`ScanPlan::FullScan`-class work) — see ScanPlan::sched_class. The
+        // fair scheduler weights it as Bulk so it cedes to any Foreground work
+        // sharing the pool (interactive scans today bypass; B3 folds in
+        // compaction/repair, which this weighting then arbitrates).
         ferrosa_sched::global_pool().submit_scan(
+            ferrosa_sched::SchedClass::Bulk,
             ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET,
             move |slot| {
                 let active_iter = view

--- a/ferrosa-storage/tests/scan_cooperative_yield_guard.rs
+++ b/ferrosa-storage/tests/scan_cooperative_yield_guard.rs
@@ -18,12 +18,14 @@
 
 use std::fs;
 
-/// Extract each `submit_scan` producer's closure body — from `submit_scan(` up
-/// to the `Box::pin(futures::stream::unfold` stream return that immediately
-/// follows every producer's closure. Bounds the body precisely so post-closure
-/// code isn't mis-attributed.
+/// Extract each range-scan producer's closure body. Producers route through the
+/// `spawn_bounded_range_scan(tx, ...)` helper (which wraps the raw `submit_scan`
+/// admission with cancellation + fail-loud overload); each body runs from that
+/// call up to the `Box::pin(futures::stream::unfold` stream return that
+/// immediately follows the producer's closure. Matching `spawn_bounded_range_scan(tx`
+/// picks the call sites, not the `spawn_bounded_range_scan<F>(tx:` definition.
 fn producer_bodies(src: &str) -> Vec<&str> {
-    src.match_indices("submit_scan(")
+    src.match_indices("spawn_bounded_range_scan(tx")
         .map(|(start, _)| {
             let rest = &src[start..];
             let end = rest
@@ -45,14 +47,14 @@ fn every_submit_scan_producer_calls_slot_tick() {
     let bodies = producer_bodies(&src);
     assert!(
         bodies.len() >= 4,
-        "expected >= 4 store.rs scan producers routed through submit_scan, found {} — \
+        "expected >= 4 store.rs scan producers routed through spawn_bounded_range_scan, found {} — \
          did a producer switch back to submit_blocking (no cooperative yield)?",
         bodies.len()
     );
     for (n, body) in bodies.iter().enumerate() {
         assert!(
             body.contains("slot.tick()"),
-            "submit_scan producer #{n} does not call slot.tick() in its page loop — a long \
+            "range-scan producer #{n} does not call slot.tick() in its page loop — a long \
              scan would monopolize the bounded pool and reintroduce the starvation B1 fixes \
              (T1.3 / FM-2)"
         );
@@ -60,27 +62,48 @@ fn every_submit_scan_producer_calls_slot_tick() {
 }
 
 #[test]
-fn scheduler_pool_is_only_used_by_range_scan_producers() {
-    // B1 T1.5 / FM-6 — interactive point-read bypass. Every `global_pool()` call
-    // must live inside a `range_iter*` scan producer. The point-read methods
-    // (`read` / `read_limited_rows` / `read_clustering_row`) therefore never
-    // touch the scheduler, so a `PartitionKeyLookup` has zero scheduler calls and
-    // is never queued behind a full-table scan. This fails if a future edit
-    // routes a point read through the pool.
+fn scheduler_pool_is_reached_only_through_the_range_scan_helper() {
+    // B1 T1.5 / FM-6 — interactive point-read bypass. Two invariants keep the
+    // scheduler off the point-read path:
+    //   (a) `global_pool()` is called ONLY inside `spawn_bounded_range_scan`, the
+    //       single helper that routes a scan through the pool; and
+    //   (b) every `spawn_bounded_range_scan(...)` CALL site is a `range_iter*`
+    //       scan producer.
+    // Together they guarantee the point-read methods (`read` /
+    // `read_limited_rows` / `read_clustering_row`) never touch the scheduler, so a
+    // `PartitionKeyLookup` has zero scheduler calls. Fails if a future edit routes
+    // a point read through the pool or calls the pool outside the helper.
     let src = store_src();
-    let mut checked = 0usize;
+
+    let mut pool_calls = 0usize;
     for (idx, _) in src.match_indices("global_pool()") {
         let name = enclosing_fn_name(&src, idx);
         assert!(
-            name.contains("range_iter"),
-            "global_pool() is called from `{name}` — only range_iter* scan producers may use \
-             the scheduler pool. A point read must have zero scheduler calls (T1.5 / FM-6)."
+            name == "spawn_bounded_range_scan",
+            "global_pool() is called from `{name}` — the scheduler pool must be reached only \
+             through spawn_bounded_range_scan. A point read must have zero scheduler calls \
+             (T1.5 / FM-6)."
         );
-        checked += 1;
+        pool_calls += 1;
     }
     assert!(
-        checked >= 4,
-        "expected >= 4 pool call sites, found {checked}"
+        pool_calls >= 1,
+        "expected spawn_bounded_range_scan to call global_pool(), found {pool_calls}"
+    );
+
+    let mut call_sites = 0usize;
+    for (idx, _) in src.match_indices("spawn_bounded_range_scan(tx") {
+        let name = enclosing_fn_name(&src, idx);
+        assert!(
+            name.contains("range_iter"),
+            "spawn_bounded_range_scan is called from `{name}` — only range_iter* scan producers \
+             may route work through the scheduler pool (T1.5 / FM-6)."
+        );
+        call_sites += 1;
+    }
+    assert!(
+        call_sites >= 4,
+        "expected >= 4 range scan producer call sites, found {call_sites}"
     );
 }
 

--- a/ferrosa-storage/tests/scan_cooperative_yield_guard.rs
+++ b/ferrosa-storage/tests/scan_cooperative_yield_guard.rs
@@ -1,14 +1,15 @@
-//! B1 T1.3 + T1.7 source-inspection guards for the cooperative scan producers.
+//! B1 T1.3 + T1.5 + T1.7 source-inspection guards for the scan/scheduler seam.
 //!
-//! Every `store.rs` scan producer submitted to the bounded scheduler pool via
-//! `SchedPool::submit_scan` must:
-//!
-//! * **T1.3** — call `slot.tick()` in its page loop, or a long scan holds its
-//!   pool slot for the whole scan and reintroduces the monopolization B1 fixes.
-//! * **T1.7** — hold **no lock across `slot.tick()`**. `tick()` blocks on a
-//!   fair re-acquire of the pool permit (released only as *other* scans yield),
-//!   so a storage/index lock held across it could deadlock (FM-3/FM-7), mirroring
-//!   the Accord `handlers.rs` "no lock across `.await`" contract.
+//! * **T1.3** — every `submit_scan` scan producer must call `slot.tick()` in its
+//!   page loop, or a long scan holds its pool slot for the whole scan and
+//!   reintroduces the monopolization B1 fixes.
+//! * **T1.5** — the scheduler pool must be used *only* by the `range_iter*` scan
+//!   producers, so a `PartitionKeyLookup` point read never touches the scheduler
+//!   (zero overhead, never queued behind a scan).
+//! * **T1.7** — a producer must hold **no lock across `slot.tick()`**. `tick()`
+//!   blocks on a fair re-acquire of the pool permit (released only as *other*
+//!   scans yield), so a storage/index lock held across it could deadlock
+//!   (FM-3/FM-7), mirroring the Accord `handlers.rs` "no lock across `.await`".
 //!
 //! Static analysis can't see these call/no-call invariants, so this test greps
 //! the source — the same "guard the invariant at the source" pattern as the
@@ -56,6 +57,41 @@ fn every_submit_scan_producer_calls_slot_tick() {
              (T1.3 / FM-2)"
         );
     }
+}
+
+#[test]
+fn scheduler_pool_is_only_used_by_range_scan_producers() {
+    // B1 T1.5 / FM-6 — interactive point-read bypass. Every `global_pool()` call
+    // must live inside a `range_iter*` scan producer. The point-read methods
+    // (`read` / `read_limited_rows` / `read_clustering_row`) therefore never
+    // touch the scheduler, so a `PartitionKeyLookup` has zero scheduler calls and
+    // is never queued behind a full-table scan. This fails if a future edit
+    // routes a point read through the pool.
+    let src = store_src();
+    let mut checked = 0usize;
+    for (idx, _) in src.match_indices("global_pool()") {
+        let name = enclosing_fn_name(&src, idx);
+        assert!(
+            name.contains("range_iter"),
+            "global_pool() is called from `{name}` — only range_iter* scan producers may use \
+             the scheduler pool. A point read must have zero scheduler calls (T1.5 / FM-6)."
+        );
+        checked += 1;
+    }
+    assert!(
+        checked >= 4,
+        "expected >= 4 pool call sites, found {checked}"
+    );
+}
+
+/// Name of the `fn` enclosing byte offset `at` (nearest preceding declaration).
+fn enclosing_fn_name(src: &str, at: usize) -> String {
+    let before = &src[..at];
+    let fn_pos = before.rfind("fn ").expect("call must be inside a fn");
+    before[fn_pos + "fn ".len()..]
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect()
 }
 
 #[test]

--- a/ferrosa-storage/tests/scan_cooperative_yield_guard.rs
+++ b/ferrosa-storage/tests/scan_cooperative_yield_guard.rs
@@ -1,0 +1,38 @@
+//! B1 T1.3 source-inspection guard.
+//!
+//! Every `store.rs` scan producer submitted to the bounded scheduler pool via
+//! `SchedPool::submit_scan` MUST cooperatively yield — i.e. call `slot.tick()`
+//! in its page loop. A producer that omits `tick()` holds its pool slot for the
+//! whole scan and reintroduces the monopolization B1 fixes (a long full-table
+//! scan starving every other scan). Static analysis can't see the call, so this
+//! test greps the source: it fails if any `submit_scan` producer lacks a
+//! `slot.tick()` in its body — the same "guard the invariant at the source"
+//! pattern used for the viz-drain `truncations.push` check.
+
+use std::fs;
+
+#[test]
+fn every_submit_scan_producer_calls_slot_tick() {
+    let src = fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/store.rs"))
+        .expect("read store.rs source");
+
+    let producers: Vec<usize> = src.match_indices("submit_scan(").map(|(i, _)| i).collect();
+    assert!(
+        producers.len() >= 4,
+        "expected >= 4 store.rs scan producers routed through submit_scan, found {} — \
+         did a producer switch back to submit_blocking (no cooperative yield)?",
+        producers.len()
+    );
+
+    // Each producer's body runs from its `submit_scan(` to the next one (or EOF).
+    for (n, &start) in producers.iter().enumerate() {
+        let end = producers.get(n + 1).copied().unwrap_or(src.len());
+        let body = &src[start..end];
+        assert!(
+            body.contains("slot.tick()"),
+            "the submit_scan scan producer starting at byte {start} does not call \
+             slot.tick() in its page loop — a long scan would monopolize the bounded \
+             pool and reintroduce the starvation B1 fixes (T1.3 / FM-2)"
+        );
+    }
+}

--- a/ferrosa-storage/tests/scan_cooperative_yield_guard.rs
+++ b/ferrosa-storage/tests/scan_cooperative_yield_guard.rs
@@ -1,38 +1,77 @@
-//! B1 T1.3 source-inspection guard.
+//! B1 T1.3 + T1.7 source-inspection guards for the cooperative scan producers.
 //!
 //! Every `store.rs` scan producer submitted to the bounded scheduler pool via
-//! `SchedPool::submit_scan` MUST cooperatively yield — i.e. call `slot.tick()`
-//! in its page loop. A producer that omits `tick()` holds its pool slot for the
-//! whole scan and reintroduces the monopolization B1 fixes (a long full-table
-//! scan starving every other scan). Static analysis can't see the call, so this
-//! test greps the source: it fails if any `submit_scan` producer lacks a
-//! `slot.tick()` in its body — the same "guard the invariant at the source"
-//! pattern used for the viz-drain `truncations.push` check.
+//! `SchedPool::submit_scan` must:
+//!
+//! * **T1.3** — call `slot.tick()` in its page loop, or a long scan holds its
+//!   pool slot for the whole scan and reintroduces the monopolization B1 fixes.
+//! * **T1.7** — hold **no lock across `slot.tick()`**. `tick()` blocks on a
+//!   fair re-acquire of the pool permit (released only as *other* scans yield),
+//!   so a storage/index lock held across it could deadlock (FM-3/FM-7), mirroring
+//!   the Accord `handlers.rs` "no lock across `.await`" contract.
+//!
+//! Static analysis can't see these call/no-call invariants, so this test greps
+//! the source — the same "guard the invariant at the source" pattern as the
+//! viz-drain `truncations.push` check. It fails the build (not production) if a
+//! future producer forgets to yield or holds a lock across the yield.
 
 use std::fs;
 
+/// Extract each `submit_scan` producer's closure body — from `submit_scan(` up
+/// to the `Box::pin(futures::stream::unfold` stream return that immediately
+/// follows every producer's closure. Bounds the body precisely so post-closure
+/// code isn't mis-attributed.
+fn producer_bodies(src: &str) -> Vec<&str> {
+    src.match_indices("submit_scan(")
+        .map(|(start, _)| {
+            let rest = &src[start..];
+            let end = rest
+                .find("Box::pin(futures::stream::unfold")
+                .unwrap_or(rest.len());
+            &rest[..end]
+        })
+        .collect()
+}
+
+fn store_src() -> String {
+    fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/store.rs"))
+        .expect("read store.rs source")
+}
+
 #[test]
 fn every_submit_scan_producer_calls_slot_tick() {
-    let src = fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/store.rs"))
-        .expect("read store.rs source");
-
-    let producers: Vec<usize> = src.match_indices("submit_scan(").map(|(i, _)| i).collect();
+    let src = store_src();
+    let bodies = producer_bodies(&src);
     assert!(
-        producers.len() >= 4,
+        bodies.len() >= 4,
         "expected >= 4 store.rs scan producers routed through submit_scan, found {} — \
          did a producer switch back to submit_blocking (no cooperative yield)?",
-        producers.len()
+        bodies.len()
     );
-
-    // Each producer's body runs from its `submit_scan(` to the next one (or EOF).
-    for (n, &start) in producers.iter().enumerate() {
-        let end = producers.get(n + 1).copied().unwrap_or(src.len());
-        let body = &src[start..end];
+    for (n, body) in bodies.iter().enumerate() {
         assert!(
             body.contains("slot.tick()"),
-            "the submit_scan scan producer starting at byte {start} does not call \
-             slot.tick() in its page loop — a long scan would monopolize the bounded \
-             pool and reintroduce the starvation B1 fixes (T1.3 / FM-2)"
+            "submit_scan producer #{n} does not call slot.tick() in its page loop — a long \
+             scan would monopolize the bounded pool and reintroduce the starvation B1 fixes \
+             (T1.3 / FM-2)"
+        );
+    }
+}
+
+#[test]
+fn no_lock_held_across_the_cooperative_yield() {
+    let src = store_src();
+    for (n, body) in producer_bodies(&src).iter().enumerate() {
+        // `.lock()` is the clear mutex-guard signal. `tick()` blocks on a fair
+        // permit re-acquire, so a guard live across it risks deadlock (T1.7).
+        // The producers deliberately use arc-swap `load_full()` (owned Arcs), so
+        // no guard is held; this fails if a future edit introduces one.
+        assert!(
+            !body.contains(".lock()"),
+            "submit_scan producer #{n} acquires a `.lock()` guard inside the scan closure — \
+             a lock held across slot.tick()'s blocking permit re-acquire can deadlock \
+             (T1.7 / FM-3/FM-7). Load shared state via arc-swap (`load_full()`) instead, or \
+             scope the guard so it is dropped before the page loop."
         );
     }
 }


### PR DESCRIPTION
**Stacked on #286 (B0).** Merge #286 first; this rebases onto main after.

## What & why

B0 (#286) stops full-table scans from *starving consensus* (bounded pool). B1 makes concurrent scans share that pool **fairly** — no single full-table scan monopolizes the slots — via CFS-inspired virtual-runtime scheduling.

## Landed so far

- **T1.1 — `RunQueue` + `min_vruntime` floor** (`ferrosa-sched/src/runqueue.rs`): pick-min (FIFO among ties), enqueue clamps a waking unit up to `min_vruntime - boost` (bounded sleeper credit), monotonic floor. `weight_for_class` (Foreground 1024 / Bulk 256).
- **T1.2 core — `Scheduler` + real `SchedTicket`** (`ferrosa-sched/src/scheduler.rs`): `advance_vruntime` (service charged inversely to weight, saturating), `should_switch` (yield only for a strictly-more-deserving waiter — no thrash), and `SchedTicket::reschedule`/`yield_back` driven per chunk. Lock held only for O(log n) queue ops, never across service/await (T1.7 contract).
- **Tests (21):** pick-min/clamp/monotonic floor; accounting + switch decision; two equal-weight scans interleave within `diff ≤ 2` over 1000 pages; Foreground gets ~4:1 service over Bulk; and the **MockStorage** harness — 3 concurrent scans on a single slot interleave (no >2 consecutive chunks while contended) and all complete.

## Coming in this PR

- **T1.4** ScanPlan classifier (point→Foreground, FullScan/ALLOW FILTERING→Bulk) at the `ferrosa-cql` router/planner seam.
- **T1.2 integration** — thread `pick_ticket`/`reschedule`/`yield_back` through the 4 `store.rs` `range_iter*` producers (release + fair re-acquire per chunk). The hot-path restructure; done with care (T1.7 no-lock audit guards deadlock).
- T1.3 chunk-budget tripwire ★, T1.5 interactive bypass, T1.6 fairness proptests, T1.7 no-lock audit.

Note: the `POLL_INTERVAL` doc-fix commit is a cherry-pick of #286's fix and is a no-op against this PR's base.