### PR TITLE
docs(sched): query QoS / fair-scheduler blueprint (epic t_f9a0500a)

### DIFF
--- a/specs/proposed/query-scheduler/architecture.md
+++ b/specs/proposed/query-scheduler/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: "Query QoS / Fair Scheduler — Architecture"
-status: proposed
-component: ferrosa-sched (new) + ferrosa-cql, ferrosa-cluster, ferrosa-storage, ferrosa-index
+status: partially-implemented
+component: ferrosa-sched + ferrosa-cql, ferrosa-cluster, ferrosa-storage, ferrosa-index
 last_revised: 2026-07-20
 executive_summary: >
   A CFS-inspired, two-dimensional (CPU + I/O), hierarchical (per-tenant) fair
@@ -15,6 +15,11 @@ executive_summary: >
 ---
 
 # Query QoS / Fair Scheduler — Architecture
+
+> **Status note (2026-07-28).** `ferrosa-sched` EXISTS and is wired into
+> `ferrosa-cql` and `ferrosa-cluster`; this document describes the design, not
+> pending work. See the implementation-status table in `project-plan.md` for
+> what has landed per phase.
 
 > Read `decisions.md` first — this spec assumes DR-1..10 are locked.
 

--- a/specs/proposed/query-scheduler/architecture.md
+++ b/specs/proposed/query-scheduler/architecture.md
@@ -1,0 +1,223 @@
+---
+title: "Query QoS / Fair Scheduler — Architecture"
+status: proposed
+component: ferrosa-sched (new) + ferrosa-cql, ferrosa-cluster, ferrosa-storage, ferrosa-index
+last_revised: 2026-07-20
+executive_summary: >
+  A CFS-inspired, two-dimensional (CPU + I/O), hierarchical (per-tenant) fair
+  scheduler for ferrosa. Consensus and interactive queries are isolated by
+  reservation; analytical scans and background jobs run in a bounded, fairly
+  scheduled pool that can never oversubscribe the cores. The load-bearing
+  refactor is cooperative yielding: every long operation is decomposed into
+  resumable chunks that check in with the scheduler at page/candidate
+  boundaries. Phase 0 (reservation + bounded pool) fixes the raft-heartbeat
+  starvation regression (t_88223ad0) on its own.
+---
+
+# Query QoS / Fair Scheduler — Architecture
+
+> Read `decisions.md` first — this spec assumes DR-1..10 are locked.
+
+## Current state (as-is, from code reconnaissance)
+
+Ferrosa already has strong **runtime isolation** but **no query QoS**:
+
+- **Consensus is isolated at the runtime level.** Raft runs on a dedicated
+  8-thread runtime (`ferrosa/src/runtime.rs:38`) plus a per-peer OS thread with
+  its own current-thread runtime (`ferrosa-net/src/lane_actor.rs:444`). Data,
+  CQL, and background each get their own runtime (`runtime.rs:48/57/66`).
+- **Scan classification is already computed** at `ferrosa-cql/src/planner.rs`
+  (`ScanPlan` enum) and inspected at `router.rs:5082-5156`
+  (`ScanPlan::FullScan`, `s.allow_filtering`, `unbounded_scan_shape`, `LIMIT`).
+- **Streaming scans page with backpressure.** `TableStore::range_iter` /
+  `range_iter_projected` (`store.rs:2810/2703`) spawn a `spawn_blocking`
+  producer feeding a bounded mpsc (`STREAM_BUFFER = 4`); the coordinator rides
+  `Lane::Bulk` (`write_path.rs:657`, `coordinator/range_read_stream.rs:1557`).
+- **Piecemeal throttles exist** but no unified scheduler: CQL per-connection
+  in-flight `Semaphore(max_in_flight)` (`connection.rs:346`), index-builder
+  `Semaphore(max_workers)` (`worker.rs:103`), compaction `CompactionGate`
+  (Mutex+Condvar, `compaction/executor.rs:143`), write admission
+  (`coordinator/write.rs:320`).
+
+**Why consensus still starved (root cause of `t_88223ad0`).** Two gaps:
+
+1. **`max_blocking_threads` is never configured** — every runtime uses tokio's
+   default of **512** (`runtime.rs`, confirmed absent). The storage streaming
+   producers `spawn_blocking` **one unbounded task per concurrent scan**
+   (`store.rs:2747/2844/2937/3017`). A full-table `ALLOW FILTERING` fan-out
+   across replicas spawns a swarm of CPU-hot blocking producers.
+2. That swarm **oversubscribes the physical cores**, so the OS scheduler cannot
+   place even the dedicated raft-lane thread within the 3 s election window
+   (`raft_election_timeout_min_ms = 3000`, `config.rs:117`) → CheckQuorum
+   step-down.
+
+PR #131 already removed the *inline* sync-on-async block; the residual vector is
+**blocking-pool saturation + `Lane::Bulk` contention**, which is a *scheduling
+and admission* problem — exactly what this feature solves. Adding more offload
+threads makes it strictly worse.
+
+There is **no** read-side query priority, class, or fair scheduler today
+(confirmed absent).
+
+## Design overview
+
+Three ideas, layered like the Linux scheduler stack:
+
+```
+                    ┌───────────────────────────────────────────┐
+   RESERVED (never  │  Consensus: raft runtime + per-peer lanes  │  cpu.max
+   in the fair pool)│  Interactive: partition-key point reads    │  headroom
+                    └───────────────────────────────────────────┘
+                    ┌───────────────────────────────────────────┐
+   FAIR POOL        │  Background class — bounded to cores−R      │
+   (this feature)   │   hierarchical fair scheduling:            │
+                    │     tenant-group rbtree (weighted)         │
+                    │       └─ per-query rbtree (vruntime)       │
+                    │   two resource dims: CPU-service + I/O      │
+                    └───────────────────────────────────────────┘
+```
+
+1. **Scheduling classes (isolation).** Consensus and interactive point reads are
+   *reserved* — outside the fair pool. Everything scan-shaped or background is in
+   the fair pool, whose **aggregate concurrency is hard-capped** so the reserved
+   classes always have a CPU (DR-5).
+2. **Hierarchical fair scheduling (fairness).** Within the pool, pick the runnable
+   unit with the smallest `vruntime`, computed first across tenant groups, then
+   across queries (DR-4, DR-7). Classic CFS rbtree, two levels.
+3. **Two resource dimensions (DR-2).** A schedulable chunk advances `vruntime` by
+   its **CPU service time** and holds **I/O permits** (`Lane::Bulk`); an
+   I/O-bound scan is throttled by permits even when it burns little CPU.
+
+### Schedulable unit
+
+The unit is a **chunk of work**, not a whole query: one page of a scan, one batch
+of the k-way merge, one candidate-expansion window of an ANN walk, one repair
+fetch chunk. A query is a *sequence* of chunks that re-enters the runqueue
+between chunks. This is what makes long queries preemptible (DR-6).
+
+## Components
+
+### C1 — Classifier (admission)
+
+At `router.rs:5082-5156`, map `ScanPlan` + predicates to a `SchedClass` and seed
+weight:
+
+| Query shape | Class | Seed weight (nice) |
+|---|---|---|
+| `PartitionKeyLookup` (full PK eq) | `Interactive` (reserved / bypass) | n/a (DD-2) |
+| Bounded index read, small `LIMIT` | `Interactive` or light `Background` | 0 |
+| `FullScan`, `ALLOW FILTERING`, no PK | `Background` | +10 |
+| `VectorAnn` large `ef`, aggregates, `DISTINCT` scans | `Background` | +10 |
+| Repair / compaction / index-build reads | `Background` (system group) | +15 |
+
+The classifier produces a `SchedTicket` (query id, group = `TenantContext`,
+class, seed weight) that travels with the request.
+
+### C2 — Scheduler core (`ferrosa-sched`, new crate — DR-10)
+
+Runtime-agnostic primitives, no storage/cluster/cql dependency:
+
+- `SchedClass { Consensus, Interactive, Background }`.
+- `Group` (tenant): weight, `min_vruntime`, a child rbtree of queries.
+- `RunQueue`: two-level `BTreeMap<VRuntime, _>` (group → query). Pick-min = the
+  next chunk to admit. `min_vruntime` floor on enqueue clamps both a returning
+  long scan (can't hoard credit) and a fresh query (can't starve the scan) —
+  fairness both directions (DR-7).
+- `SchedTicket` — the per-query handle the executor calls between chunks:
+  `ticket.reschedule(cpu_used, io_used).await` accounts service time, advances
+  `vruntime`, and yields if a smaller-`vruntime` unit is waiting.
+- `Reservation` — the hard cap: `background_permits = cores − reserved`; the pool
+  never runs more than that many CPU-bound chunks at once, guaranteeing headroom
+  for consensus + interactive.
+
+### C3 — Bounded background executor pool (DR-9)
+
+Replaces the unbounded storage `spawn_blocking` producers with a
+**scheduler-owned, bounded** pool sized `cores − reserved`. Scan producers,
+compaction merge steps, repair fetches, and index-build walks submit chunk
+closures here; the pool admits by pick-min `vruntime`. This is the single most
+important structural change and the whole of Phase 0's safety guarantee.
+
+### C4 — Resource accounting (DR-2)
+
+- **CPU dimension:** measure elapsed (or thread-CPU) time per chunk; advance
+  `vruntime += cpu_time × weight_factor` (DD-1 pins the exact unit).
+- **I/O dimension:** the pool holds a bounded set of `Lane::Bulk` permits
+  (`ferrosa-net`); a chunk waiting on S3 holds a permit but consumes no CPU, so
+  it is throttled by permit scarcity, and its `vruntime` also advances on I/O
+  wait so I/O-bound scans don't get unlimited free turns.
+
+### C5 — Consensus reservation (DR-5)
+
+Phase 0: (a) set `max_blocking_threads` explicitly on the data/background
+runtimes; (b) stop using the shared unbounded blocking pool for scan producers;
+(c) size the background pool to leave `reserved` cores. Optional hardening:
+thread-priority / core-pinning for the raft lane threads. A metric
+`SCHED_CONSENSUS_HEADROOM_CORES` must stay > 0 under load.
+
+## The refactor (key deliverable — DR-3, DR-6)
+
+The user flagged this as central: the scheduler is only as good as the yield
+points feeding it. Refactor targets, with grounding and effort:
+
+| # | Target | File(s) | Current | Change | Effort |
+|---|---|---|---|---|---|
+| R1 | **Bound the scan producer pool** | `ferrosa-storage/src/store.rs:2747…` | unbounded `spawn_blocking`, `max_blocking_threads`=512 | submit to C3 bounded pool; page loop calls `ticket.reschedule()` | M |
+| R2 | **Thread `SchedTicket` through the read path** | `ferrosa-cql/src/router.rs:5082…` → `ferrosa-cluster/src/write_path.rs:657` / `coordinator/range_read_stream.rs:1557` → `store.rs:2810/2703` | no ticket | classifier mints ticket at C1; passed to producer | M |
+| R3 | **ANN/vector cooperative yield** | `ferrosa-index/src/vector/hnsw.rs:191/196/485`, `ivfflat.rs:256` | **synchronous, no yield, no chunk** | chunk candidate expansion; `reschedule()` every N candidates | M–L |
+| R4 | **Compaction under group accounting** | `ferrosa-storage/src/compaction/executor.rs:143/856` | own threads + `CompactionGate` | keep threads, add `vruntime` accounting so compaction shares the system group fairly (replace/augment `CompactionGate`) | M |
+| R5 | **Repair chunks account service** | `ferrosa-cluster/src/repair/executor.rs:376/177` | already chunked + `spawn_blocking` | add `reschedule()` at chunk boundary; system group | S |
+| R6 | **Index build under scheduler** | `ferrosa-storage/src/index/scheduler.rs:355/638`, `ferrosa-index-builder/src/worker.rs:103` | own threads + semaphore | replace ad-hoc semaphore with C3 admission | M |
+| R7 | **Hinted-handoff replay** | `ferrosa-cluster/src/raft_forward.rs`, `hints/` (loop unpinned — DD-3) | TBD | chunk + account after DD-3 | S–M |
+| R8 | **Runtime config** | `ferrosa/src/runtime.rs`, `main.rs` | `max_blocking_threads` unset | set explicit ceilings; construct the scheduler + pool at boot | S |
+
+**Shared refactor pattern (all of R1/R3/R4/R5/R6/R7):**
+
+```text
+loop over chunks {
+    let chunk = next_chunk();              // page / candidate window / merge step
+    do_work(chunk);                        // bounded by rows OR elapsed time (DR-6)
+    ticket.reschedule(cpu_used, io_used).await;  // account + maybe yield
+    if ticket.cancelled() { break; }       // deadline / client gone / drain
+}
+```
+
+R2 (thread the ticket) + R1 (bounded pool) + R8 (runtime config) are the Phase 0
+critical path and deliver the bug fix. R3 (ANN) is the biggest net-new yielding
+work. R4/R6 also *simplify* by folding two bespoke throttles (`CompactionGate`,
+index semaphore) into one scheduler — a genuine consolidation, not just additions.
+
+## Configuration & observability
+
+- **Config:** `reserved_cores` (default: `max(1, cores/4)`), per-class default
+  nice, per-tenant `weight`/`shares`, chunk budget (rows + ms), background pool
+  size. All via TOML (TOML-wins precedence per house config rules).
+- **Metrics (Prometheus):** `SCHED_CONSENSUS_HEADROOM_CORES` (must stay > 0),
+  per-class CPU%, background pool depth + admit-wait latency, per-group
+  `vruntime` lag, demotions/sec, `Overloaded` rejects, I/O-permit saturation.
+  These are the acceptance signals for the FMEA detection column.
+
+## Phasing (→ `project-plan.md`)
+
+- **Phase 0 — Reservation + bounded pool (fixes t_88223ad0).** R1, R2, R8, C3,
+  C5; single class split (reserved vs background), no vruntime yet — background
+  pool is simply bounded FIFO. Live regression under Fly 6.5%-CPU race fuzzer.
+- **Phase 1 — Fair scheduling.** C2 vruntime rbtree, C1 classifier, seed weights,
+  aging; interactive bypass (DD-2). Single (default) group.
+- **Phase 2 — Two resource dimensions.** C4 I/O accounting, `Lane::Bulk` permit
+  integration, `vruntime` on I/O wait. Pin DD-1 (vruntime unit) with a bench.
+- **Phase 3 — Tenant groups + background unification.** DR-4 two-level rbtree;
+  R4/R5/R6/R7 fold background jobs into the system group; per-tenant shares.
+
+## Open questions
+
+Tracked as `DD-1..4` in `decisions.md`. The two that most affect the design:
+the `vruntime` unit (DD-1) and whether pure point reads bypass the scheduler
+entirely (DD-2, leaning yes).
+
+## Non-goals
+
+- Preempting a synchronous storage/FFI call mid-execution (impossible; DR-6).
+- Governing the write/apply path (DR-3; separate backpressure problem).
+- Replacing openraft's internal heartbeat scheduling (we protect it, not
+  reimplement it).

--- a/specs/proposed/query-scheduler/compiled-project-plan.md
+++ b/specs/proposed/query-scheduler/compiled-project-plan.md
@@ -1,0 +1,238 @@
+---
+title: "Query QoS / Fair Scheduler — Compiled Project Plan"
+status: proposed
+component: ferrosa-sched + integration crates
+last_revised: 2026-07-20
+executive_summary: >
+  Agent-executable compilation of the four-phase plan: a task DAG, parallel
+  execution batches, and three-tier verification (unit acceptance → integration
+  → live/system) per task. Batch B0 delivers the shippable Phase-0 bug fix.
+  Each task names its files, its refactor id (R#), its FMEA guard, and the exact
+  commands that prove it done. Follow TDD (red→green→refactor) per task.
+---
+
+# Query QoS / Fair Scheduler — Compiled Project Plan
+
+**Conventions.** Every task is TDD (write the failing test first). Verification
+has three tiers: **T1** unit/acceptance (crate `cargo test`), **T2** integration
+(cross-crate / `MockStorage`), **T3** live/system (real cluster, Fly race-fuzzer,
+or load harness). A task is *done* only when its listed tier(s) pass. Repo:
+`ferrosa`; scheduler core crate: `ferrosa-sched` (new). No `#[ignore]`, no silent
+returns, RAII for every permit, no lock held across `.await` in the pool path.
+
+## Task DAG
+
+```
+B0 (Phase 0 — ships the fix)
+  T0.1 sched-crate ──┬─ T0.3 route-producers-through-pool ─┬─ T0.5 headroom-metrics ─ T0.6 live-regression*
+  T0.2 blocking-cap ─┘   T0.4 ticket-plumbing(no-op) ──────┘   T0.7 pool-RAII
+
+B1 (Phase 1 — fairness)      needs B0
+  T1.1 runqueue ─ T1.2 reschedule-impl ─┬─ T1.3 chunk-tripwire*
+                                        ├─ T1.4 classifier
+                                        ├─ T1.5 interactive-bypass
+                                        └─ T1.6 fairness-proptests ─ T1.7 no-lock-audit
+
+B2 (Phase 2 — I/O dim)       needs B1
+  T2.1 io-permits ─ T2.2 vruntime-on-io ─ T2.3 vruntime-unit-bench ─ T2.4 permit-leak-test
+
+B3 (Phase 3 — groups + bg)   needs B1 (T3.3 also needs B2 for I/O-heavy ANN)
+  T3.1 two-level-rbtree ─┬─ T3.2 tenant-weights ─ T3.9 gaming-test
+                         ├─ T3.3 ann-yield + recall-guard*
+                         ├─ T3.4 compaction-fold
+                         ├─ T3.5 repair-accounting
+                         ├─ T3.6 indexbuild-fold
+                         ├─ T3.7 hints-replay (needs DD-3)
+                         └─ T3.8 bounded-runqueue
+```
+`*` = FMEA RPN ≥ 200 guard; must pass before dependents merge.
+
+## Parallel batches
+
+- **B0** is the critical path to the bug fix. Within B0: T0.1 ‖ T0.2 first, then
+  T0.3 ‖ T0.4, then T0.5 ‖ T0.7, then T0.6.
+- **B1** T1.4/T1.5/T1.6 parallelize after T1.2.
+- **B3** T3.3/T3.4/T3.5/T3.6 parallelize (different subsystems, use worktree
+  isolation to avoid file conflicts).
+
+---
+
+## B0 — Reservation + bounded pool (Phase 0, shippable)
+
+### T0.1 — `ferrosa-sched` crate skeleton
+- **Deps:** none. **Refactor:** R10/R8.
+- **Files:** new `ferrosa-sched/{Cargo.toml,src/lib.rs}`; workspace `Cargo.toml`.
+- **Action:** `SchedClass`, `Reservation { cores, reserved }`, a bounded
+  execution pool (`submit(closure) -> JoinHandle`, admits ≤ `cores−reserved`
+  CPU-bound at once), no-op `SchedTicket`. Leaf crate — depends only on
+  `ferrosa-common` + tokio.
+- **T1:** `cargo test -p ferrosa-sched` — pool admits ≤ cap concurrently
+  (counter never exceeds); RAII slot returned on drop/panic.
+- **Guard:** DSM — `ferrosa-sched` has no storage/cluster/cql dep.
+
+### T0.2 — Explicit `max_blocking_threads`
+- **Deps:** none. **Refactor:** R8. **FMEA:** FM-1.
+- **Files:** `ferrosa/src/runtime.rs`, `ferrosa/src/main.rs`, config.
+- **Action:** set `max_blocking_threads` on data/background runtimes (default
+  derived from cores); expose `FERROSA_*_MAX_BLOCKING` + TOML.
+- **T1:** config precedence test (TOML-wins) for the new field.
+
+### T0.3 — Route scan producers through the bounded pool
+- **Deps:** T0.1, T0.2. **Refactor:** R1. **FMEA:** FM-1.
+- **Files:** `ferrosa-storage/src/store.rs:2703/2810/2747/2844/2937/3017`.
+- **Action:** replace raw `spawn_blocking` scan producers with
+  `sched_pool.submit(...)`. Page loop unchanged for now (FIFO admit).
+- **T1:** streaming range read still returns identical rows (existing
+  `range_iter` tests green). **T2:** concurrent-scan test asserts ≤ cap producers
+  run at once (new gauge).
+
+### T0.4 — Thread no-op `SchedTicket` router→coordinator→producer
+- **Deps:** T0.1. **Refactor:** R2.
+- **Files:** `ferrosa-cql/src/router.rs:5082…`, `ferrosa-cluster/src/write_path.rs:657`,
+  `coordinator/range_read_stream.rs:1557`, `store.rs:2810`.
+- **Action:** mint a `SchedTicket` at the router, pass it down to the producer
+  (unused in B0). Establishes the seam so B1 activates fairness without
+  re-touching call sites.
+- **T1:** compiles; ticket reaches the producer (trace/assert in a test).
+
+### T0.5 — Consensus-headroom + pool metrics
+- **Deps:** T0.3. **FMEA:** FM-1.
+- **Files:** `ferrosa-sched/src/metrics.rs`, Prometheus registry.
+- **Action:** `SCHED_CONSENSUS_HEADROOM_CORES`, pool depth, admit-wait latency.
+- **T1:** metric reflects `cores − active_background`.
+
+### T0.6 — Live no-step-down regression ★
+- **Deps:** T0.3, T0.5. **FMEA:** FM-1.
+- **Files:** `ferrosa-jepsen` or a scan-storm harness + Fly runbook.
+- **Action:** reproduce `t_88223ad0` on the *pre-fix* build (raft step-down under
+  full-table `ALLOW FILTERING` on Fly 6.5%-CPU), then assert *green* on the fix.
+- **T3:** leader term stable, `ELECTION_STORM_TERM_JUMPS_TOTAL` == 0, headroom > 0
+  throughout the scan storm.
+
+### T0.7 — Pool-slot RAII
+- **Deps:** T0.1. **FMEA:** FM-8.
+- **T1:** panic-in-closure test asserts the slot is returned (no leak).
+
+**B0 exit:** T0.6 green → the bug fix ships. Tag as the Phase-0 deliverable.
+
+---
+
+## B1 — Fair scheduling (Phase 1)
+
+### T1.1 — `RunQueue` (single group) + `min_vruntime` floor
+- **Deps:** B0. **FMEA:** FM-4, FM-5.
+- **Files:** `ferrosa-sched/src/runqueue.rs`.
+- **T1:** pick-min ordering; enqueue clamps to `max(self, min_vruntime − boost)`;
+  monotonic-`min_vruntime` invariant.
+
+### T1.2 — `SchedTicket::reschedule(cpu, io)` real impl
+- **Deps:** T1.1. **Refactor:** R1. **FMEA:** FM-2.
+- **Files:** `ferrosa-sched/src/ticket.rs`, `store.rs` page loop.
+- **Action:** account service time, advance `vruntime`, yield if a smaller-vruntime
+  unit waits. Page loop calls it per page.
+- **T1:** two scans interleave (neither monopolizes); **T2:** `MockStorage`
+  multi-scan fairness.
+
+### T1.3 — Chunk-budget tripwire ★
+- **Deps:** T1.2. **FMEA:** FM-2.
+- **Action:** inside `reschedule()`, assert chunk consumed ≤ budget (rows OR ms);
+  emit `sched_max_chunk_ms`; source-inspection test that every pool-submit loop
+  calls `reschedule()` (pattern like the viz-drain `truncations.push` guard).
+- **T1:** over-budget chunk trips the assertion/metric; inspection test fails if a
+  submit loop omits `reschedule()`.
+
+### T1.4 — Classifier at `ScanPlan`
+- **Deps:** T1.2. **FMEA:** FM-10.
+- **Files:** `ferrosa-cql/src/router.rs:5082-5156`, `planner.rs`.
+- **T1:** full `ScanPlan` matrix → expected class + seed weight (point→Interactive,
+  FullScan/ALLOW FILTERING→Background, etc.).
+
+### T1.5 — Interactive point-read bypass (DD-2)
+- **Deps:** T1.4. **FMEA:** FM-6.
+- **T2:** `PartitionKeyLookup` path has zero scheduler calls (overhead ~0).
+
+### T1.6 — Fairness property tests
+- **Deps:** T1.2. **FMEA:** FM-4, FM-5.
+- **T1:** proptest — equal-weight → equal service ±ε; long scan makes monotonic
+  progress under interactive churn (aging).
+
+### T1.7 — No-lock-across-`reschedule` audit
+- **Deps:** T1.2. **FMEA:** FM-3, FM-7.
+- **T1:** source-inspection + review gate: no storage/index lock held across
+  `reschedule().await` (mirror Accord `handlers.rs` deadlock-safety doc).
+
+**B1 exit:** T1.3, T1.6, T1.7 green; p99 interactive-under-scan within SLA (T3).
+
+---
+
+## B2 — Two resource dimensions (Phase 2)
+
+### T2.1 — I/O permit pool on `Lane::Bulk`
+- **Deps:** B1. **FMEA:** FM-8. **Files:** `ferrosa-sched`, `ferrosa-net` lane wiring.
+- **T1:** permit acquire/release RAII; bound respected.
+
+### T2.2 — `vruntime` advances on I/O wait
+- **Deps:** T2.1. **FMEA:** FM-4.
+- **T2:** an I/O-bound scan (mock high-latency S3) is throttled to fair share
+  despite low CPU.
+
+### T2.3 — Pin DD-1 (vruntime unit) via bench
+- **Deps:** T2.2. **Action:** microbench wall vs thread-CPU vs proxy; write ADR.
+
+### T2.4 — Permit-leak invariant
+- **Deps:** T2.1. **FMEA:** FM-8. **T1:** panic/cancel in chunk → permit returned.
+
+---
+
+## B3 — Tenant groups + background unification (Phase 3)
+
+### T3.1 — Two-level rbtree (group→query)
+- **Deps:** B1. **FMEA:** FM-12. **Files:** `ferrosa-sched/src/runqueue.rs`.
+- **T1:** group-then-query pick-min; `TenantContext` as group key.
+
+### T3.2 — Per-tenant weights (TOML) — **Deps:** T3.1. **T1:** share ∝ weight.
+
+### T3.3 — ANN cooperative yield + recall guard ★
+- **Deps:** T1.2 (+ B2 for I/O-heavy). **Refactor:** R3. **FMEA:** FM-11.
+- **Files:** `ferrosa-index/src/vector/hnsw.rs:191/196/485`, `ivfflat.rs:256`.
+- **Action:** chunk candidate expansion at safe frontier boundaries; `reschedule()`
+  every N candidates.
+- **T1:** **golden-recall** — chunked vs unchunked return identical top-k on
+  fixtures; **T2:** ANN under scan load yields (no monopolization).
+
+### T3.4 — Compaction under group accounting
+- **Deps:** T3.1. **Refactor:** R4. **Files:** `compaction/executor.rs:143/856`.
+- **Action:** fold `CompactionGate` into scheduler system-group accounting.
+- **T1:** compaction shares system-group fairly; existing compaction tests green.
+
+### T3.5 — Repair chunk accounting — **Deps:** T3.1. **Refactor:** R5.
+- **Files:** `repair/executor.rs:376/177`. **T2:** repair yields between chunks.
+
+### T3.6 — Index build under scheduler — **Deps:** T3.1. **Refactor:** R6.
+- **Files:** `index/scheduler.rs`, `ferrosa-index-builder/src/worker.rs:103`.
+- **Action:** replace bespoke semaphore with scheduler admission.
+
+### T3.7 — Hinted-handoff replay — **Deps:** DD-3 pinned. **Refactor:** R7.
+
+### T3.8 — Bounded runqueue + `Overloaded` (DD-4) — **FMEA:** FM-13.
+- **T3:** 10× admission-rate load storm → bounded memory, clean rejects.
+
+### T3.9 — Tenant-gaming fairness — **Deps:** T3.1. **FMEA:** FM-12.
+- **T2:** 1 tenant × 100 queries == 1 tenant × 1 query in aggregate share.
+
+**B3 exit:** cross-tenant isolation proven; ANN recall unchanged; `CompactionGate`
+and index semaphore removed (consolidation complete).
+
+---
+
+## Global acceptance (feature done)
+
+- **T3-A:** under full-table `ALLOW FILTERING` + repair + compaction concurrently,
+  on constrained CPU: raft leader stable, interactive p99 within SLA, each tenant
+  gets its weighted share.
+- **T3-B:** background throughput ≥ accepted delta vs pre-scheduler baseline
+  (FM-14) — the reservation didn't cripple analytics.
+- **Docs:** per-crate README/specs updated for `ferrosa-sched` and every touched
+  crate (house rule); this proposal promoted out of `specs/proposed/`.
+- **Gates:** `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D
+  warnings`, `cargo test --workspace`, and the `p0-oom-audit` all green.

--- a/specs/proposed/query-scheduler/decisions.md
+++ b/specs/proposed/query-scheduler/decisions.md
@@ -1,7 +1,7 @@
 ---
 title: "Query QoS / Fair Scheduler — Decision Records"
-status: proposed
-component: ferrosa-sched (new) + ferrosa-cql, ferrosa-cluster, ferrosa-storage, ferrosa-index
+status: partially-implemented
+component: ferrosa-sched + ferrosa-cql, ferrosa-cluster, ferrosa-storage, ferrosa-index
 last_revised: 2026-07-20
 executive_summary: >
   Locked design decisions for a CFS-inspired, multi-resource (CPU + I/O),

--- a/specs/proposed/query-scheduler/decisions.md
+++ b/specs/proposed/query-scheduler/decisions.md
@@ -1,0 +1,168 @@
+---
+title: "Query QoS / Fair Scheduler — Decision Records"
+status: proposed
+component: ferrosa-sched (new) + ferrosa-cql, ferrosa-cluster, ferrosa-storage, ferrosa-index
+last_revised: 2026-07-20
+executive_summary: >
+  Locked design decisions for a CFS-inspired, multi-resource (CPU + I/O),
+  multi-tenant fair scheduler that governs read scans and background jobs so
+  that consensus and interactive queries keep their latency SLA under heavy
+  analytical load. Delivered in phases; Phase 0 (consensus CPU reservation +
+  bounded background pool) both ships first and fixes the raft-heartbeat
+  starvation regression (t_88223ad0). Consensus is isolated by reservation,
+  not fair share; cooperative yielding is the load-bearing refactor.
+---
+
+# Query QoS / Fair Scheduler — Decision Records
+
+Each record is **locked** unless marked otherwise. `DR-1..4` come from the Phase 0
+stakeholder grill; `DR-5..10` are baked-in consequences grounded in the code
+reconnaissance (see `architecture.md` § "Current state").
+
+## DR-1 — Ambition: full fair scheduler, delivered in phases (LOCKED)
+
+Build the fair scheduler as a real, first-class subsystem, but land it in phases.
+**Phase 0** (consensus CPU reservation + a bounded background execution pool)
+ships first and, on its own, fixes the raft-heartbeat starvation
+(`t_88223ad0`). Later phases add vruntime fairness, the second resource
+dimension, and tenant groups.
+
+- **Rationale:** value early (bug fixed in Phase 0), risk staged, and the end
+  state is a genuine ferrosa differentiator vs Cassandra (which has no per-query
+  QoS). Top-down-before-shipping leaves the P0 step-down unfixed for longer.
+- **Rejected:** *minimal fix only* (not a feature; leaves analytical/OLTP
+  interference unsolved) and *full scheduler top-down* (delays the bug fix).
+
+## DR-2 — Govern both CPU and I/O (LOCKED)
+
+The scheduler accounts for **two resource dimensions**: CPU service time
+(deserialize + filter + merge) **and** I/O concurrency (outstanding S3/local
+reads, expressed as `Lane::Bulk` permits). A query's `vruntime` advances on
+whichever dimension it consumes.
+
+- **Rationale:** ferrosa is S3-backed; a full scan is frequently I/O-bound, so
+  CPU-only accounting would let an I/O-heavy scan escape throttling. The
+  `Lane::Bulk` seam already exists (`ferrosa-net`), so the I/O dimension has a
+  natural home.
+- **Rejected:** *CPU only* (dead-ends on I/O-bound scans).
+
+## DR-3 — Refactor scope: reads + background jobs (LOCKED)
+
+v1 makes these cooperatively yield to the scheduler: **range scans, `ALLOW
+FILTERING`, secondary-index reads, ANN/vector scans** (read side) **and
+compaction reads, repair, hinted-handoff replay, index build** (background
+side). The **write/apply path is out of v1** (writes already have admission
+control and are latency-bounded, not scan-shaped).
+
+- **Rationale:** unify all heavy, long-running work under one scheduler so no
+  single class of background work can starve consensus or OLTP. The write path
+  is a separate control problem (backpressure by bytes) already partly solved.
+- **Consequence:** ANN/vector search is currently synchronous with **no yield
+  points** (`ferrosa-index/src/vector/hnsw.rs`) — it is a required refactor
+  target, not just an integration.
+
+## DR-4 — Per-tenant group scheduling in v1 (LOCKED)
+
+The scheduler is **hierarchical**: fairness is computed first across **tenant
+groups** (weighted, cgroup/`cpu.shares` style), then across queries within a
+group. Ships in v1, aligned with ferrosa-dbaas multi-tenancy.
+
+- **Rationale:** in a shared cluster, one tenant's analytical scan must not
+  starve another tenant's OLTP. This is the highest-value fairness axis for the
+  DBaaS product and is cheap to design in from the start but expensive to retrofit.
+- **Consequence:** the scheduler runqueue is a two-level structure
+  (group rbtree → query rbtree), and `TenantContext` (already threaded
+  everywhere) is the group key.
+
+## DR-5 — Consensus is isolated by reservation, NOT fair share (LOCKED, baked)
+
+Raft/consensus is **not** a high-weight participant in the fair pool. It keeps
+its dedicated runtime (`runtime.rs:38`, 8 threads) and per-peer OS threads
+(`lane_actor.rs:444`), and the scheduler **hard-caps aggregate background
+concurrency** so those threads always get a CPU. Think Linux `SCHED_FIFO` above
+`SCHED_OTHER`, plus a `cpu.max` bandwidth cap on the background class.
+
+- **Rationale:** fairness ≠ isolation. A proportional share can still miss the
+  3 s election deadline (`raft_election_timeout_min_ms = 3000`,
+  `config.rs:117`). The recon proves this is the actual failure: raft *already*
+  has a dedicated thread, yet unbounded storage `spawn_blocking` producers
+  (`max_blocking_threads` unset → 512, `runtime.rs`) oversubscribe the cores and
+  the OS can't schedule the raft thread → CheckQuorum step-down.
+- **Consequence:** Phase 0 = set/enforce a bounded background execution pool
+  sized `cores − reserved` and stop using the unbounded shared blocking pool for
+  scan producers.
+
+## DR-6 — Cooperative yielding is the preemption model (LOCKED, baked)
+
+There is no mid-syscall preemption. Every long operation is decomposed into
+**resumable chunks**; at each chunk boundary the worker calls the scheduler to
+account service time and possibly yield. Chunk size is bounded by **rows OR
+elapsed time** (whichever first), so a slow decode can't monopolize between
+yield points.
+
+- **Rationale:** you cannot preempt a synchronous storage/decode call in FFI.
+  Cooperative yield points are mandatory; this is the load-bearing refactor.
+- **Grounding:** the streaming scan already pages (`store.rs:2810 range_iter`,
+  bounded mpsc `STREAM_BUFFER=4`), so read-side yield points mostly exist at page
+  boundaries; ANN and some background loops do not yet.
+
+## DR-7 — Aging over a-priori classification (LOCKED, baked)
+
+Weight is *seeded* from query shape at admission (point read → interactive; full
+scan / `ALLOW FILTERING` → background), but **accumulated service time
+(`vruntime`) drives ongoing scheduling**, so a surprise-long "interactive"
+query self-demotes without us predicting its cost.
+
+- **Rationale:** classification alone is brittle; CFS's insight is that runtime
+  accounting handles the unknown-length case for free.
+
+## DR-8 — Admission at the `ScanPlan` seam (LOCKED, baked)
+
+Classification and admission attach at the planner/router boundary
+(`ferrosa-cql/src/planner.rs` `ScanPlan`; `router.rs:5082-5156`), where
+partition-key presence, `ALLOW FILTERING`, `LIMIT`, `ORDER BY`, `DISTINCT`, and
+aggregate shape are all known *before* any storage call.
+
+- **Rationale:** the query shape is free here; no extra parsing. This is the one
+  place that sees the whole query before dispatch.
+
+## DR-9 — Cover the streaming seam, and bound the producer pool (LOCKED, baked)
+
+The scheduler hooks the **streaming** read seams (`WritePath::range_read_stream_*`,
+`ferrosa-cluster/src/coordinator/range_read_stream.rs`, `TableStore::range_iter` /
+`range_iter_projected`, `store.rs:2703/2810`), not only `DataStore::read_range`
+(which materializes). The unbounded `spawn_blocking` scan producers
+(`store.rs:2747…`) are replaced by a **bounded, scheduler-owned executor pool**.
+
+- **Rationale:** the recon shows streaming scans bypass `DataStore`; hooking only
+  the materializing trait would miss the actual scan path and the actual
+  starvation vector.
+
+## DR-10 — New `ferrosa-sched` crate for the scheduler core (LOCKED, baked)
+
+The scheduler primitives (classes, groups, runqueue, resource accounting, the
+`SchedTicket` yield handle) live in a **new leaf crate `ferrosa-sched`** with no
+dependency on storage/cluster/cql, so all of them can depend *on it* without a
+cycle. Integration code (classifier, executor-pool wiring) lives in the
+consuming crates.
+
+- **Rationale:** keeps the DSM acyclic (storage, cluster, cql, index all consume
+  the scheduler); mirrors how `ferrosa-common` is a shared leaf.
+- **Open sub-question:** whether the bounded executor pool itself lives in
+  `ferrosa-sched` or `ferrosa-storage` (it needs `spawn_blocking`); leaning
+  `ferrosa-sched` owning a runtime-agnostic pool abstraction, storage supplying
+  the closures. Resolve in Phase 1 design review.
+
+## Deferred / open decisions
+
+- **DD-1:** exact `vruntime` unit — wall-time vs thread-CPU-time vs a row/byte
+  proxy. Leaning a hybrid: measured elapsed per chunk, weighted; revisit with a
+  microbenchmark in Phase 2.
+- **DD-2:** whether interactive point reads bypass the scheduler entirely (own
+  fast lane) or enter with a large vruntime credit. Leaning **bypass** for pure
+  partition-key lookups (zero scheduler overhead on the OLTP hot path).
+- **DD-3:** hinted-handoff replay loop was not pinned in recon (`§7` gap) —
+  confirm its main loop before wiring it into the background group.
+- **DD-4:** admission-reject vs queue behavior when the background pool is
+  saturated (fail-loud `Overloaded` like CQL backpressure, vs bounded queue with
+  a deadline). Leaning bounded queue + deadline, `Overloaded` past the deadline.

--- a/specs/proposed/query-scheduler/fmea.md
+++ b/specs/proposed/query-scheduler/fmea.md
@@ -1,0 +1,51 @@
+---
+title: "Query QoS / Fair Scheduler — FMEA"
+status: proposed
+component: ferrosa-sched + integration crates
+last_revised: 2026-07-20
+executive_summary: >
+  Failure-mode analysis for the fair scheduler. RPN = Severity × Occurrence ×
+  Detection (1–10 each). The dominant risks are (a) consensus still starving if
+  the reservation is wrong or a yield point is missing, and (b) yield-gap
+  regressions where a refactored loop forgets to reschedule and reintroduces the
+  current bug. Both are RPN ≥ 200 and become Sprint-1 work items with mandatory
+  live regressions.
+---
+
+# Query QoS / Fair Scheduler — FMEA
+
+Severity/Occurrence/Detection each 1–10 (higher = worse / more frequent / harder
+to detect). RPN = S×O×D. Test cases required for RPN ≥ 50; work items
+(`source: fmea`) for RPN ≥ 200.
+
+| ID | Failure mode | Effect | S | O | D | RPN | Mitigation / detection |
+|---|---|---|---|---|---|---|---|
+| FM-1 | **Consensus still starves** — reservation too small, pool cap too high, or a non-scan CPU hog escapes the cap | Raft step-down, cluster unavailability (the exact `t_88223ad0` regression) | 10 | 4 | 5 | **200** | Hard cap `cores−reserved`; `SCHED_CONSENSUS_HEADROOM_CORES` metric alerts if ≤0; live Fly 6.5%-CPU race-fuzzer regression asserting no step-down under scan load |
+| FM-2 | **Yield-point gap** — a refactored loop (esp. R3 ANN, R4 compaction) misses a `reschedule()` and runs a chunk unbounded | Localized starvation returns; one query monopolizes a core | 9 | 6 | 6 | **324** | Chunk-budget assertion (rows OR elapsed ms) enforced *inside* `reschedule()`; a `sched_max_chunk_ms` tripwire metric; source-inspection test that every submit-to-pool loop calls `reschedule()`; watchdog logs a chunk exceeding budget |
+| FM-3 | **Priority inversion** — interactive request blocked behind a background chunk holding a shared lock/permit | OLTP latency spike despite reservation | 8 | 5 | 6 | **240** | Never hold a storage/index lock across `reschedule()`/`.await` (mirrors the Accord dep-wait deadlock-safety rule); priority-inheritance on the few unavoidable shared locks; p99 interactive-latency-under-scan test |
+| FM-4 | **vruntime accounting drift** — bad time source or weight math → one query/group hogs | Unfair scheduling, effective starvation of a tenant | 7 | 5 | 7 | **245** | `min_vruntime` floor clamp on enqueue; property test: N queries of equal weight converge to equal service ±ε; monotonic-vruntime invariant assertion |
+| FM-5 | **Background starvation** — long scan never finishes because fresh queries keep preempting | Analytical queries hang / time out | 6 | 4 | 5 | 120 | `min_vruntime` floor prevents infinite deferral; a fresh query cannot get more than one slice of credit; aging test that a long scan makes monotonic progress under interactive churn |
+| FM-6 | **Scheduler is the bottleneck** — runqueue lock contention on the hot path | Throughput collapse; scheduler overhead > work | 7 | 3 | 5 | 105 | Per-shard runqueues (like `memtable/sharded`); interactive point reads bypass entirely (DD-2); benchmark scheduler overhead < 2% at target QPS |
+| FM-7 | **Reschedule deadlock** — chunk awaits `reschedule()` while holding a resource the pool needs to admit the next chunk | Pool wedges, all scans hang | 9 | 2 | 7 | 126 | Release all permits/locks before `reschedule().await`; loom/`cargo miri` on the pool admit path; deadlock watchdog on pool admit latency |
+| FM-8 | **I/O permit leak** — a cancelled/panicked chunk drops a `Lane::Bulk` permit without returning it | Slow permit exhaustion → scans stall | 7 | 4 | 6 | 168 | RAII permit guard (like `CompactionPermit`); permit-count invariant metric; panic-in-chunk test asserts permit returned |
+| FM-9 | **Cancellation/deadline ignored** — a drained/timed-out query keeps consuming (ties to the viz idle-drain class) | Wasted capacity, zombie scans | 6 | 4 | 5 | 120 | `ticket.cancelled()` checked every chunk; deadline propagated from CQL request; test: dropping the client stops the scan within one chunk budget |
+| FM-10 | **Misclassification** — point read tagged Background (latency spike) or big scan tagged Interactive (bypasses cap → starvation) | Either OLTP latency or FM-1 recurrence | 8 | 3 | 4 | 96 | Classifier unit tests over the full `ScanPlan` matrix; a scan that *escalates* (exceeds interactive service budget) auto-demotes (DR-7 aging) — a misclassified scan self-corrects |
+| FM-11 | **ANN chunking changes results** — breaking the HNSW walk into chunks alters recall/ordering | Wrong query answers (silent correctness bug) | 9 | 3 | 8 | **216** | Golden-recall test: chunked vs unchunked ANN return identical top-k on fixtures; chunk only at safe frontier boundaries (no partial-layer state loss) |
+| FM-12 | **Tenant gaming** — a tenant issues many tiny queries to grab more aggregate share than its weight | Cross-tenant unfairness | 5 | 4 | 6 | 120 | Fairness is at the *group* level (weight per tenant), not per-query — many small queries share one group's slice; test: 1 tenant × 100 queries gets same share as 1 tenant × 1 query |
+| FM-13 | **Runqueue unbounded growth** — query storm enqueues faster than drain | Memory blowup / OOM (violates bounded-collection rule) | 8 | 3 | 5 | 120 | Bounded runqueue + `Overloaded` reject past a depth/deadline (DD-4); depth metric; load test at 10× target admission rate |
+| FM-14 | **Reservation starves throughput** — `reserved_cores` too large, background pool too small | Analytical throughput tanks; scans crawl | 5 | 4 | 4 | 80 | Default `reserved = max(1, cores/4)`; tunable; background-throughput regression vs pre-scheduler baseline |
+
+## Work items (RPN ≥ 200) → `todo/`
+
+- **FM-1** (200): consensus reservation correctness + live no-step-down regression. Sprint 1 / Phase 0.
+- **FM-2** (324): yield-gap tripwire (budget assertion inside `reschedule()` + source-inspection test). Sprint 1 — this is the guard that stops the whole feature from silently regressing.
+- **FM-4** (245): vruntime fairness property tests. Sprint 2 / Phase 1.
+- **FM-3** (240): priority-inversion / no-lock-across-await audit. Sprint 2.
+- **FM-11** (216): ANN chunking golden-recall guard. Sprint (Phase where R3 lands).
+
+## Cross-cutting test themes
+
+1. **No lock across `reschedule().await`** — a source-inspection + review gate, mirroring the Accord dep-wait deadlock-safety comment (`handlers.rs`).
+2. **Every submit loop calls `reschedule()`** — inspection test (like the viz-drain `progress.truncations.push` guard we just added).
+3. **Live starvation regression under constrained CPU** — the Fly 6.5%-CPU fuzzer is the canonical harness (per house memory).
+4. **RAII for every permit** — no manual permit release anywhere.

--- a/specs/proposed/query-scheduler/fmea.md
+++ b/specs/proposed/query-scheduler/fmea.md
@@ -1,6 +1,6 @@
 ---
 title: "Query QoS / Fair Scheduler — FMEA"
-status: proposed
+status: partially-implemented
 component: ferrosa-sched + integration crates
 last_revised: 2026-07-20
 executive_summary: >

--- a/specs/proposed/query-scheduler/project-plan.md
+++ b/specs/proposed/query-scheduler/project-plan.md
@@ -1,0 +1,108 @@
+---
+title: "Query QoS / Fair Scheduler — Project Plan"
+status: proposed
+component: ferrosa-sched + integration crates
+last_revised: 2026-07-20
+executive_summary: >
+  Four phases. Phase 0 (reservation + bounded background pool) is a shippable
+  slice that fixes the raft-heartbeat starvation regression (t_88223ad0) with no
+  vruntime machinery. Phases 1–3 add fair scheduling, the I/O resource
+  dimension, and per-tenant groups plus the background-job unification refactor.
+  Sequenced by FMEA risk (FM-1/FM-2 first) and by dependency: the bounded pool
+  and the SchedTicket plumbing gate everything downstream.
+---
+
+# Query QoS / Fair Scheduler — Project Plan
+
+Priorities: **P1** = FMEA RPN ≥ 200 or blocks the bug fix; **P2** = high-risk /
+dependency-unblocking; **P3** = completeness; **P4** = polish/tuning.
+
+## Phase 0 — Reservation + bounded pool (fixes t_88223ad0)
+
+**Goal:** stop the raft step-down under scan load. No vruntime; the background
+pool is a bounded FIFO. Ship independently.
+
+| Item | P | Refactor | FMEA | Deliverable |
+|---|---|---|---|---|
+| P0-1 Create `ferrosa-sched` crate (skeleton: `SchedClass`, `Reservation`, bounded pool, `SchedTicket` no-op) | P1 | R8 | — | new leaf crate, compiles, unit-tested pool |
+| P0-2 Set explicit `max_blocking_threads` on data/background runtimes | P1 | R8 | FM-1 | `runtime.rs` ceilings; config field |
+| P0-3 Route scan producers through the bounded pool | P1 | R1 | FM-1 | `store.rs:2747…` submits to C3, not raw `spawn_blocking` |
+| P0-4 Thread a (no-op) `SchedTicket` router→coordinator→producer | P1 | R2 | — | plumbing seam for Phase 1 |
+| P0-5 `SCHED_CONSENSUS_HEADROOM_CORES` + pool-depth metrics | P1 | — | FM-1 | Prometheus gauges |
+| P0-6 **Live no-step-down regression** under Fly 6.5%-CPU fuzzer | P1 | — | FM-1 | reproduces old bug on baseline, green on fix |
+| P0-7 RAII permit guard for pool slots | P2 | — | FM-8 | no manual release |
+
+**Exit:** full-table `ALLOW FILTERING` fan-out under constrained CPU keeps raft
+leader stable; headroom metric > 0 throughout; background throughput within an
+accepted delta of pre-change baseline (FM-14 watch).
+
+## Phase 1 — Fair scheduling (vruntime)
+
+**Goal:** within the background pool, interleave chunks fairly; interactive
+bypass.
+
+| Item | P | Refactor | FMEA | Deliverable |
+|---|---|---|---|---|
+| P1-1 `RunQueue` (single group) vruntime rbtree + `min_vruntime` floor | P1 | — | FM-4, FM-5 | `ferrosa-sched` core |
+| P1-2 `SchedTicket::reschedule(cpu,io)` real impl (account + yield) | P1 | R1 | FM-2 | chunk-boundary yield |
+| P1-3 **Chunk-budget tripwire** (rows OR ms) inside `reschedule()` | P1 | — | FM-2 | assertion + `sched_max_chunk_ms` metric |
+| P1-4 Classifier at `ScanPlan` seam; seed weights | P1 | R2 | FM-10 | `router.rs:5082…` |
+| P1-5 Interactive point-read bypass (DD-2) | P2 | — | FM-6 | zero scheduler overhead on PK reads |
+| P1-6 Fairness property tests (equal-weight convergence, aging) | P1 | — | FM-4, FM-5 | proptest suite |
+| P1-7 No-lock-across-`reschedule` audit + inspection test | P1 | — | FM-3, FM-7 | review gate + test |
+
+**Exit:** N equal-weight scans get equal service ±ε; a long scan makes monotonic
+progress under interactive churn; p99 interactive latency under scan load within
+SLA.
+
+## Phase 2 — Two resource dimensions (CPU + I/O)
+
+**Goal:** throttle I/O-bound scans, not just CPU-bound ones.
+
+| Item | P | Refactor | FMEA | Deliverable |
+|---|---|---|---|---|
+| P2-1 I/O permit pool bound to `Lane::Bulk` | P1 | R1 | FM-8 | permit accounting |
+| P2-2 `vruntime` advances on I/O wait | P1 | — | FM-4 | dual-dimension accounting |
+| P2-3 Pin DD-1 (vruntime unit) with a microbenchmark | P2 | — | FM-4 | ADR + bench |
+| P2-4 Permit-leak invariant test (panic-in-chunk) | P1 | — | FM-8 | RAII verified |
+
+**Exit:** an I/O-bound scan is throttled to its fair share of `Lane::Bulk`; permit
+count invariant holds across panics/cancels.
+
+## Phase 3 — Tenant groups + background unification
+
+**Goal:** per-tenant fairness; fold all background jobs under the scheduler.
+
+| Item | P | Refactor | FMEA | Deliverable |
+|---|---|---|---|---|
+| P3-1 Two-level rbtree (group → query); `TenantContext` as group key | P1 | — | FM-12 | hierarchical fairness |
+| P3-2 Per-tenant weights/shares (TOML) | P2 | — | FM-12 | config + tests |
+| P3-3 ANN cooperative yield + **golden-recall guard** | P1 | R3 | FM-11 | chunked HNSW/IVF, identical top-k |
+| P3-4 Compaction under group accounting (fold `CompactionGate`) | P2 | R4 | — | consolidation |
+| P3-5 Repair chunk accounting | P2 | R5 | — | `repair/executor.rs:376` |
+| P3-6 Index build under scheduler (fold semaphore) | P2 | R6 | — | consolidation |
+| P3-7 Hinted-handoff replay (after DD-3 pin) | P3 | R7 | — | system group |
+| P3-8 Bounded runqueue + `Overloaded` reject (DD-4) | P2 | — | FM-13 | no OOM under storm |
+| P3-9 Tenant-gaming fairness test (1×100 vs 1×1) | P1 | — | FM-12 | group-level share proven |
+
+**Exit:** tenant A's scan cannot starve tenant B's OLTP; ANN recall unchanged;
+`CompactionGate` and the index semaphore are gone (replaced by the scheduler).
+
+## Cross-phase risks
+
+- **R3/ANN (FM-11)** is the highest-uncertainty refactor (correctness, not just
+  perf) — golden-recall guard is non-negotiable.
+- **FM-2 yield-gap** is the systemic risk: the whole feature silently regresses if
+  a refactored loop forgets to `reschedule()`. The Phase 1 tripwire + inspection
+  test must land before the Phase 3 background refactors.
+- **DSM:** `ferrosa-sched` must stay a leaf (no storage/cluster/cql deps) or it
+  creates a cycle — enforce in Phase 0.
+
+## Sequencing rationale
+
+Phase 0 ships the bug fix with minimal surface. `SchedTicket` plumbing (P0-4) is
+laid down as a no-op so Phase 1 activates fairness without re-touching every call
+site. The I/O dimension (Phase 2) needs the vruntime core (Phase 1) to advance
+on. Tenant groups + background unification (Phase 3) are last because they are
+additive on a proven single-group scheduler and carry the correctness-sensitive
+ANN refactor.

--- a/specs/proposed/query-scheduler/project-plan.md
+++ b/specs/proposed/query-scheduler/project-plan.md
@@ -1,8 +1,8 @@
 ---
 title: "Query QoS / Fair Scheduler — Project Plan"
-status: proposed
+status: partially-implemented
 component: ferrosa-sched + integration crates
-last_revised: 2026-07-20
+last_revised: 2026-07-28
 executive_summary: >
   Four phases. Phase 0 (reservation + bounded background pool) is a shippable
   slice that fixes the raft-heartbeat starvation regression (t_88223ad0) with no
@@ -13,6 +13,24 @@ executive_summary: >
 ---
 
 # Query QoS / Fair Scheduler — Project Plan
+
+> **Implementation status (2026-07-28).** This plan was authored before the work
+> began and is preserved for its design rationale, FMEA-driven sequencing, and
+> decision record — NOT as a description of unbuilt work. Much of it has since
+> landed in `ferrosa-sched`; read the code as the source of truth and this plan
+> as the "why".
+>
+> | Phase | Plan intent | On `main` today |
+> |---|---|---|
+> | 0 — reservation + bounded pool | fix raft starvation (t_88223ad0) | **Landed.** `SchedPool` bounds the `spawn_blocking` fan-out; `lib.rs` documents the reserved-headroom invariant. |
+> | 1 — fair scheduling (vruntime) | vruntime run queue, chunk-budget yielding | **Largely landed.** `runqueue.rs` + `scheduler.rs` vruntime core; `SchedPool::submit_scan`/`ScanSlot` do cooperative re-acquire so one scan cannot monopolize the pool. |
+> | 2 — two resource dimensions (CPU + I/O) | separate I/O accounting | **Partly landed.** `io_permits.rs` exists; check it against the plan's dimension model before assuming full coverage. |
+> | 3 — tenant groups + background unification | per-tenant fair share | **Partly landed.** `group_runqueue.rs` + `fair_admit.rs` provide group-level admission; the background-job unification refactor is the piece to verify. |
+>
+> Consumers already wired: `ferrosa-cql` (planner) and `ferrosa-cluster`
+> (coordinator). Before using this document to plan new work, diff each phase's
+> task list against the modules above — some tasks are done, some were superseded,
+> and the per-phase tables below have NOT been individually re-audited.
 
 Priorities: **P1** = FMEA RPN ≥ 200 or blocks the bug fix; **P2** = high-risk /
 dependency-unblocking; **P3** = completeness; **P4** = polish/tuning.


### PR DESCRIPTION
## Summary

Blueprint for a CFS-inspired, two-dimensional (CPU + I/O), hierarchical (per-tenant) fair scheduler governing read scans and background jobs. Docs-only — no source touched.

Phase 0 (consensus CPU reservation + bounded background pool) fixes the raft-heartbeat starvation regression (t_88223ad0); later phases add vruntime fairness, the I/O dimension, and tenant groups. The load-bearing refactor is cooperative yielding.

## Artifacts (`specs/proposed/query-scheduler/`)

- `decisions.md` — design decisions
- `architecture.md` — architecture incl. refactor plan grounded in code recon
- `fmea.md` — failure-mode analysis
- `project-plan.md` / `compiled-project-plan.md` — phased plan

Epic: t_f9a0500a

## Verification

Docs-only; `git diff --stat origin/main` shows only files under `specs/proposed/query-scheduler/` (5 files, +788). No cargo gates needed.