### PR TITLE
fix(install): retain memory release templates

### DIFF
--- a/install/install-memory.sh
+++ b/install/install-memory.sh
@@ -32,6 +32,9 @@ CONFIG_DIR="${INSTALL_ROOT}/config"
 DATA_DIR="${INSTALL_ROOT}/data"
 LOG_DIR="${INSTALL_ROOT}/logs"
 RUN_DIR="${INSTALL_ROOT}/run"
+# Released HTTP/auth templates are documentation, not active configuration.
+# Keep them outside config/ so upgrades never overwrite generated credentials.
+EXAMPLES_DIR="${INSTALL_ROOT}/share/ferrosa-memory/examples"
 # Separate stamp from ferrosa's own .version so the two installers don't clobber
 # each other's idempotency state.
 VERSION_STAMP="${INSTALL_ROOT}/.memory-version"
@@ -183,6 +186,15 @@ else
   say "kept existing $CONFIG_DIR/ferrosa-memory.toml"
 fi
 
+if [ -d "$TMP/examples" ]; then
+  mkdir -p "$(dirname "$EXAMPLES_DIR")"
+  rm -rf "${EXAMPLES_DIR:?}"
+  cp -R "$TMP/examples" "$EXAMPLES_DIR"
+  say "installed release templates to $EXAMPLES_DIR"
+else
+  say "warning: this release bundles no examples; upgrade for HTTP/auth templates"
+fi
+
 # ---------- service registration ----------
 prompt_yes() {
   local q="$1" a
@@ -273,6 +285,7 @@ fi
 cat <<EOF >&2
   binary: $BIN_DIR/ferrosa-memory-mcp
   config: $CONFIG_DIR/ferrosa-memory.toml
+  templates: $EXAMPLES_DIR
 
 This MCP server connects to a running Ferrosa instance at localhost:9042
 (default from https://ferrosadb.com/install.sh). Ensure Ferrosa is up:

--- a/install/setup-memory.sh
+++ b/install/setup-memory.sh
@@ -174,6 +174,15 @@ chmod +x "$BIN_DIR/ferrosa-memory-mcp"
 if [ ! -f "$CONFIG_DIR/ferrosa-memory.toml" ]; then
   cp "$M_TMP/config/ferrosa-memory.example.toml" "$CONFIG_DIR/ferrosa-memory.toml"
 fi
+# Retain released HTTP/auth templates after the temporary archive is removed.
+# They are reference material, never active credentials or generated config.
+if [ -d "$M_TMP/examples" ]; then
+  MEMORY_EXAMPLES_DIR="$INSTALL_ROOT/share/ferrosa-memory/examples"
+  mkdir -p "$(dirname "$MEMORY_EXAMPLES_DIR")"
+  rm -rf "${MEMORY_EXAMPLES_DIR:?}"
+  cp -R "$M_TMP/examples" "$MEMORY_EXAMPLES_DIR"
+  say "installed memory templates to $MEMORY_EXAMPLES_DIR"
+fi
 # The release tarball ships a LaunchAgent plist template (with __BINARY_PATH__ /
 # __REPO_ROOT__ / __CONFIG_PATH__ / __HOME__ placeholders). Stash it to a stable
 # location now, before $M_TMP is removed, so the server-start stage can render it.

--- a/tests/install_smoke.sh
+++ b/tests/install_smoke.sh
@@ -206,12 +206,12 @@ build_memory_tarball() {
   log "building ferrosa-memory-mcp from $MEMORY_REPO"
   ( cd "$MEMORY_REPO" && cargo build $profile_flag -p ferrosa-memory-mcp --bin ferrosa-memory-mcp >/dev/null )
   [ -x "$bindir/ferrosa-memory-mcp" ] || fail "ferrosa-memory-mcp not built at $bindir"
-  # Stage a tarball in the layout install-memory.sh expects: top-level binary +
-  # config/ferrosa-memory.example.toml.
+  # Stage the same binary/config/template layout shipped by a memory release.
   local stage; stage="$(mktemp -d)"
   cp "$bindir/ferrosa-memory-mcp" "$stage/"
   mkdir -p "$stage/config"
   cp "$MEMORY_REPO/config/ferrosa-memory.example.toml" "$stage/config/"
+  cp -R "$MEMORY_REPO/examples" "$stage/examples"
   MEMORY_TARBALL="$WORK/ferrosa-memory-v0.0.0-smoke.tar.gz"
   ( cd "$stage" && tar czf "$MEMORY_TARBALL" . )
   rm -rf "$stage"
@@ -337,6 +337,8 @@ run_memory_smoke() {
     > "$LOGDIR/install-memory.log" 2>&1 \
     || { cat "$LOGDIR/install-memory.log" >&2; fail "install-memory.sh failed"; }
   [ -x "$INSTALL/bin/ferrosa-memory-mcp" ] || fail "ferrosa-memory-mcp not installed"
+  [ -f "$INSTALL/share/ferrosa-memory/examples/http-auth.toml" ] \
+    || fail "install-memory.sh did not retain bundled HTTP/auth templates"
   ok "ferrosa-memory installed via install/install-memory.sh to $INSTALL/bin"
   write_memory_config
   start_memory

--- a/tests/setup_memory_b1_test.sh
+++ b/tests/setup_memory_b1_test.sh
@@ -44,7 +44,7 @@ PY
 make_tarballs() {
   local db_stage="$WORK/db-stage" memory_stage="$WORK/memory-stage"
   mkdir -p "$db_stage/config" "$db_stage/launchd" "$db_stage/systemd"
-  mkdir -p "$memory_stage/config" "$memory_stage/launchd"
+  mkdir -p "$memory_stage/config" "$memory_stage/examples" "$memory_stage/launchd"
 
   printf '#!/usr/bin/env bash\nexit 0\n' > "$db_stage/ferrosa"
   printf '#!/usr/bin/env bash\nexit 0\n' > "$db_stage/ferrosa-ctl"
@@ -61,6 +61,7 @@ printf started > "$MCP_STARTED_FILE"
 EOF
   chmod +x "$memory_stage/ferrosa-memory-mcp"
   printf '[server]\ntransport = "stdio"\n' > "$memory_stage/config/ferrosa-memory.example.toml"
+  printf '# shared HTTP auth template\n' > "$memory_stage/examples/http-auth.toml"
   printf '<plist>ferrosa-memory-mcp __BINARY_PATH__</plist>\n' > "$memory_stage/launchd/com.ferrosa-memory.mcp.plist"
   tar -czf "$WORK/ferrosa-memory.tar.gz" -C "$memory_stage" .
 }
@@ -199,6 +200,8 @@ grep -F "enable --now ferrosa.service" "$WORK/systemctl-ready.log" >/dev/null \
   || fail "quick start did not use the canonical systemd DB start path"
 grep -F "database ready on 127.0.0.1:$ready_port" "$ready_log" >/dev/null \
   || fail "quick start did not wait for the DB readiness probe"
+[ -f "$ready_home/.ferrosa/share/ferrosa-memory/examples/http-auth.toml" ] \
+  || fail "quick start did not retain the bundled HTTP/auth templates"
 [ ! -e "$WORK/mcp-ready.started" ] \
   || fail "--no-start must not launch MCP after the DB gate"
 ok "supported Linux service path starts and verifies the database before MCP handling"


### PR DESCRIPTION
## Summary
- retain the Memory release example bundle in both documented binary-install paths
- exercise the hosted quick start and cross-repo install smoke with the shipped templates

## Verification
- `bash tests/setup_memory_b1_test.sh`
- `bash tests/install_smoke.sh --with-memory --memory-repo /private/tmp/ferrosa-memory-install-artifact-examples`