### PR TITLE
ci(oracle): pin the differential-oracle job to the docker runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,10 @@ jobs:
       - name: Run differential oracle (corpus + restricted-query + DML)
         env:
           FERROSA_TEST_CONTAINERS: "1"
+          # Pin the runtime: the harness prefers podman when it is on PATH, but
+          # this job verifies and pre-pulls with docker. ubuntu-latest runners
+          # ship both, and their podman/crun setup is not guaranteed to work.
+          FERROSA_CONTAINER_RUNTIME: docker
         run: |
           cargo test -p ferrosa-postgres --features live-infra-tests \
             --test differential_oracle -- --test-threads=1 --nocapture


### PR DESCRIPTION
## Why

PR #317 was ejected from the merge queue twice by `Differential Oracle (vs PostgreSQL)` failures that had nothing to do with its diff:

- `differential_oracle_corpus_agrees`: `podman run` failed resolving the unqualified image name `postgres` via registries.conf
- `differential_oracle_dml_agrees`: `crun: unknown version specified`

## Root cause

`container_runtime()` in `ferrosa-postgres/tests/differential_oracle.rs` prefers **podman** whenever it is on PATH. The CI job, however, verifies **docker** and pre-pulls `postgres:16` **with docker**. ubuntu-latest runners ship both runtimes, so the tests ran against a podman that CI never provisioned — and whose rootless podman/crun stack is broken on some runner images. Whether the job passes depends on which runner you land on (#319's queue run passed 27 minutes before #317's failed).

## Fix

Set `FERROSA_CONTAINER_RUNTIME: docker` on the oracle step so the harness deterministically uses the runtime the job actually set up. The env var already exists as the harness's explicit override; no test-code change needed.

