### PR TITLE
fix(jepsen): report setup failures distinctly from invariant violations

### DIFF
--- a/ferrosa-jepsen/src/alert.rs
+++ b/ferrosa-jepsen/src/alert.rs
@@ -44,10 +44,22 @@ pub async fn send_alert(webhook_url: &str, payload: &AlertPayload) -> Result<()>
 
 /// Create an alert payload from a run report.
 pub fn alert_from_report(report: &crate::report::RunReport, tier: &str) -> AlertPayload {
+    // Label each failure by class so an alert (and the auto-filed issue built
+    // from it) never presents a setup/infrastructure failure as a correctness
+    // violation — see issue #303.
     let violations: Vec<String> = report
         .failures()
         .iter()
-        .map(|f| format!("{}/{}: {:?}", f.workload, f.nemesis, f.invariant_error))
+        .map(|f| match &f.setup_error {
+            Some(setup) => format!(
+                "{}/{}: SETUP FAILED (no invariant evaluated): {setup}",
+                f.workload, f.nemesis
+            ),
+            None => format!(
+                "{}/{}: INVARIANT VIOLATED: {:?}",
+                f.workload, f.nemesis, f.invariant_error
+            ),
+        })
         .collect();
 
     AlertPayload {
@@ -110,6 +122,7 @@ mod tests {
             linearizability: vec![],
             invariant_passed: false,
             invariant_error: Some("invariant violated".into()),
+            setup_error: None,
             duration_secs: 1.0,
             op_count: 10,
         }];
@@ -118,5 +131,50 @@ mod tests {
         assert!(matches!(alert.status, AlertStatus::Fail));
         assert_eq!(alert.failed, 1);
         assert_eq!(alert.violations.len(), 1);
+        assert!(
+            alert.violations[0].contains("INVARIANT VIOLATED"),
+            "a real invariant failure must be labelled as one: {}",
+            alert.violations[0]
+        );
+    }
+
+    /// Issue #303: a combination that never RAN (cluster/DDL/driver setup error)
+    /// must not be reported as a correctness violation. It still fails the run,
+    /// but the alert — and the issue auto-filed from it — must say so plainly,
+    /// because "violated an invariant" sends triage after a correctness bug that
+    /// was never observed.
+    #[test]
+    fn alert_labels_setup_failure_distinctly_from_invariant_violation() {
+        let results = vec![CombinationResult {
+            workload: "bank".into(),
+            nemesis: "dc-partition+dc-slow".into(),
+            topology: "T3".into(),
+            concurrency: "low".into(),
+            driver: "rust".into(),
+            passed: false,
+            linearizability: vec![],
+            invariant_passed: false,
+            // No invariant was evaluated — the combination died in setup.
+            invariant_error: None,
+            setup_error: Some(
+                "executing query `CREATE KEYSPACE ...`: Failed to await schema agreement".into(),
+            ),
+            duration_secs: 0.0,
+            op_count: 0,
+        }];
+        let report = RunReport::from_results("test-setup-fail", results);
+        let alert = alert_from_report(&report, "multi-dc");
+
+        assert!(matches!(alert.status, AlertStatus::Fail), "still a failure");
+        assert_eq!(alert.violations.len(), 1);
+        let v = &alert.violations[0];
+        assert!(
+            v.contains("SETUP FAILED") && v.contains("no invariant evaluated"),
+            "setup failure must be labelled as such: {v}"
+        );
+        assert!(
+            !v.contains("INVARIANT VIOLATED"),
+            "must NOT claim an invariant was violated: {v}"
+        );
     }
 }

--- a/ferrosa-jepsen/src/endurance.rs
+++ b/ferrosa-jepsen/src/endurance.rs
@@ -159,6 +159,7 @@ pub async fn run_endurance(config: &RunConfig, endurance: &EnduranceConfig) -> R
             linearizability: linear,
             invariant_passed: passed,
             invariant_error: None,
+            setup_error: None,
             duration_secs: endurance.pattern_duration.as_secs_f64(),
             op_count: history.len(),
         });

--- a/ferrosa-jepsen/src/main.rs
+++ b/ferrosa-jepsen/src/main.rs
@@ -159,10 +159,22 @@ async fn main() -> Result<()> {
                 if !report.all_passed() {
                     println!("\nFailures:");
                     for f in report.failures() {
-                        println!(
-                            "  - {} / {}: {:?}",
-                            f.workload, f.nemesis, f.invariant_error
-                        );
+                        // Distinguish a harness/infrastructure failure from a real
+                        // correctness result (issue #303). A setup failure produced
+                        // NO history, so no invariant was evaluated — saying it
+                        // "violated an invariant" announces a flaky nightly as a
+                        // correctness regression.
+                        if let Some(setup) = &f.setup_error {
+                            println!(
+                                "  - {} / {}: SETUP FAILED (no invariant evaluated): {}",
+                                f.workload, f.nemesis, setup
+                            );
+                        } else {
+                            println!(
+                                "  - {} / {}: INVARIANT VIOLATED: {:?}",
+                                f.workload, f.nemesis, f.invariant_error
+                            );
+                        }
                     }
                 }
             }
@@ -180,11 +192,33 @@ async fn main() -> Result<()> {
                 );
             }
             if !report.all_passed() {
-                anyhow::bail!(
-                    "jepsen run failed: {} of {} combination(s) violated an invariant",
-                    report.failed,
-                    report.total
-                );
+                // Report the two failure classes separately. Both still fail the
+                // run (a harness that cannot provision is not a green result),
+                // but calling a setup failure an invariant violation misdirects
+                // triage at a correctness bug that was never observed (#303).
+                let setup_failures = report
+                    .failures()
+                    .iter()
+                    .filter(|f| f.is_setup_failure())
+                    .count();
+                let invariant_failures = report.failed.saturating_sub(setup_failures);
+                match (setup_failures, invariant_failures) {
+                    (s, 0) => anyhow::bail!(
+                        "jepsen run failed: {s} of {} combination(s) FAILED TO RUN \
+                         (setup/infrastructure — no invariant was evaluated, so this is \
+                         not a correctness result)",
+                        report.total
+                    ),
+                    (0, i) => anyhow::bail!(
+                        "jepsen run failed: {i} of {} combination(s) violated an invariant",
+                        report.total
+                    ),
+                    (s, i) => anyhow::bail!(
+                        "jepsen run failed: {i} of {} combination(s) violated an invariant; \
+                         {s} more FAILED TO RUN (setup/infrastructure)",
+                        report.total
+                    ),
+                }
             }
 
             Ok(())

--- a/ferrosa-jepsen/src/orchestrator.rs
+++ b/ferrosa-jepsen/src/orchestrator.rs
@@ -219,8 +219,27 @@ pub struct CombinationResult {
     pub linearizability: Vec<CheckResult>,
     pub invariant_passed: bool,
     pub invariant_error: Option<String>,
+    /// Set when the combination never RAN to completion — cluster provisioning,
+    /// DDL, or driver setup failed — so no history was produced and no invariant
+    /// was ever evaluated.
+    ///
+    /// This is deliberately distinct from `invariant_error`. Both used to be
+    /// reported as "violated an invariant", which announced a flaky harness or
+    /// infrastructure failure as a CORRECTNESS regression (see issue #303: a
+    /// schema-agreement timeout at `CREATE KEYSPACE` was reported that way, and
+    /// the bank invariant it named had never been tested).
+    #[serde(default)]
+    pub setup_error: Option<String>,
     pub duration_secs: f64,
     pub op_count: usize,
+}
+
+impl CombinationResult {
+    /// True when this combination failed before producing any history — the
+    /// failure says nothing about the database's correctness.
+    pub fn is_setup_failure(&self) -> bool {
+        self.setup_error.is_some()
+    }
 }
 
 /// Run the full test suite per the config.
@@ -311,7 +330,8 @@ pub async fn run(config: &RunConfig) -> Result<RunReport> {
                                     nemesis = nemesis_name.as_str(),
                                     driver = driver_name.as_str(),
                                     error = %e,
-                                    "Combination failed"
+                                    "Combination failed to run (setup/execution error — no \
+                                     invariant was evaluated)"
                                 );
                                 results.push(CombinationResult {
                                     workload: workload_name.clone(),
@@ -321,8 +341,11 @@ pub async fn run(config: &RunConfig) -> Result<RunReport> {
                                     driver: driver_name.clone(),
                                     passed: false,
                                     linearizability: vec![],
+                                    // The combination never ran, so no invariant
+                                    // was checked — do NOT claim one was violated.
                                     invariant_passed: false,
-                                    invariant_error: Some(e.to_string()),
+                                    invariant_error: None,
+                                    setup_error: Some(e.to_string()),
                                     duration_secs: 0.0,
                                     op_count: 0,
                                 });
@@ -495,6 +518,7 @@ async fn run_single_combination(
         linearizability,
         invariant_passed,
         invariant_error,
+        setup_error: None,
         duration_secs: duration.as_secs_f64(),
         op_count: history.len(),
     })
@@ -516,6 +540,7 @@ mod tests {
             linearizability: vec![],
             invariant_passed: true,
             invariant_error: None,
+            setup_error: None,
             duration_secs: 1.5,
             op_count: 42,
         };

--- a/ferrosa-jepsen/src/report/anomaly.rs
+++ b/ferrosa-jepsen/src/report/anomaly.rs
@@ -67,6 +67,7 @@ mod tests {
             } else {
                 Some("invariant violated".into())
             },
+            setup_error: None,
             duration_secs: 1.0,
             op_count: 10,
         }
@@ -108,6 +109,7 @@ mod tests {
             }],
             invariant_passed: false,
             invariant_error: None,
+            setup_error: None,
             duration_secs: 1.0,
             op_count: 5,
         };

--- a/ferrosa-jepsen/src/report/comparison.rs
+++ b/ferrosa-jepsen/src/report/comparison.rs
@@ -103,6 +103,7 @@ mod tests {
             linearizability: vec![],
             invariant_passed: passed,
             invariant_error: if passed { None } else { Some("bad".into()) },
+            setup_error: None,
             duration_secs: 1.0,
             op_count: 10,
         }

--- a/ferrosa-jepsen/src/report/mod.rs
+++ b/ferrosa-jepsen/src/report/mod.rs
@@ -124,6 +124,7 @@ mod tests {
             linearizability: vec![],
             invariant_passed: passed,
             invariant_error: if passed { None } else { Some("bad".into()) },
+            setup_error: None,
             duration_secs: 1.0,
             op_count: 10,
         }


### PR DESCRIPTION
Fixes the misreporting half of #303.

## The problem

A combination that never **ran** — cluster provisioning, DDL, or driver setup failed, producing no history — was recorded with the error stuffed into `invariant_error` and summarized as **"violated an invariant"**. A flaky harness/infrastructure failure was therefore announced as a **correctness regression**.

That is exactly what happened on the 2026-07-25 nightly (#301): a schema-agreement timeout at `CREATE KEYSPACE` was reported as a bank invariant violation — but the bank invariant had **never been evaluated**, because the workload never ran. Triage went looking for a correctness bug that was never observed.

## The fix

- `CombinationResult` gains `setup_error` (`serde(default)`, so existing archived reports still deserialize) plus `is_setup_failure()`. The setup path sets `setup_error` and leaves `invariant_error: None` — it must not claim an invariant was checked.
- The CLI summary prints `SETUP FAILED (no invariant evaluated): …` vs `INVARIANT VIOLATED: …`, and the final bail counts the two classes separately. **Both still fail the run** — a harness that cannot provision is not a green result.
- `alert_from_report` labels failures the same way, so the auto-filed nightly issue no longer reads as a correctness alarm.

## Tests

`alert_labels_setup_failure_distinctly_from_invariant_violation` asserts a setup failure is labelled as such and does **not** say "INVARIANT VIOLATED"; the existing failing-report test now asserts the positive case still does. 234 `ferrosa-jepsen` lib tests green, clippy `--all-targets -D warnings` clean.

## Scope

This does **not** fix the underlying schema-agreement race — #303 stays open for that (gate the first DDL on full pool membership; note the driver's "Host with id 0" is a scylla `thiserror` format-arg bug masking the real host id).