### PR TITLE
fix(ci): stop the smoke log collector from erasing its own evidence

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -275,12 +275,37 @@ jobs:
       - name: Collect Docker state and logs
         if: always()
         run: |
-          docker compose ps > docker-compose-ps.log 2>&1 || true
-          docker compose ps -a >> docker-compose-ps.log 2>&1 || true
-          docker system df >> docker-compose-ps.log 2>&1 || true
+          # This step runs AFTER docker-smoke.sh's EXIT trap has already run
+          # `docker compose down -v --remove-orphans`, so the containers are
+          # gone and `compose logs` HERE returns nothing. The script captures
+          # the real logs at failure time (collect_default_compose_logs, called
+          # from fail() before the trap fires) — and this step used to TRUNCATE
+          # those good captures to zero bytes with `>`. That is why every
+          # "node1 CQL did not become ready" nightly shipped an empty
+          # node1.log/node2.log and could never be diagnosed.
+          #
+          # Only write a file the script did not already fill.
+          if [ ! -s docker-compose-ps.log ]; then
+            docker compose ps > docker-compose-ps.log 2>&1 || true
+          fi
+          {
+            echo "--- post-teardown snapshot (containers may already be removed) ---"
+            docker compose ps -a 2>&1 || true
+            docker system df 2>&1 || true
+          } >> docker-compose-ps.log
           for service in node1 node2 node3 rustfs rustfs-init; do
-            docker compose logs --tail 500 "$service" > "${service}.log" 2>&1 || true
+            if [ -s "${service}.log" ]; then
+              echo "preserving script-captured ${service}.log ($(wc -c < "${service}.log") bytes)"
+            else
+              docker compose logs --tail 500 "$service" > "${service}.log" 2>&1 || true
+            fi
           done
+          # An empty node1.log after a FAILED smoke run means the capture path
+          # is broken again. Say so loudly — a silent empty artifact is exactly
+          # what hid this for weeks.
+          if [ ! -s node1.log ]; then
+            echo "::warning::node1.log is EMPTY — if the smoke run failed, the capture path is broken (see collect_default_compose_logs in tests/docker-smoke.sh)"
+          fi
 
       - name: Upload Docker logs
         if: always()


### PR DESCRIPTION
The Fuzz+Smoke nightly has failed every night with `FAIL: node1 CQL did not become ready in 240s`, and every artifact shipped an **empty `node1.log` and `node2.log`**. This is why.

**The evidence was captured, then destroyed on the way out.**

1. `docker-smoke.sh`'s `fail()` calls `collect_default_compose_logs` **before** the EXIT trap — deliberately, with a comment saying "keep failure artifacts before the EXIT trap removes containers. The workflow's follow-up collection step may run after cleanup has completed."
2. The EXIT trap then runs `docker compose down -v --remove-orphans`.
3. The workflow's `if: always()` collect step runs **after** that, when no containers exist, and redirects with `>` — **truncating the script's good captures to zero bytes**.

Verified against the 2026-08-04 artifact (`docker-compose-ps.log` shows two empty `ps` headers plus the `system df` append — the exact signature of the second collection running post-teardown).

**Fix:** the step now only writes a file the script did not already fill, appends its post-teardown snapshot rather than overwriting the `ps` capture, and emits a `::warning::` when `node1.log` is still empty — since a silent empty artifact is what hid this for weeks.

No test, timeout, or threshold was changed. This does not fix the underlying readiness failure (`t_0be09790`) — it makes the next occurrence diagnosable, which is currently the blocker to fixing it at all.
