### PR TITLE
fix(sparql): stream the scan path and fail loud at a real bound (t_33a231e7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,6 +2654,7 @@ dependencies = [
  "ferrosa-schema",
  "ferrosa-sstable",
  "ferrosa-storage",
+ "futures",
  "oxrdf",
  "serde",
  "serde_json",

--- a/ferrosa-sparql/Cargo.toml
+++ b/ferrosa-sparql/Cargo.toml
@@ -22,6 +22,9 @@ ferrosa-cluster = { path = "../ferrosa-cluster" }
 ferrosa-storage = { path = "../ferrosa-storage" }
 ferrosa-schema = { path = "../ferrosa-schema" }
 
+# Streaming range scans (`StreamExt::next` over WritePath's partition stream)
+futures = "0.3"
+
 # HTTP server
 axum = "0.8"
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }

--- a/ferrosa-sparql/README.md
+++ b/ferrosa-sparql/README.md
@@ -55,9 +55,53 @@ LIMIT/OFFSET) → **shape** (ASK boolean / CONSTRUCT+DESCRIBE graph assembly in
 
 Each triple pattern is planned into the cheapest storage access it can prove:
 `SubjectLookup` (point read on the partition key) when the subject is bound,
-`PredicateScan`/`FullScan` (range read) otherwise, `ObjectScan` (secondary index
-on `object`, falling back to range scan) when only the object is bound, or
-`PropertyPath` (BFS) for closure operators.
+`PredicateScan`/`FullScan` (streaming range read) otherwise, `ObjectScan`
+(secondary index on `object`, falling back to a streaming range scan) when only
+the object is bound, or `PropertyPath` (BFS) for closure operators. The access
+path is only a *pushdown*: every constant in the triple pattern is enforced
+again when a row is bound, so choosing a path on one constant never discards
+another.
+
+### Scans stream, and the bound is real
+
+Range scans pull **one partition at a time** from
+`WritePath::range_read_stream_all` — the same streaming primitive the CQL path
+uses — decode each row, filter it, and bind it immediately. No intermediate
+`Vec` of fetched triples exists, so the memory a scan costs is one partition
+rather than the table. `SELECT * WHERE { ?s ?p ?o }` no longer materializes the
+whole triple store.
+
+`SparqlConfig::max_rows` (default `100_000`) is the engine's single row bound.
+It is enforced in two places, both real:
+
+- **at the source** — storage rows read by a scan, counted as they arrive;
+- **at each operator** — solutions buffered by a pattern, counted as appended.
+
+Crossing either returns `SparqlError::Execution`. **Nothing is silently
+truncated**: a clipped result reported as complete is indistinguishable from a
+correct short one, which is worse than a failure. This replaces the former
+`SCAN_ROW_CAP` constant, which only logged "scan results truncated at row cap"
+*after* the whole table had already been materialized and truncated nothing, and
+the former `SparqlConfig::max_results` field, which nothing read.
+
+`LIMIT` is pushed **into** the scan — the scan stops after `offset + limit`
+solutions — whenever that is provably safe: exactly one triple pattern, and no
+`ORDER BY`, `DISTINCT`, `FILTER`, or `CONSTRUCT`/`DESCRIBE` above it. Those
+operators either block (they must see every solution before emitting one) or
+drop rows after binding (so stopping early would return too few), and in each
+case the scan runs to completion under the bound instead. `ASK` is planned with
+`LIMIT 1`, so it terminates on the first match.
+
+### What is and is not bounded
+
+| Path | Status |
+|------|--------|
+| Single-pattern scan (`FullScan`, `PredicateScan`, `ObjectScan` fallback) | **Streamed and bounded.** One partition resident; `max_rows` enforced at the source. |
+| `SubjectLookup` point read | **Bounded** by one partition, by construction. |
+| `LIMIT`/`OFFSET`/`ASK` over a single pattern | **Bounded by the query**; the scan stops at `offset + limit`. |
+| `ORDER BY` / `DISTINCT` buffers | **Bounded, fail-loud.** They may buffer (both are blocking) but cannot exceed `max_rows`. |
+| Property-path adjacency (BFS) | **Streamed read, bounded buffer.** BFS is blocking, so the adjacency list is buffered; past `max_rows` it errors rather than traversing a partial graph. |
+| Multi-pattern join intermediates | **Bounded, NOT pipelined.** The nested-loop join still rebuilds a materialized solution set per pattern, so peak memory for a multi-pattern BGP is set by the intermediates, not by the scan. They are capped at `max_rows` and fail loud past it; pipelining the join is a separate redesign (FMEA SP-6). |
 
 ## Public API (key entry points)
 
@@ -66,7 +110,7 @@ on `object`, falling back to range scan) when only the object is bound, or
 | Engine | `SparqlEngine::{new, execute, execute_update}`, `SparqlConfig`, `SparqlResult`, `ConstructedTriple` |
 | HTTP | `start_sparql_http`, `build_router` (internal), `SparqlHttpConfig`, `AppState` |
 | Planner | `plan_query`, `plan_where`, `QueryPlan`, `TripleOp`, `GraphQueryMode`, `OrderCondition` |
-| Executor | `execute`, `execute_bindings`, `extract_subject_from_key`, `clustering_component` |
+| Executor | `execute`, `execute_bindings`, `ExecutionLimits`, `DEFAULT_MAX_ROWS`, `extract_subject_from_key`, `clustering_component` |
 | Update | `execute_update`, `UpdateResult` |
 | Triple store | `rdf_triples_schema`, `triples_table_id`, `partition_key`, `RdfTriple`, `ObjectType` |
 | Results | `SparqlJsonResults`, `Binding`, `SparqlAskResult`, `ResultFormat` |
@@ -76,8 +120,11 @@ on `object`, falling back to range scan) when only the object is bound, or
 
 **Calls** (ferrosa crates this depends on):
 
-- **`ferrosa-cluster`** — `write_path::WritePath` for all reads
-  (`read`, `range_read`, `index_read`) on the query/path side.
+- **`ferrosa-cluster`** — `write_path::WritePath` for all reads on the
+  query/path side: `read` (point), `index_read` (keyed), and
+  `range_read_stream_all` (streaming scan). The `Vec`-returning `range_read` is
+  **not** used and a unit tripwire (`sparql_scans_never_call_a_materializing_range_read`)
+  fails the build if it is reintroduced.
 - **`ferrosa-storage`** — `engine::StorageEngine` (`write`, `register_table`) for
   the UPDATE write/tombstone path; `TableId`.
 - **`ferrosa-common`** — `CellValue`, `DecoratedKey`/`PartitionKey`, schema
@@ -88,8 +135,9 @@ on `object`, falling back to range scan) when only the object is bound, or
 - **`ferrosa-schema`** — `Schema` carried in `AppState`.
 
 External: `spargebra`, `sparesults`, `oxrdf` (all with `sparql-12`/`rdf-12`),
-`axum`, `tokio`, `tower-http`, `serde`/`serde_json`, `serde_urlencoded`,
-`base64` (declared, currently unused), `uuid`, `tracing`.
+`axum`, `tokio`, `futures` (`StreamExt` over the partition stream), `tower-http`,
+`serde`/`serde_json`, `serde_urlencoded`, `base64` (declared, currently unused),
+`uuid`, `tracing`.
 
 **Called by** (crates that depend on this):
 
@@ -97,11 +145,27 @@ External: `spargebra`, `sparesults`, `oxrdf` (all with `sparql-12`/`rdf-12`),
 
 ## Tests
 
-110 tests: 79 in-crate unit tests (executor 21, planner 14, property_path 11,
-results 11, engine 8, filter 7, plus rdf_star/update/triple_store/namespace) and
-31 integration tests (`sparql_m3_completeness` 14, `sparql_update_s02_mgmt` 11,
-`sparql_update_pattern_delete` 6). Coverage gaps — OPTIONAL, real UNION
-semantics, auth, property-path cost — are tracked in
+83 in-crate unit tests plus 5 integration suites.
+
+**Invariant suites** — these drive `executor::execute` END TO END (a real
+`QueryPlan` from the real planner, a real `WritePath` over a temp
+`StorageEngine`, real rows written by `INSERT DATA`) and assert what MUST be
+true of a SPARQL engine, rather than describing what the code currently does:
+
+- `tests/sparql_executor_invariants.rs` — constant-term enforcement in every
+  position, read-path agreement between a point lookup and a full scan, delete
+  honesty, LIMIT/OFFSET totality over any `usize`, DISTINCT exactness.
+  **4 of these currently FAIL** against t_af4eb9f0; see
+  [specs/fmea.md](specs/fmea.md) SP-11.
+- `tests/sparql_scan_bound_invariants.rs` (10) — completeness (complete result
+  or an error, never a silent truncation) and boundedness (`LIMIT n` does not
+  read the whole table), asserted without timing by setting `max_rows` below the
+  table size so "did this read everything?" is directly observable.
+
+**Behavioural suites**: `sparql_m3_completeness` (14),
+`sparql_update_s02_mgmt` (11), `sparql_update_pattern_delete` (6).
+
+Coverage gaps — OPTIONAL, real UNION semantics, auth, join cost — are tracked in
 [specs/fmea.md](specs/fmea.md).
 
 ## Specs

--- a/ferrosa-sparql/specs/fmea.md
+++ b/ferrosa-sparql/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-sparql
 doc: fmea
-last_updated: 2026-06-19
+last_updated: 2026-07-25
 ---
 
 # ferrosa-sparql — FMEA / Known Issues
@@ -15,24 +15,35 @@ surface area, so both correctness-coverage and security gaps dominate.
 | SP-1 | **No authentication or authorization.** `SparqlError::AccessDenied` and `AppState::auth_disabled` exist but no handler ever checks credentials; `base64` is a declared-but-unused dep. `auth_disabled` only toggles health-check verbosity. | Any network client can `SELECT`, `INSERT DATA`, `DELETE WHERE`, or `DROP` against any keyspace. Full read+write data exposure. | 10 | 8 | 3 | **240** | **Open gap.** No mitigation in this crate. The `X-Keyspace` header is attacker-controlled. Must add an auth layer (token/mTLS) before any untrusted exposure. |
 | SP-2 | **OPTIONAL (LeftJoin) right side silently dropped.** `collect_ops` evaluates only the left side of a `LeftJoin` and logs `warn!`; the optional pattern never binds. | `OPTIONAL { … }` returns rows missing the optional variables — a silent wrong (incomplete) result, not an error. | 8 | 6 | 7 | **336** | **Open gap.** Only a `tracing::warn!` fires; the HTTP client sees a 200 with wrong bindings. Should fail loud or implement the left-join. |
 | SP-3 | **UNION is concatenation, not a true two-branch union.** Both `Union` arms append their `TripleOp`s into one flat `ops` list, then run through the same nested-loop join. | UNION of two BGPs is joined rather than unioned; cross-branch variable bindings can over- or under-constrain. Wrong result set for any non-trivial UNION. | 8 | 5 | 7 | **280** | **Open gap.** Tested only for parse/plan, not for join semantics. Needs branch-isolated evaluation then set union. |
-| SP-4 | **Property paths load the entire predicate adjacency into memory.** `fetch_triples_for_predicate` does a full `range_read` of the table, filters by predicate in-process, then BFS. No bound on adjacency size; `range_read` itself is capped at 10k partitions elsewhere but not here. | A `knows+` over a large graph buffers all `knows` edges in a `Vec` and BFS over them — unbounded memory + latency; a single query can OOM or stall the node. | 7 | 5 | 5 | **175** | **Partial.** BFS has cycle detection and is correct; cost is unbounded. Needs a hop/row cap and index-driven neighbor fetch (violates Power-of-10 Rule 2/3). |
-| SP-5 | **Scan results truncated at a 10k row cap, returning partial answers as success.** `SCAN_ROW_CAP = 10_000`; on `PredicateScan`/`FullScan`/ObjectScan fallback the executor logs `warn!` and returns the truncated set. | A query over >10k partitions returns an incomplete result with a 200 OK — silent under-reporting. | 7 | 4 | 7 | **196** | **Partial.** Logged, but not surfaced to the client. Should return a "results truncated" signal or paginate. |
+| SP-4 | **Property-path BFS buffers the predicate adjacency.** `fetch_triples_for_predicate` now STREAMS the table (`range_read_stream_all`) and keeps only matching `(subject, object)` pairs, but BFS is a blocking operator so the adjacency list itself is still buffered. | A `knows+` over a very large graph buffers all `knows` edges before traversing. Memory is now capped, not unbounded. | 5 | 4 | 3 | **60** | **Mitigated.** The read streams; the adjacency buffer is bounded by `SparqlConfig::max_rows` and exceeding it returns `SparqlError::Execution` rather than traversing a partial graph (a partial adjacency would give a wrong reachability answer that looks complete). Index-driven neighbour expansion is still the right long-term fix. |
+| SP-5 | ~~**Scan results truncated at a 10k row cap.**~~ The `SCAN_ROW_CAP = 10_000` constant truncated **nothing**: both uses were a `tracing::warn!` fired *after* `range_read` had already materialized the whole table, and the warning text ("scan results truncated at row cap") was false. `SparqlConfig::max_results` was likewise dead — zero reads workspace-wide. | Unbounded materialization of the full table (the real OOM), plus a log line asserting a truncation that never happened. | 8 | 6 | 8 | **384** | **FIXED.** Scans stream via `range_read_stream_all`; both fictions are deleted and replaced by one real bound, `SparqlConfig::max_rows`, enforced at the source and on every operator buffer. Crossing it returns `SparqlError::Execution` — never a silent truncation. `LIMIT` is pushed into the scan when provably safe. Covered by `tests/sparql_scan_bound_invariants.rs`. |
 | SP-6 | **Multi-pattern joins are O(rows^patterns) nested-loop with no index-driven join.** `evaluate_standard_op` cross-products existing bindings against every fetched row per pattern. | A 3+ pattern BGP over moderate data degrades quadratically/cubically; latency spikes, possible request timeout. | 6 | 5 | 5 | **150** | **Open gap.** Correct but not scalable. No join reordering or hash join. |
 | SP-7 | **RDF\* annotation queries unsupported but parseable.** `<< s p o >> :prop ?v` parses (sparql-12) but `plan_triple_pattern` / `rdf_star.rs` reject it. | Users expecting RDF-star annotations get a 400. Feature appears available (parses) but is not. | 4 | 3 | 2 | **24** | **By design, fail-loud.** Documented in `rdf_star.rs`; returns `SparqlError::Plan`, never a silent wrong binding. Lowest-risk gap. |
 | SP-8 | **Turtle output is an N-Triples subset; CONSTRUCT XML is ad-hoc RDF/XML.** `to_turtle` delegates to `to_ntriples`; CONSTRUCT XML is hand-built, not via `oxrdf`/`sparesults` serializers. | Clients requesting `text/turtle` get valid-but-unprefixed/ungrouped output; RDF/XML may mishandle literals with special structure. | 3 | 5 | 4 | **60** | **Partial.** Output is valid N-Triples (a valid Turtle subset). Full Turtle/RDF-XML deferred. |
 | SP-9 | **`datatype`/`language` columns read with `from_utf8_lossy`; lossy on non-UTF-8 bytes.** Object/predicate/datatype decoding uses `String::from_utf8_lossy` throughout the executor. | A non-UTF-8 stored value is silently mangled (replacement chars) rather than erroring. | 4 | 2 | 6 | **48** | **Partial.** RDF terms are UTF-8 by construction here, so occurrence is low; still a silent-corruption path. |
 | SP-10 | **`ObjectScan` index fallback can't distinguish empty index from no-index.** `fetch_by_object_index` treats an empty `index_read` as "no index" and falls back to a full scan. | If the object genuinely has no matches, the engine still pays for a full range scan; correctness OK, cost surprise. | 3 | 4 | 5 | **60** | **Partial.** Documented in code; performance-only, not a correctness bug. |
+| SP-11 | **Writes and reads disagree about the graph partition-key component (t_af4eb9f0).** `update.rs` maps `GraphName::DefaultGraph` to the literal string `"default"` when building the partition key, while the planner sets the graph component from the KEYSPACE. On any keyspace other than `default` — **including `rdf`, the keyspace the HTTP endpoint defaults to** — a point read computes a key that no row was written under. | A `SubjectLookup` returns nothing for data a full scan finds, so two access paths disagree about whether a triple exists. `DELETE` reports a non-zero `triples_deleted` while tombstoning keys that hold nothing, so the data survives — a silent data-integrity lie. | 9 | 8 | 4 | **288** | **OPEN — needs a decision, not a patch.** Fixing the read side (use `"default"`) is backward-compatible with existing data; fixing the write side (use the keyspace) orphans every row already written. Someone must decide whether the default graph is named by the keyspace or by the constant. Four failing tests in `tests/sparql_executor_invariants.rs` pin the invariants: `constant_subject_matches_exactly_that_subjects_triples`, `constant_subject_and_object_are_both_enforced`, `point_lookup_and_full_scan_agree_on_existence`, `reported_delete_actually_removes_the_data`. The existing behavioural suites hide this by pinning `KS = "default"`. |
+| SP-12 | ~~**Constant terms in a triple pattern were never enforced (t_c3a2d3e4).**~~ `try_bind_triple` handled only the `Variable` arms, so a constant in a position the access path was not chosen on was silently dropped: `?s <ex:status> "active"` planned a `PredicateScan` and returned subjects with ANY status. Separately, the planner keyed `ObjectScan` on `Literal::to_string()` — the quoted N-Triples form `"Alice"` — against the bare stored lexical `Alice`, so a literal-object pattern matched nothing. | Silent wrong results in both directions: too many rows (dropped constant) and zero rows (quoted literal). | 8 | 7 | 8 | **448** | **FIXED.** Constants are enforced in all three positions, with term-kind checking (an IRI constant no longer matches a literal spelling the same characters), and the planner keys `ObjectScan` on `Literal::value()`. Covered by the I1 invariants in `tests/sparql_executor_invariants.rs`. |
+| SP-13 | ~~**`OFFSET k LIMIT n` computed `k + n` as an unchecked `usize` add.**~~ Both values come straight from attacker-controlled query text. `OFFSET 1 LIMIT 18446744073709551615` panicked in debug and wrapped to 0 in release, silently returning no rows. | Debug panic / release silent-empty from a 60-byte query. | 7 | 5 | 6 | **210** | **FIXED** with `saturating_add`. This was a prerequisite for streaming: the accidental `.min(len)` clamp that masked the wrap only worked because a materialized `Vec` had a `len()` to clamp against. Covered by `limit_and_offset_never_overflow_for_any_usize`. |
 
 ## Top risks to act on
 
-1. **SP-2 (RPN 336) — OPTIONAL silently dropped.** The highest-RPN correctness
-   bug: a common, well-formed query returns wrong (incomplete) results with a
-   200. Either implement the left-join or fail loud like the other gaps.
-2. **SP-1 (RPN 240) — no auth.** Severity-10 security gap: the endpoint is fully
+1. **SP-11 (RPN 288) — read/write graph-key mismatch.** The highest open
+   correctness risk, and it fires on the DEPLOYED default keyspace (`rdf`).
+   Point reads miss data that scans find, and `DELETE` reports success while
+   deleting nothing. Needs an owner decision on which side to change.
+2. **SP-2 (RPN 336) — OPTIONAL silently dropped.** A common, well-formed query
+   returns wrong (incomplete) results with a 200. Either implement the left-join
+   or fail loud like the other gaps.
+3. **SP-1 (RPN 240) — no auth.** Severity-10 security gap: the endpoint is fully
    unauthenticated read+write across keyspaces. The `X-Keyspace` header is the
    only tenancy boundary and it is client-supplied.
-3. **SP-3 (RPN 280) — UNION semantics.** Plausible queries silently get join
+4. **SP-3 (RPN 280) — UNION semantics.** Plausible queries silently get join
    instead of union semantics.
+
+Resolved this cycle: **SP-5** (fictional scan cap → real streaming + fail-loud
+bound), **SP-12** (constant terms never enforced), **SP-13** (LIMIT/OFFSET
+overflow). **SP-4** downgraded from unbounded to bounded.
 
 ## Detection assets
 
@@ -42,7 +53,17 @@ surface area, so both correctness-coverage and security gaps dominate.
   LOAD fail-loud.
 - `tests/sparql_update_s02_mgmt.rs` (11) — CLEAR/DROP/CREATE, atomicity,
   cross-graph rejection.
-- 79 in-crate unit tests (executor join/decode, planner access selection,
-  property-path BFS, filter evaluation).
-- **No** test today covers OPTIONAL semantics, true UNION semantics, auth, or
-  property-path memory bounds — the SP-1/2/3/4 blind spots.
+- `tests/sparql_executor_invariants.rs` (21) — the first END-TO-END tests of
+  `executor::execute`. Constant-term enforcement in every position, read-path
+  agreement, delete honesty, LIMIT/OFFSET totality, DISTINCT exactness. Run on
+  the DEPLOYED keyspace (`rdf`), not on `default`, so SP-11 is visible rather
+  than hidden. **4 fail today** — that is SP-11, deliberately not weakened.
+- `tests/sparql_scan_bound_invariants.rs` (10) — completeness and boundedness:
+  a scan past the bound errors instead of truncating, a scan within it returns
+  the complete result, `LIMIT n` stops early, and blocking operators
+  (ORDER BY / DISTINCT) and `FILTER` correctly refuse the pushdown.
+- 83 in-crate unit tests (executor join/decode/filter, planner access selection,
+  property-path BFS, filter evaluation), including a source tripwire that fails
+  the build if the `Vec`-returning `WritePath::range_read` is reintroduced.
+- **No** test today covers OPTIONAL semantics, true UNION semantics, or auth —
+  the SP-1/2/3 blind spots.

--- a/ferrosa-sparql/specs/overview.md
+++ b/ferrosa-sparql/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-sparql
 status: implemented
-last_updated: 2026-06-19
+last_updated: 2026-07-25
 executive_summary: >
   The SPARQL 1.1 Query + Update endpoint for ferrosa. Parses SPARQL with
   spargebra/oxrdf, plans algebra into TripleOps over a single CQL-backed
@@ -41,9 +41,9 @@ rejected, never silently mapped onto the default graph.
 |--------|----------------|
 | `engine` (`src/engine.rs`, ~600 LoC) | `SparqlEngine`: parse→plan→execute orchestration, `SparqlResult`, ASK/CONSTRUCT/DESCRIBE graph assembly, JSON/XML/NT/Turtle dispatch |
 | `planner` (`src/planner.rs`, ~770 LoC) | `spargebra` algebra → `QueryPlan` of `TripleOp`s; per-pattern access-method selection; CONSTRUCT/DESCRIBE mode detection |
-| `executor` (`src/executor.rs`, ~970 LoC) | Nested-loop join over triple patterns, FILTER/ORDER BY/DISTINCT/LIMIT, composite-key decode, tombstone skipping, ObjectScan index |
+| `executor` (`src/executor.rs`, ~1150 LoC) | Streaming triple-pattern scans + `ExecutionLimits` row bound, LIMIT pushdown, nested-loop join, constant-term enforcement, FILTER/ORDER BY/DISTINCT/LIMIT, composite-key decode, tombstone skipping, ObjectScan index |
 | `update` (`src/update.rs`, ~730 LoC) | INSERT/DELETE DATA, DELETE WHERE, DELETE/INSERT WHERE, CLEAR, DROP, CREATE; up-front atomicity validation; one shared tombstone primitive |
-| `property_path` (`src/property_path.rs`, ~420 LoC) | `+ * ? ^` evaluation via in-memory BFS with cycle detection |
+| `property_path` (`src/property_path.rs`, ~440 LoC) | `+ * ? ^` evaluation via BFS with cycle detection over a streamed, bounded adjacency read |
 | `filter` (`src/filter.rs`, ~490 LoC) | `Expression` evaluation: comparisons, boolean ops, arithmetic, a function subset; `unsupported_expr` gate for ORDER BY fail-loud |
 | `results` (`src/results.rs`, ~415 LoC) | `Binding`, `SparqlJsonResults`, `ResultFormat`; JSON / W3C XML / N-Triples serializers |
 | `http` (`src/http.rs`, ~234 LoC) | axum router, content negotiation, 1 MiB body limit, error→status mapping |
@@ -59,7 +59,7 @@ flowchart TD
     ENG --> PARSE["spargebra parse<br/>query / update"]
     PARSE --> PLAN["planner::plan_query<br/>algebra to Vec&lt;TripleOp&gt;"]
     PLAN --> EXEC["executor::execute<br/>nested-loop join"]
-    EXEC --> WP["ferrosa-cluster WritePath<br/>read / range_read / index_read"]
+    EXEC --> WP["ferrosa-cluster WritePath<br/>read / range_read_stream_all / index_read"]
     WP --> POST["FILTER to ORDER BY to DISTINCT to LIMIT/OFFSET"]
     POST --> SHAPE{"query form?"}
     SHAPE -->|SELECT| SER["results.rs serialize"]
@@ -73,11 +73,15 @@ flowchart TD
 ```
 
 **Read path.** A bound subject plans to `SubjectLookup` (point read on the
-partition key); a bound predicate to `PredicateScan` (range read + filter); a
-bound object to `ObjectScan` (secondary index `rdf_triples_object_idx`, falling
-back to a capped range scan); nothing bound to `FullScan`. The executor folds
-each `TripleOp`'s rows into the running binding set with a compatibility check on
-both value and `binding_type`.
+partition key); a bound predicate to `PredicateScan` (streaming range scan +
+filter); a bound object to `ObjectScan` (secondary index
+`rdf_triples_object_idx`, falling back to a streaming range scan); nothing bound
+to `FullScan`. Range scans pull one partition at a time from
+`WritePath::range_read_stream_all` and bind each row as it arrives — no
+intermediate `Vec` of fetched triples exists. The executor folds each
+`TripleOp`'s rows into the running binding set with a compatibility check on both
+value and `binding_type`, and enforces every constant term in the pattern (the
+access path is a pushdown, not the whole match).
 
 **Write path.** UPDATE first validates **every** operation (atomicity), then
 applies them sequentially. Inserts write a live row; every delete form funnels
@@ -86,9 +90,18 @@ through one `tombstone_triple` primitive that writes a deletion-marker row with
 
 ## Key invariants
 
-1. **One graph per keyspace.** The `graph` partition-key component equals the
-   keyspace. Operations addressing a different named graph fail loud, never
-   retarget (`check_quad_graph_pattern`, `check_pattern_graph_reads`).
+1. **One graph per keyspace.** Operations addressing a different named graph
+   fail loud, never retarget (`check_quad_graph_pattern`,
+   `check_pattern_graph_reads`).
+
+   > **This invariant is VIOLATED today (FMEA SP-11 / t_af4eb9f0).** The read
+   > side sets the `graph` partition-key component from the KEYSPACE, but
+   > `update.rs` writes it as the literal string `"default"`. The two agree only
+   > when the keyspace *is* `default` — and the HTTP endpoint defaults the
+   > keyspace to `rdf`. On any other keyspace a point read computes a key
+   > nothing was written under, so `SubjectLookup` misses data a `FullScan`
+   > finds and `DELETE` reports success while tombstoning empty keys. Resolving
+   > it requires deciding which side is authoritative; see the roadmap.
 2. **UPDATE atomicity by up-front rejection.** Because execution has no rollback,
    `validate_update` rejects the whole request before any mutation if any op is
    unaddressable — preventing a desugared `Drop` from wiping data before a later
@@ -102,6 +115,23 @@ through one `tombstone_triple` primitive that writes a deletion-marker row with
    `SparqlError::Plan`, not approximate results.
 5. **Deleted rows never surface.** The executor skips any row whose deletion
    marker is non-live (URS-QEC-D05).
+6. **Complete result, or an error — never a silent truncation.**
+   `ExecutionLimits::max_rows` (from `SparqlConfig::max_rows`) is the one row
+   bound. It is enforced at the SOURCE, as storage rows arrive from the
+   partition stream, and on every operator's solution buffer. Crossing it
+   returns `SparqlError::Execution`. Blocking operators (`ORDER BY`, `DISTINCT`,
+   property-path BFS) may buffer but not exceed it.
+7. **A constant is a match constraint in every position.** The access method is
+   chosen from ONE bound term, but `try_bind_triple` re-checks subject,
+   predicate, and object — including term kind, so an IRI constant never matches
+   a literal spelling the same characters. A blank node in a pattern is a
+   non-selectable variable and constrains nothing.
+8. **LIMIT pushdown only where it is provably safe.** The scan stops after
+   `offset + limit` solutions only for a single triple pattern with no
+   `ORDER BY`, `DISTINCT`, `FILTER`, or graph query form above it; those
+   operators either block or drop rows after binding, so an early stop would
+   return the wrong rows or too few. LIMIT/OFFSET arithmetic saturates — both
+   values are attacker-controlled `usize`.
 
 ## Position in the dependency graph
 

--- a/ferrosa-sparql/specs/roadmap.md
+++ b/ferrosa-sparql/specs/roadmap.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-sparql
 doc: roadmap
-last_updated: 2026-06-19
+last_updated: 2026-07-25
 ---
 
 # ferrosa-sparql — Roadmap
@@ -11,6 +11,14 @@ stubs), the FMEA ([fmea.md](fmea.md)), and the dependency/usage review.
 
 ## Now (highest value)
 
+- **Decide the graph/keyspace partition-key contract (FMEA SP-11, t_af4eb9f0).**
+  `update.rs` writes the graph component as the literal `"default"`; the planner
+  reads it from the keyspace. On the deployed keyspace (`rdf`) point reads miss
+  data full scans find, and `DELETE` reports success while deleting nothing.
+  This is a **decision**, not a patch: changing the read side is
+  backward-compatible with data already on disk, changing the write side orphans
+  it. Four invariant tests in `tests/sparql_executor_invariants.rs` are red
+  against this and must not be weakened.
 - **Authentication + authorization (FMEA SP-1).** The endpoint is fully
   unauthenticated read+write. Wire a real auth layer (token / mTLS), make
   `auth_disabled` actually gate request handling, and return
@@ -25,14 +33,22 @@ stubs), the FMEA ([fmea.md](fmea.md)), and the dependency/usage review.
 
 ## Next
 
-- **Bound property-path cost (FMEA SP-4).** Replace the full-adjacency
-  `range_read` + in-memory BFS with index-driven neighbor expansion and a
-  hop/row cap; surface truncation instead of OOM risk.
-- **Surface scan truncation (FMEA SP-5).** When a scan hits `SCAN_ROW_CAP`,
-  return a machine-readable "results truncated" signal (or paginate) rather than
-  a 200 OK with a silently partial body.
-- **Join planning (FMEA SP-6).** Add pattern reordering (most-selective first)
-  and a hash join to escape the nested-loop O(rows^patterns) blowup.
+- **Pipeline the multi-pattern join (FMEA SP-6).** The scan streams, but the
+  nested-loop join still rebuilds a materialized solution set per pattern, so
+  peak memory for a multi-pattern BGP is set by the intermediates rather than by
+  the scan. They are now capped at `max_rows` and fail loud past it, so this is
+  a scalability limit rather than an OOM — but a pattern that could stream
+  end-to-end still cannot. Needs pattern reordering (most-selective first) plus
+  either a pipelined or hash join.
+- **Index-driven property-path expansion (FMEA SP-4).** The adjacency read
+  streams and its buffer is bounded, but BFS still materializes every edge for
+  the predicate before traversing. Expand neighbours through the index instead,
+  with a hop cap.
+- **Paginate instead of failing at the bound.** Crossing `max_rows` is now a
+  loud error, which is correct but blunt: the right answer for a large honest
+  result set is a continuation token over the streaming scan (`ScanResume` in
+  `WritePath` already supports it) rather than asking the operator to raise a
+  limit.
 
 ## Later
 

--- a/ferrosa-sparql/src/engine.rs
+++ b/ferrosa-sparql/src/engine.rs
@@ -6,6 +6,7 @@ use ferrosa_cluster::write_path::WritePath;
 use ferrosa_storage::engine::StorageEngine;
 
 use crate::error::SparqlError;
+use crate::executor::{ExecutionLimits, DEFAULT_MAX_ROWS};
 use crate::planner::{self, GraphQueryMode};
 use crate::results::{SparqlAskResult, SparqlJsonResults};
 
@@ -176,15 +177,24 @@ impl SparqlResult {
 pub struct SparqlConfig {
     /// Default graph name for queries without explicit FROM.
     pub default_graph: String,
-    /// Maximum result rows returned per query.
-    pub max_results: usize,
+    /// The executor's row bound: the most storage rows a single scan may read,
+    /// and the most solutions any operator may buffer.
+    ///
+    /// This replaces the former `max_results` field, which was never read
+    /// anywhere in the workspace, and the former `SCAN_ROW_CAP` constant, which
+    /// only logged a warning claiming results had been "truncated at row cap"
+    /// AFTER the whole table had already been materialized and truncated
+    /// nothing. Unlike both of those, this bound is real: it is enforced at the
+    /// storage scan and on every operator's buffer, and crossing it returns a
+    /// [`SparqlError::Execution`] rather than a silently short result.
+    pub max_rows: usize,
 }
 
 impl Default for SparqlConfig {
     fn default() -> Self {
         Self {
             default_graph: "default".into(),
-            max_results: 10_000,
+            max_rows: DEFAULT_MAX_ROWS,
         }
     }
 }
@@ -194,6 +204,7 @@ pub struct SparqlEngine {
     storage: Arc<StorageEngine>,
     write_path: Arc<WritePath>,
     config: SparqlConfig,
+    limits: ExecutionLimits,
 }
 
 impl SparqlEngine {
@@ -212,10 +223,14 @@ impl SparqlEngine {
         if let Err(e) = storage.register_table(schema) {
             tracing::warn!(%e, "failed to register rdf_triples table for default graph");
         }
+        let limits = ExecutionLimits {
+            max_rows: config.max_rows,
+        };
         Self {
             storage,
             write_path,
             config,
+            limits,
         }
     }
 
@@ -251,7 +266,14 @@ impl SparqlEngine {
             )));
         }
         self.ensure_table_registered(ks);
-        crate::update::execute_update(update_str, ks, &self.storage, &self.write_path).await
+        crate::update::execute_update(
+            update_str,
+            ks,
+            &self.storage,
+            &self.write_path,
+            &self.limits,
+        )
+        .await
     }
 
     /// Execute a SPARQL query and return results.
@@ -289,7 +311,7 @@ impl SparqlEngine {
         let plan = planner::plan_query(&query, graph)?;
 
         // 3. Execute plan against storage.
-        let results = crate::executor::execute(&plan, &self.write_path).await?;
+        let results = crate::executor::execute(&plan, &self.write_path, &self.limits).await?;
 
         // BUG-S6 fix: ASK queries return boolean result format.
         if plan.is_ask {
@@ -303,7 +325,8 @@ impl SparqlEngine {
         // URS-QEC-S01: CONSTRUCT / DESCRIBE return a graph result.
         if let Some(graph_mode) = &plan.graph_mode {
             return Ok(SparqlResult::Graph(
-                build_graph_result(graph_mode, &results, &plan, &self.write_path).await?,
+                build_graph_result(graph_mode, &results, &plan, &self.write_path, &self.limits)
+                    .await?,
             ));
         }
 
@@ -324,6 +347,7 @@ async fn build_graph_result(
     where_results: &SparqlJsonResults,
     plan: &planner::QueryPlan,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<Vec<ConstructedTriple>, SparqlError> {
     use spargebra::term::{NamedNodePattern, TermPattern};
 
@@ -430,7 +454,7 @@ async fn build_graph_result(
                     filters: vec![],
                     graph_mode: None,
                 };
-                let sub = crate::executor::execute(&lookup_plan, write_path).await?;
+                let sub = crate::executor::execute(&lookup_plan, write_path, limits).await?;
                 for row in sub.results.bindings {
                     let pred = match row.get("__p") {
                         Some(b) => b.value.clone(),
@@ -501,7 +525,7 @@ async fn build_graph_result(
                     filters: vec![],
                     graph_mode: None,
                 };
-                let sub_result = crate::executor::execute(&dummy_plan, write_path).await?;
+                let sub_result = crate::executor::execute(&dummy_plan, write_path, limits).await?;
                 for row in sub_result.results.bindings {
                     let pred = match row.get("__p") {
                         Some(b) => b.value.clone(),

--- a/ferrosa-sparql/src/executor.rs
+++ b/ferrosa-sparql/src/executor.rs
@@ -2,24 +2,81 @@
 //!
 //! Executes a [`QueryPlan`] against ferrosa's StorageEngine, producing
 //! binding sets that are serialized into SPARQL results.
+//!
+//! # Streaming scans
+//!
+//! Triple-pattern scans STREAM. A scan pulls one partition at a time from
+//! [`WritePath::range_read_stream_all`], decodes its rows, filters them, and
+//! pushes each surviving triple straight into the binding loop. There is no
+//! intermediate `Vec` of fetched triples, so the memory a scan costs is one
+//! partition — not the table. This is what stops `SELECT * WHERE { ?s ?p ?o }`
+//! (30 bytes of query) from materializing an entire triple store.
+//!
+//! # Bounds
+//!
+//! [`ExecutionLimits::max_rows`] is the executor's ONE row bound. It is checked
+//! at the source (storage rows read by a scan) and on every operator's solution
+//! buffer. Exceeding it is an ERROR, never a truncation: a clipped result
+//! reported as complete is worse than a failure, because the caller cannot tell
+//! the difference. `LIMIT` is pushed INTO the scan whenever it is safe to do so
+//! — one triple pattern, no ORDER BY, DISTINCT, FILTER, or graph query form —
+//! so a bounded query does bounded work rather than reading the whole table and
+//! throwing most of it away.
 
 use std::collections::HashMap;
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use ferrosa_cluster::write_path::WritePath;
-use ferrosa_sstable::types::Row;
+use ferrosa_sstable::types::{Partition, Row};
+use futures::StreamExt;
 
 use crate::error::SparqlError;
 use crate::planner::{QueryPlan, TripleOp};
 use crate::results::{Binding, SparqlJsonResults};
 use crate::triple_store;
 
+/// Default value for [`ExecutionLimits::max_rows`].
+///
+/// Sized so that the worst case an unconstrained query can buffer — one
+/// solution row per storage row — stays in tens of megabytes rather than
+/// exhausting the server. Deployments with larger stores should raise it
+/// deliberately via `SparqlConfig::max_rows` and accept the memory cost.
+pub const DEFAULT_MAX_ROWS: usize = 100_000;
+
+/// The executor's resource bounds.
+///
+/// One number, enforced in two places, both of them real:
+///
+/// - **at the source** — the number of storage rows a single triple-pattern
+///   scan may read, checked as rows are pulled from the partition stream;
+/// - **at each operator** — the number of solutions a pattern may buffer,
+///   checked as solutions are appended.
+///
+/// Crossing either is a [`SparqlError::Execution`]. Nothing is silently
+/// truncated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionLimits {
+    /// Maximum storage rows read per scan, and maximum solutions buffered per
+    /// operator.
+    pub max_rows: usize,
+}
+
+impl Default for ExecutionLimits {
+    fn default() -> Self {
+        Self {
+            max_rows: DEFAULT_MAX_ROWS,
+        }
+    }
+}
+
 /// Execute a query plan and return SPARQL JSON results.
 pub async fn execute(
     plan: &QueryPlan,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<SparqlJsonResults, SparqlError> {
-    let mut binding_sets = evaluate_triple_patterns(plan, write_path).await?;
+    let mut binding_sets = evaluate_triple_patterns(plan, write_path, limits).await?;
 
     // Apply FILTER expressions to binding sets.
     if !plan.filters.is_empty() {
@@ -40,9 +97,19 @@ pub async fn execute(
     }
 
     // BUG-S5 fix: clamp start to len so slicing never panics.
+    //
+    // `offset` and `limit` come straight out of the query text and are
+    // attacker-controlled `usize` values, so `start + limit` MUST saturate:
+    // `OFFSET 1 LIMIT 18446744073709551615` panics in debug and wraps to 0 in
+    // release (silently returning no rows) with an unchecked add. Do not rely
+    // on the trailing `.min(len)` to mask the wrap — it only happens to work
+    // because a materialized `Vec` has a `len()` to clamp against.
     let start = plan.offset.unwrap_or(0).min(binding_sets.len());
-    let end = plan.limit.map(|l| start + l).unwrap_or(binding_sets.len());
-    let end = end.min(binding_sets.len());
+    let end = plan
+        .limit
+        .map(|l| start.saturating_add(l))
+        .unwrap_or(binding_sets.len())
+        .min(binding_sets.len());
 
     let mut results = SparqlJsonResults::new(plan.projection.clone());
     for row in &binding_sets[start..end] {
@@ -66,8 +133,9 @@ pub async fn execute(
 pub async fn execute_bindings(
     plan: &QueryPlan,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
-    let mut binding_sets = evaluate_triple_patterns(plan, write_path).await?;
+    let mut binding_sets = evaluate_triple_patterns(plan, write_path, limits).await?;
 
     if !plan.filters.is_empty() {
         binding_sets.retain(|row| {
@@ -81,11 +149,20 @@ pub async fn execute_bindings(
 }
 
 /// Evaluate all triple patterns via nested-loop join, returning binding sets.
+///
+/// SCOPE NOTE (unchanged by the streaming work): the join itself is still a
+/// nested loop that rebuilds a materialized `binding_sets` per pattern, so for
+/// a multi-pattern query the peak memory is set by the INTERMEDIATE solution
+/// sets, not by the scan. Those intermediates are now *bounded* — appending
+/// past [`ExecutionLimits::max_rows`] is a loud error — but they are not
+/// pipelined. Pipelining the join is a separate redesign.
 async fn evaluate_triple_patterns(
     plan: &QueryPlan,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
     let mut binding_sets: Vec<HashMap<String, Binding>> = vec![HashMap::new()];
+    let budget = scan_budget(plan);
 
     for (tp, op) in &plan.ops {
         let new_bindings = match op {
@@ -94,13 +171,57 @@ async fn evaluate_triple_patterns(
                 subject,
                 path,
                 object,
-            } => evaluate_path_op(graph, subject, path, object, &binding_sets, write_path).await?,
-            _ => evaluate_standard_op(tp, op, &binding_sets, write_path).await?,
+            } => {
+                evaluate_path_op(
+                    graph,
+                    subject,
+                    path,
+                    object,
+                    &binding_sets,
+                    write_path,
+                    limits,
+                )
+                .await?
+            }
+            _ => evaluate_standard_op(tp, op, &binding_sets, write_path, limits, budget).await?,
         };
         binding_sets = new_bindings;
     }
 
     Ok(binding_sets)
+}
+
+/// How many solutions a single-pattern scan must produce before the executor
+/// can stop reading storage — the LIMIT pushdown budget.
+///
+/// `LIMIT` may only be pushed into the scan when every operator between the
+/// scan and the LIMIT preserves both the row count and the row order:
+///
+/// - exactly one triple pattern — a join re-pairs solutions, so pattern *n*'s
+///   rows are not the query's rows;
+/// - no `ORDER BY` and no `DISTINCT` — both are blocking, and the top *n* of a
+///   sorted or deduplicated sequence is not the first *n* rows read;
+/// - no `FILTER` — a filter drops solutions after binding, so stopping at *n*
+///   bound rows can return fewer than *n* results;
+/// - no `CONSTRUCT`/`DESCRIBE`, whose graph result is derived from every
+///   solution rather than from the projected window.
+///
+/// `None` means "read every matching row". That is still bounded by
+/// [`ExecutionLimits::max_rows`] — it is unbounded LIMIT, not unbounded work.
+fn scan_budget(plan: &QueryPlan) -> Option<usize> {
+    if plan.ops.len() != 1
+        || !plan.order_by.is_empty()
+        || plan.distinct
+        || !plan.filters.is_empty()
+        || plan.graph_mode.is_some()
+    {
+        return None;
+    }
+    // OFFSET rows are consumed and discarded downstream, so the scan must
+    // produce `offset + limit` solutions. Saturating: both come from the query
+    // text and `usize::MAX` is a legal LIMIT.
+    plan.limit
+        .map(|l| plan.offset.unwrap_or(0).saturating_add(l))
 }
 
 /// Evaluate a property path op via BFS traversal.
@@ -111,10 +232,12 @@ async fn evaluate_path_op(
     object: &spargebra::term::TermPattern,
     existing_bindings: &[HashMap<String, Binding>],
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
-    let results =
-        crate::property_path::evaluate_property_path(subject, path, object, graph, write_path)
-            .await?;
+    let results = crate::property_path::evaluate_property_path(
+        subject, path, object, graph, write_path, limits,
+    )
+    .await?;
     let path_bindings = crate::property_path::path_results_to_bindings(subject, object, &results);
 
     let mut new_bindings = Vec::new();
@@ -122,29 +245,59 @@ async fn evaluate_path_op(
         for pb in &path_bindings {
             if let Some(merged) = try_merge_bindings(existing, pb) {
                 new_bindings.push(merged);
+                check_solution_bound(new_bindings.len(), limits)?;
             }
         }
     }
     Ok(new_bindings)
 }
 
-/// Evaluate a standard (non-path) triple pattern op.
+/// Evaluate a standard (non-path) triple pattern op against a STREAMING scan.
+///
+/// The loop nesting is triple-major (`for each streamed triple { for each
+/// existing binding }`) rather than the binding-major form it replaced. That
+/// inversion is what lets the triple side stream: a triple is bound and dropped
+/// before the next one is pulled, so no `Vec<FetchedTriple>` ever exists. For
+/// the single-pattern case (`existing_bindings == [{}]`) the emitted order is
+/// identical to the old code; for a join the solution order changes, which
+/// SPARQL bag semantics do not constrain in the absence of `ORDER BY`.
 async fn evaluate_standard_op(
     tp: &spargebra::term::TriplePattern,
     op: &TripleOp,
     existing_bindings: &[HashMap<String, Binding>],
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
+    budget: Option<usize>,
 ) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
-    let rows = fetch_triples(op, write_path).await?;
-    let mut new_bindings = Vec::new();
-    for existing in existing_bindings {
-        for triple in &rows {
-            if let Some(row) = try_bind_triple(tp, triple, existing) {
-                new_bindings.push(row);
+    let mut new_bindings: Vec<HashMap<String, Binding>> = Vec::new();
+    for_each_triple(op, write_path, limits, |triple| {
+        for existing in existing_bindings {
+            let Some(row) = try_bind_triple(tp, &triple, existing) else {
+                continue;
+            };
+            new_bindings.push(row);
+            check_solution_bound(new_bindings.len(), limits)?;
+            if budget.is_some_and(|needed| new_bindings.len() >= needed) {
+                return Ok(ControlFlow::Break(()));
             }
         }
-    }
+        Ok(ControlFlow::Continue(()))
+    })
+    .await?;
     Ok(new_bindings)
+}
+
+/// Fail loud when an operator's solution buffer crosses the row bound.
+fn check_solution_bound(buffered: usize, limits: &ExecutionLimits) -> Result<(), SparqlError> {
+    if buffered > limits.max_rows {
+        return Err(SparqlError::Execution(format!(
+            "SPARQL query buffered more than {} solutions. Refusing to return a \
+             truncated result that would look complete — add a LIMIT, constrain the \
+             pattern, or raise the engine's max_rows bound.",
+            limits.max_rows
+        )));
+    }
+    Ok(())
 }
 
 /// Merge two binding sets if compatible (no conflicting values).
@@ -162,9 +315,17 @@ fn try_merge_bindings(
 }
 
 /// Try to bind a fetched triple into an existing binding row.
-/// Returns `None` if the triple is incompatible with existing bindings.
+/// Returns `None` if the triple does not match the pattern, or is incompatible
+/// with the existing bindings.
 ///
 /// BUG-S4 fix: checks both value AND binding_type for compatibility.
+///
+/// t_c3a2d3e4 fix: a CONSTANT term in the pattern is a match constraint, not
+/// decoration. Every position is checked, not only the ones the access path
+/// happened to push down — a `PredicateScan` is chosen on the predicate alone
+/// and would otherwise return every object, and a `SubjectLookup` is chosen on
+/// the subject alone. A blank node in a pattern is a non-selectable variable
+/// per SPARQL 1.1 §4.1.4, so it constrains nothing.
 fn try_bind_triple(
     tp: &spargebra::term::TriplePattern,
     triple: &FetchedTriple,
@@ -173,48 +334,96 @@ fn try_bind_triple(
     let (s, p, o, obj_type, datatype, lang) = triple;
     let mut row = existing.clone();
 
-    // Bind or check subject.
-    // BUG-S11 fix: detect blank nodes by `_:` prefix instead of assuming URI.
-    if let spargebra::term::TermPattern::Variable(var) = &tp.subject {
-        let subject_type = if s.starts_with("_:") { "bnode" } else { "uri" };
-        let binding = Binding {
-            binding_type: subject_type.into(),
-            value: s.clone(),
-            datatype: None,
-            lang: None,
-        };
-        if !try_insert_binding(&mut row, var.as_str(), &binding) {
-            return None;
-        }
+    if !bind_or_check_subject(&tp.subject, s, &mut row)
+        || !bind_or_check_predicate(&tp.predicate, p, &mut row)
+        || !bind_or_check_object(&tp.object, o, obj_type, datatype, lang, &mut row)
+    {
+        return None;
     }
-
-    // Bind or check predicate.
-    if let spargebra::term::NamedNodePattern::Variable(var) = &tp.predicate {
-        let binding = Binding {
-            binding_type: "uri".into(),
-            value: p.clone(),
-            datatype: None,
-            lang: None,
-        };
-        if !try_insert_binding(&mut row, var.as_str(), &binding) {
-            return None;
-        }
-    }
-
-    // Bind or check object.
-    if let spargebra::term::TermPattern::Variable(var) = &tp.object {
-        let binding = Binding {
-            binding_type: obj_type.clone(),
-            value: o.clone(),
-            datatype: datatype.clone(),
-            lang: lang.clone(),
-        };
-        if !try_insert_binding(&mut row, var.as_str(), &binding) {
-            return None;
-        }
-    }
-
     Some(row)
+}
+
+/// Bind the subject variable, or check a subject constant.
+///
+/// BUG-S11 fix: detect blank nodes by the `_:` prefix instead of assuming URI.
+fn bind_or_check_subject(
+    pattern: &spargebra::term::TermPattern,
+    subject: &str,
+    row: &mut HashMap<String, Binding>,
+) -> bool {
+    use spargebra::term::TermPattern;
+    match pattern {
+        TermPattern::Variable(var) => {
+            let binding = Binding {
+                binding_type: if subject.starts_with("_:") {
+                    "bnode"
+                } else {
+                    "uri"
+                }
+                .into(),
+                value: subject.to_string(),
+                datatype: None,
+                lang: None,
+            };
+            try_insert_binding(row, var.as_str(), &binding)
+        }
+        TermPattern::NamedNode(n) => n.as_str() == subject,
+        // A blank node in the PATTERN is a non-selectable variable and
+        // constrains nothing; a quoted triple is rejected by the planner.
+        _ => true,
+    }
+}
+
+/// Bind the predicate variable, or check a predicate constant.
+fn bind_or_check_predicate(
+    pattern: &spargebra::term::NamedNodePattern,
+    predicate: &str,
+    row: &mut HashMap<String, Binding>,
+) -> bool {
+    use spargebra::term::NamedNodePattern;
+    match pattern {
+        NamedNodePattern::Variable(var) => {
+            let binding = Binding {
+                binding_type: "uri".into(),
+                value: predicate.to_string(),
+                datatype: None,
+                lang: None,
+            };
+            try_insert_binding(row, var.as_str(), &binding)
+        }
+        NamedNodePattern::NamedNode(n) => n.as_str() == predicate,
+    }
+}
+
+/// Bind the object variable, or check an object constant.
+fn bind_or_check_object(
+    pattern: &spargebra::term::TermPattern,
+    object: &str,
+    obj_type: &str,
+    datatype: &Option<String>,
+    lang: &Option<String>,
+    row: &mut HashMap<String, Binding>,
+) -> bool {
+    use spargebra::term::TermPattern;
+    match pattern {
+        TermPattern::Variable(var) => {
+            let binding = Binding {
+                binding_type: obj_type.to_string(),
+                value: object.to_string(),
+                datatype: datatype.clone(),
+                lang: lang.clone(),
+            };
+            try_insert_binding(row, var.as_str(), &binding)
+        }
+        // An IRI constant matches only a stored IRI object with the same value
+        // — never a literal that happens to spell the same characters.
+        TermPattern::NamedNode(n) => obj_type == "uri" && n.as_str() == object,
+        // A literal constant is compared against the stored LEXICAL value.
+        // `Literal::to_string()` is the quoted N-Triples serialization and can
+        // never equal a stored object (t_c3a2d3e4).
+        TermPattern::Literal(l) => obj_type == "literal" && l.value() == object,
+        _ => true,
+    }
 }
 
 /// Insert a binding into a row, or check compatibility if already present.
@@ -295,95 +504,165 @@ type FetchedTriple = (
     Option<String>,
 );
 
-/// Maximum number of partitions returned by a range scan.
-const SCAN_ROW_CAP: usize = 10_000;
-
 /// Name of the secondary index on the object column.
 const OBJECT_INDEX_NAME: &str = "rdf_triples_object_idx";
 
-/// Attempt to fetch partitions matching an object value via secondary index.
-///
-/// Falls back to a full range scan with post-fetch filtering if the index
-/// does not exist. Logs a warning on fallback and on truncation.
-async fn fetch_by_object_index(
-    table_id: &ferrosa_storage::TableId,
-    object: &str,
-    write_path: &Arc<WritePath>,
-) -> Result<Vec<ferrosa_sstable::types::Partition>, SparqlError> {
-    let index_key = ferrosa_index::IndexKey(object.as_bytes().to_vec());
-    let indexed = write_path
-        .index_read(table_id, OBJECT_INDEX_NAME, &index_key)
-        .await?;
-    if !indexed.is_empty() {
-        return Ok(indexed);
-    }
-
-    // Fallback: no index or no matches — use range scan.
-    tracing::warn!(
-        object,
-        "ObjectScan: no secondary index hit; falling back to full scan with filtering"
-    );
-    let results = write_path.range_read(table_id).await?;
-    if results.len() >= SCAN_ROW_CAP {
-        tracing::warn!(
-            cap = SCAN_ROW_CAP,
-            "ObjectScan results truncated at row cap; results may be incomplete"
-        );
-    }
-    Ok(results)
-}
-
-/// Fetch triples from storage for a single triple pattern operation.
-async fn fetch_triples(
-    op: &TripleOp,
-    write_path: &Arc<WritePath>,
-) -> Result<Vec<FetchedTriple>, SparqlError> {
-    // BUG-S2 fix: use the graph from the execution plan, not hardcoded "rdf".
-    let graph = match op {
+/// The graph a storage-backed op reads from. `None` for `PropertyPath`, which
+/// is evaluated by [`evaluate_path_op`] and never reaches the scan.
+fn op_graph(op: &TripleOp) -> Option<&str> {
+    match op {
+        // BUG-S2 fix: use the graph from the execution plan, not hardcoded "rdf".
         TripleOp::SubjectLookup { graph, .. }
         | TripleOp::PredicateScan { graph, .. }
         | TripleOp::ObjectScan { graph, .. }
-        | TripleOp::FullScan { graph, .. } => graph.as_str(),
-        TripleOp::PropertyPath { .. } => {
-            // PropertyPath ops are handled in evaluate_path_op; this is unreachable.
-            return Ok(vec![]);
+        | TripleOp::FullScan { graph, .. } => Some(graph.as_str()),
+        TripleOp::PropertyPath { .. } => None,
+    }
+}
+
+/// Human-readable access path, for bound-exceeded diagnostics.
+fn describe_op(op: &TripleOp) -> String {
+    match op {
+        TripleOp::SubjectLookup { subject, .. } => format!("a subject lookup of <{subject}>"),
+        TripleOp::PredicateScan { predicate, .. } => format!("a scan for predicate <{predicate}>"),
+        TripleOp::ObjectScan { object, .. } => format!("a scan for object '{object}'"),
+        TripleOp::FullScan { graph } => format!("a full scan of graph '{graph}'"),
+        TripleOp::PropertyPath { .. } => "a property path".to_string(),
+    }
+}
+
+/// Per-scan state: the caller's sink plus the storage-row counter that enforces
+/// [`ExecutionLimits::max_rows`] AT THE SOURCE — where the unbounded data
+/// enters, not after it has already been materialized.
+struct Scan<'a, F> {
+    op: &'a TripleOp,
+    limits: &'a ExecutionLimits,
+    sink: F,
+    rows_read: usize,
+}
+
+impl<F> Scan<'_, F>
+where
+    F: FnMut(FetchedTriple) -> Result<ControlFlow<()>, SparqlError>,
+{
+    /// Decode one partition and push its matching triples to the sink.
+    ///
+    /// Nothing accumulates here: a row is decoded, filtered, handed to the sink
+    /// and dropped before the next one is touched.
+    fn feed(&mut self, partition: &Partition) -> Result<ControlFlow<()>, SparqlError> {
+        // BUG-S3 fix: decode composite partition key (graph, subject) properly.
+        let subject = extract_subject_from_partition_key(partition.key.key.as_bytes());
+        for row in &partition.rows {
+            self.rows_read += 1;
+            if self.rows_read > self.limits.max_rows {
+                return Err(SparqlError::Execution(format!(
+                    "SPARQL scan read more than {} storage rows while evaluating {}. \
+                     Refusing to return a truncated result that would look complete — \
+                     add a LIMIT, constrain the pattern, or raise the engine's max_rows \
+                     bound.",
+                    self.limits.max_rows,
+                    describe_op(self.op),
+                )));
+            }
+            let Some(triple) = decode_triple(row, &subject) else {
+                continue;
+            };
+            if !triple_matches_op(self.op, &triple) {
+                continue;
+            }
+            if (self.sink)(triple)?.is_break() {
+                return Ok(ControlFlow::Break(()));
+            }
         }
+        Ok(ControlFlow::Continue(()))
+    }
+}
+
+/// Drive `op`'s access path, handing every matching triple to `sink`.
+///
+/// This is the streaming source. A range scan pulls ONE PARTITION AT A TIME
+/// from [`WritePath::range_read_stream_all`] — the same streaming primitive the
+/// CQL path uses — instead of collecting the whole table into a `Vec` first.
+/// `sink` returns [`ControlFlow::Break`] to stop the scan early, which is how
+/// `LIMIT` pushdown terminates a scan without reading the rest of the table.
+async fn for_each_triple<F>(
+    op: &TripleOp,
+    write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
+    sink: F,
+) -> Result<(), SparqlError>
+where
+    F: FnMut(FetchedTriple) -> Result<ControlFlow<()>, SparqlError>,
+{
+    let Some(graph) = op_graph(op) else {
+        return Ok(());
     };
     let table_id = triple_store::triples_table_id(graph);
+    let mut scan = Scan {
+        op,
+        limits,
+        sink,
+        rows_read: 0,
+    };
 
-    let partitions = match op {
-        TripleOp::SubjectLookup { graph, subject, .. } => {
+    match op {
+        TripleOp::SubjectLookup { subject, .. } => {
+            // Point read: bounded by one partition's row count by construction.
             let key = triple_store::partition_key(graph, subject);
-            match write_path.read(&table_id, &key).await? {
-                Some(p) => vec![p],
-                None => vec![],
+            if let Some(partition) = write_path.read(&table_id, &key).await? {
+                // Exactly one partition: `Break` and `Continue` are equivalent
+                // here because there is nothing left to feed either way.
+                let _ = scan.feed(&partition)?;
             }
         }
         TripleOp::ObjectScan { object, .. } => {
-            fetch_by_object_index(&table_id, object, write_path).await?
+            // Keyed index read first: bounded by the number of index matches.
+            let index_key = ferrosa_index::IndexKey(object.as_bytes().to_vec());
+            let indexed = write_path
+                .index_read(&table_id, OBJECT_INDEX_NAME, &index_key)
+                .await?;
+            if indexed.is_empty() {
+                tracing::warn!(
+                    object,
+                    "ObjectScan: no secondary index hit; falling back to a streaming \
+                     full scan with filtering"
+                );
+                stream_scan(&table_id, write_path, &mut scan).await?;
+            } else {
+                for partition in &indexed {
+                    if scan.feed(partition)?.is_break() {
+                        break;
+                    }
+                }
+            }
         }
         TripleOp::PredicateScan { .. } | TripleOp::FullScan { .. } => {
-            let results = write_path.range_read(&table_id).await?;
-            if results.len() >= SCAN_ROW_CAP {
-                tracing::warn!(
-                    cap = SCAN_ROW_CAP,
-                    "scan results truncated at row cap; results may be incomplete"
-                );
-            }
-            results
+            stream_scan(&table_id, write_path, &mut scan).await?;
         }
-        TripleOp::PropertyPath { .. } => return Ok(vec![]),
-    };
-
-    let mut triples = Vec::new();
-    for partition in &partitions {
-        // BUG-S3 fix: decode composite partition key (graph, subject) properly.
-        let subject = extract_subject_from_partition_key(partition.key.key.as_bytes());
-        extract_rows_from_partition(&partition.rows, &subject, &mut triples);
+        TripleOp::PropertyPath { .. } => {}
     }
+    Ok(())
+}
 
-    apply_scan_filters(op, &mut triples);
-    Ok(triples)
+/// Consume a streaming range scan, feeding each partition to `scan` as it
+/// arrives and stopping as soon as the sink is satisfied.
+async fn stream_scan<F>(
+    table_id: &ferrosa_storage::TableId,
+    write_path: &Arc<WritePath>,
+    scan: &mut Scan<'_, F>,
+) -> Result<(), SparqlError>
+where
+    F: FnMut(FetchedTriple) -> Result<ControlFlow<()>, SparqlError>,
+{
+    // `row_limit = 0` means "do not truncate rows within a partition"; the
+    // executor's own bound and LIMIT budget decide when to stop.
+    let mut partitions = write_path.range_read_stream_all(table_id, 0).await?;
+    while let Some(partition) = partitions.next().await {
+        if scan.feed(&partition?)?.is_break() {
+            break;
+        }
+    }
+    Ok(())
 }
 
 /// BUG-S3 fix: Properly decode CQL composite partition key to extract the subject.
@@ -430,80 +709,71 @@ fn extract_composite_component(data: &[u8], position: usize) -> Option<String> {
     None
 }
 
-/// Extract triples from partition rows into the output vec.
-fn extract_rows_from_partition(rows: &[Row], subject: &str, triples: &mut Vec<FetchedTriple>) {
-    for row in rows {
-        // Skip deleted rows: a row whose deletion marker is non-live is a
-        // tombstone (or a row masked by one in the merge) and MUST NOT surface
-        // as a triple. Without this, a SPARQL delete would remain visible to a
-        // subsequent SELECT (URS-QEC-D05).
-        if !row.deletion.is_live() {
-            continue;
-        }
-
-        let predicate = extract_clustering_string(&row.clustering, 0);
-        let object = extract_clustering_string(&row.clustering, 1);
-
-        // BUG-S18 fix: validate object type against known values.
-        let raw_obj_type = row
-            .cells
-            .iter()
-            .find(|(idx, _)| *idx == triple_store::COL_OBJECT_TYPE)
-            .and_then(|(_, cell)| cell.value.as_ref())
-            .map(|v| String::from_utf8_lossy(v).to_string())
-            .unwrap_or_else(|| "literal".into());
-        let obj_type = match raw_obj_type.as_str() {
-            "uri" | "literal" | "bnode" => raw_obj_type,
-            other => {
-                tracing::warn!(value = other, "invalid object type, defaulting to literal");
-                "literal".into()
-            }
-        };
-
-        let datatype = row
-            .cells
-            .iter()
-            .find(|(idx, _)| *idx == triple_store::COL_DATATYPE)
-            .and_then(|(_, cell)| cell.value.as_ref())
-            .map(|v| String::from_utf8_lossy(v).to_string());
-
-        let language = row
-            .cells
-            .iter()
-            .find(|(idx, _)| *idx == triple_store::COL_LANGUAGE)
-            .and_then(|(_, cell)| cell.value.as_ref())
-            .map(|v| String::from_utf8_lossy(v).to_string());
-
-        triples.push((
-            subject.to_string(),
-            predicate,
-            object,
-            obj_type,
-            datatype,
-            language,
-        ));
+/// Decode one storage row into a triple, or `None` if it is not a live triple.
+///
+/// Returns `None` for a row whose deletion marker is non-live: that row is a
+/// tombstone (or is masked by one in the merge) and MUST NOT surface as a
+/// triple. Without this, a SPARQL delete would remain visible to a subsequent
+/// SELECT (URS-QEC-D05).
+fn decode_triple(row: &Row, subject: &str) -> Option<FetchedTriple> {
+    if !row.deletion.is_live() {
+        return None;
     }
+
+    let predicate = extract_clustering_string(&row.clustering, 0);
+    let object = extract_clustering_string(&row.clustering, 1);
+
+    // BUG-S18 fix: validate object type against known values.
+    let raw_obj_type =
+        cell_string(row, triple_store::COL_OBJECT_TYPE).unwrap_or_else(|| "literal".to_string());
+    let obj_type = match raw_obj_type.as_str() {
+        "uri" | "literal" | "bnode" => raw_obj_type,
+        other => {
+            tracing::warn!(value = other, "invalid object type, defaulting to literal");
+            "literal".into()
+        }
+    };
+
+    Some((
+        subject.to_string(),
+        predicate,
+        object,
+        obj_type,
+        cell_string(row, triple_store::COL_DATATYPE),
+        cell_string(row, triple_store::COL_LANGUAGE),
+    ))
 }
 
-/// Apply post-fetch filters for scan operations.
+/// Read a regular column's value out of a row as a UTF-8 string.
+fn cell_string(row: &Row, column: u16) -> Option<String> {
+    row.cells
+        .iter()
+        .find(|(idx, _)| *idx == column)
+        .and_then(|(_, cell)| cell.value.as_ref())
+        .map(|v| String::from_utf8_lossy(v).to_string())
+}
+
+/// Access-path filter: does this triple satisfy the constraint the op was
+/// chosen on?
 ///
-/// BUG-S8 fix: ObjectScan now filters by object value.
-/// BUG-S9 fix: PredicateScan now filters by predicate value.
-fn apply_scan_filters(op: &TripleOp, triples: &mut Vec<FetchedTriple>) {
+/// This is the pushdown half of matching — it discards non-matching rows at the
+/// scan, before they ever become solutions. It is deliberately NOT the whole
+/// story: [`try_bind_triple`] enforces every constant in the triple pattern,
+/// including the ones no access path was chosen on. Applying it per row rather
+/// than to a collected `Vec` is what lets the scan stream.
+///
+/// BUG-S8 fix: ObjectScan filters by object value.
+/// BUG-S9 fix: PredicateScan filters by predicate value.
+fn triple_matches_op(op: &TripleOp, triple: &FetchedTriple) -> bool {
+    let (_, p, o, _, _, _) = triple;
     match op {
         TripleOp::SubjectLookup {
             predicate_filter: Some(pred),
             ..
-        } => {
-            triples.retain(|(_, p, _, _, _, _)| p == pred);
-        }
-        TripleOp::PredicateScan { predicate, .. } => {
-            triples.retain(|(_, p, _, _, _, _)| p == predicate);
-        }
-        TripleOp::ObjectScan { object, .. } => {
-            triples.retain(|(_, _, o, _, _, _)| o == object);
-        }
-        _ => {}
+        } => p == pred,
+        TripleOp::PredicateScan { predicate, .. } => p == predicate,
+        TripleOp::ObjectScan { object, .. } => o == object,
+        _ => true,
     }
 }
 
@@ -671,23 +941,17 @@ mod tests {
         );
     }
 
-    // --- BUG-S5: OFFSET clamping ---
-
-    #[test]
-    fn offset_clamp_prevents_panic() {
-        // Verify that start.min(len) prevents out-of-bounds access.
-        let binding_sets: Vec<HashMap<String, Binding>> =
-            vec![make_binding_row("s", "a"), make_binding_row("s", "b")];
-        let offset: usize = 999;
-        let start = offset.min(binding_sets.len());
-        let end = binding_sets.len();
-        // This must not panic.
-        let slice = &binding_sets[start..end];
-        assert!(
-            slice.is_empty(),
-            "OFFSET beyond result size yields empty slice"
-        );
-    }
+    // --- BUG-S5: OFFSET/LIMIT clamping ---
+    //
+    // Covered END TO END by `tests/sparql_executor_invariants.rs`:
+    // `offset_skips_exactly_k_solutions` and
+    // `limit_and_offset_never_overflow_for_any_usize`.
+    //
+    // The unit test that used to live here (`offset_clamp_prevents_panic`)
+    // re-implemented `start.min(len)` in its own body instead of calling
+    // `execute`, so it asserted a property of the test, not of the executor —
+    // it could not have detected the `start + limit` overflow that the
+    // end-to-end invariant test caught immediately.
 
     // --- BUG-S13: ORDER BY ---
 
@@ -829,61 +1093,94 @@ mod tests {
 
     #[test]
     fn predicate_scan_filters_by_predicate() {
-        let mut triples = vec![
-            triple("s1", "http://foaf/name", "Alice", "literal"),
-            triple("s1", "http://foaf/knows", "s2", "uri"),
-        ];
         let op = TripleOp::PredicateScan {
             graph: "default".into(),
             predicate: "http://foaf/name".into(),
         };
-        apply_scan_filters(&op, &mut triples);
-        assert_eq!(triples.len(), 1);
-        assert_eq!(triples[0].1, "http://foaf/name");
+        assert!(triple_matches_op(
+            &op,
+            &triple("s1", "http://foaf/name", "Alice", "literal")
+        ));
+        assert!(!triple_matches_op(
+            &op,
+            &triple("s1", "http://foaf/knows", "s2", "uri")
+        ));
     }
 
     #[test]
     fn object_scan_filters_by_object() {
-        let mut triples = vec![
-            triple("s1", "http://foaf/name", "Alice", "literal"),
-            triple("s2", "http://foaf/name", "Bob", "literal"),
-        ];
         let op = TripleOp::ObjectScan {
             graph: "default".into(),
             object: "Bob".into(),
         };
-        apply_scan_filters(&op, &mut triples);
-        assert_eq!(triples.len(), 1);
-        assert_eq!(triples[0].0, "s2");
+        assert!(!triple_matches_op(
+            &op,
+            &triple("s1", "http://foaf/name", "Alice", "literal")
+        ));
+        assert!(triple_matches_op(
+            &op,
+            &triple("s2", "http://foaf/name", "Bob", "literal")
+        ));
     }
 
-    // --- ObjectScan index + post-filter tests ---
-
     #[test]
-    fn object_scan_post_filter_retains_matching_object() {
-        // Verify that ObjectScan applies post-fetch object filter even
-        // when results come from a range scan (no index).
-        let mut triples = vec![
-            triple("s1", "p1", "target", "uri"),
-            triple("s2", "p2", "other", "uri"),
-            triple("s3", "p3", "target", "uri"),
-        ];
-        let op = TripleOp::ObjectScan {
+    fn subject_lookup_filters_by_predicate_filter() {
+        let op = TripleOp::SubjectLookup {
             graph: "default".into(),
-            object: "target".into(),
+            subject: "s1".into(),
+            predicate_filter: Some("http://foaf/name".into()),
         };
-        apply_scan_filters(&op, &mut triples);
-        assert_eq!(
-            triples.len(),
-            2,
-            "only triples with object=target should remain"
-        );
-        assert!(triples.iter().all(|(_, _, o, _, _, _)| o == "target"));
+        assert!(triple_matches_op(
+            &op,
+            &triple("s1", "http://foaf/name", "Alice", "literal")
+        ));
+        assert!(!triple_matches_op(
+            &op,
+            &triple("s1", "http://foaf/age", "30", "literal")
+        ));
     }
 
     #[test]
-    fn scan_row_cap_constant_is_10k() {
-        assert_eq!(SCAN_ROW_CAP, 10_000, "scan cap must be 10,000");
+    fn full_scan_matches_every_triple() {
+        let op = TripleOp::FullScan {
+            graph: "default".into(),
+        };
+        assert!(triple_matches_op(
+            &op,
+            &triple("s1", "p1", "anything", "literal")
+        ));
+    }
+
+    /// Tripwire: the SPARQL crate must never reach for a `Vec`-returning range
+    /// read.
+    ///
+    /// `WritePath::range_read` / `range_read_with` collect EVERY partition of a
+    /// table before returning. That is the API that let `SELECT * WHERE { ?s ?p
+    /// ?o }` — 30 bytes of query — materialize an entire triple store and OOM
+    /// the server. Scans go through `range_read_stream_all`, which yields one
+    /// partition at a time and can be dropped early. This test fails if a
+    /// materializing call is reintroduced.
+    #[test]
+    fn sparql_scans_never_call_a_materializing_range_read() {
+        // Assembled by `concat!` so this test's own source does not match.
+        let banned = [
+            concat!(".range_", "read("),
+            concat!(".range_", "read_with("),
+        ];
+        for (file, src) in [
+            ("executor.rs", include_str!("executor.rs")),
+            ("property_path.rs", include_str!("property_path.rs")),
+            ("update.rs", include_str!("update.rs")),
+            ("engine.rs", include_str!("engine.rs")),
+        ] {
+            for call in banned {
+                assert!(
+                    !src.contains(call),
+                    "{file} calls the Vec-returning WritePath{call}) — use \
+                     range_read_stream_all so the scan stays bounded and streams"
+                );
+            }
+        }
     }
 
     #[test]

--- a/ferrosa-sparql/src/planner.rs
+++ b/ferrosa-sparql/src/planner.rs
@@ -536,7 +536,13 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> Result<Triple
     } else if object_bound {
         let object = match &tp.object {
             TermPattern::NamedNode(n) => n.as_str().to_string(),
-            TermPattern::Literal(l) => l.to_string(),
+            // The object column stores the BARE lexical form of a literal
+            // (`update::write_triple` writes `Literal::value()`), so the scan
+            // key must be the lexical form too. `Literal::to_string()` is the
+            // N-Triples *serialization* (`"beta"`, quoted, possibly with a
+            // `^^<datatype>` suffix) and never equals a stored object, which
+            // made every literal-object pattern match nothing (t_c3a2d3e4).
+            TermPattern::Literal(l) => l.value().to_string(),
             _ => unreachable!(),
         };
         TripleOp::ObjectScan { graph, object }

--- a/ferrosa-sparql/src/property_path.rs
+++ b/ferrosa-sparql/src/property_path.rs
@@ -8,10 +8,12 @@ use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 use ferrosa_cluster::write_path::WritePath;
+use futures::StreamExt;
 use spargebra::algebra::PropertyPathExpression;
 use spargebra::term::TermPattern;
 
 use crate::error::SparqlError;
+use crate::executor::ExecutionLimits;
 use crate::results::Binding;
 use crate::triple_store;
 
@@ -27,24 +29,33 @@ pub async fn evaluate_property_path(
     object: &TermPattern,
     graph: &str,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<PathResult, SparqlError> {
     match path {
         PropertyPathExpression::NamedNode(predicate) => {
-            evaluate_single_hop(subject, predicate.as_str(), object, graph, write_path).await
+            evaluate_single_hop(
+                subject,
+                predicate.as_str(),
+                object,
+                graph,
+                write_path,
+                limits,
+            )
+            .await
         }
         PropertyPathExpression::OneOrMore(inner) => {
-            evaluate_closure(subject, inner, object, graph, write_path, false).await
+            evaluate_closure(subject, inner, object, graph, write_path, limits, false).await
         }
         PropertyPathExpression::ZeroOrMore(inner) => {
-            evaluate_closure(subject, inner, object, graph, write_path, true).await
+            evaluate_closure(subject, inner, object, graph, write_path, limits, true).await
         }
         PropertyPathExpression::ZeroOrOne(inner) => {
-            evaluate_zero_or_one(subject, inner, object, graph, write_path).await
+            evaluate_zero_or_one(subject, inner, object, graph, write_path, limits).await
         }
         PropertyPathExpression::Reverse(inner) => {
             // Swap subject and object, evaluate, then swap results back.
             let results = Box::pin(evaluate_property_path(
-                object, inner, subject, graph, write_path,
+                object, inner, subject, graph, write_path, limits,
             ))
             .await?;
             Ok(results.into_iter().map(|(s, o)| (o, s)).collect())
@@ -62,8 +73,9 @@ async fn evaluate_single_hop(
     object: &TermPattern,
     graph: &str,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<PathResult, SparqlError> {
-    let triples = fetch_triples_for_predicate(graph, predicate, write_path).await?;
+    let triples = fetch_triples_for_predicate(graph, predicate, write_path, limits).await?;
     filter_by_endpoints(subject, object, &triples)
 }
 
@@ -77,10 +89,11 @@ async fn evaluate_closure(
     object: &TermPattern,
     graph: &str,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
     include_start: bool,
 ) -> Result<PathResult, SparqlError> {
     let predicate = extract_single_predicate(inner)?;
-    let adjacency = fetch_triples_for_predicate(graph, &predicate, write_path).await?;
+    let adjacency = fetch_triples_for_predicate(graph, &predicate, write_path, limits).await?;
     let starts = collect_start_nodes(subject, &adjacency);
 
     let mut results = Vec::new();
@@ -99,9 +112,10 @@ async fn evaluate_zero_or_one(
     object: &TermPattern,
     graph: &str,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<PathResult, SparqlError> {
     let predicate = extract_single_predicate(inner)?;
-    let adjacency = fetch_triples_for_predicate(graph, &predicate, write_path).await?;
+    let adjacency = fetch_triples_for_predicate(graph, &predicate, write_path, limits).await?;
     let starts = collect_start_nodes(subject, &adjacency);
 
     let mut results = Vec::new();
@@ -167,18 +181,41 @@ fn extract_single_predicate(path: &PropertyPathExpression) -> Result<String, Spa
 }
 
 /// Fetch all (subject, object) pairs for a given predicate from storage.
+///
+/// The scan STREAMS: partitions arrive one at a time from
+/// [`WritePath::range_read_stream_all`] and only the matching `(subject,
+/// object)` pairs are retained, so the whole table is never materialized.
+///
+/// BFS closure is a blocking operator — it cannot emit a reachable node before
+/// it has seen the edges that reach it — so the adjacency list it walks IS
+/// buffered. That buffer is bounded by [`ExecutionLimits::max_rows`] and
+/// crossing the bound is a loud error, never a silent partial traversal (a
+/// partial adjacency would produce a wrong answer that looks complete).
 async fn fetch_triples_for_predicate(
     graph: &str,
     predicate: &str,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<Vec<(String, String)>, SparqlError> {
     let table_id = triple_store::triples_table_id(graph);
-    let partitions = write_path.range_read(&table_id).await?;
+    let mut partitions = write_path.range_read_stream_all(&table_id, 0).await?;
 
     let mut pairs = Vec::new();
-    for partition in &partitions {
-        let subject = crate::executor::extract_subject_from_key(partition);
+    let mut rows_read: usize = 0;
+    while let Some(partition) = partitions.next().await {
+        let partition = partition?;
+        let subject = crate::executor::extract_subject_from_key(&partition);
         for row in &partition.rows {
+            rows_read += 1;
+            if rows_read > limits.max_rows {
+                return Err(SparqlError::Execution(format!(
+                    "property path over <{predicate}> read more than {} storage rows. \
+                     A partial adjacency would yield a wrong reachability answer that \
+                     looks complete, so this fails instead of truncating — constrain the \
+                     path or raise the engine's max_rows bound.",
+                    limits.max_rows
+                )));
+            }
             let pred = crate::executor::clustering_component(&row.clustering, 0);
             if pred == predicate {
                 let obj = crate::executor::clustering_component(&row.clustering, 1);

--- a/ferrosa-sparql/src/update.rs
+++ b/ferrosa-sparql/src/update.rs
@@ -22,6 +22,7 @@ use ferrosa_sstable::types::{DeletionTime, LivenessInfo, Row};
 use ferrosa_storage::engine::StorageEngine;
 
 use crate::error::SparqlError;
+use crate::executor::ExecutionLimits;
 use crate::results::Binding;
 use crate::triple_store;
 
@@ -42,6 +43,7 @@ pub async fn execute_update(
     keyspace: &str,
     storage: &Arc<StorageEngine>,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<UpdateResult, SparqlError> {
     let update = spargebra::SparqlParser::new()
         .parse_update(update_str)
@@ -79,15 +81,16 @@ pub async fn execute_update(
                 using: _,
                 pattern,
             } => {
-                let (d, i) =
-                    exec_delete_insert(delete, insert, pattern, keyspace, storage, write_path)
-                        .await?;
+                let (d, i) = exec_delete_insert(
+                    delete, insert, pattern, keyspace, storage, write_path, limits,
+                )
+                .await?;
                 total_deleted += d;
                 total_inserted += i;
             }
             spargebra::GraphUpdateOperation::Clear { graph, .. }
             | spargebra::GraphUpdateOperation::Drop { graph, .. } => {
-                total_deleted += exec_clear(graph, keyspace, storage, write_path).await?;
+                total_deleted += exec_clear(graph, keyspace, storage, write_path, limits).await?;
             }
             spargebra::GraphUpdateOperation::Load { .. } => {
                 // URS-QEC-X01: LOAD fetches and parses an external RDF document.
@@ -280,6 +283,7 @@ async fn exec_delete_insert(
     keyspace: &str,
     storage: &Arc<StorageEngine>,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<(usize, usize), SparqlError> {
     // URS-QEC-X01: a delete or insert template whose target graph is a named
     // graph distinct from this keyspace's default graph is NOT addressable in
@@ -300,7 +304,7 @@ async fn exec_delete_insert(
     }
 
     let plan = crate::planner::plan_where(pattern, keyspace)?;
-    let solutions = crate::executor::execute_bindings(&plan, write_path).await?;
+    let solutions = crate::executor::execute_bindings(&plan, write_path, limits).await?;
 
     let mut deleted = 0usize;
     let mut inserted = 0usize;
@@ -343,6 +347,7 @@ async fn exec_clear(
     keyspace: &str,
     storage: &Arc<StorageEngine>,
     write_path: &Arc<WritePath>,
+    limits: &ExecutionLimits,
 ) -> Result<usize, SparqlError> {
     // The triple store is single-graph-per-keyspace; the partition-key graph
     // component is the keyspace. DEFAULT / NAMED / ALL therefore all resolve to
@@ -359,7 +364,7 @@ async fn exec_clear(
         .parse_query("SELECT ?s ?p ?o WHERE { ?s ?p ?o }")
         .map_err(|e| SparqlError::Parse(format!("{e}")))?;
     let plan = crate::planner::plan_query(&scan, keyspace)?;
-    let solutions = crate::executor::execute_bindings(&plan, write_path).await?;
+    let solutions = crate::executor::execute_bindings(&plan, write_path, limits).await?;
 
     let mut deleted = 0usize;
     for sol in &solutions {

--- a/ferrosa-sparql/tests/sparql_executor_invariants.rs
+++ b/ferrosa-sparql/tests/sparql_executor_invariants.rs
@@ -1,0 +1,534 @@
+//! Invariant tests for [`ferrosa_sparql::executor::execute`].
+//!
+//! These are a SPECIFICATION, not a description. Each test asserts something
+//! that MUST be true of any SPARQL query engine, driven END TO END: a real
+//! [`QueryPlan`] from the real planner, a real `WritePath` over a temporary
+//! `StorageEngine`, real rows written by `INSERT DATA`, and assertions on the
+//! rows `execute` returns.
+//!
+//! They exist because before this file `executor::execute` had no direct test
+//! at all — all 26 executor unit tests targeted private helpers, and the one
+//! that claimed to cover OFFSET clamping re-implemented the clamp inline
+//! instead of calling `execute`, so it could never catch a regression.
+//!
+//! # Deployed configuration, not a workaround
+//!
+//! These tests run the configuration the server actually ships: the SPARQL HTTP
+//! handler defaults the keyspace to `"rdf"` (`http.rs`), and `main.rs`
+//! constructs the engine with `SparqlConfig::default()`. The existing
+//! integration tests pin `KS = "default"` to dodge the graph/keyspace
+//! partition-key mismatch (t_af4eb9f0); doing that here would hide the defect
+//! rather than surface it, so this file uses the deployed keyspace and lets the
+//! mismatch show up as a failing invariant.
+//!
+//! # Invariants covered
+//!
+//! - I1 constant-term enforcement (subject, predicate, object; IRI + literal)
+//! - I2 read-path agreement (point lookup and full scan agree on existence)
+//! - I3 delete honesty (a reported-successful delete actually deletes)
+//! - I4 LIMIT/OFFSET (at most n; skip exactly k; compose; total for any usize)
+//! - I5 DISTINCT exactness (removes exactly the duplicates, and no more)
+//!
+//! Completeness (I6) and boundedness (I7) live in
+//! `sparql_scan_bound_invariants.rs` because they need the execution bound.
+
+// -----------------------------------------------------------------------------
+// HELD INVARIANT TESTS - four tests are deliberately ABSENT from this file.
+//
+// They assert invariants this crate genuinely violates today, so committing
+// them would mean committing a red suite (the repo forbids that, and forbids
+// #[ignore] and silent returns as ways to hide it). They are NOT abandoned -
+// they are preserved verbatim and restored when t_af4eb9f0 is resolved:
+//
+//   constant_subject_matches_exactly_that_subjects_triples
+//       expected ["alpha", "alpha2"], observed []
+//   constant_subject_and_object_are_both_enforced
+//       expected ["http://ex/p"], observed []
+//   point_lookup_and_full_scan_agree_on_existence
+//       expected 1, observed 0
+//   reported_delete_actually_removes_the_data
+//       expected 0 remaining, observed 3 remaining AFTER reporting 3 deleted
+//
+// Root cause (t_af4eb9f0): writes set the partition-key graph component to the
+// literal "default", reads take it from the KEYSPACE (planner.rs), and
+// pattern-delete uses a third combination. On the deployed keyspace ("rdf")
+// a point read misses data a full scan finds, and DELETE reports success while
+// deleting nothing.
+//
+// NOT patched on either side: changing the read side makes the component carry
+// no information; changing the write side orphans every existing row. SPARQL
+// named graphs need a real model first - how they map onto keyspaces and
+// partition keys - after which all four paths conform to it.
+//
+// Tests here do NOT pin KS = "default". That workaround is the bug talking,
+// and it is how the pre-existing integration suite hid this.
+// -----------------------------------------------------------------------------
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_sparql::engine::{SparqlConfig, SparqlEngine};
+use ferrosa_sparql::error::SparqlError;
+use ferrosa_sparql::executor::{self, ExecutionLimits};
+use ferrosa_sparql::planner::{self, QueryPlan};
+use ferrosa_sparql::results::Binding;
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+};
+use tempfile::TempDir;
+
+/// The keyspace the shipped SPARQL HTTP endpoint defaults to (`http.rs`
+/// `default_keyspace()` and the `X-Ferrosa-Keyspace` fallback).
+const KS: &str = "rdf";
+
+fn storage_config(dir: &TempDir) -> StorageEngineConfig {
+    StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 4096,
+            max_segment_age: std::time::Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.path().join("commitlog"),
+            checkpoint_dir: dir.path().join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.path().to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    }
+}
+
+/// A live engine over a fresh temp store, plus the `WritePath` the executor is
+/// driven against directly.
+pub struct Fixture {
+    engine: SparqlEngine,
+    write_path: Arc<WritePath>,
+    _dir: TempDir,
+}
+
+fn fixture() -> Fixture {
+    let dir = TempDir::new().unwrap();
+    let storage = Arc::new(StorageEngine::new(storage_config(&dir), None).unwrap());
+    let write_path = Arc::new(WritePath::direct(Arc::clone(&storage)));
+    // Exactly what `main.rs` builds: the default config, addressed with the
+    // HTTP layer's default keyspace.
+    let engine = SparqlEngine::new(storage, Arc::clone(&write_path), SparqlConfig::default());
+    Fixture {
+        engine,
+        write_path,
+        _dir: dir,
+    }
+}
+
+impl Fixture {
+    async fn insert(&self, update: &str) {
+        self.engine
+            .execute_update(update, KS)
+            .await
+            .expect("INSERT DATA must succeed");
+    }
+
+    // NOTE: `Fixture::update` was removed alongside the four held tests — they
+    // were its only callers, and leaving it would trip the zero-warning gate.
+    // Restore it together with them (it is preserved in the same backup).
+
+    /// Plan `query` with the real planner and run it through `executor::execute`.
+    async fn execute(&self, query: &str) -> Vec<HashMap<String, Binding>> {
+        self.try_execute(query)
+            .await
+            .expect("executor::execute must succeed")
+    }
+
+    async fn try_execute(&self, query: &str) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
+        let plan = plan(query);
+        Ok(
+            executor::execute(&plan, &self.write_path, &ExecutionLimits::default())
+                .await?
+                .results
+                .bindings,
+        )
+    }
+}
+
+fn plan(query: &str) -> QueryPlan {
+    let parsed = spargebra::SparqlParser::new()
+        .parse_query(query)
+        .expect("query must parse");
+    planner::plan_query(&parsed, KS).expect("query must plan")
+}
+
+/// Bound values of `var` across rows, in result order.
+fn values(rows: &[HashMap<String, Binding>], var: &str) -> Vec<String> {
+    rows.iter()
+        .map(|r| {
+            r.get(var)
+                .unwrap_or_else(|| panic!("every row must bind ?{var}"))
+                .value
+                .clone()
+        })
+        .collect()
+}
+
+/// Bound values of `var`, sorted — for invariants where scan order is not part
+/// of the contract under test.
+fn sorted_values(rows: &[HashMap<String, Binding>], var: &str) -> Vec<String> {
+    let mut v = values(rows, var);
+    v.sort();
+    v
+}
+
+/// Three triples, three subjects, one shared predicate, three distinct objects.
+const THREE_SUBJECTS: &str = "INSERT DATA { \
+     <http://ex/a> <http://ex/p> \"alpha\" . \
+     <http://ex/b> <http://ex/p> \"beta\" . \
+     <http://ex/c> <http://ex/p> \"gamma\" }";
+
+/// I1(predicate): `?s <p> ?o` must return exactly the triples whose predicate
+/// is `<p>`.
+#[tokio::test]
+async fn constant_predicate_matches_exactly_that_predicates_triples() {
+    let f = fixture();
+    f.insert(
+        "INSERT DATA { \
+         <http://ex/a> <http://ex/p> \"alpha\" . \
+         <http://ex/b> <http://ex/p> \"beta\" . \
+         <http://ex/c> <http://ex/q> \"gamma\" }",
+    )
+    .await;
+
+    let rows = f
+        .execute("SELECT ?s ?o WHERE { ?s <http://ex/p> ?o }")
+        .await;
+
+    assert_eq!(
+        sorted_values(&rows, "s"),
+        vec!["http://ex/a", "http://ex/b"]
+    );
+    assert_eq!(sorted_values(&rows, "o"), vec!["alpha", "beta"]);
+}
+
+/// I1(object, IRI): `?s ?p <o>` must return exactly the triples whose object is
+/// the IRI `<o>`.
+#[tokio::test]
+async fn constant_iri_object_matches_exactly_that_objects_triples() {
+    let f = fixture();
+    f.insert(
+        "INSERT DATA { \
+         <http://ex/a> <http://ex/knows> <http://ex/target> . \
+         <http://ex/b> <http://ex/knows> <http://ex/other> }",
+    )
+    .await;
+
+    let rows = f
+        .execute("SELECT ?s WHERE { ?s ?p <http://ex/target> }")
+        .await;
+
+    assert_eq!(
+        values(&rows, "s"),
+        vec!["http://ex/a"],
+        "only the triple pointing at :target may match"
+    );
+}
+
+/// I1(object, literal): `?s ?p "lit"` must return exactly the triples whose
+/// object is the literal `"lit"`. A literal constant must be compared against
+/// the stored lexical value, not against its quoted serialization.
+#[tokio::test]
+async fn constant_literal_object_matches_exactly_that_objects_triples() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f.execute("SELECT ?s WHERE { ?s ?p \"beta\" }").await;
+
+    assert_eq!(
+        values(&rows, "s"),
+        vec!["http://ex/b"],
+        "a literal object constant must match the one triple carrying it"
+    );
+}
+
+/// I1(two constants): when BOTH the predicate and the object are constants,
+/// BOTH must be enforced. Choosing an access path on one constant must not
+/// discard the other.
+#[tokio::test]
+async fn constant_predicate_and_object_are_both_enforced() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f
+        .execute("SELECT ?s WHERE { ?s <http://ex/p> \"beta\" }")
+        .await;
+
+    assert_eq!(
+        values(&rows, "s"),
+        vec!["http://ex/b"],
+        "the object constant must narrow the predicate scan, not be ignored"
+    );
+}
+
+/// I1(negative): a constant that matches nothing returns nothing — not
+/// everything. This is the failure mode a dropped constant produces.
+#[tokio::test]
+async fn constant_object_matching_nothing_returns_nothing() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f
+        .execute("SELECT ?s WHERE { ?s <http://ex/p> \"no-such-object\" }")
+        .await;
+
+    assert!(
+        rows.is_empty(),
+        "an unmatched object constant must yield zero rows, never the whole scan"
+    );
+}
+
+// =======================================================================
+// I4 — LIMIT returns at most n rows; OFFSET skips exactly k; they compose;
+//      and no usize value may panic or wrap.
+// =======================================================================
+
+/// I4: `LIMIT n` returns at most `n` rows.
+#[tokio::test]
+async fn limit_returns_at_most_n_rows() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    for (limit, expected) in [(0usize, 0usize), (1, 1), (2, 2), (3, 3), (100, 3)] {
+        let rows = f
+            .execute(&format!("SELECT ?s WHERE {{ ?s ?p ?o }} LIMIT {limit}"))
+            .await;
+        assert_eq!(
+            rows.len(),
+            expected,
+            "LIMIT {limit} over 3 solutions must return {expected} rows"
+        );
+    }
+}
+
+/// I4: `OFFSET k` skips exactly `k` solutions, and past the end yields nothing
+/// rather than panicking.
+#[tokio::test]
+async fn offset_skips_exactly_k_solutions() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    for (offset, expected) in [(1usize, 2usize), (2, 1), (3, 0), (999, 0)] {
+        let rows = f
+            .execute(&format!("SELECT ?s WHERE {{ ?s ?p ?o }} OFFSET {offset}"))
+            .await;
+        assert_eq!(
+            rows.len(),
+            expected,
+            "OFFSET {offset} over 3 solutions must leave {expected} rows"
+        );
+    }
+}
+
+/// I4: LIMIT and OFFSET compose — `ORDER BY ?o LIMIT 1 OFFSET 1` selects the
+/// second-smallest solution, deterministically.
+#[tokio::test]
+async fn limit_and_offset_compose_into_a_deterministic_window() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f
+        .execute("SELECT ?o WHERE { ?s <http://ex/p> ?o } ORDER BY ?o LIMIT 1 OFFSET 1")
+        .await;
+
+    assert_eq!(values(&rows, "o"), vec!["beta"]);
+}
+
+/// I4: ORDER BY is a blocking operator — it must see every solution before
+/// LIMIT clips the sequence, or the "top n" is the wrong n.
+#[tokio::test]
+async fn order_by_sees_every_solution_before_limit_clips() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f
+        .execute("SELECT ?o WHERE { ?s <http://ex/p> ?o } ORDER BY DESC(?o) LIMIT 2")
+        .await;
+
+    assert_eq!(values(&rows, "o"), vec!["gamma", "beta"]);
+}
+
+/// I4: LIMIT and OFFSET are attacker-controlled `usize` values straight out of
+/// the query text. NO value may panic (debug: `attempt to add with overflow`)
+/// or wrap to zero (release: silently returns no rows). `OFFSET 1 LIMIT
+/// usize::MAX` means "everything after the first solution".
+#[tokio::test]
+async fn limit_and_offset_never_overflow_for_any_usize() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f
+        .execute(&format!(
+            "SELECT ?s WHERE {{ ?s ?p ?o }} OFFSET 1 LIMIT {}",
+            usize::MAX
+        ))
+        .await;
+    assert_eq!(
+        rows.len(),
+        2,
+        "OFFSET 1 with an unbounded LIMIT must return the 2 remaining solutions"
+    );
+
+    let rows = f
+        .execute(&format!(
+            "SELECT ?s WHERE {{ ?s ?p ?o }} OFFSET {} LIMIT {}",
+            usize::MAX,
+            usize::MAX
+        ))
+        .await;
+    assert!(
+        rows.is_empty(),
+        "an OFFSET past every solution must yield zero rows, not panic"
+    );
+}
+
+// =======================================================================
+// I5 — DISTINCT removes exactly the duplicates and no more.
+// =======================================================================
+
+/// I5: solutions that agree on every projected variable collapse to one;
+/// solutions that differ in any projected variable are all retained.
+#[tokio::test]
+async fn distinct_removes_exactly_the_duplicates() {
+    let f = fixture();
+    f.insert(
+        "INSERT DATA { \
+         <http://ex/a> <http://ex/p> \"alpha\" . \
+         <http://ex/b> <http://ex/p> \"beta\" . \
+         <http://ex/c> <http://ex/q> \"gamma\" . \
+         <http://ex/d> <http://ex/q> \"delta\" }",
+    )
+    .await;
+
+    // Bag semantics: four solutions, two distinct predicates.
+    let all = f.execute("SELECT ?p WHERE { ?s ?p ?o }").await;
+    assert_eq!(all.len(), 4, "without DISTINCT every solution is retained");
+
+    let distinct = f.execute("SELECT DISTINCT ?p WHERE { ?s ?p ?o }").await;
+    assert_eq!(
+        sorted_values(&distinct, "p"),
+        vec!["http://ex/p", "http://ex/q"],
+        "DISTINCT must collapse the duplicates and keep BOTH distinct predicates"
+    );
+}
+
+/// I5: DISTINCT over a projection where every solution is unique removes
+/// nothing.
+#[tokio::test]
+async fn distinct_removes_nothing_when_all_solutions_differ() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f
+        .execute("SELECT DISTINCT ?s ?p ?o WHERE { ?s ?p ?o }")
+        .await;
+
+    assert_eq!(
+        rows.len(),
+        3,
+        "three distinct triples must survive DISTINCT intact"
+    );
+}
+
+/// I5: DISTINCT keys on the PROJECTED variables only — two solutions differing
+/// solely in an unprojected variable are duplicates and must collapse.
+#[tokio::test]
+async fn distinct_keys_on_the_projection_only() {
+    let f = fixture();
+    f.insert(
+        "INSERT DATA { \
+         <http://ex/a> <http://ex/p> \"same\" . \
+         <http://ex/b> <http://ex/p> \"same\" }",
+    )
+    .await;
+
+    let rows = f.execute("SELECT DISTINCT ?o WHERE { ?s ?p ?o }").await;
+
+    assert_eq!(values(&rows, "o"), vec!["same"]);
+}
+
+// =======================================================================
+// Join and empty-store invariants (the degenerate cases the streaming
+// rewrite must keep working).
+// =======================================================================
+
+/// A join emits exactly the compatible pairs — never a cross product.
+#[tokio::test]
+async fn join_emits_only_compatible_solutions() {
+    let f = fixture();
+    f.insert(
+        "INSERT DATA { \
+         <http://ex/alice> <http://ex/knows> <http://ex/bob> . \
+         <http://ex/bob>   <http://ex/name>  \"Bob\" . \
+         <http://ex/carol> <http://ex/name>  \"Carol\" }",
+    )
+    .await;
+
+    let rows = f
+        .execute(
+            "SELECT ?x ?n WHERE { \
+             ?a <http://ex/knows> ?x . \
+             ?x <http://ex/name> ?n }",
+        )
+        .await;
+
+    assert_eq!(rows.len(), 1, "only Bob satisfies both patterns");
+    assert_eq!(rows[0]["x"].value, "http://ex/bob");
+    assert_eq!(rows[0]["n"].value, "Bob");
+}
+
+/// An empty store yields zero solutions and no error — an empty stream, not a
+/// failure.
+#[tokio::test]
+async fn empty_store_yields_no_solutions_and_no_error() {
+    let f = fixture();
+
+    let rows = f.execute("SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await;
+
+    assert!(rows.is_empty());
+}
+
+/// FILTER is applied to solutions before ORDER BY / DISTINCT / LIMIT.
+#[tokio::test]
+async fn filter_removes_exactly_the_non_matching_solutions() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f
+        .execute("SELECT ?o WHERE { ?s <http://ex/p> ?o . FILTER(?o = \"beta\") }")
+        .await;
+
+    assert_eq!(values(&rows, "o"), vec!["beta"]);
+}
+
+/// The result carries only the projected variables.
+#[tokio::test]
+async fn projection_carries_only_projected_variables() {
+    let f = fixture();
+    f.insert(THREE_SUBJECTS).await;
+
+    let rows = f.execute("SELECT ?o WHERE { ?s ?p ?o }").await;
+
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        assert_eq!(row.len(), 1, "only ?o may appear in a projected row");
+        assert!(row.contains_key("o"));
+    }
+}

--- a/ferrosa-sparql/tests/sparql_scan_bound_invariants.rs
+++ b/ferrosa-sparql/tests/sparql_scan_bound_invariants.rs
@@ -1,0 +1,350 @@
+//! Completeness and boundedness invariants for the SPARQL executor.
+//!
+//! Two invariants, both about the SOURCE of the data rather than the shape of
+//! the output:
+//!
+//! - **I6 completeness** — the engine returns either a COMPLETE result or an
+//!   ERROR. It must never return a silently truncated result that looks
+//!   complete. A short answer a caller cannot distinguish from the real one is
+//!   the worst possible outcome; a loud failure is recoverable.
+//!
+//! - **I7 boundedness** — a bounded query does bounded work. `LIMIT n` must
+//!   stop reading once it has `n` solutions instead of reading the whole table
+//!   and discarding the rest.
+//!
+//! These are asserted WITHOUT timing or instrumentation. The executor's row
+//! bound (`ExecutionLimits::max_rows`) is set below the table size, which makes
+//! "did this query read the whole table?" directly observable: a query that
+//! reads past the bound errors, and a query that stops early succeeds. A test
+//! that cannot tell the difference is not testing boundedness.
+//!
+//! Keyspace note: these tests use `KS = "default"`, matching the graph
+//! component `INSERT DATA` writes, because they are about HOW MUCH data the
+//! scan reads and must not be confounded by t_af4eb9f0 (the graph/keyspace
+//! partition-key mismatch, which makes point reads miss). The read-path
+//! agreement invariant that t_af4eb9f0 violates is asserted separately, on the
+//! deployed keyspace, in `sparql_executor_invariants.rs`.
+
+use std::sync::Arc;
+
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_sparql::engine::{SparqlConfig, SparqlEngine};
+use ferrosa_sparql::error::SparqlError;
+use ferrosa_sparql::executor::{self, ExecutionLimits, DEFAULT_MAX_ROWS};
+use ferrosa_sparql::planner;
+use ferrosa_sparql::results::Binding;
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+};
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+const KS: &str = "default";
+
+/// Rows written by [`Fixture::seed`]. Chosen so a bound of
+/// [`BOUND`] sits strictly between a `LIMIT` window and the table size.
+const TABLE_ROWS: usize = 20;
+
+/// The row bound under test — well below `TABLE_ROWS`, so any query that reads
+/// the whole table trips it.
+const BOUND: usize = 8;
+
+fn storage_config(dir: &TempDir) -> StorageEngineConfig {
+    StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 4096,
+            max_segment_age: std::time::Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.path().join("commitlog"),
+            checkpoint_dir: dir.path().join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.path().to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    }
+}
+
+struct Fixture {
+    engine: SparqlEngine,
+    write_path: Arc<WritePath>,
+    _dir: TempDir,
+}
+
+fn fixture() -> Fixture {
+    let dir = TempDir::new().unwrap();
+    let storage = Arc::new(StorageEngine::new(storage_config(&dir), None).unwrap());
+    let write_path = Arc::new(WritePath::direct(Arc::clone(&storage)));
+    let config = SparqlConfig {
+        default_graph: KS.to_string(),
+        ..Default::default()
+    };
+    let engine = SparqlEngine::new(storage, Arc::clone(&write_path), config);
+    Fixture {
+        engine,
+        write_path,
+        _dir: dir,
+    }
+}
+
+impl Fixture {
+    /// Write [`TABLE_ROWS`] triples, each in its own partition.
+    async fn seed(&self) {
+        let mut data = String::from("INSERT DATA {");
+        for i in 0..TABLE_ROWS {
+            data.push_str(&format!(
+                " <http://ex/s{i}> <http://ex/p> \"object-{i:03}\" ."
+            ));
+        }
+        data.push('}');
+        self.engine
+            .execute_update(&data, KS)
+            .await
+            .expect("INSERT DATA must succeed");
+    }
+
+    /// Run `query` through `executor::execute` under an explicit row bound.
+    async fn run(
+        &self,
+        query: &str,
+        max_rows: usize,
+    ) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
+        let parsed = spargebra::SparqlParser::new()
+            .parse_query(query)
+            .expect("query must parse");
+        let plan = planner::plan_query(&parsed, KS).expect("query must plan");
+        Ok(
+            executor::execute(&plan, &self.write_path, &ExecutionLimits { max_rows })
+                .await?
+                .results
+                .bindings,
+        )
+    }
+}
+
+// =======================================================================
+// I6 — Complete result, or an error. Never a silent truncation.
+// =======================================================================
+
+/// I6: a scan that cannot finish within the row bound must ERROR. Returning the
+/// first `BOUND` rows and calling it the answer is indistinguishable from a
+/// correct short result, which is exactly the failure mode the old
+/// `SCAN_ROW_CAP` warning pretended to guard against while truncating nothing.
+#[tokio::test]
+async fn scan_exceeding_the_row_bound_errors_instead_of_truncating() {
+    let f = fixture();
+    f.seed().await;
+
+    let err = f
+        .run("SELECT ?s ?p ?o WHERE { ?s ?p ?o }", BOUND)
+        .await
+        .expect_err("a full scan of 20 rows under an 8-row bound must fail, not truncate");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&BOUND.to_string()),
+        "the error must name the bound that was crossed: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("truncat"),
+        "the error must say it is refusing to truncate, so an operator knows the \
+         result is missing rather than empty: {msg}"
+    );
+}
+
+/// I6: a scan that DOES fit within the bound returns the complete result and no
+/// error. The bound must not fire early — a guard that rejects valid queries is
+/// as wrong as one that truncates silently.
+#[tokio::test]
+async fn scan_within_the_row_bound_returns_the_complete_result() {
+    let f = fixture();
+    f.seed().await;
+
+    let rows = f
+        .run("SELECT ?s ?p ?o WHERE { ?s ?p ?o }", TABLE_ROWS)
+        .await
+        .expect("a scan that fits inside the bound must succeed");
+
+    assert_eq!(
+        rows.len(),
+        TABLE_ROWS,
+        "the result must be complete, not clipped at the bound"
+    );
+}
+
+/// I6: ORDER BY is a blocking operator — it must see every solution before it
+/// can emit the first. It may therefore buffer, but it must respect the bound
+/// and fail loud past it rather than sorting a clipped window and presenting it
+/// as the global order.
+#[tokio::test]
+async fn order_by_over_a_scan_exceeding_the_bound_errors() {
+    let f = fixture();
+    f.seed().await;
+
+    let err = f
+        .run(
+            "SELECT ?o WHERE { ?s <http://ex/p> ?o } ORDER BY ?o LIMIT 3",
+            BOUND,
+        )
+        .await
+        .expect_err(
+            "ORDER BY must see all 20 solutions to know the smallest 3; it may not \
+             sort the first 8 and call the answer global",
+        );
+
+    assert!(err.to_string().contains(&BOUND.to_string()));
+}
+
+/// I6: DISTINCT is likewise blocking — it cannot know a solution is a duplicate
+/// without having seen the earlier one.
+#[tokio::test]
+async fn distinct_over_a_scan_exceeding_the_bound_errors() {
+    let f = fixture();
+    f.seed().await;
+
+    let err = f
+        .run("SELECT DISTINCT ?p WHERE { ?s ?p ?o } LIMIT 1", BOUND)
+        .await
+        .expect_err("DISTINCT must not deduplicate a clipped window and report success");
+
+    assert!(err.to_string().contains(&BOUND.to_string()));
+}
+
+/// I6: a FILTER drops solutions AFTER they are bound, so a `LIMIT` above a
+/// filter cannot be pushed into the scan — stopping at `n` bound rows could
+/// return fewer than `n` results. The scan must therefore run to completion (and
+/// trip the bound) rather than quietly returning a short answer.
+#[tokio::test]
+async fn filtered_limit_does_not_push_down_and_stay_short() {
+    let f = fixture();
+    f.seed().await;
+
+    let err = f
+        .run(
+            "SELECT ?o WHERE { ?s ?p ?o . FILTER(?o = \"object-019\") } LIMIT 1",
+            BOUND,
+        )
+        .await
+        .expect_err(
+            "the matching triple is the last one written; a pushed-down LIMIT would \
+             stop after 1 bound row and return nothing, so LIMIT must not push \
+             through a FILTER",
+        );
+
+    assert!(err.to_string().contains(&BOUND.to_string()));
+}
+
+// =======================================================================
+// I7 — A bounded query does bounded work.
+// =======================================================================
+
+/// I7: `LIMIT n` must stop reading once it has `n` solutions.
+///
+/// The bound is 8 rows and the table is 20. A `LIMIT 3` full scan that reads
+/// only what it needs touches 3 rows and succeeds; one that materializes the
+/// table first reads 20 and trips the bound. The unbounded form of the same
+/// query is asserted to fail in the same test, which is what proves the success
+/// above comes from stopping early rather than from the bound being inert.
+#[tokio::test]
+async fn limit_stops_the_scan_instead_of_reading_the_whole_table() {
+    let f = fixture();
+    f.seed().await;
+
+    let rows = f
+        .run("SELECT ?s WHERE { ?s ?p ?o } LIMIT 3", BOUND)
+        .await
+        .expect("LIMIT 3 must read ~3 rows, not all 20");
+    assert_eq!(rows.len(), 3);
+
+    f.run("SELECT ?s WHERE { ?s ?p ?o }", BOUND)
+        .await
+        .expect_err(
+            "control: the same scan without a LIMIT must trip the bound — otherwise \
+             the assertion above proves nothing about early termination",
+        );
+}
+
+/// I7: OFFSET rows are read and discarded, so the scan must produce
+/// `offset + limit` solutions — no fewer (which would lose rows) and, within
+/// the bound, no more.
+#[tokio::test]
+async fn limit_with_offset_reads_offset_plus_limit_rows() {
+    let f = fixture();
+    f.seed().await;
+
+    let rows = f
+        .run("SELECT ?s WHERE { ?s ?p ?o } LIMIT 2 OFFSET 4", BOUND)
+        .await
+        .expect("OFFSET 4 LIMIT 2 needs 6 rows, which fits inside the 8-row bound");
+    assert_eq!(
+        rows.len(),
+        2,
+        "the window must still be exactly 2 rows wide"
+    );
+
+    f.run("SELECT ?s WHERE { ?s ?p ?o } LIMIT 2 OFFSET 12", BOUND)
+        .await
+        .expect_err(
+            "OFFSET 12 LIMIT 2 needs 14 rows, past the 8-row bound: it must fail \
+             loud rather than return a window built from the rows it managed to read",
+        );
+}
+
+/// I7: an ASK query is planned with `LIMIT 1`, so it must terminate after the
+/// first matching row instead of scanning the store to answer a yes/no.
+#[tokio::test]
+async fn ask_terminates_after_the_first_match() {
+    let f = fixture();
+    f.seed().await;
+
+    let result = f.engine.execute("ASK { ?s ?p ?o }", KS).await;
+
+    match result.expect("ASK must not read the whole table") {
+        ferrosa_sparql::engine::SparqlResult::Ask(a) => assert!(a.boolean),
+        other => panic!("expected an ASK result, got {other:?}"),
+    }
+}
+
+/// A `LIMIT` larger than the table is not a pushdown opportunity, but it must
+/// still return everything rather than erroring — the bound is about work done,
+/// not about the number the user typed.
+#[tokio::test]
+async fn limit_larger_than_the_table_returns_everything() {
+    let f = fixture();
+    f.seed().await;
+
+    let rows = f
+        .run("SELECT ?s WHERE { ?s ?p ?o } LIMIT 1000", TABLE_ROWS)
+        .await
+        .expect("a LIMIT above the table size is satisfied by the whole table");
+
+    assert_eq!(rows.len(), TABLE_ROWS);
+}
+
+/// The default bound is a real number the engine actually enforces, not a
+/// constant nothing reads. `SparqlConfig::default()` must carry it.
+#[tokio::test]
+async fn default_config_carries_the_enforced_row_bound() {
+    assert_eq!(
+        SparqlConfig::default().max_rows,
+        DEFAULT_MAX_ROWS,
+        "the shipped config must use the executor's documented default bound"
+    );
+    assert_eq!(
+        ExecutionLimits::default().max_rows,
+        DEFAULT_MAX_ROWS,
+        "ExecutionLimits::default must agree with the config default"
+    );
+}


### PR DESCRIPTION
**P0 — the `/sparql` endpoint is on by default and `SELECT * WHERE { ?s ?p ?o }` (30 bytes) materialized the entire triple store.** This bounds the *source*, where the unbounded data enters, rather than capping the output.

## The guards were fiction and are now gone

- **`SCAN_ROW_CAP` truncated nothing.** Both uses were a `tracing::warn!` *after* `range_read` had already materialized, and the warning's own text — "scan results truncated at row cap" — was false. Deleted, along with the unit test asserting the fiction equalled 10,000.
- **`SparqlConfig::max_results` was dead code** — zero reads workspace-wide. Now live as `max_rows`, threaded through a new `ExecutionLimits` and enforced **at the storage layer** via `range_read_stream_all`. Exceeding it returns a `SparqlError`; it never silently truncates.
- **`WritePath::range_read`** (the `Vec`-returning unbounded API) is gone from this crate, with a **source tripwire test that fails the build if it is reintroduced**.

## Prerequisite fix: LIMIT/OFFSET overflow

`start + l` was an unchecked `usize` add on attacker-controlled values — `OFFSET 1 LIMIT 18446744073709551615` panicked in debug, wrapped to 0 in release and silently returned zero rows. Now `saturating_add`. The `.min(len)` over a materialized `Vec` had been masking this *by accident*, and that accident disappears under streaming — so this had to land first, not after.

## What is and is not bounded

**Bounded:** single-pattern scans (one partition resident), `SubjectLookup`, `LIMIT`/`OFFSET`/`ASK` over one pattern (the scan stops at `offset+limit`), ORDER BY and DISTINCT buffers, property-path adjacency.

**Not bounded in the pipelined sense:** multi-pattern join intermediates. Peak memory for a multi-pattern BGP is still set by the materialized per-pattern solution set. They now **fail loud** at `max_rows` instead of growing freely — a hard limit rather than an OOM — but the join is not pipelined. **Do not read this as "joins are fixed."** The single-pattern case in the ticket is.

`LIMIT` deliberately does **not** push through ORDER BY, DISTINCT, FILTER, joins, or CONSTRUCT/DESCRIBE; each has a test proving the scan runs to completion rather than returning too few rows.

## Two correctness bugs found and fixed red→green (t_c3a2d3e4)

- `try_bind_triple` only handled `Variable` arms, so `?s <ex:p> "beta"` returned every subject with *any* `<ex:p>`. Constants are now enforced in all three term positions, with term-kind checking so an IRI no longer matches a literal spelling the same characters.
- The planner keyed `ObjectScan` on `Literal::to_string()` — the **quoted** oxrdf `Display` form — against the bare stored lexical, so literal-object patterns matched nothing. Now `Literal::value()`.

## Tests assert invariants, not current behavior

They pin what must be *true* of a query engine: constants match only matching triples; a point lookup and a full scan agree on existence; LIMIT/OFFSET never wrap for any `usize`; complete result **or** error, never silent truncation; a bounded query does bounded work. The boundedness tests include a **control** — the same query without `LIMIT` must fail — without which success would prove nothing.

### Four invariant tests are held out, not abandoned

They fail on **t_af4eb9f0** (writes set the graph partition-key component to `"default"`, reads take it from the keyspace), and the repo forbids committing a red suite as firmly as it forbids `#[ignore]`. They are preserved verbatim with expected-vs-observed recorded in the test file:

| Held test | Expected | Observed |
|---|---|---|
| `constant_subject_matches_exactly_that_subjects_triples` | `["alpha","alpha2"]` | `[]` |
| `constant_subject_and_object_are_both_enforced` | `["http://ex/p"]` | `[]` |
| `point_lookup_and_full_scan_agree_on_existence` | `1` | `0` |
| `reported_delete_actually_removes_the_data` | `0` remaining | `3` remaining, after reporting 3 deleted |

It is **not** being patched on either side: changing the read side makes the component carry no information, changing the write side orphans every existing row. Named graphs need a real model first. Tests here deliberately do **not** pin `KS = "default"` — that workaround is how the pre-existing suite hid this.

## Removed tests

Three, each with a comment recording why: `offset_clamp_prevents_panic` (re-implemented `start.min(len)` in its own body, so it tested the test, not the executor), `scan_row_cap_constant_is_10k` (asserted the fiction above), and a duplicate object-scan filter test.

## Verification

141 tests green (83 lib + 58 integration); the 114 baseline is intact. `clippy --all-targets` zero warnings with no `#[allow]` added; `cargo doc` clean; workspace builds.