### PR TITLE
Query scheduler B3: tenant groups + background unification [stacked on #288]

### DIFF
--- a/ferrosa-sched/README.md
+++ b/ferrosa-sched/README.md
@@ -102,8 +102,14 @@ a CheckQuorum leader step-down.
   (group→query) fair queue with the T3.9 anti-gaming property (1 tenant × 100
   queries == 1 tenant × 1 query) and a T3.2 weight preview (share ∝ weight),
   plus an `advance_vruntime` floor so a high-weight group can't monopolize via
-  integer-division rounding. T3.8 (bounded runqueue + `Overloaded`) already
-  shipped in B1.5. Next: make it live in `FairAdmit` (thread the tenant group
-  through `submit_scan`), per-tenant weights from TOML (T3.2), and fold the
-  background work — compaction/repair/index-build/ANN — into the pool as the
-  `system` group (T3.3–T3.6), where the weighting finally arbitrates.
+  integer-division rounding. **Now LIVE in `FairAdmit`**: admission uses the
+  two-level queue (`admit(group, group_weight, class, cancel)`), charging the
+  group on each `reschedule` and yielding on a lexicographic `(group_vruntime,
+  query_vruntime)` compare — cross-tenant fairness proven end-to-end
+  (`tenants_get_equal_share_regardless_of_query_count`). All current pool work
+  runs in one `DEFAULT_TENANT_GROUP` (behavior-preserving); T3.8 (bounded
+  runqueue + `Overloaded`) already shipped in B1.5. Next: per-tenant weights
+  from TOML (T3.2), thread real `TenantContext` → group through the read path,
+  and fold background work — compaction/repair/index-build/ANN — into the pool
+  as the `system` group (T3.3–T3.6), where the weighting finally arbitrates
+  real mixed-weight contention.

--- a/ferrosa-sched/README.md
+++ b/ferrosa-sched/README.md
@@ -44,6 +44,13 @@ a CheckQuorum leader step-down.
   `FairAdmit` is built from: a pick-min run queue with a monotonic `min_vruntime`
   floor, service charged inversely to weight, and the strictly-more-deserving
   yield rule.
+- `group_runqueue::GroupRunQueue` (**B3**) — the **hierarchical** (per-tenant)
+  dimension. A two-level fair queue: the outer level schedules groups (tenants)
+  by group `vruntime`, the inner level schedules a group's queries (a nested
+  `RunQueue`). A group's `vruntime` advances by the service of *any* of its
+  queries, so a tenant's aggregate share is independent of how many queries it
+  runs (`GroupId` is an opaque `u64` — the caller maps `TenantContext` → id,
+  keeping the crate leaf).
 - `io_permits::IoPermits` (**B2**) — the **I/O** resource dimension. Where
   `FairAdmit` bounds concurrent scan *compute*, this bounds concurrent bulk
   *I/O* (`Lane::Bulk`): at most `capacity` `IoPermit`s are held at once, so a
@@ -91,3 +98,12 @@ a CheckQuorum leader step-down.
   - Remaining refinement: acquire the I/O permit at the *per-I/O operation*
     (release the CPU slot while blocked on S3) rather than per-scan — the deeper
     `ferrosa-net`/storage seam integration.
+- **B3 (in progress):** `group_runqueue::GroupRunQueue` — T3.1 two-level
+  (group→query) fair queue with the T3.9 anti-gaming property (1 tenant × 100
+  queries == 1 tenant × 1 query) and a T3.2 weight preview (share ∝ weight),
+  plus an `advance_vruntime` floor so a high-weight group can't monopolize via
+  integer-division rounding. T3.8 (bounded runqueue + `Overloaded`) already
+  shipped in B1.5. Next: make it live in `FairAdmit` (thread the tenant group
+  through `submit_scan`), per-tenant weights from TOML (T3.2), and fold the
+  background work — compaction/repair/index-build/ANN — into the pool as the
+  `system` group (T3.3–T3.6), where the weighting finally arbitrates.

--- a/ferrosa-sched/src/fair_admit.rs
+++ b/ferrosa-sched/src/fair_admit.rs
@@ -31,7 +31,8 @@ use std::sync::{Arc, Mutex};
 
 use tokio::sync::Notify;
 
-use crate::runqueue::{RunQueue, SchedEntity};
+use crate::group_runqueue::{GroupId, GroupRunQueue};
+use crate::runqueue::SchedEntity;
 use crate::scheduler::advance_vruntime;
 use crate::SchedClass;
 
@@ -55,10 +56,14 @@ pub enum Admitted {
 struct State {
     /// Free slots (starts at `capacity`).
     free: usize,
-    /// Scans waiting for a slot, ordered by `vruntime`.
-    queue: RunQueue,
-    /// Scans currently holding a slot: id → its live scheduling state.
-    running: HashMap<u64, SchedEntity>,
+    /// Scans waiting for a slot, ordered by (group `vruntime`, query `vruntime`)
+    /// — the two-level hierarchical queue (B3), so scheduling is fair between
+    /// tenants (groups) as well as between a tenant's queries.
+    queue: GroupRunQueue,
+    /// Scans currently holding a slot: id → (group, group weight, live
+    /// scheduling state). The group + weight are kept so a yielding scan
+    /// re-enters its own group.
+    running: HashMap<u64, (GroupId, u32, SchedEntity)>,
     /// Per-waiter wakeups, keyed by scan id.
     waiters: HashMap<u64, Arc<Notify>>,
     next_id: u64,
@@ -106,13 +111,13 @@ impl FairAdmit {
     /// A pool granting at most `capacity` (≥1) concurrent slots, admitting up to
     /// `max_waiters` (≥1) scans to *wait* before rejecting further requests with
     /// [`Admitted::Overloaded`]; waking scans get `boost` sleeper credit (see
-    /// [`RunQueue::new`]).
+    /// [`GroupRunQueue::new`]).
     pub fn new(capacity: usize, boost: u64, max_waiters: usize) -> Self {
         let capacity = capacity.max(1);
         Self {
             state: Mutex::new(State {
                 free: capacity,
-                queue: RunQueue::new(boost),
+                queue: GroupRunQueue::new(boost),
                 running: HashMap::new(),
                 waiters: HashMap::new(),
                 next_id: 0,
@@ -147,8 +152,16 @@ impl FairAdmit {
     ///   occupies a slot just to discover the closed channel.
     ///
     /// Pass [`std::future::pending()`] for `cancel` when the caller has no
-    /// cancellation signal.
-    pub async fn admit(&self, class: SchedClass, cancel: impl Future<Output = ()>) -> Admitted {
+    /// cancellation signal. `group` (weighted by `group_weight`) is the tenant
+    /// the scan belongs to — admission is fair *between* groups as well as within
+    /// them (B3).
+    pub async fn admit(
+        &self,
+        group: GroupId,
+        group_weight: u32,
+        class: SchedClass,
+        cancel: impl Future<Output = ()>,
+    ) -> Admitted {
         let (id, notify) = {
             let mut s = self.state.lock().expect("fair-admit poisoned");
             // Backpressure: no free slot and the waiter queue is full → reject
@@ -161,7 +174,8 @@ impl FairAdmit {
             }
             let id = s.next_id;
             s.next_id += 1;
-            s.queue.enqueue(SchedEntity::new(id, class));
+            s.queue
+                .enqueue(group, group_weight, SchedEntity::new(id, class));
             let notify = Arc::new(Notify::new());
             s.waiters.insert(id, notify.clone());
             self.dispatch(&mut s);
@@ -221,21 +235,28 @@ impl FairAdmit {
     pub fn reschedule(&self, handle: &tokio::runtime::Handle, id: u64, service: u64) {
         let notify = {
             let mut s = self.state.lock().expect("fair-admit poisoned");
-            let mut entity = match s.running.remove(&id) {
-                Some(e) => e,
+            let (group, weight, mut entity) = match s.running.remove(&id) {
+                Some(x) => x,
                 None => return, // not currently granted — nothing to do
             };
             entity.vruntime = advance_vruntime(entity.vruntime, service, entity.weight);
-            // Keep the slot unless a strictly-more-deserving scan waits.
-            let should_yield =
-                crate::scheduler::should_switch(entity.vruntime, s.queue.peek_min_vruntime());
+            // Charge the group too, so its aggregate share reflects all its
+            // queries' service (B3 group fairness).
+            s.queue.charge(group, service);
+            // Yield only if a strictly-more-deserving scan waits, compared
+            // lexicographically (group `vruntime`, then query `vruntime`): same
+            // group → the query comparison decides (within-tenant fairness);
+            // different group → the group dominates (cross-tenant fairness).
+            let group_vruntime = s.queue.group_vruntime(group).unwrap_or(entity.vruntime);
+            let running_key = (group_vruntime, entity.vruntime);
+            let should_yield = s.queue.peek_min().is_some_and(|min| min < running_key);
             if !should_yield {
-                s.running.insert(id, entity);
+                s.running.insert(id, (group, weight, entity));
                 return;
             }
-            // Yield: release the slot and re-compete.
+            // Yield: release the slot and re-compete within its group.
             s.free += 1;
-            s.queue.enqueue(entity);
+            s.queue.enqueue(group, weight, entity);
             let notify = Arc::new(Notify::new());
             s.waiters.insert(id, notify.clone());
             self.dispatch(&mut s);
@@ -266,14 +287,16 @@ impl FairAdmit {
         self.dispatch(&mut s);
     }
 
-    /// Grant every free slot to the least-`vruntime` waiter and wake it.
+    /// Grant every free slot to the most-deserving waiter (least-`vruntime`
+    /// query of the least-`vruntime` group) and wake it.
     fn dispatch(&self, s: &mut State) {
         while s.free > 0 {
             match s.queue.pick_next() {
-                Some(entity) => {
-                    let id = entity.id;
+                Some(picked) => {
+                    let id = picked.entity.id;
                     s.free -= 1;
-                    s.running.insert(id, entity);
+                    s.running
+                        .insert(id, (picked.group, picked.group_weight, picked.entity));
                     if let Some(n) = s.waiters.get(&id) {
                         n.notify_one();
                     }
@@ -294,6 +317,11 @@ mod tests {
 
     use super::*;
 
+    /// A single test tenant group (equal weight) — most tests exercise one group,
+    /// so the class weighting and cancellation logic show without group effects.
+    const G: GroupId = 7;
+    const GW: u32 = crate::group_runqueue::DEFAULT_GROUP_WEIGHT;
+
     /// Unwrap a granted slot or fail the test loudly.
     fn slot(outcome: Admitted) -> u64 {
         match outcome {
@@ -313,7 +341,7 @@ mod tests {
             tasks.push(tokio::spawn(async move {
                 let id = slot(
                     admit
-                        .admit(SchedClass::Bulk, std::future::pending::<()>())
+                        .admit(G, GW, SchedClass::Bulk, std::future::pending::<()>())
                         .await,
                 );
                 let now = admit.active();
@@ -353,7 +381,8 @@ mod tests {
             let ran = ran.clone();
             let served = served.clone();
             tokio::task::spawn_blocking(move || {
-                let id = slot(handle.block_on(admit.admit(class, std::future::pending::<()>())));
+                let id =
+                    slot(handle.block_on(admit.admit(G, GW, class, std::future::pending::<()>())));
                 while served.fetch_add(1, Ordering::SeqCst) < BUDGET {
                     *ran.lock().unwrap().entry(tag).or_insert(0) += 1;
                     admit.reschedule(&handle, id, 10);
@@ -386,9 +415,12 @@ mod tests {
             let handle = handle.clone();
             let ran = ran.clone();
             tasks.push(tokio::task::spawn_blocking(move || {
-                let id = slot(
-                    handle.block_on(admit.admit(SchedClass::Bulk, std::future::pending::<()>())),
-                );
+                let id = slot(handle.block_on(admit.admit(
+                    G,
+                    GW,
+                    SchedClass::Bulk,
+                    std::future::pending::<()>(),
+                )));
                 for _ in 0..600 {
                     *ran.lock().unwrap().entry(tag).or_insert(0) += 1;
                     admit.reschedule(&handle, id, 10);
@@ -407,6 +439,54 @@ mod tests {
         assert_eq!(admit.active(), 0);
     }
 
+    /// B3 — cross-tenant fairness through the LIVE admission path. Two tenants
+    /// contend for one slot: group 1 runs three scans, group 2 runs one, at equal
+    /// group weight. They get ~equal AGGREGATE service — the anti-gaming property
+    /// holds end-to-end through `admit`/`reschedule`, not just in the queue unit.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+    async fn tenants_get_equal_share_regardless_of_query_count() {
+        let admit = Arc::new(FairAdmit::new(1, 0, 64));
+        let handle = tokio::runtime::Handle::current();
+        let served: Arc<Mutex<Map<GroupId, u64>>> = Arc::new(Mutex::new(Map::new()));
+        let total = Arc::new(AtomicUsize::new(0));
+        const BUDGET: usize = 6000;
+
+        let run = |group: GroupId| {
+            let admit = admit.clone();
+            let handle = handle.clone();
+            let served = served.clone();
+            let total = total.clone();
+            tokio::task::spawn_blocking(move || {
+                let id = slot(handle.block_on(admit.admit(
+                    group,
+                    GW,
+                    SchedClass::Bulk,
+                    std::future::pending::<()>(),
+                )));
+                while total.fetch_add(1, Ordering::SeqCst) < BUDGET {
+                    *served.lock().unwrap().entry(group).or_insert(0) += 1;
+                    admit.reschedule(&handle, id, 10);
+                }
+                admit.finish(id);
+            })
+        };
+        // Group 1: three scans (the "gaming" tenant); group 2: one scan.
+        let tasks = vec![run(1), run(1), run(1), run(2)];
+        for t in tasks {
+            t.await.unwrap();
+        }
+
+        let served = served.lock().unwrap();
+        let (a, b) = (served[&1] as f64, served[&2] as f64);
+        let ratio = a / b;
+        assert!(
+            (0.5..=2.0).contains(&ratio),
+            "tenants should get ~equal aggregate share regardless of query count: \
+             group1(3 scans)={a} group2(1 scan)={b} ratio={ratio:.2}"
+        );
+        assert_eq!(admit.active(), 0);
+    }
+
     /// A scan whose `cancel` fires before it is granted returns `Cancelled`,
     /// vacates the queue, and leaves NO phantom entry that would later steal a
     /// slot — the core of Ben's "dropped range stream leaks a queued admission".
@@ -415,12 +495,14 @@ mod tests {
         let admit = FairAdmit::new(1, 0, 16);
         let held = slot(
             admit
-                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .admit(G, GW, SchedClass::Bulk, std::future::pending::<()>())
                 .await,
         );
         // The single slot is held; a second scan whose cancel is already ready
         // must resolve to Cancelled rather than wait or grab a slot.
-        let outcome = admit.admit(SchedClass::Bulk, std::future::ready(())).await;
+        let outcome = admit
+            .admit(G, GW, SchedClass::Bulk, std::future::ready(()))
+            .await;
         assert_eq!(outcome, Admitted::Cancelled);
         // Releasing the held slot finds no waiter (no phantom) → fully free.
         admit.finish(held);
@@ -434,13 +516,13 @@ mod tests {
         let admit = FairAdmit::new(1, 0, 16);
         let held = slot(
             admit
-                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .admit(G, GW, SchedClass::Bulk, std::future::pending::<()>())
                 .await,
         );
         let mut cx = Context::from_waker(std::task::Waker::noop());
         {
             // Enqueues, then parks (no free slot). Poll once, then drop.
-            let mut fut = pin!(admit.admit(SchedClass::Bulk, std::future::pending::<()>()));
+            let mut fut = pin!(admit.admit(G, GW, SchedClass::Bulk, std::future::pending::<()>()));
             assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
         }
         admit.finish(held);
@@ -454,7 +536,7 @@ mod tests {
         let admit = FairAdmit::new(1, 0, 2); // 1 slot, at most 2 waiters
         let held = slot(
             admit
-                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .admit(G, GW, SchedClass::Bulk, std::future::pending::<()>())
                 .await,
         );
         let mut cx = Context::from_waker(std::task::Waker::noop());
@@ -462,13 +544,13 @@ mod tests {
             // Fill the waiter queue (poll once each). The `pin!`ed futures live
             // to the end of this block, so they must be scoped here — dropping
             // the `Pin<&mut _>` handle would not drop the future.
-            let mut w1 = pin!(admit.admit(SchedClass::Bulk, std::future::pending::<()>()));
-            let mut w2 = pin!(admit.admit(SchedClass::Bulk, std::future::pending::<()>()));
+            let mut w1 = pin!(admit.admit(G, GW, SchedClass::Bulk, std::future::pending::<()>()));
+            let mut w2 = pin!(admit.admit(G, GW, SchedClass::Bulk, std::future::pending::<()>()));
             assert!(matches!(w1.as_mut().poll(&mut cx), Poll::Pending));
             assert!(matches!(w2.as_mut().poll(&mut cx), Poll::Pending));
             // Third request: no slot, queue full → Overloaded (resolves at once).
             let outcome = admit
-                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .admit(G, GW, SchedClass::Bulk, std::future::pending::<()>())
                 .await;
             assert_eq!(outcome, Admitted::Overloaded);
         }

--- a/ferrosa-sched/src/group_runqueue.rs
+++ b/ferrosa-sched/src/group_runqueue.rs
@@ -63,10 +63,12 @@ pub struct GroupRunQueue {
 }
 
 /// A query picked to run, tagged with the group it belongs to (pass `group` back
-/// to [`charge`](GroupRunQueue::charge) when the query consumes service).
+/// to [`charge`](GroupRunQueue::charge) when the query consumes service, and
+/// `group_weight` to re-enqueue it on a cooperative yield).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Picked {
     pub group: GroupId,
+    pub group_weight: u32,
     pub entity: SchedEntity,
 }
 
@@ -123,14 +125,29 @@ impl GroupRunQueue {
         self.min_vruntime = self.min_vruntime.max(group.vruntime);
         // If the group has no more queued queries, it leaves the outer tree
         // until one of its queries re-enqueues.
+        let group_weight = group.weight;
         if group.queries.is_empty() {
             self.tree.remove(&key);
             group.tree_key = None;
         }
         Some(Picked {
             group: group_id,
+            group_weight,
             entity,
         })
+    }
+
+    /// The `(group_vruntime, query_vruntime)` of the query that [`pick_next`] would
+    /// return — the lexicographic priority of the most-deserving waiting scan.
+    /// A running scan yields when this is strictly smaller than its own
+    /// `(group_vruntime, query_vruntime)`, giving fairness at both levels: same
+    /// group → compare queries; different group → the group dominates.
+    ///
+    /// [`pick_next`]: GroupRunQueue::pick_next
+    pub fn peek_min(&self) -> Option<(u64, u64)> {
+        let (&(group_vruntime, _), group_id) = self.tree.iter().next()?;
+        let query_vruntime = self.groups[group_id].queries.peek_min_vruntime()?;
+        Some((group_vruntime, query_vruntime))
     }
 
     /// Charge `service` to group `group_id` (a query in it ran for `service`),
@@ -155,6 +172,39 @@ impl GroupRunQueue {
     /// for a should-switch decision at the group level.
     pub fn peek_min_group_vruntime(&self) -> Option<u64> {
         self.tree.keys().next().map(|(vruntime, _seq)| *vruntime)
+    }
+
+    /// Current `vruntime` of `group_id` (`None` if the group is unknown) — lets a
+    /// running query compare its group against the least waiting group.
+    pub fn group_vruntime(&self, group_id: GroupId) -> Option<u64> {
+        self.groups.get(&group_id).map(|g| g.vruntime)
+    }
+
+    /// Total queued queries across all groups (the admission-waiter count, for
+    /// the bounded-queue / `Overloaded` backpressure check).
+    pub fn len(&self) -> usize {
+        self.groups.values().map(|g| g.queries.len()).sum()
+    }
+
+    /// Remove the queued query `id` from whichever group holds it, dropping the
+    /// group from the outer tree if it becomes empty. Returns whether one was
+    /// removed. Used by admission cancellation cleanup (across groups).
+    pub fn remove_by_id(&mut self, id: u64) -> bool {
+        let mut emptied_key: Option<(u64, u64)> = None;
+        let mut removed = false;
+        for group in self.groups.values_mut() {
+            if group.queries.remove_by_id(id) {
+                removed = true;
+                if group.queries.is_empty() {
+                    emptied_key = group.tree_key.take();
+                }
+                break;
+            }
+        }
+        if let Some(key) = emptied_key {
+            self.tree.remove(&key);
+        }
+        removed
     }
 
     /// The monotonic group-level floor.

--- a/ferrosa-sched/src/group_runqueue.rs
+++ b/ferrosa-sched/src/group_runqueue.rs
@@ -1,0 +1,289 @@
+//! Module: Two-level (group→query) hierarchical fair run queue (B3 T3.1).
+//! Correctness: Correct when `pick_next` returns the least-`vruntime` query of
+//!   the least-`vruntime` group, a group's `vruntime` advances by the service of
+//!   *any* of its queries (so its aggregate share is independent of its query
+//!   count), and both group- and query-level `min_vruntime` floors are monotonic.
+//! Last revised: 2026-07-22
+//! Last changed: New module — B3 T3.1. Extends the single-group [`RunQueue`]
+//!   (B1) to two levels so scheduling is fair *between tenants* (groups), not
+//!   just between queries: a tenant that submits 100 queries gets the same
+//!   aggregate share as one that submits 1 (FM-12, the anti-gaming property).
+//!
+//! # Model (CFS group scheduling, adapted)
+//!
+//! The outer level schedules **groups** (tenants) by group `vruntime`; the inner
+//! level schedules a group's **queries** by query `vruntime` (a nested
+//! [`RunQueue`]). Picking runs the least-`vruntime` query of the least-`vruntime`
+//! group. When a query runs for some *service*, both its own `vruntime`
+//! ([`advance_vruntime`] on the [`SchedEntity`]) and its **group's** `vruntime`
+//! ([`charge`](GroupRunQueue::charge)) advance — so a group drifts back in
+//! proportion to the *total* service consumed by all its queries. That is what
+//! makes the per-tenant share independent of query count.
+//!
+//! `GroupId` is an opaque `u64` (the caller maps `TenantContext` → id) so this
+//! leaf crate keeps its tokio-only dependency set (DSM guard).
+
+use std::collections::{BTreeMap, HashMap};
+
+use crate::runqueue::{RunQueue, SchedEntity};
+use crate::scheduler::advance_vruntime;
+
+/// Opaque tenant/group identifier. The caller maps its `TenantContext` to a
+/// stable `u64`.
+pub type GroupId = u64;
+
+/// Default fair-share weight of a group when the caller does not set a per-tenant
+/// weight (T3.2). Equal-weight groups get equal aggregate share.
+pub const DEFAULT_GROUP_WEIGHT: u32 = 1024;
+
+struct Group {
+    /// Group-level virtual runtime — the sum of its queries' service, weighted
+    /// by the group weight. Least-`vruntime` group is scheduled next.
+    vruntime: u64,
+    /// Fair-share weight for this group (per-tenant share; T3.2).
+    weight: u32,
+    /// This group's queries, ordered by query `vruntime` (the inner level).
+    queries: RunQueue,
+    /// The group's current key in `tree`, or `None` when it has no queued
+    /// queries (a running query's group is absent until the query re-enqueues).
+    tree_key: Option<(u64, u64)>,
+}
+
+/// A two-level fair run queue: groups (tenants) over queries.
+pub struct GroupRunQueue {
+    /// `(group_vruntime, seq) → group_id`, holding only groups with ≥1 queued
+    /// query. `seq` breaks ties in group-arrival order (FIFO among equal groups).
+    tree: BTreeMap<(u64, u64), GroupId>,
+    groups: HashMap<GroupId, Group>,
+    /// Monotonic group-level floor: a newly-arriving or waking group cannot
+    /// undercut running groups by more than `boost`.
+    min_vruntime: u64,
+    seq: u64,
+    boost: u64,
+}
+
+/// A query picked to run, tagged with the group it belongs to (pass `group` back
+/// to [`charge`](GroupRunQueue::charge) when the query consumes service).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Picked {
+    pub group: GroupId,
+    pub entity: SchedEntity,
+}
+
+impl GroupRunQueue {
+    /// A queue whose waking groups may dip at most `boost` below the group-level
+    /// `min_vruntime` (bounded sleeper credit, as in [`RunQueue::new`]).
+    pub fn new(boost: u64) -> Self {
+        Self {
+            tree: BTreeMap::new(),
+            groups: HashMap::new(),
+            min_vruntime: 0,
+            seq: 0,
+            boost,
+        }
+    }
+
+    /// Enqueue `entity` under group `group_id` (weight `group_weight`), creating
+    /// the group if it is new. A new/waking group's `vruntime` is clamped up to
+    /// at least `min_vruntime - boost` so it cannot monopolize on arrival.
+    pub fn enqueue(&mut self, group_id: GroupId, group_weight: u32, entity: SchedEntity) {
+        let floor = self.min_vruntime.saturating_sub(self.boost);
+        let group = self.groups.entry(group_id).or_insert_with(|| Group {
+            vruntime: floor,
+            weight: group_weight.max(1),
+            queries: RunQueue::new(self.boost),
+            tree_key: None,
+        });
+        // A group that had gone idle wakes clamped to the current floor.
+        if group.tree_key.is_none() {
+            group.vruntime = group.vruntime.max(floor);
+        }
+        group.queries.enqueue(entity);
+        if group.tree_key.is_none() {
+            let key = (group.vruntime, self.seq);
+            self.seq += 1;
+            self.tree.insert(key, group_id);
+            group.tree_key = Some(key);
+        }
+    }
+
+    /// Remove and return the least-`vruntime` query of the least-`vruntime`
+    /// group (FIFO among ties at each level), advancing the group-level floor.
+    /// `None` if empty.
+    pub fn pick_next(&mut self) -> Option<Picked> {
+        let (&key, &group_id) = self.tree.iter().next()?;
+        let group = self
+            .groups
+            .get_mut(&group_id)
+            .expect("group in tree exists");
+        let entity = group
+            .queries
+            .pick_next()
+            .expect("group in tree has a query");
+        self.min_vruntime = self.min_vruntime.max(group.vruntime);
+        // If the group has no more queued queries, it leaves the outer tree
+        // until one of its queries re-enqueues.
+        if group.queries.is_empty() {
+            self.tree.remove(&key);
+            group.tree_key = None;
+        }
+        Some(Picked {
+            group: group_id,
+            entity,
+        })
+    }
+
+    /// Charge `service` to group `group_id` (a query in it ran for `service`),
+    /// advancing the group's `vruntime` weighted by the group weight and re-keying
+    /// it in the outer tree. This is what equalizes *aggregate* per-tenant share
+    /// regardless of how many queries the tenant runs.
+    pub fn charge(&mut self, group_id: GroupId, service: u64) {
+        let Some(group) = self.groups.get_mut(&group_id) else {
+            return;
+        };
+        group.vruntime = advance_vruntime(group.vruntime, service, group.weight);
+        if let Some(old) = group.tree_key.take() {
+            self.tree.remove(&old);
+            let key = (group.vruntime, self.seq);
+            self.seq += 1;
+            self.tree.insert(key, group_id);
+            group.tree_key = Some(key);
+        }
+    }
+
+    /// The `vruntime` of the least group with queued work (`None` if empty) —
+    /// for a should-switch decision at the group level.
+    pub fn peek_min_group_vruntime(&self) -> Option<u64> {
+        self.tree.keys().next().map(|(vruntime, _seq)| *vruntime)
+    }
+
+    /// The monotonic group-level floor.
+    pub fn min_vruntime(&self) -> u64 {
+        self.min_vruntime
+    }
+
+    /// Number of groups with queued queries.
+    pub fn active_groups(&self) -> usize {
+        self.tree.len()
+    }
+
+    /// Whether any group has a queued query.
+    pub fn is_empty(&self) -> bool {
+        self.tree.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SchedClass;
+
+    fn ent(id: u64) -> SchedEntity {
+        SchedEntity::new(id, SchedClass::Bulk)
+    }
+
+    #[test]
+    fn picks_least_vruntime_group_then_least_query() {
+        let mut q = GroupRunQueue::new(0);
+        // Group 10 has queries 0,1; group 20 has query 2. All equal weight.
+        q.enqueue(10, DEFAULT_GROUP_WEIGHT, ent(0));
+        q.enqueue(10, DEFAULT_GROUP_WEIGHT, ent(1));
+        q.enqueue(20, DEFAULT_GROUP_WEIGHT, ent(2));
+        // Both groups at vruntime 0; group 10 arrived first → picked first.
+        let p = q.pick_next().unwrap();
+        assert_eq!(p.group, 10);
+        // Charge group 10 a big service → group 20 is now more deserving.
+        q.charge(10, 1000);
+        q.enqueue(10, DEFAULT_GROUP_WEIGHT, ent(0)); // requeue the ran query
+        let p = q.pick_next().unwrap();
+        assert_eq!(
+            p.group, 20,
+            "after group 10 ran, group 20 is least-vruntime"
+        );
+    }
+
+    /// T3.9 / FM-12 — the anti-gaming property: a tenant that floods the queue
+    /// with 100 queries gets the SAME aggregate share as a tenant with 1 query.
+    /// Fairness is per-GROUP: group `vruntime` advances by the service of
+    /// whichever of its queries ran, so 100 queries share one group's slice.
+    #[test]
+    fn one_tenant_hundred_queries_equals_one_tenant_one_query() {
+        const HEAVY: GroupId = 1; // 100 queries
+        const LIGHT: GroupId = 2; // 1 query
+        let mut q = GroupRunQueue::new(0);
+        for id in 0..100u64 {
+            q.enqueue(HEAVY, DEFAULT_GROUP_WEIGHT, ent(id));
+        }
+        q.enqueue(LIGHT, DEFAULT_GROUP_WEIGHT, ent(1000));
+
+        let mut service = std::collections::HashMap::<GroupId, u64>::new();
+        // Each round: run one query for a fixed unit of service, then requeue it
+        // (both tenants have effectively unbounded work).
+        for _ in 0..10_000 {
+            let p = q.pick_next().expect("work remains");
+            *service.entry(p.group).or_insert(0) += 1;
+            q.charge(p.group, 1);
+            // Requeue the query that just ran (its own vruntime advanced).
+            let mut e = p.entity;
+            e.vruntime = advance_vruntime(e.vruntime, 1, e.weight);
+            q.enqueue(p.group, DEFAULT_GROUP_WEIGHT, e);
+        }
+
+        let heavy = service[&HEAVY] as f64;
+        let light = service[&LIGHT] as f64;
+        let ratio = heavy / light;
+        // Equal group weight → equal aggregate share (~1:1), NOT 100:1.
+        assert!(
+            (0.8..=1.25).contains(&ratio),
+            "per-tenant share should be independent of query count: \
+             heavy(100q)={heavy} light(1q)={light} ratio={ratio:.2}"
+        );
+    }
+
+    #[test]
+    fn per_tenant_weight_sets_share() {
+        // T3.2 preview: a 3× weight group gets ~3× the aggregate share. Service
+        // is a realistic per-round cost (like elapsed µs) so the weighting shows
+        // in the proportion rather than being masked by the ≥1 rounding floor.
+        const BIG: GroupId = 1;
+        const SMALL: GroupId = 2;
+        const SERVICE: u64 = 1000;
+        let weight_of = |g: GroupId| {
+            if g == BIG {
+                DEFAULT_GROUP_WEIGHT * 3
+            } else {
+                DEFAULT_GROUP_WEIGHT
+            }
+        };
+        let mut q = GroupRunQueue::new(0);
+        q.enqueue(BIG, weight_of(BIG), ent(0));
+        q.enqueue(SMALL, weight_of(SMALL), ent(1));
+        let mut service = std::collections::HashMap::<GroupId, u64>::new();
+        for _ in 0..9000 {
+            let p = q.pick_next().expect("work remains");
+            *service.entry(p.group).or_insert(0) += 1;
+            q.charge(p.group, SERVICE);
+            let mut e = p.entity;
+            e.vruntime = advance_vruntime(e.vruntime, SERVICE, e.weight);
+            q.enqueue(p.group, weight_of(p.group), e);
+        }
+        let ratio = service[&BIG] as f64 / service[&SMALL] as f64;
+        assert!(
+            (2.4..=3.6).contains(&ratio),
+            "share should scale with weight (~3:1), got {ratio:.2} ({service:?})"
+        );
+    }
+
+    #[test]
+    fn empty_and_active_groups_track_membership() {
+        let mut q = GroupRunQueue::new(0);
+        assert!(q.is_empty());
+        q.enqueue(1, DEFAULT_GROUP_WEIGHT, ent(0));
+        q.enqueue(2, DEFAULT_GROUP_WEIGHT, ent(1));
+        assert_eq!(q.active_groups(), 2);
+        q.pick_next(); // group 1's only query leaves → group 1 exits the tree
+        assert_eq!(q.active_groups(), 1);
+        q.pick_next();
+        assert!(q.is_empty());
+    }
+}

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -32,11 +32,13 @@ use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 
 pub mod fair_admit;
+pub mod group_runqueue;
 pub mod io_permits;
 pub mod runqueue;
 pub mod scheduler;
 
 pub use fair_admit::Admitted;
+pub use group_runqueue::{GroupId, GroupRunQueue, Picked};
 pub use io_permits::{IoPermit, IoPermits};
 
 // Process-wide pool metrics. Cumulative counters live here (the Prometheus

--- a/ferrosa-sched/src/lib.rs
+++ b/ferrosa-sched/src/lib.rs
@@ -366,7 +366,12 @@ impl SchedPool {
         // future; overload is still surfaced as `None`.
         match self
             .admit
-            .admit(SchedClass::Bulk, std::future::pending::<()>())
+            .admit(
+                DEFAULT_TENANT_GROUP,
+                group_runqueue::DEFAULT_GROUP_WEIGHT,
+                SchedClass::Bulk,
+                std::future::pending::<()>(),
+            )
             .await
         {
             Admitted::Slot(id) => {
@@ -395,7 +400,12 @@ impl SchedPool {
         tokio::spawn(async move {
             let waited = Instant::now();
             match admit
-                .admit(SchedClass::Bulk, std::future::pending::<()>())
+                .admit(
+                    DEFAULT_TENANT_GROUP,
+                    group_runqueue::DEFAULT_GROUP_WEIGHT,
+                    SchedClass::Bulk,
+                    std::future::pending::<()>(),
+                )
                 .await
             {
                 Admitted::Slot(id) => {
@@ -448,7 +458,15 @@ impl SchedPool {
         let io_permits = self.io_permits.clone();
         tokio::spawn(async move {
             let waited = Instant::now();
-            match admit.admit(class, cancel).await {
+            match admit
+                .admit(
+                    DEFAULT_TENANT_GROUP,
+                    group_runqueue::DEFAULT_GROUP_WEIGHT,
+                    class,
+                    cancel,
+                )
+                .await
+            {
                 Admitted::Slot(id) => {
                     record_admission(waited.elapsed());
                     // B2 T2.1: hold a bulk-I/O permit for the scan's producing
@@ -607,6 +625,13 @@ pub const DEFAULT_SCAN_CHUNK_BUDGET: u32 = 64;
 /// as [`ScanOutcome::Overloaded`]. Bounds the queue so a flood of scans cannot
 /// grow it without limit; generous enough that only genuine overload trips it.
 pub const DEFAULT_MAX_WAITERS_PER_SLOT: usize = 256;
+
+/// The tenant group every pool scan is charged to today (B3). Until per-query
+/// `TenantContext` is threaded through the read path, all interactive scan work
+/// shares one group, so the hierarchical [`GroupRunQueue`] is behavior-preserving;
+/// folded background work (compaction/repair/index) joins as its *own* group,
+/// which is what makes cross-group fair-share arbitration live.
+pub const DEFAULT_TENANT_GROUP: GroupId = 0;
 
 static GLOBAL_POOL: std::sync::OnceLock<SchedPool> = std::sync::OnceLock::new();
 

--- a/ferrosa-sched/src/scheduler.rs
+++ b/ferrosa-sched/src/scheduler.rs
@@ -24,11 +24,19 @@ pub const BASE_WEIGHT: u64 = 1024;
 
 /// Advance `vruntime` by `service` charged inversely to `weight`. Pure.
 ///
-/// `delta = service × BASE_WEIGHT / weight`. Saturating so a pathological
+/// `delta = service × BASE_WEIGHT / weight`, **floored at 1 for any positive
+/// service** so a unit whose weighted service rounds down to zero (a group whose
+/// `weight` exceeds `service × BASE_WEIGHT` — reachable once B3 allows per-tenant
+/// weights above [`BASE_WEIGHT`]) still advances and cannot monopolize the queue
+/// via integer-division rounding. For realistic service (microseconds) the floor
+/// never binds — `delta` is already `≥ service`. Saturating so a pathological
 /// service value can never wrap the counter.
 pub fn advance_vruntime(vruntime: u64, service: u64, weight: u32) -> u64 {
     let weight = u64::from(weight.max(1));
-    let delta = service.saturating_mul(BASE_WEIGHT) / weight;
+    let mut delta = service.saturating_mul(BASE_WEIGHT) / weight;
+    if service > 0 {
+        delta = delta.max(1);
+    }
     vruntime.saturating_add(delta)
 }
 
@@ -54,6 +62,16 @@ mod tests {
         assert_eq!(advance_vruntime(0, 100, 256), 400);
         // Zero weight is treated as 1 (no divide-by-zero).
         assert_eq!(advance_vruntime(0, 1, 0), 1024);
+    }
+
+    #[test]
+    fn positive_service_always_advances_at_least_one() {
+        // A high-weight group whose weighted service would round to 0 still
+        // advances by 1 — it cannot monopolize via integer-division rounding.
+        assert_eq!(advance_vruntime(0, 1, 3072), 1); // 1×1024/3072 = 0 → floored to 1
+        assert_eq!(advance_vruntime(5, 1, u32::MAX), 6);
+        // Zero service does not advance.
+        assert_eq!(advance_vruntime(7, 0, 1024), 7);
     }
 
     #[test]


### PR DESCRIPTION
## Query scheduler B3 — tenant groups + background unification (stacked on #288)

The third dimension: **hierarchical, per-tenant** fair scheduling, plus folding the background work (compaction/repair/index-build/ANN) into the pool so the class weighting finally arbitrates real mixed-weight contention.

**Stacked on #288** — base branch `feat/sched-b2-io-dimension`. Merge #286 → #287 → #288 → this, in order.

### Landed
- **T3.1 — two-level (group→query) fair queue** (`group_runqueue::GroupRunQueue`): the outer level schedules groups (tenants) by group `vruntime`, the inner level schedules a group's queries. A group's `vruntime` advances by the service of *any* of its queries, so a tenant's aggregate share is independent of its query count. `GroupId` is an opaque `u64` (caller maps `TenantContext` → id) — the crate stays leaf.
- **T3.9 — anti-gaming property** proven: `one_tenant_hundred_queries_equals_one_tenant_one_query` (100 queries == 1 query in aggregate share, 0.8–1.25×).
- **T3.2 preview** — `per_tenant_weight_sets_share` (a 3× weight group gets ~3× share). TOML wiring still to come.
- **`advance_vruntime` monopolization floor** — a positive service always advances `vruntime` by ≥ 1, so a high-weight group can't monopolize via integer-division rounding (reachable once per-tenant weights exceed `BASE_WEIGHT`). Transparent to B1/B2.
- **T3.8** (bounded runqueue + `Overloaded`) already shipped in B1.5 (#287).

### Remaining
- Make `GroupRunQueue` **live** in `FairAdmit` — thread the tenant group through `submit_scan` (and `TenantContext` → `GroupId` at the storage/CQL seam).
- **T3.2** — per-tenant weights from TOML.
- **T3.3–T3.6** — fold background work into the pool as a `system` group: ANN cooperative yield + golden-recall guard (T3.3 ★), compaction (`CompactionGate`, T3.4), repair (T3.5), index build (bespoke semaphore, T3.6). This is where the class weighting starts arbitrating.
- **T3.7** — hinted-handoff replay (needs DD-3 pinned).

### Gates (local)
36 `ferrosa-sched` tests + 3 fairness tests green; `clippy --workspace --all-targets -D warnings`, `fmt`, `cargo doc -D warnings` clean; workspace builds; storage lib regression clean.

Epic: `t_f9a0500a` · B3 task: `t_f059c7f5`.
