### PR TITLE
ci: retry docker build to survive Docker Hub base-image timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,16 @@ jobs:
           ENV FERROSA_DATA_DIR=/var/lib/ferrosa
           CMD ["ferrosa"]
           DEOF
-          docker build -t ferrosa-test-node:latest node-bin
+          # Retry: pulling the debian:trixie-slim base from Docker Hub
+          # intermittently times out (registry-1.docker.io i/o timeout), which
+          # fails the job and DROPS the PR from the merge queue. A bounded retry
+          # rides out the transient registry blip (see forge t_75ec87fd).
+          for attempt in 1 2 3 4; do
+            docker build -t ferrosa-test-node:latest node-bin && break
+            [ "$attempt" = 4 ] && { echo "docker build failed after 4 attempts"; exit 1; }
+            echo "docker build attempt $attempt failed (likely Docker Hub base-image pull); retrying in $((attempt * 10))s…"
+            sleep $((attempt * 10))
+          done
           docker save ferrosa-test-node:latest | gzip > ferrosa-node-image.tar.gz
       - name: Push image to GHCR (cross-workflow reuse)
         # Lets the separate, path-filtered driver-smoke workflow and paired
@@ -329,7 +338,15 @@ jobs:
           ENV FERROSA_DATA_DIR=/var/lib/ferrosa
           CMD ["ferrosa"]
           DEOF
-          docker build -t ferrosa-ci:latest -f /tmp/Dockerfile.ci /tmp/ferrosa-bin
+          # Retry: the debian:trixie-slim base pull from Docker Hub
+          # intermittently times out and fails the job (dropping the PR from the
+          # merge queue). A bounded retry rides it out (see forge t_75ec87fd).
+          for attempt in 1 2 3 4; do
+            docker build -t ferrosa-ci:latest -f /tmp/Dockerfile.ci /tmp/ferrosa-bin && break
+            [ "$attempt" = 4 ] && { echo "docker build failed after 4 attempts"; exit 1; }
+            echo "docker build attempt $attempt failed (likely Docker Hub base-image pull); retrying in $((attempt * 10))s…"
+            sleep $((attempt * 10))
+          done
 
       - name: Start single-node Ferrosa with RustFS
         run: |


### PR DESCRIPTION
Fixes the transient Docker Hub base-image pull failure that dropped PRs from the merge queue on 2026-07-24 (#293/#296/#297 each needed manual re-enqueue).

**Symptom:** the `Example CQL Scripts` and `Build node image` jobs `docker build` from `debian:trixie-slim`; pulling that base intermittently fails with `Head "https://registry-1.docker.io/…" i/o timeout` / `DeadlineExceeded`, failing the whole job. In the merge queue a failed combined-branch build **evicts the PR**, so it looks "stuck" and needs manual re-enqueue.

**Fix:** wrap both `docker build` invocations in a bounded 4-attempt retry with linear backoff. A single transient registry blip no longer fails the job. No code change, no new secrets, YAML validated + both retry snippets pass `bash -n`.

A fuller fix (pinned base digest + pull-through cache, or authenticated Docker Hub pulls for higher rate limits) remains tracked in forge `t_75ec87fd`; this stops the queue churn immediately.
