### PR TITLE
fix(cql): report metadata for parameterized LIMIT

### DIFF
--- a/ferrosa-cql/README.md
+++ b/ferrosa-cql/README.md
@@ -29,7 +29,10 @@ unaffected (see [Bridge re-export](#bridge-re-export-d10)).
   custom `STREAMING_FLAG` (bit 0x10) for SUBSCRIBE response frames.
 - **Connection state machine** (`connection.rs`, ~4k LoC) — STARTUP → (AUTH) →
   READY handshake, per-opcode dispatch (QUERY / PREPARE / EXECUTE / BATCH /
-  REGISTER / OPTIONS), bind-marker counting, subscription push pump.
+  REGISTER / OPTIONS), bind-marker counting, subscription push pump. PREPARE
+  metadata preserves bind order and includes synthetic typed specs for
+  non-column parameters such as `LIMIT ?` (`[limit] : int`), so strict drivers
+  receive one variable specification per placeholder.
 - **Lexer + parser** (`lexer.rs`, `parser.rs` ~5.9k LoC, `ast.rs`) — hand-written
   tokenizer and recursive-descent parser producing a `Statement` AST: full DML,
   DDL (keyspace/table/index/type/role/function/aggregate), BATCH, LWT `IF`

--- a/ferrosa-cql/specs/data-flow.md
+++ b/ferrosa-cql/specs/data-flow.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 doc: data-flow
-last_updated: 2026-06-19
+last_updated: 2026-07-30
 ---
 
 # ferrosa-cql — Data Flow
@@ -98,6 +98,14 @@ page 1 forever and ignored `fetch_size`. Router-level tests that hand-built
 `ctx.paging` passed while the live wire path was broken, which is why the
 regression must be pinned through the real codec
 (`live_wire_paged_scan_advances_and_terminates_exactly`).
+
+**Prepared SELECT metadata.** A PREPARE frame follows the same parse path but
+stops before routing: `connection::handle_prepare` counts AST bind markers,
+resolves table-backed columns, and emits a Prepared RESULT with the matching
+ordered variable specifications. Statement-only values do not go through table
+schema lookup: `LIMIT ?` emits the synthetic `[limit]` variable with CQL type
+`int` after any WHERE or ANN variables. This lets the driver encode every bound
+value before the later EXECUTE reaches `router::route_select`.
 
 ## Bridge re-export relationship (D10)
 

--- a/ferrosa-cql/specs/fmea.md
+++ b/ferrosa-cql/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 doc: fmea
-last_updated: 2026-07-13
+last_updated: 2026-07-30
 ---
 
 # ferrosa-cql — FMEA / Known Issues
@@ -25,6 +25,7 @@ high. Entries below reflect gaps found in the code, not hypotheticals.
 | CQL-11 | DataStax Java driver `DROP KEYSPACE` times out during schema-agreement on v5 | The driver closes its control connection after receiving the preceding CREATE INDEX schema-change event (normal metadata refresh). When `DROP KEYSPACE` fires, the broadcast has no active subscriber; the new control connection subscribes ~2 ms too late. A `watch` channel retains the missed event, but the driver does not process it on probe connections. Duplicate replay previously also triggered concurrent metadata refreshes after index DDL. | 5 | 8 | 3 | 120 | **Partial mitigation**: `watch` fallback delivers each missed event once to a new control connection (`register_replays_retained_table_schema_event_once`). 37/38 DataStax Java v5 smoke tests pass. Full fix likely requires matching Cassandra's schema-version polling behavior or ensuring the event reaches the driver's active control connection before it closes. |
 | CQL-12 | Out-of-range `timestamp` value written verbatim (integer literal or bound 8-byte value) | An i64 outside `chrono`'s representable millisecond range lands in a `timestamp` cell; on read the driver's date decode crashes, breaking `SELECT *` for the whole partition (forensically observed as `days=-1917935064`) | 9 | 2 | 6 | 108 → 18 | **Fixed (Bug C)**: `bridge::validate_timestamp_ms` rejects any timestamp cell outside `[TIMESTAMP_MIN_MS, TIMESTAMP_MAX_MS]` (chrono `MIN_UTC`/`MAX_UTC` millis) at the write boundary for integer-literal, string, and bound-blob paths. Read robustness: `cell_to_cql_value` fails loud (`ServerError` with the offending millis) on already-corrupt on-disk timestamps instead of emitting an undecodable value. Tests: `term_out_of_range_integer_timestamp_is_rejected`, `bound_out_of_range_timestamp_blob_is_rejected`, `timestamp_bounds_match_chrono`, `cell_to_cql_value_rejects_corrupt_timestamp`. |
 | CQL-13 | The generic keyed scalar planner selects a full-text/vector/geo index for `column = value` | A valid keyed equality read can consult an incompatible index map and return an empty result; selection was iteration-order dependent when phonetic and full-text indexes shared a column | 8 | 3 | 5 | 120 → 16 | **Fixed:** scalar plans admit only B-tree, hash, composite, phonetic, and filtered indexes. Full-text/vector/geo remain on dedicated query branches. Regression: `keyed_equality_does_not_consult_fulltext_index`. |
+| CQL-14 | PREPARE counted `LIMIT ?` but tried to resolve every marker as a table column | PREPARE returned `Invalid` with one fewer variable specification, preventing strict drivers from preparing an otherwise valid parameterized scan | 6 | 3 | 3 | 54 → 6 | **Fixed:** `connection::analyze_prepared_columns` emits the Cassandra-style synthetic `[limit] : int` spec after WHERE/ANN markers instead of schema-resolving it. Wire regression: `prepare_select_with_where_and_limit_bind_markers_reports_col_count_two`. |
 
 ## Top risks to act on
 

--- a/ferrosa-cql/specs/overview.md
+++ b/ferrosa-cql/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 status: implemented
-last_updated: 2026-07-12
+last_updated: 2026-07-30
 executive_summary: >
   The CQL native-protocol (v3/v4/v5) server and the largest, most central crate in
   the workspace (~54k LoC). It owns the full client path — TCP accept, frame
@@ -36,7 +36,7 @@ same encode/decode without depending on this large crate.
 |--------|-----|----------------|
 | `router` | ~22.4k | Central `route()` dispatch: permission checks, DML/DDL handlers, prepared fast paths, ORDER BY planning, `SharedState` |
 | `parser` | ~5.9k | Recursive-descent CQL parser → `Statement` AST |
-| `connection` | ~4.0k | Per-connection state machine, handshake, per-opcode dispatch, subscription pump |
+| `connection` | ~4.0k | Per-connection state machine, handshake, per-opcode dispatch, PREPARE variable metadata, subscription pump |
 | `bridge` | ~2.7k | `Term`↔`CqlValue`↔storage conversions, server-side fn eval, **row-codec re-export** |
 | `frame` | ~1.4k | CQL header/body codec, opcodes, LZ4/Snappy compression, streaming flag |
 | `lexer` | ~1.4k | Hand-written CQL tokenizer |
@@ -94,6 +94,13 @@ geo indexes use their dedicated operators; allowing them into a scalar `=` plan
 would consult an incompatible storage map and could turn a valid keyed read
 into a false empty result when, for example, a full-text and phonetic index
 share the same column.
+
+**Prepared metadata.** `connection::handle_prepare` counts placeholders from the
+AST and emits the same number of ordered variable specifications. Table-backed
+markers resolve through the schema; statement-only markers use typed synthetic
+names. In particular, `SELECT ... WHERE pk = ? LIMIT ?` advertises the key
+column followed by `[limit] : int`, allowing strict drivers to bind both values
+without treating `limit` as a missing schema column.
 
 Full-text predicates (`WHERE col = fts_match('...')`) take a dedicated branch:
 it resolves the matching row-granular doc keys through the cluster write path

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -1,3 +1,9 @@
+//! Module: Per-connection CQL native-protocol handler.
+//! Correctness: Correct when protocol state transitions, prepared metadata, and bound-value
+//! substitution preserve the CQL wire contract for every accepted opcode.
+//! Last revised: 2026-07-30
+//! Last changed: Added the synthetic `int` variable specification for `SELECT ... LIMIT ?`.
+//!
 //! Per-connection CQL protocol handler.
 //!
 //! Implements the CQL v5 connection lifecycle:
@@ -2212,11 +2218,19 @@ fn analyze_prepared_columns(
     match stmt {
         Statement::Select(s) => {
             // Bind markers in SELECT clauses, preserving statement bind order:
-            // WHERE predicates first, then ANN vector term if `ANN OF ?` is used.
+            // WHERE predicates first, then ANN vector term, then LIMIT.
             for col_name in select_bind_marker_columns(s) {
                 if let Some(cql_type) = resolve(col_name) {
                     bound_columns.push((col_name.to_string(), cql_type));
                 }
+            }
+            // `LIMIT ?` is an integer bind variable, not a table column. Its
+            // metadata therefore uses Cassandra's synthetic `[limit]` name.
+            if matches!(
+                s.limit,
+                Some(crate::ast::Limit::BindMarker | crate::ast::Limit::NamedBindMarker(_))
+            ) {
+                bound_columns.push(("[limit]".into(), CqlType::Int));
             }
 
             // Build result columns from the SELECT column list

--- a/ferrosa-cql/tests/handshake.rs
+++ b/ferrosa-cql/tests/handshake.rs
@@ -2257,6 +2257,47 @@ fn extract_bind_col_count_from_prepared_response(body: &[u8]) -> i32 {
     i32::from_be_bytes(body[26..30].try_into().unwrap())
 }
 
+/// Decode the simple global-table bind metadata emitted by the v4 test server.
+///
+/// The regression uses only scalar types, so every variable spec ends after its
+/// two-byte type id; collection and UDT type parameters are deliberately out of
+/// scope for this narrow wire assertion.
+fn extract_global_bind_specs_from_prepared_response(body: &[u8]) -> Vec<(String, u16)> {
+    let id_len = u16::from_be_bytes(body[4..6].try_into().unwrap()) as usize;
+    let mut offset = 6 + id_len;
+    let bind_flags = i32::from_be_bytes(body[offset..offset + 4].try_into().unwrap());
+    offset += 4;
+    assert_eq!(
+        bind_flags & 0x0001,
+        0x0001,
+        "expected global-table metadata"
+    );
+    let bind_col_count = i32::from_be_bytes(body[offset..offset + 4].try_into().unwrap());
+    offset += 4;
+
+    let pk_count = i32::from_be_bytes(body[offset..offset + 4].try_into().unwrap()) as usize;
+    offset += 4 + pk_count * 2;
+    for _ in 0..2 {
+        let string_len = u16::from_be_bytes(body[offset..offset + 2].try_into().unwrap()) as usize;
+        offset += 2 + string_len;
+    }
+
+    (0..bind_col_count)
+        .map(|_| {
+            let name_len =
+                u16::from_be_bytes(body[offset..offset + 2].try_into().unwrap()) as usize;
+            offset += 2;
+            let name = std::str::from_utf8(&body[offset..offset + name_len])
+                .unwrap()
+                .to_string();
+            offset += name_len;
+            let type_id = u16::from_be_bytes(body[offset..offset + 2].try_into().unwrap());
+            offset += 2;
+            (name, type_id)
+        })
+        .collect()
+}
+
 /// P0-22 regression: INSERT with 3 `?` bind markers must report col_count = 3.
 ///
 /// This is the canonical external-driver compatibility test.  A strict driver
@@ -2377,6 +2418,66 @@ async fn prepare_select_with_one_where_bind_marker_reports_col_count_one() {
         col_count, 1,
         "PREPARE SELECT with 1 WHERE bind marker must report bind col_count = 1; \
          got {col_count}"
+    );
+}
+
+/// A parameterized LIMIT must contribute its synthetic `int` variable spec
+/// after the table-column marker in the prepared response.
+#[tokio::test]
+async fn prepare_select_with_where_and_limit_bind_markers_reports_col_count_two() {
+    let (state, _dir) = setup_state();
+    let server = ferrosa_cql::server::CqlServer::new(test_config(true), state);
+    let addr = server.start_background().await.unwrap();
+    let mut stream = connect_auth_disabled(addr).await;
+
+    let body = encode_query_body(
+        "CREATE KEYSPACE control WITH replication = \
+         {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+    );
+    send_raw_frame(&mut stream, Opcode::Query, &body).await;
+    assert_result(&read_frame(&mut stream).await);
+
+    let body =
+        encode_query_body("CREATE TABLE control.vm_health (vm_id uuid PRIMARY KEY, status text)");
+    send_raw_frame(&mut stream, Opcode::Query, &body).await;
+    assert_result(&read_frame(&mut stream).await);
+
+    let vm_id = uuid::Uuid::parse_str("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
+    let body = encode_query_body(
+        "INSERT INTO control.vm_health (vm_id, status) \
+         VALUES (aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee, 'healthy')",
+    );
+    send_raw_frame(&mut stream, Opcode::Query, &body).await;
+    assert_result(&read_frame(&mut stream).await);
+
+    let prep_body = encode_prepare_body("SELECT * FROM control.vm_health WHERE vm_id = ? LIMIT ?");
+    send_raw_frame(&mut stream, Opcode::Prepare, &prep_body).await;
+    let resp = read_frame(&mut stream).await;
+    assert_result(&resp);
+
+    let col_count = extract_bind_col_count_from_prepared_response(&resp.body);
+    assert_eq!(
+        col_count, 2,
+        "PREPARE SELECT with WHERE ? and LIMIT ? must report two bind column specs; \
+         got {col_count}"
+    );
+    assert_eq!(
+        extract_global_bind_specs_from_prepared_response(&resp.body),
+        vec![("vm_id".into(), 0x000C), ("[limit]".into(), 0x0009)],
+        "PREPARE must advertise LIMIT ? as the synthetic [limit] int variable"
+    );
+
+    let mut prepared_id = [0u8; 16];
+    prepared_id.copy_from_slice(&resp.body[6..22]);
+    let limit = 1i32.to_be_bytes();
+    let exec_body = encode_execute_body_with_values(&prepared_id, &[vm_id.as_bytes(), &limit]);
+    send_raw_frame(&mut stream, Opcode::Execute, &exec_body).await;
+    let resp = read_frame(&mut stream).await;
+    assert_result(&resp);
+    assert_eq!(
+        extract_row_count_from_result(&resp.body),
+        1,
+        "the prepared LIMIT value must be accepted during EXECUTE"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes PREPARE metadata for `SELECT ... WHERE vm_id = ? LIMIT ?` by reporting the synthetic `[limit] : int` variable specification after table-backed bind markers.

## Changes

- Preserve bind metadata cardinality and ordering for parameterized SELECT limits.
- Add a raw-wire PREPARE and EXECUTE regression for `control.vm_health`.
- Update ferrosa-cql crate documentation and FMEA.

## Validation

- [x] Focused PREPARE + EXECUTE wire regression
- [x] `cargo test -p ferrosa-cql --test handshake` (41 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p ferrosa-cql --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p ferrosa-cql --no-deps`
- [ ] Full `ferrosa-cql` suite: local runs were stopped at 5 and 10 minutes without emitted failure output; CI remains the final verifier.
