### PR TITLE
docs(storage): O_DIRECT compaction I/O design (salvaged from Sprint 0 worktree)

### DIFF
--- a/specs/proposed/o-direct-compaction-io/architecture.md
+++ b/specs/proposed/o-direct-compaction-io/architecture.md
@@ -1,0 +1,184 @@
+---
+title: "Opt-in Linux O_DIRECT compaction/rebuild reader — architecture"
+status: proposed
+component: storage-io
+task: t_bed7ed0f
+executive_summary: >
+  Extends ferrosa-sstable's ReadAt seam with a default-off, Linux-only direct-I/O
+  reader for compaction and index-rebuild scans. A safe IoMode selects between the
+  existing buffered FileReadAt and a new DirectReadAt whose unsafe/platform code
+  (O_DIRECT open, aligned allocation, raw pread) is isolated in one audited Linux
+  adapter. DirectReadAt probes STATX_DIOALIGN, reads aligned supersets into bounded
+  aligned bounce buffers, copies out the requested slice (handling unaligned
+  head/tail), verifies checksums on reassembled data, and falls back to buffered on
+  any unproven alignment or unsupported filesystem/platform. Compaction/rebuild use
+  a SEPARATE reader pool; foreground reads and the shared foreground pool are
+  untouched. Instrumentation captures buffered/direct bytes, fallbacks, tail
+  fallbacks, foreground latency, faults/refaults, PSI, and device latency to feed
+  the measurement promotion gate.
+last_revised: 2026-07-21
+---
+
+# Opt-in Linux `O_DIRECT` compaction/rebuild reader — architecture
+
+## Problem
+
+Compaction and index rebuild stream cold `Data.db` bodies through the OS page cache
+via buffered `FileReadAt` (pooled in `compaction/executor.rs` as
+`SharedReaderPool<FileReadAt>`). Under a bounded cgroup this evicts the foreground
+random-read hot set, raising serving tail latency and refaults.
+
+## Goal
+
+Let compaction/rebuild read `Data.db` **without polluting the page cache** on
+Linux/NVMe, behind a default-off flag, without touching foreground reads.
+
+## Non-goals
+
+- Changing foreground point/range read I/O (they keep using the page cache).
+- Reusing the shared foreground reader pool for direct I/O.
+- Direct **writes** (this task is read-side only; writers keep buffered I/O).
+- io_uring / async direct I/O; `mmap`; a portable `fadvise` scheme (possible later,
+  not here).
+- Enabling the feature by default (promotion is measurement-gated).
+
+## Current state
+
+```mermaid
+flowchart LR
+  subgraph fg[Foreground read path]
+    Q[point/range read] --> FP[shared foreground ReaderPool]
+    FP --> FR1[FileReadAt buffered]
+  end
+  subgraph cx[Compaction / rebuild]
+    C[compaction executor] --> CP[SharedReaderPool&lt;FileReadAt&gt;]
+    CP --> FR2[FileReadAt buffered]
+    RB[index rebuild] --> FR3[FileReadAt buffered]
+  end
+  FR1 --> PC[(OS page cache)]
+  FR2 --> PC
+  FR3 --> PC
+  PC --> DISK[(NVMe Data.db)]
+```
+
+Every reader is buffered; compaction and foreground share the page cache, so the
+cold scan evicts the hot set.
+
+## Proposed state
+
+```mermaid
+flowchart LR
+  subgraph fg[Foreground read path - UNCHANGED]
+    Q[point/range read] --> FP[shared foreground ReaderPool]
+    FP --> FR1[FileReadAt buffered]
+  end
+  subgraph cx[Compaction / rebuild - SEPARATE pool]
+    C[compaction executor] --> CP[direct-capable compaction ReaderPool]
+    RB[index rebuild reader]
+    CP --> M{IoMode}
+    RB --> M
+    M -- Direct + aligned proven --> DR[DirectReadAt via audited Linux adapter]
+    M -- Buffered / fallback --> FR2[FileReadAt buffered]
+  end
+  FR1 --> PC[(OS page cache)]
+  FR2 --> PC
+  DR -- O_DIRECT, bypasses --> DISK[(NVMe Data.db)]
+  PC --> DISK
+```
+
+Foreground stays buffered/cached; compaction/rebuild select `Direct` when supported,
+else transparently fall back to buffered.
+
+## Additions (trait / types)
+
+Extend `ferrosa-sstable/src/io.rs` (the `ReadAt` seam) — no change to the trait
+signature, one new impl + a mode enum:
+
+```rust
+/// Selects how a compaction/rebuild reader opens a Data.db. Safe, platform-neutral.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum IoMode {
+    #[default]
+    Buffered,
+    /// Prefer O_DIRECT on Linux where alignment is provable; else buffered.
+    Direct,
+}
+
+/// Direct-I/O reader. Implements the SAME `ReadAt` trait. All unsafe + platform
+/// code is inside `io::direct` (Linux adapter); this type is a safe facade that
+/// falls back to `FileReadAt` when direct I/O is unavailable/unproven.
+pub struct DirectReadAt {
+    inner: DirectOrBuffered,          // Direct(linux::DirectFd) | Buffered(FileReadAt)
+    align: DioAlign,                  // from STATX_DIOALIGN (mem/offset), or fallback marker
+    buf_bytes_cap: usize,             // bounded aligned bounce-buffer residency
+    len: u64,
+}
+
+impl ReadAt for DirectReadAt { /* read_at/len/is_empty — bounce-buffer + tail logic */ }
+
+/// Open a compaction/rebuild reader for a Data.db under the given mode. Returns a
+/// `DirectReadAt` that is already resolved to Direct or Buffered.
+pub fn open_scan_reader(path: &Path, mode: IoMode, cfg: &DirectIoConfig)
+    -> Result<DirectReadAt>;
+```
+
+`io::direct` (Linux-only, audited): `libc::open(O_DIRECT|O_RDONLY)`, `statx` with
+`STATX_DIOALIGN`, aligned `Vec`/`alloc` for bounce buffers, raw `pread`. `#[cfg(not(target_os = "linux"))]` compiles to an always-buffered stub.
+
+**Config** (`DirectIoConfig`, default-off): `enabled: bool`, `max_buffer_bytes`,
+`readahead_bytes`, plus env overrides (e.g. `FERROSA_COMPACTION_IO_DIRECT=1`).
+
+## Data flow — a compaction scan read
+
+```mermaid
+sequenceDiagram
+  participant CE as Compaction executor
+  participant OP as open_scan_reader
+  participant AD as io::direct (Linux adapter)
+  participant DR as DirectReadAt
+  participant D as NVMe Data.db
+  CE->>OP: open(path, IoMode::Direct, cfg)
+  OP->>AD: open O_DIRECT + statx(STATX_DIOALIGN)
+  alt alignment proven & fs supports O_DIRECT
+    AD-->>OP: DirectFd{align}
+    OP-->>CE: DirectReadAt(Direct)
+    CE->>DR: read_at(buf, offset)  %% arbitrary alignment
+    DR->>DR: align offset down / len up to superset
+    DR->>D: pread(aligned_buf, aligned_off)  %% O_DIRECT
+    D-->>DR: aligned bytes (or short read at EOF)
+    DR->>DR: copy requested slice; handle unaligned tail; verify checksum on reassembled data
+    DR-->>CE: n bytes
+  else EINVAL / unsupported fs / non-Linux / unproven align
+    AD-->>OP: fallback
+    OP-->>CE: DirectReadAt(Buffered = FileReadAt)
+    CE->>DR: read_at(buf, offset) -> buffered pread (page cache)
+  end
+```
+
+## Acceptance criteria
+
+1. **Default-off + fallback:** with the flag off, behavior is byte-identical to
+   today. On macOS / unsupported fs / older Linux, `open_scan_reader(Direct)`
+   silently resolves to buffered; `read_at` results are identical to `FileReadAt`.
+2. **Isolation:** foreground point/range reads and the shared foreground reader pool
+   are provably untouched (no direct fd ever opened for a foreground read; separate
+   compaction pool). No direct+buffered+mmap access to an overlapping `Data.db`
+   range in any code path.
+3. **Correctness:** short reads at EOF, unaligned head/tail, and per-chunk checksums
+   pass on the reassembled data; a compaction whose inputs are read via `Direct`
+   produces byte-identical output SSTables to the buffered path; crash/restart
+   mid-compaction recovers exactly as today (read-only path adds no durability risk);
+   in-flight reads cancel cleanly.
+4. **Measurement gate:** on the owner-pinned baseline environment — a multi-node fly
+   cluster of 2-core `performance` instances (Linux + local NVMe, RF=3) — a
+   buffered-only baseline first shows page-cache eviction materially hurts the
+   foreground hot set (else the feature is not built), then an A/B on the same
+   environment shows, for an identical compaction workload + a concurrent foreground
+   hot set, that `Direct` reduces foreground refaults/tail latency vs `Buffered`
+   without a compaction-throughput regression. Metrics emitted: buffered/direct
+   bytes, fallback + error counts,
+   tail-fallback count, readahead depth, foreground read latency, faults/refaults,
+   memory + I/O PSI, device latency.
+5. **Audit:** all `unsafe` confined to `io::direct` with safety comments; the module
+   passes clippy `-D warnings` and (where the harness supports it) Miri on the
+   alignment/copy logic exercised with a mock fd.

--- a/specs/proposed/o-direct-compaction-io/decisions.md
+++ b/specs/proposed/o-direct-compaction-io/decisions.md
@@ -1,0 +1,109 @@
+---
+title: "ADR: Opt-in Linux O_DIRECT for compaction and rebuild I/O"
+status: proposed
+component: storage-io
+task: t_bed7ed0f
+source_pr: https://github.com/ferrosadb/ferrosa/pull/279
+executive_summary: >
+  Compaction and index-rebuild stream whole SSTable Data.db files through the OS
+  page cache, evicting the foreground hot working set and inflating read-path tail
+  latency + refaults under a bounded cgroup. Decision: add a DEFAULT-OFF, Linux-only
+  O_DIRECT reader for compaction/rebuild only, exposed behind a safe internal
+  `IoMode`, with all unsafe/platform-specific opening + aligned allocation isolated
+  in a small audited Linux adapter. Alignment is probed via STATX_DIOALIGN; any
+  unproven alignment or unsupported filesystem/platform falls back to the existing
+  buffered `FileReadAt`. Direct and buffered access to an overlapping Data.db range
+  are never mixed, and the foreground reader pool is never reused. The feature stays
+  off until a Linux NVMe cgroup-limited comparison proves page-cache eviction is a
+  material problem and the direct path wins. Rejected: global O_DIRECT, mmap, and
+  posix_fadvise(DONTNEED) as the primary mechanism.
+last_revised: 2026-07-21
+---
+
+# ADR: Opt-in Linux `O_DIRECT` for compaction and rebuild I/O
+
+## Status
+
+Proposed. Default-off, gated behind a measurement promotion criterion.
+
+## Context
+
+- **Issue (`t_bed7ed0f`, from the PR #279 "I/O Page-Cache and Copy Audit"):**
+  compaction reads every input `Data.db` sequentially and index rebuild re-reads
+  whole bodies. These are buffered reads through the OS page cache
+  (`ferrosa-sstable::io::FileReadAt`, pooled as
+  `compaction/executor.rs::SharedReaderPool<FileReadAt>`). A large sequential
+  compaction scan pulls cold SSTable pages into the page cache and evicts the
+  foreground random-read hot set, degrading serving-path tail latency and driving
+  refaults — especially under the intentional 2 GiB cgroup cap the fmem-dev cluster
+  runs with.
+- **Current behavior:** all reads (foreground point/range reads *and* compaction/
+  rebuild scans) go through the same buffered `ReadAt` implementations and share a
+  reader pool abstraction. There is no `IoMode`, no direct I/O, and no
+  page-cache-avoidance control anywhere in `ferrosa-storage`/`ferrosa-sstable`.
+- **Stated preference (task body):** a default-off, Linux-only compaction/rebuild
+  reader that uses `O_DIRECT` to bypass the page cache for the scan, isolates all
+  `unsafe`/platform code in a small audited adapter, and falls back to buffered I/O
+  whenever alignment cannot be proven — never changing foreground reads and never
+  reusing the shared foreground reader pool.
+
+## Decision
+
+Add an **opt-in, default-off, Linux-only `O_DIRECT` read path for compaction and
+index-rebuild scans only**, with these load-bearing controls:
+
+1. **Safe seam:** a `ReadAt`-implementing direct reader selected by a safe
+   `IoMode { Buffered, Direct }` enum. All `unsafe` (`libc::open(O_DIRECT)`,
+   aligned allocation, `pread` on the raw fd) and platform `#[cfg(target_os =
+   "linux")]` code lives in one small, audited adapter module; the rest of the
+   codebase only sees the safe `ReadAt` trait.
+2. **Prove alignment or fall back:** query `STATX_DIOALIGN` (Linux ≥ 6.1) for the
+   required memory/offset alignment. Require proven address, length, **and** offset
+   alignment before issuing a direct read; otherwise transparently use the existing
+   buffered `FileReadAt`. Unsupported filesystems (EINVAL on `O_DIRECT` open) and
+   macOS/older Linux always take the buffered fallback.
+3. **Bounce-buffer the unaligned edges:** since `ReadAt::read_at(buf, offset)` is
+   called with arbitrary offset/length, the direct reader reads into bounded,
+   aligned internal buffers over the aligned superset range and copies the requested
+   slice out, handling the unaligned head/tail explicitly. (The goal is
+   page-cache-eviction avoidance, not eliminating the userspace copy.)
+4. **No mixing, no foreground reuse:** direct, buffered, and mmap access to an
+   overlapping `Data.db` byte range are never combined. The direct reader is used by
+   a **separate** compaction/rebuild reader pool; the shared foreground reader pool
+   is never reused for direct I/O and foreground reads stay buffered.
+5. **Measurement-gated promotion:** the feature ships behind a config flag that
+   stays off until a comparison on the **owner-pinned baseline environment — a
+   multi-node fly cluster of 2-core `performance` instances (Linux + local NVMe,
+   RF=3)** — demonstrates the direct path reduces foreground refaults/tail latency
+   without a compaction-throughput regression. A *buffered-only* baseline on that
+   same environment must first establish that page-cache eviction is a material
+   problem at all (Sprint 0 gate); if it is not, the feature is not built.
+
+## Alternatives considered and rejected
+
+| Alternative | Why rejected |
+|---|---|
+| **Global `O_DIRECT`** (foreground reads too) | Foreground random reads *benefit* from the page cache; direct I/O would add alignment cost + bounce copies to the serving path. Out of scope; explicitly excluded. |
+| **`posix_fadvise(POSIX_FADV_DONTNEED)` after the scan** | Cheaper and portable, but reactive — pages are still admitted (evicting the hot set) before being dropped, and `DONTNEED` is advisory/racy under concurrent mmap. Keep as a possible complementary follow-up, not the primary mechanism. |
+| **`mmap` + `MADV_DONTNEED`/`MADV_SEQUENTIAL`** | Still populates the page cache; mmap read faults are hard to bound and cancel; conflicts with the "never mmap an overlapping range" constraint. |
+| **A brand-new async io_uring reader** | Larger surface, new failure modes, and unnecessary for a sequential scan; `O_DIRECT` + `pread` on a blocking pool is sufficient and auditable. |
+
+## Consequences
+
+- **Positive:** compaction/rebuild stop evicting the foreground hot set on Linux/NVMe;
+  bounded-memory, cancellable scan reads; a reusable `IoMode` seam for future
+  page-cache-sensitive batch paths.
+- **Cost/risk:** one small `unsafe` adapter (audited, Miri where feasible);
+  correctness surface around alignment, short reads, unaligned tails, and checksums;
+  a second reader pool to bound. All gated behind default-off + the measurement.
+- **Required controls (carried into the FMEA):** never mix access modes on a range;
+  bound aligned-buffer residency; verify checksums on the reassembled (not partial)
+  data; survive crash/restart mid-compaction (direct reads are read-only, so no new
+  durability surface); fail loud + fall back on any alignment/filesystem rejection.
+
+## Prerequisites (disposition before implementing)
+
+Resolve or explicitly disposition the sibling PR #279 audit tasks first, since they
+share the copy/residency surface: bounded remote index staging (`t_6edd8c1c`),
+direct nested CQL encoding (`t_74c3c7a3`), `CachedReadAt` policy (`t_74cdda11`),
+compaction compression-batch residency (`t_63c878ed`).

--- a/specs/proposed/o-direct-compaction-io/fmea.md
+++ b/specs/proposed/o-direct-compaction-io/fmea.md
@@ -1,0 +1,50 @@
+---
+title: "O_DIRECT compaction/rebuild reader — FMEA"
+status: proposed
+component: storage-io
+task: t_bed7ed0f
+executive_summary: >
+  Failure-mode analysis for the opt-in Linux O_DIRECT compaction/rebuild reader.
+  Highest risks (RPN 18): silent data corruption from mixing direct/buffered access
+  to an overlapping Data.db range, a wrong bounce-buffer copy dropping the unaligned
+  tail, and checksum verification over partial (aligned-superset) rather than
+  reassembled data. Each maps to an explicit test. RPN = Severity x Occurrence x
+  Detection (1-3 each; higher = worse). The read-only nature of the path bounds
+  durability risk; correctness and residency dominate.
+last_revised: 2026-07-21
+---
+
+# `O_DIRECT` compaction/rebuild reader — FMEA
+
+Severity/Occurrence/Detection scored 1 (best) to 3 (worst). RPN = S x O x D.
+Every RPN >= 50-equivalent (here RPN >= 8 on the 1-3 scale) maps to a named test.
+
+| # | Failure mode | Effect | S | O | D | RPN | Control + test |
+|---|---|---|---|---|---|---|---|
+| F1 | **Mixed access on an overlapping range** — same Data.db read both direct and buffered (or mmap) → stale/incoherent bytes | Silent corruption in compacted output | 3 | 2 | 3 | 18 | Direct reader used ONLY by the separate compaction/rebuild pool; foreground stays buffered; assert no fd is opened both ways. Test: `direct_and_buffered_never_share_a_datadb_range` (fail-loud guard) + a compaction whose input is direct produces byte-identical output to buffered. |
+| F2 | **Unaligned tail dropped** — bounce-buffer copies only the aligned superset, loses the requested head/tail slice | Wrong bytes returned; corrupt merge | 3 | 2 | 3 | 18 | Explicit head/tail slice math; property test over random (offset, len) vs `FileReadAt` oracle. Test: `direct_read_matches_buffered_for_arbitrary_offset_len` (proptest). |
+| F3 | **Checksum over partial data** — verify runs on the aligned superset, not the reassembled logical range | Accepts corruption / rejects good data | 3 | 1 | 2 | 6 | Checksum only on reassembled logical bytes. Test: `checksum_verified_on_reassembled_range`. |
+| F4 | **Short read at EOF mis-handled** — aligned read past EOF returns < requested; treated as error or over-copied | Compaction fails or truncates | 3 | 2 | 2 | 12 | EOF-aware superset clamp; return exact byte count. Test: `direct_short_read_at_eof_matches_buffered`. |
+| F5 | **Alignment mis-probe** — STATX_DIOALIGN absent/wrong, direct read issued anyway → EINVAL / partial | Scan errors instead of falling back | 3 | 2 | 2 | 12 | Require proven mem+offset+len alignment before any direct read; else buffered fallback. Test: `unproven_alignment_falls_back_to_buffered`. |
+| F6 | **Unsupported filesystem** — O_DIRECT open returns EINVAL (tmpfs/overlay/some network fs) | Compaction crash on that fs | 3 | 2 | 1 | 6 | Detect at open; fall back per-file; count fallbacks. Test: `unsupported_fs_open_falls_back` (mock EINVAL). |
+| F7 | **Non-Linux / old-kernel build** — direct path compiled/enabled where unavailable | Build break or runtime panic | 3 | 1 | 1 | 3 | `#[cfg(target_os="linux")]` adapter + always-buffered stub elsewhere; runtime kernel check. Test: `non_linux_uses_buffered` (cfg-gated). |
+| F8 | **Unbounded aligned buffers** — per-reader bounce/readahead buffers grow with request size or reader count | OOM under the 2 GiB cgroup | 3 | 2 | 2 | 12 | Bounded `max_buffer_bytes` per reader + bounded compaction pool size; fail-loud on exceed. Test: `aligned_buffer_residency_is_bounded`. |
+| F9 | **Foreground pool contamination** — direct reader accidentally handed to a foreground read | Foreground latency/alignment cost, cache bypass on hot reads | 3 | 1 | 2 | 6 | Separate pool + type/flag preventing foreground use. Test: `foreground_reads_never_use_direct`. |
+| F10 | **Cancellation leak** — compaction cancelled mid-read leaves fd/aligned buffer or a blocked pread | fd/mem leak, stuck worker | 2 | 2 | 2 | 8 | RAII fd + buffer; cancellation checked between bounded reads (never mid-syscall on a huge buffer). Test: `cancel_mid_scan_releases_resources`. |
+| F11 | **Readahead too deep** — large explicit readahead re-pollutes memory or stalls | Defeats the purpose; latency spike | 2 | 2 | 2 | 8 | Bounded `readahead_bytes`; metric `readahead_depth`. Test: `readahead_within_config_bound`. |
+| F12 | **Silent perf regression** — direct path slower (extra copies/syscalls) but shipped on | Compaction throughput drop | 2 | 2 | 3 | 12 | Default-off + measurement promotion gate; emit direct vs buffered bytes + device latency. Gate: NVMe cgroup comparison must show no throughput regression before enabling. |
+| F13 | **Crash/restart mid-compaction** — partial output while inputs read direct | (No new risk — read-only) | 2 | 1 | 1 | 2 | Direct reads add no durability surface; existing staging→rename atomic-commit unchanged. Test: existing compaction crash-recovery suite runs with direct inputs. |
+
+## Priority summary
+
+- **RPN 18 (critical), gate before enabling:** F1 (mixed access), F2 (tail drop) —
+  both are silent-corruption paths and must have the byte-identical-output proof +
+  proptest green.
+- **RPN 12 (high):** F4 EOF, F5 alignment probe, F8 buffer residency, F12 perf
+  regression — the correctness + OOM + promotion surface.
+- **RPN <= 8:** checksum scope, fs/platform fallback, contamination, cancellation,
+  readahead — controlled by the fallback-first design + bounded buffers.
+
+The read-only nature (F13) keeps durability out of scope; the dominant surface is
+copy/alignment correctness (F1-F5) and memory residency (F8, F11), all gated behind
+default-off + the measurement criterion (F12).

--- a/specs/proposed/o-direct-compaction-io/project-plan.md
+++ b/specs/proposed/o-direct-compaction-io/project-plan.md
@@ -1,0 +1,104 @@
+---
+title: "O_DIRECT compaction/rebuild reader — project plan"
+status: proposed
+component: storage-io
+task: t_bed7ed0f
+executive_summary: >
+  Five workstreams gated on measurement. Sprint 0 (GATE, do first) establishes a
+  compaction-plus-hot-read baseline on a MULTI-NODE fly cluster of 2-core
+  `performance` instances (Linux + local NVMe) to prove page-cache eviction is a
+  material problem before any feature code is written — if the baseline shows no
+  material foreground degradation, the feature is NOT built. Sprint 1 adds the safe
+  IoMode + DirectReadAt with alignment probe + buffered fallback and the correctness
+  suite (byte-identical to FileReadAt). Sprint 2 adds bounded buffers + metrics and
+  extends the baseline harness into a direct-vs-buffered comparison. Sprint 3 wires
+  it into the compaction/rebuild pool (separate from foreground) behind a default-off
+  flag. Promotion to on requires the comparison to show reduced foreground
+  refaults/tail latency with no compaction-throughput regression.
+last_revised: 2026-07-21
+---
+
+# `O_DIRECT` compaction/rebuild reader — project plan
+
+Dependency: **Sprint 0 gates everything.** S1 -> S2 -> S3; prereq dispositions run
+in parallel with S0/S1.
+
+## Sprint 0 — Baseline measurement GATE (do first; may end the project)
+
+**Outcome:** a decision-grade report answering "does compaction's page-cache
+eviction materially hurt the foreground hot set on our target hardware?"
+
+- **Environment (pinned by owner):** a multi-node fly cluster on **2-core
+  `performance` instances** (Linux, local NVMe), RF=3. Reuse the
+  `deploy/fly-accord-elle` harness pattern (build+push, machine run, self-teardown
+  trap).
+- **Workload:** write + force a compaction-heavy load (large SSTable inputs → UCS
+  compaction) while a concurrent foreground **hot read set** issues random point
+  reads over a working set sized to exceed... no — sized to *fit* in page cache when
+  idle but be evicted by the compaction scan. Hold the foreground read set steady;
+  trigger compaction; measure the delta.
+- **Metrics (buffered baseline only, no feature yet):** foreground point-read p50/p99
+  latency (idle vs during-compaction), page faults/refaults, memory + I/O PSI,
+  device read latency, compaction throughput. Optionally constrain node memory
+  (`--vm-memory`) to force the cache-pressure regime.
+- **Gate / Definition of done:** report shows whether foreground p99 + refaults
+  degrade materially during compaction. **PROCEED** to S1 only if yes; otherwise
+  disposition `t_bed7ed0f` as "not warranted on this hardware" with the evidence and
+  stop.
+
+## Sprint 1 — Safe seam + DirectReadAt (default-off, correctness)
+
+- **S1.1** `IoMode { Buffered, Direct }` + `DirectIoConfig` (default-off) in
+  `ferrosa-sstable/src/io.rs`.
+- **S1.2** `io::direct` Linux adapter (audited `unsafe`): `open(O_DIRECT|O_RDONLY)`,
+  `statx(STATX_DIOALIGN)`, aligned bounce-buffer allocation, raw `pread`; non-Linux =
+  always-buffered stub.
+- **S1.3** `DirectReadAt: ReadAt` — aligned-superset read + head/tail slice + EOF
+  clamp + checksum on reassembled data + per-file buffered fallback on unproven
+  alignment / EINVAL.
+- **S1.4** `open_scan_reader(path, mode, cfg) -> DirectReadAt`.
+- **Gate (FMEA F1-F7):** proptest `direct_read_matches_buffered_for_arbitrary_offset_len`;
+  `direct_short_read_at_eof_matches_buffered`; `unproven_alignment_falls_back_to_buffered`;
+  `unsupported_fs_open_falls_back`; `non_linux_uses_buffered`; clippy `-D warnings`;
+  Miri on the copy/alignment logic with a mock fd where feasible.
+
+## Sprint 2 — Bounds + metrics + comparison harness
+
+- **S2.1** Bounded `max_buffer_bytes` per reader + bounded compaction pool; fail-loud
+  on exceed (FMEA F8, F11). Test `aligned_buffer_residency_is_bounded`.
+- **S2.2** Metrics: buffered/direct bytes, fallback + error counts, tail-fallback
+  count, readahead depth (plus reuse of the S0 foreground-latency/PSI/refault/device
+  metrics).
+- **S2.3** Extend the Sprint 0 fly harness into an A/B: same workload, `Buffered` vs
+  `Direct`, same 2-core `performance` NVMe nodes; emit the comparison report.
+
+## Sprint 3 — Wire in + promotion
+
+- **S3.1** Compaction executor + index-rebuild reader use a **separate**
+  direct-capable pool via `open_scan_reader`; foreground path + shared foreground
+  pool provably untouched (FMEA F9). Test `foreground_reads_never_use_direct` +
+  `direct_and_buffered_never_share_a_datadb_range`.
+- **S3.2** Byte-identical output proof: a compaction with `Direct` inputs produces
+  identical SSTables to `Buffered`; existing crash-recovery suite runs with direct
+  inputs (FMEA F1, F13).
+- **S3.3** Cancellation + RAII (FMEA F10) `cancel_mid_scan_releases_resources`.
+- **Promotion gate (FMEA F12):** enable-by-default ONLY if the S2.3 comparison shows
+  reduced foreground refaults/p99 with no compaction-throughput regression on the
+  2-core `performance` NVMe baseline. Until then: default-off, docs describe the
+  flag + when to turn it on.
+
+## Prereq dispositions (parallel with S0/S1)
+
+Resolve/close before S3 lands, since they share the copy/residency surface:
+`t_6edd8c1c` (bounded remote index staging), `t_74c3c7a3` (direct nested CQL
+encoding), `t_74cdda11` (CachedReadAt policy), `t_63c878ed` (compaction
+compression-batch residency).
+
+## Definition of done
+
+- Sprint 0 baseline report exists and justifies (or cancels) the work.
+- Feature ships **default-off**; buffered behavior byte-identical when off or on an
+  unsupported platform.
+- Foreground reads + shared foreground pool untouched; no mixed access to a range.
+- FMEA RPN>=high items have green tests; `unsafe` confined + audited.
+- Promotion is backed by the 2-core `performance` NVMe A/B comparison, not inspection.


### PR DESCRIPTION
## Summary

Salvages the design docs for an **opt-in, default-off, Linux-only `O_DIRECT` read path for compaction and index-rebuild scans** (task `t_bed7ed0f`, from the PR #279 I/O page-cache audit). Docs-only — no source touched.

Lands four `status: proposed` docs under `specs/proposed/o-direct-compaction-io/`:

- `decisions.md` — ADR: opt-in Linux `O_DIRECT` for compaction/rebuild I/O
- `architecture.md` — `IoMode` seam + `DirectReadAt` + audited Linux adapter, with current/proposed Mermaid flows
- `fmea.md` — failure-mode analysis (top RPN: mixed direct/buffered access, dropped unaligned tail, partial-data checksum)
- `project-plan.md` — five workstreams; **Sprint 0 is a measurement GATE that may cancel the project**

The design is read-side only (writers stay buffered), measurement-gated (default-off until a Linux/NVMe cgroup A/B proves page-cache eviction materially hurts the foreground hot set), and isolates all `unsafe`/platform code in one audited adapter.

## Flag for reviewer: relationship to existing O_DIRECT results on `main`

These are **design docs and state no benchmark results**, so there is no direct results-contradiction to correct. But there is a scope/evidence relationship worth calling out, since `deploy/fly-bench/ODIRECT-*-RESULT.txt` already exist on `main`:

- **Different feature/scope.** This design is a read-side compaction/rebuild **reader** (`DirectReadAt`, env `FERROSA_COMPACTION_IO_DIRECT`, task `t_bed7ed0f`). The results on `main` are for an already-built write-side **`DirectWriter`** (`FERROSA_SSTABLE_DIRECT_IO`, task `t_d1af57de`). Same syscall, different code path.
- **Existing evidence is relevant to this design's Sprint 0 gate.** The write-side A/B (`ODIRECT-AB-HARSH-RESULT`, `ODIRECT-RAMP-RESULT`) found **no demonstrated O_DIRECT benefit on fly fast NVMe** — the device never saturated (~8% util) and the writeback-freeze did not reproduce. Critically, `ODIRECT-RAMP-RESULT` notes the **cache-preservation hypothesis is UNMEASURED** (concurrent full-table scans never completed within the ramp), which is exactly the hypothesis this read-side design's Sprint 0 gate exists to test.
- **Not a contradiction, a caveat.** The design's motivating claim (compaction scans evict the foreground hot set under a bounded cgroup) is framed internally as unproven and gated behind Sprint 0. Existing results tested a different regime (4GB RAM / 64MB cache / no cache-pressure, fast NVMe) than the design's target (2 GiB cgroup cache-pressure). Sprint 0 should incorporate the existing write-side results and use bounded/token-range scans so the read-side cache hypothesis is actually measured before any code is written.

No edits were made to the salvaged docs; this flag is surfaced here rather than in-file per the salvage instructions.

## Verification

Docs-only; `git diff --stat origin/main` shows only files under `specs/proposed/o-direct-compaction-io/` (4 files, +447). No cargo gates needed.