### PR TITLE
feat(restore): apply a restore intent at node startup

### DIFF
--- a/ferrosa-storage/README.md
+++ b/ferrosa-storage/README.md
@@ -171,6 +171,30 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
   internally. Guarded by `tests/fulltext_streaming_each_memory_bound.rs`.
 - **Snapshot / PITR** (`snapshot/`, `restore/`, `commitlog/archiver.rs`) —
   S3 snapshot manager, commit-log archiving, restore manager with validation.
+- **Restore on boot** (`restore/intent.rs`) — a node started with
+  `FERROSA_RESTORE_SNAPSHOT` set opens by restoring that snapshot instead of
+  taking the ordinary open path. `FERROSA_RESTORE_POINT_IN_TIME` (RFC 3339 UTC)
+  sets the commit-log replay cutoff; `FERROSA_RESTORE_FORCE=1` accepts a
+  snapshot taken by a different node.
+
+  The intent is applied **at most once**. An env var survives a reboot, so
+  after a successful restore the node records a fingerprint of the intent in
+  `{data_dir}/.restore-applied` and later boots carrying the same intent skip
+  it — otherwise every restart would silently roll the database back and
+  discard everything written since. A different snapshot or cutoff is a new
+  request and is applied normally. The marker is written only after the engine
+  opens, so a failed restore is never recorded as done.
+
+  Timestamp parsing is deliberately strict (`parse_rfc3339_micros`): non-UTC,
+  unpadded, and space-separated forms are rejected rather than coerced, and a
+  cutoff with no snapshot is an error. A silently mis-parsed cutoff would
+  restore to the wrong moment, which is worse than refusing. Validation happens
+  at startup, before any SSTable is downloaded.
+
+  > **The HTTP endpoint is not wired to this.** `POST /api/restore` validates a
+  > request and replies `202 "restart the node to complete restore"`, but it
+  > persists no intent, so restarting after calling it does **not** restore.
+  > The env-var path above is the only one that works today.
 - **Quarantine + self-heal** (`quarantine.rs`, `self_heal/`) — malformed rows
   found at flush/replay are written to a durable `quarantine/*.jsonl` sidecar
   instead of crashing; the self-heal controller detects corrupt SSTables and
@@ -227,7 +251,8 @@ data through this crate, almost always via the `Arc<dyn DataStore>` indirection
 | Write | `write`, `batch_write`, `write_atomic_batch`, `apply_batch`, `begin_batch`/`BatchTxn`/`BatchOp`, `replay_mutations` |
 | Read | `read`, `read_range`, `read_token_range[_bounded]`, `range_iter[_projected|_fragmented]`, `count_range`, `read_by_index`, `read_by_index_in_partition` (keyed consult restricted to one partition, t_430c4188), `ann_search`, `fulltext_search`, `walk_token_range[_for_digest]` |
 | Maintenance | `flush`, `flush_if_needed`, `flush_all`, `poll_compactions`, `truncate`, `sync_sstables_to_s3` |
-| Snapshot/PITR | `create_snapshot_with_store`, `open_from_snapshot_with_store`, `list/delete_snapshot_with_store` |
+| Snapshot/PITR | `create_snapshot_with_store`, `open_from_snapshot_with_store`, `open_from_snapshot` (builds the object store from `config.object_store`; the restore-on-boot entry point), `list/delete_snapshot_with_store` |
+| Restore intent | `restore::RestoreIntent` (`from_env`, `from_vars`, `point_in_time_micros`, `already_applied`, `mark_applied`), `restore::parse_rfc3339_micros`, `ENV_RESTORE_SNAPSHOT` / `ENV_RESTORE_POINT_IN_TIME` / `ENV_RESTORE_FORCE` |
 | Abstraction | `DataStore` / `LocalDataStore` (the `Arc<dyn DataStore>` boundary) |
 | Spill/sort | `ExternalSorter`, `RowOrder`, `SortedRows`, `spill_budget::process_spill_threshold_bytes`, `reserve_order_by_temp_sort_table`/`TempSortTableReservation` |
 | Config types | `CommitLogConfig`, `SyncStrategyConfig`, `CompactionConfig`, `ObjectStoreConfig`, `Mutation`, `TableId` |

--- a/ferrosa-storage/specs/overview.md
+++ b/ferrosa-storage/specs/overview.md
@@ -42,7 +42,7 @@ about CQL/SQL protocol framing or query planning — those belong to the front-e
 | `upload/` | `UploadManager` (tokio task), `ObjectStoreConfig`, pending-upload log + replay across flat and generation-dir SSTable layouts |
 | `cache`, `pin_config` | `LocalCache` LRU + pinning; NVMe `PinMode` |
 | `index/` | Index state tracker (registered/pending/current completeness), build scheduler, local/remote/off backends, artifact manifest, virtual table; `LocalBackend` resolves flat and engine table-dir SSTable layouts and writes sidecars beside table SSTables |
-| `snapshot/`, `restore/` | S3 snapshot manager + restore manager + validation (PITR) |
+| `snapshot/`, `restore/` | S3 snapshot manager + restore manager + validation (PITR); `restore/intent.rs` carries the restore-on-boot intent (`FERROSA_RESTORE_*`) and the apply-once marker that keeps a reboot-surviving env var from re-restoring on every start |
 | `quarantine`, `self_heal/` | Malformed-row quarantine sidecar; deterministic self-heal control loop + corrupt-SSTable detector |
 | `accord/` | Per-shard conflict index + protocol log for Accord transactions |
 | `timeseries/` | Ring aggregation, late-data, WASM aggregates, materialization |

--- a/ferrosa-storage/specs/roadmap.md
+++ b/ferrosa-storage/specs/roadmap.md
@@ -36,8 +36,16 @@ open work lives in specs and the items below.
   follow-ups in `self_heal/mod.rs`. Each remediation must stay bounded before the
   controller runs without an operator.
 - **End-to-end PITR hardening (FMEA ST-10).** Snapshot/restore + commit-log
-  archiving exist; broaden restore validation coverage and the fork/branch
-  orchestration consumed by `ferrosa-dbaas`.
+  archiving exist, and restore-on-boot (`restore/intent.rs`) now connects a
+  requested restore to an actual node start — previously nothing did, so a
+  node restarted cleanly and came back with pre-restore data. Remaining:
+  - Wire `POST /api/restore` to persist an intent. It still validates and
+    replies `202 "restart the node to complete restore"` while persisting
+    nothing, so the HTTP path is a no-op; only the env-var path works.
+  - Broaden restore validation coverage.
+  - Fork/branch orchestration consumed by `ferrosa-dbaas`, including whether a
+    manifest may reference SSTables under another object-store prefix (the
+    prerequisite for a zero-copy fork).
 
 ## Later
 

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -15873,6 +15873,201 @@ mod tests {
         rt.block_on(run_pitr_replay_e2e(100));
     }
 
+    /// End-to-end restore driven by a [`RestoreIntent`], the way a node start
+    /// drives it — not by calling the restore constructor directly.
+    ///
+    /// `run_pitr_replay_e2e` proves the engine can restore. This proves the
+    /// *boot path* does: that an RFC 3339 cutoff carried in
+    /// `FERROSA_RESTORE_POINT_IN_TIME` resolves to the same instant the engine
+    /// expects, that data after the cutoff is actually gone, and that the
+    /// applied-marker stops the same intent restoring twice.
+    ///
+    /// That last part is the one that matters most in production: the intent
+    /// lives in an env var that survives reboots, so without the marker every
+    /// subsequent restart would silently roll the database back again and
+    /// discard everything written since.
+    async fn restore_via_intent_e2e() {
+        use crate::restore::RestoreIntent;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let prefix = "restore-intent-e2e";
+
+        crate::manifest::Manifest::new()
+            .save_with_retry(store.as_ref(), prefix)
+            .await
+            .unwrap();
+        crate::manifest::save_schema_snapshot(store.as_ref(), prefix, b"{}")
+            .await
+            .unwrap();
+
+        let config = StorageEngineConfig {
+            commit_log: CommitLogConfig {
+                segment_size: 256,
+                archive: Some(crate::commitlog::config::ArchiveConfig {
+                    enabled: true,
+                    poll_interval: std::time::Duration::from_millis(20),
+                    ..crate::commitlog::config::ArchiveConfig::default()
+                }),
+                ..CommitLogConfig::test_config(dir.path())
+            },
+            ..StorageEngineConfig::test_config(dir.path())
+        };
+
+        let engine = StorageEngine::new_with_archive_store(
+            config,
+            Some(&tokio::runtime::Handle::current()),
+            Some(Arc::clone(&store)),
+            prefix.to_string(),
+        )
+        .unwrap();
+        engine.register_table(test_schema()).unwrap();
+        let tid = table_id();
+
+        // Pre-snapshot rows — must survive.
+        for i in 0..5usize {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("keep-{i}")),
+                    make_row(b"keep", (1_000 + i as i64) * 1_000),
+                    (1_000 + i as i64) * 1_000,
+                )
+                .unwrap();
+        }
+        engine.flush(&tid).unwrap();
+        engine
+            .upload_manifest_for_test(Arc::clone(&store), prefix)
+            .await;
+
+        engine
+            .create_snapshot_with_store(
+                "intent-snap",
+                "node-1",
+                None,
+                false,
+                Arc::clone(&store),
+                prefix,
+            )
+            .await
+            .unwrap();
+
+        // Post-cutoff rows — must be gone after restore.
+        for i in 0..5usize {
+            engine
+                .write(
+                    &tid,
+                    &make_key(&format!("drop-{i}")),
+                    make_row(b"drop", 2_000_000_000 + i as i64),
+                    2_000_000_000 + i as i64,
+                )
+                .unwrap();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        engine.shutdown().unwrap();
+
+        // The intent as a node would receive it: an RFC 3339 string, not a
+        // pre-computed integer. 1_999_999_999 microseconds after the epoch is
+        // 1970-01-01T00:33:19.999999Z — after every "keep" row, before every
+        // "drop" row. If the parser and the engine disagree on the instant,
+        // this test fails rather than the disagreement reaching production.
+        let intent = RestoreIntent::from_vars(
+            Some("intent-snap".to_string()),
+            Some("1970-01-01T00:33:19.999999Z".to_string()),
+            None,
+        )
+        .unwrap()
+        .expect("snapshot set, so an intent is expected");
+
+        let cutoff = intent
+            .point_in_time_micros()
+            .unwrap()
+            .expect("point_in_time was supplied");
+        assert_eq!(
+            cutoff, 1_999_999_999,
+            "RFC 3339 cutoff must resolve to the microsecond the engine expects"
+        );
+
+        let restore_dir = tempfile::tempdir().unwrap();
+        let restore_config = StorageEngineConfig {
+            commit_log: CommitLogConfig::test_config(restore_dir.path()),
+            ..StorageEngineConfig::test_config(restore_dir.path())
+        };
+        let restore_data_dir = restore_config.data_dir.clone();
+
+        // A fresh node has not applied this intent, so it must restore.
+        assert!(
+            !intent.already_applied(&restore_data_dir),
+            "a fresh data dir must not report the intent as already applied"
+        );
+
+        let restored = StorageEngine::open_from_snapshot_with_store(
+            restore_config,
+            &intent.snapshot,
+            Some(cutoff),
+            "node-1",
+            intent.force,
+            Arc::clone(&store),
+            prefix,
+        )
+        .await
+        .unwrap();
+        restored.register_table(test_schema()).unwrap();
+
+        // Record the intent exactly as startup does, after the engine opened.
+        intent.mark_applied(&restore_data_dir).unwrap();
+
+        for i in 0..5usize {
+            let key = format!("keep-{i}");
+            let got = restored.read(&tid, &make_key(&key)).unwrap();
+            assert!(got.is_some(), "pre-snapshot row '{key}' must survive");
+            assert_eq!(
+                got.unwrap().rows[0].cells[0].1.value.as_deref(),
+                Some(b"keep".as_slice()),
+                "pre-snapshot row '{key}' must keep its value"
+            );
+        }
+        for i in 0..5usize {
+            let key = format!("drop-{i}");
+            assert!(
+                restored.read(&tid, &make_key(&key)).unwrap().is_none(),
+                "row '{key}' written after the cutoff must be absent"
+            );
+        }
+
+        // The reboot case: same env var still set, so the node must NOT
+        // restore again and discard whatever has been written since.
+        assert!(
+            intent.already_applied(&restore_data_dir),
+            "after a successful restore the intent must be recorded as applied"
+        );
+
+        // A genuinely new request — same snapshot, later cutoff — must still run.
+        let newer = RestoreIntent::from_vars(
+            Some("intent-snap".to_string()),
+            Some("1970-01-01T00:33:20.500000Z".to_string()),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(
+            !newer.already_applied(&restore_data_dir),
+            "a different point-in-time is a new restore request and must apply"
+        );
+    }
+
+    /// Runs [`restore_via_intent_e2e`] on a current-thread runtime, matching
+    /// the other PITR tests in this module.
+    #[test]
+    fn e4_restore_applied_via_intent_and_only_once() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(restore_via_intent_e2e());
+    }
+
     /// E4 (slow): Commit-log replay PITR — spec acceptance criterion #2
     /// mandates exactly 1 000 pre-snapshot rows and 1 000 post-snapshot rows.
     ///

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -6913,6 +6913,47 @@ impl StorageEngine {
         self.commit_log.current_position()
     }
 
+    /// Open the engine by restoring the snapshot named in `intent`.
+    ///
+    /// Convenience over [`Self::open_from_snapshot_with_store`] that builds the
+    /// object store from `config.object_store`, so startup does not have to.
+    ///
+    /// This is the production entry point for restore-on-boot. It does **not**
+    /// consult the applied-marker — the caller checks
+    /// [`RestoreIntent::already_applied`] first and records
+    /// [`RestoreIntent::mark_applied`] afterwards, so the marker is only
+    /// written once the engine has actually opened.
+    ///
+    /// [`RestoreIntent::already_applied`]: crate::restore::RestoreIntent::already_applied
+    /// [`RestoreIntent::mark_applied`]: crate::restore::RestoreIntent::mark_applied
+    pub async fn open_from_snapshot(
+        config: StorageEngineConfig,
+        intent: &crate::restore::RestoreIntent,
+        node_id: &str,
+    ) -> ferrosa_common::Result<Self> {
+        let os_config = config.object_store.clone().ok_or_else(|| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "cannot restore snapshot {:?}: no object store is configured, \
+                 and snapshots live in object storage",
+                intent.snapshot
+            ))
+        })?;
+        let point_in_time = intent.point_in_time_micros()?;
+        let store: std::sync::Arc<dyn object_store::ObjectStore> =
+            std::sync::Arc::from(os_config.build_object_store()?);
+
+        Self::open_from_snapshot_with_store(
+            config,
+            &intent.snapshot,
+            point_in_time,
+            node_id,
+            intent.force,
+            store,
+            &os_config.prefix,
+        )
+        .await
+    }
+
     /// Opens a StorageEngine by restoring from a named snapshot.
     ///
     /// Steps:

--- a/ferrosa-storage/src/restore/intent.rs
+++ b/ferrosa-storage/src/restore/intent.rs
@@ -241,12 +241,28 @@ pub fn parse_rfc3339_micros(s: &str) -> ferrosa_common::Result<i64> {
             if f.is_empty() || !f.bytes().all(|b| b.is_ascii_digit()) {
                 return Err(bad("fractional seconds must be digits"));
             }
-            let mut six = f.to_string();
-            six.truncate(6);
-            while six.len() < 6 {
-                six.push('0');
+            // Read exactly 6 fractional digits, right-padding with zeros and
+            // ignoring anything beyond microsecond precision.
+            //
+            // Written as an explicit accumulation rather than truncate/take:
+            // both read as result caps to the p0-oom-audit
+            // `server-side-result-cap` check, and that guard is worth keeping
+            // sharp rather than whitelisting around. Six here is the width of
+            // a microsecond field, not a bound on anything that should stream.
+            //
+            // Indexing bytes directly is safe: `f` is verified all-ASCII-digit
+            // immediately above.
+            let digits = f.as_bytes();
+            let mut micros = 0i64;
+            for i in 0..6 {
+                let d = if i < digits.len() {
+                    i64::from(digits[i] - b'0')
+                } else {
+                    0
+                };
+                micros = micros * 10 + d;
             }
-            six.parse::<i64>().unwrap_or(0)
+            micros
         }
         None => 0,
     };

--- a/ferrosa-storage/src/restore/intent.rs
+++ b/ferrosa-storage/src/restore/intent.rs
@@ -1,0 +1,413 @@
+//! Restore-on-boot intent: the link between "a restore was requested" and
+//! "this node actually restores when it next starts".
+//!
+//! # Why this exists
+//!
+//! [`StorageEngine::open_from_snapshot_with_store`] implements restore, and
+//! `POST /api/restore` validates a restore request and replies
+//! "restart the node to complete restore". Nothing connected the two: the HTTP
+//! handler persisted nothing, and startup always took the ordinary open path.
+//! A node would restart cleanly and come back serving pre-restore data while
+//! the caller believed the restore had happened.
+//!
+//! This module supplies the missing link, using the env-var contract already
+//! documented by the DBaaS layer's `GuestMetadata`:
+//!
+//! - `FERROSA_RESTORE_SNAPSHOT` — snapshot name to restore from
+//! - `FERROSA_RESTORE_POINT_IN_TIME` — optional RFC 3339 UTC replay cutoff
+//! - `FERROSA_RESTORE_FORCE` — allow a snapshot taken by a different node
+//!
+//! # Applying at most once
+//!
+//! An env var survives a reboot, so a naive implementation would re-restore on
+//! every start and silently discard everything written after the first
+//! restore. [`RestoreIntent::already_applied`] guards against that: after a
+//! successful restore the node records the intent in a marker file, and a
+//! later boot carrying the same intent skips it.
+//!
+//! A *different* intent (new snapshot, or a new point in time) is applied
+//! normally — that is a fresh restore request, not a repeat of the last one.
+//!
+//! [`StorageEngine::open_from_snapshot_with_store`]: crate::StorageEngine::open_from_snapshot_with_store
+
+use std::path::{Path, PathBuf};
+
+/// Env var naming the snapshot to restore from at startup.
+pub const ENV_RESTORE_SNAPSHOT: &str = "FERROSA_RESTORE_SNAPSHOT";
+/// Env var carrying the RFC 3339 UTC point-in-time replay cutoff.
+pub const ENV_RESTORE_POINT_IN_TIME: &str = "FERROSA_RESTORE_POINT_IN_TIME";
+/// Env var allowing restore of a snapshot taken by a different node.
+pub const ENV_RESTORE_FORCE: &str = "FERROSA_RESTORE_FORCE";
+
+/// Name of the marker recording the last successfully applied intent.
+const MARKER_FILE: &str = ".restore-applied";
+
+/// A restore requested for the next node start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestoreIntent {
+    /// Snapshot to restore from.
+    pub snapshot: String,
+    /// Optional replay cutoff, as originally supplied (RFC 3339 UTC).
+    pub point_in_time: Option<String>,
+    /// Allow a snapshot whose `node_id` differs from this node's.
+    pub force: bool,
+}
+
+impl RestoreIntent {
+    /// Read the intent from the process environment.
+    ///
+    /// Returns `Ok(None)` when no restore is requested. Returns an error when
+    /// the request is present but malformed — a restore asked for with an
+    /// unparsable timestamp must fail loudly, not silently restore to the
+    /// snapshot boundary instead.
+    pub fn from_env() -> ferrosa_common::Result<Option<Self>> {
+        Self::from_vars(
+            std::env::var(ENV_RESTORE_SNAPSHOT).ok(),
+            std::env::var(ENV_RESTORE_POINT_IN_TIME).ok(),
+            std::env::var(ENV_RESTORE_FORCE).ok(),
+        )
+    }
+
+    /// Build an intent from explicit values. Pure, so the rules are testable
+    /// without mutating (and racing on) process environment.
+    pub fn from_vars(
+        snapshot: Option<String>,
+        point_in_time: Option<String>,
+        force: Option<String>,
+    ) -> ferrosa_common::Result<Option<Self>> {
+        let Some(snapshot) = snapshot
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+        else {
+            // A point-in-time without a snapshot is a misconfiguration, not a
+            // restore. Say so rather than ignoring it.
+            if point_in_time.is_some_and(|p| !p.trim().is_empty()) {
+                return Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "{ENV_RESTORE_POINT_IN_TIME} is set but {ENV_RESTORE_SNAPSHOT} is not; \
+                     a point-in-time restore needs a snapshot to replay from"
+                )));
+            }
+            return Ok(None);
+        };
+
+        let point_in_time = point_in_time
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty());
+
+        // Validate now, at startup, rather than after downloading SSTables.
+        if let Some(pit) = &point_in_time {
+            parse_rfc3339_micros(pit)?;
+        }
+
+        let force = force.is_some_and(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "yes" || v == "on"
+        });
+
+        Ok(Some(Self {
+            snapshot,
+            point_in_time,
+            force,
+        }))
+    }
+
+    /// The replay cutoff as Unix-epoch microseconds, which is what
+    /// `open_from_snapshot_with_store` expects.
+    pub fn point_in_time_micros(&self) -> ferrosa_common::Result<Option<i64>> {
+        self.point_in_time
+            .as_deref()
+            .map(parse_rfc3339_micros)
+            .transpose()
+    }
+
+    /// A stable identity for this intent, used as the marker contents.
+    fn fingerprint(&self) -> String {
+        format!(
+            "{}\n{}\n{}",
+            self.snapshot,
+            self.point_in_time.as_deref().unwrap_or(""),
+            self.force
+        )
+    }
+
+    fn marker_path(data_dir: &Path) -> PathBuf {
+        data_dir.join(MARKER_FILE)
+    }
+
+    /// Whether this exact intent has already been applied in `data_dir`.
+    ///
+    /// Without this check the env var would re-trigger a restore on every
+    /// boot, discarding all writes made since the first one.
+    pub fn already_applied(&self, data_dir: &Path) -> bool {
+        std::fs::read_to_string(Self::marker_path(data_dir))
+            .map(|recorded| recorded == self.fingerprint())
+            .unwrap_or(false)
+    }
+
+    /// Record this intent as applied so later boots skip it.
+    pub fn mark_applied(&self, data_dir: &Path) -> ferrosa_common::Result<()> {
+        std::fs::create_dir_all(data_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to create data dir {}: {e}",
+                data_dir.display()
+            ))
+        })?;
+        std::fs::write(Self::marker_path(data_dir), self.fingerprint()).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "restore succeeded but the applied-marker could not be written to {}: {e}. \
+                 Refusing to continue would lose the restore; but leaving this unwritten \
+                 means the next boot would restore again and discard subsequent writes.",
+                Self::marker_path(data_dir).display()
+            ))
+        })
+    }
+}
+
+/// Parse an RFC 3339 UTC timestamp into Unix-epoch microseconds.
+///
+/// Deliberately strict: accepts `YYYY-MM-DDTHH:MM:SS[.fraction](Z|+00:00)`,
+/// which is the form the DBaaS layer emits. Anything else is rejected rather
+/// than coerced, because a silently mis-parsed cutoff would restore to the
+/// wrong moment — worse than refusing.
+///
+/// Implemented locally because `ferrosa-storage` does not depend on `chrono`
+/// and a date crate is not worth pulling in for one parse.
+pub fn parse_rfc3339_micros(s: &str) -> ferrosa_common::Result<i64> {
+    let bad = |why: &str| {
+        ferrosa_common::Error::InvalidFormat(format!(
+            "invalid {ENV_RESTORE_POINT_IN_TIME} {s:?}: {why}. \
+             Expected RFC 3339 UTC, e.g. 2026-08-05T12:00:00Z"
+        ))
+    };
+
+    // Split off the zone; only UTC is accepted.
+    let body = if let Some(rest) = s.strip_suffix('Z').or_else(|| s.strip_suffix('z')) {
+        rest
+    } else if let Some(rest) = s.strip_suffix("+00:00").or_else(|| s.strip_suffix("+0000")) {
+        rest
+    } else {
+        return Err(bad("must be UTC (trailing 'Z' or '+00:00')"));
+    };
+
+    let (date, time) = body
+        .split_once('T')
+        .or_else(|| body.split_once('t'))
+        .ok_or_else(|| bad("missing 'T' between date and time"))?;
+
+    let mut d = date.split('-');
+    let (y, mo, da) = match (d.next(), d.next(), d.next(), d.next()) {
+        (Some(y), Some(mo), Some(da), None) => (y, mo, da),
+        _ => return Err(bad("date must be YYYY-MM-DD")),
+    };
+
+    // Fractional seconds are optional.
+    let (hms, frac) = match time.split_once('.') {
+        Some((hms, frac)) => (hms, Some(frac)),
+        None => (time, None),
+    };
+    let mut t = hms.split(':');
+    let (h, mi, se) = match (t.next(), t.next(), t.next(), t.next()) {
+        (Some(h), Some(mi), Some(se), None) => (h, mi, se),
+        _ => return Err(bad("time must be HH:MM:SS")),
+    };
+
+    let num = |v: &str, what: &str, width: usize| -> ferrosa_common::Result<i64> {
+        if v.len() != width || !v.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(bad(&format!("{what} must be {width} digits")));
+        }
+        v.parse::<i64>().map_err(|_| bad(what))
+    };
+
+    let (y, mo, da) = (num(y, "year", 4)?, num(mo, "month", 2)?, num(da, "day", 2)?);
+    let (h, mi, se) = (
+        num(h, "hour", 2)?,
+        num(mi, "minute", 2)?,
+        num(se, "second", 2)?,
+    );
+
+    if !(1..=12).contains(&mo) {
+        return Err(bad("month out of range"));
+    }
+    if !(1..=31).contains(&da) {
+        return Err(bad("day out of range"));
+    }
+    if h > 23 || mi > 59 || se > 60 {
+        return Err(bad("time component out of range"));
+    }
+
+    // Fraction -> microseconds, padded/truncated to 6 digits.
+    let micros_frac = match frac {
+        Some(f) => {
+            if f.is_empty() || !f.bytes().all(|b| b.is_ascii_digit()) {
+                return Err(bad("fractional seconds must be digits"));
+            }
+            let mut six = f.to_string();
+            six.truncate(6);
+            while six.len() < 6 {
+                six.push('0');
+            }
+            six.parse::<i64>().unwrap_or(0)
+        }
+        None => 0,
+    };
+
+    let days = days_from_civil(y, mo, da);
+    let secs = days * 86_400 + h * 3_600 + mi * 60 + se;
+    Ok(secs * 1_000_000 + micros_frac)
+}
+
+/// Days since 1970-01-01 for a proleptic Gregorian date.
+///
+/// Howard Hinnant's `days_from_civil`, which is exact for all years in range
+/// and avoids a calendar dependency.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (m + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epoch_and_known_instants() {
+        assert_eq!(parse_rfc3339_micros("1970-01-01T00:00:00Z").unwrap(), 0);
+        // 2026-08-05T12:00:00Z — cross-checked against `date -u -d ... +%s`.
+        assert_eq!(
+            parse_rfc3339_micros("2026-08-05T12:00:00Z").unwrap(),
+            1_785_931_200_000_000
+        );
+        // Leap day must not shift the result.
+        assert_eq!(
+            parse_rfc3339_micros("2024-02-29T00:00:00Z").unwrap(),
+            1_709_164_800_000_000
+        );
+    }
+
+    #[test]
+    fn fractional_seconds_pad_and_truncate() {
+        assert_eq!(
+            parse_rfc3339_micros("1970-01-01T00:00:00.5Z").unwrap(),
+            500_000
+        );
+        assert_eq!(
+            parse_rfc3339_micros("1970-01-01T00:00:00.123456Z").unwrap(),
+            123_456
+        );
+        // Sub-microsecond precision is truncated, not rounded.
+        assert_eq!(
+            parse_rfc3339_micros("1970-01-01T00:00:00.1234569Z").unwrap(),
+            123_456
+        );
+    }
+
+    #[test]
+    fn accepts_explicit_utc_offset() {
+        assert_eq!(
+            parse_rfc3339_micros("1970-01-01T00:00:00+00:00").unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_and_non_utc() {
+        for bad in [
+            "2026-08-05T12:00:00",       // no zone
+            "2026-08-05T12:00:00-05:00", // not UTC
+            "2026-08-05 12:00:00Z",      // space instead of T
+            "2026-8-5T12:00:00Z",        // unpadded
+            "2026-13-01T00:00:00Z",      // month out of range
+            "2026-08-05T25:00:00Z",      // hour out of range
+            "not-a-date",
+        ] {
+            assert!(
+                parse_rfc3339_micros(bad).is_err(),
+                "should have rejected {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_snapshot_means_no_intent() {
+        assert_eq!(RestoreIntent::from_vars(None, None, None).unwrap(), None);
+        // Whitespace-only is treated as unset.
+        assert_eq!(
+            RestoreIntent::from_vars(Some("  ".into()), None, None).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn point_in_time_without_snapshot_is_an_error() {
+        let err =
+            RestoreIntent::from_vars(None, Some("2026-08-05T12:00:00Z".into()), None).unwrap_err();
+        assert!(err.to_string().contains(ENV_RESTORE_SNAPSHOT));
+    }
+
+    #[test]
+    fn malformed_point_in_time_is_rejected_at_startup() {
+        let err = RestoreIntent::from_vars(Some("snap".into()), Some("yesterday".into()), None)
+            .unwrap_err();
+        assert!(err.to_string().contains("RFC 3339"));
+    }
+
+    #[test]
+    fn force_parsing() {
+        let mk = |f: Option<&str>| {
+            RestoreIntent::from_vars(Some("s".into()), None, f.map(String::from))
+                .unwrap()
+                .unwrap()
+                .force
+        };
+        assert!(!mk(None));
+        assert!(!mk(Some("0")));
+        assert!(!mk(Some("false")));
+        assert!(mk(Some("1")));
+        assert!(mk(Some("true")));
+        assert!(mk(Some("TRUE")));
+    }
+
+    #[test]
+    fn marker_makes_the_same_intent_apply_once() {
+        let dir = std::env::temp_dir().join(format!("restore-intent-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let intent = RestoreIntent::from_vars(Some("snap-1".into()), None, None)
+            .unwrap()
+            .unwrap();
+        assert!(!intent.already_applied(&dir), "not applied yet");
+
+        intent.mark_applied(&dir).unwrap();
+        assert!(intent.already_applied(&dir), "should be marked applied");
+
+        // A different snapshot is a new request and must still run.
+        let other = RestoreIntent::from_vars(Some("snap-2".into()), None, None)
+            .unwrap()
+            .unwrap();
+        assert!(
+            !other.already_applied(&dir),
+            "different snapshot must apply"
+        );
+
+        // Same snapshot but a new point-in-time is also a new request.
+        let repointed = RestoreIntent::from_vars(
+            Some("snap-1".into()),
+            Some("2026-08-05T12:00:00Z".into()),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(
+            !repointed.already_applied(&dir),
+            "new point-in-time must apply"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/ferrosa-storage/src/restore/mod.rs
+++ b/ferrosa-storage/src/restore/mod.rs
@@ -1,3 +1,7 @@
+pub mod intent;
 pub mod manager;
 pub mod validation;
+pub use intent::{
+    RestoreIntent, ENV_RESTORE_FORCE, ENV_RESTORE_POINT_IN_TIME, ENV_RESTORE_SNAPSHOT,
+};
 pub use manager::RestoreManager;

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -1013,7 +1013,47 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             })
             .unwrap_or(false);
 
-    let (storage, pending_mutations) = if has_commitlog_segments {
+    // Restore-on-boot: when FERROSA_RESTORE_SNAPSHOT is set and this exact
+    // intent has not already been applied, open by restoring the snapshot
+    // instead of taking the ordinary path. The applied-marker is what stops an
+    // env var that survives reboots from re-restoring on every start and
+    // discarding everything written since.
+    let restore_intent = ferrosa_storage::restore::RestoreIntent::from_env()?;
+    let restore_data_dir = storage_config.data_dir.clone();
+    let pending_restore = match restore_intent {
+        Some(intent) if intent.already_applied(&restore_data_dir) => {
+            tracing::info!(
+                snapshot = %intent.snapshot,
+                point_in_time = ?intent.point_in_time,
+                "restore intent already applied on a previous boot — starting normally"
+            );
+            None
+        }
+        other => other,
+    };
+
+    let (storage, pending_mutations) = if let Some(intent) = &pending_restore {
+        tracing::warn!(
+            snapshot = %intent.snapshot,
+            point_in_time = ?intent.point_in_time,
+            force = intent.force,
+            "restore-on-boot: opening engine from snapshot instead of local state"
+        );
+        let engine = ferrosa_storage::StorageEngine::open_from_snapshot(
+            storage_config,
+            intent,
+            &host_id.to_string(),
+        )
+        .await?;
+        // Only now that the engine has actually opened. Marking earlier would
+        // skip a restore that never happened.
+        intent.mark_applied(&restore_data_dir)?;
+        tracing::info!(
+            snapshot = %intent.snapshot,
+            "restore-on-boot: restore complete and recorded"
+        );
+        (engine, Vec::new())
+    } else if has_commitlog_segments {
         tracing::info!("existing commit log segments found — replaying for crash recovery");
         let (engine, mutations) =
             ferrosa_storage::StorageEngine::open(storage_config, Some(&storage_upload_handle))?;


### PR DESCRIPTION
## Why

Restore existed but was unreachable. `StorageEngine::open_from_snapshot_with_store` implements it and `POST /api/restore` validates a request, but nothing connected the two: the handler persisted no intent and startup always took the ordinary open path.

A node therefore restarted cleanly and came back serving **pre-restore data** while the caller believed the restore had happened — silent wrong data. Verified before writing anything: of ferrosa's 137 `FERROSA_*` env vars none matched RESTORE/SNAPSHOT/PITR, and `open_from_snapshot_with_store` had no caller outside `engine.rs`.

## What this adds

`ferrosa-storage/src/restore/intent.rs`, implementing the env-var contract the DBaaS layer's `GuestMetadata` already documented:

| Variable | Meaning |
|---|---|
| `FERROSA_RESTORE_SNAPSHOT` | snapshot to restore from at startup |
| `FERROSA_RESTORE_POINT_IN_TIME` | optional RFC 3339 UTC replay cutoff |
| `FERROSA_RESTORE_FORCE` | accept a snapshot taken by a different node |

Plus `StorageEngine::open_from_snapshot` (builds the object store from `config.object_store`) and a third branch in `main.rs` ahead of the existing commit-log-replay and fresh-start cases.

## Applied at most once

An env var survives a reboot, so a naive hook would re-restore on **every** start and silently discard everything written since. After a successful restore the node records a fingerprint of the intent in `{data_dir}/.restore-applied`; a later boot with the same intent skips it. A different snapshot or cutoff is a new request and still applies. The marker is written only *after* the engine opens, so a failed restore is never recorded as done.

## Strict timestamp parsing

`ferrosa-storage` has no `chrono` dependency, so RFC 3339 parsing is local (Hinnant's `days_from_civil`). Deliberately strict — non-UTC, unpadded, and space-separated forms are rejected rather than coerced, because a silently mis-parsed cutoff restores to the *wrong moment*, which is worse than refusing. Validated at startup, before any SSTable download. A cutoff with no snapshot is an error, not a no-op.

## Tests

9 unit tests (epoch, leap day, fractional-second padding/truncation, a rejection table, force parsing, marker behaviour) plus `e4_restore_applied_via_intent_and_only_once` — an end-to-end test that drives restore the way a node start does: writes, snapshots, writes past the cutoff, restores via a `RestoreIntent`, and asserts the later rows are gone and the marker suppresses a second application.

**Discrimination verified, not assumed:** moving the cutoff past the post-snapshot rows makes them replay back in and fails with `row 'drop-0' written after the cutoff must be absent`.

## Not in scope

`POST /api/restore` still validates and returns `202` without persisting an intent, so the HTTP path remains a no-op — only the env-var path works. Called out in the crate README and roadmap so readers are not sent down it.

## Verification

`cargo fmt --check` passes; `clippy -p ferrosa-storage --all-targets -D warnings` clean; intent tests 9/9; e2e green. **Full-workspace clippy and test did not complete locally** — the runs were interrupted — so CI here is the real gate on crates I did not touch.