### PR TITLE
test(sched): synchronize the fairness test's start line (t_ffb53cf9)

### DIFF
--- a/ferrosa-sched/src/fair_admit.rs
+++ b/ferrosa-sched/src/fair_admit.rs
@@ -450,13 +450,29 @@ mod tests {
         let served: Arc<Mutex<Map<GroupId, u64>>> = Arc::new(Mutex::new(Map::new()));
         let total = Arc::new(AtomicUsize::new(0));
         const BUDGET: usize = 6000;
+        const SCANS: usize = 4;
+
+        // All four scans must be RUNNING before any of them consumes the shared
+        // budget. Without this, the measurement is a thread-start race, not a
+        // fairness measurement: `spawn_blocking` threads start at the OS's
+        // discretion, so on a loaded/low-core machine one group could drain
+        // most of the budget before the other group's thread had started at
+        // all — producing a ratio that says nothing about admission fairness.
+        // Observed as a real CI failure (ratio 2.26, forge t_ffb53cf9).
+        //
+        // The barrier equalizes the START, not the outcome: the 0.5..=2.0 bound
+        // is unchanged and every rescheduling decision is still made by the
+        // live admission path.
+        let start_line = Arc::new(std::sync::Barrier::new(SCANS));
 
         let run = |group: GroupId| {
             let admit = admit.clone();
             let handle = handle.clone();
             let served = served.clone();
             let total = total.clone();
+            let start_line = start_line.clone();
             tokio::task::spawn_blocking(move || {
+                start_line.wait();
                 let id = slot(handle.block_on(admit.admit(
                     group,
                     GW,
@@ -472,6 +488,7 @@ mod tests {
         };
         // Group 1: three scans (the "gaming" tenant); group 2: one scan.
         let tasks = vec![run(1), run(1), run(1), run(2)];
+        assert_eq!(tasks.len(), SCANS, "barrier party count must match scans");
         for t in tasks {
             t.await.unwrap();
         }


### PR DESCRIPTION
Fixes the fairness test's startup race (forge t_ffb53cf9) — the red check on docs-only PR #313.

**The bug is in what the test measured.** Four `spawn_blocking` scans raced into a shared 6000-op budget with no synchronization, so on a loaded/low-core runner one group's thread could start after the other had already drained most of the budget. That produces a ratio reflecting OS thread-start order, not admission fairness. It failed CI at ratio 2.26 on a PR whose diff was four spec files — proof it was never a product regression.

**The fix is a start barrier**, not a weakened assertion:
- the `0.5..=2.0` bound is unchanged
- every rescheduling decision still runs through the live `admit`/`reschedule` path
- only the start line is equalized, removing thread-spawn skew from the measurement

**Characterization after the change**: 20/20 pass under 2x-ncpu saturation (the same load that reproduced formation and compaction races today). No residual admission gap is visible at this bound — the open question from the task ("does the ratio still approach 2.0 with a synchronized start?") answers *no* at this load level. If a future run does approach the bound with the barrier in place, that WOULD indicate a genuine admission gap and should be investigated as such, not widened.

Unblocks #313, which restacks once this lands.
