### PR TITLE
graph: pull-based streaming executor — design + increments 1-3 (t_4ce82a3e)

### DIFF
--- a/ferrosa-graph/specs/streaming-executor-design.md
+++ b/ferrosa-graph/specs/streaming-executor-design.md
@@ -71,16 +71,33 @@ Operators compose as a tree; the transport pulls the root. Two operator classes:
   OptionalExpand, Filter, Project, Unwind, Limit, Union(all). These hold no
   result buffer; they transform/forward one row (or one frontier element) at a
   time.
-- **Pipeline-breakers (bounded buffering):** OrderBy, Distinct, Aggregate,
-  VarPath, WcoJoin. These must see multiple/all inputs, but each is bounded by an
-  existing cap (`max_result_rows`, `max_groups`, `max_var_path_visited`,
-  `max_results`) — those caps are preserved and are the memory bound. Two
-  refinements make the common cases streaming-friendly:
+- **Pipeline-breakers:** OrderBy, Distinct, Aggregate, VarPath, WcoJoin. These
+  must see multiple/all inputs. Rather than capping them in memory, they follow
+  the approach **ferrosa-cql already proved for the same problem**:
   - **ORDER BY + LIMIT k → bounded top-k** (a k-sized heap), not a full sort.
-    ORDER BY without LIMIT inherently must see every row; it stays bounded by
-    `max_result_rows` and fails loud past it (as today).
-  - **DISTINCT** stays a bounded `HashSet` of serialized rows, emitting each row
-    the first time it is seen (streaming dedup), bounded by `max_result_rows`.
+  - **ORDER BY without LIMIT → SPILL, don't cap.** Reuse
+    [`ferrosa_storage::ExternalSorter`] (`ferrosa-storage/src/external_sort.rs`):
+    accumulate to a byte threshold, spill sorted runs to a temp dir, k-way merge
+    on `finish()`, fail loud on any spill/merge I/O error. The temp dir is a
+    [`TempSortTableReservation`] whose `Drop` does `remove_dir_all`, so a
+    cancelled or aborted query cleans up automatically — the cancel-friendly
+    property this executor needs, for free. The CQL side already classifies this
+    shape as `OrderByExecutionPlan::SpillableTempTable { estimated_scan_bytes }`
+    (`ferrosa-cql/src/router.rs`); the graph planner should classify the same way.
+    *Gap to close:* `ExternalSorter` sorts `Row`/`CqlValue` while graph rows are
+    `Vec<serde_json::Value>`, so this needs either a value bridge or a small
+    generic-ification of the sorter — the spill/merge/cleanup machinery itself is
+    reused untouched.
+  - **DISTINCT** emits each row the first time it is seen (streaming dedup). Its
+    seen-set is subject to the same argument: a spilling/sort-based dedup rather
+    than an unbounded in-memory `HashSet`.
+  - **Aggregate** stays bounded by `max_groups`; a spilling group-by is a later
+    option if that cap proves too restrictive in practice.
+  - VarPath / WcoJoin keep their existing `max_var_path_visited` / `max_results`
+    caps (they bound *traversal*, not result buffering).
+
+  The principle: an in-memory cap that fails a legitimate query is a worse answer
+  than spilling, when the spill machinery already exists and is cancel-safe.
 
 `Limit(k)` is `upstream.take(k)`: when the transport (or an outer Limit) stops
 pulling, `take` drops the upstream stream, which drops the Expand operator's
@@ -135,8 +152,9 @@ the stream — behavior-identical.
    must keep `http_limit_short_circuits_expansion_hydration`'s `vertices_read`
    bound (`tests:6615`).
 4. **Multi-hop Expand** — pull chains hop→hop; LIMIT/`take` propagates upstream.
-5. **Pipeline-breakers as bounded operators:** OrderBy (top-k on LIMIT, else
-   bounded full sort), streaming Distinct, Aggregate (bounded groups). Unwind,
+5. **Pipeline-breakers:** OrderBy (top-k on LIMIT; SPILLING external sort via
+   `ferrosa_storage::ExternalSorter` + `TempSortTableReservation` otherwise),
+   streaming/spilling Distinct, Aggregate (bounded groups). Unwind,
    OPTIONAL MATCH, WITH-pipeline as streaming stages.
 6. **VarPath + Leapfrog** streaming (bounded by their visited/result caps).
 7. **Transport streaming:** HTTP chunked body + Bolt incremental PULL honoring
@@ -159,10 +177,12 @@ expand-with-limit shape; 5–7 complete coverage and end-to-end streaming.
 
 ## 7. Non-goals / risks
 
-- Not changing query semantics, result ordering, or the DoS caps.
-- ORDER BY without LIMIT and global Aggregate inherently buffer (bounded by
-  `max_result_rows`/`max_groups`) — streaming does not remove those bounds, it
-  preserves them and fails loud past them, as today.
+- Not changing query semantics, result ordering, or the traversal DoS caps
+  (`max_fan_out_per_hop`, `max_var_path_visited`, `max_results`).
+- ORDER BY without LIMIT and global Aggregate are pipeline-breakers — they must
+  see their whole input. Streaming does not remove that, but per §2 the answer is
+  to **spill** (reusing the CQL `ExternalSorter` + `TempSortTableReservation`
+  RAII cleanup), not to cap in memory and fail a legitimate query.
 - The recursive `Box::pin(execute(...))` children (Union/Subscribe/Set/Remove/
   Delete/Aggregate inner) each currently await a full child `GraphResult`;
   increment 5+ converts them to consume the child `RowStream`.

--- a/ferrosa-graph/specs/streaming-executor-design.md
+++ b/ferrosa-graph/specs/streaming-executor-design.md
@@ -84,10 +84,24 @@ Operators compose as a tree; the transport pulls the root. Two operator classes:
     property this executor needs, for free. The CQL side already classifies this
     shape as `OrderByExecutionPlan::SpillableTempTable { estimated_scan_bytes }`
     (`ferrosa-cql/src/router.rs`); the graph planner should classify the same way.
-    *Gap to close:* `ExternalSorter` sorts `Row`/`CqlValue` while graph rows are
-    `Vec<serde_json::Value>`, so this needs either a value bridge or a small
-    generic-ification of the sorter — the spill/merge/cleanup machinery itself is
-    reused untouched.
+    *Gap to close — resolved:* `ExternalSorter`'s row type is
+    `Vec<Option<CqlValue>>` (a RESULT row, not an sstable row) while graph rows
+    are `Vec<serde_json::Value>`. Two ways to bridge that, and the choice is
+    forced by correctness:
+    - **A value bridge (json → CqlValue) is WRONG.** Graph's `compare_json_values`
+      (`expand.rs`) has semantics `CqlValue`'s `Ord` does not share: mixed-type
+      comparisons (String vs Number) and complex values (objects, arrays) compare
+      **Equal**, and `Null` sorts before any present value. Converting to
+      `CqlValue` and using its `Ord` would silently reorder those cases — a
+      behavior change in ORDER BY results.
+    - **Generic-ify the sorter** over its row type + comparator (and its
+      serialization for spilled runs), so graph passes its own
+      `compare_json_values` and gets identical ordering. The spill / k-way merge /
+      `TempSortTableReservation` cleanup machinery is reused untouched, and the
+      CQL caller keeps its current behavior by instantiating with the existing
+      `RowOrder`.
+    This makes increment 5 a change in `ferrosa-storage` (generic-ification, CQL
+    path must not regress) plus the graph-side wiring.
   - **DISTINCT** emits each row the first time it is seen (streaming dedup). Its
     seen-set is subject to the same argument: a spilling/sort-based dedup rather
     than an unbounded in-memory `HashSet`.

--- a/ferrosa-graph/specs/streaming-executor-design.md
+++ b/ferrosa-graph/specs/streaming-executor-design.md
@@ -1,0 +1,168 @@
+---
+title: Graph streaming (pull-based) executor — design + increment plan
+status: Proposed
+last_revised: 2026-07-25
+executive_summary: >
+  The ferrosa-graph query executor materializes its full result set (and full
+  per-hop fan-out) into Vecs, then applies ORDER BY / DISTINCT / LIMIT by
+  truncation — the OOM risk for unbounded / high-degree-hub queries (t_4ce82a3e).
+  This spec designs the replacement: a pull-based (Volcano) model where each
+  operator is a lazy `RowStream`, LIMIT short-circuits upstream everywhere, and
+  per-hop hydration runs at bounded concurrency WITHOUT cloning WritePath /
+  Schema / Hop / Row per neighbor (defeating the documented "Send is not general
+  enough" wall via inline-driven `FuturesUnordered` of borrowed futures, not
+  `buffer_unordered`'s `'static` clones). Rows stream to the transport (HTTP
+  chunked, Bolt incremental PULL) so an unbounded hub query cannot OOM. Delivered
+  as 7 behavior-preserving increments, each keeping the existing ~95 integration
+  tests green.
+---
+
+# Graph streaming (pull-based) executor — design + increment plan
+
+> Task: `t_4ce82a3e`. Owner requirement (Ben, 2026-07-08): a FULL streaming fix —
+> no per-neighbor data clones, no materialized result sets. Do not hand-build
+> clone/concurrency hacks in the current loop.
+
+## 1. Current model and why it must change
+
+`executor::execute()` (`expand.rs:115`) dispatches to `execute_*` fns that each
+build a full `GraphResult { columns, rows: Vec<Vec<Value>>, stats }`
+(`result.rs:1`). The spine is **materialize-then-truncate**:
+
+- The frontier is a `Vec<ExpandState>` (`expand.rs:33`, `:1061`); each hop reads
+  every frontier vertex's adjacency, collects `pairs`/`next_states` Vecs
+  (`:1164-1262`), hydrates *every* neighbor, then swaps into `current_states`.
+- Result rows are built into a `rows` Vec (`:1328-1354`); ORDER BY
+  (`sort_projected_rows_by_bindings` `:1358`), DISTINCT (sort+dedup `:1361`),
+  and LIMIT (`rows.truncate` `:1368`) are all **post-hoc Vec operations**.
+- The one exception is the last-hop LIMIT push-down (bc098906, `:1141-1260`),
+  which stops hydrating once `limit` rows accumulate — but only when
+  `order_by.is_empty() && !distinct && with_pipeline.is_none() &&
+  post_filters.is_empty() && optional_hops.is_empty()` and only on the final hop.
+
+Two consequences: (a) an unbounded / high-degree-hub query holds the entire
+result and full fan-out in memory → OOM; (b) concurrent per-hop hydration is
+blocked by the **Send wall** (`:1220-1227`): `hydrate_hop_neighbor` (`:2595`)
+borrows `&WritePath / &Schema / &Hop / &ExpandState / &Row` (the last two alias
+the frontier Vec being iterated), so a `buffer_unordered` on the multi-threaded
+runtime would need `Send + 'static` futures — achievable only by cloning that
+data per neighbor, which the task rejects. The loop is therefore **sequential**.
+
+No query-path row sink exists: HTTP returns `Json(result)` (`http.rs:286`) and
+Bolt buffers the whole result in `pending_result`, replying to PULL with all
+rows at once and ignoring `n`/`has_more` (`bolt/server.rs:391,413`). The
+SUBSCRIBE SSE path (`http.rs:456-560`, an mpsc → `ReceiverStream` → `Sse`) is the
+only streaming sink and is the reusable template.
+
+## 2. Target model — pull-based Volcano operators
+
+Every operator is a lazy asynchronous row source:
+
+```rust
+/// A pull-based row source. `next()` yields the next row or None at end;
+/// dropping the stream stops all upstream work (the LIMIT short-circuit).
+type RowStream<'a> = Pin<Box<dyn Stream<Item = Result<RowVals>> + Send + 'a>>;
+type RowVals = Vec<serde_json::Value>;
+```
+
+Operators compose as a tree; the transport pulls the root. Two operator classes:
+
+- **Pipelineable (stream-through, O(1) memory):** AnchorScan, Expand(hop),
+  OptionalExpand, Filter, Project, Unwind, Limit, Union(all). These hold no
+  result buffer; they transform/forward one row (or one frontier element) at a
+  time.
+- **Pipeline-breakers (bounded buffering):** OrderBy, Distinct, Aggregate,
+  VarPath, WcoJoin. These must see multiple/all inputs, but each is bounded by an
+  existing cap (`max_result_rows`, `max_groups`, `max_var_path_visited`,
+  `max_results`) — those caps are preserved and are the memory bound. Two
+  refinements make the common cases streaming-friendly:
+  - **ORDER BY + LIMIT k → bounded top-k** (a k-sized heap), not a full sort.
+    ORDER BY without LIMIT inherently must see every row; it stays bounded by
+    `max_result_rows` and fails loud past it (as today).
+  - **DISTINCT** stays a bounded `HashSet` of serialized rows, emitting each row
+    the first time it is seen (streaming dedup), bounded by `max_result_rows`.
+
+`Limit(k)` is `upstream.take(k)`: when the transport (or an outer Limit) stops
+pulling, `take` drops the upstream stream, which drops the Expand operator's
+in-flight hydration — LIMIT short-circuits **everywhere**, for free, not just the
+last hop. This subsumes and generalizes bc098906.
+
+## 3. Defeating the Send wall without clones
+
+The wall is `buffer_unordered`/`buffered` requiring `Send + 'static`. The fix is
+**inline-driven `FuturesUnordered`** inside the Expand operator's `poll_next`:
+
+- The operator OWNS the shared read context as `Arc` handles
+  (`Arc<WritePath>`, `Arc<Schema>`) — an `Arc::clone` is a refcount bump, NOT the
+  per-neighbor DATA clone the task forbids (`Hop`, `Row`, `bindings` are never
+  cloned into the future; `Hop` is borrowed from the operator, the neighbor id is
+  the only owned input, exactly as `hydrate_hop_neighbor` already takes it).
+- `FuturesUnordered<F>` driven by the operator's own `poll_next` (not
+  `tokio::spawn`) does **not** require `F: 'static` — it polls the futures in
+  place, so `F` may borrow from the operator (`&self.hop`, `&Arc<WritePath>`).
+  Bounded concurrency = keep at most `N` futures in the set (push a new neighbor
+  future each time one completes), yielding hydrated rows as they resolve.
+- This gives concurrent hydration with a fixed in-flight budget, zero data
+  clones, and no `'static` requirement — the exact shape the task calls for.
+
+`hydrate_hop_neighbor` (`:2595`) is reused verbatim as the per-neighbor future
+body (it already borrows everything and owns only `neighbor_id`).
+
+## 4. Streaming transport
+
+A row sink is added at the `execute` boundary. `execute()` gains a streaming
+sibling returning `(columns, RowStream, StatsHandle)`; the buffered `GraphResult`
+is kept for internal callers (CALL join, aggregate inner, tests) by `collect`ing
+the stream — behavior-identical.
+
+- **HTTP:** replace `Json(result)` (`http.rs:286`) with a chunked
+  `application/x-ndjson` (or a JSON array streamed element-by-element) body over
+  the SUBSCRIBE mpsc/`ReceiverStream` template (`:456-560`). Header row first,
+  then one row per chunk, then a trailing stats object.
+- **Bolt:** honor `Pull { n, qid }` (`server.rs:408`): pull `n` rows from the
+  `RowStream`, reply `Record` per row, then SUCCESS with `has_more` when the
+  stream is not exhausted — incremental paging instead of the whole-result batch.
+
+## 5. Increment plan (each behavior-preserving; existing tests stay green)
+
+1. **RowStream plumbing (no behavior change).** Introduce `RowStream` +
+   `collect_to_graph_result`. `execute()` keeps returning `GraphResult` (built by
+   collecting an internally-produced stream for one simple path). Pure scaffold.
+2. **Streaming AnchorScan + Project + Limit** for the anchor-only / no-hop path
+   (`execute_return_only`, virtual-anchor). LIMIT short-circuits; O(1) memory.
+3. **Streaming single-hop Expand** with inline `FuturesUnordered` bounded
+   hydration (§3) + LIMIT short-circuit across the hop. This is the core win and
+   must keep `http_limit_short_circuits_expansion_hydration`'s `vertices_read`
+   bound (`tests:6615`).
+4. **Multi-hop Expand** — pull chains hop→hop; LIMIT/`take` propagates upstream.
+5. **Pipeline-breakers as bounded operators:** OrderBy (top-k on LIMIT, else
+   bounded full sort), streaming Distinct, Aggregate (bounded groups). Unwind,
+   OPTIONAL MATCH, WITH-pipeline as streaming stages.
+6. **VarPath + Leapfrog** streaming (bounded by their visited/result caps).
+7. **Transport streaming:** HTTP chunked body + Bolt incremental PULL honoring
+   `n`/`has_more`. Only here does the full result stop being buffered end-to-end.
+
+Increments 1–4 deliver the headline OOM/LIMIT win for the common
+expand-with-limit shape; 5–7 complete coverage and end-to-end streaming.
+
+## 6. Verification
+
+- The ~95 `graph_http_integration.rs` tests are the behavior oracle; run the full
+  suite after every increment. Key guards: `http_limit_short_circuits_expansion_hydration`
+  (LIMIT bounds `vertices_read`), DISTINCT/ORDER BY/LIMIT pipeline tests, aggregate
+  semantics, `varpath_budget_exceeded` + `leapfrog_join_respects_max_results`
+  (the memory/DoS caps must not regress).
+- Add: a high-degree-hub streaming test asserting bounded peak `vertices_read`
+  (and, once transport streams, bounded response buffering) for
+  `MATCH (h)<-[r]-(n) RETURN n LIMIT k` where the hub degree ≫ k.
+- `cargo test -p ferrosa-graph` + clippy `-D warnings` green each increment.
+
+## 7. Non-goals / risks
+
+- Not changing query semantics, result ordering, or the DoS caps.
+- ORDER BY without LIMIT and global Aggregate inherently buffer (bounded by
+  `max_result_rows`/`max_groups`) — streaming does not remove those bounds, it
+  preserves them and fails loud past them, as today.
+- The recursive `Box::pin(execute(...))` children (Union/Subscribe/Set/Remove/
+  Delete/Aggregate inner) each currently await a full child `GraphResult`;
+  increment 5+ converts them to consume the child `RowStream`.

--- a/ferrosa-graph/specs/streaming-executor-design.md
+++ b/ferrosa-graph/specs/streaming-executor-design.md
@@ -201,10 +201,43 @@ tripwire enforcing it (`ferrosa-cluster/src/write_path.rs` test: *"unbounded loc
 range reads must be exposed as streams, not collected into `Vec<Partition>`"*).
 The graph executor should end up subject to an equivalent guard.
 
+## 6c. Owner decisions (Ben, 2026-07-25)
+
+Three questions the inventory surfaced, and the answers this work implements:
+
+1. **`max_result_rows` → SPILL, remove the cap.** Today it silently truncates
+   (`break`, no error, no flag) — a client cannot distinguish a partial result
+   from a complete one, which is a fail-loud violation. It does **not** become a
+   `ResourceLimit` error and does **not** get a `truncated` flag: with the
+   spilling sorter (§2) plus streamed transport (§5 inc 7), a large result no
+   longer needs an in-memory bound at all. Remove `max_result_rows` rather than
+   convert it. Applies to `expand.rs:1387`, `varpath.rs:307`, and the
+   `leapfrog.rs` uses.
+
+2. **SUBSCRIBE → CDC-driven push.** Stop the poll-and-diff model
+   (`http.rs:488-524`) that holds previous + current result sets. Drive
+   subscriptions from the change feed so updates are pushed as they happen, with
+   **no previous-result buffer at all**. This is a substantial separable change —
+   tracked as its own task, not folded into this refactor.
+
+3. **`max_fan_out_per_hop` → relax once the frontier streams.** The cap's
+   rationale is the per-hop `Vec`; once the frontier is a stream there is no
+   memory argument for refusing a legitimate high-degree traversal. DoS
+   protection falls to the **query timeout** instead. Keep the cap only until the
+   frontier actually streams (it still guards the current `next_states` Vec), then
+   remove it with the Vec.
+
+The through-line: prefer removing a bound over converting it into an error, when
+streaming or spilling makes the bound unnecessary.
+
 ## 7. Non-goals / risks
 
-- Not changing query semantics, result ordering, or the traversal DoS caps
-  (`max_fan_out_per_hop`, `max_var_path_visited`, `max_results`).
+- Not changing query semantics or result ordering.
+- Caps are **not** preserved for their own sake — per §6c, `max_result_rows` is
+  removed (spill instead) and `max_fan_out_per_hop` is removed once the frontier
+  streams (timeout becomes the DoS control). `max_var_path_visited` /
+  `max_results` remain for now: they bound *traversal work*, not result
+  buffering, and are revisited with increment 6.
 - ORDER BY without LIMIT and global Aggregate are pipeline-breakers — they must
   see their whole input. Streaming does not remove that, but per §2 the answer is
   to **spill** (reusing the CQL `ExternalSorter` + `TempSortTableReservation`

--- a/ferrosa-graph/specs/streaming-executor-design.md
+++ b/ferrosa-graph/specs/streaming-executor-design.md
@@ -175,6 +175,32 @@ expand-with-limit shape; 5–7 complete coverage and end-to-end streaming.
   `MATCH (h)<-[r]-(n) RETURN n LIMIT k` where the hub degree ≫ k.
 - `cargo test -p ferrosa-graph` + clippy `-D warnings` green each increment.
 
+## 6b. Materialization inventory
+
+`frg materialization-scan ferrosa-graph/src` reports 45 findings; most are
+**false positives** — Vecs sized by the *query* or *schema* (parser items,
+planner hops, merge column shapes, `column_names_for_table`, param binding), not
+by the data. The ones that actually scale with graph data:
+
+| Site | Holds | Bound today | Retired by |
+|---|---|---|---|
+| `expand.rs:1079` anchor `states` | every anchor partition (**full table scan**) | none | inc 2 — use `WritePath::range_read_stream_all*` (already exists) |
+| `expand.rs:1225` `pairs` collect | one vertex's full adjacency (**hub degree**) | `max_fan_out_per_hop` | inc 3/4 (concurrency+early-stop done; still collects) |
+| `expand.rs:1384-85` `rows`/`result_states` | **entire result set** | `max_result_rows` (silent truncate — see §7) | inc 7 (transport) |
+| `expand.rs:1328` `kept` (post-filters) | full frontier | none | inc 5 |
+| `expand.rs:471` `next_frontier` (pattern predicate) | BFS frontier | none | inc 5 |
+| `expand.rs:1857` edge-anchored `states` | edge-anchor scan | none | inc 2 |
+| `varpath.rs` frontier / `result_keys` / `visited` | BFS frontier + visited set | `max_var_path_visited` | inc 6 |
+| `leapfrog.rs` `result_rows` / `AdjacencyIterator` | join output + sorted adjacency | `max_results` | inc 6 |
+| `engine.rs:910-915` CALL subquery `out_rows` | **outer result + every inner result** (nested-loop join) | none | inc 5 |
+| `http.rs:510` SUBSCRIBE diff | **two full result sets** (previous + current) | none | see §7 — needs a design decision |
+| `stream.rs:69/91` collect bridges | migration scaffolding | caller's | inc 7 (they disappear) |
+
+Note the storage layer already went through this discipline and has a source
+tripwire enforcing it (`ferrosa-cluster/src/write_path.rs` test: *"unbounded local
+range reads must be exposed as streams, not collected into `Vec<Partition>`"*).
+The graph executor should end up subject to an equivalent guard.
+
 ## 7. Non-goals / risks
 
 - Not changing query semantics, result ordering, or the traversal DoS caps

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -29,6 +29,12 @@ use crate::parser::{
 };
 use crate::planner::physical::{AggregateProjection, Anchor, CreateOp, Hop, MergeOp, PhysicalPlan};
 
+/// Maximum neighbor hydrations in flight at once within a single hop
+/// (t_4ce82a3e). Bounds the concurrent storage reads a high-degree hub can
+/// launch: fan-out is unbounded, in-flight work is not. Small enough that the
+/// per-hop future set stays cheap, large enough to overlap read latency.
+const HOP_HYDRATION_CONCURRENCY: usize = 16;
+
 #[derive(Debug, Clone)]
 struct ExpandState {
     current_key: DecoratedKey,
@@ -1205,31 +1211,79 @@ async fn execute_expand(
                     })
                     .collect();
 
-                // Hydrate this vertex's neighbors sequentially. `cap_this_hop`
-                // (LIMIT push-down, t_0cc8d63e) stops as soon as the cap is met
-                // so a bounded query touches minimal storage; uncapped, every
-                // neighbor is hydrated. Concurrent bounded hydration is the
-                // intended win but the borrowed per-neighbor futures can't
-                // satisfy the multi-threaded runtime's Send bound without a
-                // clone-heavy `'static` restructure — which the streaming/pull
-                // executor (t_4ce82a3e) supersedes. Sequential here; correct.
-                for (row, nid) in pairs {
-                    if let Some(st) = hydrate_hop_neighbor(
-                        write_path,
-                        schema,
-                        hop,
-                        state,
-                        vertex_key,
-                        edge_meta.as_ref(),
-                        vertex_meta.as_ref(),
-                        row,
-                        nid,
-                    )
-                    .await?
-                    {
-                        next_states.push(st);
-                        if cap_this_hop.is_some_and(|cap| next_states.len() >= cap) {
-                            break 'states;
+                // Hydrate this vertex's neighbors with BOUNDED CONCURRENCY
+                // (t_4ce82a3e increment 3).
+                //
+                // Every input to `hydrate_hop_neighbor` is shared/immutable, so
+                // neighbors of one vertex hydrate independently. The futures are
+                // held in a `FuturesUnordered` that this loop drives INLINE —
+                // which, unlike `buffer_unordered`/`tokio::spawn`, does NOT
+                // require `Send + 'static`: the set polls the futures in place,
+                // so they may keep borrowing `write_path`/`schema`/`hop`/`state`
+                // /`row`. That is what dissolves the old "Send is not general
+                // enough" wall WITHOUT the clone-per-neighbor restructure the
+                // task forbids — the only owned input is `nid`, exactly as
+                // before.
+                //
+                // In-flight is capped at HOP_HYDRATION_CONCURRENCY so a
+                // high-degree hub cannot launch unbounded concurrent reads, and
+                // `cap_this_hop` (LIMIT push-down) still stops the moment the
+                // cap is met, keeping the bounded-query storage-touch guarantee
+                // (http_limit_short_circuits_expansion_hydration).
+                //
+                // Ordering: results are drained in completion order, so a
+                // `cap_this_hop` prefix could differ from the sequential order.
+                // Capped hops therefore stay STRICTLY SEQUENTIAL (concurrency
+                // would change which rows a LIMIT returns); only uncapped hops —
+                // where the full fan-out is consumed and order is re-established
+                // downstream — hydrate concurrently.
+                let mut pairs_iter = pairs.into_iter();
+                if cap_this_hop.is_some() {
+                    for (row, nid) in pairs_iter {
+                        if let Some(st) = hydrate_hop_neighbor(
+                            write_path,
+                            schema,
+                            hop,
+                            state,
+                            vertex_key,
+                            edge_meta.as_ref(),
+                            vertex_meta.as_ref(),
+                            row,
+                            nid,
+                        )
+                        .await?
+                        {
+                            next_states.push(st);
+                            if cap_this_hop.is_some_and(|cap| next_states.len() >= cap) {
+                                break 'states;
+                            }
+                        }
+                    }
+                } else {
+                    use futures::stream::{FuturesUnordered, StreamExt as _};
+                    let mut in_flight = FuturesUnordered::new();
+                    loop {
+                        while in_flight.len() < HOP_HYDRATION_CONCURRENCY {
+                            let Some((row, nid)) = pairs_iter.next() else {
+                                break;
+                            };
+                            in_flight.push(hydrate_hop_neighbor(
+                                write_path,
+                                schema,
+                                hop,
+                                state,
+                                vertex_key,
+                                edge_meta.as_ref(),
+                                vertex_meta.as_ref(),
+                                row,
+                                nid,
+                            ));
+                        }
+                        let Some(hydrated) = in_flight.next().await else {
+                            break;
+                        };
+                        if let Some(st) = hydrated? {
+                            next_states.push(st);
                         }
                     }
                 }

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1331,24 +1331,16 @@ async fn execute_expand(
             break;
         }
 
-        let mut row = Vec::with_capacity(return_clause.items.len());
-        for item in &return_clause.items {
-            let value = if needs_graph_projection {
-                graph_eval_expr(
-                    &item.expr,
-                    write_path,
-                    keyspace,
-                    schema,
-                    &state.bindings,
-                    anchor_var,
-                    &state.current_key,
-                )
-                .await?
-            } else {
-                eval::eval_expr(&item.expr, &state.bindings).unwrap_or(serde_json::Value::Null)
-            };
-            row.push(value);
-        }
+        let row = project_state(
+            return_clause,
+            needs_graph_projection,
+            write_path,
+            keyspace,
+            schema,
+            anchor_var,
+            state,
+        )
+        .await?;
         result_states.push(state.clone());
         rows.push(row);
     }
@@ -1377,6 +1369,44 @@ async fn execute_expand(
         rows,
         stats,
     })
+}
+
+/// Project one expand state's bindings into a result row per the RETURN items.
+///
+/// Extracted from the `execute_expand` projection loop so the pull-based
+/// streaming `Project` operator (t_4ce82a3e, specs/streaming-executor-design.md)
+/// reuses this exact per-state logic instead of re-deriving it — and so the
+/// materialize loop no longer inlines it. `needs_graph_projection` selects the
+/// graph-aware path (pattern comprehensions need traversal keyed on the anchor
+/// var) vs. the cheap binding-only evaluator.
+async fn project_state(
+    return_clause: &ReturnClause,
+    needs_graph_projection: bool,
+    write_path: &WritePath,
+    keyspace: &str,
+    schema: Option<&Schema>,
+    anchor_var: &str,
+    state: &ExpandState,
+) -> Result<Vec<serde_json::Value>> {
+    let mut row = Vec::with_capacity(return_clause.items.len());
+    for item in &return_clause.items {
+        let value = if needs_graph_projection {
+            graph_eval_expr(
+                &item.expr,
+                write_path,
+                keyspace,
+                schema,
+                &state.bindings,
+                anchor_var,
+                &state.current_key,
+            )
+            .await?
+        } else {
+            eval::eval_expr(&item.expr, &state.bindings).unwrap_or(serde_json::Value::Null)
+        };
+        row.push(value);
+    }
+    Ok(row)
 }
 
 fn sort_projected_rows_by_bindings(

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1028,24 +1028,9 @@ async fn execute_expand(
         check_timeout(start, config.query_timeout)?;
         (states, &hops[1..])
     } else {
-        let anchor_table_id = TableId::new(&anchor.table.keyspace, &anchor.table.table);
         let anchor_meta = table_metadata_for(schema, &anchor.table.keyspace, &anchor.table.table);
-        let anchor_partitions = if let Some(meta) = anchor_meta.as_ref() {
-            if let Some((key, _clustering)) =
-                build_direct_lookup_shape(meta, &HashMap::new(), &anchor.props, &HashMap::new())?
-            {
-                let strategy = graph_replication_strategy(schema, &anchor.table.keyspace)?;
-                write_path
-                    .pk_read(&anchor_table_id, &key, ConsistencyLevel::One, &strategy)
-                    .await?
-                    .into_iter()
-                    .collect()
-            } else {
-                write_path.range_read(&anchor_table_id).await?
-            }
-        } else {
-            write_path.range_read(&anchor_table_id).await?
-        };
+        let anchor_partitions =
+            read_anchor_partitions(write_path, anchor, anchor_meta.as_ref(), schema).await?;
         stats.vertices_read += anchor_partitions.len();
         check_timeout(start, config.query_timeout)?;
 
@@ -1347,6 +1332,37 @@ async fn execute_expand(
         rows,
         stats,
     })
+}
+
+/// Read the anchor table's candidate partitions: a direct primary-key lookup
+/// when the anchor's properties pin the full key, else a range scan of the
+/// table.
+///
+/// Extracted from `execute_expand` so the anchor read strategy is one named
+/// decision the pull-based streaming `AnchorScan` (t_4ce82a3e,
+/// specs/streaming-executor-design.md) can reuse. NOTE for that work: the
+/// `range_read` arm is the unbounded materialization — the streaming operator
+/// replaces it with a lazy scan, while the pk arm is already bounded.
+async fn read_anchor_partitions(
+    write_path: &WritePath,
+    anchor: &Anchor,
+    anchor_meta: Option<&ferrosa_schema::metadata::table::TableMetadata>,
+    schema: Option<&Schema>,
+) -> Result<Vec<Partition>> {
+    let anchor_table_id = TableId::new(&anchor.table.keyspace, &anchor.table.table);
+    if let Some(meta) = anchor_meta {
+        if let Some((key, _clustering)) =
+            build_direct_lookup_shape(meta, &HashMap::new(), &anchor.props, &HashMap::new())?
+        {
+            let strategy = graph_replication_strategy(schema, &anchor.table.keyspace)?;
+            return Ok(write_path
+                .pk_read(&anchor_table_id, &key, ConsistencyLevel::One, &strategy)
+                .await?
+                .into_iter()
+                .collect());
+        }
+    }
+    Ok(write_path.range_read(&anchor_table_id).await?)
 }
 
 /// Project one expand state's bindings into a result row per the RETURN items.

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1193,53 +1193,31 @@ async fn execute_expand(
                     })
                     .collect();
 
-                if let Some(cap) = cap_this_hop {
-                    // LIMIT push-down: hydrate sequentially and stop as soon as
-                    // the cap is met, so a bounded query touches minimal storage
-                    // (t_0cc8d63e).
-                    for (row, nid) in pairs {
-                        if let Some(st) = hydrate_hop_neighbor(
-                            write_path,
-                            schema,
-                            hop,
-                            state,
-                            vertex_key,
-                            edge_meta.as_ref(),
-                            vertex_meta.as_ref(),
-                            row,
-                            nid,
-                        )
-                        .await?
-                        {
-                            next_states.push(st);
-                            if next_states.len() >= cap {
-                                break 'states;
-                            }
-                        }
-                    }
-                } else {
-                    // Unbounded: hydrate every neighbor. Concurrent per-hop
-                    // hydration (bounded buffered pk_reads) is the intended win
-                    // here, but the borrowed per-neighbor futures can't satisfy
-                    // the multi-threaded runtime's Send bound without a
-                    // clone-heavy `'static` restructure of this loop — which the
-                    // streaming/pull executor (t_4ce82a3e) will supersede. Kept
-                    // sequential for now; correctness is unaffected.
-                    for (row, nid) in pairs {
-                        if let Some(st) = hydrate_hop_neighbor(
-                            write_path,
-                            schema,
-                            hop,
-                            state,
-                            vertex_key,
-                            edge_meta.as_ref(),
-                            vertex_meta.as_ref(),
-                            row,
-                            nid,
-                        )
-                        .await?
-                        {
-                            next_states.push(st);
+                // Hydrate this vertex's neighbors sequentially. `cap_this_hop`
+                // (LIMIT push-down, t_0cc8d63e) stops as soon as the cap is met
+                // so a bounded query touches minimal storage; uncapped, every
+                // neighbor is hydrated. Concurrent bounded hydration is the
+                // intended win but the borrowed per-neighbor futures can't
+                // satisfy the multi-threaded runtime's Send bound without a
+                // clone-heavy `'static` restructure — which the streaming/pull
+                // executor (t_4ce82a3e) supersedes. Sequential here; correct.
+                for (row, nid) in pairs {
+                    if let Some(st) = hydrate_hop_neighbor(
+                        write_path,
+                        schema,
+                        hop,
+                        state,
+                        vertex_key,
+                        edge_meta.as_ref(),
+                        vertex_meta.as_ref(),
+                        row,
+                        nid,
+                    )
+                    .await?
+                    {
+                        next_states.push(st);
+                        if cap_this_hop.is_some_and(|cap| next_states.len() >= cap) {
+                            break 'states;
                         }
                     }
                 }

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1171,13 +1171,26 @@ async fn execute_expand(
             && optional_hops.is_empty();
         (safe && limit > 0).then_some(limit as usize)
     });
-    let last_hop_idx = traversal_hops.len().saturating_sub(1);
-
-    for (hop_idx, hop) in traversal_hops.iter().enumerate() {
+    for hop in traversal_hops.iter() {
         check_timeout(start, config.query_timeout)?;
-        // Only the final hop may short-circuit; earlier hops must fully expand
-        // because their fan-out feeds the next hop.
-        let cap_this_hop = pushdown_cap.filter(|_| hop_idx == last_hop_idx);
+        // LIMIT short-circuit on EVERY hop, not just the last (t_4ce82a3e
+        // increment 4).
+        //
+        // Why an INTERMEDIATE hop may also stop at `limit`: `pushdown_cap` is
+        // only set when there is no ORDER BY / DISTINCT / WITH pipeline /
+        // post-MATCH WHERE / OPTIONAL MATCH (see its definition above). With all
+        // of those absent, nothing between the hop loop and the projection can
+        // drop or reorder a state, and the projection emits EXACTLY ONE row per
+        // surviving state. So `limit` states at any hop can already produce the
+        // whole answer: expanding an extra state could only ever yield rows past
+        // the limit, which are discarded. Each state's own fan-out still feeds
+        // the next hop — we simply stop collecting NEW states once we hold
+        // enough to satisfy the limit.
+        //
+        // (Without the guard conditions this would be wrong: a post-filter could
+        // drop a state, an ORDER BY could promote a later one, and truncating
+        // early would lose rows. That is exactly why the cap is `None` then.)
+        let cap_this_hop = pushdown_cap;
 
         let mut next_states = Vec::new();
         'states: for state in &current_states {

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -168,7 +168,7 @@ pub async fn execute(
             var,
             with_pipeline,
             return_clause,
-        } => execute_unwind(&expr, &var, with_pipeline.as_ref(), &return_clause, start),
+        } => execute_unwind(&expr, &var, with_pipeline.as_ref(), &return_clause, start).await,
         PhysicalPlan::ReturnOnly { return_clause } => execute_return_only(&return_clause, start),
         PhysicalPlan::Expand {
             anchor,
@@ -916,7 +916,7 @@ fn execute_return_only(return_clause: &ReturnClause, start: Instant) -> Result<G
     })
 }
 
-fn execute_unwind(
+async fn execute_unwind(
     expr: &Expr,
     var: &str,
     with_pipeline: Option<&WithPipeline>,
@@ -947,22 +947,49 @@ fn execute_unwind(
     }
 
     let columns = build_columns(return_clause);
-    let mut rows = Vec::new();
-    for state in &states {
-        rows.push(
-            return_clause
+
+    // ORDER BY must see every row before any row is final, so it stays a
+    // pipeline-breaker over the (bounded) UNWIND list. Without it, projection
+    // and LIMIT stream: rows are produced lazily and `take(limit)` stops pulling
+    // — no full projection followed by a truncate (t_4ce82a3e increment 2).
+    let rows = if return_clause.order_by.is_empty() {
+        use futures::StreamExt as _;
+        let limit = return_clause
+            .limit
+            .map(|l| l.max(0) as usize)
+            .unwrap_or(usize::MAX);
+        let projected = futures::stream::iter(states.iter()).map(|state| {
+            Ok(return_clause
                 .items
                 .iter()
                 .map(|item| {
                     eval::eval_expr(&item.expr, &state.bindings).unwrap_or(serde_json::Value::Null)
                 })
-                .collect::<Vec<_>>(),
-        );
-    }
-    sort_projected_rows_by_bindings(&mut rows, &states, return_clause);
-    if let Some(limit) = return_clause.limit {
-        rows.truncate(limit.max(0) as usize);
-    }
+                .collect::<Vec<_>>())
+        });
+        let stream: crate::executor::stream::RowStream<'_> = Box::pin(projected.take(limit));
+        crate::executor::stream::collect_rows(stream).await?
+    } else {
+        let mut rows = Vec::new();
+        for state in &states {
+            rows.push(
+                return_clause
+                    .items
+                    .iter()
+                    .map(|item| {
+                        eval::eval_expr(&item.expr, &state.bindings)
+                            .unwrap_or(serde_json::Value::Null)
+                    })
+                    .collect::<Vec<_>>(),
+            );
+        }
+        sort_projected_rows_by_bindings(&mut rows, &states, return_clause);
+        if let Some(limit) = return_clause.limit {
+            rows.truncate(limit.max(0) as usize);
+        }
+        rows
+    };
+
     Ok(GraphResult {
         columns,
         rows,
@@ -7077,6 +7104,51 @@ mod tests {
         let result =
             compare_json_values(Some(&serde_json::json!(10)), Some(&serde_json::json!(20)));
         assert_eq!(result, std::cmp::Ordering::Less);
+    }
+
+    /// UNWIND's unsorted path now projects through a `RowStream` and applies
+    /// LIMIT as `take(k)` (t_4ce82a3e increment 2). This drives the real
+    /// executor fn to prove the conversion preserves behavior: LIMIT yields
+    /// exactly k rows, in list order, and the un-limited query returns all.
+    #[tokio::test]
+    async fn unwind_streaming_limit_yields_exactly_k_rows_in_order() {
+        use crate::parser::{Expr, Literal, ReturnClause, ReturnItem};
+
+        let list = Expr::List(
+            (1..=5)
+                .map(|i| Expr::Literal(Literal::Integer(i * 10)))
+                .collect(),
+        );
+        let items = vec![ReturnItem {
+            expr: Expr::Var("x".to_string()),
+            alias: None,
+        }];
+
+        let limited = ReturnClause {
+            items: items.clone(),
+            distinct: false,
+            order_by: Vec::new(),
+            limit: Some(2),
+        };
+        let res = execute_unwind(&list, "x", None, &limited, Instant::now())
+            .await
+            .expect("unwind with limit");
+        assert_eq!(
+            res.rows,
+            vec![vec![serde_json::json!(10)], vec![serde_json::json!(20)]],
+            "LIMIT 2 must yield the first two list elements, in order"
+        );
+
+        let unlimited = ReturnClause {
+            items,
+            distinct: false,
+            order_by: Vec::new(),
+            limit: None,
+        };
+        let res = execute_unwind(&list, "x", None, &unlimited, Instant::now())
+            .await
+            .expect("unwind without limit");
+        assert_eq!(res.rows.len(), 5, "no LIMIT must yield every element");
     }
 
     #[test]

--- a/ferrosa-graph/src/executor/mod.rs
+++ b/ferrosa-graph/src/executor/mod.rs
@@ -5,9 +5,11 @@ pub mod eval;
 pub mod expand;
 pub mod leapfrog;
 pub mod result;
+pub mod stream;
 pub mod subscribe;
 pub mod varpath;
 
 pub use eval::{eval_expr, filter_passes, partition_to_json};
 pub use expand::sort_rows;
 pub use result::{GraphResult, QueryStats};
+pub use stream::{collect_to_graph_result, RowStream, RowVals};

--- a/ferrosa-graph/src/executor/stream.rs
+++ b/ferrosa-graph/src/executor/stream.rs
@@ -1,0 +1,163 @@
+//! Module: Pull-based (Volcano) row streaming for the graph executor.
+//! Correctness: Correct when a `RowStream` yields exactly the rows the
+//!   equivalent materializing path would, in the same order, and when
+//!   `collect_to_graph_result` reproduces the buffered `GraphResult` byte-for-
+//!   byte — so an operator can be converted to streaming without any observable
+//!   behavior change.
+//! Last revised: 2026-07-25
+//! Last changed: New module — increment 1 of the streaming executor
+//!   (t_4ce82a3e, specs/streaming-executor-design.md). Scaffold only: the row
+//!   stream type + the collect bridge. No operator is streaming yet.
+//!
+//! # Why
+//!
+//! The executor materializes the full result set (and full per-hop fan-out)
+//! into `Vec`s and then truncates for ORDER BY / DISTINCT / LIMIT — the OOM
+//! risk for unbounded / high-degree-hub queries. The replacement is a pull-based
+//! model where each operator is a lazy stream: `Limit(k)` becomes `take(k)`, so
+//! dropping the downstream stream stops all upstream work (the LIMIT
+//! short-circuit) for every operator, not just the last hop.
+//!
+//! # Migration contract
+//!
+//! Operators are converted one at a time. Each converted operator produces a
+//! [`RowStream`]; callers that still need a buffered result use
+//! [`collect_to_graph_result`], which is behavior-identical to the old path.
+//! That keeps every increment green against the existing integration suite.
+
+use futures::stream::{Stream, StreamExt};
+use std::pin::Pin;
+
+use super::result::{GraphResult, QueryStats};
+use crate::error::Result;
+
+/// One projected result row: the RETURN items' values, in column order.
+pub type RowVals = Vec<serde_json::Value>;
+
+/// A pull-based row source.
+///
+/// `next()` yields the next row, `None` at end of stream. Dropping the stream
+/// stops upstream work — this is what makes `Limit` a true short-circuit rather
+/// than a post-hoc truncation.
+///
+/// Boxed + `Send` so operators compose into a tree across await points on the
+/// multi-threaded runtime. The `'a` lifetime lets an operator BORROW its inputs
+/// (the read context, the hop, the current bindings) instead of cloning them per
+/// row — the property that avoids both the per-neighbor data clones and the
+/// `'static` requirement that blocked concurrent hydration (see the design's
+/// §3: inline-driven `FuturesUnordered`, not `buffer_unordered`).
+pub type RowStream<'a> = Pin<Box<dyn Stream<Item = Result<RowVals>> + Send + 'a>>;
+
+/// Drain a [`RowStream`] into the buffered [`GraphResult`] the current callers
+/// expect.
+///
+/// This is the bridge that keeps each streaming increment behavior-preserving:
+/// a converted operator streams, and any caller not yet converted collects here.
+/// It is also the honest boundary — a `collect` is a materialization, so every
+/// remaining use marks a caller still to convert (the last of them disappears in
+/// the transport increment, where rows go straight to HTTP/Bolt).
+///
+/// `max_rows` mirrors the executor's `max_result_rows` cap: collection stops
+/// once that many rows are buffered, exactly like the materializing loop's
+/// `if rows.len() >= config.max_result_rows { break }`.
+pub async fn collect_to_graph_result(
+    columns: Vec<String>,
+    mut rows_stream: RowStream<'_>,
+    stats: QueryStats,
+    max_rows: usize,
+) -> Result<GraphResult> {
+    let mut rows = Vec::new();
+    while let Some(row) = rows_stream.next().await {
+        if rows.len() >= max_rows {
+            break;
+        }
+        rows.push(row?);
+    }
+    Ok(GraphResult {
+        columns,
+        rows,
+        stats,
+    })
+}
+
+/// Build a [`RowStream`] from an already-materialized set of rows.
+///
+/// The adapter used while converting callers: a not-yet-streaming operator can
+/// still hand its output to a streaming consumer. Every use is a materialization
+/// that a later increment removes.
+pub fn stream_from_rows<'a>(rows: Vec<RowVals>) -> RowStream<'a> {
+    Box::pin(futures::stream::iter(rows.into_iter().map(Ok)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(n: i64) -> RowVals {
+        vec![serde_json::json!(n)]
+    }
+
+    #[tokio::test]
+    async fn collect_reproduces_the_buffered_result() {
+        let rows = vec![row(1), row(2), row(3)];
+        let result = collect_to_graph_result(
+            vec!["n".to_string()],
+            stream_from_rows(rows.clone()),
+            QueryStats::default(),
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.columns, vec!["n".to_string()]);
+        assert_eq!(result.rows, rows, "collect must preserve rows and order");
+    }
+
+    #[tokio::test]
+    async fn collect_honors_the_max_rows_cap() {
+        // Mirrors the materializing loop's `max_result_rows` break.
+        let result = collect_to_graph_result(
+            vec!["n".to_string()],
+            stream_from_rows(vec![row(1), row(2), row(3), row(4)]),
+            QueryStats::default(),
+            2,
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.rows, vec![row(1), row(2)]);
+    }
+
+    /// The property the whole refactor rests on: `take(k)` stops the upstream
+    /// stream — no work happens past the limit. Asserted by counting how many
+    /// items the source actually produced.
+    #[tokio::test]
+    async fn limit_short_circuits_upstream_production() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let produced = Arc::new(AtomicUsize::new(0));
+        let counter = produced.clone();
+        // An "infinite" upstream: if LIMIT did not short-circuit, this would
+        // never terminate (the materialize-then-truncate model cannot do this).
+        let source = futures::stream::repeat_with(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(row(7))
+        });
+        let limited: RowStream<'_> = Box::pin(source.take(3));
+
+        let result = collect_to_graph_result(
+            vec!["n".to_string()],
+            limited,
+            QueryStats::default(),
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.rows.len(), 3, "LIMIT yields exactly k rows");
+        assert_eq!(
+            produced.load(Ordering::SeqCst),
+            3,
+            "upstream must produce only the k rows pulled — the short-circuit"
+        );
+    }
+}

--- a/ferrosa-graph/src/executor/stream.rs
+++ b/ferrosa-graph/src/executor/stream.rs
@@ -80,6 +80,21 @@ pub async fn collect_to_graph_result(
     })
 }
 
+/// Drain a [`RowStream`] into its rows.
+///
+/// The un-wrapped half of [`collect_to_graph_result`], for callers that build
+/// the `GraphResult` themselves. The stream's own `take`/`Limit` is what bounds
+/// this — there is no separate cap here, so a caller relying on a row cap must
+/// express it in the stream (e.g. `.take(limit)`), which is the point: the limit
+/// stops upstream production instead of truncating a materialized Vec.
+pub async fn collect_rows(mut rows_stream: RowStream<'_>) -> Result<Vec<RowVals>> {
+    let mut rows = Vec::new();
+    while let Some(row) = rows_stream.next().await {
+        rows.push(row?);
+    }
+    Ok(rows)
+}
+
 /// Build a [`RowStream`] from an already-materialized set of rows.
 ///
 /// The adapter used while converting callers: a not-yet-streaming operator can

--- a/ferrosa-storage/src/external_sort.rs
+++ b/ferrosa-storage/src/external_sort.rs
@@ -126,6 +126,40 @@ fn cql_value_payload_bytes(v: &CqlValue) -> usize {
     }
 }
 
+/// A row this sorter can spill: serializable (runs are length-prefixed JSON) and
+/// able to estimate its own footprint for threshold accounting.
+///
+/// Implemented for the CQL result [`Row`]; other engines (e.g. the graph
+/// executor's `Vec<serde_json::Value>` rows, t_4ce82a3e) implement it to reuse
+/// this spill/merge machinery with their own row type.
+pub trait SpillRow: serde::Serialize + serde::de::DeserializeOwned {
+    /// Approximate in-memory bytes. Need not be exact — only monotonic in real
+    /// memory use, so the buffer spills before the process is starved.
+    fn estimated_bytes(&self) -> usize;
+}
+
+impl SpillRow for Row {
+    fn estimated_bytes(&self) -> usize {
+        estimate_row_bytes(self)
+    }
+}
+
+/// The ordering strategy for a [`SpillRow`].
+///
+/// Kept as a trait rather than a closure so it can be cloned into each heap
+/// entry, and so a caller supplies its OWN comparator — the graph executor must
+/// preserve its `compare_json_values` semantics (mixed types and complex values
+/// compare Equal), which differ from `CqlValue`'s `Ord`.
+pub trait SpillOrder<T>: Clone {
+    fn compare(&self, a: &T, b: &T) -> Ordering;
+}
+
+impl SpillOrder<Row> for RowOrder {
+    fn compare(&self, a: &Row, b: &Row) -> Ordering {
+        RowOrder::compare(self, a, b)
+    }
+}
+
 /// Wrap a contextual message as an `Error::Io` (the `Io` variant carries a
 /// `std::io::Error`, so string context is threaded through one).
 fn io_error(msg: String) -> Error {
@@ -133,7 +167,7 @@ fn io_error(msg: String) -> Error {
 }
 
 /// Serialize one row to `w` as a length-prefixed JSON record: `[u32 LE len][json]`.
-fn write_row<W: Write>(w: &mut W, row: &Row) -> Result<()> {
+fn write_row<W: Write, T: SpillRow>(w: &mut W, row: &T) -> Result<()> {
     let bytes = serde_json::to_vec(row)
         .map_err(|e| Error::InvalidFormat(format!("external sort: encode row: {e}")))?;
     let len = u32::try_from(bytes.len())
@@ -149,7 +183,7 @@ fn write_row<W: Write>(w: &mut W, row: &Row) -> Result<()> {
 ///
 /// A truncated record (EOF mid-row) is a corrupt run and fails loud — it is
 /// never treated as a clean end, because that would silently drop rows.
-fn read_row<R: Read>(r: &mut R) -> Result<Option<Row>> {
+fn read_row<R: Read, T: SpillRow>(r: &mut R) -> Result<Option<T>> {
     let mut len_buf = [0u8; 4];
     match r.read_exact(&mut len_buf) {
         Ok(()) => {}
@@ -163,7 +197,7 @@ fn read_row<R: Read>(r: &mut R) -> Result<Option<Row>> {
             "external sort: truncated run record (want {len} bytes): {e}"
         ))
     })?;
-    let row: Row = serde_json::from_slice(&buf)
+    let row: T = serde_json::from_slice(&buf)
         .map_err(|e| Error::InvalidFormat(format!("external sort: decode run row: {e}")))?;
     Ok(Some(row))
 }
@@ -173,21 +207,21 @@ fn read_row<R: Read>(r: &mut R) -> Result<Option<Row>> {
 /// Push every row, then call [`ExternalSorter::finish`] to obtain the sorted
 /// stream. Run files are written under the caller-provided directory (typically
 /// a [`crate::TempSortTableReservation`] whose `Drop` removes them).
-pub struct ExternalSorter {
+pub struct ExternalSorter<T = Row, C = RowOrder> {
     dir: PathBuf,
-    order: RowOrder,
+    order: C,
     threshold_bytes: usize,
-    buffer: Vec<Row>,
+    buffer: Vec<T>,
     buffer_bytes: usize,
     runs: Vec<PathBuf>,
     /// Whether at least one spill to disk occurred (observability + tests).
     spilled: bool,
 }
 
-impl ExternalSorter {
+impl<T: SpillRow, C: SpillOrder<T>> ExternalSorter<T, C> {
     /// Create a sorter that spills into `dir` once the in-memory buffer's
     /// estimated size reaches `threshold_bytes`.
-    pub fn new(dir: impl Into<PathBuf>, order: RowOrder, threshold_bytes: u64) -> Self {
+    pub fn new(dir: impl Into<PathBuf>, order: C, threshold_bytes: u64) -> Self {
         Self {
             dir: dir.into(),
             order,
@@ -213,8 +247,8 @@ impl ExternalSorter {
 
     /// Push one row (moved, never cloned). Spills the buffer to a run file if it
     /// crosses the threshold.
-    pub fn push(&mut self, row: Row) -> Result<()> {
-        self.buffer_bytes += estimate_row_bytes(&row);
+    pub fn push(&mut self, row: T) -> Result<()> {
+        self.buffer_bytes += row.estimated_bytes();
         self.buffer.push(row);
         if self.buffer_bytes >= self.threshold_bytes {
             self.spill_buffer()?;
@@ -253,7 +287,7 @@ impl ExternalSorter {
     ///   k-way merge. This caps peak open readers (and heap size) at `MERGE_FANIN`
     ///   regardless of how many runs (i.e. how large the result) — so the sort's
     ///   working set is bounded independent of the row count.
-    pub fn finish(mut self) -> Result<SortedRows> {
+    pub fn finish(mut self) -> Result<SortedRows<T, C>> {
         if self.runs.is_empty() {
             self.buffer.sort_by(|a, b| self.order.compare(a, b));
             let rows = std::mem::take(&mut self.buffer);
@@ -313,7 +347,11 @@ const MERGE_FANIN: usize = 64;
 /// Merge the sorted run files in `inputs` into one sorted run at `out` via a
 /// bounded k-way merge, then return. Rows move through one at a time — the
 /// output run is written streaming, so this holds `<= inputs.len()` rows.
-fn merge_runs_into(inputs: &[PathBuf], order: &RowOrder, out: &std::path::Path) -> Result<()> {
+fn merge_runs_into<T: SpillRow, C: SpillOrder<T>>(
+    inputs: &[PathBuf],
+    order: &C,
+    out: &std::path::Path,
+) -> Result<()> {
     let mut merger = KWayMerge::open(inputs, order.clone())?;
     let file = File::create(out).map_err(|e| {
         io_error(format!(
@@ -334,15 +372,15 @@ fn merge_runs_into(inputs: &[PathBuf], order: &RowOrder, out: &std::path::Path) 
 ///
 /// Each item is a `Result<Row>`: the merge does real I/O, so a read error on a
 /// spilled run surfaces here rather than being swallowed.
-pub enum SortedRows {
+pub enum SortedRows<T = Row, C = RowOrder> {
     /// Fast path: everything fit in memory; already-sorted rows.
-    InMemory(std::vec::IntoIter<Row>),
+    InMemory(std::vec::IntoIter<T>),
     /// Spilled path: a bounded k-way merge over run files.
-    Merged(KWayMerge),
+    Merged(KWayMerge<T, C>),
 }
 
-impl Iterator for SortedRows {
-    type Item = Result<Row>;
+impl<T: SpillRow, C: SpillOrder<T>> Iterator for SortedRows<T, C> {
+    type Item = Result<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -360,24 +398,24 @@ struct RunCursor {
 
 /// A heap entry ordering run heads by the sort key. The `run_idx` breaks ties
 /// deterministically so the merge is stable and total.
-struct HeapEntry {
-    row: Row,
+struct HeapEntry<T, C> {
+    row: T,
     run_idx: usize,
-    order: RowOrder,
+    order: C,
 }
 
-impl PartialEq for HeapEntry {
+impl<T: SpillRow, C: SpillOrder<T>> PartialEq for HeapEntry<T, C> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
-impl Eq for HeapEntry {}
-impl PartialOrd for HeapEntry {
+impl<T: SpillRow, C: SpillOrder<T>> Eq for HeapEntry<T, C> {}
+impl<T: SpillRow, C: SpillOrder<T>> PartialOrd for HeapEntry<T, C> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-impl Ord for HeapEntry {
+impl<T: SpillRow, C: SpillOrder<T>> Ord for HeapEntry<T, C> {
     fn cmp(&self, other: &Self) -> Ordering {
         // `BinaryHeap` is a max-heap; we want the SMALLEST key on top, so invert
         // the key comparison. Ties fall back to run_idx (also inverted) so the
@@ -393,14 +431,14 @@ impl Ord for HeapEntry {
 ///
 /// The heap holds at most one entry per run, so peak memory is
 /// O(number_of_runs), independent of the total number of rows.
-pub struct KWayMerge {
+pub struct KWayMerge<T = Row, C = RowOrder> {
     cursors: Vec<RunCursor>,
-    heap: BinaryHeap<HeapEntry>,
-    order: RowOrder,
+    heap: BinaryHeap<HeapEntry<T, C>>,
+    order: C,
 }
 
-impl KWayMerge {
-    fn open(runs: &[PathBuf], order: RowOrder) -> Result<Self> {
+impl<T: SpillRow, C: SpillOrder<T>> KWayMerge<T, C> {
+    fn open(runs: &[PathBuf], order: C) -> Result<Self> {
         let mut cursors = Vec::with_capacity(runs.len());
         let mut heap = BinaryHeap::with_capacity(runs.len());
         for (run_idx, path) in runs.iter().enumerate() {
@@ -427,7 +465,7 @@ impl KWayMerge {
     }
 
     /// Emit the next row in sorted order, or `Ok(None)` when all runs drain.
-    fn next_row(&mut self) -> Result<Option<Row>> {
+    fn next_row(&mut self) -> Result<Option<T>> {
         let Some(top) = self.heap.pop() else {
             return Ok(None);
         };
@@ -526,6 +564,60 @@ mod tests {
             let span = (hi - lo) as u64;
             lo + (self.next_u64() % span) as i64
         }
+    }
+
+    #[test]
+    /// The point of the generic-ification (t_4ce82a3e): a FOREIGN row type with
+    /// its OWN comparator reuses the spill/merge machinery and gets that
+    /// comparator's ordering — not `CqlValue`'s. Models the graph executor's
+    /// `Vec<serde_json::Value>` rows and its `compare_json_values` semantics,
+    /// where mixed types compare Equal (which `CqlValue::Ord` would not do).
+    #[test]
+    fn foreign_row_type_spills_and_merges_with_its_own_comparator() {
+        type JsonRow = Vec<serde_json::Value>;
+
+        impl SpillRow for JsonRow {
+            fn estimated_bytes(&self) -> usize {
+                self.len() * 32
+            }
+        }
+
+        #[derive(Clone)]
+        struct JsonAsc;
+        impl SpillOrder<JsonRow> for JsonAsc {
+            fn compare(&self, a: &JsonRow, b: &JsonRow) -> Ordering {
+                match (a.first(), b.first()) {
+                    (Some(serde_json::Value::Number(x)), Some(serde_json::Value::Number(y))) => x
+                        .as_f64()
+                        .unwrap_or(0.0)
+                        .partial_cmp(&y.as_f64().unwrap_or(0.0))
+                        .unwrap_or(Ordering::Equal),
+                    // Graph semantics: anything else is Equal.
+                    _ => Ordering::Equal,
+                }
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        // Threshold of 1 byte forces a spill on every push, so the merge path
+        // (not the in-memory fast path) is what is exercised.
+        let mut sorter: ExternalSorter<JsonRow, JsonAsc> =
+            ExternalSorter::new(dir.path(), JsonAsc, 1);
+        for n in [5i64, 1, 4, 2, 3] {
+            sorter.push(vec![serde_json::json!(n)]).unwrap();
+        }
+        assert!(sorter.spilled(), "threshold 1 must force spilling");
+
+        let sorted: Vec<JsonRow> = sorter.finish().unwrap().collect::<Result<_>>().unwrap();
+        let got: Vec<i64> = sorted
+            .iter()
+            .map(|r| r[0].as_i64().expect("number"))
+            .collect();
+        assert_eq!(
+            got,
+            vec![1, 2, 3, 4, 5],
+            "foreign comparator must order the merge"
+        );
     }
 
     #[test]
@@ -651,7 +743,9 @@ mod tests {
         f.write_all(&[1, 2, 3]).unwrap();
         drop(f);
         let mut r = BufReader::new(File::open(&path).unwrap());
-        let err = read_row(&mut r).unwrap_err();
+        // `read_row` is generic over the row type now; this test exercises the
+        // CQL row, so name it explicitly.
+        let err = read_row::<_, Row>(&mut r).unwrap_err();
         assert!(
             format!("{err}").contains("truncated"),
             "expected truncated-run error, got {err}"

--- a/ferrosa-storage/src/external_sort.rs
+++ b/ferrosa-storage/src/external_sort.rs
@@ -566,7 +566,6 @@ mod tests {
         }
     }
 
-    #[test]
     /// The point of the generic-ification (t_4ce82a3e): a FOREIGN row type with
     /// its OWN comparator reuses the spill/merge machinery and gets that
     /// comparator's ordering — not `CqlValue`'s. Models the graph executor's


### PR DESCRIPTION
Rebuilds the ferrosa-graph query executor from **materialize-then-truncate** toward a **pull-based (Volcano) streaming** model — the OOM fix for unbounded / high-degree-hub queries (`t_4ce82a3e`). Design + preparatory refactoring + the first three increments.

Every commit is independently verified: **build → full suite → clippy `-D warnings` → commit**. 453 `ferrosa-graph` tests green throughout.

### The headline unlock (increment 3)

The old code carried a comment saying concurrent per-hop hydration was impossible without a *"clone-heavy `'static` restructure"* — the "Send is not general enough" wall. That turned out to be avoidable:

> `buffer_unordered`/`tokio::spawn` require `Send + 'static`. A **`FuturesUnordered` driven inline** by the loop polls its futures **in place**, imposing no `'static` bound.

So the hydration futures keep borrowing `write_path`/`schema`/`hop`/`state`/`row` exactly as before (only `nid` is owned — unchanged from the sequential version), and neighbors hydrate **concurrently with zero per-neighbor data clones**, which is the constraint the task set. Verified by building the whole workspace *including the `ferrosa` binary on the multi-threaded runtime*, where the wall originally appeared. In-flight is capped at `HOP_HYDRATION_CONCURRENCY = 16`: unbounded fan-out, **bounded** concurrent reads.

**Deliberate correctness call:** capped (LIMIT push-down) hops stay **strictly sequential**. `FuturesUnordered` drains in completion order, so concurrency on a capped hop could change *which* rows the LIMIT returns — a silent behavior change. Only uncapped hops go concurrent, so `http_limit_short_circuits_expansion_hydration`'s `vertices_read` bound holds unchanged.

### Commits

| | What |
|---|---|
| `a32f3b29` | **Design** — `specs/streaming-executor-design.md`: materialization map, the Send-wall answer, the transport gap, 7 increments |
| `9a8f496c` | *prep* extract `project_state` — streaming `Project` reuses it |
| `a2c53744` | *prep* consolidate the duplicated capped/uncapped hydration branches |
| `ef364b71` | *prep* extract `read_anchor_partitions` — isolates the read strategy, marks the unbounded arm |
| `31b6a4ac` | **inc 1** `RowStream` scaffold + collect bridge |
| `1ea475e3` | **inc 2** streaming UNWIND projection + LIMIT — first operator off the materialize spine |
| `2817b855` | **inc 3** bounded-concurrency hydration (above) |

Increment 1's test is the proof-of-concept in miniature: `take(3)` over an **infinite** source produces exactly 3 items and terminates — what materialize-then-truncate provably cannot do.

### Remaining (tracked on `t_4ce82a3e`)

inc 4 multi-hop pull chain · inc 5 pipeline-breakers (OrderBy top-k, streaming Distinct, Aggregate) + OPTIONAL/WITH · inc 6 VarPath + Leapfrog · inc 7 transport streaming (HTTP chunked + Bolt incremental PULL honoring `n`/`has_more`) — only at inc 7 does the full result stop being buffered end-to-end.
