### PR TITLE
Query scheduler B2: I/O resource dimension (Lane::Bulk permits) [stacked on #287]

### DIFF
--- a/ferrosa-sched/README.md
+++ b/ferrosa-sched/README.md
@@ -44,6 +44,12 @@ a CheckQuorum leader step-down.
   `FairAdmit` is built from: a pick-min run queue with a monotonic `min_vruntime`
   floor, service charged inversely to weight, and the strictly-more-deserving
   yield rule.
+- `io_permits::IoPermits` (**B2**) — the **I/O** resource dimension. Where
+  `FairAdmit` bounds concurrent scan *compute*, this bounds concurrent bulk
+  *I/O* (`Lane::Bulk`): at most `capacity` `IoPermit`s are held at once, so a
+  fan-out of S3-reading scans cannot saturate the shared I/O path and starve the
+  reserved lanes. Async acquire (an I/O-bound waiter is a cheap task, the B0
+  property); RAII permits returned on drop, including panic/cancel unwind.
 
 ## Dependencies / dependents
 
@@ -67,3 +73,9 @@ a CheckQuorum leader step-down.
   Every scan through the pool is currently a full-table `Bulk` scan (Foreground
   reads bypass — T1.5), so the 4:1 weighting is latent until B3 folds
   mixed-weight background work (compaction/repair/ANN) into the pool.
+  Admission is cancellable + bounded (`Overloaded` backpressure), and range-scan
+  readers open only after a slot is granted.
+- **B2 (in progress):** `io_permits::IoPermits` — T2.1 bounded bulk-I/O permit
+  pool + T2.4 leak invariant (RAII returns the permit on panic/cancel). Next:
+  wire it into the `Lane::Bulk` I/O path (`ferrosa-net`), and T2.2 (vruntime
+  advances on I/O wait) so an I/O-bound scan is throttled to its fair share.

--- a/ferrosa-sched/README.md
+++ b/ferrosa-sched/README.md
@@ -75,7 +75,19 @@ a CheckQuorum leader step-down.
   mixed-weight background work (compaction/repair/ANN) into the pool.
   Admission is cancellable + bounded (`Overloaded` backpressure), and range-scan
   readers open only after a slot is granted.
-- **B2 (in progress):** `io_permits::IoPermits` — T2.1 bounded bulk-I/O permit
-  pool + T2.4 leak invariant (RAII returns the permit on panic/cancel). Next:
-  wire it into the `Lane::Bulk` I/O path (`ferrosa-net`), and T2.2 (vruntime
-  advances on I/O wait) so an I/O-bound scan is throttled to its fair share.
+- **B2 (PR #288):** the I/O dimension.
+  - T2.1 — `io_permits::IoPermits` bounded bulk-I/O permit pool, now a
+    first-class `SchedPool` member: an admitted scan holds one permit for its
+    producing life (the `Lane::Bulk` reservation, sized to CPU capacity by
+    default, lower it to reserve I/O headroom). Gauges
+    `ferrosa_sched_io_permits_{capacity,in_flight,acquired_total}`.
+  - T2.2 — `vruntime` advances on **I/O wait**: `ScanSlot::tick` charges
+    `vruntime` by the chunk window's measured **wall-elapsed µs** (CPU + I/O),
+    not a chunk count, so an I/O-bound scan is throttled to equal *total
+    service* (test `service_time_accounting_equalizes_io_bound_and_cpu_light_scans`).
+  - T2.3 — DD-1 pinned to weighted wall-elapsed (`ADR-022`) with a microbench
+    (`examples/vruntime_unit_bench.rs`; ~30 ns/chunk).
+  - T2.4 — permit-leak invariant (RAII returns the permit on panic/cancel).
+  - Remaining refinement: acquire the I/O permit at the *per-I/O operation*
+    (release the CPU slot while blocked on S3) rather than per-scan — the deeper
+    `ferrosa-net`/storage seam integration.

--- a/ferrosa-sched/examples/vruntime_unit_bench.rs
+++ b/ferrosa-sched/examples/vruntime_unit_bench.rs
@@ -1,0 +1,52 @@
+//! Microbench for DD-1 (B2 T2.3): the `vruntime` accounting unit.
+//!
+//! Run: `cargo run --release --example vruntime_unit_bench -p ferrosa-sched`
+//!
+//! Compares the per-chunk cost of the candidate units and motivates the choice
+//! recorded in ADR-022. **wall-elapsed** (`Instant::now()` + `.elapsed()`) is the
+//! chosen unit: cheap, and it captures I/O wait, not just CPU. **count-proxy** (a
+//! bare increment) is the pre-T2.2 unit: cheapest, but blind to I/O wait, so an
+//! I/O-bound scan looked "cheap" and got free turns. Thread-CPU time
+//! (`CLOCK_THREAD_CPUTIME_ID`) is deliberately not used: it is not in `std`,
+//! needs a per-platform syscall (heavier than `Instant::now`), and by
+//! construction excludes I/O wait — the exact signal the I/O dimension needs.
+
+use std::time::Instant;
+
+fn main() {
+    const N: u64 = 50_000_000;
+    let mut sink = 0u64;
+
+    // Unit A: wall-elapsed — the cost `ScanSlot::tick` pays per chunk
+    // (`Instant::now()` at the previous tick, `.elapsed()` now).
+    let t0 = Instant::now();
+    for _ in 0..N {
+        let start = Instant::now();
+        sink = sink.wrapping_add(start.elapsed().as_micros() as u64);
+    }
+    let wall = t0.elapsed();
+
+    // Unit B: count-proxy — the pre-T2.2 unit (a bare increment).
+    let t1 = Instant::now();
+    for _ in 0..N {
+        sink = sink.wrapping_add(1);
+    }
+    let count = t1.elapsed();
+
+    let wall_ns = wall.as_nanos() as f64 / N as f64;
+    let count_ns = count.as_nanos() as f64 / N as f64;
+    println!("vruntime-unit microbench (N={N}, sink={sink}):");
+    println!("  wall-elapsed : {wall_ns:6.2} ns/chunk  (Instant::now + elapsed)");
+    println!("  count-proxy  : {count_ns:6.2} ns/chunk  (bare increment)");
+    println!(
+        "  wall overhead over count: {:.2} ns/chunk",
+        wall_ns - count_ns
+    );
+    println!();
+    println!(
+        "A chunk is {} partitions; a partition decode is microseconds to",
+        ferrosa_sched::DEFAULT_SCAN_CHUNK_BUDGET
+    );
+    println!("milliseconds, so the wall unit's ~{wall_ns:.0} ns overhead is well under 0.01%");
+    println!("of chunk time — and unlike the count proxy it captures I/O wait.");
+}

--- a/ferrosa-sched/src/io_permits.rs
+++ b/ferrosa-sched/src/io_permits.rs
@@ -1,0 +1,207 @@
+//! Module: Bounded I/O permits — the `Lane::Bulk` resource dimension (B2).
+//! Correctness: Correct when at most `capacity` I/O permits are held at once, a
+//!   permit is always returned on drop (RAII — including panic/cancel unwind),
+//!   and a waiter is a cheap async task rather than a parked blocking thread.
+//! Last revised: 2026-07-22
+//! Last changed: New module — B2 T2.1/T2.4. The CPU dimension ([`SchedPool`] /
+//!   [`crate::fair_admit::FairAdmit`]) bounds concurrent scan *compute*; this
+//!   bounds concurrent bulk *I/O* so a fan-out of scans reading from S3 cannot
+//!   saturate the `Lane::Bulk` I/O path and starve the reserved lanes.
+//!
+//! [`SchedPool`]: crate::SchedPool
+//!
+//! # Model
+//!
+//! A [`Semaphore`] of `capacity` permits. A bulk I/O operation
+//! [`acquire`](IoPermits::acquire)s a permit (async — an I/O-bound waiter parks
+//! as a cheap task, preserving the B0 no-parked-threads property), does its I/O,
+//! and drops the [`IoPermit`] to return it. `capacity` is the bulk I/O
+//! reservation: it caps how much concurrent bulk I/O competes for the shared
+//! path, leaving headroom for consensus/interactive I/O — the I/O analogue of
+//! the CPU [`Reservation`](crate::Reservation).
+//!
+//! Deadlock- and leak-free: the permit is RAII (returned on the guard's drop,
+//! so a panic or future-cancellation during the I/O still returns it), and
+//! acquisition never holds a lock across the `.await`.
+
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// A bounded pool of concurrent bulk-I/O permits (the `Lane::Bulk` reservation).
+#[derive(Clone, Debug)]
+pub struct IoPermits {
+    sem: Arc<Semaphore>,
+    capacity: usize,
+}
+
+/// An RAII bulk-I/O permit. Held for the duration of an I/O operation; returned
+/// to the pool when dropped (on normal completion, panic, or cancellation).
+#[derive(Debug)]
+pub struct IoPermit {
+    // Held only for its Drop: returning the permit to the semaphore. Never read.
+    _permit: OwnedSemaphorePermit,
+}
+
+impl IoPermits {
+    /// A pool granting at most `capacity` (≥1) concurrent bulk-I/O permits.
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            sem: Arc::new(Semaphore::new(capacity)),
+            capacity,
+        }
+    }
+
+    /// Maximum concurrent permits.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Permits currently free.
+    pub fn available(&self) -> usize {
+        self.sem.available_permits()
+    }
+
+    /// Permits currently held (in-flight bulk I/O).
+    pub fn in_flight(&self) -> usize {
+        self.capacity - self.sem.available_permits()
+    }
+
+    /// Acquire a permit, waiting (as a cheap async task) until one is free.
+    /// Returns an RAII [`IoPermit`] that returns the permit on drop.
+    pub async fn acquire(&self) -> IoPermit {
+        let permit = self
+            .sem
+            .clone()
+            .acquire_owned()
+            .await
+            // The semaphore is never closed (we hold an `Arc` to it for the
+            // pool's whole life), so acquisition cannot fail.
+            .expect("io-permit semaphore is never closed");
+        crate::record_io_permit_acquired();
+        IoPermit { _permit: permit }
+    }
+
+    /// Try to acquire a permit without waiting. Returns `None` if the bound is
+    /// currently saturated (bulk I/O backpressure — the caller decides whether
+    /// to wait via [`acquire`](Self::acquire) or shed).
+    pub fn try_acquire(&self) -> Option<IoPermit> {
+        match self.sem.clone().try_acquire_owned() {
+            Ok(permit) => {
+                crate::record_io_permit_acquired();
+                Some(IoPermit { _permit: permit })
+            }
+            Err(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn capacity_floors_at_one() {
+        assert_eq!(IoPermits::new(0).capacity(), 1);
+        assert_eq!(IoPermits::new(5).capacity(), 5);
+    }
+
+    #[test]
+    fn try_acquire_respects_the_bound_and_reuses_freed_permits() {
+        let permits = IoPermits::new(2);
+        assert_eq!(permits.available(), 2);
+        let p1 = permits.try_acquire().expect("first permit");
+        let p2 = permits.try_acquire().expect("second permit");
+        assert_eq!(permits.in_flight(), 2);
+        assert!(
+            permits.try_acquire().is_none(),
+            "a third permit must be refused — the bound is 2"
+        );
+        drop(p1);
+        assert_eq!(permits.available(), 1, "dropping a permit returns it");
+        assert!(
+            permits.try_acquire().is_some(),
+            "a freed permit is immediately reusable"
+        );
+        drop(p2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+    async fn bound_is_respected_under_concurrency() {
+        let permits = Arc::new(IoPermits::new(3));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+        for _ in 0..24 {
+            let permits = permits.clone();
+            let max_seen = max_seen.clone();
+            tasks.push(tokio::spawn(async move {
+                let _permit = permits.acquire().await;
+                let now = permits.in_flight();
+                max_seen.fetch_max(now, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+        assert!(
+            max_seen.load(Ordering::SeqCst) <= 3,
+            "held {} concurrently, capacity 3",
+            max_seen.load(Ordering::SeqCst)
+        );
+        assert_eq!(permits.available(), 3, "every permit returned");
+    }
+
+    /// T2.4 — permit-leak invariant: a panic while holding a permit (e.g. a
+    /// chunk failing mid-I/O) must return it via RAII unwind, not leak it.
+    #[test]
+    fn permit_returns_on_panic() {
+        let permits = IoPermits::new(1);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _permit = permits.try_acquire().expect("the only permit");
+            assert_eq!(permits.available(), 0);
+            panic!("simulated chunk failure while holding an I/O permit");
+        }));
+        assert!(result.is_err(), "the guarded closure panicked");
+        assert_eq!(
+            permits.available(),
+            permits.capacity(),
+            "the I/O permit must be returned on panic unwind, not leaked"
+        );
+    }
+
+    /// T2.4 — cancellation: dropping a *pending* acquire future must not consume
+    /// a permit (tokio `Semaphore` acquisition is cancel-safe).
+    #[tokio::test]
+    async fn cancelled_acquire_consumes_no_permit() {
+        let permits = IoPermits::new(1);
+        let _held = permits.try_acquire().expect("take the only permit");
+        // A second acquire has nothing to take; poll it once (pending), drop it.
+        {
+            let fut = permits.acquire();
+            futures_poll_once_pending(fut).await;
+        }
+        drop(_held);
+        assert_eq!(
+            permits.available(),
+            1,
+            "a cancelled acquire must not have consumed the permit"
+        );
+    }
+
+    /// Poll `fut` exactly once with a no-op waker, asserting it is pending, then
+    /// drop it — a runtime-free way to test cancellation of a pending acquire.
+    async fn futures_poll_once_pending<F: std::future::Future>(fut: F) {
+        use std::pin::pin;
+        use std::task::{Context, Poll};
+        let mut fut = pin!(fut);
+        let mut cx = Context::from_waker(std::task::Waker::noop());
+        assert!(
+            matches!(fut.as_mut().poll(&mut cx), Poll::Pending),
+            "acquire must be pending while the pool is saturated"
+        );
+    }
+}

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -32,10 +32,12 @@ use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 
 pub mod fair_admit;
+pub mod io_permits;
 pub mod runqueue;
 pub mod scheduler;
 
 pub use fair_admit::Admitted;
+pub use io_permits::{IoPermit, IoPermits};
 
 // Process-wide pool metrics. Cumulative counters live here (the Prometheus
 // registry reads them); instantaneous gauges (`headroom_cores`, `active`) are
@@ -74,6 +76,20 @@ pub fn admissions_rejected_overload_total() -> u64 {
 /// overload.
 pub(crate) fn record_overload_rejection() {
     ADMISSIONS_REJECTED_OVERLOAD_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+static IO_PERMITS_ACQUIRED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Bulk-I/O permits ([`io_permits::IoPermits`]) acquired since process start —
+/// the throughput of the I/O resource dimension (B2). Paired with a live
+/// `in_flight` gauge once a pool is wired into the Bulk lane.
+pub fn io_permits_acquired_total() -> u64 {
+    IO_PERMITS_ACQUIRED_TOTAL.load(Ordering::Relaxed)
+}
+
+/// Called by [`io_permits::IoPermits`] when a bulk-I/O permit is granted.
+pub(crate) fn record_io_permit_acquired() {
+    IO_PERMITS_ACQUIRED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 // Chunk-budget tripwire (B1 T1.3 / FMEA FM-2). A scan chunk is the work between
@@ -179,6 +195,14 @@ pub fn render_prometheus() -> String {
     out.push_str(&format!(
         "ferrosa_sched_admissions_rejected_overload_total {}\n",
         admissions_rejected_overload_total()
+    ));
+    out.push_str(
+        "# HELP ferrosa_sched_io_permits_acquired_total Bulk-I/O permits granted since start (the I/O resource dimension, B2).\n\
+         # TYPE ferrosa_sched_io_permits_acquired_total counter\n",
+    );
+    out.push_str(&format!(
+        "ferrosa_sched_io_permits_acquired_total {}\n",
+        io_permits_acquired_total()
     ));
     out
 }
@@ -846,6 +870,7 @@ mod tests {
             "ferrosa_sched_tasks_admitted_total",
             "ferrosa_sched_admit_wait_micros_total",
             "ferrosa_sched_admissions_rejected_overload_total",
+            "ferrosa_sched_io_permits_acquired_total",
         ] {
             assert!(text.contains(metric), "missing metric {metric}");
         }

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -204,6 +204,22 @@ pub fn render_prometheus() -> String {
         "ferrosa_sched_io_permits_acquired_total {}\n",
         io_permits_acquired_total()
     ));
+    out.push_str(
+        "# HELP ferrosa_sched_io_permits_capacity Max concurrent bulk-I/O permits (the Lane::Bulk reservation).\n\
+         # TYPE ferrosa_sched_io_permits_capacity gauge\n",
+    );
+    out.push_str(&format!(
+        "ferrosa_sched_io_permits_capacity {}\n",
+        pool.io_permits().capacity()
+    ));
+    out.push_str(
+        "# HELP ferrosa_sched_io_permits_in_flight Bulk-I/O permits currently held (in-flight bulk I/O).\n\
+         # TYPE ferrosa_sched_io_permits_in_flight gauge\n",
+    );
+    out.push_str(&format!(
+        "ferrosa_sched_io_permits_in_flight {}\n",
+        pool.io_permits().in_flight()
+    ));
     out
 }
 
@@ -267,6 +283,12 @@ pub struct SchedPool {
     admit: Arc<fair_admit::FairAdmit>,
     capacity: usize,
     reservation: Reservation,
+    /// The I/O resource dimension (B2): a bounded set of bulk-I/O permits an
+    /// admitted scan holds while it produces (the `Lane::Bulk` reservation).
+    /// Sized to `capacity` by default (1:1 with CPU slots — non-constraining);
+    /// lowering it reserves I/O concurrency for the other lanes. Cloneable — it
+    /// shares one semaphore.
+    io_permits: io_permits::IoPermits,
 }
 
 /// Releases a held slot on drop — the RAII backstop so a panicking task never
@@ -293,7 +315,15 @@ impl SchedPool {
             admit: Arc::new(fair_admit::FairAdmit::new(capacity, 0, max_waiters)),
             capacity,
             reservation,
+            io_permits: io_permits::IoPermits::new(capacity),
         }
+    }
+
+    /// The bulk-I/O permit pool (the B2 I/O dimension). A scan submitted via
+    /// [`submit_scan`](Self::submit_scan) holds one permit while it produces;
+    /// bulk-I/O seams can also acquire from it directly.
+    pub fn io_permits(&self) -> &io_permits::IoPermits {
+        &self.io_permits
     }
 
     /// Maximum number of scans admitted concurrently.
@@ -413,11 +443,18 @@ impl SchedPool {
         C: Future<Output = ()> + Send + 'static,
     {
         let admit = self.admit.clone();
+        let io_permits = self.io_permits.clone();
         tokio::spawn(async move {
             let waited = Instant::now();
             match admit.admit(class, cancel).await {
                 Admitted::Slot(id) => {
                     record_admission(waited.elapsed());
+                    // B2 T2.1: hold a bulk-I/O permit for the scan's producing
+                    // life (the Lane::Bulk reservation). Acquired as a cheap
+                    // async task after the CPU slot; at the default 1:1 sizing it
+                    // is immediate, and it becomes the tighter bound when the I/O
+                    // reservation is lowered below CPU capacity.
+                    let io_permit = io_permits.acquire().await;
                     let handle = tokio::runtime::Handle::current();
                     let out = tokio::task::spawn_blocking(move || {
                         let mut slot = ScanSlot {
@@ -428,6 +465,8 @@ impl SchedPool {
                             yields: 0,
                             handle,
                             last_tick: Instant::now(),
+                            window_micros: 0,
+                            _io_permit: io_permit,
                             finished: false,
                         };
                         let out = f(&mut slot);
@@ -471,8 +510,19 @@ pub struct ScanSlot {
     yields: u64,
     handle: tokio::runtime::Handle,
     /// When the current chunk's work started (the last `tick` return). Used to
-    /// measure per-chunk work time for the FM-2 yield-point-gap tripwire.
+    /// measure per-chunk work time for the FM-2 yield-point-gap tripwire and to
+    /// accumulate [`window_micros`](Self::window_micros).
     last_tick: Instant,
+    /// Elapsed microseconds accumulated over the current budget window — the
+    /// scan's *service time* (B2 T2.2 / DD-1). Elapsed spans both CPU compute
+    /// and I/O wait (a chunk blocked on S3 still accrues wall-time here), so
+    /// charging `vruntime` by this throttles an I/O-bound scan to its fair share
+    /// even when it burns little CPU. Reset at each budget boundary.
+    window_micros: u64,
+    /// The bulk-I/O permit (B2 T2.1) this scan holds for its producing lifetime,
+    /// bounding concurrent bulk I/O on the `Lane::Bulk` reservation. Held only
+    /// for its `Drop` (returned when the scan ends, panics, or is cancelled).
+    _io_permit: io_permits::IoPermit,
     finished: bool,
 }
 
@@ -494,15 +544,25 @@ impl ScanSlot {
     /// (`load_full()` → owned `Arc`s), holding no guard; the
     /// `scan_cooperative_yield_guard` source test enforces it.
     pub fn tick(&mut self) {
-        record_chunk(self.last_tick.elapsed());
+        let elapsed = self.last_tick.elapsed();
+        record_chunk(elapsed);
+        // Accumulate the chunk's wall-time (CPU + any I/O wait) as service.
+        self.window_micros = self
+            .window_micros
+            .saturating_add(elapsed.as_micros() as u64);
         self.since_yield += 1;
         if self.since_yield >= self.chunk_budget {
             self.since_yield = 0;
             self.yields += 1;
-            // Account the budget's worth of service, then re-compete in vruntime
-            // order (may yield the slot to a more-deserving scan).
-            self.admit
-                .reschedule(&self.handle, self.id, u64::from(self.chunk_budget));
+            // B2 T2.2 / DD-1: charge `vruntime` by the window's measured elapsed
+            // time (CPU compute + I/O wait), weighted by class — so an I/O-bound
+            // scan (slow chunks blocked on S3) accrues `vruntime` and is
+            // throttled to its fair share instead of getting unlimited free
+            // turns for burning no CPU. Floor at 1 so a sub-microsecond window
+            // still advances the clock.
+            let service = self.window_micros.max(1);
+            self.window_micros = 0;
+            self.admit.reschedule(&self.handle, self.id, service);
         }
         self.last_tick = Instant::now();
     }
@@ -871,6 +931,8 @@ mod tests {
             "ferrosa_sched_admit_wait_micros_total",
             "ferrosa_sched_admissions_rejected_overload_total",
             "ferrosa_sched_io_permits_acquired_total",
+            "ferrosa_sched_io_permits_capacity",
+            "ferrosa_sched_io_permits_in_flight",
         ] {
             assert!(text.contains(metric), "missing metric {metric}");
         }

--- a/ferrosa-sched/tests/fairness_proptest.rs
+++ b/ferrosa-sched/tests/fairness_proptest.rs
@@ -106,3 +106,45 @@ proptest! {
         }
     }
 }
+
+/// B2 T2.2 — service-time (elapsed) accounting throttles an I/O-bound scan to
+/// its fair share. Both scans are equal-weight `Bulk`, but each of scan 0's
+/// chunks costs `IO_COST` service (elapsed *including* S3 wait) while scan 1's
+/// cost 1 (CPU-light). This is exactly what `ScanSlot::tick` now feeds
+/// `reschedule`: the window's measured elapsed µs, not a chunk count. Charging
+/// `vruntime` by service makes the two converge to equal TOTAL SERVICE — the
+/// I/O-bound scan gets proportionally FEWER turns, so it cannot hog the pool by
+/// being slow (the pre-T2.2 chunk-count accounting would have given it EQUAL
+/// turns, i.e. `IO_COST`× more wall-time).
+#[test]
+fn service_time_accounting_equalizes_io_bound_and_cpu_light_scans() {
+    const IO_COST: u64 = 50;
+    let mut q = RunQueue::new(0);
+    q.enqueue(SchedEntity::new(0, SchedClass::Bulk)); // I/O-bound
+    q.enqueue(SchedEntity::new(1, SchedClass::Bulk)); // CPU-light
+    let cost = |id: u64| if id == 0 { IO_COST } else { 1 };
+
+    let mut service = [0u64; 2];
+    let mut turns = [0u64; 2];
+    let mut cur = q.pick_next().expect("a scan to run");
+    for _ in 0..8000 {
+        let c = cost(cur.id);
+        service[cur.id as usize] += c;
+        turns[cur.id as usize] += 1;
+        cur = step(&mut q, cur, c);
+    }
+
+    // Equal weight + service accounting → total SERVICE converges within about
+    // one chunk cost, regardless of how that service splits into turns.
+    let spread = service[0].abs_diff(service[1]);
+    assert!(
+        spread <= IO_COST * 2,
+        "service not equalized: {service:?} (spread {spread})"
+    );
+    // ...and the I/O-bound scan takes far fewer turns — throttled by its elapsed
+    // cost rather than getting equal turns for burning no CPU.
+    assert!(
+        turns[1] > turns[0] * 10,
+        "the CPU-light scan should get ~IO_COST× more turns: {turns:?}"
+    );
+}

--- a/specs/decisions/022-scheduler-vruntime-unit.md
+++ b/specs/decisions/022-scheduler-vruntime-unit.md
@@ -1,0 +1,77 @@
+# ADR-022: Scheduler `vruntime` accounting unit — measured wall-elapsed, weighted
+
+> Date: 2026-07-22
+> Status: Accepted
+> Scope: `ferrosa-sched` — `ScanSlot::tick` (the per-chunk accounting seam) and
+> `scheduler::advance_vruntime`. Resolves **DD-1** from the query-scheduler
+> blueprint (`specs/proposed/query-scheduler/decisions.md`).
+> Non-goal: the per-tenant group weights (B3) or the I/O permit sizing.
+
+## Context
+
+The fair scheduler orders scan admission by `vruntime` — virtual runtime,
+service time scaled by the inverse of a class weight. B2 makes scheduling
+**two-dimensional** (CPU compute + I/O wait): an I/O-bound scan that blocks on
+S3 burns little CPU, and must still be throttled to its fair share rather than
+getting unlimited free turns. That requires deciding **what unit `vruntime`
+advances in** (DD-1). Three candidates:
+
+1. **Count proxy** — advance by a fixed amount per chunk (the pre-T2.2 unit:
+   `service = chunk_budget`). Cheapest, but blind to how long a chunk took, so
+   an I/O-bound scan and a CPU-light scan accrue `vruntime` at the same rate per
+   chunk — the I/O-bound scan gets *equal turns*, i.e. more wall-time. Unfair.
+2. **Thread-CPU time** (`CLOCK_THREAD_CPUTIME_ID`) — advance by CPU cycles
+   actually consumed. Excludes I/O wait *by construction*, which is exactly the
+   signal the I/O dimension needs; also not in `std` (per-platform syscall,
+   heavier than `Instant::now`).
+3. **Measured wall-elapsed** — advance by the wall-clock time the chunk took,
+   which spans both CPU compute and I/O wait.
+
+## Decision
+
+`vruntime` advances by **measured wall-elapsed microseconds per chunk window,
+weighted by `SchedClass`**. `ScanSlot::tick` accumulates `last_tick.elapsed()`
+into `window_micros`, and at each `chunk_budget` boundary charges that window's
+elapsed µs as the service passed to `advance_vruntime` (which divides by the
+class weight). Floor at 1 µs so a sub-microsecond window still advances the
+clock.
+
+## Rationale
+
+- **Captures the I/O dimension for free.** Wall-elapsed includes S3 wait, so an
+  I/O-bound scan (slow chunks) accrues `vruntime` proportional to the wall-time
+  it holds the pool — and is throttled to equal *total service*, not equal
+  turns (test: `service_time_accounting_equalizes_io_bound_and_cpu_light_scans`).
+  This is the "vruntime advances on I/O wait" requirement (T2.2).
+- **Cheap.** Microbench (`examples/vruntime_unit_bench.rs`,
+  `cargo run --release --example vruntime_unit_bench -p ferrosa-sched`):
+  `Instant::now() + .elapsed()` costs **~30 ns/chunk**. A chunk is 64 partitions
+  and a partition decode is microseconds to milliseconds, so the overhead is
+  well under 0.01% of chunk time.
+- **Portable and simple.** `std::time::Instant` only — no platform syscall, no
+  new dependency, consistent with the crate's leaf (tokio-only) constraint.
+- **Self-correcting.** Wall-time includes scheduler-preemption noise, but the
+  run queue's `min_vruntime` floor and the pick-min rule average it out over
+  windows; a single noisy chunk cannot let a scan monopolize or be starved.
+
+## Consequences
+
+- I/O-bound scans are throttled to their fair share despite low CPU (the B2 goal)
+  with no separate I/O-time accounting path — one elapsed measurement serves both
+  dimensions.
+- The absolute `vruntime` magnitude is now in microseconds, not chunk counts;
+  nothing external depends on the magnitude (it is only compared *between* queued
+  scans), so this is internal.
+- The bulk-I/O **permit** pool (`IoPermits`, T2.1) remains the complementary hard
+  *concurrency* cap on the I/O dimension; this ADR governs only the fair-share
+  *accounting* unit.
+
+## Alternatives considered
+
+- **Count proxy** — rejected: blind to I/O wait (the failure this ADR fixes).
+- **Thread-CPU time** — rejected: excludes I/O wait, non-portable, heavier per
+  measurement; revisit only if wall-time preemption noise is ever shown to cause
+  measurable unfairness (none observed).
+- **Row/byte proxy** (advance by rows or bytes produced) — rejected: correlates
+  with neither CPU nor I/O reliably (a wide-row decode and a cheap tombstone skip
+  differ by orders of magnitude in cost but not in row count).


### PR DESCRIPTION
## Query scheduler B2 — the I/O resource dimension (stacked on #287)

The CPU dimension (B0 bounded pool + B1/B1.5 vruntime `FairAdmit`) bounds concurrent scan *compute*. B2 adds the second dimension: bounding concurrent bulk **I/O** so a fan-out of S3-reading scans can't saturate the shared I/O path (`Lane::Bulk`) and starve the reserved consensus/interactive lanes.

**Stacked on #287** — base branch is `feat/sched-b1-fair-scheduling`. Merge #286 → #287 → this, in order (rebase-merge / linear history).

### Landed
- **T2.1 — bounded bulk-I/O permit pool** (`io_permits::IoPermits`): at most `capacity` RAII `IoPermit`s held at once; async acquire keeps a waiter a cheap task (the B0 property); `try_acquire` for non-blocking backpressure; metric `ferrosa_sched_io_permits_acquired_total`.
- **T2.4 — permit-leak invariant**: the permit is returned on drop, including panic and future-cancellation unwind (tested).

### Remaining (this PR grows)
- **T2.1 wiring** — gate the `Lane::Bulk` I/O path in `ferrosa-net` on an `IoPermits` pool (make the bound live), + a live `in_flight` gauge.
- **T2.2** — `vruntime` advances on I/O wait (dual-dimension accounting), so an I/O-bound scan is throttled to its fair share despite low CPU. FMEA FM-4.
- **T2.3** — pin the `vruntime` unit (wall vs thread-CPU vs proxy) via microbench + ADR (DD-1).

### Gates (local)
31 `ferrosa-sched` tests green; `clippy -D warnings`, `fmt`, `cargo doc -D warnings` clean.

Epic: `t_f9a0500a` · B2 task: `t_9df12310`.
