### PR TITLE
ci: nightly Accord strict-serializability (Elle) certification

### DIFF
--- a/.github/workflows/elle-strict-serializable-nightly.yml
+++ b/.github/workflows/elle-strict-serializable-nightly.yml
@@ -15,6 +15,13 @@ on:
   schedule:
     - cron: '0 7 * * *' # 7 AM UTC daily — staggered against the other nightlies
   workflow_dispatch:
+  # Also run when this cert's own workflow or cluster compose changes, so edits
+  # to it are validated on their PR (not just discovered by the next nightly).
+  # Path-filtered: it never runs on unrelated PRs.
+  pull_request:
+    paths:
+      - '.github/workflows/elle-strict-serializable-nightly.yml'
+      - 'ferrosa-jepsen/tests/docker/elle-cluster-rf3.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/elle-strict-serializable-nightly.yml
+++ b/.github/workflows/elle-strict-serializable-nightly.yml
@@ -22,6 +22,7 @@ on:
     paths:
       - '.github/workflows/elle-strict-serializable-nightly.yml'
       - 'ferrosa-jepsen/tests/docker/elle-cluster-rf3.yml'
+      - 'ferrosa-jepsen/elle-checker/**'
 
 permissions:
   contents: read
@@ -37,6 +38,10 @@ env:
   ELLE_GEN_CLEAN: "8 300 8 3"
   ELLE_GEN_NEMESIS: "8 700 8 3"
   COMPOSE: ferrosa-jepsen/tests/docker/elle-cluster-rf3.yml
+  # Propagate to every JVM (incl. the checker subprocess `lein run` spawns):
+  # Elle/jepsen touches AWT, which throws HeadlessException on a display-less
+  # CI host. Belt-and-suspenders with the checker's project.clj :jvm-opts.
+  JAVA_TOOL_OPTIONS: "-Djava.awt.headless=true"
 
 jobs:
   elle-cert:

--- a/.github/workflows/elle-strict-serializable-nightly.yml
+++ b/.github/workflows/elle-strict-serializable-nightly.yml
@@ -1,0 +1,182 @@
+name: Nightly Elle Strict-Serializability
+
+# Certifies the Accord list-append transaction path as strict-serializable on a
+# fresh RF=3 single-DC cluster, both fault-free AND under a partition + latency
+# nemesis — the automated form of deploy/fly-accord-elle/certify{,-nemesis}.sh.
+# See specs/reference/testing-methodology-and-results-2026-07.md (t_48d5eeaa /
+# t_5a3a12e3). Nightly + on-demand; files an issue on failure. NOT a per-PR gate
+# (a cluster + generator + Elle is too heavy for that).
+#
+# 12-factor: the cluster runs the pre-built nightly .deb image (no source build
+# alongside the containers); only the small elle_list_append generator + the
+# lein Elle checker are built/bootstrapped in the job.
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # 7 AM UTC daily — staggered against the other nightlies
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: elle-strict-serializable
+  cancel-in-progress: false
+
+env:
+  # Fault-free and nemesis generator args: <keys> <ops-per-worker> <workers> <rf>.
+  # The nemesis workload is larger so it outlasts the fault schedule.
+  ELLE_GEN_CLEAN: "8 300 8 3"
+  ELLE_GEN_NEMESIS: "8 700 8 3"
+  COMPOSE: ferrosa-jepsen/tests/docker/elle-cluster-rf3.yml
+
+jobs:
+  elle-cert:
+    name: Elle strict-serializable (RF=3, fault-free + nemesis)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL || true
+          sudo docker system prune -af >/dev/null 2>&1 || true
+          df -h /
+
+      # ── Build the Elle generator (small; the cluster stays pre-built) ──
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install capnproto
+        run: sudo apt-get update && sudo apt-get install -y capnproto
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Build elle_list_append generator
+        run: cargo build --release -p ferrosa-jepsen --example elle_list_append
+
+      # ── Bootstrap the lein Elle checker (Java + cached deps) ──
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install Leiningen + warm Elle deps
+        working-directory: ferrosa-jepsen/elle-checker
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /usr/local/bin/lein \
+            https://raw.githubusercontent.com/technomancy/leiningen/2.11.2/bin/lein
+          sudo chmod +x /usr/local/bin/lein
+          lein deps   # download jepsen/Elle once (cached via ~/.m2 across runs)
+      - name: Cache lein/Elle deps
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: ~/.m2
+          key: lein-m2-${{ hashFiles('ferrosa-jepsen/elle-checker/project.clj') }}
+
+      # ── Bring up the RF=3 cluster from the nightly .deb image ──
+      - name: Download nightly Ferrosa .deb
+        id: nightly_deb
+        uses: ./.github/actions/ferrosa-nightly-deb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build runtime image (from the .deb, no source build)
+        run: |
+          set -euo pipefail
+          cp "${{ steps.nightly_deb.outputs.deb_path }}" tests/ferrosa.deb
+          docker build -f tests/Dockerfile.nightly-deb -t ferrosa-nightly:latest tests/
+          rm -f tests/ferrosa.deb
+      - name: Bring up RF=3 cluster
+        env:
+          FERROSA_NIGHTLY_IMAGE: ferrosa-nightly:latest
+        run: |
+          set -euo pipefail
+          docker compose -f "$COMPOSE" up -d --no-build
+          # All three nodes must report ready (/health is 503 until a Raft leader
+          # is elected, so a green probe means the cluster actually formed).
+          for port in 9090 9091 9092; do
+            ok=0
+            for i in $(seq 1 60); do
+              if curl -sf "http://localhost:${port}/health" >/dev/null; then ok=1; break; fi
+              sleep 3
+            done
+            [ "$ok" = 1 ] || { echo "node on :$port never became ready"; \
+              docker compose -f "$COMPOSE" logs --tail 200; exit 1; }
+          done
+          echo "RF=3 cluster formed."
+
+      # ── Certification 1: fault-free ──
+      - name: Elle cert — fault-free
+        run: |
+          set -euo pipefail
+          ./target/release/examples/elle_list_append 127.0.0.1:9042 \
+            /tmp/hist-clean.edn $ELLE_GEN_CLEAN
+          echo "=== fault-free op breakdown ==="
+          for t in ok info fail; do printf '  :%s = %s\n' "$t" \
+            "$(grep -oc ":type :$t" /tmp/hist-clean.edn || true)"; done
+          ( cd ferrosa-jepsen/elle-checker && lein run /tmp/hist-clean.edn ) \
+            || { echo "FAULT-FREE Elle check did NOT return valid? true"; exit 1; }
+          echo "fault-free: valid? true"
+
+      # ── Certification 2: under partition + latency nemesis ──
+      - name: Elle cert — nemesis (partition + latency)
+        run: |
+          set -euo pipefail
+          ip() { docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$1"; }
+          N1=$(ip ferrosa-elle-node1); N2=$(ip ferrosa-elle-node2); N3=$(ip ferrosa-elle-node3)
+          drop()  { docker exec "$1" iptables -A INPUT  -s "$2" -j DROP; \
+                    docker exec "$1" iptables -A OUTPUT -d "$2" -j DROP; }
+          heal()  { for n in node1 node2 node3; do \
+                    docker exec "ferrosa-elle-$n" iptables -F INPUT  || true; \
+                    docker exec "ferrosa-elle-$n" iptables -F OUTPUT || true; done; }
+          slow()  { docker exec "$1" tc qdisc add dev eth0 root netem delay 200ms || true; }
+          unslow(){ for n in node2 node3; do \
+                    docker exec "ferrosa-elle-$n" tc qdisc del dev eth0 root || true; done; }
+
+          # Preflight: confirm the fault tooling is really present (else the run
+          # would be a silent no-op and the verdict meaningless).
+          docker exec ferrosa-elle-node1 iptables -L INPUT >/dev/null \
+            && docker exec ferrosa-elle-node2 tc qdisc show dev eth0 >/dev/null \
+            || { echo "nemesis tooling (iptables/tc) unavailable in the image — aborting"; exit 1; }
+
+          # Generator in the background; nemesis schedule in the foreground.
+          ./target/release/examples/elle_list_append 127.0.0.1:9042 \
+            /tmp/hist-nemesis.edn $ELLE_GEN_NEMESIS & GEN=$!
+
+          sleep 15
+          echo ":: partition-one: isolate node3 (minority; majority keeps quorum)"
+          drop ferrosa-elle-node1 "$N3"; drop ferrosa-elle-node2 "$N3"
+          drop ferrosa-elle-node3 "$N1"; drop ferrosa-elle-node3 "$N2"
+          sleep 30
+          echo ":: heal partition"; heal
+          sleep 20
+          echo ":: slow: 200ms on node2+node3"; slow ferrosa-elle-node2; slow ferrosa-elle-node3
+          sleep 30
+          echo ":: heal slow"; unslow
+
+          wait "$GEN" || echo "generator exited non-zero (expected under faults)"
+          heal; unslow   # ensure a clean cluster for the check
+
+          echo "=== nemesis op breakdown ==="
+          for t in ok info fail; do printf '  :%s = %s\n' "$t" \
+            "$(grep -oc ":type :$t" /tmp/hist-nemesis.edn || true)"; done
+          ( cd ferrosa-jepsen/elle-checker && lein run /tmp/hist-nemesis.edn ) \
+            || { echo "NEMESIS Elle check did NOT return valid? true"; exit 1; }
+          echo "nemesis: valid? true"
+
+      - name: Cluster logs (always)
+        if: always()
+        run: docker compose -f "$COMPOSE" logs --tail 300 || true
+      - name: Tear down
+        if: always()
+        run: docker compose -f "$COMPOSE" down -v || true
+
+      - name: File an issue on failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Nightly Elle strict-serializability FAILED ($(date -u +%F))" \
+            --label correctness \
+            --body "The nightly Accord Elle certification did not return \`valid? true\`. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. See specs/reference/testing-methodology-and-results-2026-07.md." \
+            || true

--- a/ferrosa-jepsen/elle-checker/project.clj
+++ b/ferrosa-jepsen/elle-checker/project.clj
@@ -6,4 +6,7 @@
   :license {:name "Apache-2.0"}
   :dependencies [[org.clojure/clojure "1.12.0"]
                  [jepsen "0.3.6"]]
+  ;; Run headless: Elle/jepsen pulls in AWT, which throws HeadlessException on a
+  ;; display-less host (CI). The verdict is printed to stdout; no graphs needed.
+  :jvm-opts ["-Djava.awt.headless=true"]
   :main ferrosa.elle-check)

--- a/ferrosa-jepsen/tests/docker/elle-cluster-rf3.yml
+++ b/ferrosa-jepsen/tests/docker/elle-cluster-rf3.yml
@@ -1,0 +1,182 @@
+# Single-DC 3-node RF=3 ferrosa cluster for the Accord strict-serializability
+# (Elle list-append) certification in CI. Mirrors the T3 nightly compose but with
+# ONE datacenter and 3 voters (SimpleStrategy RF=3 is what the elle_list_append
+# generator creates), and a single flat network so the nemesis schedule can
+# partition/slow individual nodes with `docker exec` iptables/tc (NET_ADMIN).
+#
+# 12-factor: nodes run the pre-built ${FERROSA_NIGHTLY_IMAGE}; `up --no-build`
+# never compiles. The host driver reconnects through the mapped 127.0.0.1 ports,
+# so each node advertises its CQL broadcast as its host-mapped port.
+name: ferrosa-elle-rf3
+
+networks:
+  elle-net:
+    driver: bridge
+
+volumes:
+  elle-rustfs-data:
+  elle-node1-data:
+  elle-node2-data:
+  elle-node3-data:
+
+services:
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: ferrosa-elle-rustfs
+    networks: [elle-net]
+    environment:
+      RUSTFS_VOLUMES: /data/rustfs0
+      RUSTFS_ADDRESS: "0.0.0.0:9000"
+      RUSTFS_ACCESS_KEY: rustfsadmin
+      RUSTFS_SECRET_KEY: rustfsadmin  # pragma: allowlist secret
+      RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
+    volumes:
+      - elle-rustfs-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+
+  rustfs-init:
+    image: minio/mc
+    container_name: ferrosa-elle-rustfs-init
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    networks: [elle-net]
+    entrypoint: >
+      sh -c "mc alias set local http://rustfs:9000 rustfsadmin rustfsadmin &&
+             mc mb local/ferrosa-elle --ignore-existing &&
+             echo 'bucket ferrosa-elle ready'"
+    restart: "no"
+
+  node1:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
+    container_name: ferrosa-elle-node1
+    depends_on:
+      rustfs-init:
+        condition: service_completed_successfully
+    networks: [elle-net]
+    ports:
+      - "9042:9042"
+      - "9090:9090"
+    environment:
+      FERROSA_HOST_ID: "e11e0001-0001-0001-0001-000000000001"
+      FERROSA_INTERNODE_BIND: "0.0.0.0:7000"
+      FERROSA_INTERNODE_BROADCAST: "node1:7000"
+      FERROSA_SEED: "node2:7000,node3:7000"
+      FERROSA_CQL_BIND: "0.0.0.0:9042"
+      FERROSA_CQL_BROADCAST: "127.0.0.1:9042"
+      FERROSA_WEB_BIND: "0.0.0.0:9090"
+      FERROSA_CLUSTER_NAME: "ferrosa-elle"
+      FERROSA_DATA_DIR: "/var/lib/ferrosa"
+      FERROSA_AUTH_DISABLED: "true"
+      FERROSA_S3_ENDPOINT: "http://rustfs:9000"
+      FERROSA_S3_BUCKET: "ferrosa-elle"
+      FERROSA_S3_ALLOW_HTTP: "true"
+      FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
+      FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      FERROSA_CACHE_MAX_BYTES: "536870912"
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728"
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"
+    cap_add: [NET_ADMIN]
+    volumes:
+      - elle-node1-data:/var/lib/ferrosa
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9090/health || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 18
+      start_period: 15s
+
+  node2:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
+    container_name: ferrosa-elle-node2
+    depends_on:
+      rustfs-init:
+        condition: service_completed_successfully
+    networks: [elle-net]
+    ports:
+      - "9043:9042"
+      - "9091:9090"
+    environment:
+      FERROSA_HOST_ID: "e11e0002-0002-0002-0002-000000000002"
+      FERROSA_INTERNODE_BIND: "0.0.0.0:7000"
+      FERROSA_INTERNODE_BROADCAST: "node2:7000"
+      FERROSA_SEED: "node1:7000,node3:7000"
+      FERROSA_CQL_BIND: "0.0.0.0:9042"
+      FERROSA_CQL_BROADCAST: "127.0.0.1:9043"
+      FERROSA_WEB_BIND: "0.0.0.0:9090"
+      FERROSA_CLUSTER_NAME: "ferrosa-elle"
+      FERROSA_DATA_DIR: "/var/lib/ferrosa"
+      FERROSA_AUTH_DISABLED: "true"
+      FERROSA_S3_ENDPOINT: "http://rustfs:9000"
+      FERROSA_S3_BUCKET: "ferrosa-elle"
+      FERROSA_S3_ALLOW_HTTP: "true"
+      FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
+      FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      FERROSA_CACHE_MAX_BYTES: "536870912"
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728"
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"
+    cap_add: [NET_ADMIN]
+    volumes:
+      - elle-node2-data:/var/lib/ferrosa
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9090/health || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 18
+      start_period: 15s
+
+  node3:
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-nightly:latest}
+    container_name: ferrosa-elle-node3
+    depends_on:
+      rustfs-init:
+        condition: service_completed_successfully
+    networks: [elle-net]
+    ports:
+      - "9044:9042"
+      - "9092:9090"
+    environment:
+      FERROSA_HOST_ID: "e11e0003-0003-0003-0003-000000000003"
+      FERROSA_INTERNODE_BIND: "0.0.0.0:7000"
+      FERROSA_INTERNODE_BROADCAST: "node3:7000"
+      FERROSA_SEED: "node1:7000,node2:7000"
+      FERROSA_CQL_BIND: "0.0.0.0:9042"
+      FERROSA_CQL_BROADCAST: "127.0.0.1:9044"
+      FERROSA_WEB_BIND: "0.0.0.0:9090"
+      FERROSA_CLUSTER_NAME: "ferrosa-elle"
+      FERROSA_DATA_DIR: "/var/lib/ferrosa"
+      FERROSA_AUTH_DISABLED: "true"
+      FERROSA_S3_ENDPOINT: "http://rustfs:9000"
+      FERROSA_S3_BUCKET: "ferrosa-elle"
+      FERROSA_S3_ALLOW_HTTP: "true"
+      FERROSA_S3_ACCESS_KEY_ID: "rustfsadmin"
+      FERROSA_S3_SECRET_ACCESS_KEY: "rustfsadmin"  # pragma: allowlist secret
+      FERROSA_CACHE_MAX_BYTES: "536870912"
+      FERROSA_MEMTABLE_BACKPRESSURE_BYTES: "134217728"
+      FERROSA_FLUSH_THRESHOLD_BYTES: "33554432"
+    cap_add: [NET_ADMIN]
+    volumes:
+      - elle-node3-data:/var/lib/ferrosa
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9090/health || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 18
+      start_period: 15s


### PR DESCRIPTION
Wires the Accord strict-serializability (Elle) certification into CI as a **nightly + on-demand** gate — the automated form of `deploy/fly-accord-elle/certify{,-nemesis}.sh`. This locks in the manual certification from today (#292/#297) so it can't silently regress. Strand B of `t_48d5eeaa` / `t_5a3a12e3`.

**Not a per-PR gate** — a 3-node cluster + generator + Elle is too heavy for that.

- **`ferrosa-jepsen/tests/docker/elle-cluster-rf3.yml`** — single-DC 3-node RF=3 cluster (RustFS S3), `NET_ADMIN`-capped for the nemesis, host-reachable via mapped ports. Runs the pre-built nightly `.deb` image (`up --no-build`; nothing compiles alongside the containers — the 12-factor rule the nightly-jepsen workflow established).
- **`.github/workflows/elle-strict-serializable-nightly.yml`** — builds only the small `elle_list_append` generator + bootstraps the `lein` Elle checker (Java 17, cached `~/.m2`), forms the cluster, then runs **two** certifications:
  1. **fault-free** — generator → Elle check (job fails unless `valid? true`);
  2. **nemesis** — isolate node3 (minority) → heal → 200 ms netem on node2/3 → heal, with a preflight that aborts if `iptables`/`tc` are missing (so faults can never be silent no-ops) → Elle check.
  Files a `correctness` issue on a scheduled failure; always tears down.

Cadence nightly + `workflow_dispatch`; fault-injected coverage from the start (per request). Action SHAs reuse the repo's existing pins. I'm triggering a `workflow_dispatch` run to validate the cluster/nemesis/lein path on a real runner and will iterate on the result.
