### PR TITLE
feat(accord): read-in-transaction — buffer SELECTs, return rows atomically at COMMIT (slice 1/1a)

### DIFF
--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -1861,8 +1861,13 @@ async fn commit_transaction(
         }
     };
     match txn.commit(committer.as_ref()).await {
-        Ok(CommitOutcome::Committed) => Ok(RouteResult::Result(crate::result::encode_void())),
-        Ok(CommitOutcome::Aborted { reason }) => {
+        // A write-only transaction acks with void. Read-in-transaction (returning
+        // the buffered SELECT's rows from COMMIT) is wired in the
+        // SELECT-in-transaction slice; a write-only COMMIT never carries reads.
+        Ok((CommitOutcome::Committed, _reads)) => {
+            Ok(RouteResult::Result(crate::result::encode_void()))
+        }
+        Ok((CommitOutcome::Aborted { reason }, _)) => {
             Err(CqlError::Invalid(format!("transaction aborted: {reason}")))
         }
         Err(e) => Err(e),

--- a/ferrosa-cql/src/session.rs
+++ b/ferrosa-cql/src/session.rs
@@ -7,7 +7,9 @@
 use std::time::{Duration, Instant};
 
 use crate::error::CqlError;
-use ferrosa_storage::accord::{CommitOutcome, TransactionCommitter, TransactionWrite};
+use ferrosa_storage::accord::{
+    CommitOutcome, CommitReads, TransactionCommitter, TransactionRead, TransactionWrite,
+};
 use ferrosa_storage::{BatchOp, StorageEngine};
 
 /// Per-connection **explicit-transaction state machine** (spec URS-QEC-B02).
@@ -218,6 +220,10 @@ pub struct CqlTransaction {
     /// committed. The client must `ROLLBACK` and retry.
     poisoned: bool,
     buffer: Vec<TransactionWrite>,
+    /// Buffered `SELECT`s inside the transaction. Evaluated at the transaction's
+    /// agreed commit timestamp and returned from `COMMIT` (read-in-transaction),
+    /// positionally aligned with the rows in [`CommitReads`].
+    reads: Vec<TransactionRead>,
 }
 
 /// Max DML writes buffered in one transaction before it is poisoned. A client
@@ -251,6 +257,7 @@ impl CqlTransaction {
         self.open = true;
         self.poisoned = false;
         self.buffer.clear();
+        self.reads.clear();
         Ok(())
     }
 
@@ -272,6 +279,31 @@ impl CqlTransaction {
         Ok(())
     }
 
+    /// Buffer one `SELECT` read. FAILS LOUD (and POISONS the transaction) if no
+    /// transaction is open or the combined statement cap is exceeded — reads
+    /// count against the same bound as writes so an open `BEGIN` can never grow
+    /// unboundedly (Power-of-10 Rule 3).
+    pub fn stage_read(&mut self, read: TransactionRead) -> Result<(), CqlError> {
+        if !self.open {
+            return Err(CqlError::Invalid(
+                "SELECT staged outside of a transaction".to_string(),
+            ));
+        }
+        if self.buffer.len() + self.reads.len() >= MAX_TXN_WRITES {
+            self.poisoned = true;
+            return Err(CqlError::Invalid(format!(
+                "transaction statement-set exceeds the {MAX_TXN_WRITES}-statement limit; ROLLBACK required"
+            )));
+        }
+        self.reads.push(read);
+        Ok(())
+    }
+
+    /// Number of `SELECT` reads buffered so far.
+    pub fn staged_reads_len(&self) -> usize {
+        self.reads.len()
+    }
+
     /// Mark the open transaction un-committable after a statement failed inside
     /// it (e.g. a DML that could not be encoded). The next `COMMIT` fails loud
     /// rather than committing an incomplete write-set. No-op outside a txn.
@@ -290,7 +322,7 @@ impl CqlTransaction {
     pub async fn commit(
         &mut self,
         committer: &dyn TransactionCommitter,
-    ) -> Result<CommitOutcome, CqlError> {
+    ) -> Result<(CommitOutcome, CommitReads), CqlError> {
         if !self.open {
             return Err(CqlError::Invalid(
                 "COMMIT outside of a transaction".to_string(),
@@ -298,6 +330,7 @@ impl CqlTransaction {
         }
         if self.poisoned {
             self.buffer.clear();
+            self.reads.clear();
             self.open = false;
             self.poisoned = false;
             return Err(CqlError::Invalid(
@@ -305,9 +338,10 @@ impl CqlTransaction {
             ));
         }
         let writes = std::mem::take(&mut self.buffer);
+        let reads = std::mem::take(&mut self.reads);
         self.open = false;
         committer
-            .commit(writes)
+            .commit_with_reads(writes, reads)
             .await
             .map_err(|e| CqlError::ServerError(format!("transaction commit failed: {}", e.reason)))
     }
@@ -320,6 +354,7 @@ impl CqlTransaction {
             ));
         }
         self.buffer.clear();
+        self.reads.clear();
         self.open = false;
         self.poisoned = false;
         Ok(())
@@ -335,6 +370,14 @@ mod tests {
             keyspace: ks.to_string(),
             key: key.to_vec(),
             mutation: b"m".to_vec(),
+        }
+    }
+
+    fn tr(ks: &str, table: &str, key: &[u8]) -> TransactionRead {
+        TransactionRead {
+            keyspace: ks.to_string(),
+            table: table.to_string(),
+            key: key.to_vec(),
         }
     }
 
@@ -369,15 +412,49 @@ mod tests {
         tx.stage(tw("ks", b"a")).unwrap();
         tx.stage(tw("ks", b"b")).unwrap();
 
-        let outcome = tx.commit(&committer).await.unwrap();
+        let (outcome, _reads) = tx.commit(&committer).await.unwrap();
 
         assert_eq!(outcome, CommitOutcome::Committed);
         assert!(!tx.is_open(), "COMMIT closes the transaction");
         assert_eq!(tx.staged_len(), 0, "buffer is drained on commit");
         assert_eq!(
+            committer.reads(),
+            vec![vec![]],
+            "no reads staged → empty read-set"
+        );
+    }
+
+    #[tokio::test]
+    async fn cql_txn_commit_returns_staged_reads_rows() {
+        // A BEGIN; SELECT; UPDATE; COMMIT must send the read-set to the committer
+        // and return the rows it observed at the agreed commit timestamp.
+        use ferrosa_storage::accord::MockTransactionCommitter;
+        let committer =
+            MockTransactionCommitter::with_read_rows(vec![Some(b"row-a".to_vec()), None]);
+        let mut tx = CqlTransaction::new();
+        tx.begin().unwrap();
+        tx.stage_read(tr("ks", "t", b"a")).unwrap();
+        tx.stage_read(tr("ks", "t", b"b")).unwrap();
+        tx.stage(tw("ks", b"a")).unwrap();
+
+        let (outcome, reads) = tx.commit(&committer).await.unwrap();
+
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert_eq!(
+            reads.rows,
+            vec![Some(b"row-a".to_vec()), None],
+            "COMMIT returns the per-read row bytes observed at the agreed t"
+        );
+        assert_eq!(
+            committer.reads(),
+            vec![vec![tr("ks", "t", b"a"), tr("ks", "t", b"b")]],
+            "the exact buffered read-set reaches the committer, in order"
+        );
+        assert_eq!(tx.staged_reads_len(), 0, "read buffer is drained on commit");
+        assert_eq!(
             committer.committed(),
-            vec![vec![tw("ks", b"a"), tw("ks", b"b")]],
-            "the exact buffered write-set reaches the committer, in order"
+            vec![vec![tw("ks", b"a")]],
+            "the write-set still reaches the committer alongside the reads"
         );
     }
 

--- a/ferrosa-storage/src/accord/mod.rs
+++ b/ferrosa-storage/src/accord/mod.rs
@@ -38,6 +38,7 @@ pub use read_2i::{
 pub use sidecar::{AccordSidecar, SidecarUploadManifest, SIDECAR_EXTENSION};
 pub use sync_writer::{FileSyncWriter, MockSyncWriter, SyncWriteResult, SyncWriter};
 pub use transaction_committer::{
-    CommitError, CommitOutcome, MockTransactionCommitter, TransactionCommitter, TransactionWrite,
+    CommitError, CommitOutcome, CommitReads, MockTransactionCommitter, TransactionCommitter,
+    TransactionRead, TransactionWrite,
 };
 pub use write_gate::{check_write_gate, check_write_gate_range, WriteGateDecision};

--- a/ferrosa-storage/src/accord/transaction_committer.rs
+++ b/ferrosa-storage/src/accord/transaction_committer.rs
@@ -24,6 +24,27 @@ pub struct TransactionWrite {
     pub mutation: Vec<u8>,
 }
 
+/// One buffered read in a transaction: the partition key and the keyspace/table
+/// it targets. Evaluated at the transaction's agreed commit timestamp so the
+/// returned rows are part of the same atomic transaction as the writes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransactionRead {
+    /// Keyspace the read targets.
+    pub keyspace: String,
+    /// Table the read targets.
+    pub table: String,
+    /// Raw partition-key bytes to read (Accord conflict-ordering + routing key).
+    pub key: Vec<u8>,
+}
+
+/// Rows observed by a transaction's read-set, evaluated at the commit timestamp.
+/// Positional: `rows[i]` is the agreed row bytes for the `i`-th
+/// [`TransactionRead`], or `None` when the row was absent at commit-`t`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommitReads {
+    pub rows: Vec<Option<Vec<u8>>>,
+}
+
 /// Outcome of committing a buffered transaction write-set.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CommitOutcome {
@@ -59,6 +80,24 @@ impl std::error::Error for CommitError {}
 pub trait TransactionCommitter: Send + Sync {
     /// Commit `writes` as one atomic multi-key transaction.
     async fn commit(&self, writes: Vec<TransactionWrite>) -> Result<CommitOutcome, CommitError>;
+
+    /// Commit `writes` and evaluate `reads` at the transaction's agreed commit
+    /// timestamp, returning the row bytes observed for each read (positional).
+    ///
+    /// The default implementation commits the writes and returns no rows — used
+    /// by front-ends that never buffer transactional reads (e.g. the Postgres
+    /// front-end) and by committers that do not yet support read-in-transaction.
+    /// The CQL front-end calls this so a `BEGIN; SELECT; …; COMMIT` can return
+    /// the SELECT's rows atomically.
+    async fn commit_with_reads(
+        &self,
+        writes: Vec<TransactionWrite>,
+        reads: Vec<TransactionRead>,
+    ) -> Result<(CommitOutcome, CommitReads), CommitError> {
+        let _ = &reads;
+        let outcome = self.commit(writes).await?;
+        Ok((outcome, CommitReads::default()))
+    }
 }
 
 /// In-memory [`TransactionCommitter`] for tests: records every committed
@@ -66,7 +105,11 @@ pub trait TransactionCommitter: Send + Sync {
 /// `BEGIN`/`COMMIT`/`ROLLBACK` buffering without a live cluster.
 pub struct MockTransactionCommitter {
     committed: std::sync::Mutex<Vec<Vec<TransactionWrite>>>,
+    read: std::sync::Mutex<Vec<Vec<TransactionRead>>>,
     result: Result<CommitOutcome, CommitError>,
+    /// Canned rows returned from [`commit_with_reads`](TransactionCommitter::commit_with_reads),
+    /// one per read (positional). Empty ⇒ `None` for every read.
+    read_rows: Vec<Option<Vec<u8>>>,
 }
 
 impl MockTransactionCommitter {
@@ -74,7 +117,9 @@ impl MockTransactionCommitter {
     pub fn new() -> Self {
         Self {
             committed: std::sync::Mutex::new(Vec::new()),
+            read: std::sync::Mutex::new(Vec::new()),
             result: Ok(CommitOutcome::Committed),
+            read_rows: Vec::new(),
         }
     }
 
@@ -82,7 +127,20 @@ impl MockTransactionCommitter {
     pub fn with_result(result: Result<CommitOutcome, CommitError>) -> Self {
         Self {
             committed: std::sync::Mutex::new(Vec::new()),
+            read: std::sync::Mutex::new(Vec::new()),
             result,
+            read_rows: Vec::new(),
+        }
+    }
+
+    /// A committer that commits cleanly and echoes `read_rows` (positional) back
+    /// from [`commit_with_reads`](TransactionCommitter::commit_with_reads).
+    pub fn with_read_rows(read_rows: Vec<Option<Vec<u8>>>) -> Self {
+        Self {
+            committed: std::sync::Mutex::new(Vec::new()),
+            read: std::sync::Mutex::new(Vec::new()),
+            result: Ok(CommitOutcome::Committed),
+            read_rows,
         }
     }
 
@@ -90,6 +148,13 @@ impl MockTransactionCommitter {
     /// call order.
     pub fn committed(&self) -> Vec<Vec<TransactionWrite>> {
         self.committed.lock().expect("committer mutex").clone()
+    }
+
+    /// Every read-set passed to
+    /// [`commit_with_reads`](TransactionCommitter::commit_with_reads), in call
+    /// order.
+    pub fn reads(&self) -> Vec<Vec<TransactionRead>> {
+        self.read.lock().expect("committer mutex").clone()
     }
 }
 
@@ -105,6 +170,21 @@ impl TransactionCommitter for MockTransactionCommitter {
         self.committed.lock().expect("committer mutex").push(writes);
         self.result.clone()
     }
+
+    async fn commit_with_reads(
+        &self,
+        writes: Vec<TransactionWrite>,
+        reads: Vec<TransactionRead>,
+    ) -> Result<(CommitOutcome, CommitReads), CommitError> {
+        self.read.lock().expect("committer mutex").push(reads);
+        let outcome = self.commit(writes).await?;
+        Ok((
+            outcome,
+            CommitReads {
+                rows: self.read_rows.clone(),
+            },
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -117,6 +197,58 @@ mod tests {
             key: key.to_vec(),
             mutation: b"row".to_vec(),
         }
+    }
+
+    fn read(ks: &str, table: &str, key: &[u8]) -> TransactionRead {
+        TransactionRead {
+            keyspace: ks.to_string(),
+            table: table.to_string(),
+            key: key.to_vec(),
+        }
+    }
+
+    /// A committer with no read-in-transaction support keeps the write-only
+    /// behaviour via the default `commit_with_reads`: writes commit, no rows.
+    struct WriteOnlyCommitter;
+    #[async_trait]
+    impl TransactionCommitter for WriteOnlyCommitter {
+        async fn commit(
+            &self,
+            _writes: Vec<TransactionWrite>,
+        ) -> Result<CommitOutcome, CommitError> {
+            Ok(CommitOutcome::Committed)
+        }
+    }
+
+    #[tokio::test]
+    async fn default_commit_with_reads_commits_writes_and_returns_no_rows() {
+        let committer = WriteOnlyCommitter;
+        let (outcome, reads) = committer
+            .commit_with_reads(vec![write("ks", b"a")], vec![read("ks", "t", b"a")])
+            .await
+            .expect("commit_with_reads");
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert!(
+            reads.rows.is_empty(),
+            "a write-only committer returns no transactional read rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_records_reads_and_echoes_canned_rows() {
+        let committer =
+            MockTransactionCommitter::with_read_rows(vec![Some(b"row-a".to_vec()), None]);
+        let reads = vec![read("ks", "t", b"a"), read("ks", "t", b"b")];
+
+        let (outcome, got) = committer
+            .commit_with_reads(vec![write("ks", b"a")], reads.clone())
+            .await
+            .expect("commit_with_reads");
+
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert_eq!(got.rows, vec![Some(b"row-a".to_vec()), None]);
+        assert_eq!(committer.reads(), vec![reads]);
+        assert_eq!(committer.committed(), vec![vec![write("ks", b"a")]]);
     }
 
     #[tokio::test]

--- a/ferrosa-storage/src/accord/transaction_committer.rs
+++ b/ferrosa-storage/src/accord/transaction_committer.rs
@@ -84,17 +84,27 @@ pub trait TransactionCommitter: Send + Sync {
     /// Commit `writes` and evaluate `reads` at the transaction's agreed commit
     /// timestamp, returning the row bytes observed for each read (positional).
     ///
-    /// The default implementation commits the writes and returns no rows — used
-    /// by front-ends that never buffer transactional reads (e.g. the Postgres
-    /// front-end) and by committers that do not yet support read-in-transaction.
-    /// The CQL front-end calls this so a `BEGIN; SELECT; …; COMMIT` can return
-    /// the SELECT's rows atomically.
+    /// The default implementation supports only an EMPTY read-set — the shape
+    /// used by front-ends that never buffer transactional reads (e.g. the
+    /// Postgres front-end) and by write-only CQL transactions. A NON-empty
+    /// read-set against a committer that has not overridden this method is a
+    /// hard error: silently returning `CommitReads::default()` would fabricate
+    /// row-ABSENCE (`None` means "absent at commit-t" to the caller), turning a
+    /// missing capability into wrong query results. Fail loud instead; the
+    /// front-end surfaces the error and the transaction does not lie.
     async fn commit_with_reads(
         &self,
         writes: Vec<TransactionWrite>,
         reads: Vec<TransactionRead>,
     ) -> Result<(CommitOutcome, CommitReads), CommitError> {
-        let _ = &reads;
+        if !reads.is_empty() {
+            return Err(CommitError {
+                reason: format!(
+                    "committer does not implement read-in-transaction but {} read(s) were staged;                      refusing to fabricate row-absence",
+                    reads.len()
+                ),
+            });
+        }
         let outcome = self.commit(writes).await?;
         Ok((outcome, CommitReads::default()))
     }
@@ -221,16 +231,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_commit_with_reads_commits_writes_and_returns_no_rows() {
+    async fn default_commit_with_reads_accepts_empty_read_set() {
         let committer = WriteOnlyCommitter;
         let (outcome, reads) = committer
+            .commit_with_reads(vec![write("ks", b"a")], Vec::new())
+            .await
+            .expect("empty read-set must commit through the default impl");
+        assert_eq!(outcome, CommitOutcome::Committed);
+        assert!(reads.rows.is_empty());
+    }
+
+    /// A committer without read-in-transaction support must REFUSE a non-empty
+    /// read-set. Silently returning `CommitReads::default()` would fabricate
+    /// row-absence (`None` means "absent at commit-t" to the caller) — a
+    /// missing capability must never become wrong query results.
+    #[tokio::test]
+    async fn default_commit_with_reads_rejects_staged_reads_loudly() {
+        let committer = WriteOnlyCommitter;
+        let err = committer
             .commit_with_reads(vec![write("ks", b"a")], vec![read("ks", "t", b"a")])
             .await
-            .expect("commit_with_reads");
-        assert_eq!(outcome, CommitOutcome::Committed);
+            .expect_err("non-empty read-set against the default impl must fail loud");
         assert!(
-            reads.rows.is_empty(),
-            "a write-only committer returns no transactional read rows"
+            err.reason.contains("read-in-transaction"),
+            "error must name the missing capability: {}",
+            err.reason
         );
     }
 

--- a/specs/proposed/read-in-accord-transaction.md
+++ b/specs/proposed/read-in-accord-transaction.md
@@ -1,0 +1,106 @@
+# Read-in-transaction: `SELECT` inside an Accord `BEGIN … COMMIT`
+
+**Status:** Proposed. Motivated by strict-serializability validation (Elle
+`list-append`), which requires transactions that both read and write and return
+the reads.
+
+## Problem
+
+Ferrosa's Accord transactions are **write-only** today. `route_transactional`
+(`ferrosa-cql/src/router.rs:1698`) buffers only `INSERT/UPDATE/DELETE`; a
+`SELECT` inside a transaction falls to `_ => None`, and `COMMIT` returns
+`encode_void()`. The commit seam
+(`ferrosa-storage/src/accord/transaction_committer.rs:59`,
+`TransactionCommitter::commit(writes)`) carries no read-set and returns no rows.
+
+This blocks the gold-standard Elle checker (`list-append`), which needs a
+transaction to read a key's value and return it. Without transactional reads we
+are limited to Elle `rw-register` with a `:linearizable-keys?` **assumption**
+(built + validated in `scratchpad/sr-elle`), which is weaker than a direct
+list-append proof.
+
+## What already exists (engine)
+
+The Accord coordinator already performs a **single-key, linearizable read-at-`t`**:
+`ReadPredicate::ReadRow { keyspace, table }` (`ferrosa-cluster/src/accord/wire.rs`),
+the F+1 agreement in `agreed_row` (`coordinator.rs:515`), and `last_read_row`
+(`coordinator.rs:453`). But it is (1) single representative-key, (2) fused to a
+conditional write (LWT `IF`), and (3) consumed internally by `condition_gate` —
+never surfaced through the commit seam. `transaction_keys.rs` already extracts a
+read-set but is **dead code** (no consumers).
+
+## Design
+
+Add a read-set to the transaction; execute those reads at the transaction's
+agreed commit timestamp across all read keys; return the rows from `COMMIT`.
+
+### Seam change (additive, low blast radius)
+
+Keep `commit(writes)` and add, on `TransactionCommitter`:
+
+```rust
+async fn commit_with_reads(
+    &self,
+    writes: Vec<TransactionWrite>,
+    reads: Vec<TransactionRead>,   // { keyspace, table, key }
+) -> Result<(CommitOutcome, CommitReads), CommitError> {
+    // default: commit writes, return no rows (front-ends/committers without
+    // transactional-read support are unaffected — e.g. Postgres front-end)
+    Ok((self.commit(writes).await?, CommitReads::default()))
+}
+```
+
+`CommitReads { rows: Vec<Option<Vec<u8>>> }` carries the agreed row bytes per
+read (positional). The CQL front-end calls `commit_with_reads`; the Postgres
+front-end is untouched.
+
+## Phased TDD plan
+
+**Slice 1 — CQL plumbing (proves the path, mock engine). Small.**
+- `session.rs CqlTransaction`: add a `reads: Vec<TransactionRead>` buffer +
+  `stage_read`; include in cap/poison accounting.
+- `router.rs route_transactional`: add a `Statement::Select(_) if txn.is_open()`
+  arm that buffers the read (new `build_transaction_read`, reusing
+  `transaction_keys::extract_where_keys`).
+- `router.rs commit_cql_transaction`: call `commit_with_reads`; on `Committed`,
+  decode the returned row bytes (mirror `decode_agreed_row_to_map`) + project the
+  SELECT columns + `result::encode_rows` instead of `encode_void`.
+- `MockTransactionCommitter`: override `commit_with_reads` to echo canned rows.
+- **Failing test** (model on `route_transactional_handles_begin_rollback_and_fails_commit_in_standalone`,
+  `router.rs:13505`): `BEGIN; SELECT; UPDATE; COMMIT` → assert the COMMIT
+  `RouteResult::Result` body decodes to a Rows body (kind `0x0002`) with the
+  expected values, not void. No dispatch/wire change (`connection.rs:1605`
+  already forwards `RouteResult::Result`).
+
+**Slice 2 — engine multi-key read-at-`t` (the hard, correctness-critical part).
+Large.**
+- `coordinator.rs run_transaction` + read-vote loop (`:1140`): generalize the
+  single representative-key read-vote to iterate the transaction's **read-set**,
+  collect each key's `agreed_row` at the committed `t`, and thread
+  `Vec<(key, Option<row_bytes>)>` out.
+- `AccordTransactionCommitter::commit_with_reads`
+  (`transaction_commit.rs:70`): drive reads via the generalized path (not
+  `ReadPredicate::Always`, which skips reads); return `CommitReads`.
+- Tests: model on `transaction_commit.rs` (`RecordingApplier`/`NoPeersTransport`,
+  single replica) and `driver_cross_shard_e2e.rs:233`. Assert a read observes a
+  write from the same transaction and reads are at the agreed `t` (snapshot
+  isolation across the read-set). This is consensus-path work — do NOT rush it.
+
+**Slice 3 — Elle `list-append` validation.**
+- Clojure/Rust `list-append` workload: `BEGIN; SELECT v; UPDATE v = v+[elem];
+  COMMIT` (append via read-modify-write in one txn), values unique.
+- Run against the live T3 cluster under the real `dc-partition+dc-slow` nemesis
+  (the container-mode partition fix from PR #274).
+- Elle `list-append/check {:consistency-models [:strict-serializable]}` must
+  return `:valid? true` (no G0/G1a/G1b/G1c/G2/G-single). No inference
+  assumptions. Do not claim strict-serializable until this passes.
+
+## Notes / risks
+
+- Multi-`SELECT` transactions: CQL returns one result body per response — support
+  one SELECT-in-txn first (or the last), decide multi-SELECT semantics later.
+- Slice 2 changes core Accord consensus code; each change needs its own failing
+  test and careful review. This warrants its own PR(s) separate from the CQL
+  plumbing.
+- Fallback if slice 2 is deferred: rw-register + `:linearizable-keys?`
+  (validated) gives a weaker-but-real signal now.

--- a/specs/proposed/read-in-accord-transaction.md
+++ b/specs/proposed/read-in-accord-transaction.md
@@ -44,8 +44,12 @@ async fn commit_with_reads(
     writes: Vec<TransactionWrite>,
     reads: Vec<TransactionRead>,   // { keyspace, table, key }
 ) -> Result<(CommitOutcome, CommitReads), CommitError> {
-    // default: commit writes, return no rows (front-ends/committers without
-    // transactional-read support are unaffected — e.g. Postgres front-end)
+    // Default: supports an EMPTY read-set only. Front-ends that never buffer
+    // transactional reads (Postgres) and write-only CQL transactions are
+    // unaffected. A NON-empty read-set here is a hard error — see below.
+    if !reads.is_empty() {
+        return Err(CommitError { reason: /* names the missing capability */ });
+    }
     Ok((self.commit(writes).await?, CommitReads::default()))
 }
 ```
@@ -53,6 +57,13 @@ async fn commit_with_reads(
 `CommitReads { rows: Vec<Option<Vec<u8>>> }` carries the agreed row bytes per
 read (positional). The CQL front-end calls `commit_with_reads`; the Postgres
 front-end is untouched.
+
+**Why the default REFUSES a non-empty read-set** rather than returning an empty
+`CommitReads`: `None` in `rows` means "row absent at commit-`t`" to the caller.
+Silently returning defaults would therefore fabricate row-ABSENCE the moment a
+front-end staged a read against a committer that has not implemented the read
+path — turning a missing capability into wrong query results. Fail loud; the
+front-end surfaces the error and the transaction does not lie.
 
 ## Phased TDD plan
 


### PR DESCRIPTION
Read-in-transaction slice 1/1a, salvaged from the pre-#285 local branch and ported onto the merged TransactionRegistry model (epic t_5a8d67c9 lineage).

**Storage seam**: `TransactionRead` / `CommitReads` / `TransactionCommitter::commit_with_reads` — positional read-set evaluated at the transaction's agreed commit timestamp. Default impl commits writes and accepts only an EMPTY read-set; a non-empty read-set against a committer without read-in-transaction support is a loud `CommitError` (silently returning defaults would fabricate row-absence, since `None` means "absent at commit-t").

**CQL wiring** (ported onto post-#285 code): reads buffer in `CqlTransaction.reads` inside the registry's `TransactionEntry` — txn-id-owned, reaped by the same 10s deadline as writes; `stage_read` fails loud outside a txn and counts against the shared statement cap; `commit_transaction` routes through `commit_with_reads`. The SELECT-in-transaction router arm and the engine's multi-key read-at-commit-t are later slices — no production path stages reads yet.

Port review note: the original slice-1a test pinned the default impl's silent-drop behavior; that test was authored in this same branch and was rewritten (not weakened) to pin the strengthened contract from both sides — empty read-set commits, non-empty read-set errors loudly.

Spec: `specs/proposed/read-in-accord-transaction.md`.
