### PR TITLE
fix(cql): complete Write_timeout trailer for TransactionTimeout error frame

### DIFF
--- a/ferrosa-cql/src/error.rs
+++ b/ferrosa-cql/src/error.rs
@@ -125,6 +125,19 @@ impl CqlError {
                 buf.put_i32(saturating_i32(*required));
                 buf.put_u8(u8::from(*data_present));
             }
+            Self::TransactionTimeout { .. } => {
+                // Shares the Write_timeout code (0x1100), so it MUST carry the
+                // Write_timeout trailer — without it the driver reads past the
+                // buffer ("Malformed error field CONSISTENCY … failed to fill
+                // whole buffer"). A transaction timeout carries no CL/counts, so
+                // report the paxos/transaction shape: serial consistency, zero
+                // acknowledged writes (the transaction aborted; nothing
+                // persisted), and Cassandra's `CAS` write type.
+                put_consistency(&mut buf, ConsistencyLevel::Serial);
+                buf.put_i32(0); // received
+                buf.put_i32(0); // blockfor
+                put_string(&mut buf, "CAS");
+            }
             Self::AlreadyExists { keyspace, table } => {
                 buf.put_u16(keyspace.len() as u16);
                 buf.put_slice(keyspace.as_bytes());
@@ -482,6 +495,39 @@ mod tests {
         offset += 2;
         assert_eq!(&body[offset..offset + write_type_len], b"SIMPLE");
         assert_eq!(offset + write_type_len, body.len());
+    }
+
+    #[test]
+    fn encode_transaction_timeout_has_complete_write_timeout_trailer() {
+        // A transaction timeout is sent as Write_timeout (0x1100) so drivers
+        // classify it as transient. The trailer MUST be present and exact, or
+        // the driver fails to deserialize the frame ("Malformed error field
+        // CONSISTENCY … failed to fill whole buffer"), as seen against Accord
+        // commit timeouts in the nemesis certification (t_03c8b79b).
+        let err = CqlError::TransactionTimeout {
+            timeout_ms: 1000,
+            elapsed_ms: 1200,
+        };
+        let body = err.encode_body();
+
+        assert_eq!(&body[..4], &0x1100u32.to_be_bytes());
+        let msg_len = u16::from_be_bytes([body[4], body[5]]) as usize;
+        let mut offset = 6 + msg_len;
+        // [short consistency] — serial (transactions use serial consistency)
+        assert_eq!(
+            u16::from_be_bytes([body[offset], body[offset + 1]]),
+            ConsistencyLevel::Serial.to_wire()
+        );
+        offset += 2;
+        // [int received] + [int blockfor]
+        offset += 8;
+        // [string writeType] = "CAS" (Cassandra's paxos/transaction write type)
+        let wt_len = u16::from_be_bytes([body[offset], body[offset + 1]]) as usize;
+        offset += 2;
+        assert_eq!(&body[offset..offset + wt_len], b"CAS");
+        // Exact length: the frame is precisely code+message+trailer, so the
+        // driver's buffer fills exactly — no under-run, no trailing garbage.
+        assert_eq!(offset + wt_len, body.len());
     }
 
     #[test]


### PR DESCRIPTION
Fixes the *"Malformed error field CONSISTENCY of DB error WRITE_TIMEOUT: failed to fill whole buffer"* the driver logged against Accord commit timeouts in the fault-injected Elle certification (forge `t_03c8b79b`).

**Root cause:** `TransactionTimeout` shares the `Write_timeout` code (`0x1100`) with `WriteTimeout`, but `encode_body` had no arm for it — it fell through to `_ => {}`, emitting an ERROR frame of just `[code][message]` with **no trailer**. A driver that sees `0x1100` then reads the required `[short consistency][int received][int blockfor][string writeType]` off the end of the buffer and fails.

**Fix:** add the `TransactionTimeout` arm. A transaction timeout carries no CL/counts, so it reports the paxos/transaction shape — serial consistency, 0 received, 0 blockfor, writeType `CAS` (Cassandra's convention). The frame is now well-formed and drivers classify it as a transient CAS timeout, which was the intent.

**TDD:** `encode_transaction_timeout_has_complete_write_timeout_trailer` parses the full trailer field-by-field and asserts the exact body length (no under-run). It panicked index-out-of-bounds before the fix; passes after. Clippy clean.
