### PR TITLE
fix(graph): spill expand/leapfrog results incrementally — no full materialization before the sorter

### DIFF
--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1482,10 +1482,48 @@ async fn execute_expand_streaming<'a>(
     };
 
     // ORDER BY (with or without DISTINCT) is a pipeline breaker: no row is
-    // final until every row is projected. Keep the buffered tail, which also
-    // keeps the spill path and the ordering-by-non-projected-expressions
-    // behavior intact.
+    // final until every row is projected. But "must see every row" does not
+    // mean "must hold every row": when the spilling sorter applies, project
+    // each state straight INTO it and stream the merged output — the full
+    // result set is never resident (t_3f2f961a). DISTINCT still takes the
+    // buffered tail: its buffered semantics re-sort by debug string after the
+    // ORDER BY sort (t_363c1316 tracks that bug), and this path must not
+    // change observable behavior.
     if !parts.return_clause.order_by.is_empty() {
+        let columns = build_columns(&parts.return_clause);
+        if !parts.return_clause.distinct {
+            if let Some(mut sink) = crate::executor::spill::SpillSortSink::try_new(
+                &columns,
+                &parts.return_clause,
+                ctx.config,
+                "graph_order_by_stream",
+            )? {
+                let proj = ExpandProjection {
+                    needs_graph_projection: parts
+                        .return_clause
+                        .items
+                        .iter()
+                        .any(|item| expr_has_pattern_comprehension(&item.expr)),
+                    anchor_var: parts.anchor.var.clone().unwrap_or_default(),
+                    return_clause: parts.return_clause.clone(),
+                    write_path: ctx.write_path,
+                    keyspace: ctx.keyspace,
+                    schema: ctx.schema,
+                };
+                project_states_into_sink(
+                    &states,
+                    &proj,
+                    &mut sink,
+                    ctx.start,
+                    ctx.config.query_timeout,
+                )
+                .await?;
+                stats.execution_ms = ctx.start.elapsed().as_millis() as u64;
+                return Ok((columns, sink.finish_stream()?, stats));
+            }
+        }
+        // Fallback: no spill backend, LIMIT present, an order term that is not
+        // a projected column (needs the states' bindings), or DISTINCT.
         let result = finish_expand_buffered(states, stats, plan, ctx).await?;
         return Ok((result.columns, stream_from_rows(result.rows), result.stats));
     }
@@ -1944,39 +1982,65 @@ async fn finish_expand_buffered(
     // Project every surviving state. The old `max_result_rows` break here
     // SILENTLY TRUNCATED the result — no error, no flag, so a client could not
     // tell a partial answer from a complete one. Removed (t_4ce82a3e): an
-    // unbounded ORDER BY now SPILLS (below) instead of being capped, which is
-    // the honest answer rather than a quiet wrong one.
-    let mut result_states = Vec::new();
-    let mut rows = Vec::new();
-    for state in &current_states {
-        let row = project_state(
-            return_clause,
-            needs_graph_projection,
-            write_path,
-            keyspace,
-            schema,
-            anchor_var,
-            state,
-        )
-        .await?;
-        result_states.push(state.clone());
-        rows.push(row);
-    }
-
-    // Apply ORDER BY before projection-only values disappear. Cypher permits
-    // ordering by expressions that are not part of RETURN.
+    // unbounded ORDER BY now SPILLS instead of being capped, which is the
+    // honest answer rather than a quiet wrong one.
     //
-    // An UNBOUNDED ORDER BY (no LIMIT) must see every row before the first
-    // output row is known — a pipeline-breaker. Rather than cap it in memory,
-    // spill through the storage engine's bounded external merge sort when a
-    // backend is available (t_4ce82a3e). `spill_order_by` returns Ok(false) when
-    // it cannot apply (no backend, no LIMIT-free ORDER BY, or an order term that
-    // is not a projected column), leaving the in-memory sort below to run
-    // exactly as before.
-    let spilled =
-        crate::executor::spill::spill_order_by(&mut rows, &columns, return_clause, config).await?;
-    if !spilled {
-        sort_projected_rows_by_bindings(&mut rows, &result_states, return_clause);
+    // When the spilling sorter applies, each projected row goes straight INTO
+    // it — the interim rows `Vec` and the per-state clones (only ever needed by
+    // the bindings-based fallback sort) are skipped entirely, so projection
+    // memory is bounded by the spill threshold rather than the result size
+    // (t_3f2f961a). The final `Vec` below is this function's buffered
+    // contract; the streaming entry point avoids even that.
+    //
+    // ORDER BY runs before projection-only values disappear: Cypher permits
+    // ordering by expressions that are not part of RETURN, and exactly that
+    // case is why the fallback sorts via the states' bindings — a spilled row
+    // carries no binding context, so `SpillSortSink::try_new` refuses it.
+    let sink = crate::executor::spill::SpillSortSink::try_new(
+        &columns,
+        return_clause,
+        config,
+        "graph_order_by",
+    )?;
+    let mut rows = Vec::new();
+    match sink {
+        Some(mut sink) => {
+            let proj = ExpandProjection {
+                return_clause: return_clause.clone(),
+                anchor_var: anchor_var.to_string(),
+                needs_graph_projection,
+                write_path,
+                keyspace,
+                schema,
+            };
+            project_states_into_sink(
+                &current_states,
+                &proj,
+                &mut sink,
+                start,
+                config.query_timeout,
+            )
+            .await?;
+            rows = sink.finish_rows()?;
+        }
+        None => {
+            let mut result_states = Vec::new();
+            for state in &current_states {
+                let row = project_state(
+                    return_clause,
+                    needs_graph_projection,
+                    write_path,
+                    keyspace,
+                    schema,
+                    anchor_var,
+                    state,
+                )
+                .await?;
+                result_states.push(state.clone());
+                rows.push(row);
+            }
+            sort_projected_rows_by_bindings(&mut rows, &result_states, return_clause);
+        }
     }
 
     // Apply DISTINCT.
@@ -2081,6 +2145,40 @@ struct ExpandProjection<'a> {
     write_path: &'a WritePath,
     keyspace: &'a str,
     schema: Option<&'a Schema>,
+}
+
+/// Project every surviving state sequentially, pushing each row straight into
+/// the spilling ORDER BY sorter — the interim rows `Vec` never exists, so
+/// projection memory is bounded by the spill threshold rather than the result
+/// size (t_3f2f961a). Shared by the streaming and buffered ORDER BY tails so
+/// they cannot drift.
+///
+/// Checks the query timeout once per state: projection can read storage (a
+/// pattern comprehension traverses per row), so it is WORK and gets the same
+/// bound as the hop loop. The buffered tail historically skipped that check —
+/// a gap, not a behavior worth preserving.
+async fn project_states_into_sink(
+    states: &[ExpandState],
+    proj: &ExpandProjection<'_>,
+    sink: &mut crate::executor::spill::SpillSortSink,
+    start: Instant,
+    query_timeout: std::time::Duration,
+) -> Result<()> {
+    for state in states {
+        check_timeout(start, query_timeout)?;
+        let row = project_state(
+            &proj.return_clause,
+            proj.needs_graph_projection,
+            proj.write_path,
+            proj.keyspace,
+            proj.schema,
+            &proj.anchor_var,
+            state,
+        )
+        .await?;
+        sink.push(row)?;
+    }
+    Ok(())
 }
 
 /// Project the surviving expand states lazily: one [`project_state`] call per

--- a/ferrosa-graph/src/executor/leapfrog.rs
+++ b/ferrosa-graph/src/executor/leapfrog.rs
@@ -11,6 +11,8 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
+use futures::StreamExt as _;
+
 use ferrosa_cluster::write_path::WritePath;
 use ferrosa_common::{DecoratedKey, PartitionKey};
 use ferrosa_schema::VirtualTableRegistry;
@@ -22,9 +24,35 @@ use crate::executor::expand::{
     build_columns, check_timeout, extract_neighbor_id, GraphEngineConfig,
 };
 use crate::executor::result::{GraphResult, QueryStats};
+use crate::executor::spill::SpillSortSink;
+use crate::executor::stream::RowVals;
 use crate::executor::{eval, sort_rows};
 use crate::parser::ReturnClause;
 use crate::planner::physical::WcoJoinPlan;
+
+/// Where enumerated result rows go.
+///
+/// `Spilling` pushes each row into the external merge sort AS IT IS PRODUCED,
+/// so an unbounded ORDER BY result never sits fully in memory (t_3f2f961a).
+/// `Buffered` is the fallback when the sink cannot apply (no backend, LIMIT
+/// present, no ORDER BY, or an order term that is not a projected column) —
+/// identical to the old accumulation.
+enum RowAcc {
+    Buffered(Vec<RowVals>),
+    Spilling(SpillSortSink),
+}
+
+impl RowAcc {
+    fn push(&mut self, row: RowVals) -> Result<()> {
+        match self {
+            Self::Buffered(rows) => {
+                rows.push(row);
+                Ok(())
+            }
+            Self::Spilling(sink) => sink.push(row),
+        }
+    }
+}
 
 /// A sorted iterator over neighbor IDs from the adjacency index.
 /// Supports seek (advance to a position >= target) and next.
@@ -185,25 +213,35 @@ pub async fn execute_wco_join(
     let adj_ks = adjacency_keyspace_name(keyspace);
     let adj_table_id = TableId::new(&adj_ks, "adjacency");
 
-    // Get all candidate vertices for the first variable.
+    // Get all candidate vertices for the first variable — STREAMED, not
+    // materialized: `range_read` returned every partition of the table in one
+    // `Vec` before the first candidate was examined (t_3f2f961a). Each pull
+    // now yields one partition; only the candidate's key survives the
+    // iteration.
     let first_var = &plan.variables[0];
     let first_table = plan.var_tables.get(first_var).ok_or_else(|| {
         GraphError::Validation(format!("no resolved table for variable '{first_var}'"))
     })?;
     let first_table_id = TableId::new(&first_table.keyspace, &first_table.table);
-    let candidates = write_path.range_read(&first_table_id).await?;
-    stats.vertices_read += candidates.len();
-    check_timeout(start, config.query_timeout)?;
 
     let columns = build_columns(return_clause);
 
-    // For each candidate binding of the first variable, do variable elimination.
-    let mut result_rows: Vec<Vec<serde_json::Value>> = Vec::new();
+    // Result accumulation is spill-backed when the sorter applies, so an
+    // unbounded ORDER BY never holds the full result in memory. The silent
+    // `max_result_rows` truncation that used to stop enumeration is REMOVED
+    // (result caps are bugs: a client could not tell a partial answer from a
+    // complete one). Work stays bounded by `check_timeout`, which every
+    // enumeration step already consults.
+    let mut acc =
+        match SpillSortSink::try_new(&columns, return_clause, config, "graph_wco_order_by")? {
+            Some(sink) => RowAcc::Spilling(sink),
+            None => RowAcc::Buffered(Vec::new()),
+        };
 
-    for candidate in &candidates {
-        if result_rows.len() >= config.max_result_rows {
-            break;
-        }
+    let mut candidates = write_path.range_read_stream_all(&first_table_id, 0).await?;
+    while let Some(candidate) = candidates.next().await {
+        let candidate = candidate?;
+        stats.vertices_read += 1;
         check_timeout(start, config.query_timeout)?;
 
         let first_key_bytes = candidate.key.key.as_bytes().to_vec();
@@ -220,7 +258,7 @@ pub async fn execute_wco_join(
             &plan.variables,
             1, // Start from second variable.
             &mut var_bindings,
-            &mut result_rows,
+            &mut acc,
             return_clause,
             &columns,
             config,
@@ -231,28 +269,17 @@ pub async fn execute_wco_join(
         .await?;
     }
 
-    // Apply ORDER BY. An unbounded one spills through the storage engine's
-    // bounded external merge sort (t_4ce82a3e); `spill_order_by` returns false —
-    // leaving the in-memory sort — when it cannot apply.
-    //
-    // NOTE: unlike the expand and varpath paths, this file's `max_result_rows`
-    // uses are NOT removed here. Several of them bound JOIN WORK rather than the
-    // result buffer (`leapfrog_join(&mut iterators, config.max_result_rows)`
-    // caps the intersection itself, and `enumerate_bindings` stops recursing on
-    // it), so removing them is a different change that needs its own analysis of
-    // what each cap is actually protecting.
-    if !return_clause.order_by.is_empty() {
-        let spilled = crate::executor::spill::spill_order_by(
-            &mut result_rows,
-            &columns,
-            return_clause,
-            config,
-        )
-        .await?;
-        if !spilled {
-            sort_rows(&mut result_rows, &columns, &return_clause.order_by);
+    // Terminal ORDER BY: the spilling accumulator already sorted while
+    // accumulating; the buffered fallback sorts in memory exactly as before.
+    let mut result_rows = match acc {
+        RowAcc::Spilling(sink) => sink.finish_rows()?,
+        RowAcc::Buffered(mut rows) => {
+            if !return_clause.order_by.is_empty() {
+                sort_rows(&mut rows, &columns, &return_clause.order_by);
+            }
+            rows
         }
-    }
+    };
 
     // Apply DISTINCT.
     if return_clause.distinct {
@@ -288,7 +315,7 @@ async fn enumerate_bindings(
     variables: &[String],
     var_idx: usize,
     var_bindings: &mut HashMap<String, Vec<u8>>,
-    result_rows: &mut Vec<Vec<serde_json::Value>>,
+    acc: &mut RowAcc,
     return_clause: &ReturnClause,
     columns: &[String],
     config: &GraphEngineConfig,
@@ -296,9 +323,6 @@ async fn enumerate_bindings(
     stats: &mut QueryStats,
     schema: Option<&ferrosa_schema::Schema>,
 ) -> Result<()> {
-    if result_rows.len() >= config.max_result_rows {
-        return Ok(());
-    }
     check_timeout(start, config.query_timeout)?;
 
     // Base case: all variables are bound. Verify that all relations are satisfied
@@ -310,7 +334,7 @@ async fn enumerate_bindings(
             let row =
                 project_bindings(write_path, plan, var_bindings, return_clause, stats, schema)
                     .await?;
-            result_rows.push(row);
+            acc.push(row)?;
         }
         return Ok(());
     }
@@ -372,16 +396,16 @@ async fn enumerate_bindings(
 
     if iterators.is_empty() {
         // No constraints on this variable from bound variables yet.
-        // Fall back to scanning all candidates for this variable.
+        // Fall back to scanning all candidates for this variable — streamed,
+        // one partition per pull, instead of materializing the whole table
+        // (t_3f2f961a).
         if let Some(table) = plan.var_tables.get(current_var) {
             let table_id = TableId::new(&table.keyspace, &table.table);
-            let candidates = write_path.range_read(&table_id).await?;
-            stats.vertices_read += candidates.len();
+            let mut candidates = write_path.range_read_stream_all(&table_id, 0).await?;
 
-            for candidate in &candidates {
-                if result_rows.len() >= config.max_result_rows {
-                    break;
-                }
+            while let Some(candidate) = candidates.next().await {
+                let candidate = candidate?;
+                stats.vertices_read += 1;
                 let key_bytes = candidate.key.key.as_bytes().to_vec();
                 var_bindings.insert(current_var.clone(), key_bytes);
                 Box::pin(enumerate_bindings(
@@ -391,7 +415,7 @@ async fn enumerate_bindings(
                     variables,
                     var_idx + 1,
                     var_bindings,
-                    result_rows,
+                    acc,
                     return_clause,
                     columns,
                     config,
@@ -406,13 +430,13 @@ async fn enumerate_bindings(
         return Ok(());
     }
 
-    // Leapfrog join: intersect all iterators for the current variable.
-    let valid_bindings = leapfrog_join(&mut iterators, config.max_result_rows);
+    // Leapfrog join: intersect all iterators for the current variable. The
+    // intersection is bounded by the smallest adjacency list, which is already
+    // resident — truncating it (`max_result_rows`, removed) only dropped valid
+    // join results without saving memory.
+    let valid_bindings = leapfrog_join(&mut iterators, usize::MAX);
 
     for binding in &valid_bindings {
-        if result_rows.len() >= config.max_result_rows {
-            break;
-        }
         var_bindings.insert(current_var.clone(), binding.clone());
         Box::pin(enumerate_bindings(
             write_path,
@@ -421,7 +445,7 @@ async fn enumerate_bindings(
             variables,
             var_idx + 1,
             var_bindings,
-            result_rows,
+            acc,
             return_clause,
             columns,
             config,

--- a/ferrosa-graph/src/executor/spill.rs
+++ b/ferrosa-graph/src/executor/spill.rs
@@ -132,12 +132,17 @@ impl SpillOrder<GraphRow> for GraphRowOrder {
     }
 }
 
-/// Sort `rows` in place through the storage engine's bounded external merge
-/// sort, spilling to a cancellable temp directory instead of holding the whole
-/// sorted set in memory (t_4ce82a3e).
+/// An incremental, spill-backed ORDER BY accumulator.
 ///
-/// Returns `Ok(false)` — leaving `rows` untouched for the in-memory sort — when
-/// this cannot apply:
+/// The original `spill_order_by` took a fully-materialized `Vec` of rows and
+/// drained it into the external sorter — so the complete result still had to
+/// fit in memory once before any spilling happened (owner finding on #308,
+/// t_3f2f961a). This sink is the same sorter behind a push-per-row surface:
+/// producers hand each row over AS IT IS PRODUCED, and memory is bounded by
+/// `spill_threshold_bytes` regardless of result size.
+///
+/// Eligibility ([`SpillSortSink::try_new`] returns `Ok(None)`) matches the old
+/// `spill_order_by` exactly:
 /// - no spill backend configured (unit tests, embedded use);
 /// - no ORDER BY, or a LIMIT is present (the bounded case does not need spill);
 /// - an ORDER BY term is not a projected column, which the in-memory
@@ -146,65 +151,158 @@ impl SpillOrder<GraphRow> for GraphRowOrder {
 ///
 /// Fails loud on any spill/merge I/O error — a dropped run would silently lose
 /// rows, which is strictly worse than the old cap.
+pub(super) struct SpillSortSink {
+    reservation: ferrosa_storage::TempSortTableReservation,
+    sorter: ferrosa_storage::external_sort::ExternalSorter<GraphRow, GraphRowOrder>,
+    rows_pushed: usize,
+}
+
+impl std::fmt::Debug for SpillSortSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpillSortSink")
+            .field("rows_pushed", &self.rows_pushed)
+            .field("temp_dir", &self.reservation.path())
+            .finish()
+    }
+}
+
+impl SpillSortSink {
+    /// Build a sink when the spilling ORDER BY sort can apply; `Ok(None`)
+    /// otherwise (caller keeps its in-memory path, exactly as before).
+    pub(super) fn try_new(
+        columns: &[String],
+        return_clause: &crate::parser::ReturnClause,
+        config: &super::expand::GraphEngineConfig,
+        label: &str,
+    ) -> crate::error::Result<Option<Self>> {
+        let Some(reserver) = config.spill.as_ref() else {
+            return Ok(None);
+        };
+        if return_clause.order_by.is_empty() || return_clause.limit.is_some() {
+            return Ok(None);
+        }
+        // Resolve every order term to a projected column index; bail to the
+        // in-memory path if any term is not projected.
+        let mut terms = Vec::with_capacity(return_clause.order_by.len());
+        for item in &return_clause.order_by {
+            let name = super::expand::expr_to_column_name(&item.expr);
+            let Some(column) = columns.iter().position(|c| c == &name) else {
+                return Ok(None);
+            };
+            terms.push(GraphOrderTerm {
+                column,
+                ascending: matches!(item.direction, crate::parser::SortDir::Asc),
+            });
+        }
+
+        let reservation = reserver.reserve(label).map_err(|e| {
+            crate::error::GraphError::Internal(format!("ORDER BY temp-sort setup failed: {e}"))
+        })?;
+        let sorter = ferrosa_storage::external_sort::ExternalSorter::new(
+            reservation.path(),
+            GraphRowOrder::new(terms),
+            config.spill_threshold_bytes,
+        );
+        Ok(Some(Self {
+            reservation,
+            sorter,
+            rows_pushed: 0,
+        }))
+    }
+
+    /// Accept one produced row. Spills a sorted run when the buffer crosses
+    /// the byte threshold; fails loud on I/O error.
+    pub(super) fn push(&mut self, row: RowVals) -> crate::error::Result<()> {
+        self.rows_pushed += 1;
+        self.sorter
+            .push(GraphRow(row))
+            .map_err(|e| crate::error::GraphError::Internal(format!("ORDER BY spill: {e}")))
+    }
+
+    /// Finish the sort and materialize the merged output into a `Vec`, for
+    /// callers bound to the buffered `GraphResult` contract.
+    pub(super) fn finish_rows(self) -> crate::error::Result<Vec<RowVals>> {
+        let rows_pushed = self.rows_pushed;
+        let spilled_to_disk = self.sorter.spilled();
+        let temp_dir = self.reservation.path().display().to_string();
+        let sorted = self.sorter.finish().map_err(|e| {
+            crate::error::GraphError::Internal(format!("ORDER BY spill finish: {e}"))
+        })?;
+        let mut rows = Vec::with_capacity(rows_pushed);
+        for row in sorted {
+            rows.push(
+                row.map_err(|e| {
+                    crate::error::GraphError::Internal(format!("ORDER BY merge: {e}"))
+                })?
+                .0,
+            );
+        }
+        if spilled_to_disk {
+            tracing::info!(
+                rows = rows.len(),
+                temp_sort_table = %temp_dir,
+                "graph ORDER BY spilled to a cancellable temp-sort table"
+            );
+        }
+        // `self.reservation` drops here — its Drop removes the temp directory,
+        // so a cancelled or failed query cleans up exactly like a successful one.
+        Ok(rows)
+    }
+
+    /// Finish the sort and stream the merged output WITHOUT re-materializing
+    /// it: each pull reads the next row from the merge. The temp-dir
+    /// reservation is moved into the stream, so the spilled runs live exactly
+    /// as long as a consumer can still pull from them and are removed when the
+    /// stream drops — cancelled, exhausted, or abandoned alike.
+    pub(super) fn finish_stream(self) -> crate::error::Result<super::stream::RowStream<'static>> {
+        let spilled_to_disk = self.sorter.spilled();
+        let rows_pushed = self.rows_pushed;
+        let temp_dir = self.reservation.path().display().to_string();
+        let sorted = self.sorter.finish().map_err(|e| {
+            crate::error::GraphError::Internal(format!("ORDER BY spill finish: {e}"))
+        })?;
+        if spilled_to_disk {
+            tracing::info!(
+                rows = rows_pushed,
+                temp_sort_table = %temp_dir,
+                "graph ORDER BY streaming from a cancellable temp-sort table"
+            );
+        }
+        let reservation = self.reservation;
+        let iter = sorted.map(move |row| {
+            // The closure owns `reservation`; referencing it keeps the temp
+            // dir alive until the stream itself is dropped.
+            let _keep_alive = &reservation;
+            row.map(|r| r.0)
+                .map_err(|e| crate::error::GraphError::Internal(format!("ORDER BY merge: {e}")))
+        });
+        Ok(Box::pin(futures::stream::iter(iter)))
+    }
+}
+
+/// Sort `rows` in place through the storage engine's bounded external merge
+/// sort, spilling to a cancellable temp directory instead of holding the whole
+/// sorted set in memory (t_4ce82a3e).
+///
+/// Returns `Ok(false)` — leaving `rows` untouched for the in-memory sort — when
+/// the sink cannot apply (see [`SpillSortSink::try_new`]). Retained for callers
+/// that already hold a materialized `Vec`; producers that can hand rows over
+/// one at a time should push into a [`SpillSortSink`] instead and never build
+/// the interim `Vec` at all (t_3f2f961a).
 pub(super) async fn spill_order_by(
     rows: &mut Vec<Vec<serde_json::Value>>,
     columns: &[String],
     return_clause: &crate::parser::ReturnClause,
     config: &super::expand::GraphEngineConfig,
 ) -> crate::error::Result<bool> {
-    let Some(reserver) = config.spill.as_ref() else {
+    let Some(mut sink) = SpillSortSink::try_new(columns, return_clause, config, "graph_order_by")?
+    else {
         return Ok(false);
     };
-    if return_clause.order_by.is_empty() || return_clause.limit.is_some() {
-        return Ok(false);
-    }
-    // Resolve every order term to a projected column index; bail to the
-    // in-memory path if any term is not projected.
-    let mut terms = Vec::with_capacity(return_clause.order_by.len());
-    for item in &return_clause.order_by {
-        let name = super::expand::expr_to_column_name(&item.expr);
-        let Some(column) = columns.iter().position(|c| c == &name) else {
-            return Ok(false);
-        };
-        terms.push(GraphOrderTerm {
-            column,
-            ascending: matches!(item.direction, crate::parser::SortDir::Asc),
-        });
-    }
-
-    let reservation = reserver.reserve("graph_order_by").map_err(|e| {
-        crate::error::GraphError::Internal(format!("ORDER BY temp-sort setup failed: {e}"))
-    })?;
-    let mut sorter: ferrosa_storage::external_sort::ExternalSorter<GraphRow, GraphRowOrder> =
-        ferrosa_storage::external_sort::ExternalSorter::new(
-            reservation.path(),
-            GraphRowOrder::new(terms),
-            config.spill_threshold_bytes,
-        );
     for row in rows.drain(..) {
-        sorter
-            .push(GraphRow(row))
-            .map_err(|e| crate::error::GraphError::Internal(format!("ORDER BY spill: {e}")))?;
+        sink.push(row)?;
     }
-    let spilled_to_disk = sorter.spilled();
-    let sorted = sorter
-        .finish()
-        .map_err(|e| crate::error::GraphError::Internal(format!("ORDER BY spill finish: {e}")))?;
-    for row in sorted {
-        rows.push(
-            row.map_err(|e| crate::error::GraphError::Internal(format!("ORDER BY merge: {e}")))?
-                .0,
-        );
-    }
-    if spilled_to_disk {
-        tracing::info!(
-            rows = rows.len(),
-            temp_sort_table = %reservation.path().display(),
-            "graph ORDER BY spilled to a cancellable temp-sort table"
-        );
-    }
-    // `reservation` drops here — its Drop removes the temp directory, so a
-    // cancelled or failed query cleans up exactly like a successful one.
+    *rows = sink.finish_rows()?;
     Ok(true)
 }
 
@@ -222,6 +320,183 @@ mod tests {
             column,
             ascending: true,
         }])
+    }
+
+    /// Test double for the spill backend: reserves subdirectories of one
+    /// tempdir and records each reservation path so tests can assert cleanup.
+    #[derive(Debug)]
+    struct TempDirReserver {
+        root: std::path::PathBuf,
+        reserved: std::sync::Mutex<Vec<std::path::PathBuf>>,
+    }
+
+    impl TempDirReserver {
+        fn new(root: &std::path::Path) -> std::sync::Arc<Self> {
+            std::sync::Arc::new(Self {
+                root: root.to_path_buf(),
+                reserved: std::sync::Mutex::new(Vec::new()),
+            })
+        }
+
+        fn reserved_paths(&self) -> Vec<std::path::PathBuf> {
+            self.reserved.lock().unwrap().clone()
+        }
+    }
+
+    impl SpillReserver for TempDirReserver {
+        fn reserve(
+            &self,
+            label: &str,
+        ) -> ferrosa_common::Result<ferrosa_storage::TempSortTableReservation> {
+            let path = self.root.join(format!("{label}_{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&path)
+                .map_err(|e| ferrosa_common::Error::InvalidFormat(e.to_string()))?;
+            self.reserved.lock().unwrap().push(path.clone());
+            Ok(ferrosa_storage::TempSortTableReservation::claim_dir(path))
+        }
+    }
+
+    /// A config whose sink ALWAYS spills (threshold 1 byte), so tests exercise
+    /// the run-file + merge path rather than the in-memory fast path.
+    fn spilling_config(
+        reserver: std::sync::Arc<TempDirReserver>,
+    ) -> super::super::expand::GraphEngineConfig {
+        super::super::expand::GraphEngineConfig {
+            spill: Some(reserver),
+            spill_threshold_bytes: 1,
+            ..Default::default()
+        }
+    }
+
+    fn order_by_n_return_clause() -> crate::parser::ReturnClause {
+        crate::parser::ReturnClause {
+            order_by: vec![crate::parser::OrderItem {
+                expr: crate::parser::Expr::Var("n".to_string()),
+                direction: crate::parser::SortDir::Asc,
+            }],
+            ..return_n_clause()
+        }
+    }
+
+    fn return_n_clause() -> crate::parser::ReturnClause {
+        crate::parser::ReturnClause {
+            items: vec![crate::parser::ReturnItem {
+                expr: crate::parser::Expr::Var("n".to_string()),
+                alias: None,
+            }],
+            distinct: false,
+            order_by: vec![],
+            limit: None,
+        }
+    }
+
+    /// The sink must produce exactly what the Vec-based `spill_order_by`
+    /// produces — same rows, same order — because callers were converted from
+    /// one to the other with no intended behavior change (t_3f2f961a).
+    #[tokio::test]
+    async fn sink_matches_the_vec_based_spill_order_by() {
+        let dir = tempfile::tempdir().unwrap();
+        let reserver = TempDirReserver::new(dir.path());
+        let config = spilling_config(reserver);
+        let columns = vec!["n".to_string()];
+        let clause = order_by_n_return_clause();
+        let source: Vec<RowVals> = [5i64, 1, 4, 2, 3]
+            .iter()
+            .map(|n| vec![serde_json::json!(n)])
+            .collect();
+
+        let mut vec_path = source.clone();
+        assert!(
+            spill_order_by(&mut vec_path, &columns, &clause, &config)
+                .await
+                .unwrap(),
+            "spill path must apply"
+        );
+
+        let mut sink = SpillSortSink::try_new(&columns, &clause, &config, "test")
+            .unwrap()
+            .expect("sink must apply under the same conditions");
+        for row in source {
+            sink.push(row).unwrap();
+        }
+        assert_eq!(sink.finish_rows().unwrap(), vec_path);
+    }
+
+    /// `finish_stream` yields the merged rows in sorted order WITHOUT
+    /// re-materializing, and the temp dir lives exactly as long as the stream.
+    #[tokio::test]
+    async fn finish_stream_yields_sorted_rows_then_cleans_up_on_drop() {
+        use futures::StreamExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reserver = TempDirReserver::new(dir.path());
+        let config = spilling_config(reserver.clone());
+        let clause = order_by_n_return_clause();
+
+        let mut sink = SpillSortSink::try_new(&["n".to_string()], &clause, &config, "test")
+            .unwrap()
+            .expect("sink must apply");
+        for n in [3i64, 1, 2] {
+            sink.push(vec![serde_json::json!(n)]).unwrap();
+        }
+
+        let reserved = reserver.reserved_paths();
+        assert_eq!(reserved.len(), 1);
+        let mut stream = sink.finish_stream().unwrap();
+        assert!(
+            reserved[0].exists(),
+            "spilled runs must survive until the stream is dropped"
+        );
+
+        let mut got = Vec::new();
+        while let Some(row) = stream.next().await {
+            got.push(row.unwrap()[0].as_i64().unwrap());
+        }
+        assert_eq!(got, vec![1, 2, 3]);
+
+        drop(stream);
+        assert!(
+            !reserved[0].exists(),
+            "dropping the stream must remove the temp-sort directory"
+        );
+    }
+
+    /// Eligibility must match the old `spill_order_by` gates exactly.
+    #[test]
+    fn try_new_refuses_the_ineligible_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let reserver = TempDirReserver::new(dir.path());
+        let config = spilling_config(reserver);
+        let columns = vec!["n".to_string()];
+
+        // No ORDER BY.
+        assert!(
+            SpillSortSink::try_new(&columns, &return_n_clause(), &config, "t")
+                .unwrap()
+                .is_none()
+        );
+        // LIMIT present.
+        let mut with_limit = order_by_n_return_clause();
+        with_limit.limit = Some(10);
+        assert!(SpillSortSink::try_new(&columns, &with_limit, &config, "t")
+            .unwrap()
+            .is_none());
+        // Order term not projected (needs binding context downstream).
+        assert!(SpillSortSink::try_new(
+            &["other".to_string()],
+            &order_by_n_return_clause(),
+            &config,
+            "t"
+        )
+        .unwrap()
+        .is_none());
+        // No backend.
+        let no_backend = super::super::expand::GraphEngineConfig::default();
+        assert!(
+            SpillSortSink::try_new(&columns, &order_by_n_return_clause(), &no_backend, "t")
+                .unwrap()
+                .is_none()
+        );
     }
 
     /// The load-bearing property: this comparator must order rows EXACTLY as the

--- a/ferrosa-graph/tests/graph_http_integration.rs
+++ b/ferrosa-graph/tests/graph_http_integration.rs
@@ -501,6 +501,29 @@ fn build_app_with_write_path(
     build_router(state)
 }
 
+fn build_app_with_config(
+    schema: Arc<Schema>,
+    storage: Arc<StorageEngine>,
+    config: GraphEngineConfig,
+) -> axum::Router {
+    let write_path = Arc::new(arc_swap::ArcSwap::from_pointee(
+        ferrosa_cluster::write_path::WritePath::direct(Arc::clone(&storage)),
+    ));
+    let engine = Arc::new(GraphEngine::new(
+        Arc::clone(&schema),
+        Arc::clone(&storage),
+        write_path,
+        config,
+        std::time::Duration::from_secs(300),
+    ));
+    let state = AppState {
+        engine,
+        schema: Arc::clone(&schema),
+        auth_disabled: false,
+    };
+    build_router(state)
+}
+
 fn build_app_and_engine(
     schema: Arc<Schema>,
     storage: Arc<StorageEngine>,
@@ -954,6 +977,72 @@ async fn graph_full_workflow() {
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A WCO (leapfrog) triangle join must return EVERY match. Before t_3f2f961a
+/// the enumeration stopped silently at `max_result_rows` — a partial answer
+/// indistinguishable from a complete one. With the cap gone (work is bounded
+/// by the query timeout; ORDER BY results spill), a config whose cap is
+/// SMALLER than the match count must still yield all matches.
+#[tokio::test]
+async fn wco_triangle_join_returns_all_matches_not_a_truncated_prefix() {
+    let (schema, storage, _dir) = setup();
+    create_social_graph_schema(&schema);
+    register_social_tables_with_storage(&storage);
+
+    for name in ["TriA", "TriB", "TriC"] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!("MERGE (n:Person {{name: '{name}'}}) RETURN n"),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+    }
+    for (src, dst) in [("TriA", "TriB"), ("TriB", "TriC"), ("TriC", "TriA")] {
+        let app = build_app(Arc::clone(&schema), Arc::clone(&storage));
+        let req = json_request(
+            "POST",
+            "/graph/query",
+            Some(serde_json::json!({
+                "query": format!(
+                    "MERGE (a:Person {{name: '{src}'}})-[r:KNOWS]->(b:Person {{name: '{dst}'}}) RETURN r"
+                ),
+                "keyspace": "social"
+            })),
+        );
+        assert_eq!(app.oneshot(req).await.unwrap().status(), StatusCode::OK);
+    }
+
+    // The triangle has 3 matches (one per rotation of the anchor). A cap of 2
+    // silently returned a 2-row prefix before the fix.
+    let capped_config = GraphEngineConfig {
+        max_result_rows: 2,
+        ..GraphEngineConfig::default()
+    };
+    let app = build_app_with_config(Arc::clone(&schema), Arc::clone(&storage), capped_config);
+    let req = json_request(
+        "POST",
+        "/graph/query",
+        Some(serde_json::json!({
+            "query": "MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person)-[:KNOWS]->(a) \
+                      RETURN a.name, b.name, c.name",
+            "keyspace": "social"
+        })),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_json(resp).await;
+    let rows = body["rows"].as_array().unwrap();
+    assert_eq!(
+        rows.len(),
+        3,
+        "triangle WCO join must return all 3 rotations, not a silent \
+         max_result_rows prefix; got {rows:?}"
+    );
 }
 
 #[tokio::test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -316,6 +316,17 @@ impl TempSortTableReservation {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    /// Take ownership of an existing directory as a temp-sort reservation:
+    /// dropping the reservation deletes the directory.
+    ///
+    /// For spill-backend test doubles and embedded callers that manage their
+    /// own temp roots. The storage engine's own reservations come from
+    /// [`StorageEngine::reserve_order_by_temp_sort_table`], which also creates
+    /// the directory under the engine's data dir.
+    pub fn claim_dir(path: PathBuf) -> Self {
+        Self { path }
+    }
 }
 
 impl Drop for TempSortTableReservation {


### PR DESCRIPTION
Closes the owner finding from the #308 review (forge t_3f2f961a): the capless `collect_to_graph_result` change removed result caps before the execution paths were actually streaming — Expand cloned and accumulated every state/result before spilling, and leapfrog materialized complete ranges/results before spill or LIMIT.

## What changed

- **`executor/spill`**: extracted `SpillSortSink` from `spill_order_by` — same external merge sort, push-per-row surface. `finish_rows()` serves buffered-contract callers; `finish_stream()` streams the merged output without re-materializing (the temp-dir reservation is owned by the stream, so cancellation/exhaustion/abandonment all clean up identically). `spill_order_by` is now a thin wrapper; varpath's use is unchanged.
- **Expand, streaming ORDER BY tail**: when the sink applies and DISTINCT is absent (its buffered debug-string re-sort is tracked as t_363c1316), each surviving state is projected straight into the sink and the merge is streamed — the full result set is never resident. Peak memory: states + spill threshold.
- **Expand, buffered tail**: projection pushes through the same sink when eligible, skipping both the interim rows Vec and the per-state `clone()` that only the bindings-sort fallback needs. The shared `project_states_into_sink` also adds the projection loop's missing query-timeout check (projection reads storage for pattern comprehensions — it is WORK).
- **Leapfrog/WCO**: candidate scans stream one partition per pull (`range_read_stream_all`) instead of materializing whole tables; result accumulation is sink-backed when ORDER BY applies; the **silent `max_result_rows` truncation of join results is removed** — a capped enumeration returned a partial answer indistinguishable from a complete one. Work remains bounded by `check_timeout` at every enumeration step.
- **Storage**: `TempSortTableReservation::claim_dir` so spill backends can be test-doubled outside the engine.

## Testing

- New sink unit tests: equivalence with the Vec-based `spill_order_by`, `finish_stream` ordering + temp-dir lifetime (survives until stream drop, removed after), eligibility gates.
- **RED-proven regression test** `wco_triangle_join_returns_all_matches_not_a_truncated_prefix`: with `max_result_rows = 2`, the old leapfrog returned a 2-row prefix of the 3 triangle rotations; it fails on the old code and passes now.
- Full battery: ferrosa-graph 402 lib + 96 integration, ferrosa-storage 1027 lib, clippy/fmt/doc (-D warnings) clean.

## Deliberately out of scope

- Phase-A frontier materialization in `expand_to_states` (later increments of the streaming executor epic t_4ce82a3e).
- Anchor `range_read` in expand (t_250fa355) and DISTINCT-destroys-ORDER-BY (t_363c1316).

