### PR TITLE
fix(ci): unblock the merge queue — deterministic DDL drain test + perf suite to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,18 @@ jobs:
           # repair fuzz harness (ferrosa-storage `fuzz-fileio` feature, on under
           # --all-features) from the per-PR gate; it runs deeply in
           # nightly-fuzz.yml. Add new tests/repair_fuzz.rs properties to both.
+          # `accord::perf_regression` asserts ABSOLUTE wall-clock bounds (e.g.
+          # a 1000-message ReorderBuffer drain under 10 ms). On a contended
+          # shared runner — especially a merge-group build running several jobs
+          # at once — that measures the runner, not the code: it was observed at
+          # 52.8 ms and ejected a DOCS-ONLY PR from the merge queue
+          # (forge t_430e21f7). The thresholds are UNCHANGED and still enforced,
+          # nightly, in nightly-fuzz.yml's `perf-regression` job where the
+          # machine is not competing with the rest of the PR gate. Keep the two
+          # in sync: a new perf assertion added here must run there.
           cargo test --all-features --workspace --lib --tests \
             --exclude ferrosa-jepsen --exclude ferrosa-loadgen \
-            -- --skip batch_atomicity --skip pause_resume --skip recovery_coordinator \
+            -- --skip accord::perf_regression --skip batch_atomicity --skip pause_resume --skip recovery_coordinator \
                --skip cassandra_reads_compacted --skip compaction_end_to_end_pipeline \
                --skip dep_wait_ordering --skip disk_fail_no_phantom \
                --skip packet_reorder_linearizability --skip lwt_batch_atomicity_all \

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -310,6 +310,41 @@ jobs:
         if: always()
         run: docker compose down -v --remove-orphans 2>/dev/null || true
 
+  perf-regression:
+    name: Accord perf regression (wall-clock thresholds)
+    runs-on: ubuntu-latest
+    # These assertions are ABSOLUTE wall-clock bounds, so they only mean
+    # something when the machine is not competing with the rest of the PR gate.
+    # They were moved out of the per-PR lane (ci.yml `--skip
+    # accord::perf_regression`) after a contended merge-group build measured a
+    # 1000-message ReorderBuffer drain at 52.8 ms against a 10 ms bound and
+    # ejected a docs-only PR from the merge queue (forge t_430e21f7).
+    #
+    # HONEST LIMIT: a GitHub-hosted nightly runner is still shared hardware, so
+    # this job catches GROSS regressions, not small ones. Precise measurement
+    # belongs on the Fly perf-tier instances (see ~/ferrosa-perf-evidence and
+    # the write-path A/B methodology). Do NOT widen a threshold to make this
+    # green — investigate, or move the measurement to dedicated hardware.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04-25
+
+      - name: Install Cap'n Proto compiler
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends capnproto
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - name: Run Accord perf regression suite
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
+        run: |
+          cargo test -p ferrosa-cluster --lib accord::perf_regression -- --nocapture
+
   race-stress-fly:
     name: Read-vs-compaction stress (shared-cpu Fly)
     runs-on: ubuntu-latest

--- a/ferrosa-cluster/src/accord/perf_regression.rs
+++ b/ferrosa-cluster/src/accord/perf_regression.rs
@@ -1,9 +1,22 @@
 //! Performance regression test suite for Accord.
 //!
-//! Deterministic performance tests that verify operation latency stays within
-//! acceptable thresholds. These use wall-clock timing to catch regressions in
-//! the critical path, but with generous bounds that pass on CI (no
-//! micro-benchmarking).
+//! Performance tests that verify operation latency stays within acceptable
+//! thresholds, using ABSOLUTE wall-clock bounds to catch regressions in the
+//! critical path.
+//!
+//! # Where these run
+//!
+//! NOT in the per-PR / merge-queue lane. `ci.yml` skips `accord::perf_regression`
+//! and the suite runs nightly (`nightly-fuzz.yml`, job `perf-regression`).
+//! Absolute time bounds measure the RUNNER when the machine is contended: a
+//! merge-group build clocked the 1000-message `ReorderBuffer` drain at 52.8 ms
+//! against the 10 ms bound and ejected a docs-only PR from the merge queue
+//! (forge t_430e21f7). The thresholds below are unchanged — only where they are
+//! evaluated changed.
+//!
+//! A nightly GitHub runner is still shared hardware, so this catches GROSS
+//! regressions only; precise measurement belongs on the Fly perf-tier rigs. If a
+//! threshold trips, investigate or move the measurement — do not widen it.
 //!
 //! # A7.9 Tests
 //!

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -2779,7 +2779,15 @@ async fn forming_falls_back_to_pair_on_timeout() {
 /// dropped late arrivals because it observed an empty queue once and
 /// exited; the new helper waits N consecutive empties so in-flight
 /// `Forming` senders can still land.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// `start_paused` puts BOTH the late sender's delay and the drain's
+// cool-downs on the same VIRTUAL clock, which auto-advances only when the
+// runtime is idle. That makes the interleaving deterministic instead of a
+// wall-clock race: the previous version slept 80 ms of real time hoping to
+// land inside the drain's ~150 ms quiet window, but that 80 ms starts when
+// the spawned task is FIRST POLLED, so on a loaded runner the send landed
+// after the drain had already exited (2 of 3 replayed — observed ejecting a
+// PR from the merge queue, forge t_58da3900).
+#[tokio::test(start_paused = true)]
 async fn ddl_during_forming_queues_and_replays() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -2790,12 +2798,11 @@ async fn ddl_during_forming_queues_and_replays() {
     tx.send(1).unwrap();
     tx.send(2).unwrap();
 
-    // Inject a third op AFTER the drain starts but before its
-    // first try_recv-empty cool-down completes.
+    // Inject a third op AFTER the drain has seen the queue go empty, so the
+    // test still exercises the cool-down path this helper exists for: a
+    // try_recv-once-then-quit drain would miss it.
     let tx_for_late = tx.clone();
     tokio::spawn(async move {
-        // Sleep long enough for drain_ddl_queue to consume the first
-        // two ops and start its first cool-down (50 ms).
         tokio::time::sleep(std::time::Duration::from_millis(80)).await;
         tx_for_late.send(3).unwrap();
     });


### PR DESCRIPTION
Unblocks the merge queue: two pre-existing failures were ejecting unrelated PRs (a docs-only PR among them).

## 1. `ddl_during_forming_queues_and_replays` — deterministic timing (t_58da3900)

The test slept **80 ms of real time** in a spawned task, aiming to land inside `drain_ddl_queue`'s ~150 ms quiet window (3 × 50 ms cool-downs). But that 80 ms starts when the task is **first polled** — under merge-group load the scheduling delay pushed the send past the drain's exit, replaying 2 of 3.

`start_paused` puts the sender's delay and the drain's cool-downs on one virtual clock that advances only when the runtime is idle, so the interleaving is fixed under any load.

**Not a weakening — verified both directions:** passes with the correct drain, and still fails with the identical `got 2` when `REQUIRED_CONSECUTIVE_EMPTY` is temporarily set to 1, i.e. it still catches the try-recv-once-then-quit regression it was written for. Runtime 150 ms → 0.01 s.

**Production was never at risk** (checked, and it corrects my initial suspicion): `transition_to_cluster` stores `DdlPath::Cluster` *before* draining, so post-switchover DDL goes to the live path; and the `Forming` path error-logs a failed enqueue *and* always returns a retry error to the client (`ddl_path.rs:128`). Nothing is silently dropped.

## 2. Accord perf regression moved to nightly (t_430e21f7)

`accord::perf_regression` asserts absolute wall-clock bounds. A contended merge-group build clocked the 1000-message `ReorderBuffer` drain at **52.8 ms against a 10 ms bound** — measuring the runner, not the code.

Moved to a new `perf-regression` job in `nightly-fuzz.yml`, following the `--skip`-in-CI / run-in-nightly convention already used for the repair fuzz harness. **Every threshold is unchanged**; only where they're evaluated changed. Both the job and the module doc record the honest limit: a nightly GitHub runner is still shared hardware, so this catches gross regressions only, precise measurement belongs on the Fly perf-tier rigs, and a tripped threshold means investigate — never widen.
