### PR TITLE
feat(graph/http): stream query responses end-to-end, ending server-side buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,6 +2398,7 @@ name = "ferrosa-graph"
 version = "0.17.0"
 dependencies = [
  "arc-swap",
+ "async-stream",
  "async-trait",
  "axum 0.8.9",
  "axum-server",

--- a/ferrosa-graph/Cargo.toml
+++ b/ferrosa-graph/Cargo.toml
@@ -11,6 +11,7 @@ ferrosa-sstable = { path = "../ferrosa-sstable" }
 ferrosa-cluster = { path = "../ferrosa-cluster" }
 ferrosa-storage = { path = "../ferrosa-storage" }
 arc-swap = "1.7"
+async-stream = "0.3"
 hex = "0.4"
 indexmap = { version = "2", features = ["serde"] }
 phf = { version = "0.13", features = ["macros"] }

--- a/ferrosa-graph/README.md
+++ b/ferrosa-graph/README.md
@@ -58,6 +58,26 @@ resolved port.
   then tombstone), `Aggregate`, `WcoJoin`, `ExpandVarLength` and the
   virtual-table anchor are deliberately excluded. The hop loop is still fully
   materializing. See `specs/streaming-executor-design.md` §5.
+- **Owned-handle entry point** (`executor/expand.rs`) — `execute_streaming_owned(plan,
+  OwnedExecCtx)` returns `(columns, RowStream<'static>, QueryStats)`. Same
+  dispatch as `execute_streaming()`, but the handles are owned
+  (`ArcSwap::load_full()` instead of `load()`, `Schema::virtual_tables_arc()`
+  instead of `virtual_tables()`, `Arc<Schema>` instead of `&Schema`), so the row
+  stream can outlive the frame that started it — which is what a transport
+  needs. `GraphEngine::execute_stream_with_params()` is the engine-level form;
+  `execute_with_params()` is a `collect` over it.
+- **Streamed HTTP response** (`http.rs`) — `POST /graph/query` writes the JSON
+  body straight from the row stream. Nothing buffers the result server-side for
+  a plan the executor streams. **Scope**: this bounds the *response*, not the
+  query — phase A of `Expand` still materializes the frontier, and the
+  buffering plan variants above still materialize, so a high-fan-out query can
+  still exhaust memory. The trailing `"stats"` object is built **after** the
+  last row, so `execution_ms` now covers the projection too (a larger, more
+  accurate number than the buffered path reported). A failure that surfaces
+  after the first chunk **aborts the body**; the client sees a `200` with a
+  truncated chunked transfer, never a `4xx`/`5xx`, because the status line is
+  already on the wire. Bolt (`bolt/server.rs`) still buffers — it holds results
+  in the connection struct across protocol messages and emits stats before rows.
 - **`RETURN DISTINCT` ordering** — `DISTINCT` **without** an `ORDER BY` returns
   rows in **first-seen (expansion) order**, not sorted order. This changed
   deliberately when DISTINCT became a streaming dedup; earlier releases returned

--- a/ferrosa-graph/specs/streaming-executor-design.md
+++ b/ferrosa-graph/specs/streaming-executor-design.md
@@ -192,7 +192,8 @@ expand-with-limit shape; 5–7 complete coverage and end-to-end streaming.
 | 1 — `RowStream` + collect bridges | **done** (`executor/stream.rs`) |
 | 2 — streaming entry point | **partial** — see below |
 | 3 — Expand projection + DISTINCT + SET/REMOVE | **partial** — see below |
-| 4–7 | not started |
+| 4–6 | not started |
+| 7 — transport streaming | **HTTP done** (t_81087be0) — Bolt not started; see below |
 
 Increment 2 landed as an **additive scaffold**: `execute_streaming()` exists and
 `execute()` is now a thin `collect` over it, so there is one executor rather than
@@ -219,12 +220,57 @@ Every other variant computes today's buffered `GraphResult` and is wrapped with
 - The sequential-vs-concurrent hop split (`expand.rs`, capped hops run
   sequentially) is untouched: completion-order draining changes which rows a
   LIMIT returns.
-- `http.rs` / `bolt/server.rs` are untouched: `Body::from_stream` requires
-  `'static`, and Bolt holds the result in a struct field across protocol
-  messages. That is increment 7.
+- `bolt/server.rs` is untouched: Bolt holds the result in a struct field across
+  protocol messages and emits stats before rows, so it needs its own pass.
+  `http.rs` is done — see *Increment 7 (HTTP)* below.
 
 Known behavior preserved rather than fixed: the buffered `UNION` never summed
 `edges_deleted` across arms, and the streaming one does not either.
+
+#### Increment 7 (HTTP done, Bolt not started)
+
+`Body::from_stream` requires `Stream + Send + 'static`, and the response body
+outlives the handler frame, so a borrowing `RowStream<'a>` could not feed it.
+Two concrete borrows caused that, both in `engine.rs`: `self.write_path.load()`
+returns an `arc_swap` `Guard` that is a *local* of the calling frame, and
+`self.schema.snapshot()` / `virtual_tables()` borrow the caller's `Arc<Schema>`.
+
+Resolved with an **owned-handle wrapper**, not a second executor:
+
+- `OwnedExecCtx` (`expand.rs`) holds `Arc<WritePath>` (from `load_full()`),
+  `String` keyspace, `Arc<GraphEngineConfig>`, `Arc<VirtualTableRegistry>` (from
+  `Schema::virtual_tables_arc()`), and `Arc<Schema>`.
+- `execute_streaming_owned(plan, ctx)` moves the ctx into an `async_stream`
+  generator and calls `execute_streaming` **inside** it, so the executor's
+  borrows are borrows of the generator's own locals — legal across yield points
+  and invisible from outside. The result is a `RowStream<'static>` with no
+  per-row clone, no spawned task, and one dispatch.
+- The generator's first item is the head (columns + stats);
+  `execute_streaming_owned` peels it back off so a **setup** failure is still an
+  `Err` return, which is what lets the HTTP layer choose a status code before
+  any byte is written.
+- `GraphEngine::execute_stream_with_params()` is the engine-level entry;
+  `execute_with_params()` and `execute_statement()` are now `collect` bridges
+  over their streaming halves. `FOREACH` and `CALL {}` still materialize (they
+  orchestrate many sub-executions).
+- `http.rs::stream_graph_rows()` writes the body from the stream. The trailing
+  `"stats"` object is produced by a `StatsFinalizer` closure run **after** the
+  last row, so `execution_ms` covers the projection too — larger and more
+  accurate than the buffered path's number.
+
+**Scope — this bounds the RESPONSE, not the query.** Phase A of `Expand` still
+materializes the frontier before the first row is projected, and every
+non-converted variant still materializes. A high-fan-out query can still exhaust
+memory. The OOM class is not closed.
+
+**Failure after the first chunk.** The status line is chosen before any byte is
+written. A mid-stream executor error, or a row that fails to serialize, aborts
+the body rather than emitting the closing `],"stats":{…}}`, because
+truncated-but-parsable JSON would read as a complete, shorter result. The client
+observes a `200` with an incomplete chunked transfer — never a `4xx`/`5xx`. It
+must treat an incomplete body as a failure, not as an empty tail. The completion
+log line also moves to the end of the body, so a client that disconnects
+mid-stream produces no `graph query completed` line.
 
 #### Increment 3 (partial)
 
@@ -264,9 +310,14 @@ increment changed ordering and latency, **not** the memory bound; a
 high-cardinality `DISTINCT` can still exhaust memory. Bounding it is separate
 work.
 
-**`execution_ms` now under-reports for a streamed Expand.** Stats are returned
-up front (§4), so `execution_ms` is measured before any row is projected, where
-the buffered tail measured after. Fixing this needs the deferred stats handle.
+**`execution_ms` now under-reports for a streamed Expand** *at the executor
+boundary*. Stats are returned up front (§4), so `execution_ms` is measured
+before any row is projected, where the buffered tail measured after. Fixing that
+inside the executor still needs the deferred stats handle. The **HTTP**
+transport compensates: `stream_graph_rows`'s `StatsFinalizer` adds the drain
+duration after the last row, so a `POST /graph/query` response reports the whole
+query. Internal `collect` callers (`execute`, Bolt) still see the setup-only
+number.
 
 
 ## 6. Verification
@@ -292,7 +343,7 @@ by the data. The ones that actually scale with graph data:
 |---|---|---|---|
 | `expand.rs:1079` anchor `states` | every anchor partition (**full table scan**) | none | inc 2 — use `WritePath::range_read_stream_all*` (already exists) |
 | `expand.rs:1225` `pairs` collect | one vertex's full adjacency (**hub degree**) | `max_fan_out_per_hop` | inc 3/4 (concurrency+early-stop done; still collects) |
-| `expand.rs:1384-85` `rows`/`result_states` | **entire result set** | `max_result_rows` (silent truncate — see §7) | inc 7 (transport) |
+| `expand.rs:1384-85` `rows`/`result_states` | **entire result set** | `max_result_rows` (silent truncate — see §7) | inc 3 (streamed projection) + inc 7 (HTTP transport) — **done for the HTTP path**; still buffered for Bolt and for ORDER BY / aggregate / DELETE / varpath / leapfrog |
 | `expand.rs:1328` `kept` (post-filters) | full frontier | none | inc 5 |
 | `expand.rs:471` `next_frontier` (pattern predicate) | BFS frontier | none | inc 5 |
 | `expand.rs:1857` edge-anchored `states` | edge-anchor scan | none | inc 2 |
@@ -300,7 +351,7 @@ by the data. The ones that actually scale with graph data:
 | `leapfrog.rs` `result_rows` / `AdjacencyIterator` | join output + sorted adjacency | `max_results` | inc 6 |
 | `engine.rs:910-915` CALL subquery `out_rows` | **outer result + every inner result** (nested-loop join) | none | inc 5 |
 | `http.rs:510` SUBSCRIBE diff | **two full result sets** (previous + current) | none | see §7 — needs a design decision |
-| `stream.rs:69/91` collect bridges | migration scaffolding | caller's | inc 7 (they disappear) |
+| `stream.rs:69/91` collect bridges | migration scaffolding | caller's | inc 7 — **HTTP no longer collects**; the bridges remain for Bolt, `execute()`, FOREACH/`CALL {}`, and every non-converted variant |
 
 Note the storage layer already went through this discipline and has a source
 tripwire enforcing it (`ferrosa-cluster/src/write_path.rs` test: *"unbounded local

--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -27,8 +27,11 @@ use crate::adjacency::{adjacency_keyspace_name, adjacency_table_metadata};
 use crate::error::{GraphError, Result};
 use crate::executor::aggregate::{create_accumulator, is_aggregate_function};
 use crate::executor::eval::eval_expr;
-use crate::executor::expand::{build_columns, execute, sort_rows, GraphEngineConfig};
+use crate::executor::expand::{
+    build_columns, execute, execute_streaming_owned, sort_rows, GraphEngineConfig, OwnedExecCtx,
+};
 use crate::executor::result::{GraphResult, QueryStats};
+use crate::executor::stream::{collect_to_graph_result, stream_from_rows, RowStream};
 use crate::executor::subscribe::SubscriptionRegistry;
 use crate::parser::{
     parse, Assignment, Expr, Literal, Pattern, ReturnClause, ReturnItem, Statement, WithPipeline,
@@ -60,6 +63,16 @@ fn adjacency_keyspace_metadata(
             },
         }
     }
+}
+
+/// Present an already-materialized [`GraphResult`] in the streaming shape.
+///
+/// Every use marks a path that genuinely buffers — FOREACH and `CALL {}` (both
+/// orchestrate many sub-executions), and the missing-label short circuit. Naming
+/// it keeps those honest instead of hiding them behind an inline
+/// `stream_from_rows`.
+fn buffered_as_stream(result: GraphResult) -> (Vec<String>, RowStream<'static>, QueryStats) {
+    (result.columns, stream_from_rows(result.rows), result.stats)
 }
 
 fn replication_needs_repair(replication: &ferrosa_schema::ReplicationParams) -> bool {
@@ -707,6 +720,9 @@ impl GraphEngine {
             .await
     }
 
+    /// Buffered façade over [`GraphEngine::execute_stream_with_params`]: drains
+    /// the row stream into a `GraphResult`. There is one query pipeline, not
+    /// two — this entry point adds only the materialization.
     pub async fn execute_with_params(
         &self,
         query: &str,
@@ -714,11 +730,51 @@ impl GraphEngine {
         auth: &AuthContext,
         params: &HashMap<String, Value>,
     ) -> Result<GraphResult> {
+        let (columns, rows, stats) = self
+            .execute_stream_with_params(query, keyspace, auth, params)
+            .await?;
+        // `usize::MAX`, deliberately NOT `config.max_result_rows` — matching
+        // `executor::expand::execute`, which has never applied a global cap.
+        collect_to_graph_result(columns, rows, stats, usize::MAX).await
+    }
+
+    /// Execute a query and return its columns, a `'static` row stream, and the
+    /// stats known at that point.
+    ///
+    /// The streaming entry point for transports: the row stream borrows nothing
+    /// from this call, so it can be handed to an HTTP response body that
+    /// outlives the handler frame (see
+    /// [`crate::executor::expand::OwnedExecCtx`]).
+    ///
+    /// # What actually streams
+    ///
+    /// Whatever [`crate::executor::expand::execute_streaming`] streams — today
+    /// `Subscribe`, `UNION ALL`, `RETURN`-only, the `Expand` projection without
+    /// `ORDER BY`, `SET`/`REMOVE`, and `DISTINCT`. Everything else computes a
+    /// buffered result and hands it back as an already-materialized stream. This
+    /// is a transport change, not an operator conversion.
+    ///
+    /// `FOREACH` and `CALL {}` are orchestrated across many sub-executions and
+    /// are materialized here, exactly as before.
+    ///
+    /// # Stats
+    ///
+    /// `execution_ms` is measured where the executor measures it today — at
+    /// setup, i.e. *before* the rows are pulled. A caller that drains the stream
+    /// and wants a total should add its own drain time; the HTTP transport does.
+    pub async fn execute_stream_with_params(
+        &self,
+        query: &str,
+        keyspace: &str,
+        auth: &AuthContext,
+        params: &HashMap<String, Value>,
+    ) -> Result<(Vec<String>, RowStream<'static>, QueryStats)> {
         let statement = bind_statement_params(parse(query)?, params)?;
         if let Statement::Foreach { var, list, body } = statement {
-            return self
+            let result = self
                 .execute_foreach(&var, &list, &body, keyspace, auth)
-                .await;
+                .await?;
+            return Ok(buffered_as_stream(result));
         }
         if let Statement::CallSubquery {
             outer,
@@ -727,22 +783,39 @@ impl GraphEngine {
             return_clause,
         } = statement
         {
-            return self
+            let result = self
                 .execute_call_subquery(*outer, &imports, *inner, return_clause, keyspace, auth)
-                .await;
+                .await?;
+            return Ok(buffered_as_stream(result));
         }
-        self.execute_statement(statement, keyspace, auth).await
+        self.execute_statement_streaming(statement, keyspace, auth)
+            .await
     }
 
     /// Validate, plan, and execute a single non-orchestrated statement (i.e. not
     /// FOREACH / CALL {}, which the engine expands first). Shared by the top-level
     /// query path and the CALL {} subquery orchestrator.
+    ///
+    /// Buffered façade over [`GraphEngine::execute_statement_streaming`].
     async fn execute_statement(
         &self,
         statement: Statement,
         keyspace: &str,
         auth: &AuthContext,
     ) -> Result<GraphResult> {
+        let (columns, rows, stats) = self
+            .execute_statement_streaming(statement, keyspace, auth)
+            .await?;
+        collect_to_graph_result(columns, rows, stats, usize::MAX).await
+    }
+
+    /// The streaming half of [`GraphEngine::execute_statement`].
+    async fn execute_statement_streaming(
+        &self,
+        statement: Statement,
+        keyspace: &str,
+        auth: &AuthContext,
+    ) -> Result<(Vec<String>, RowStream<'static>, QueryStats)> {
         if statement_requires_adjacency(&statement) {
             let adjacency_registered = self.ensure_adjacency_storage_for_keyspace(keyspace).await?;
             if adjacency_registered {
@@ -763,21 +836,28 @@ impl GraphEngine {
                 if msg.contains("no table with graph.label")
                     && empty_match_for_missing_label(&statement) =>
             {
-                return Ok(empty_match_result(&statement));
+                return Ok(buffered_as_stream(empty_match_result(&statement)));
             }
             Err(e) => return Err(e),
         };
         let physical = plan(logical)?;
-        let wp = self.write_path.load();
-        execute(
-            physical,
-            &wp,
-            keyspace,
-            &self.config,
-            Some(self.schema.virtual_tables()),
-            Some(&self.schema),
-        )
-        .await
+        execute_streaming_owned(physical, self.owned_exec_ctx(keyspace)).await
+    }
+
+    /// Collect the engine's execution handles as owned values.
+    ///
+    /// `load_full()` rather than `load()`, and `virtual_tables_arc()` rather
+    /// than `virtual_tables()`: both of the borrowed forms produce a guard or a
+    /// reference tied to *this* frame, which is precisely what stops a row
+    /// stream from outliving the handler that started it.
+    fn owned_exec_ctx(&self, keyspace: &str) -> OwnedExecCtx {
+        OwnedExecCtx {
+            write_path: self.write_path.load_full(),
+            keyspace: keyspace.to_string(),
+            config: Arc::new(self.config.clone()),
+            virtual_tables: Some(self.schema.virtual_tables_arc()),
+            schema: Some(Arc::clone(&self.schema)),
+        }
     }
 
     /// Execute `FOREACH (var IN list | body...)`: run each body update clause

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -210,6 +210,156 @@ pub async fn execute_streaming<'a>(
     execute_streaming_inner(plan, write_path, keyspace, config, virtual_tables, schema).await
 }
 
+/// Owned handles for one query execution — the same inputs
+/// [`execute_streaming`] borrows, held by value.
+///
+/// # Why this exists
+///
+/// [`execute_streaming`] returns a `RowStream<'a>` that borrows its inputs. That
+/// is exactly what we want inside the executor (no per-row clones), and exactly
+/// what a *transport* cannot use: an HTTP response body outlives the handler
+/// frame, so `axum::body::Body::from_stream` demands `Stream + Send + 'static`.
+///
+/// Two concrete borrows blocked it. `arc_swap::ArcSwap::load()` yields a `Guard`
+/// that is a local of the calling frame, and `Schema::snapshot()` /
+/// `Schema::virtual_tables()` borrow the `Arc<Schema>` the caller is holding.
+/// Both have owned counterparts (`load_full()`, `virtual_tables_arc()`, an
+/// `Arc<Schema>` clone), which is what this struct collects.
+///
+/// This is a wrapper, not a second executor: [`execute_streaming_owned`] calls
+/// straight through to [`execute_streaming`]. There is one dispatch.
+pub struct OwnedExecCtx {
+    /// From `ArcSwap::load_full()`, not `load()` — an owned `Arc`, not a `Guard`.
+    pub write_path: std::sync::Arc<WritePath>,
+    /// Owned copy of the caller's `&str`.
+    pub keyspace: String,
+    /// Owned config; `GraphEngineConfig` is small and `Clone`.
+    pub config: std::sync::Arc<GraphEngineConfig>,
+    /// From `Schema::virtual_tables_arc()`, not `virtual_tables()`.
+    pub virtual_tables: Option<std::sync::Arc<VirtualTableRegistry>>,
+    /// An `Arc<Schema>` clone, not a `&Schema`.
+    pub schema: Option<std::sync::Arc<Schema>>,
+}
+
+/// One item of the internal owned execution generator.
+///
+/// The generator has to deliver the columns and stats *through* the stream
+/// (they are produced inside it, where the borrows of the owned context live),
+/// so the first item is the head and every later item is a row.
+/// [`execute_streaming_owned`] peels the head back off, which is why this type
+/// never escapes the module.
+enum OwnedStreamItem {
+    Head(Vec<String>, QueryStats),
+    Row(crate::executor::stream::RowVals),
+}
+
+/// [`execute_streaming`] with owned handles: the row stream is `'static`, so it
+/// can be handed to a response body that outlives this frame.
+///
+/// # Error timing (this is a transport-visible contract)
+///
+/// A failure raised while *setting up* the execution — validation, a fallback
+/// plan's whole buffered execution, the first storage read — comes back as
+/// `Err` from this function, before the caller has written a byte. That is what
+/// lets the HTTP layer still choose a status code.
+///
+/// A failure raised *after* the first row has been yielded can only appear as an
+/// `Err` item on the stream. A transport must abort the body there; the status
+/// line is already on the wire.
+///
+/// # Laziness
+///
+/// Unchanged from [`execute_streaming`]: whatever streams there streams here,
+/// and whatever falls back to a buffered `GraphResult` there falls back here.
+/// Wrapping does not convert an operator.
+pub async fn execute_streaming_owned(
+    plan: PhysicalPlan,
+    ctx: OwnedExecCtx,
+) -> Result<(Vec<String>, RowStream<'static>, QueryStats)> {
+    use futures::StreamExt as _;
+
+    let mut items = Box::pin(owned_stream_items(plan, ctx));
+
+    // Drive the generator up to (and including) the head. This is what runs
+    // setup, so a setup error is returned as `Err` rather than becoming the
+    // stream's first item.
+    let (columns, stats) = match items.next().await {
+        Some(Ok(OwnedStreamItem::Head(columns, stats))) => (columns, stats),
+        Some(Ok(OwnedStreamItem::Row(_))) => {
+            return Err(GraphError::Internal(
+                "owned execution stream yielded a row before its head".to_string(),
+            ))
+        }
+        Some(Err(e)) => return Err(e),
+        None => {
+            return Err(GraphError::Internal(
+                "owned execution stream ended before its head".to_string(),
+            ))
+        }
+    };
+
+    let rows: RowStream<'static> = Box::pin(items.map(|item| match item {
+        Ok(OwnedStreamItem::Row(row)) => Ok(row),
+        // Fail loud rather than drop: a second head would mean the generator
+        // below was restructured and this peel is now wrong.
+        Ok(OwnedStreamItem::Head(..)) => Err(GraphError::Internal(
+            "owned execution stream yielded a second head".to_string(),
+        )),
+        Err(e) => Err(e),
+    }));
+
+    Ok((columns, rows, stats))
+}
+
+/// The owned execution generator.
+///
+/// `ctx` is *moved into* the async generator, so the `&ctx.write_path` /
+/// `&ctx.keyspace` / `&ctx.config` borrows [`execute_streaming`] needs are
+/// borrows of the generator's own locals — legal to hold across yield points,
+/// and invisible from outside. That is what turns a `RowStream<'a>` into a
+/// `'static` one without cloning per row, spawning a task, or duplicating the
+/// executor.
+fn owned_stream_items(
+    plan: PhysicalPlan,
+    ctx: OwnedExecCtx,
+) -> impl futures::Stream<Item = Result<OwnedStreamItem>> + Send + 'static {
+    use futures::StreamExt as _;
+
+    async_stream::stream! {
+        let started = execute_streaming(
+            plan,
+            &ctx.write_path,
+            &ctx.keyspace,
+            &ctx.config,
+            ctx.virtual_tables.as_deref(),
+            ctx.schema.as_deref(),
+        )
+        .await;
+
+        let (columns, mut rows, stats) = match started {
+            Ok(started) => started,
+            Err(e) => {
+                yield Err(e);
+                return;
+            }
+        };
+
+        yield Ok(OwnedStreamItem::Head(columns, stats));
+
+        while let Some(row) = rows.next().await {
+            match row {
+                Ok(row) => yield Ok(OwnedStreamItem::Row(row)),
+                Err(e) => {
+                    // Surface and stop: continuing past an error would emit a
+                    // short result that looks complete.
+                    yield Err(e);
+                    return;
+                }
+            }
+        }
+    }
+}
+
 /// Boxed body of [`execute_streaming`].
 ///
 /// `Subscribe` and `Union` recurse into it, so the future has to be type-erased.
@@ -8257,6 +8407,190 @@ mod tests {
             rows,
             stats,
         }
+    }
+
+    // --- owned-handle entry point (`execute_streaming_owned`) -------------
+    //
+    // The HTTP body outlives the handler frame, so it can only be fed by a
+    // `RowStream<'static>`. These pin the three properties that makes possible:
+    // same rows as the borrowed entry point, a stream that genuinely outlives
+    // the scope that built its handles, and setup errors that still surface as
+    // `Err` (so the transport can still pick an HTTP status before writing).
+
+    fn owned_test_ctx(wp: Arc<WritePath>, keyspace: &str) -> OwnedExecCtx {
+        OwnedExecCtx {
+            write_path: wp,
+            keyspace: keyspace.to_string(),
+            config: Arc::new(GraphEngineConfig::default()),
+            virtual_tables: None,
+            schema: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn owned_streaming_matches_the_borrowed_entry_point() {
+        let (_tmp, wp) = streaming_test_write_path();
+        let wp = Arc::new(wp);
+        let config = GraphEngineConfig::default();
+        let build = || PhysicalPlan::Union {
+            arms: vec![
+                return_one_plan(&[("a", 1)], None),
+                return_one_plan(&[("a", 2)], None),
+            ],
+            all: true,
+        };
+
+        let (borrowed_cols, borrowed_stream, _) =
+            execute_streaming(build(), &wp, "social", &config, None, None)
+                .await
+                .unwrap();
+        let borrowed_rows = crate::executor::stream::collect_rows(borrowed_stream)
+            .await
+            .unwrap();
+
+        let (owned_cols, owned_stream, _) =
+            execute_streaming_owned(build(), owned_test_ctx(Arc::clone(&wp), "social"))
+                .await
+                .unwrap();
+        let owned_rows = crate::executor::stream::collect_rows(owned_stream)
+            .await
+            .unwrap();
+
+        assert_eq!(owned_cols, borrowed_cols);
+        assert_eq!(owned_rows, borrowed_rows);
+    }
+
+    /// The whole point of the owned entry point: the returned stream is
+    /// `'static`, so it can be handed to a response body that outlives the
+    /// function that built the handles.
+    ///
+    /// The `RowStream<'static>` annotation is the real assertion — it does not
+    /// compile if the stream borrows the write path, the keyspace, the config,
+    /// or the schema. Draining it after the builder frame has returned proves
+    /// the handles are genuinely kept alive by the stream.
+    #[tokio::test]
+    async fn owned_row_stream_is_static_and_outlives_its_builder() {
+        async fn build_stream(wp: Arc<WritePath>) -> (Vec<String>, RowStream<'static>, QueryStats) {
+            // Everything borrowed by the executor is created and dropped inside
+            // this frame; only the stream escapes.
+            execute_streaming_owned(
+                return_one_plan(&[("a", 42)], None),
+                OwnedExecCtx {
+                    write_path: wp,
+                    keyspace: "social".to_string(),
+                    config: Arc::new(GraphEngineConfig::default()),
+                    virtual_tables: None,
+                    schema: None,
+                },
+            )
+            .await
+            .unwrap()
+        }
+
+        let (_tmp, wp) = streaming_test_write_path();
+        let (columns, stream, _stats) = build_stream(Arc::new(wp)).await;
+        let stream: RowStream<'static> = stream;
+        assert_eq!(columns, vec!["a".to_string()]);
+        assert_eq!(
+            crate::executor::stream::collect_rows(stream).await.unwrap(),
+            vec![vec![serde_json::json!(42)]]
+        );
+    }
+
+    /// A setup failure must still come back as `Err` from the owned entry
+    /// point, NOT as an error item on the stream. The transport picks its HTTP
+    /// status here, before the first byte of the body is written — once the
+    /// body starts there is no status left to choose.
+    #[tokio::test]
+    async fn owned_streaming_setup_error_surfaces_before_the_stream() {
+        let (_tmp, wp) = streaming_test_write_path();
+        let plan = PhysicalPlan::Union {
+            arms: vec![
+                return_one_plan(&[("a", 1)], None),
+                return_one_plan(&[("b", 2)], None),
+            ],
+            all: true,
+        };
+        // `RowStream` is not `Debug`, so the Ok arm cannot be unwrapped.
+        let err = match execute_streaming_owned(plan, owned_test_ctx(Arc::new(wp), "social")).await
+        {
+            Ok(_) => panic!("owned streaming must reject arms with mismatched columns"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, GraphError::Validation(ref m) if m.contains("identical columns")),
+            "got {err:?}"
+        );
+    }
+
+    /// Laziness survives the owned wrapper: a downstream `take(k)` still stops
+    /// the chain. If the wrapper collected internally this would be the only
+    /// visible symptom — the rows would be right, but every arm would run.
+    #[tokio::test]
+    async fn owned_streaming_take_still_short_circuits() {
+        use futures::StreamExt as _;
+
+        let (_tmp, wp) = streaming_test_write_path();
+        let plan = PhysicalPlan::Union {
+            arms: (0..64)
+                .map(|i| return_one_plan(&[("a", i)], None))
+                .collect(),
+            all: true,
+        };
+        let (_columns, rows_stream, _stats) =
+            execute_streaming_owned(plan, owned_test_ctx(Arc::new(wp), "social"))
+                .await
+                .unwrap();
+        let limited: RowStream<'static> = Box::pin(rows_stream.take(2));
+        assert_eq!(
+            crate::executor::stream::collect_rows(limited)
+                .await
+                .unwrap(),
+            vec![vec![serde_json::json!(0)], vec![serde_json::json!(1)]]
+        );
+    }
+
+    /// An error raised MID-stream (after rows have already been yielded) must
+    /// still reach the consumer as an `Err` item — never be swallowed into a
+    /// short-but-successful result.
+    #[tokio::test]
+    async fn owned_streaming_propagates_a_mid_stream_error() {
+        use futures::StreamExt as _;
+
+        let (_tmp, wp) = streaming_test_write_path();
+        let (_columns, rows_stream, _stats) = execute_streaming_owned(
+            return_one_plan(&[("a", 1)], None),
+            owned_test_ctx(Arc::new(wp), "social"),
+        )
+        .await
+        .unwrap();
+
+        // Splice a failure in after the real row, the way a lazily-hydrated hop
+        // surfaces a storage error partway through the projection.
+        let spliced: RowStream<'static> = Box::pin(rows_stream.chain(stream_error_once()));
+        let mut rows = Vec::new();
+        let mut seen_err = None;
+        let mut spliced = spliced;
+        while let Some(item) = futures::StreamExt::next(&mut spliced).await {
+            match item {
+                Ok(row) => rows.push(row),
+                Err(e) => {
+                    seen_err = Some(e);
+                    break;
+                }
+            }
+        }
+        assert_eq!(rows, vec![vec![serde_json::json!(1)]]);
+        assert!(
+            matches!(seen_err, Some(GraphError::Internal(ref m)) if m == "mid-stream boom"),
+            "the mid-stream error must reach the consumer"
+        );
+    }
+
+    fn stream_error_once() -> RowStream<'static> {
+        Box::pin(futures::stream::once(async {
+            Err(GraphError::Internal("mid-stream boom".to_string()))
+        }))
     }
 
     // --- converted: ReturnOnly -------------------------------------------

--- a/ferrosa-graph/src/executor/stream.rs
+++ b/ferrosa-graph/src/executor/stream.rs
@@ -25,6 +25,11 @@
 //! [`RowStream`]; callers that still need a buffered result use
 //! [`collect_to_graph_result`], which is behavior-identical to the old path.
 //! That keeps every increment green against the existing integration suite.
+//!
+//! The `'a` lifetime is also why a transport cannot consume a [`RowStream`]
+//! directly: a response body outlives the handler frame, so it needs `'static`.
+//! [`crate::executor::expand::execute_streaming_owned`] supplies that without
+//! forking the executor — see its docs for how.
 
 use futures::stream::{Stream, StreamExt};
 use std::pin::Pin;

--- a/ferrosa-graph/src/http.rs
+++ b/ferrosa-graph/src/http.rs
@@ -3,6 +3,11 @@
 //! Provides a REST API for executing Cypher queries, explaining query plans,
 //! inspecting graph schema, and health checks. Includes Basic auth middleware (T2),
 //! error sanitization (T8), and TLS support (T11).
+//!
+//! `POST /graph/query` consumes a `RowStream` end to end: the handler never
+//! holds the result set. See `stream_graph_rows` (private) for the exact scope
+//! of that claim — it bounds the response, not the query — and for what a
+//! client observes when a query fails after N rows.
 
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -266,7 +271,7 @@ async fn handle_query(State(state): State<AppState>, req: Request<Body>) -> Resp
 
     match state
         .engine
-        .execute_with_params(
+        .execute_stream_with_params(
             &query_req.query,
             &query_req.keyspace,
             &auth,
@@ -274,16 +279,38 @@ async fn handle_query(State(state): State<AppState>, req: Request<Body>) -> Resp
         )
         .await
     {
-        Ok(result) => {
-            tracing::info!(
-                user = %auth.role,
-                keyspace = %query_req.keyspace,
-                rows = result.rows.len(),
-                execution_ms = result.stats.execution_ms,
-                status = "Ok",
-                "graph query completed"
-            );
-            stream_graph_result(result)
+        Ok((columns, rows, stats)) => {
+            // The completion log moves to the end of the body: with a streamed
+            // response the row count and the total duration are not known until
+            // the last row is out. A client that disconnects mid-stream
+            // therefore produces no completion line — the drain never finishes.
+            let user = auth.role.clone();
+            let keyspace = query_req.keyspace.clone();
+            let drain_start = std::time::Instant::now();
+            stream_graph_rows(
+                columns,
+                rows,
+                Box::new(move |emitted| {
+                    let mut stats = stats;
+                    // The executor's measurement stops at setup; the streamed
+                    // projection happens after it. Adding the drain makes
+                    // `execution_ms` cover the whole query rather than its
+                    // prefix — a MORE accurate number than the buffered path
+                    // reported, not a differently-defined one.
+                    stats.execution_ms = stats
+                        .execution_ms
+                        .saturating_add(drain_start.elapsed().as_millis() as u64);
+                    tracing::info!(
+                        user = %user,
+                        keyspace = %keyspace,
+                        rows = emitted,
+                        execution_ms = stats.execution_ms,
+                        status = "Ok",
+                        "graph query completed"
+                    );
+                    stats
+                }),
+            )
         }
         Err(ref e) => {
             let status_str = match e {
@@ -455,32 +482,48 @@ async fn handle_subscribe(State(state): State<AppState>, req: Request<Body>) -> 
 
 /// Build an SSE stream that yields the initial snapshot followed by
 /// periodic re-executions of the query.
-/// Serialize a [`GraphResult`] into a STREAMING chunked response body instead of
-/// `Json(result)`.
+/// Produces the response's trailing `"stats"` object once the row stream has
+/// drained, given the number of rows actually emitted.
 ///
-/// `Json` serializes the whole result into one contiguous buffer before writing
-/// a byte — for a large result that is a second full copy of the data on top of
-/// the rows themselves, at peak. This emits the identical JSON
-/// (`{"columns":…,"rows":[…],"stats":…}`, same field order as the derive) one
-/// row at a time, so the serialized form is never fully resident and the client
-/// starts receiving data immediately (t_4ce82a3e inc 7).
+/// A closure rather than a value because `execution_ms` is not knowable until
+/// the last row is out — the executor's own measurement stops at setup, and for
+/// a genuinely streamed plan the projection happens afterwards. Capturing the
+/// stats up front would report a duration that excludes most of the query.
+type StatsFinalizer = Box<dyn FnOnce(usize) -> crate::executor::QueryStats + Send>;
+
+/// Write a query result to the wire as a STREAMING chunked response body,
+/// pulling rows from `rows` as the client consumes them.
 ///
-/// SCOPE: this removes the serialization copy, not the row buffer — `result`
-/// still owns every row. Ending server-side buffering needs `execute()` to
-/// return a `RowStream`, which is tracked separately.
+/// Emits exactly the JSON `Json(GraphResult)` would
+/// (`{"columns":…,"rows":[…],"stats":…}`, same field order as the derive), one
+/// row at a time. Neither the rows nor their serialized form is ever fully
+/// resident on the server, and the client starts receiving data immediately.
 ///
-/// A row that fails to serialize aborts the body with an error rather than
-/// silently emitting truncated JSON — a partial body that parses would be worse
-/// than a broken connection.
-fn stream_graph_result(result: crate::executor::GraphResult) -> Response {
+/// # Scope — this bounds the RESPONSE, not the query
+///
+/// Server-side buffering of the *result* is gone for every plan the executor
+/// streams. It is NOT gone for the query as a whole: phase A of `Expand` still
+/// materializes the frontier before the first row is projected, and the plans
+/// that legitimately buffer (ORDER BY, aggregation, DELETE, `WcoJoin`,
+/// `ExpandVarLength`) still hand back a fully-materialized stream. A
+/// high-fan-out query can still exhaust memory in phase A.
+///
+/// # Failure after the first chunk
+///
+/// The status line is chosen before any byte is written, so a failure that
+/// surfaces mid-stream — an executor error, or a row that fails to serialize —
+/// can only ABORT the body. It does that rather than emit the closing
+/// `],"stats":{…}}`, because truncated-but-parsable JSON would be read by the
+/// client as a complete, shorter result. The client observes a 200 with an
+/// incomplete body (a broken chunked transfer), not an error status.
+fn stream_graph_rows(
+    columns: Vec<String>,
+    rows: crate::executor::stream::RowStream<'static>,
+    finish: StatsFinalizer,
+) -> Response {
     use futures::stream::StreamExt as _;
 
-    let crate::executor::GraphResult {
-        columns,
-        rows,
-        stats,
-    } = result;
-
+    // Built eagerly: a failure here still happens before the status is chosen.
     let head = match serde_json::to_string(&columns) {
         Ok(cols) => format!("{{\"columns\":{cols},\"rows\":["),
         Err(e) => {
@@ -491,37 +534,44 @@ fn stream_graph_result(result: crate::executor::GraphResult) -> Response {
                 .into_response()
         }
     };
-    let tail = match serde_json::to_string(&stats) {
-        Ok(st) => format!("],\"stats\":{st}}}"),
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": format!("encode stats: {e}") })),
-            )
-                .into_response()
+
+    let mut rows = rows;
+    let body_stream = async_stream::stream! {
+        yield Ok::<_, std::io::Error>(head);
+
+        let mut emitted = 0usize;
+        while let Some(row) = rows.next().await {
+            let row = match row {
+                Ok(row) => row,
+                // Fail loud: abort mid-body rather than close the JSON around a
+                // short result the client cannot distinguish from a complete one.
+                Err(e) => {
+                    yield Err(std::io::Error::other(format!("row {emitted}: {e}")));
+                    return;
+                }
+            };
+            let mut chunk = String::new();
+            if emitted > 0 {
+                chunk.push(',');
+            }
+            match serde_json::to_string(&row) {
+                Ok(encoded) => chunk.push_str(&encoded),
+                Err(e) => {
+                    yield Err(std::io::Error::other(format!("encode row {emitted}: {e}")));
+                    return;
+                }
+            }
+            emitted += 1;
+            yield Ok(chunk);
+        }
+
+        // Only now are the stats final.
+        let stats = finish(emitted);
+        match serde_json::to_string(&stats) {
+            Ok(st) => yield Ok(format!("],\"stats\":{st}}}")),
+            Err(e) => yield Err(std::io::Error::other(format!("encode stats: {e}"))),
         }
     };
-
-    let body_stream = futures::stream::once(async move { Ok::<_, std::io::Error>(head) })
-        .chain(
-            futures::stream::iter(rows.into_iter().enumerate()).map(|(i, row)| {
-                let mut chunk = String::new();
-                if i > 0 {
-                    chunk.push(',');
-                }
-                match serde_json::to_string(&row) {
-                    Ok(encoded) => {
-                        chunk.push_str(&encoded);
-                        Ok(chunk)
-                    }
-                    // Fail loud: abort the body rather than emit truncated-but-parsable JSON.
-                    Err(e) => Err(std::io::Error::other(format!("encode row {i}: {e}"))),
-                }
-            }),
-        )
-        .chain(futures::stream::once(async move {
-            Ok::<_, std::io::Error>(tail)
-        }));
 
     Response::builder()
         .status(StatusCode::OK)
@@ -814,6 +864,15 @@ pub async fn start_graph_disabled_http(config: &GraphHttpConfig) -> crate::error
 mod tests {
     use super::*;
 
+    use crate::executor::stream::{stream_from_rows, RowStream};
+
+    /// A finalizer that ignores the row count and returns fixed stats, so the
+    /// byte-identity assertion stays deterministic (the production finalizer
+    /// stamps a wall-clock `execution_ms`).
+    fn fixed_stats(stats: crate::executor::QueryStats) -> StatsFinalizer {
+        Box::new(move |_rows| stats)
+    }
+
     /// The streamed body MUST be byte-identical to what `Json(result)` produced,
     /// or every existing client breaks on a change that was supposed to be pure
     /// plumbing. Field order, separators, and escaping all have to match serde's
@@ -838,14 +897,20 @@ mod tests {
         ];
 
         for rows in cases {
+            // The rows now arrive as a stream, so the expected value is built
+            // from the same rows the stream will yield.
             let result = crate::executor::GraphResult {
                 columns: vec!["x".to_string(), "y".to_string()],
-                rows,
+                rows: rows.clone(),
                 stats: crate::executor::QueryStats::default(),
             };
             let expected = serde_json::to_string(&result).expect("serde encodes the result");
 
-            let resp = stream_graph_result(result);
+            let resp = stream_graph_rows(
+                result.columns.clone(),
+                stream_from_rows(rows),
+                fixed_stats(crate::executor::QueryStats::default()),
+            );
             assert_eq!(resp.status(), StatusCode::OK);
             let got = axum::body::to_bytes(resp.into_body(), usize::MAX)
                 .await
@@ -857,6 +922,135 @@ mod tests {
                 "streamed body diverged from Json(result)"
             );
         }
+    }
+
+    /// The trailing `"stats"` object is built AFTER the last row, not captured
+    /// up front — `execution_ms` is not knowable until the stream drains.
+    ///
+    /// Asserted by having the finalizer observe a counter that the row stream
+    /// itself increments: if `stats` were serialized eagerly the finalizer would
+    /// see 0 rows, and the body would report 0.
+    #[tokio::test]
+    async fn stats_are_built_after_the_last_row_not_captured_up_front() {
+        use futures::stream::StreamExt as _;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let pulled = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&pulled);
+        let rows: RowStream<'static> = Box::pin(
+            stream_from_rows(vec![
+                vec![serde_json::json!(1)],
+                vec![serde_json::json!(2)],
+                vec![serde_json::json!(3)],
+            ])
+            .inspect(move |_| {
+                counter.fetch_add(1, Ordering::SeqCst);
+            }),
+        );
+
+        let observed = Arc::clone(&pulled);
+        let resp = stream_graph_rows(
+            vec!["n".to_string()],
+            rows,
+            Box::new(move |row_count| crate::executor::QueryStats {
+                // Two independent witnesses that the finalizer ran last: the
+                // row count handed to it, and what the stream had produced.
+                vertices_read: row_count,
+                edges_read: observed.load(Ordering::SeqCst),
+                ..Default::default()
+            }),
+        );
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("streamed body collects");
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&body).expect("body is well-formed JSON");
+        assert_eq!(parsed["stats"]["vertices_read"], serde_json::json!(3));
+        assert_eq!(parsed["stats"]["edges_read"], serde_json::json!(3));
+    }
+
+    /// The response is NOT buffered server-side: its first chunk is deliverable
+    /// while the rows are still unproduced.
+    ///
+    /// This is the property the whole change exists for. The row stream here
+    /// cannot yield until it is released, so a handler that collected rows
+    /// before writing the body would deadlock at the first `next()` instead of
+    /// handing back the head.
+    #[tokio::test]
+    async fn the_response_head_is_deliverable_before_any_row_exists() {
+        use futures::stream::StreamExt as _;
+
+        let (release, released) = tokio::sync::oneshot::channel::<()>();
+        let rows: RowStream<'static> = Box::pin(futures::stream::once(async move {
+            released.await.expect("release signal");
+            Ok(vec![serde_json::json!(1)])
+        }));
+
+        let resp = stream_graph_rows(
+            vec!["n".to_string()],
+            rows,
+            fixed_stats(crate::executor::QueryStats::default()),
+        );
+        let mut chunks = resp.into_body().into_data_stream();
+
+        let head = chunks
+            .next()
+            .await
+            .expect("a head chunk before the rows")
+            .expect("head chunk is not an error");
+        assert_eq!(
+            head.as_ref(),
+            br#"{"columns":["n"],"rows":["#,
+            "the head must be on the wire before the first row is produced"
+        );
+
+        // Only now let the row through.
+        release.send(()).expect("body stream is still alive");
+        let mut rest = Vec::new();
+        while let Some(chunk) = chunks.next().await {
+            rest.extend_from_slice(&chunk.expect("no mid-stream failure"));
+        }
+        assert_eq!(
+            String::from_utf8(rest).expect("utf8"),
+            format!(
+                "[1]],\"stats\":{}}}",
+                serde_json::to_string(&crate::executor::QueryStats::default()).unwrap()
+            )
+        );
+    }
+
+    /// An executor error that surfaces AFTER the first chunk is on the wire must
+    /// ABORT the body. Emitting the closing `],"stats":{…}}` anyway would produce
+    /// truncated-but-parsable JSON — a silently short result, which is strictly
+    /// worse than a broken connection.
+    ///
+    /// The client-visible consequence is spelled out here because it is a real
+    /// limitation, not an implementation detail: the status line (200) is
+    /// already sent, so the failure can only appear as an aborted/incomplete
+    /// response body, never as a 4xx/5xx.
+    #[tokio::test]
+    async fn mid_stream_error_aborts_the_body_instead_of_closing_the_json() {
+        let rows: RowStream<'static> = Box::pin(futures::stream::iter(vec![
+            Ok(vec![serde_json::json!(1)]),
+            Err(crate::error::GraphError::Internal("boom".to_string())),
+        ]));
+
+        let resp = stream_graph_rows(
+            vec!["n".to_string()],
+            rows,
+            fixed_stats(crate::executor::QueryStats::default()),
+        );
+        // The status was already chosen before any byte was written.
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let err = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect_err("a mid-stream failure must abort the body, not complete it");
+        assert!(
+            err.to_string().contains("boom"),
+            "the abort must carry the underlying cause, got: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-on to #305 (this commit was pushed after #305 merged, so it needs its own PR).

The HTTP handler held every row in a `GraphResult` before writing the body. It now consumes a `RowStream` to the wire.

## The blocker

`Body::from_stream` requires `Stream + Send + 'static`, but `RowStream<'a>` borrows — `engine.rs` used `write_path.load()`, an `arc_swap::Guard` that is a frame local, plus borrows of `Arc<Schema>` and the virtual-table registry. A stream holding those cannot outlive the handler.

## Solved with an owned-handle wrapper, not a forked dispatch

`execute_streaming_owned` moves an `OwnedExecCtx` into an `async_stream` generator and calls the **existing** `execute_streaming` inside it, so the executor's borrows become borrows of the generator's own locals — legal across yield points, invisible from outside. Yields `RowStream<'static>` with no per-row clone, no spawned task, and one executor implementation. `execute`, `execute_streaming` and `execute_streaming_inner` are untouched.

The generator's first item is the head (columns + stats), peeled back off so **setup errors still return `Err`** and the HTTP layer can still choose a status code.

## Scope — this bounds the response, not the query

**The OOM is not fixed.** Phase A of `Expand` still materializes the frontier before the first row is projected, and every non-converted variant (`UNION` without `ALL`, `DeleteNodes`, `Aggregate`, ORDER BY, `WcoJoin`, `ExpandVarLength`, virtual anchors, `FOREACH`, `CALL {}`) still buffers and is handed back as an already-full stream. A high-fan-out query can still exhaust memory. Tracked on t_4ce82a3e.

## What a client sees when a query fails after N rows

The 200 and the first chunk are already on the wire, so there is no status left to choose. The body is **aborted** — the closing `],"stats":{...}}` is never written, so the response does not parse as JSON. A client must treat an unterminated body as failure, **not** as an empty tail. `error_to_response` still maps status correctly for setup failures, which return before any byte is written. This is inherent to chunked responses and is now documented in `http.rs` and the spec.

Relatedly, the completion log moved to the end of the body, so a client that disconnects mid-stream produces no `graph query completed` line.

## Stats

Built by a `StatsFinalizer` run **after** the stream drains rather than captured up front, so `execution_ms` on the HTTP path now covers the whole query instead of just setup — larger, and more accurate. Internal collect callers (`execute()`, Bolt) still see the setup-only number.

## Byte-identity preserved, not relaxed

`streamed_body_is_byte_identical_to_json_serialization` still asserts equality with `serde_json::to_string(&GraphResult)`, now building the expected value from the same rows the stream yields, with a deterministic stats finalizer so the assertion cannot race the clock.

Three new HTTP tests pin behavior only a truly streaming handler can satisfy:
- the response head is deliverable before any row exists (a buffering handler deadlocks)
- stats are built after the last row
- a mid-stream error aborts the body instead of closing the JSON

## Not done

`bolt/server.rs` untouched — it stores results in a connection struct across protocol messages and emits stats before rows; it needs its own pass. Sequential-vs-concurrent hop split untouched. DELETE/Aggregate/ORDER BY/WcoJoin/ExpandVarLength not converted.

`async-stream` added to `ferrosa-graph`; it was already in `Cargo.lock` transitively, so no new dependency enters the build.

## Verification

399 lib + 95 integration tests green; `clippy --all-targets` zero warnings with no `#[allow]` added; `cargo doc -D warnings` clean; workspace builds.