### PR TITLE
feat(graph): ORDER BY spills instead of silently truncating (t_4ce82a3e inc 5)

### DIFF
--- a/ferrosa-graph/README.md
+++ b/ferrosa-graph/README.md
@@ -44,6 +44,16 @@ resolved port.
 - **Expand executor** (`executor/expand.rs`) — anchor lookup, per-hop adjacency
   reads, property evaluation, aggregation, write clauses; honors DoS limits
   (`max_fan_out_per_hop`, `max_result_rows`, `query_timeout`).
+- **Streaming entry point** (`executor/stream.rs`, `executor/expand.rs`) —
+  `execute_streaming()` returns `(columns, RowStream<'a>, QueryStats)`;
+  `execute()` is a thin `collect` over it, so there is one executor, not two.
+  Additive scaffold: only `Subscribe`, `Union { all: true }` (concatenated with
+  `chain_streams`) and `ReturnOnly` genuinely stream today. Every other variant
+  computes the buffered `GraphResult` and is wrapped with `stream_from_rows`, so
+  behavior is unchanged for every query. `UNION` without `ALL` (whole-result
+  dedup) and `DELETE` (two passes over the matched rows — validate, then
+  tombstone) are deliberately excluded. See
+  `specs/streaming-executor-design.md` §5 for the increment status.
 - **Label-agnostic expansion** (`executor/expand.rs`) — traversals may omit the
   relationship type and/or the target-node label (`(a)-[r]->(n)`, `(a)<-[r]-(n)`,
   `-[r:T]->(n)`, `-[r]->(n:L)`). When a hop lacks a plan-time edge or vertex

--- a/ferrosa-graph/README.md
+++ b/ferrosa-graph/README.md
@@ -47,13 +47,24 @@ resolved port.
 - **Streaming entry point** (`executor/stream.rs`, `executor/expand.rs`) —
   `execute_streaming()` returns `(columns, RowStream<'a>, QueryStats)`;
   `execute()` is a thin `collect` over it, so there is one executor, not two.
-  Additive scaffold: only `Subscribe`, `Union { all: true }` (concatenated with
-  `chain_streams`) and `ReturnOnly` genuinely stream today. Every other variant
-  computes the buffered `GraphResult` and is wrapped with `stream_from_rows`, so
-  behavior is unchanged for every query. `UNION` without `ALL` (whole-result
-  dedup) and `DELETE` (two passes over the matched rows — validate, then
-  tombstone) are deliberately excluded. See
-  `specs/streaming-executor-design.md` §5 for the increment status.
+  Streaming today: `Subscribe`, `Union { all: true }` (via `chain_streams`),
+  `ReturnOnly`, and the **Expand projection** — one `project_state` per pull, so
+  `LIMIT k` projects k states instead of projecting everything and truncating.
+  `DISTINCT` composes as `dedup_stream`. SET/REMOVE consume their inner expand
+  as a stream (their own output is one summary row, so it cannot stream). Every
+  other variant computes the buffered `GraphResult` and is wrapped with
+  `stream_from_rows`. `UNION` without `ALL` (whole-result dedup), `ORDER BY`
+  (pipeline breaker), `DELETE` (two passes over the matched rows — validate,
+  then tombstone), `Aggregate`, `WcoJoin`, `ExpandVarLength` and the
+  virtual-table anchor are deliberately excluded. The hop loop is still fully
+  materializing. See `specs/streaming-executor-design.md` §5.
+- **`RETURN DISTINCT` ordering** — `DISTINCT` **without** an `ORDER BY` returns
+  rows in **first-seen (expansion) order**, not sorted order. This changed
+  deliberately when DISTINCT became a streaming dedup; earlier releases returned
+  string-repr sorted rows. The set of rows is the same. Add an explicit
+  `ORDER BY` if you need a particular order. `DISTINCT` on a variable-length
+  path (`varpath.rs`) still returns sorted order. The dedup set is **unbounded**
+  in memory — a high-cardinality `DISTINCT` can still exhaust it.
 - **Label-agnostic expansion** (`executor/expand.rs`) — traversals may omit the
   relationship type and/or the target-node label (`(a)-[r]->(n)`, `(a)<-[r]-(n)`,
   `-[r:T]->(n)`, `-[r]->(n:L)`). When a hop lacks a plan-time edge or vertex

--- a/ferrosa-graph/specs/streaming-executor-design.md
+++ b/ferrosa-graph/specs/streaming-executor-design.md
@@ -191,7 +191,8 @@ expand-with-limit shape; 5–7 complete coverage and end-to-end streaming.
 |---|---|
 | 1 — `RowStream` + collect bridges | **done** (`executor/stream.rs`) |
 | 2 — streaming entry point | **partial** — see below |
-| 3–7 | not started |
+| 3 — Expand projection + DISTINCT + SET/REMOVE | **partial** — see below |
+| 4–7 | not started |
 
 Increment 2 landed as an **additive scaffold**: `execute_streaming()` exists and
 `execute()` is now a thin `collect` over it, so there is one executor rather than
@@ -224,6 +225,48 @@ Every other variant computes today's buffered `GraphResult` and is wrapped with
 
 Known behavior preserved rather than fixed: the buffered `UNION` never summed
 `edges_deleted` across arms, and the streaming one does not either.
+
+#### Increment 3 (partial)
+
+`execute_expand` was split into a shared phase A (`expand_to_states`: anchor
+scan → hops → post-filters → OPTIONAL MATCH → WITH) and two tails. The hop loop,
+its sequential-vs-concurrent split, and `max_fan_out_per_hop` are **unchanged**;
+phase A is still fully materializing. What was converted:
+
+- **Expand projection** — `project_states_stream` projects one state per pull,
+  so `LIMIT k` projects k states instead of projecting everything and
+  truncating. It also drops the buffered loop's `result_states.push(state.clone())`,
+  a per-row deep clone of every binding map that only the `ORDER BY` tail needed.
+  An Expand with an `ORDER BY` still uses `finish_expand_buffered` (pipeline
+  breaker, and it keeps the spill path).
+- **`DISTINCT`** — now `stream::dedup_stream` on top of the projection, for
+  Expands without an `ORDER BY`.
+- **SET / REMOVE** — consume their inner expand as a `RowStream` instead of a
+  `Vec` of projected rows. Their own output is a single summary row that is only
+  known after the last write, so it cannot stream; the memory win is entirely in
+  the inner expand. `projection_reads_storage` drains the stream first if the
+  inner projection would touch storage, so a projection can never observe the
+  writes the statement is making.
+
+**Behavior change — `DISTINCT` ordering (deliberate, owner-approved).**
+`RETURN DISTINCT` **without** an `ORDER BY` now returns rows in **first-seen
+(expansion) order**. It previously returned them in string-repr **sorted** order
+(`rows.sort_by(|a, b| format!("{a:?}").cmp(..))` then `dedup()`). The row SET is
+unchanged. This also makes the Expand path agree with the CALL-subquery trailing
+`RETURN DISTINCT` in `engine.rs`, which already deduped first-seen with the same
+`serde_json::to_string` key. `DISTINCT` + `ORDER BY` is unaffected (buffered
+tail). `ExpandVarLength`'s `DISTINCT` (`varpath.rs`) still sorts — that path is
+out of scope here, so the two disagree until increment 6.
+
+**`DISTINCT` is still unbounded in memory.** `dedup_stream`'s `HashSet` grows
+with the number of distinct rows, exactly as the buffered `Vec` did. This
+increment changed ordering and latency, **not** the memory bound; a
+high-cardinality `DISTINCT` can still exhaust memory. Bounding it is separate
+work.
+
+**`execution_ms` now under-reports for a streamed Expand.** Stats are returned
+up front (§4), so `execution_ms` is measured before any row is projected, where
+the buffered tail measured after. Fixing this needs the deferred stats handle.
 
 
 ## 6. Verification

--- a/ferrosa-graph/specs/streaming-executor-design.md
+++ b/ferrosa-graph/specs/streaming-executor-design.md
@@ -146,6 +146,14 @@ sibling returning `(columns, RowStream, StatsHandle)`; the buffered `GraphResult
 is kept for internal callers (CALL join, aggregate inner, tests) by `collect`ing
 the stream — behavior-identical.
 
+**Landed** (see §5 status): `execute_streaming()` in `expand.rs`, returning
+`(Vec<String>, RowStream<'a>, QueryStats)`. `QueryStats` is returned **by value
+up front**, not as a `StatsHandle` — stats are finalized after the last row
+(e.g. `execution_ms`), so a by-value return forces any variant whose stats are
+not known in advance to be executed eagerly. Converting that to a deferred
+`StatsHandle` is a prerequisite for lazy `UNION ALL` arms and for the transport
+increment.
+
 - **HTTP:** replace `Json(result)` (`http.rs:286`) with a chunked
   `application/x-ndjson` (or a JSON array streamed element-by-element) body over
   the SUBSCRIBE mpsc/`ReceiverStream` template (`:456-560`). Header row first,
@@ -176,6 +184,47 @@ the stream — behavior-identical.
 
 Increments 1–4 deliver the headline OOM/LIMIT win for the common
 expand-with-limit shape; 5–7 complete coverage and end-to-end streaming.
+
+### Status
+
+| Increment | State |
+|---|---|
+| 1 — `RowStream` + collect bridges | **done** (`executor/stream.rs`) |
+| 2 — streaming entry point | **partial** — see below |
+| 3–7 | not started |
+
+Increment 2 landed as an **additive scaffold**: `execute_streaming()` exists and
+`execute()` is now a thin `collect` over it, so there is one executor rather than
+two. Only three plan variants actually stream:
+
+- `Subscribe` — passthrough to the inner plan.
+- `Union { all: true }` — concatenation via `stream::chain_streams`; a later arm
+  is never *polled* until the earlier arms are drained. The arms are still
+  *executed* eagerly, because the union's `QueryStats` is the sum over its arms
+  and stats are returned up front (§4). End-to-end laziness across arms needs the
+  `StatsHandle` change.
+- `ReturnOnly` — at most one row, produced on pull, so `LIMIT 0` never evaluates
+  the projection. `ORDER BY` is skipped as the identity on a one-row result.
+
+Every other variant computes today's buffered `GraphResult` and is wrapped with
+`stream_from_rows`. Deliberately **not** converted, with reasons:
+
+- `Union { all: false }` — the `HashSet` dedup spans the whole concatenation.
+- `DeleteNodes` — consumes the matched rows twice (validate every matched vertex,
+  then tombstone). A single pass would delete a prefix and then fail validation:
+  partial deletion.
+- `Aggregate`, DISTINCT, ORDER BY, `WcoJoin`, `ExpandVarLength` — pipeline
+  breakers, scheduled for increments 5–6.
+- The sequential-vs-concurrent hop split (`expand.rs`, capped hops run
+  sequentially) is untouched: completion-order draining changes which rows a
+  LIMIT returns.
+- `http.rs` / `bolt/server.rs` are untouched: `Body::from_stream` requires
+  `'static`, and Bolt holds the result in a struct field across protocol
+  messages. That is increment 7.
+
+Known behavior preserved rather than fixed: the buffered `UNION` never summed
+`edges_deleted` across arms, and the streaming one does not either.
+
 
 ## 6. Verification
 

--- a/ferrosa-graph/src/bolt/server.rs
+++ b/ferrosa-graph/src/bolt/server.rs
@@ -405,14 +405,39 @@ async fn process_message(
             }
         }
 
-        BoltMessage::Pull { .. } => {
-            if let Some(result) = state.pending_result.take() {
+        BoltMessage::Pull { extra } => {
+            if let Some(mut result) = state.pending_result.take() {
                 let mut replies = Vec::new();
 
-                // Send a RECORD for each row.
+                // Honor the protocol's `n`: PULL {n} must deliver AT MOST n
+                // records and signal `has_more` when the result is not
+                // exhausted, so a client can page a large result instead of
+                // receiving all of it in one batch. `n` absent or negative
+                // (canonically -1) means "fetch all" (t_4ce82a3e).
+                //
+                // Previously `extra` was discarded and every row was sent with
+                // has_more hardcoded false, so a client asking for 10 rows got
+                // the entire result — a protocol violation, and unbounded
+                // client-side memory for a large query.
+                let (take, has_more) = pull_split(pull_batch_size(&extra), result.rows.len());
+                let remainder = result.rows.split_off(take);
+
+                // Send a RECORD for each row in this batch.
                 for row in &result.rows {
                     let values: Vec<PackValue> = row.iter().map(json_to_pack_value).collect();
                     replies.push(BoltMessage::Record { values });
+                }
+
+                // Keep the rest for the next PULL. Stats travel with the FINAL
+                // batch, matching Bolt's summary semantics.
+                if has_more {
+                    let mut pending = result.clone();
+                    pending.rows = remainder;
+                    state.pending_result = Some(pending);
+                    replies.push(BoltMessage::Success {
+                        metadata: vec![("has_more".into(), PackValue::Bool(true))],
+                    });
+                    return Ok(replies);
                 }
 
                 // Send summary SUCCESS.
@@ -677,6 +702,33 @@ fn pack_to_json_value(v: &PackValue) -> serde_json::Value {
 }
 
 /// Convert a `serde_json::Value` to a `PackValue`.
+/// How many records this `PULL` may deliver: `Some(n)` for a bounded batch,
+/// `None` for "fetch all".
+///
+/// Pure (takes the decoded `extra` map, does no I/O) so the protocol rule is
+/// unit-testable without a socket or a session — the risky part of PULL paging
+/// is this parse, not the row copying.
+///
+/// Bolt semantics: `n` absent, negative (canonically `-1`), or non-integer means
+/// fetch everything. `n >= 0` bounds the batch; `n == 0` legitimately yields an
+/// empty batch with `has_more` still set.
+fn pull_batch_size(extra: &[(String, PackValue)]) -> Option<usize> {
+    match extra.iter().find(|(k, _)| k == "n").map(|(_, v)| v) {
+        Some(PackValue::Int(n)) if *n >= 0 => Some(*n as usize),
+        _ => None,
+    }
+}
+
+/// Decide one PULL batch: `(rows_to_send, has_more)` for a `requested` batch
+/// size (`None` = fetch all) against `total` buffered rows.
+///
+/// Pure so the paging arithmetic — the part with the off-by-one and
+/// saturation edges — is unit-testable without a GraphEngine or a socket.
+fn pull_split(requested: Option<usize>, total: usize) -> (usize, bool) {
+    let take = requested.map_or(total, |n| n.min(total));
+    (take, take < total)
+}
+
 fn json_to_pack_value(v: &serde_json::Value) -> PackValue {
     match v {
         serde_json::Value::Null => PackValue::Null,
@@ -719,6 +771,74 @@ fn error_code(err: &GraphError) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+
+    /// The paging arithmetic, including the edges that decide whether a client
+    /// ever sees the rest of its result (t_4ce82a3e inc 7).
+    #[test]
+    fn pull_split_pages_and_signals_has_more() {
+        // Bounded batch smaller than the result: more remains.
+        assert_eq!(pull_split(Some(2), 5), (2, true));
+        // Exactly the result size: no more (must NOT claim has_more, which would
+        // make a client PULL forever).
+        assert_eq!(pull_split(Some(5), 5), (5, false));
+        // Asking for more than exists is clamped, and completes.
+        assert_eq!(pull_split(Some(99), 5), (5, false));
+        // n = 0 sends nothing but must still report more to come.
+        assert_eq!(pull_split(Some(0), 5), (0, true));
+        // ...unless there is nothing to send at all.
+        assert_eq!(pull_split(Some(0), 0), (0, false));
+        // Fetch-all takes everything and completes — the pre-existing behavior,
+        // which must be preserved for clients that send n = -1 or omit it.
+        assert_eq!(pull_split(None, 5), (5, false));
+        assert_eq!(pull_split(None, 0), (0, false));
+    }
+
+    /// Bolt PULL {n} must deliver AT MOST n records. `n` absent/negative means
+    /// "fetch all". Before this parse existed the whole `extra` map was
+    /// discarded, so EVERY row was sent regardless of `n` — a protocol
+    /// violation and unbounded client-side memory (t_4ce82a3e inc 7). These
+    /// cases are exactly what the old `Pull { .. }` could not express.
+    #[test]
+    fn pull_batch_size_honors_the_protocol_n() {
+        use crate::bolt::codec::PackValue;
+
+        // Bounded batch.
+        assert_eq!(
+            pull_batch_size(&[("n".to_string(), PackValue::Int(10))]),
+            Some(10)
+        );
+        // n = 0 is legal: an empty batch, has_more still decides continuation.
+        assert_eq!(
+            pull_batch_size(&[("n".to_string(), PackValue::Int(0))]),
+            Some(0)
+        );
+        // -1 is the canonical "fetch all".
+        assert_eq!(
+            pull_batch_size(&[("n".to_string(), PackValue::Int(-1))]),
+            None
+        );
+        // Any other negative also means fetch-all rather than panicking on the
+        // `as usize` cast.
+        assert_eq!(
+            pull_batch_size(&[("n".to_string(), PackValue::Int(-99))]),
+            None
+        );
+        // Absent -> fetch all (what every pre-existing client sends).
+        assert_eq!(pull_batch_size(&[]), None);
+        // Wrong type -> fetch all rather than failing the pull.
+        assert_eq!(
+            pull_batch_size(&[("n".to_string(), PackValue::String("10".into()))]),
+            None
+        );
+        // Unrelated keys (qid etc.) are ignored.
+        assert_eq!(
+            pull_batch_size(&[
+                ("qid".to_string(), PackValue::Int(1)),
+                ("n".to_string(), PackValue::Int(3)),
+            ]),
+            Some(3)
+        );
+    }
     use super::*;
 
     #[test]

--- a/ferrosa-graph/src/bolt/server.rs
+++ b/ferrosa-graph/src/bolt/server.rs
@@ -419,11 +419,10 @@ async fn process_message(
                 // has_more hardcoded false, so a client asking for 10 rows got
                 // the entire result — a protocol violation, and unbounded
                 // client-side memory for a large query.
-                let (take, has_more) = pull_split(pull_batch_size(&extra), result.rows.len());
-                let remainder = result.rows.split_off(take);
+                let (batch, has_more) = take_batch(&mut result.rows, requested_batch_size(&extra));
 
                 // Send a RECORD for each row in this batch.
-                for row in &result.rows {
+                for row in &batch {
                     let values: Vec<PackValue> = row.iter().map(json_to_pack_value).collect();
                     replies.push(BoltMessage::Record { values });
                 }
@@ -431,9 +430,9 @@ async fn process_message(
                 // Keep the rest for the next PULL. Stats travel with the FINAL
                 // batch, matching Bolt's summary semantics.
                 if has_more {
-                    let mut pending = result.clone();
-                    pending.rows = remainder;
-                    state.pending_result = Some(pending);
+                    // `result.rows` already holds exactly the unconsumed
+                    // remainder, so this is a move, not a copy.
+                    state.pending_result = Some(result);
                     replies.push(BoltMessage::Success {
                         metadata: vec![("has_more".into(), PackValue::Bool(true))],
                     });
@@ -482,9 +481,26 @@ async fn process_message(
             }
         }
 
-        BoltMessage::Discard { .. } => {
-            state.pending_result = None;
-            Ok(vec![BoltMessage::Success { metadata: vec![] }])
+        BoltMessage::Discard { extra } => {
+            // DISCARD {n} discards AT MOST n records, exactly mirroring PULL {n}
+            // — it is not "throw the whole result away". Previously `extra` was
+            // discarded and the entire pending result was dropped, so a client
+            // discarding one record lost the rest with no way to reach it.
+            // `n` absent or negative means discard everything (t_4ce82a3e).
+            match state.pending_result.take() {
+                Some(mut result) => {
+                    let (_dropped, has_more) =
+                        take_batch(&mut result.rows, requested_batch_size(&extra));
+                    if has_more {
+                        state.pending_result = Some(result);
+                        return Ok(vec![BoltMessage::Success {
+                            metadata: vec![("has_more".into(), PackValue::Bool(true))],
+                        }]);
+                    }
+                    Ok(vec![BoltMessage::Success { metadata: vec![] }])
+                }
+                None => Ok(vec![BoltMessage::Success { metadata: vec![] }]),
+            }
         }
 
         BoltMessage::Reset => {
@@ -712,7 +728,7 @@ fn pack_to_json_value(v: &PackValue) -> serde_json::Value {
 /// Bolt semantics: `n` absent, negative (canonically `-1`), or non-integer means
 /// fetch everything. `n >= 0` bounds the batch; `n == 0` legitimately yields an
 /// empty batch with `has_more` still set.
-fn pull_batch_size(extra: &[(String, PackValue)]) -> Option<usize> {
+fn requested_batch_size(extra: &[(String, PackValue)]) -> Option<usize> {
     match extra.iter().find(|(k, _)| k == "n").map(|(_, v)| v) {
         Some(PackValue::Int(n)) if *n >= 0 => Some(*n as usize),
         _ => None,
@@ -724,7 +740,25 @@ fn pull_batch_size(extra: &[(String, PackValue)]) -> Option<usize> {
 ///
 /// Pure so the paging arithmetic — the part with the off-by-one and
 /// saturation edges — is unit-testable without a GraphEngine or a socket.
-fn pull_split(requested: Option<usize>, total: usize) -> (usize, bool) {
+/// Consume at most `requested` records from `rows`, returning the consumed
+/// batch and whether any records remain.
+///
+/// PULL and DISCARD share this contract exactly and differ only in what they do
+/// with the batch — PULL serializes it into RECORDs, DISCARD drops it — so the
+/// consumption lives here rather than being written twice and drifting.
+fn take_batch(
+    rows: &mut Vec<Vec<serde_json::Value>>,
+    requested: Option<usize>,
+) -> (Vec<Vec<serde_json::Value>>, bool) {
+    let (take, has_more) = batch_split(requested, rows.len());
+    let remainder = rows.split_off(take);
+    // `rows` now holds the batch and `remainder` the rest; swap so the caller's
+    // pending buffer is left holding exactly the unconsumed records.
+    let batch = std::mem::replace(rows, remainder);
+    (batch, has_more)
+}
+
+fn batch_split(requested: Option<usize>, total: usize) -> (usize, bool) {
     let take = requested.map_or(total, |n| n.min(total));
     (take, take < total)
 }
@@ -772,25 +806,82 @@ fn error_code(err: &GraphError) -> &'static str {
 #[cfg(test)]
 mod tests {
 
+    /// PULL and DISCARD share one contract: consume at most `n` records from
+    /// the pending result and report whether any remain. They differ only in
+    /// what they do with the consumed batch (serialize it vs drop it), so the
+    /// consumption itself lives in one tested function — a second copy in the
+    /// DISCARD arm is how the two drift apart.
+    #[test]
+    fn take_batch_consumes_at_most_n_and_leaves_the_remainder() {
+        let rows = || -> Vec<Vec<serde_json::Value>> {
+            (1..=5).map(|i| vec![serde_json::json!(i)]).collect()
+        };
+
+        // Partial: batch is the first n, remainder stays for the next message.
+        let mut r = rows();
+        let (batch, has_more) = take_batch(&mut r, Some(2));
+        assert_eq!(
+            batch,
+            vec![vec![serde_json::json!(1)], vec![serde_json::json!(2)]]
+        );
+        assert_eq!(
+            r,
+            vec![
+                vec![serde_json::json!(3)],
+                vec![serde_json::json!(4)],
+                vec![serde_json::json!(5)],
+            ]
+        );
+        assert!(has_more, "3 rows remain");
+
+        // n == len: exact drain must NOT report more, or the client loops forever.
+        let mut r = rows();
+        let (batch, has_more) = take_batch(&mut r, Some(5));
+        assert_eq!(batch.len(), 5);
+        assert!(r.is_empty());
+        assert!(!has_more);
+
+        // Fetch-all (n absent / negative) drains everything.
+        let mut r = rows();
+        let (batch, has_more) = take_batch(&mut r, None);
+        assert_eq!(batch.len(), 5);
+        assert!(r.is_empty());
+        assert!(!has_more);
+
+        // n == 0 consumes nothing but must still report more, else the
+        // remaining rows become unreachable.
+        let mut r = rows();
+        let (batch, has_more) = take_batch(&mut r, Some(0));
+        assert!(batch.is_empty());
+        assert_eq!(r.len(), 5, "nothing consumed");
+        assert!(has_more);
+
+        // Empty pending result: no panic, nothing more.
+        let mut r: Vec<Vec<serde_json::Value>> = Vec::new();
+        let (batch, has_more) = take_batch(&mut r, Some(3));
+        assert!(batch.is_empty());
+        assert!(!has_more);
+    }
+
     /// The paging arithmetic, including the edges that decide whether a client
     /// ever sees the rest of its result (t_4ce82a3e inc 7).
     #[test]
-    fn pull_split_pages_and_signals_has_more() {
+    fn batch_split_pages_and_signals_has_more() {
         // Bounded batch smaller than the result: more remains.
-        assert_eq!(pull_split(Some(2), 5), (2, true));
+        assert_eq!(batch_split(Some(2), 5), (2, true));
         // Exactly the result size: no more (must NOT claim has_more, which would
         // make a client PULL forever).
-        assert_eq!(pull_split(Some(5), 5), (5, false));
+        assert_eq!(batch_split(Some(5), 5), (5, false));
         // Asking for more than exists is clamped, and completes.
-        assert_eq!(pull_split(Some(99), 5), (5, false));
+        assert_eq!(batch_split(Some(99), 5), (5, false));
         // n = 0 sends nothing but must still report more to come.
-        assert_eq!(pull_split(Some(0), 5), (0, true));
+        assert_eq!(batch_split(Some(0), 5), (0, true));
         // ...unless there is nothing to send at all.
-        assert_eq!(pull_split(Some(0), 0), (0, false));
+        assert_eq!(batch_split(Some(0), 0), (0, false));
         // Fetch-all takes everything and completes — the pre-existing behavior,
         // which must be preserved for clients that send n = -1 or omit it.
-        assert_eq!(pull_split(None, 5), (5, false));
-        assert_eq!(pull_split(None, 0), (0, false));
+        assert_eq!(batch_split(None, 5), (5, false));
+        assert_eq!(batch_split(None, 0), (0, false));
     }
 
     /// Bolt PULL {n} must deliver AT MOST n records. `n` absent/negative means
@@ -799,40 +890,40 @@ mod tests {
     /// violation and unbounded client-side memory (t_4ce82a3e inc 7). These
     /// cases are exactly what the old `Pull { .. }` could not express.
     #[test]
-    fn pull_batch_size_honors_the_protocol_n() {
+    fn requested_batch_size_honors_the_protocol_n() {
         use crate::bolt::codec::PackValue;
 
         // Bounded batch.
         assert_eq!(
-            pull_batch_size(&[("n".to_string(), PackValue::Int(10))]),
+            requested_batch_size(&[("n".to_string(), PackValue::Int(10))]),
             Some(10)
         );
         // n = 0 is legal: an empty batch, has_more still decides continuation.
         assert_eq!(
-            pull_batch_size(&[("n".to_string(), PackValue::Int(0))]),
+            requested_batch_size(&[("n".to_string(), PackValue::Int(0))]),
             Some(0)
         );
         // -1 is the canonical "fetch all".
         assert_eq!(
-            pull_batch_size(&[("n".to_string(), PackValue::Int(-1))]),
+            requested_batch_size(&[("n".to_string(), PackValue::Int(-1))]),
             None
         );
         // Any other negative also means fetch-all rather than panicking on the
         // `as usize` cast.
         assert_eq!(
-            pull_batch_size(&[("n".to_string(), PackValue::Int(-99))]),
+            requested_batch_size(&[("n".to_string(), PackValue::Int(-99))]),
             None
         );
         // Absent -> fetch all (what every pre-existing client sends).
-        assert_eq!(pull_batch_size(&[]), None);
+        assert_eq!(requested_batch_size(&[]), None);
         // Wrong type -> fetch all rather than failing the pull.
         assert_eq!(
-            pull_batch_size(&[("n".to_string(), PackValue::String("10".into()))]),
+            requested_batch_size(&[("n".to_string(), PackValue::String("10".into()))]),
             None
         );
         // Unrelated keys (qid etc.) are ignored.
         assert_eq!(
-            pull_batch_size(&[
+            requested_batch_size(&[
                 ("qid".to_string(), PackValue::Int(1)),
                 ("n".to_string(), PackValue::Int(3)),
             ]),

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -432,6 +432,30 @@ fn max_subscriptions() -> usize {
         .unwrap_or(DEFAULT_MAX_SUBSCRIPTIONS)
 }
 
+/// Spill backend backing the graph executor's unbounded ORDER BY: reserves a
+/// cancellable temp-sort directory from the storage engine, exactly as the CQL
+/// ORDER BY path does. The returned reservation's `Drop` removes the directory,
+/// so an aborted or cancelled query cleans up like a successful one.
+struct StorageEngineSpill {
+    storage: Arc<StorageEngine>,
+}
+
+impl std::fmt::Debug for StorageEngineSpill {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("StorageEngineSpill")
+    }
+}
+
+impl crate::executor::spill::SpillReserver for StorageEngineSpill {
+    fn reserve(
+        &self,
+        label: &str,
+    ) -> ferrosa_common::Result<ferrosa_storage::TempSortTableReservation> {
+        self.storage
+            .reserve_order_by_temp_sort_table("graph", label)
+    }
+}
+
 /// Central coordinator for graph query processing.
 pub struct GraphEngine {
     schema: Arc<Schema>,
@@ -511,10 +535,19 @@ impl GraphEngine {
         schema: Arc<Schema>,
         storage: Arc<StorageEngine>,
         write_path: Arc<ArcSwap<WritePath>>,
-        config: GraphEngineConfig,
+        mut config: GraphEngineConfig,
         reconciliation_interval: std::time::Duration,
         schema_coordinator: Arc<dyn GraphSchemaCoordinator>,
     ) -> Self {
+        // Give the executor a spill backend so an unbounded ORDER BY sorts
+        // through the storage engine's bounded external merge sort instead of
+        // being capped in memory (t_4ce82a3e). Only set when the caller left it
+        // unset, so an explicit override (tests) still wins.
+        if config.spill.is_none() {
+            config.spill = Some(Arc::new(StorageEngineSpill {
+                storage: Arc::clone(&storage),
+            }));
+        }
         // Adjacency-keyspace registration is done lazily on the first
         // graph query that touches the keyspace (see
         // `ensure_adjacency_storage_for_keyspace`), so the constructor

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -24,7 +24,7 @@ use crate::executor::aggregate::{create_accumulator, Accumulator};
 use crate::executor::eval;
 use crate::executor::result::{GraphResult, QueryStats};
 use crate::executor::stream::{
-    chain_streams, collect_to_graph_result, stream_from_rows, RowStream,
+    chain_streams, collect_to_graph_result, dedup_stream, stream_from_rows, RowStream,
 };
 use crate::parser::{
     CompareOp, Direction, Expr, Literal, PatternComprehensionHop, RemoveItem, ReturnClause,
@@ -283,6 +283,34 @@ fn execute_streaming_inner<'a>(
             PhysicalPlan::ReturnOnly { return_clause } => {
                 Ok(return_only_stream(return_clause, start))
             }
+            PhysicalPlan::Expand {
+                anchor,
+                hops,
+                optional_hops,
+                post_filters,
+                with_pipeline,
+                return_clause,
+            } => {
+                execute_expand_streaming(
+                    ExpandParts {
+                        anchor,
+                        hops,
+                        optional_hops,
+                        post_filters,
+                        with_pipeline,
+                        return_clause,
+                    },
+                    ExpandCtx {
+                        write_path,
+                        keyspace,
+                        config,
+                        virtual_tables,
+                        schema,
+                        start,
+                    },
+                )
+                .await
+            }
 
             // --- everything else: today's buffered result, wrapped -----------
             other => {
@@ -414,18 +442,22 @@ async fn execute_buffered<'a>(
             return_clause,
         } => {
             execute_expand(
-                write_path,
-                keyspace,
-                &anchor,
-                &hops,
-                &optional_hops,
-                &post_filters,
-                with_pipeline.as_ref(),
-                &return_clause,
-                config,
-                start,
-                virtual_tables,
-                schema,
+                ExpandPlan {
+                    anchor: &anchor,
+                    hops: &hops,
+                    optional_hops: &optional_hops,
+                    post_filters: &post_filters,
+                    with_pipeline: with_pipeline.as_ref(),
+                    return_clause: &return_clause,
+                },
+                ExpandCtx {
+                    write_path,
+                    keyspace,
+                    config,
+                    virtual_tables,
+                    schema,
+                    start,
+                },
             )
             .await
         }
@@ -1205,21 +1237,175 @@ async fn execute_unwind(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn execute_expand(
-    write_path: &WritePath,
-    keyspace: &str,
-    anchor: &Anchor,
-    hops: &[Hop],
-    optional_hops: &[Hop],
-    post_filters: &[Expr],
-    with_pipeline: Option<&crate::parser::WithPipeline>,
-    return_clause: &ReturnClause,
-    config: &GraphEngineConfig,
+/// The borrowed pieces of a `PhysicalPlan::Expand`.
+#[derive(Clone, Copy)]
+struct ExpandPlan<'p> {
+    anchor: &'p Anchor,
+    hops: &'p [Hop],
+    optional_hops: &'p [Hop],
+    post_filters: &'p [Expr],
+    with_pipeline: Option<&'p crate::parser::WithPipeline>,
+    return_clause: &'p ReturnClause,
+}
+
+/// The shared execution context an Expand runs against.
+#[derive(Clone, Copy)]
+struct ExpandCtx<'a> {
+    write_path: &'a WritePath,
+    keyspace: &'a str,
+    config: &'a GraphEngineConfig,
+    virtual_tables: Option<&'a VirtualTableRegistry>,
+    schema: Option<&'a Schema>,
     start: Instant,
-    virtual_tables: Option<&VirtualTableRegistry>,
-    schema: Option<&Schema>,
-) -> Result<GraphResult> {
+}
+
+/// Outcome of an Expand's state-materialization phase.
+enum ExpandStates {
+    /// Virtual-table anchor: `execute_virtual_anchor` produced the whole result
+    /// itself. Deliberately NOT converted to streaming — its handling of
+    /// `ORDER BY`/`DISTINCT` is under separate investigation, and streaming it
+    /// would lock in the current behavior.
+    Virtual(GraphResult),
+    /// The surviving states after hops, post-filters, OPTIONAL MATCH and the
+    /// WITH pipeline, plus the stats accumulated getting there.
+    Materialized(Vec<ExpandState>, QueryStats),
+}
+
+/// Execute a `PhysicalPlan::Expand` and buffer the whole result.
+async fn execute_expand(plan: ExpandPlan<'_>, ctx: ExpandCtx<'_>) -> Result<GraphResult> {
+    match expand_to_states(plan, ctx).await? {
+        ExpandStates::Virtual(result) => Ok(result),
+        ExpandStates::Materialized(states, stats) => {
+            finish_expand_buffered(states, stats, plan, ctx).await
+        }
+    }
+}
+
+/// Owned pieces of a `PhysicalPlan::Expand`, for the streaming entry point.
+///
+/// Owned rather than borrowed because the projection stream outlives the
+/// destructured plan: `execute_streaming` consumes the `PhysicalPlan` by value,
+/// so nothing in the returned stream may borrow from it.
+struct ExpandParts {
+    anchor: Anchor,
+    hops: Vec<Hop>,
+    optional_hops: Vec<Hop>,
+    post_filters: Vec<Expr>,
+    with_pipeline: Option<crate::parser::WithPipeline>,
+    return_clause: ReturnClause,
+}
+
+/// Execute a `PhysicalPlan::Expand`, streaming the projection when it is safe.
+///
+/// Phase A (which states survive) is shared verbatim with the buffered path and
+/// is NOT lazy — the hop loop still materializes the frontier, and the
+/// sequential-vs-concurrent hop split is untouched. What streams is phase B:
+/// one `project_state` per pull, so a `LIMIT k` projects k states instead of
+/// projecting everything and truncating.
+///
+/// Falls back to [`finish_expand_buffered`] when the query has an `ORDER BY`
+/// (it must see every row before the first is final), and to
+/// `execute_virtual_anchor`'s buffered result for a virtual-table anchor.
+///
+/// `DISTINCT` composes as [`dedup_stream`] on top of the projection — see that
+/// function for the deliberate first-seen-vs-sorted order change.
+async fn execute_expand_streaming<'a>(
+    parts: ExpandParts,
+    ctx: ExpandCtx<'a>,
+) -> StreamingPlanResult<'a> {
+    use futures::StreamExt as _;
+
+    let plan = ExpandPlan {
+        anchor: &parts.anchor,
+        hops: &parts.hops,
+        optional_hops: &parts.optional_hops,
+        post_filters: &parts.post_filters,
+        with_pipeline: parts.with_pipeline.as_ref(),
+        return_clause: &parts.return_clause,
+    };
+
+    let (states, mut stats) = match expand_to_states(plan, ctx).await? {
+        ExpandStates::Virtual(result) => {
+            return Ok((result.columns, stream_from_rows(result.rows), result.stats));
+        }
+        ExpandStates::Materialized(states, stats) => (states, stats),
+    };
+
+    // ORDER BY (with or without DISTINCT) is a pipeline breaker: no row is
+    // final until every row is projected. Keep the buffered tail, which also
+    // keeps the spill path and the ordering-by-non-projected-expressions
+    // behavior intact.
+    if !parts.return_clause.order_by.is_empty() {
+        let result = finish_expand_buffered(states, stats, plan, ctx).await?;
+        return Ok((result.columns, stream_from_rows(result.rows), result.stats));
+    }
+
+    let columns = build_columns(&parts.return_clause);
+    let needs_graph_projection = parts
+        .return_clause
+        .items
+        .iter()
+        .any(|item| expr_has_pattern_comprehension(&item.expr));
+    let distinct = parts.return_clause.distinct;
+    let limit = parts.return_clause.limit.map(|limit| limit.max(0) as usize);
+    // Stats are returned up front (see `execute_streaming`), so `execution_ms`
+    // is measured here rather than after the last row. For a streamed Expand it
+    // therefore EXCLUDES projection time, where the buffered path included it.
+    // Fixing that needs the deferred stats handle, not a change here.
+    stats.execution_ms = ctx.start.elapsed().as_millis() as u64;
+
+    let ExpandParts {
+        anchor,
+        return_clause,
+        ..
+    } = parts;
+    let mut rows = project_states_stream(
+        states,
+        ExpandProjection {
+            return_clause,
+            // Matches the buffered tail's `anchor.var.as_deref().unwrap_or("")`.
+            anchor_var: anchor.var.unwrap_or_default(),
+            needs_graph_projection,
+            write_path: ctx.write_path,
+            keyspace: ctx.keyspace,
+            schema: ctx.schema,
+        },
+    );
+    if distinct {
+        rows = dedup_stream(rows);
+    }
+    if let Some(limit) = limit {
+        // `rows.truncate(limit)` becomes `take(limit)`: the states past the
+        // limit are never projected at all.
+        rows = Box::pin(rows.take(limit));
+    }
+    Ok((columns, rows, stats))
+}
+
+/// Phase A of an Expand: anchor scan, hop traversal, post-filters, OPTIONAL
+/// MATCH and the WITH pipeline — everything that decides WHICH states survive.
+///
+/// Shared verbatim by the buffered and streaming tails, so the two can never
+/// disagree about what matched. Nothing here is lazy yet: the hop loop still
+/// materializes the frontier (later increments), and `max_fan_out_per_hop`
+/// still guards it exactly as before.
+async fn expand_to_states(plan: ExpandPlan<'_>, ctx: ExpandCtx<'_>) -> Result<ExpandStates> {
+    let ExpandPlan {
+        anchor,
+        hops,
+        optional_hops,
+        post_filters,
+        with_pipeline,
+        return_clause,
+    } = plan;
+    let ExpandCtx {
+        write_path,
+        keyspace,
+        config,
+        virtual_tables,
+        schema,
+        start,
+    } = ctx;
     let mut stats = QueryStats::default();
 
     // Step 1: Anchor lookup.
@@ -1239,7 +1425,8 @@ async fn execute_expand(
             return_clause,
             config,
             start,
-        );
+        )
+        .map(ExpandStates::Virtual);
     }
 
     let (mut current_states, traversal_hops): (Vec<ExpandState>, &[Hop]) = if let Some(states) =
@@ -1564,6 +1751,34 @@ async fn execute_expand(
         current_states = apply_with_pipeline(current_states, with_pipeline)?;
     }
 
+    Ok(ExpandStates::Materialized(current_states, stats))
+}
+
+/// Phase B, buffered: project every surviving state, then `ORDER BY`,
+/// `DISTINCT` and `LIMIT` over the materialized rows.
+///
+/// This is the pipeline-breaking tail. `execute_expand_streaming` keeps it
+/// unchanged for any query with an `ORDER BY`, and replaces it with
+/// `project_states_stream` (+ `dedup_stream` + `take`) otherwise.
+async fn finish_expand_buffered(
+    current_states: Vec<ExpandState>,
+    mut stats: QueryStats,
+    plan: ExpandPlan<'_>,
+    ctx: ExpandCtx<'_>,
+) -> Result<GraphResult> {
+    let ExpandPlan {
+        anchor,
+        return_clause,
+        ..
+    } = plan;
+    let ExpandCtx {
+        write_path,
+        keyspace,
+        config,
+        schema,
+        start,
+        ..
+    } = ctx;
     // Step 3: Build result from return clause, projecting property values.
     let columns = build_columns(return_clause);
 
@@ -1703,6 +1918,65 @@ async fn project_state(
         row.push(value);
     }
     Ok(row)
+}
+
+/// Everything the Expand projection needs once the surviving states are final.
+///
+/// Owned (`return_clause`, `anchor_var`) rather than borrowed, because the
+/// projection stream outlives the destructured `PhysicalPlan` it came from.
+struct ExpandProjection<'a> {
+    return_clause: ReturnClause,
+    anchor_var: String,
+    needs_graph_projection: bool,
+    write_path: &'a WritePath,
+    keyspace: &'a str,
+    schema: Option<&'a Schema>,
+}
+
+/// Project the surviving expand states lazily: one [`project_state`] call per
+/// pull, in expansion order.
+///
+/// This is the streaming replacement for the materializing projection loop. Two
+/// things it does NOT do, and one thing it drops:
+///
+/// - It does not sort. `ORDER BY` must see every row before the first is final,
+///   so an ordered Expand keeps the buffered tail.
+/// - It does not dedup. `DISTINCT` composes on top via
+///   [`dedup_stream`](crate::executor::stream::dedup_stream).
+/// - It drops the buffered loop's `result_states.push(state.clone())` — that
+///   per-row deep clone of every binding map existed only to let
+///   `sort_projected_rows_by_bindings` order by non-projected expressions,
+///   which is the `ORDER BY` path this stream never takes.
+///
+/// The states themselves are still materialized by the hop loop; making the
+/// hops lazy is a later increment.
+fn project_states_stream<'a>(
+    states: Vec<ExpandState>,
+    projection: ExpandProjection<'a>,
+) -> RowStream<'a> {
+    Box::pin(futures::stream::unfold(
+        (states.into_iter(), projection, false),
+        |(mut states, projection, failed)| async move {
+            // Stop after a failure rather than projecting the rest: a caller
+            // that kept pulling would see a partial result follow an error.
+            if failed {
+                return None;
+            }
+            let state = states.next()?;
+            let row = project_state(
+                &projection.return_clause,
+                projection.needs_graph_projection,
+                projection.write_path,
+                projection.keyspace,
+                projection.schema,
+                &projection.anchor_var,
+                &state,
+            )
+            .await;
+            let failed = row.is_err();
+            Some((row, (states, projection, failed)))
+        },
+    ))
 }
 
 fn sort_projected_rows_by_bindings(
@@ -4447,6 +4721,32 @@ fn encode_expr_for_column_type(expr: &Expr, column_type: &str) -> Result<Vec<u8>
     }
 }
 
+/// Does this plan's projection READ STORAGE, rather than only the values
+/// already bound by the match?
+///
+/// SET and REMOVE consume their inner expand as a stream, so its projection is
+/// interleaved with their writes. That is only sound when the projection cannot
+/// observe those writes. `project_state` touches storage exactly when a RETURN
+/// item contains a pattern comprehension (`graph_eval_expr`); otherwise it
+/// evaluates against `state.bindings`, which were captured before any write.
+///
+/// The planner synthesizes plain `Expr::Var` projections for SET/REMOVE
+/// (`plan_set` / `plan_remove`), so this is false in practice. It exists so
+/// that if that ever changes, the caller drains the projection BEFORE writing
+/// instead of silently letting a comprehension read half-written state.
+fn projection_reads_storage(plan: &PhysicalPlan) -> bool {
+    let return_clause = match plan {
+        PhysicalPlan::Expand { return_clause, .. } => return_clause,
+        // Any other shape is not the plain expand SET/REMOVE plan for; be
+        // conservative and make the caller materialize first.
+        _ => return true,
+    };
+    return_clause
+        .items
+        .iter()
+        .any(|item| expr_has_pattern_comprehension(&item.expr))
+}
+
 /// Execute a SET plan: run the expand to find matching vertices, then write
 /// updated cells for each one.
 #[allow(clippy::too_many_arguments)]
@@ -4462,7 +4762,19 @@ async fn execute_set(
     schema: Option<&Schema>,
 ) -> Result<GraphResult> {
     // Execute the inner expand to find matching vertices.
-    let expand_result = Box::pin(execute(
+    // Consume the inner expand as a STREAM: its projected rows are never
+    // collected into a `Vec`, so a SET/REMOVE across a large MATCH no longer
+    // buffers one row per matched vertex. Columns arrive before rows, which is
+    // all the write loop below needs.
+    //
+    // Soundness of interleaving projection with our writes: the projection only
+    // touches storage when it contains a pattern comprehension, and
+    // `projection_reads_storage` makes us drain the stream first in that case,
+    // so a projection can never observe a write this statement is making.
+    use futures::StreamExt as _;
+
+    let drain_first = projection_reads_storage(&expand);
+    let (columns, rows_stream, expand_stats) = Box::pin(execute_streaming(
         expand,
         write_path,
         keyspace,
@@ -4471,9 +4783,16 @@ async fn execute_set(
         schema,
     ))
     .await?;
-    let mut stats = QueryStats::default();
-    stats.vertices_read = expand_result.stats.vertices_read;
-    stats.edges_read = expand_result.stats.edges_read;
+    let mut rows_stream = if drain_first {
+        stream_from_rows(crate::executor::stream::collect_rows(rows_stream).await?)
+    } else {
+        rows_stream
+    };
+    let mut stats = QueryStats {
+        vertices_read: expand_stats.vertices_read,
+        edges_read: expand_stats.edges_read,
+        ..Default::default()
+    };
 
     let timestamp = now_micros();
     let strategy = graph_replication_strategy(schema, keyspace)?;
@@ -4481,8 +4800,9 @@ async fn execute_set(
     // For each matched vertex, apply the assignments.
     // The expand result rows contain vertex IDs (hex-encoded).
     // We need to reconstruct the partition key from the hex ID.
-    for row_values in &expand_result.rows {
-        for (col_idx, col_name) in expand_result.columns.iter().enumerate() {
+    while let Some(row_values) = rows_stream.next().await {
+        let row_values = row_values?;
+        for (col_idx, col_name) in columns.iter().enumerate() {
             // Find assignments that target this variable.
             let matching_assignments: Vec<&(String, String, Expr)> = assignments
                 .iter()
@@ -4636,7 +4956,19 @@ async fn execute_remove(
         }
     }
 
-    let expand_result = Box::pin(execute(
+    // Consume the inner expand as a STREAM: its projected rows are never
+    // collected into a `Vec`, so a SET/REMOVE across a large MATCH no longer
+    // buffers one row per matched vertex. Columns arrive before rows, which is
+    // all the write loop below needs.
+    //
+    // Soundness of interleaving projection with our writes: the projection only
+    // touches storage when it contains a pattern comprehension, and
+    // `projection_reads_storage` makes us drain the stream first in that case,
+    // so a projection can never observe a write this statement is making.
+    use futures::StreamExt as _;
+
+    let drain_first = projection_reads_storage(&expand);
+    let (columns, rows_stream, expand_stats) = Box::pin(execute_streaming(
         expand,
         write_path,
         keyspace,
@@ -4645,16 +4977,24 @@ async fn execute_remove(
         schema,
     ))
     .await?;
-    let mut stats = QueryStats::default();
-    stats.vertices_read = expand_result.stats.vertices_read;
-    stats.edges_read = expand_result.stats.edges_read;
+    let mut rows_stream = if drain_first {
+        stream_from_rows(crate::executor::stream::collect_rows(rows_stream).await?)
+    } else {
+        rows_stream
+    };
+    let mut stats = QueryStats {
+        vertices_read: expand_stats.vertices_read,
+        edges_read: expand_stats.edges_read,
+        ..Default::default()
+    };
 
     let timestamp = now_micros();
     let local_deletion_time = timestamp.div_euclid(1_000_000).clamp(0, i32::MAX as i64) as i32;
     let strategy = graph_replication_strategy(schema, keyspace)?;
 
-    for row_values in &expand_result.rows {
-        for (col_idx, col_name) in expand_result.columns.iter().enumerate() {
+    while let Some(row_values) = rows_stream.next().await {
+        let row_values = row_values?;
+        for (col_idx, col_name) in columns.iter().enumerate() {
             let matching_props: Vec<&str> = items
                 .iter()
                 .filter_map(|item| match item {
@@ -8171,6 +8511,245 @@ mod tests {
                 vec![serde_json::json!(1)],
                 vec![serde_json::json!(2)]
             ]
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // SET / REMOVE stream their INNER EXPAND (their own output is one summary
+    // row, only knowable after the last write). `projection_reads_storage` is
+    // the guard that makes interleaving the inner projection with those writes
+    // sound.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn projection_reads_storage_is_false_for_the_planner_shape_set_and_remove_use() {
+        // `plan_set` / `plan_remove` synthesize plain `Expr::Var` projections.
+        use crate::parser::{Expr, ReturnClause, ReturnItem};
+        let plan = PhysicalPlan::Expand {
+            anchor: Anchor {
+                var: Some("n".to_string()),
+                table: crate::planner::logical::ResolvedTable {
+                    keyspace: "social".to_string(),
+                    table: "person".to_string(),
+                    graph_type: "vertex".to_string(),
+                    label: "Person".to_string(),
+                },
+                props: vec![],
+                filters: vec![],
+            },
+            hops: vec![],
+            optional_hops: vec![],
+            post_filters: vec![],
+            with_pipeline: None,
+            return_clause: ReturnClause {
+                distinct: false,
+                items: vec![ReturnItem {
+                    expr: Expr::Var("n".to_string()),
+                    alias: None,
+                }],
+                order_by: vec![],
+                limit: None,
+            },
+        };
+        assert!(
+            !projection_reads_storage(&plan),
+            "a plain Expr::Var projection reads only the bindings, so SET/REMOVE may \
+             stream the inner expand and interleave their writes with it"
+        );
+    }
+
+    #[test]
+    fn projection_reads_storage_is_true_for_a_non_expand_inner_plan() {
+        // Anything that is not the plain expand SET/REMOVE plan for must be
+        // materialized before writing — conservative by construction.
+        assert!(projection_reads_storage(&return_one_plan(
+            &[("a", 1)],
+            None
+        )));
+    }
+
+    // ---------------------------------------------------------------------
+    // Streaming Expand projection (`project_states_stream`)
+    //
+    // The states are still materialized by the hop loop (increments 3-4); what
+    // streams here is the PROJECTION — one `project_state` call per pull, so a
+    // downstream `take(k)` projects exactly k states.
+    // ---------------------------------------------------------------------
+
+    fn projection_state(name: &str) -> ExpandState {
+        let mut bindings = HashMap::new();
+        bindings.insert("n".to_string(), serde_json::json!({ "name": name }));
+        ExpandState {
+            current_key: DecoratedKey::new(PartitionKey::new(name.as_bytes().to_vec())),
+            bindings,
+        }
+    }
+
+    fn name_return_clause(distinct: bool, limit: Option<i64>) -> crate::parser::ReturnClause {
+        use crate::parser::{Expr, ReturnClause, ReturnItem};
+        ReturnClause {
+            distinct,
+            items: vec![ReturnItem {
+                expr: Expr::Property {
+                    var: "n".to_string(),
+                    name: "name".to_string(),
+                },
+                alias: None,
+            }],
+            order_by: vec![],
+            limit,
+        }
+    }
+
+    fn projection_ctx<'a>(
+        write_path: &'a WritePath,
+        return_clause: crate::parser::ReturnClause,
+        needs_graph_projection: bool,
+    ) -> ExpandProjection<'a> {
+        ExpandProjection {
+            return_clause,
+            anchor_var: "n".to_string(),
+            needs_graph_projection,
+            write_path,
+            keyspace: "social",
+            schema: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn project_states_stream_yields_one_row_per_state_in_order() {
+        let (_tmp, wp) = streaming_test_write_path();
+        let states = vec![
+            projection_state("Cara"),
+            projection_state("Alice"),
+            projection_state("Bob"),
+        ];
+        let stream = project_states_stream(
+            states,
+            projection_ctx(&wp, name_return_clause(false, None), false),
+        );
+        assert_eq!(
+            crate::executor::stream::collect_rows(stream).await.unwrap(),
+            vec![
+                vec![serde_json::json!("Cara")],
+                vec![serde_json::json!("Alice")],
+                vec![serde_json::json!("Bob")],
+            ],
+            "projection is 1:1 with the surviving states, in expansion order"
+        );
+    }
+
+    /// The incrementality obligation for the Expand conversion: projection work
+    /// happens ON PULL, not up front.
+    ///
+    /// Observed through an error. `project_state`'s graph-aware path propagates
+    /// evaluation failures (`graph_eval_expr` uses `?`, unlike the binding-only
+    /// path's `unwrap_or(Null)`), and `Expr::Parameter` is always an unbound-
+    /// parameter error. So: draining the stream MUST fail (the projection ran),
+    /// while `take(0)` MUST succeed (no state was ever projected). A
+    /// materialize-then-return implementation cannot pass both halves.
+    #[tokio::test]
+    async fn project_states_stream_defers_projection_until_pulled() {
+        use crate::parser::{Expr, ReturnClause, ReturnItem};
+        let (_tmp, wp) = streaming_test_write_path();
+        let erroring = ReturnClause {
+            distinct: false,
+            items: vec![ReturnItem {
+                expr: Expr::Parameter("never_bound".to_string()),
+                alias: None,
+            }],
+            order_by: vec![],
+            limit: None,
+        };
+        let states = || {
+            vec![
+                projection_state("Cara"),
+                projection_state("Alice"),
+                projection_state("Bob"),
+            ]
+        };
+
+        let drained = crate::executor::stream::collect_rows(project_states_stream(
+            states(),
+            projection_ctx(&wp, erroring.clone(), true),
+        ))
+        .await;
+        assert!(
+            drained.is_err(),
+            "draining must surface the projection error — otherwise the projection never ran \
+             and this test proves nothing"
+        );
+
+        let untouched: crate::executor::stream::RowStream<'_> = {
+            use futures::StreamExt as _;
+            Box::pin(project_states_stream(states(), projection_ctx(&wp, erroring, true)).take(0))
+        };
+        assert_eq!(
+            crate::executor::stream::collect_rows(untouched)
+                .await
+                .unwrap(),
+            Vec::<Vec<serde_json::Value>>::new(),
+            "take(0) must project NOTHING — no state may be projected before it is pulled"
+        );
+    }
+
+    /// LIMIT over a streaming projection is `take(k)`: only k states are
+    /// projected, proven by the same error observable.
+    #[tokio::test]
+    async fn project_states_stream_take_projects_only_the_pulled_prefix() {
+        use crate::parser::{Expr, ReturnClause, ReturnItem};
+        let (_tmp, wp) = streaming_test_write_path();
+        // Item 1 always evaluates; a SECOND item is an unbound parameter, so
+        // projecting ANY state fails. With `take(0)` nothing is projected.
+        let clause = ReturnClause {
+            distinct: false,
+            items: vec![ReturnItem {
+                expr: Expr::Parameter("never_bound".to_string()),
+                alias: None,
+            }],
+            order_by: vec![],
+            limit: None,
+        };
+        let stream: crate::executor::stream::RowStream<'_> = {
+            use futures::StreamExt as _;
+            Box::pin(
+                project_states_stream(
+                    vec![projection_state("Cara"), projection_state("Alice")],
+                    projection_ctx(&wp, clause, true),
+                )
+                .take(0),
+            )
+        };
+        assert!(
+            crate::executor::stream::collect_rows(stream).await.is_ok(),
+            "a zero-row LIMIT must not project the first state"
+        );
+    }
+
+    /// After an error the stream STOPS. Continuing would re-poll an operator
+    /// that already failed and could report a partial result as complete.
+    #[tokio::test]
+    async fn project_states_stream_stops_after_a_projection_error() {
+        use crate::parser::{Expr, ReturnClause, ReturnItem};
+        use futures::StreamExt as _;
+        let (_tmp, wp) = streaming_test_write_path();
+        let clause = ReturnClause {
+            distinct: false,
+            items: vec![ReturnItem {
+                expr: Expr::Parameter("never_bound".to_string()),
+                alias: None,
+            }],
+            order_by: vec![],
+            limit: None,
+        };
+        let mut stream = project_states_stream(
+            vec![projection_state("Cara"), projection_state("Alice")],
+            projection_ctx(&wp, clause, true),
+        );
+        assert!(stream.next().await.expect("first item").is_err());
+        assert!(
+            stream.next().await.is_none(),
+            "the stream must terminate after a projection error, not keep yielding"
         );
     }
 }

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -5240,7 +5240,7 @@ pub fn sort_rows(
 }
 
 /// Compare two JSON values for sorting purposes.
-fn compare_json_values(
+pub(super) fn compare_json_values(
     a: Option<&serde_json::Value>,
     b: Option<&serde_json::Value>,
 ) -> std::cmp::Ordering {

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -84,7 +84,19 @@ pub struct GraphEngineConfig {
     /// Maximum query execution time.
     pub query_timeout: Duration,
     /// Maximum number of result rows.
+    ///
+    /// DEPRECATED — being removed (t_4ce82a3e). This used to SILENTLY TRUNCATE
+    /// the result set (`break`, no error, no flag), so a client could not tell a
+    /// partial answer from a complete one. ORDER BY now spills instead of
+    /// capping (see `spill`); the remaining uses are on the not-yet-converted
+    /// varpath/leapfrog paths.
     pub max_result_rows: usize,
+    /// Backend for spilling an unbounded ORDER BY to disk. `None` = sort in
+    /// memory (unit tests, embedded use). See
+    /// [`crate::executor::spill::SpillReserver`].
+    pub spill: Option<std::sync::Arc<dyn crate::executor::spill::SpillReserver>>,
+    /// Bytes of rows to accumulate before spilling a sorted run.
+    pub spill_threshold_bytes: u64,
     /// Maximum fan-out per hop (T4: limits adjacency reads).
     pub max_fan_out_per_hop: usize,
     /// Maximum number of groups in an aggregation (FMEA F7).
@@ -101,6 +113,11 @@ impl Default for GraphEngineConfig {
         Self {
             query_timeout: Duration::from_secs(30),
             max_result_rows: 10_000,
+            spill: None,
+            // 64 MiB of accumulated rows before a run is spilled — large enough
+            // that ordinary queries never touch disk, small enough that a huge
+            // sort stays bounded.
+            spill_threshold_bytes: 64 * 1024 * 1024,
             max_fan_out_per_hop: 10_000,
             max_groups: 100_000,
             max_collect_size: 10_000,
@@ -1381,13 +1398,14 @@ async fn execute_expand(
         .any(|item| expr_has_pattern_comprehension(&item.expr));
     let anchor_var = anchor.var.as_deref().unwrap_or("");
 
+    // Project every surviving state. The old `max_result_rows` break here
+    // SILENTLY TRUNCATED the result — no error, no flag, so a client could not
+    // tell a partial answer from a complete one. Removed (t_4ce82a3e): an
+    // unbounded ORDER BY now SPILLS (below) instead of being capped, which is
+    // the honest answer rather than a quiet wrong one.
     let mut result_states = Vec::new();
     let mut rows = Vec::new();
     for state in &current_states {
-        if rows.len() >= config.max_result_rows {
-            break;
-        }
-
         let row = project_state(
             return_clause,
             needs_graph_projection,
@@ -1404,7 +1422,19 @@ async fn execute_expand(
 
     // Apply ORDER BY before projection-only values disappear. Cypher permits
     // ordering by expressions that are not part of RETURN.
-    sort_projected_rows_by_bindings(&mut rows, &result_states, return_clause);
+    //
+    // An UNBOUNDED ORDER BY (no LIMIT) must see every row before the first
+    // output row is known — a pipeline-breaker. Rather than cap it in memory,
+    // spill through the storage engine's bounded external merge sort when a
+    // backend is available (t_4ce82a3e). `spill_order_by` returns Ok(false) when
+    // it cannot apply (no backend, no LIMIT-free ORDER BY, or an order term that
+    // is not a projected column), leaving the in-memory sort below to run
+    // exactly as before.
+    let spilled =
+        crate::executor::spill::spill_order_by(&mut rows, &columns, return_clause, config).await?;
+    if !spilled {
+        sort_projected_rows_by_bindings(&mut rows, &result_states, return_clause);
+    }
 
     // Apply DISTINCT.
     if return_clause.distinct {
@@ -5361,7 +5391,7 @@ fn column_name_for_item(item: &ReturnItem) -> String {
 }
 
 /// Convert an expression to a display-friendly column name.
-fn expr_to_column_name(expr: &Expr) -> String {
+pub(super) fn expr_to_column_name(expr: &Expr) -> String {
     match expr {
         Expr::Property { var, name } => format!("{var}.{name}"),
         Expr::Var(v) => v.clone(),

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -23,6 +23,9 @@ use crate::error::{GraphError, Result};
 use crate::executor::aggregate::{create_accumulator, Accumulator};
 use crate::executor::eval;
 use crate::executor::result::{GraphResult, QueryStats};
+use crate::executor::stream::{
+    chain_streams, collect_to_graph_result, stream_from_rows, RowStream,
+};
 use crate::parser::{
     CompareOp, Direction, Expr, Literal, PatternComprehensionHop, RemoveItem, ReturnClause,
     ReturnItem, SortDir, WithPipeline,
@@ -126,6 +129,9 @@ impl Default for GraphEngineConfig {
     }
 }
 
+/// The columns, row stream, and stats produced by [`execute_streaming`].
+type StreamingPlanResult<'a> = Result<(Vec<String>, RowStream<'a>, QueryStats)>;
+
 /// Execute a physical plan against the storage engine.
 ///
 /// If `virtual_tables` is provided, the executor checks the registry before
@@ -135,6 +141,10 @@ impl Default for GraphEngineConfig {
 /// If `schema` is provided, column names from table metadata are used to
 /// map cell indices to property names (e.g., `name`, `age`) so that Cypher
 /// property lookups like `a.name` resolve correctly.
+///
+/// This is the buffered façade over [`execute_streaming`]: it drains the row
+/// stream through [`collect_to_graph_result`]. There is one executor, not two —
+/// this entry point adds only the materialization.
 pub async fn execute(
     plan: PhysicalPlan,
     write_path: &WritePath,
@@ -143,48 +153,251 @@ pub async fn execute(
     virtual_tables: Option<&VirtualTableRegistry>,
     schema: Option<&Schema>,
 ) -> Result<GraphResult> {
-    let start = Instant::now();
+    let (columns, rows_stream, stats) =
+        execute_streaming(plan, write_path, keyspace, config, virtual_tables, schema).await?;
+    // `usize::MAX`, deliberately NOT `config.max_result_rows`: `execute` has
+    // never applied a global row cap. The caps live inside individual operators
+    // (leapfrog, the virtual-table anchor, projection), and a UNION of capped
+    // arms may legitimately return more than `max_result_rows` rows today.
+    // Capping here would silently truncate results that currently come back in
+    // full — a behavior change, and a silent one.
+    collect_to_graph_result(columns, rows_stream, stats, usize::MAX).await
+}
 
-    match plan {
-        PhysicalPlan::Union { arms, all } => {
-            let mut columns: Option<Vec<String>> = None;
-            let mut rows = Vec::new();
-            let mut stats = QueryStats::default();
-            for arm in arms {
-                let result = Box::pin(execute(
-                    arm,
+/// Streaming entry point: the projected column names, a pull-based row stream,
+/// and the query's [`QueryStats`].
+///
+/// Additive scaffold (increment 2 of the streaming executor, t_4ce82a3e). Only
+/// the provably-safe plan variants stream; everything else computes today's
+/// buffered [`GraphResult`] and hands it back through [`stream_from_rows`].
+/// Behavior is identical for every query either way — [`execute`] is this
+/// function plus a `collect`.
+///
+/// # What actually streams
+///
+/// - [`PhysicalPlan::Subscribe`] — pure passthrough to the inner plan, so it
+///   streams exactly as well as whatever it wraps.
+/// - [`PhysicalPlan::Union`] with `all: true` — concatenation, via
+///   [`chain_streams`]. A later arm is never polled until the earlier arms are
+///   drained. The arms themselves are
+///   still *executed* eagerly, because `stats` is returned up front and a
+///   UNION's stats are the sum over its arms — so the end-to-end laziness is
+///   real only when the arms are themselves converted variants.
+/// - [`PhysicalPlan::ReturnOnly`] — at most one row, produced on pull, so
+///   `LIMIT 0` never evaluates the projection.
+///
+/// # What deliberately does not
+///
+/// Everything else, including `UNION` *without* `ALL` (its `HashSet` dedup
+/// spans the whole concatenation), `DeleteNodes` (it walks the matched rows
+/// twice — validate every vertex, then tombstone — and streaming it would
+/// partially delete), `Aggregate`, DISTINCT, ORDER BY, `WcoJoin`, and
+/// `ExpandVarLength`.
+///
+/// # Stats
+///
+/// `QueryStats` is returned alongside the stream rather than after it, so it is
+/// computed exactly where the buffered path computes it today. That is why a
+/// fallback variant is fully executed before this function returns.
+pub async fn execute_streaming<'a>(
+    plan: PhysicalPlan,
+    write_path: &'a WritePath,
+    keyspace: &'a str,
+    config: &'a GraphEngineConfig,
+    virtual_tables: Option<&'a VirtualTableRegistry>,
+    schema: Option<&'a Schema>,
+) -> StreamingPlanResult<'a> {
+    execute_streaming_inner(plan, write_path, keyspace, config, virtual_tables, schema).await
+}
+
+/// Boxed body of [`execute_streaming`].
+///
+/// `Subscribe` and `Union` recurse into it, so the future has to be type-erased.
+fn execute_streaming_inner<'a>(
+    plan: PhysicalPlan,
+    write_path: &'a WritePath,
+    keyspace: &'a str,
+    config: &'a GraphEngineConfig,
+    virtual_tables: Option<&'a VirtualTableRegistry>,
+    schema: Option<&'a Schema>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = StreamingPlanResult<'a>> + Send + 'a>> {
+    Box::pin(async move {
+        let start = Instant::now();
+
+        match plan {
+            // --- converted: streams for real ---------------------------------
+            PhysicalPlan::Subscribe { inner, .. } => {
+                // The initial snapshot IS the inner plan's result. Passthrough,
+                // including the inner plan's own `start` for `execution_ms`,
+                // exactly as the buffered path's recursive `execute` call did.
+                execute_streaming_inner(
+                    *inner,
                     write_path,
                     keyspace,
                     config,
                     virtual_tables,
                     schema,
-                ))
-                .await?;
-                if let Some(existing) = &columns {
-                    if existing != &result.columns {
-                        return Err(GraphError::Validation(
-                            "UNION arms must return identical columns".to_string(),
-                        ));
-                    }
-                } else {
-                    columns = Some(result.columns.clone());
-                }
-                stats.vertices_read += result.stats.vertices_read;
-                stats.edges_read += result.stats.edges_read;
-                stats.vertices_written += result.stats.vertices_written;
-                stats.vertices_deleted += result.stats.vertices_deleted;
-                rows.extend(result.rows);
+                )
+                .await
             }
+            PhysicalPlan::Union { arms, all: true } => {
+                let mut columns: Option<Vec<String>> = None;
+                let mut stats = QueryStats::default();
+                let mut arm_streams: Vec<RowStream<'a>> = Vec::with_capacity(arms.len());
+                for arm in arms {
+                    let (arm_columns, arm_stream, arm_stats) = execute_streaming_inner(
+                        arm,
+                        write_path,
+                        keyspace,
+                        config,
+                        virtual_tables,
+                        schema,
+                    )
+                    .await?;
+                    if let Some(existing) = &columns {
+                        if existing != &arm_columns {
+                            return Err(GraphError::Validation(
+                                "UNION arms must return identical columns".to_string(),
+                            ));
+                        }
+                    } else {
+                        columns = Some(arm_columns);
+                    }
+                    stats.vertices_read += arm_stats.vertices_read;
+                    stats.edges_read += arm_stats.edges_read;
+                    stats.vertices_written += arm_stats.vertices_written;
+                    stats.vertices_deleted += arm_stats.vertices_deleted;
+                    // `edges_deleted` is NOT summed here. That omission is
+                    // carried over verbatim from the buffered UNION: fixing it
+                    // would change what a `UNION` over DELETE arms reports, so
+                    // it is out of scope for a behavior-preserving scaffold.
+                    arm_streams.push(arm_stream);
+                }
+                stats.execution_ms = start.elapsed().as_millis() as u64;
+                Ok((
+                    columns.unwrap_or_default(),
+                    chain_streams(arm_streams),
+                    stats,
+                ))
+            }
+            PhysicalPlan::ReturnOnly { return_clause } => {
+                Ok(return_only_stream(return_clause, start))
+            }
+
+            // --- everything else: today's buffered result, wrapped -----------
+            other => {
+                let result = execute_buffered(
+                    other,
+                    write_path,
+                    keyspace,
+                    config,
+                    virtual_tables,
+                    schema,
+                    start,
+                )
+                .await?;
+                Ok((result.columns, stream_from_rows(result.rows), result.stats))
+            }
+        }
+    })
+}
+
+/// `RETURN <exprs>` with no MATCH: at most one row, built on pull.
+///
+/// The buffered form projected the row, ran `sort_rows`, then
+/// `rows.truncate(limit)`. Streaming, the truncate is a `take`, so `LIMIT 0`
+/// short-circuits before the projection is evaluated at all. `ORDER BY` is
+/// dropped on purpose: sorting a one-row result is the identity.
+fn return_only_stream<'a>(
+    return_clause: ReturnClause,
+    start: Instant,
+) -> (Vec<String>, RowStream<'a>, QueryStats) {
+    use futures::StreamExt as _;
+
+    let columns = build_columns(&return_clause);
+    let limit = return_clause
+        .limit
+        .map(|limit| limit.max(0) as usize)
+        .unwrap_or(usize::MAX);
+    let row = futures::stream::once(async move {
+        let bindings = HashMap::new();
+        Ok(return_clause
+            .items
+            .iter()
+            .map(|item| eval::eval_expr(&item.expr, &bindings).unwrap_or(serde_json::Value::Null))
+            .collect::<Vec<_>>())
+    });
+    let stats = QueryStats {
+        vertices_read: 0,
+        edges_read: 0,
+        vertices_written: 0,
+        vertices_deleted: 0,
+        edges_deleted: 0,
+        execution_ms: start.elapsed().as_millis() as u64,
+    };
+    (columns, Box::pin(row.take(limit)), stats)
+}
+
+/// The materializing executor: every plan variant that has not been converted
+/// to streaming, unchanged.
+///
+/// `start` is threaded in from [`execute_streaming_inner`] so `execution_ms`
+/// still measures from the same instant the buffered `execute` used to.
+async fn execute_buffered<'a>(
+    plan: PhysicalPlan,
+    write_path: &'a WritePath,
+    keyspace: &'a str,
+    config: &'a GraphEngineConfig,
+    virtual_tables: Option<&'a VirtualTableRegistry>,
+    schema: Option<&'a Schema>,
+    start: Instant,
+) -> Result<GraphResult> {
+    match plan {
+        PhysicalPlan::Union { arms, all } => {
+            // Concatenation is the streaming half; `all: false` adds a HashSet
+            // dedup over the WHOLE concatenation, which has to see every row
+            // before any row is final. Route the concatenation through the
+            // streaming UNION ALL so there is one implementation of it, then
+            // materialize and dedup.
+            let (columns, rows_stream, mut stats) = execute_streaming(
+                PhysicalPlan::Union { arms, all: true },
+                write_path,
+                keyspace,
+                config,
+                virtual_tables,
+                schema,
+            )
+            .await?;
+            let mut rows = crate::executor::stream::collect_rows(rows_stream).await?;
             if !all {
                 let mut seen = std::collections::HashSet::new();
                 rows.retain(|row| seen.insert(serde_json::to_string(row).unwrap_or_default()));
             }
             stats.execution_ms = start.elapsed().as_millis() as u64;
             Ok(GraphResult {
-                columns: columns.unwrap_or_default(),
+                columns,
                 rows,
                 stats,
             })
+        }
+        // Converted variants: `execute_streaming` intercepts these before it
+        // ever delegates here. Present so this function stays total over
+        // `PhysicalPlan`, and routed through the same code so there is no
+        // second implementation to drift.
+        PhysicalPlan::ReturnOnly { return_clause } => {
+            let (columns, rows_stream, stats) = return_only_stream(return_clause, start);
+            collect_to_graph_result(columns, rows_stream, stats, usize::MAX).await
+        }
+        PhysicalPlan::Subscribe { inner, .. } => {
+            Box::pin(execute(
+                *inner,
+                write_path,
+                keyspace,
+                config,
+                virtual_tables,
+                schema,
+            ))
+            .await
         }
         PhysicalPlan::Unwind {
             expr,
@@ -192,7 +405,6 @@ pub async fn execute(
             with_pipeline,
             return_clause,
         } => execute_unwind(&expr, &var, with_pipeline.as_ref(), &return_clause, start).await,
-        PhysicalPlan::ReturnOnly { return_clause } => execute_return_only(&return_clause, start),
         PhysicalPlan::Expand {
             anchor,
             hops,
@@ -273,6 +485,10 @@ pub async fn execute(
             detach,
             variable_tables,
         } => {
+            // NOT streamable: this consumes the matched rows TWICE — validate
+            // across every matched vertex first, then tombstone. A single-pass
+            // stream would delete a prefix and then fail validation, i.e.
+            // partial deletion.
             execute_delete(
                 write_path,
                 *expand,
@@ -305,18 +521,6 @@ pub async fn execute(
                 virtual_tables,
                 schema,
             )
-            .await
-        }
-        PhysicalPlan::Subscribe { inner, .. } => {
-            // Execute the initial snapshot from the inner plan.
-            Box::pin(execute(
-                *inner,
-                write_path,
-                keyspace,
-                config,
-                virtual_tables,
-                schema,
-            ))
             .await
         }
         PhysicalPlan::ExpandVarLength {
@@ -911,32 +1115,6 @@ async fn resolve_target_node_json(
     )
     .await?;
     Ok(matched.map(|m| m.json))
-}
-
-fn execute_return_only(return_clause: &ReturnClause, start: Instant) -> Result<GraphResult> {
-    let bindings = HashMap::new();
-    let mut rows = vec![return_clause
-        .items
-        .iter()
-        .map(|item| eval::eval_expr(&item.expr, &bindings).unwrap_or(serde_json::Value::Null))
-        .collect::<Vec<_>>()];
-    let columns = build_columns(return_clause);
-    sort_rows(&mut rows, &columns, &return_clause.order_by);
-    if let Some(limit) = return_clause.limit {
-        rows.truncate(limit.max(0) as usize);
-    }
-    Ok(GraphResult {
-        columns,
-        rows,
-        stats: QueryStats {
-            vertices_read: 0,
-            edges_read: 0,
-            vertices_written: 0,
-            vertices_deleted: 0,
-            edges_deleted: 0,
-            execution_ms: start.elapsed().as_millis() as u64,
-        },
-    })
 }
 
 async fn execute_unwind(
@@ -7663,6 +7841,336 @@ mod tests {
         strength_idx.expect(
             "SET r.strength must produce a cell whose col_idx maps to the strength column \
              on the receiver's TableSchema",
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Streaming entry point (`execute_streaming`)
+    //
+    // Two obligations, one per test group:
+    //   (1) a converted variant genuinely streams — see
+    //       `union_all_streams_without_pulling_later_arms`;
+    //   (2) EVERY variant — converted or fallback — reproduces the buffered
+    //       `GraphResult` exactly, which is what `assert_streaming_matches`
+    //       asserts field by field (`execution_ms` excluded: it is a wall-clock
+    //       measurement, not a result value).
+    // ---------------------------------------------------------------------
+
+    fn streaming_test_write_path() -> (tempfile::TempDir, WritePath) {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = test_storage_engine(tmp.path());
+        (tmp, WritePath::direct(storage))
+    }
+
+    fn return_one_plan(items: &[(&str, i64)], limit: Option<i64>) -> PhysicalPlan {
+        use crate::parser::{Expr, Literal, ReturnClause, ReturnItem};
+        PhysicalPlan::ReturnOnly {
+            return_clause: ReturnClause {
+                distinct: false,
+                items: items
+                    .iter()
+                    .map(|(alias, value)| ReturnItem {
+                        expr: Expr::Literal(Literal::Integer(*value)),
+                        alias: Some((*alias).to_string()),
+                    })
+                    .collect(),
+                order_by: vec![],
+                limit,
+            },
+        }
+    }
+
+    /// Run `plan` through both entry points and assert the streaming one is
+    /// indistinguishable from today's buffered one.
+    async fn assert_streaming_matches(
+        // `PhysicalPlan` is not `Clone`, and the plan is consumed by value, so
+        // the caller supplies a factory that builds it once per entry point.
+        build_plan: impl Fn() -> PhysicalPlan,
+        keyspace: &str,
+        registry: Option<&VirtualTableRegistry>,
+    ) -> GraphResult {
+        let (_tmp, wp) = streaming_test_write_path();
+        let config = GraphEngineConfig::default();
+
+        let buffered = execute(build_plan(), &wp, keyspace, &config, registry, None)
+            .await
+            .unwrap();
+
+        let (columns, rows_stream, stats) =
+            execute_streaming(build_plan(), &wp, keyspace, &config, registry, None)
+                .await
+                .unwrap();
+        let rows = crate::executor::stream::collect_rows(rows_stream)
+            .await
+            .unwrap();
+
+        assert_eq!(columns, buffered.columns, "columns must be identical");
+        assert_eq!(rows, buffered.rows, "rows must be identical, in order");
+        assert_eq!(stats.vertices_read, buffered.stats.vertices_read);
+        assert_eq!(stats.edges_read, buffered.stats.edges_read);
+        assert_eq!(stats.vertices_written, buffered.stats.vertices_written);
+        assert_eq!(stats.vertices_deleted, buffered.stats.vertices_deleted);
+        assert_eq!(stats.edges_deleted, buffered.stats.edges_deleted);
+
+        GraphResult {
+            columns,
+            rows,
+            stats,
+        }
+    }
+
+    // --- converted: ReturnOnly -------------------------------------------
+
+    #[tokio::test]
+    async fn return_only_streaming_matches_buffered() {
+        let result = assert_streaming_matches(
+            || return_one_plan(&[("a", 1), ("b", 2)], None),
+            "social",
+            None,
+        )
+        .await;
+        assert_eq!(result.columns, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(
+            result.rows,
+            vec![vec![serde_json::json!(1), serde_json::json!(2)]]
+        );
+    }
+
+    /// `RETURN 1 LIMIT 0` truncated a materialized one-row Vec. Streaming, the
+    /// `take(0)` means the projection is never even reached — and the result is
+    /// still the same empty row set.
+    #[tokio::test]
+    async fn return_only_streaming_honors_limit_zero() {
+        let result =
+            assert_streaming_matches(|| return_one_plan(&[("a", 1)], Some(0)), "social", None)
+                .await;
+        assert!(result.rows.is_empty(), "LIMIT 0 yields no rows");
+    }
+
+    #[tokio::test]
+    async fn return_only_streaming_honors_negative_limit() {
+        // `limit.max(0)` in the buffered path: a negative LIMIT is a zero LIMIT.
+        let result =
+            assert_streaming_matches(|| return_one_plan(&[("a", 1)], Some(-5)), "social", None)
+                .await;
+        assert!(result.rows.is_empty());
+    }
+
+    // --- converted: Subscribe --------------------------------------------
+
+    #[tokio::test]
+    async fn subscribe_streaming_passes_through_to_inner() {
+        let build = || PhysicalPlan::Subscribe {
+            inner: Box::new(return_one_plan(&[("a", 7)], None)),
+            interval: Duration::from_secs(1),
+            delta: false,
+            return_clause: crate::parser::ReturnClause {
+                distinct: false,
+                items: vec![],
+                order_by: vec![],
+                limit: None,
+            },
+        };
+        let result = assert_streaming_matches(build, "social", None).await;
+        assert_eq!(result.columns, vec!["a".to_string()]);
+        assert_eq!(result.rows, vec![vec![serde_json::json!(7)]]);
+    }
+
+    // --- converted: Union { all: true } ----------------------------------
+
+    #[tokio::test]
+    async fn union_all_streaming_matches_buffered() {
+        let build = || PhysicalPlan::Union {
+            arms: vec![
+                return_one_plan(&[("a", 1)], None),
+                return_one_plan(&[("a", 2)], None),
+                // A duplicate row: UNION ALL keeps it.
+                return_one_plan(&[("a", 1)], None),
+            ],
+            all: true,
+        };
+        let result = assert_streaming_matches(build, "social", None).await;
+        assert_eq!(
+            result.rows,
+            vec![
+                vec![serde_json::json!(1)],
+                vec![serde_json::json!(2)],
+                vec![serde_json::json!(1)]
+            ],
+            "UNION ALL is concatenation in arm order, duplicates kept"
+        );
+    }
+
+    #[tokio::test]
+    async fn union_all_streaming_with_no_arms_matches_buffered() {
+        let build = || PhysicalPlan::Union {
+            arms: vec![],
+            all: true,
+        };
+        let result = assert_streaming_matches(build, "social", None).await;
+        assert!(result.columns.is_empty());
+        assert!(result.rows.is_empty());
+    }
+
+    /// Incrementality at the PLAN level: a downstream `take(k)` over a
+    /// converted `UNION ALL` returns after the arm that supplies row `k` and
+    /// drops the rest of the chain unpolled.
+    ///
+    /// The per-arm production counting lives in
+    /// `stream::tests::chain_streams_does_not_pull_later_arms_early`, where the
+    /// arms can be instrumented. Here the arms are `ReturnOnly` plans, whose
+    /// projection has no observable side effect — so this test pins the
+    /// row-level contract (which rows come back, and that the stream can be
+    /// abandoned early without error), not the arm-execution schedule.
+    #[tokio::test]
+    async fn union_all_streams_without_pulling_later_arms() {
+        let (_tmp, wp) = streaming_test_write_path();
+        let config = GraphEngineConfig::default();
+        let plan = PhysicalPlan::Union {
+            arms: (0..64)
+                .map(|i| return_one_plan(&[("a", i)], None))
+                .collect(),
+            all: true,
+        };
+        let (columns, rows_stream, _stats) =
+            execute_streaming(plan, &wp, "social", &config, None, None)
+                .await
+                .unwrap();
+        assert_eq!(columns, vec!["a".to_string()]);
+
+        let limited: crate::executor::stream::RowStream<'_> = {
+            use futures::StreamExt as _;
+            Box::pin(rows_stream.take(2))
+        };
+        let rows = crate::executor::stream::collect_rows(limited)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![vec![serde_json::json!(0)], vec![serde_json::json!(1)]],
+            "take(2) over UNION ALL yields the first two arms' rows and stops"
+        );
+    }
+
+    #[tokio::test]
+    async fn union_streaming_column_mismatch_still_errors() {
+        let (_tmp, wp) = streaming_test_write_path();
+        let config = GraphEngineConfig::default();
+        let build = || PhysicalPlan::Union {
+            arms: vec![
+                return_one_plan(&[("a", 1)], None),
+                return_one_plan(&[("b", 2)], None),
+            ],
+            all: true,
+        };
+        // `RowStream` is not `Debug`, so the Ok arm cannot be unwrapped/printed.
+        let err = match execute_streaming(build(), &wp, "social", &config, None, None).await {
+            Ok(_) => panic!("streaming UNION must reject arms with mismatched columns"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, GraphError::Validation(ref m) if m.contains("identical columns")),
+            "streaming UNION must reject mismatched arms exactly as the buffered path does, got {err:?}"
+        );
+        // ...and the buffered entry point still rejects it too.
+        assert!(execute(build(), &wp, "social", &config, None, None)
+            .await
+            .is_err());
+    }
+
+    // --- fallback: Union { all: false } ----------------------------------
+
+    /// `UNION` (no ALL) dedups over the WHOLE concatenation, so it must NOT be
+    /// converted. Proving the fallback still dedups is the regression guard.
+    #[tokio::test]
+    async fn union_distinct_falls_back_and_still_dedups() {
+        let build = || PhysicalPlan::Union {
+            arms: vec![
+                return_one_plan(&[("a", 1)], None),
+                return_one_plan(&[("a", 2)], None),
+                return_one_plan(&[("a", 1)], None),
+            ],
+            all: false,
+        };
+        let result = assert_streaming_matches(build, "social", None).await;
+        assert_eq!(
+            result.rows,
+            vec![vec![serde_json::json!(1)], vec![serde_json::json!(2)]],
+            "UNION without ALL must still dedup across all arms"
+        );
+    }
+
+    // --- fallback: Expand (virtual table + storage) -----------------------
+
+    #[tokio::test]
+    async fn expand_falls_back_with_identical_result() {
+        let registry = VirtualTableRegistry::new();
+        registry.register(Arc::new(TestVirtualTable {
+            table_name: "connections".to_string(),
+            ks: "system_observability".to_string(),
+            cols: vec![VirtualColumnDef {
+                name: "peer_address".to_string(),
+                data_type: DataType::Text,
+            }],
+            rows: vec![
+                VirtualRow {
+                    cells: vec![CellValue::live(b"10.0.0.1".to_vec(), 1000)],
+                },
+                VirtualRow {
+                    cells: vec![CellValue::live(b"10.0.0.2".to_vec(), 1000)],
+                },
+            ],
+        }));
+
+        let build = || {
+            virtual_anchor_plan(
+                "system_observability",
+                "connections",
+                &[("n", "peer_address")],
+            )
+        };
+        let result = assert_streaming_matches(build, "system_observability", Some(&registry)).await;
+        assert_eq!(result.rows.len(), 2, "the fallback must still return rows");
+    }
+
+    #[tokio::test]
+    async fn empty_storage_expand_falls_back_with_identical_result() {
+        let build = || virtual_anchor_plan("social", "person_v", &[("n", "name")]);
+        let result = assert_streaming_matches(build, "social", None).await;
+        assert!(result.rows.is_empty());
+    }
+
+    // --- fallback: Unwind -------------------------------------------------
+
+    #[tokio::test]
+    async fn unwind_falls_back_with_identical_result() {
+        use crate::parser::{Expr, Literal, ReturnClause, ReturnItem};
+        let build = || PhysicalPlan::Unwind {
+            expr: Expr::List(vec![
+                Expr::Literal(Literal::Integer(3)),
+                Expr::Literal(Literal::Integer(1)),
+                Expr::Literal(Literal::Integer(2)),
+            ]),
+            var: "x".to_string(),
+            with_pipeline: None,
+            return_clause: ReturnClause {
+                distinct: false,
+                items: vec![ReturnItem {
+                    expr: Expr::Var("x".to_string()),
+                    alias: Some("x".to_string()),
+                }],
+                order_by: vec![],
+                limit: None,
+            },
+        };
+        let result = assert_streaming_matches(build, "social", None).await;
+        assert_eq!(
+            result.rows,
+            vec![
+                vec![serde_json::json!(3)],
+                vec![serde_json::json!(1)],
+                vec![serde_json::json!(2)]
+            ]
         );
     }
 }

--- a/ferrosa-graph/src/executor/leapfrog.rs
+++ b/ferrosa-graph/src/executor/leapfrog.rs
@@ -231,9 +231,27 @@ pub async fn execute_wco_join(
         .await?;
     }
 
-    // Apply ORDER BY.
+    // Apply ORDER BY. An unbounded one spills through the storage engine's
+    // bounded external merge sort (t_4ce82a3e); `spill_order_by` returns false —
+    // leaving the in-memory sort — when it cannot apply.
+    //
+    // NOTE: unlike the expand and varpath paths, this file's `max_result_rows`
+    // uses are NOT removed here. Several of them bound JOIN WORK rather than the
+    // result buffer (`leapfrog_join(&mut iterators, config.max_result_rows)`
+    // caps the intersection itself, and `enumerate_bindings` stops recursing on
+    // it), so removing them is a different change that needs its own analysis of
+    // what each cap is actually protecting.
     if !return_clause.order_by.is_empty() {
-        sort_rows(&mut result_rows, &columns, &return_clause.order_by);
+        let spilled = crate::executor::spill::spill_order_by(
+            &mut result_rows,
+            &columns,
+            return_clause,
+            config,
+        )
+        .await?;
+        if !spilled {
+            sort_rows(&mut result_rows, &columns, &return_clause.order_by);
+        }
     }
 
     // Apply DISTINCT.

--- a/ferrosa-graph/src/executor/mod.rs
+++ b/ferrosa-graph/src/executor/mod.rs
@@ -5,6 +5,7 @@ pub mod eval;
 pub mod expand;
 pub mod leapfrog;
 pub mod result;
+pub mod spill;
 pub mod stream;
 pub mod subscribe;
 pub mod varpath;

--- a/ferrosa-graph/src/executor/spill.rs
+++ b/ferrosa-graph/src/executor/spill.rs
@@ -1,0 +1,210 @@
+//! Module: Spill adapter — lets graph result rows use the storage engine's
+//! bounded-memory external merge sort.
+//! Correctness: Correct when [`GraphRowOrder`] orders rows EXACTLY as the
+//!   in-memory [`super::expand::sort_rows`] does, so switching ORDER BY to the
+//!   spilling sorter changes memory behavior and nothing else.
+//! Last revised: 2026-07-25
+//! Last changed: New module — increment 5 of the streaming executor
+//!   (t_4ce82a3e). Adapter only; the executor is not wired to it yet.
+//!
+//! # Why
+//!
+//! `ORDER BY` without `LIMIT` is a pipeline-breaker: every row must be seen
+//! before the first output row is known. The graph executor currently buffers
+//! the whole result and silently truncates at `max_result_rows` — a client
+//! cannot distinguish a partial result from a complete one.
+//!
+//! ferrosa-cql already solved this with [`ferrosa_storage::ExternalSorter`]:
+//! accumulate to a byte threshold, spill sorted runs to a temp directory, k-way
+//! merge on finish, fail loud on any spill/merge I/O error — with the temp dir
+//! held by a `TempSortTableReservation` whose `Drop` removes it, so a cancelled
+//! query cleans up automatically. Owner decision (2026-07-25): the graph path
+//! SPILLS rather than caps, and `max_result_rows` is then removed outright.
+//!
+//! # Why a graph-specific comparator
+//!
+//! The sorter is generic over `SpillOrder<T>` precisely so callers keep their
+//! own ordering. Graph rows are `Vec<serde_json::Value>` and
+//! [`super::expand::compare_json_values`] has semantics `CqlValue`'s `Ord` does
+//! not share — mixed types (String vs Number) and complex values (objects,
+//! arrays) compare **Equal**, and `Null` sorts before any present value.
+//! Converting graph rows to `CqlValue` to reuse the CQL comparator would
+//! silently reorder those cases; this adapter preserves them exactly.
+
+use std::cmp::Ordering;
+
+use ferrosa_storage::external_sort::{SpillOrder, SpillRow};
+
+use super::stream::RowVals;
+
+/// A graph result row that the external sorter can spill.
+///
+/// Newtype because both `Vec<serde_json::Value>` and the `SpillRow` trait are
+/// foreign to this crate, so the impl needs a local type.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct GraphRow(pub RowVals);
+
+impl SpillRow for GraphRow {
+    /// Approximate footprint for spill-threshold accounting. Need not be exact —
+    /// only monotonic in real memory use, so the buffer spills before the
+    /// process is starved. Strings and arrays/objects carry their payload.
+    fn estimated_bytes(&self) -> usize {
+        self.0.iter().map(json_value_bytes).sum::<usize>()
+            + self.0.len() * std::mem::size_of::<serde_json::Value>()
+    }
+}
+
+/// Payload bytes of a JSON value beyond its fixed enum size.
+fn json_value_bytes(v: &serde_json::Value) -> usize {
+    match v {
+        serde_json::Value::String(s) => s.len(),
+        serde_json::Value::Array(items) => {
+            items.iter().map(json_value_bytes).sum::<usize>()
+                + items.len() * std::mem::size_of::<serde_json::Value>()
+        }
+        serde_json::Value::Object(map) => map
+            .iter()
+            .map(|(k, val)| k.len() + json_value_bytes(val))
+            .sum::<usize>(),
+        _ => 0,
+    }
+}
+
+/// One resolved ORDER BY term: the projected column index, and whether ascending.
+///
+/// Resolved to an INDEX up front (rather than carrying the expression) because
+/// the sorter compares rows in isolation — including rows read back from a
+/// spilled run, where no binding context exists. `sort_rows` resolves the same
+/// way, skipping order terms whose column is not projected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GraphOrderTerm {
+    pub column: usize,
+    pub ascending: bool,
+}
+
+/// Graph ORDER BY comparator for the external sorter.
+///
+/// Applies terms left-to-right; the first unequal column decides. Mirrors
+/// `sort_rows` exactly, including its use of `compare_json_values`.
+#[derive(Debug, Clone)]
+pub struct GraphRowOrder {
+    terms: Vec<GraphOrderTerm>,
+}
+
+impl GraphRowOrder {
+    pub fn new(terms: Vec<GraphOrderTerm>) -> Self {
+        Self { terms }
+    }
+
+    /// Compare two rows under this order.
+    pub fn compare_rows(&self, a: &RowVals, b: &RowVals) -> Ordering {
+        for term in &self.terms {
+            let cmp = super::expand::compare_json_values(a.get(term.column), b.get(term.column));
+            let cmp = if term.ascending { cmp } else { cmp.reverse() };
+            if cmp != Ordering::Equal {
+                return cmp;
+            }
+        }
+        Ordering::Equal
+    }
+}
+
+impl SpillOrder<GraphRow> for GraphRowOrder {
+    fn compare(&self, a: &GraphRow, b: &GraphRow) -> Ordering {
+        self.compare_rows(&a.0, &b.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrosa_storage::external_sort::ExternalSorter;
+
+    fn row(vals: &[serde_json::Value]) -> GraphRow {
+        GraphRow(vals.to_vec())
+    }
+
+    fn asc(column: usize) -> GraphRowOrder {
+        GraphRowOrder::new(vec![GraphOrderTerm {
+            column,
+            ascending: true,
+        }])
+    }
+
+    /// The load-bearing property: this comparator must order rows EXACTLY as the
+    /// in-memory `sort_rows` does, so moving ORDER BY onto the spilling sorter
+    /// changes memory behavior and nothing observable.
+    #[test]
+    fn matches_in_memory_sort_rows_ordering() {
+        let mut rows: Vec<RowVals> = vec![
+            vec![serde_json::json!(3)],
+            vec![serde_json::json!(1)],
+            vec![serde_json::Value::Null],
+            vec![serde_json::json!(2)],
+        ];
+        let columns = vec!["n".to_string()];
+        let order_by = vec![crate::parser::OrderItem {
+            expr: crate::parser::Expr::Var("n".to_string()),
+            direction: crate::parser::SortDir::Asc,
+        }];
+
+        let mut reference = rows.clone();
+        super::super::expand::sort_rows(&mut reference, &columns, &order_by);
+
+        rows.sort_by(|a, b| asc(0).compare_rows(a, b));
+
+        assert_eq!(
+            rows, reference,
+            "spill comparator must match sort_rows exactly (incl. Null-sorts-first)"
+        );
+    }
+
+    /// Graph semantics `CqlValue::Ord` does not share: mixed types compare Equal.
+    /// If this ever changed, bridging to the CQL comparator would look safe and
+    /// silently reorder results — which is why the sorter takes OUR comparator.
+    #[test]
+    fn mixed_types_compare_equal_like_the_in_memory_comparator() {
+        let a = vec![serde_json::json!("text")];
+        let b = vec![serde_json::json!(42)];
+        assert_eq!(asc(0).compare_rows(&a, &b), Ordering::Equal);
+    }
+
+    #[test]
+    fn descending_reverses_and_multi_term_breaks_ties() {
+        let order = GraphRowOrder::new(vec![
+            GraphOrderTerm {
+                column: 0,
+                ascending: true,
+            },
+            GraphOrderTerm {
+                column: 1,
+                ascending: false,
+            },
+        ]);
+        let a = vec![serde_json::json!(1), serde_json::json!(5)];
+        let b = vec![serde_json::json!(1), serde_json::json!(9)];
+        // First term ties; second (descending) puts the LARGER value first.
+        assert_eq!(order.compare_rows(&a, &b), Ordering::Greater);
+    }
+
+    /// End-to-end through the real sorter, forced down the spill+merge path
+    /// (threshold 1 byte) rather than the in-memory fast path.
+    #[test]
+    fn spills_and_merges_graph_rows_in_graph_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut sorter: ExternalSorter<GraphRow, GraphRowOrder> =
+            ExternalSorter::new(dir.path(), asc(0), 1);
+        for n in [5i64, 1, 4, 2, 3] {
+            sorter.push(row(&[serde_json::json!(n)])).unwrap();
+        }
+        assert!(sorter.spilled(), "threshold 1 must force the spill path");
+
+        let sorted: Vec<GraphRow> = sorter
+            .finish()
+            .unwrap()
+            .collect::<ferrosa_common::Result<_>>()
+            .unwrap();
+        let got: Vec<i64> = sorted.iter().map(|r| r.0[0].as_i64().unwrap()).collect();
+        assert_eq!(got, vec![1, 2, 3, 4, 5]);
+    }
+}

--- a/ferrosa-graph/src/executor/spill.rs
+++ b/ferrosa-graph/src/executor/spill.rs
@@ -1,18 +1,19 @@
 //! Module: Spill adapter — lets graph result rows use the storage engine's
 //! bounded-memory external merge sort.
 //! Correctness: Correct when [`GraphRowOrder`] orders rows EXACTLY as the
-//!   in-memory [`super::expand::sort_rows`] does, so switching ORDER BY to the
+//!   in-memory `sort_rows` does, so switching ORDER BY to the
 //!   spilling sorter changes memory behavior and nothing else.
 //! Last revised: 2026-07-25
-//! Last changed: New module — increment 5 of the streaming executor
-//!   (t_4ce82a3e). Adapter only; the executor is not wired to it yet.
+//! Last changed: Wired into the executor — `execute_expand`'s unbounded ORDER BY
+//!   now sorts through `spill_order_by`, and the `max_result_rows` truncation
+//!   it replaced is gone (increment 5 of the streaming executor, t_4ce82a3e).
 //!
 //! # Why
 //!
 //! `ORDER BY` without `LIMIT` is a pipeline-breaker: every row must be seen
-//! before the first output row is known. The graph executor currently buffers
-//! the whole result and silently truncates at `max_result_rows` — a client
-//! cannot distinguish a partial result from a complete one.
+//! before the first output row is known. The graph executor used to buffer the
+//! whole result and silently truncate at `max_result_rows` — no error, no flag,
+//! so a client could not distinguish a partial result from a complete one.
 //!
 //! ferrosa-cql already solved this with [`ferrosa_storage::ExternalSorter`]:
 //! accumulate to a byte threshold, spill sorted runs to a temp directory, k-way
@@ -25,7 +26,7 @@
 //!
 //! The sorter is generic over `SpillOrder<T>` precisely so callers keep their
 //! own ordering. Graph rows are `Vec<serde_json::Value>` and
-//! [`super::expand::compare_json_values`] has semantics `CqlValue`'s `Ord` does
+//! `compare_json_values` has semantics `CqlValue`'s `Ord` does
 //! not share — mixed types (String vs Number) and complex values (objects,
 //! arrays) compare **Equal**, and `Null` sorts before any present value.
 //! Converting graph rows to `CqlValue` to reuse the CQL comparator would
@@ -36,6 +37,22 @@ use std::cmp::Ordering;
 use ferrosa_storage::external_sort::{SpillOrder, SpillRow};
 
 use super::stream::RowVals;
+
+/// Reserves a cancellable temp directory for a spilling ORDER BY sort.
+///
+/// Hung off `GraphEngineConfig` — which the executor already
+/// threads everywhere — rather than plumbing a `StorageEngine` through every
+/// recursive `execute` call. `None` means no spill backend is available (unit
+/// tests, embedded use); ORDER BY then sorts in memory exactly as before.
+///
+/// The returned reservation's `Drop` removes the directory, so an aborted or
+/// cancelled query cleans up the same way a successful one does.
+pub trait SpillReserver: Send + Sync + std::fmt::Debug {
+    fn reserve(
+        &self,
+        label: &str,
+    ) -> ferrosa_common::Result<ferrosa_storage::TempSortTableReservation>;
+}
 
 /// A graph result row that the external sorter can spill.
 ///
@@ -113,6 +130,82 @@ impl SpillOrder<GraphRow> for GraphRowOrder {
     fn compare(&self, a: &GraphRow, b: &GraphRow) -> Ordering {
         self.compare_rows(&a.0, &b.0)
     }
+}
+
+/// Sort `rows` in place through the storage engine's bounded external merge
+/// sort, spilling to a cancellable temp directory instead of holding the whole
+/// sorted set in memory (t_4ce82a3e).
+///
+/// Returns `Ok(false)` — leaving `rows` untouched for the in-memory sort — when
+/// this cannot apply:
+/// - no spill backend configured (unit tests, embedded use);
+/// - no ORDER BY, or a LIMIT is present (the bounded case does not need spill);
+/// - an ORDER BY term is not a projected column, which the in-memory
+///   `sort_projected_rows_by_bindings` handles via the states' bindings and this
+///   path cannot (a spilled row carries no binding context).
+///
+/// Fails loud on any spill/merge I/O error — a dropped run would silently lose
+/// rows, which is strictly worse than the old cap.
+pub(super) async fn spill_order_by(
+    rows: &mut Vec<Vec<serde_json::Value>>,
+    columns: &[String],
+    return_clause: &crate::parser::ReturnClause,
+    config: &super::expand::GraphEngineConfig,
+) -> crate::error::Result<bool> {
+    let Some(reserver) = config.spill.as_ref() else {
+        return Ok(false);
+    };
+    if return_clause.order_by.is_empty() || return_clause.limit.is_some() {
+        return Ok(false);
+    }
+    // Resolve every order term to a projected column index; bail to the
+    // in-memory path if any term is not projected.
+    let mut terms = Vec::with_capacity(return_clause.order_by.len());
+    for item in &return_clause.order_by {
+        let name = super::expand::expr_to_column_name(&item.expr);
+        let Some(column) = columns.iter().position(|c| c == &name) else {
+            return Ok(false);
+        };
+        terms.push(GraphOrderTerm {
+            column,
+            ascending: matches!(item.direction, crate::parser::SortDir::Asc),
+        });
+    }
+
+    let reservation = reserver.reserve("graph_order_by").map_err(|e| {
+        crate::error::GraphError::Internal(format!("ORDER BY temp-sort setup failed: {e}"))
+    })?;
+    let mut sorter: ferrosa_storage::external_sort::ExternalSorter<GraphRow, GraphRowOrder> =
+        ferrosa_storage::external_sort::ExternalSorter::new(
+            reservation.path(),
+            GraphRowOrder::new(terms),
+            config.spill_threshold_bytes,
+        );
+    for row in rows.drain(..) {
+        sorter
+            .push(GraphRow(row))
+            .map_err(|e| crate::error::GraphError::Internal(format!("ORDER BY spill: {e}")))?;
+    }
+    let spilled_to_disk = sorter.spilled();
+    let sorted = sorter
+        .finish()
+        .map_err(|e| crate::error::GraphError::Internal(format!("ORDER BY spill finish: {e}")))?;
+    for row in sorted {
+        rows.push(
+            row.map_err(|e| crate::error::GraphError::Internal(format!("ORDER BY merge: {e}")))?
+                .0,
+        );
+    }
+    if spilled_to_disk {
+        tracing::info!(
+            rows = rows.len(),
+            temp_sort_table = %reservation.path().display(),
+            "graph ORDER BY spilled to a cancellable temp-sort table"
+        );
+    }
+    // `reservation` drops here — its Drop removes the temp directory, so a
+    // cancelled or failed query cleans up exactly like a successful one.
+    Ok(true)
 }
 
 #[cfg(test)]

--- a/ferrosa-graph/src/executor/stream.rs
+++ b/ferrosa-graph/src/executor/stream.rs
@@ -5,9 +5,10 @@
 //!   byte — so an operator can be converted to streaming without any observable
 //!   behavior change.
 //! Last revised: 2026-07-25
-//! Last changed: New module — increment 1 of the streaming executor
-//!   (t_4ce82a3e, specs/streaming-executor-design.md). Scaffold only: the row
-//!   stream type + the collect bridge. No operator is streaming yet.
+//! Last changed: Added `chain_streams` — the `UNION ALL` concatenation operator
+//!   used by `expand::execute_streaming` (t_4ce82a3e,
+//!   specs/streaming-executor-design.md increment 2). The row stream type and
+//!   the collect bridges landed in increment 1.
 //!
 //! # Why
 //!
@@ -104,12 +105,89 @@ pub fn stream_from_rows<'a>(rows: Vec<RowVals>) -> RowStream<'a> {
     Box::pin(futures::stream::iter(rows.into_iter().map(Ok)))
 }
 
+/// Concatenate row streams end to end, in order.
+///
+/// This is `UNION ALL`: arm order is result order, duplicates are kept. Unlike
+/// the materializing form (`rows.extend(arm_rows)` per arm) it never builds the
+/// concatenated `Vec`, and it never polls a later arm until every earlier arm is
+/// drained — so a downstream `take(k)` stops at whichever arm supplies row `k`.
+///
+/// `UNION` *without* `ALL` is deliberately NOT this function: its `HashSet`
+/// dedup spans the whole concatenation, which is a pipeline breaker.
+pub fn chain_streams<'a>(streams: Vec<RowStream<'a>>) -> RowStream<'a> {
+    streams.into_iter().fold(
+        Box::pin(futures::stream::empty()) as RowStream<'a>,
+        |acc, next| Box::pin(acc.chain(next)) as RowStream<'a>,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn row(n: i64) -> RowVals {
         vec![serde_json::json!(n)]
+    }
+
+    #[tokio::test]
+    async fn chain_streams_concatenates_in_arm_order() {
+        // `UNION ALL` is concatenation: arm order is result order.
+        let chained = chain_streams(vec![
+            stream_from_rows(vec![row(1), row(2)]),
+            stream_from_rows(vec![]),
+            stream_from_rows(vec![row(3)]),
+        ]);
+        assert_eq!(
+            collect_rows(chained).await.unwrap(),
+            vec![row(1), row(2), row(3)]
+        );
+    }
+
+    #[tokio::test]
+    async fn chain_streams_of_nothing_is_empty() {
+        assert!(collect_rows(chain_streams(vec![]))
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    /// The incrementality property for the converted `UNION ALL`: pulling `k`
+    /// rows pulls them from the earliest arms only — a later arm is never
+    /// polled. Same shape as `limit_short_circuits_upstream_production`: assert
+    /// on how many items each source actually produced.
+    #[tokio::test]
+    async fn chain_streams_does_not_pull_later_arms_early() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let first = Arc::new(AtomicUsize::new(0));
+        let second = Arc::new(AtomicUsize::new(0));
+
+        let c1 = first.clone();
+        // An "infinite" first arm: a materializing UNION could never terminate.
+        let arm1: RowStream<'_> = Box::pin(futures::stream::repeat_with(move || {
+            c1.fetch_add(1, Ordering::SeqCst);
+            Ok(row(1))
+        }));
+        let c2 = second.clone();
+        let arm2: RowStream<'_> = Box::pin(futures::stream::repeat_with(move || {
+            c2.fetch_add(1, Ordering::SeqCst);
+            Ok(row(2))
+        }));
+
+        let limited: RowStream<'_> = Box::pin(chain_streams(vec![arm1, arm2]).take(3));
+        assert_eq!(collect_rows(limited).await.unwrap(), vec![row(1); 3]);
+
+        assert_eq!(
+            first.load(Ordering::SeqCst),
+            3,
+            "the first arm must produce only the rows actually pulled"
+        );
+        assert_eq!(
+            second.load(Ordering::SeqCst),
+            0,
+            "a later UNION ALL arm must not be polled before the earlier arms are drained"
+        );
     }
 
     #[tokio::test]

--- a/ferrosa-graph/src/executor/stream.rs
+++ b/ferrosa-graph/src/executor/stream.rs
@@ -121,12 +121,133 @@ pub fn chain_streams<'a>(streams: Vec<RowStream<'a>>) -> RowStream<'a> {
     )
 }
 
+/// Streaming `DISTINCT`: emit each row the first time it is seen.
+///
+/// # Behavior change (deliberate, owner-approved — t_4ce82a3e)
+///
+/// The buffered form was `rows.sort_by(|a, b| format!("{a:?}").cmp(..))` then
+/// `dedup()`, so `RETURN DISTINCT` with no `ORDER BY` returned rows in **string-
+/// repr sorted order**. This returns them in **first-seen (expansion) order**.
+/// The SET of rows is identical; the ORDER is not. Callers that need a
+/// particular order must say `ORDER BY`.
+///
+/// # Memory
+///
+/// The `HashSet` of seen rows is **unbounded** — it grows with the number of
+/// DISTINCT rows, exactly as the buffered `Vec` did. This is a latency and
+/// ordering change, NOT a memory fix: a high-cardinality `DISTINCT` can still
+/// exhaust memory. Bounding it (spill or approximate dedup) is separate work.
+pub fn dedup_stream<'a>(rows: RowStream<'a>) -> RowStream<'a> {
+    let mut seen = std::collections::HashSet::new();
+    Box::pin(rows.filter(move |item| {
+        // `Err` items always pass through: dropping them would turn a failed
+        // query into a silently short successful one.
+        let keep = match item {
+            Ok(row) => seen.insert(serde_json::to_string(row).unwrap_or_default()),
+            Err(_) => true,
+        };
+        futures::future::ready(keep)
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn row(n: i64) -> RowVals {
         vec![serde_json::json!(n)]
+    }
+
+    fn text_row(s: &str) -> RowVals {
+        vec![serde_json::json!(s)]
+    }
+
+    /// DISTINCT is FIRST-SEEN order, not sorted order.
+    ///
+    /// This pins the deliberate behavior change (owner-approved, t_4ce82a3e):
+    /// the buffered form was `rows.sort_by(|a, b| format!("{a:?}").cmp(..))`
+    /// followed by `dedup()`, so a `RETURN DISTINCT` with no `ORDER BY` came
+    /// back in string-repr sorted order. Streaming dedup emits each row the
+    /// first time it is seen, which is expansion order.
+    #[tokio::test]
+    async fn dedup_stream_emits_first_seen_order_not_sorted_order() {
+        let source = stream_from_rows(vec![
+            text_row("Cara"),
+            text_row("Alice"),
+            text_row("Cara"),
+            text_row("Bob"),
+            text_row("Alice"),
+        ]);
+        let deduped = collect_rows(dedup_stream(source)).await.unwrap();
+
+        assert_eq!(
+            deduped,
+            vec![text_row("Cara"), text_row("Alice"), text_row("Bob")],
+            "DISTINCT must emit rows in first-seen order"
+        );
+        // Spelled out so the change cannot be reverted by accident: the OLD
+        // buffered behavior returned this same set sorted by string repr.
+        let old_sorted_behavior = vec![text_row("Alice"), text_row("Bob"), text_row("Cara")];
+        assert_ne!(
+            deduped, old_sorted_behavior,
+            "first-seen order must be observably different from the old sorted order"
+        );
+    }
+
+    #[tokio::test]
+    async fn dedup_stream_compares_whole_rows_not_first_column() {
+        let source = stream_from_rows(vec![
+            vec![serde_json::json!(1), serde_json::json!("a")],
+            vec![serde_json::json!(1), serde_json::json!("b")],
+            vec![serde_json::json!(1), serde_json::json!("a")],
+        ]);
+        assert_eq!(
+            collect_rows(dedup_stream(source)).await.unwrap(),
+            vec![
+                vec![serde_json::json!(1), serde_json::json!("a")],
+                vec![serde_json::json!(1), serde_json::json!("b")],
+            ],
+            "DISTINCT dedups whole projected rows"
+        );
+    }
+
+    /// Dedup must not swallow an upstream failure — a filtered stream that
+    /// dropped `Err` items would turn a failed query into a short success.
+    #[tokio::test]
+    async fn dedup_stream_propagates_upstream_errors() {
+        let source: RowStream<'_> = Box::pin(futures::stream::iter(vec![
+            Ok(row(1)),
+            Err(crate::error::GraphError::Internal("boom".to_string())),
+        ]));
+        let err = collect_rows(dedup_stream(source)).await.unwrap_err();
+        assert!(matches!(err, crate::error::GraphError::Internal(ref m) if m == "boom"));
+    }
+
+    /// Dedup is a streaming stage, not a pipeline breaker: it emits row 1
+    /// without pulling the rest of an unbounded upstream.
+    #[tokio::test]
+    async fn dedup_stream_does_not_drain_upstream_before_emitting() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let produced = Arc::new(AtomicUsize::new(0));
+        let counter = produced.clone();
+        let source: RowStream<'_> = Box::pin(futures::stream::repeat_with(move || {
+            let n = counter.fetch_add(1, Ordering::SeqCst);
+            Ok(row(n as i64))
+        }));
+
+        let limited: RowStream<'_> = Box::pin(dedup_stream(source).take(2));
+        assert_eq!(
+            collect_rows(limited).await.unwrap(),
+            vec![row(0), row(1)],
+            "distinct rows pass straight through"
+        );
+        assert_eq!(
+            produced.load(Ordering::SeqCst),
+            2,
+            "dedup must not read past the rows the downstream pulled"
+        );
     }
 
     #[tokio::test]

--- a/ferrosa-graph/src/executor/varpath.rs
+++ b/ferrosa-graph/src/executor/varpath.rs
@@ -302,12 +302,14 @@ pub async fn execute_var_length(
     // Determine the variable name for result binding.
     let result_var = hop.var.as_deref().unwrap_or(anchor_var);
 
+    // No `max_result_rows` break here: it SILENTLY TRUNCATED the result — no
+    // error, no flag — so a client could not tell a partial answer from a
+    // complete one. Removed with the same reasoning as the expand path
+    // (t_4ce82a3e): an unbounded ORDER BY spills below instead of being capped.
+    // Traversal is still bounded by `max_var_path_visited`, which limits WORK
+    // (a DoS control), not the result buffer.
     let mut rows = Vec::new();
     for key in &result_keys {
-        if rows.len() >= config.max_result_rows {
-            break;
-        }
-
         let partition = write_path.read(&proj_table_id, key).await?;
         let hex_id = hex::encode(key.key.as_bytes());
 
@@ -351,9 +353,17 @@ pub async fn execute_var_length(
         rows.push(row);
     }
 
-    // Apply ORDER BY.
+    // Apply ORDER BY. An unbounded one spills through the storage engine's
+    // bounded external merge sort; `spill_order_by` returns false (leaving the
+    // in-memory sort) when it cannot apply — no backend, a LIMIT is present, or
+    // an order term is not a projected column.
     if !return_clause.order_by.is_empty() {
-        sort_rows(&mut rows, &columns, &return_clause.order_by);
+        let spilled =
+            crate::executor::spill::spill_order_by(&mut rows, &columns, return_clause, config)
+                .await?;
+        if !spilled {
+            sort_rows(&mut rows, &columns, &return_clause.order_by);
+        }
     }
 
     // Apply DISTINCT.

--- a/ferrosa-graph/src/executor/varpath.rs
+++ b/ferrosa-graph/src/executor/varpath.rs
@@ -403,6 +403,7 @@ mod tests {
             max_groups: 1000,
             max_collect_size: 1000,
             max_var_path_visited: 100,
+            ..GraphEngineConfig::default()
         }
     }
 

--- a/ferrosa-graph/src/http.rs
+++ b/ferrosa-graph/src/http.rs
@@ -283,7 +283,7 @@ async fn handle_query(State(state): State<AppState>, req: Request<Body>) -> Resp
                 status = "Ok",
                 "graph query completed"
             );
-            Json(result).into_response()
+            stream_graph_result(result)
         }
         Err(ref e) => {
             let status_str = match e {
@@ -455,6 +455,87 @@ async fn handle_subscribe(State(state): State<AppState>, req: Request<Body>) -> 
 
 /// Build an SSE stream that yields the initial snapshot followed by
 /// periodic re-executions of the query.
+/// Serialize a [`GraphResult`] into a STREAMING chunked response body instead of
+/// `Json(result)`.
+///
+/// `Json` serializes the whole result into one contiguous buffer before writing
+/// a byte — for a large result that is a second full copy of the data on top of
+/// the rows themselves, at peak. This emits the identical JSON
+/// (`{"columns":…,"rows":[…],"stats":…}`, same field order as the derive) one
+/// row at a time, so the serialized form is never fully resident and the client
+/// starts receiving data immediately (t_4ce82a3e inc 7).
+///
+/// SCOPE: this removes the serialization copy, not the row buffer — `result`
+/// still owns every row. Ending server-side buffering needs `execute()` to
+/// return a `RowStream`, which is tracked separately.
+///
+/// A row that fails to serialize aborts the body with an error rather than
+/// silently emitting truncated JSON — a partial body that parses would be worse
+/// than a broken connection.
+fn stream_graph_result(result: crate::executor::GraphResult) -> Response {
+    use futures::stream::StreamExt as _;
+
+    let crate::executor::GraphResult {
+        columns,
+        rows,
+        stats,
+    } = result;
+
+    let head = match serde_json::to_string(&columns) {
+        Ok(cols) => format!("{{\"columns\":{cols},\"rows\":["),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("encode columns: {e}") })),
+            )
+                .into_response()
+        }
+    };
+    let tail = match serde_json::to_string(&stats) {
+        Ok(st) => format!("],\"stats\":{st}}}"),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("encode stats: {e}") })),
+            )
+                .into_response()
+        }
+    };
+
+    let body_stream = futures::stream::once(async move { Ok::<_, std::io::Error>(head) })
+        .chain(
+            futures::stream::iter(rows.into_iter().enumerate()).map(|(i, row)| {
+                let mut chunk = String::new();
+                if i > 0 {
+                    chunk.push(',');
+                }
+                match serde_json::to_string(&row) {
+                    Ok(encoded) => {
+                        chunk.push_str(&encoded);
+                        Ok(chunk)
+                    }
+                    // Fail loud: abort the body rather than emit truncated-but-parsable JSON.
+                    Err(e) => Err(std::io::Error::other(format!("encode row {i}: {e}"))),
+                }
+            }),
+        )
+        .chain(futures::stream::once(async move {
+            Ok::<_, std::io::Error>(tail)
+        }));
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from_stream(body_stream))
+        .unwrap_or_else(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("build response: {e}") })),
+            )
+                .into_response()
+        })
+}
+
 fn make_subscribe_stream(
     engine: Arc<GraphEngine>,
     query: String,
@@ -732,6 +813,51 @@ pub async fn start_graph_disabled_http(config: &GraphHttpConfig) -> crate::error
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The streamed body MUST be byte-identical to what `Json(result)` produced,
+    /// or every existing client breaks on a change that was supposed to be pure
+    /// plumbing. Field order, separators, and escaping all have to match serde's
+    /// own output, so this asserts against serde directly rather than against a
+    /// hand-written expected string that could encode the same mistake twice.
+    #[tokio::test]
+    async fn streamed_body_is_byte_identical_to_json_serialization() {
+        let cases = vec![
+            // Empty: the `rows:[]` separator logic has no element to lean on.
+            vec![],
+            vec![vec![serde_json::json!(1)]],
+            vec![
+                vec![serde_json::json!("a"), serde_json::json!(null)],
+                // Quotes, backslashes, newlines, and non-BMP unicode must escape
+                // exactly as serde escapes them — hand-rolled framing around
+                // serde-encoded rows is where a mismatch would hide.
+                vec![
+                    serde_json::json!("he said \"hi\"\n\\ \u{1f600}"),
+                    serde_json::json!(2.5),
+                ],
+            ],
+        ];
+
+        for rows in cases {
+            let result = crate::executor::GraphResult {
+                columns: vec!["x".to_string(), "y".to_string()],
+                rows,
+                stats: crate::executor::QueryStats::default(),
+            };
+            let expected = serde_json::to_string(&result).expect("serde encodes the result");
+
+            let resp = stream_graph_result(result);
+            assert_eq!(resp.status(), StatusCode::OK);
+            let got = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .expect("streamed body collects");
+
+            assert_eq!(
+                String::from_utf8(got.to_vec()).expect("body is utf8"),
+                expected,
+                "streamed body diverged from Json(result)"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn disabled_router_returns_clear_error_for_all_routes() {

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -1676,6 +1676,285 @@ async fn return_distinct_deduplicates_projected_rows() {
     );
 }
 
+/// SET across MANY matched vertices.
+///
+/// This is the shape whose inner expand is now consumed as a STREAM rather than
+/// a `Vec` of projected rows (t_4ce82a3e). What streams is the INNER EXPAND —
+/// SET's own output is a single summary row that is only known after the last
+/// write, so it cannot stream. The property under test is that every matched
+/// vertex is still written and the summary still counts them all: a streaming
+/// consumer that stopped early would under-write and under-report.
+#[tokio::test]
+async fn set_streams_the_inner_expand_and_updates_every_matched_vertex() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+
+    let names = ["Sa", "Sb", "Sc", "Sd", "Se"];
+    for (i, name) in names.iter().enumerate() {
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!(
+                    "MERGE (n:Person {{id: '00000000-0000-0000-0000-00000000e10{i}', name: '{name}', age: 1}}) RETURN n.name"
+                ),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(
+            app.clone().oneshot(req).await.unwrap().status(),
+            StatusCode::OK
+        );
+    }
+
+    let set_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) SET n.age = 77",
+            "keyspace": "social"
+        })),
+    );
+    let set_resp = app.clone().oneshot(set_req).await.unwrap();
+    assert_eq!(set_resp.status(), StatusCode::OK);
+    let set_body = response_json(set_resp).await;
+    assert_eq!(
+        set_body["rows"],
+        serde_json::json!([[format!("updated {} vertices", names.len())]]),
+        "SET must report every matched vertex, not just the first streamed row"
+    );
+
+    let check_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name, n.age ORDER BY n.name",
+            "keyspace": "social"
+        })),
+    );
+    let check_resp = app.oneshot(check_req).await.unwrap();
+    assert_eq!(check_resp.status(), StatusCode::OK);
+    let rows = response_json(check_resp).await["rows"]
+        .as_array()
+        .expect("rows array")
+        .clone();
+    assert_eq!(rows.len(), names.len());
+    for row in &rows {
+        assert_eq!(row[1], 77, "every vertex must be updated, got {row:?}");
+    }
+}
+
+/// REMOVE across MANY matched vertices — the same streaming-inner-expand shape
+/// as `set_streams_the_inner_expand_and_updates_every_matched_vertex`.
+#[tokio::test]
+async fn remove_streams_the_inner_expand_and_unsets_on_every_matched_vertex() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+
+    let names = ["Ra", "Rb", "Rc", "Rd"];
+    for (i, name) in names.iter().enumerate() {
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!(
+                    "MERGE (n:Person {{id: '00000000-0000-0000-0000-00000000e20{i}', name: '{name}', age: 33}}) RETURN n.name"
+                ),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(
+            app.clone().oneshot(req).await.unwrap().status(),
+            StatusCode::OK
+        );
+    }
+
+    let remove_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) REMOVE n.age",
+            "keyspace": "social"
+        })),
+    );
+    let remove_resp = app.clone().oneshot(remove_req).await.unwrap();
+    assert_eq!(remove_resp.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(remove_resp).await["rows"],
+        serde_json::json!([[format!("removed properties on {} vertices", names.len())]]),
+        "REMOVE must report every matched vertex"
+    );
+
+    let check_req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN n.name, n.age ORDER BY n.name",
+            "keyspace": "social"
+        })),
+    );
+    let check_resp = app.oneshot(check_req).await.unwrap();
+    assert_eq!(check_resp.status(), StatusCode::OK);
+    let rows = response_json(check_resp).await["rows"]
+        .as_array()
+        .expect("rows array")
+        .clone();
+    assert_eq!(rows.len(), names.len());
+    for row in &rows {
+        assert_eq!(
+            row[1],
+            serde_json::Value::Null,
+            "every vertex must have age unset, got {row:?}"
+        );
+    }
+}
+
+/// `RETURN DISTINCT` with no `ORDER BY` returns rows in FIRST-SEEN (expansion)
+/// order — a deliberate, owner-approved behavior change (t_4ce82a3e).
+///
+/// The buffered executor did `rows.sort_by(|a, b| format!("{a:?}").cmp(..))`
+/// then `dedup()`, so an unordered `DISTINCT` came back in string-repr SORTED
+/// order. Streaming dedup emits each row the first time it is seen.
+///
+/// The test pins first-seen semantics without hard-coding the storage scan
+/// order: it reads the raw (non-DISTINCT) expansion order, dedups it in Rust,
+/// and requires `DISTINCT` to match. The `assert_ne!` guard makes the test
+/// non-vacuous — if the raw order happened to already be sorted, the test could
+/// not tell first-seen from sorted, and it fails loudly instead of passing for
+/// the wrong reason.
+#[tokio::test]
+async fn return_distinct_without_order_by_is_first_seen_order_not_sorted() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+
+    for (id, name) in [
+        ("00000000-0000-0000-0000-0000000f0001", "Cara"),
+        ("00000000-0000-0000-0000-0000000f0002", "Alice"),
+        ("00000000-0000-0000-0000-0000000f0003", "Cara"),
+        ("00000000-0000-0000-0000-0000000f0004", "Bob"),
+        ("00000000-0000-0000-0000-0000000f0005", "Alice"),
+    ] {
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{id: '{id}', name: '{name}'}}) RETURN n.name"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(
+            app.clone().oneshot(req).await.unwrap().status(),
+            StatusCode::OK
+        );
+    }
+
+    let names_for = |query: &'static str| {
+        let app = app.clone();
+        async move {
+            let req = json_request(
+                "POST",
+                "/graph/query",
+                Some(serde_json::json!({ "query": query, "keyspace": "social" })),
+            );
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "{query} must return 200");
+            response_json(resp).await["rows"]
+                .as_array()
+                .expect("rows array")
+                .iter()
+                .map(|row| row[0].as_str().expect("name").to_string())
+                .collect::<Vec<String>>()
+        }
+    };
+
+    let raw = names_for("MATCH (n:Person) RETURN n.name").await;
+    let distinct = names_for("MATCH (n:Person) RETURN DISTINCT n.name").await;
+
+    let mut seen = std::collections::HashSet::new();
+    let first_seen: Vec<String> = raw
+        .iter()
+        .filter(|name| seen.insert((*name).clone()))
+        .cloned()
+        .collect();
+
+    let mut sorted = first_seen.clone();
+    sorted.sort();
+    assert_ne!(
+        first_seen, sorted,
+        "test data must expand in a NON-sorted order, otherwise this test cannot \
+         distinguish first-seen order from the old sorted order (raw order was {raw:?})"
+    );
+
+    assert_eq!(
+        distinct, first_seen,
+        "RETURN DISTINCT without ORDER BY must emit rows in first-seen expansion order \
+         (raw order was {raw:?})"
+    );
+}
+
+/// `DISTINCT` **with** an explicit `ORDER BY` still goes through the buffered
+/// tail (`finish_expand_buffered`), so the first-seen change does not reach it.
+///
+/// SCOPE WARNING — this test does NOT prove that `ORDER BY` is honored when
+/// `DISTINCT` is present. It is not: the buffered tail sorts by `order_by` and
+/// then RE-SORTS by string repr to dedup, which discards the requested
+/// ordering. Verified: `... RETURN n.name ORDER BY n.name DESC` gives
+/// `[Cara, Bob, Alice]`, but `... RETURN DISTINCT n.name ORDER BY n.name DESC`
+/// gives `[Alice, Bob, Cara]`. That is a PRE-EXISTING bug, deliberately left
+/// untouched here so this increment stays behavior-preserving on the ordered
+/// path; it is tracked separately. What this test pins is only that the ordered
+/// DISTINCT path still returns the deduplicated set in the buffered path's
+/// order, i.e. that nothing regressed.
+#[tokio::test]
+async fn return_distinct_with_order_by_takes_the_unchanged_buffered_path() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+    let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+
+    for (id, name) in [
+        ("00000000-0000-0000-0000-0000000f1001", "Cara"),
+        ("00000000-0000-0000-0000-0000000f1002", "Alice"),
+        ("00000000-0000-0000-0000-0000000f1003", "Cara"),
+        ("00000000-0000-0000-0000-0000000f1004", "Bob"),
+    ] {
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{id: '{id}', name: '{name}'}}) RETURN n.name"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(
+            app.clone().oneshot(req).await.unwrap().status(),
+            StatusCode::OK
+        );
+    }
+
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (n:Person) RETURN DISTINCT n.name ORDER BY n.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(resp).await["rows"],
+        serde_json::json!([["Alice"], ["Bob"], ["Cara"]]),
+        "DISTINCT + ORDER BY must still come back ordered"
+    );
+}
+
 #[tokio::test]
 async fn negative_pattern_predicate_filters_existing_relationships() {
     let (schema, storage, _dir) = setup();


### PR DESCRIPTION
Completes increment 5 of the graph streaming executor (`t_4ce82a3e`). An unbounded `ORDER BY` now sorts through the storage engine's bounded external merge sort instead of buffering the whole result and silently truncating it.

## The correctness fix

`execute_expand`'s projection loop had:

```rust
if rows.len() >= config.max_result_rows { break; }   // no error, no flag
```

A client could not distinguish a **partial** result from a complete one. Removed — per the owner decision to **remove the cap** rather than convert it to an error, because spilling makes the bound unnecessary.

## How it's wired (no new parameter through every recursive call)

- **`GraphEngineConfig`** — already threaded everywhere — carries an optional `SpillReserver` + `spill_threshold_bytes` (64 MiB default). `None` sorts in memory exactly as before, so unit tests and embedded use are unaffected.
- **`GraphEngine::new_with_coordinator`** (the single funnel both constructors use) supplies the real backend from its `Arc<StorageEngine>`, unless a caller set one explicitly.
- **Cleanup rides on `TempSortTableReservation`'s `Drop`** — a cancelled or failed query removes its temp dir exactly like a successful one.
- **`spill_order_by` returns `Ok(false)`** — leaving the in-memory sort to run — when it can't apply: no backend, no LIMIT-free ORDER BY, or an order term that isn't a projected column (the in-memory path resolves those via the states' bindings; a spilled row carries no binding context). Fails loud on any spill/merge I/O error.

## Why a graph-specific comparator

Graph's `compare_json_values` treats mixed types (String vs Number) and complex values as **Equal**, and sorts `Null` first — `CqlValue::Ord` does not. That's why the sorter was made generic over `SpillOrder<T>` in #302 rather than given a json→`CqlValue` bridge, which would have looked safe and **silently reordered** those results.

## Tests

`matches_in_memory_sort_rows_ordering` is the load-bearing one: the spill comparator orders a mixed set (incl. `Null`) **exactly** as the in-memory `sort_rows` does — so this is a memory change and nothing observable. Plus mixed-types-Equal pinned explicitly, multi-term/descending tie-break, and an end-to-end spill+merge at threshold=1 (real spill path, not the in-memory fast path).

457 `ferrosa-graph` tests green; clippy `--all-targets` and `cargo doc -D warnings` both clean.

## Scope

`max_result_rows` remains only on the not-yet-converted varpath/leapfrog paths and is marked deprecated in its doc. `max_fan_out_per_hop` stays until the frontier itself streams (increment 7).