### PR TITLE
feat(restore): persist a restore intent from POST /api/restore

### DIFF
--- a/ferrosa-storage/src/restore/intent.rs
+++ b/ferrosa-storage/src/restore/intent.rs
@@ -42,6 +42,13 @@ pub const ENV_RESTORE_FORCE: &str = "FERROSA_RESTORE_FORCE";
 /// Name of the marker recording the last successfully applied intent.
 const MARKER_FILE: &str = ".restore-applied";
 
+/// Name of the file recording a restore requested over HTTP.
+///
+/// `POST /api/restore` writes this; the next startup reads it. It shares the
+/// intent-fingerprint wire format with the applied-marker file, so
+/// "requested" and "already applied" are directly comparable.
+pub const INTENT_FILE: &str = ".restore-intent";
+
 /// A restore requested for the next node start.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RestoreIntent {
@@ -142,6 +149,158 @@ impl RestoreIntent {
         std::fs::read_to_string(Self::marker_path(data_dir))
             .map(|recorded| recorded == self.fingerprint())
             .unwrap_or(false)
+    }
+
+    fn intent_path(data_dir: &Path) -> PathBuf {
+        data_dir.join(INTENT_FILE)
+    }
+
+    /// Record this intent so the next startup applies it.
+    ///
+    /// This is what makes `POST /api/restore` more than a validation call: the
+    /// handler replies "restart the node to complete restore", and this is the
+    /// only thing that makes the restart honour it.
+    pub fn persist(&self, data_dir: &Path) -> ferrosa_common::Result<()> {
+        // The on-disk form is line-oriented, so an embedded newline would
+        // silently change what a later boot reads back. Refuse it here rather
+        // than restore from a snapshot nobody asked for.
+        for (field, value) in [
+            ("snapshot", self.snapshot.as_str()),
+            ("point_in_time", self.point_in_time.as_deref().unwrap_or("")),
+        ] {
+            if value.contains('\n') {
+                return Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "restore {field} contains a newline, which the {INTENT_FILE} \
+                     format cannot represent: {value:?}"
+                )));
+            }
+        }
+
+        std::fs::create_dir_all(data_dir).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to create data dir {}: {e}",
+                data_dir.display()
+            ))
+        })?;
+        std::fs::write(Self::intent_path(data_dir), self.fingerprint()).map_err(|e| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "failed to record the restore intent at {}: {e}",
+                Self::intent_path(data_dir).display()
+            ))
+        })
+    }
+
+    /// Read a previously [`persist`](Self::persist)ed intent.
+    ///
+    /// Returns `Ok(None)` when no restore was requested. A file that exists but
+    /// cannot be parsed is an error: someone asked for a restore and we cannot
+    /// tell which, so booting normally would quietly ignore the request.
+    pub fn from_data_dir(data_dir: &Path) -> ferrosa_common::Result<Option<Self>> {
+        let path = Self::intent_path(data_dir);
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "failed to read {INTENT_FILE} at {}: {e}",
+                    path.display()
+                )))
+            }
+        };
+        Self::parse_persisted(&raw, &path).map(Some)
+    }
+
+    fn parse_persisted(raw: &str, path: &Path) -> ferrosa_common::Result<Self> {
+        let malformed = |detail: &str| {
+            ferrosa_common::Error::InvalidFormat(format!(
+                "malformed {INTENT_FILE} at {}: {detail}. Remove the file to \
+                 cancel the restore, or rewrite it as \
+                 snapshot/point-in-time/force on three lines.",
+                path.display()
+            ))
+        };
+
+        let lines: Vec<&str> = raw.split('\n').collect();
+        let [snapshot, point_in_time, force] = lines.as_slice() else {
+            return Err(malformed(&format!(
+                "expected 3 lines, found {}",
+                lines.len()
+            )));
+        };
+        if snapshot.trim().is_empty() {
+            return Err(malformed("snapshot name is empty"));
+        }
+        let force = match *force {
+            "true" => true,
+            "false" => false,
+            other => {
+                return Err(malformed(&format!(
+                    "force must be true or false, got {other:?}"
+                )))
+            }
+        };
+        let point_in_time = (!point_in_time.is_empty()).then(|| (*point_in_time).to_string());
+        if let Some(pit) = &point_in_time {
+            parse_rfc3339_micros(pit)?;
+        }
+
+        Ok(Self {
+            snapshot: (*snapshot).to_string(),
+            point_in_time,
+            force,
+        })
+    }
+
+    /// Remove any persisted intent. Absent is success — the env-var path never
+    /// writes one, and startup clears unconditionally after applying.
+    pub fn clear_persisted(data_dir: &Path) -> ferrosa_common::Result<()> {
+        match std::fs::remove_file(Self::intent_path(data_dir)) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(ferrosa_common::Error::InvalidFormat(format!(
+                "restore applied but {INTENT_FILE} could not be removed from {}: {e}. \
+                 Leaving it would restore again on the next boot and discard \
+                 everything written since.",
+                data_dir.display()
+            ))),
+        }
+    }
+
+    /// The restore this node should apply at startup, from either source.
+    ///
+    /// The environment carries an orchestrator's request (DBaaS MMDS); the
+    /// persisted file carries an operator's `POST /api/restore`. Both are
+    /// honoured so the two paths converge on one apply-once mechanism.
+    pub fn resolve(data_dir: &Path) -> ferrosa_common::Result<Option<Self>> {
+        Self::decide(Self::from_env()?, Self::from_data_dir(data_dir)?, data_dir)
+    }
+
+    /// Pick between the two intent sources. Split out from
+    /// [`resolve`](Self::resolve) so the rules are testable without mutating
+    /// the process environment.
+    pub fn decide(
+        from_env: Option<Self>,
+        from_file: Option<Self>,
+        data_dir: &Path,
+    ) -> ferrosa_common::Result<Option<Self>> {
+        // A spent intent is not a competing request. A DBaaS node keeps
+        // FERROSA_RESTORE_SNAPSHOT set forever, so without this an operator
+        // could never request a second restore over HTTP.
+        let pending = |i: Option<Self>| i.filter(|i| !i.already_applied(data_dir));
+        match (pending(from_env), pending(from_file)) {
+            (Some(env), Some(file)) if env != file => {
+                Err(ferrosa_common::Error::InvalidFormat(format!(
+                    "two different restores are pending: {ENV_RESTORE_SNAPSHOT} asks for \
+                     {:?} and {INTENT_FILE} asks for {:?}. Refusing to guess — clear one \
+                     (delete {}/{INTENT_FILE} or unset the env var) and restart.",
+                    env.snapshot,
+                    file.snapshot,
+                    data_dir.display(),
+                )))
+            }
+            (Some(intent), _) | (None, Some(intent)) => Ok(Some(intent)),
+            (None, None) => Ok(None),
+        }
     }
 
     /// Record this intent as applied so later boots skip it.
@@ -425,5 +584,172 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ---- persisted intent (the `POST /api/restore` path) -------------------
+
+    fn intent(snapshot: &str, pit: Option<&str>, force: bool) -> RestoreIntent {
+        RestoreIntent::from_vars(
+            Some(snapshot.into()),
+            pit.map(String::from),
+            force.then(|| "true".to_string()),
+        )
+        .unwrap()
+        .unwrap()
+    }
+
+    #[test]
+    fn persisted_intent_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+
+        assert_eq!(
+            RestoreIntent::from_data_dir(d).unwrap(),
+            None,
+            "no file means no persisted intent"
+        );
+
+        for original in [
+            intent("snap-1", None, false),
+            intent("snap-2", Some("2026-08-05T12:00:00Z"), false),
+            intent("snap-3", Some("1970-01-01T00:33:19.999999Z"), true),
+        ] {
+            original.persist(d).unwrap();
+            assert_eq!(
+                RestoreIntent::from_data_dir(d).unwrap(),
+                Some(original.clone()),
+                "persisted intent must read back identically"
+            );
+        }
+    }
+
+    #[test]
+    fn clear_persisted_removes_the_file_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+
+        intent("snap-1", None, false).persist(d).unwrap();
+        RestoreIntent::clear_persisted(d).unwrap();
+        assert_eq!(RestoreIntent::from_data_dir(d).unwrap(), None);
+
+        // Clearing an absent intent is not an error — the env path never
+        // writes one, and startup clears unconditionally.
+        RestoreIntent::clear_persisted(d).unwrap();
+    }
+
+    #[test]
+    fn a_corrupt_intent_file_fails_loud() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+
+        for junk in [
+            "",
+            "only-one-line",
+            "a\nb",
+            "snap\n\nnotabool",
+            "a\nb\nc\nd",
+        ] {
+            std::fs::write(d.join(INTENT_FILE), junk).unwrap();
+            let err = RestoreIntent::from_data_dir(d).unwrap_err();
+            assert!(
+                err.to_string().contains(INTENT_FILE),
+                "a corrupt intent must name the file it could not parse, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn persist_rejects_values_that_would_corrupt_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let smuggled = RestoreIntent {
+            snapshot: "snap\nnot-a-real-line".into(),
+            point_in_time: None,
+            force: false,
+        };
+        let err = smuggled.persist(dir.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("newline"),
+            "a newline in a field must be refused, got: {err}"
+        );
+    }
+
+    #[test]
+    fn decide_uses_whichever_source_supplied_the_intent() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        let env_only = intent("from-env", None, false);
+        let file_only = intent("from-file", None, false);
+
+        assert_eq!(RestoreIntent::decide(None, None, d).unwrap(), None);
+        assert_eq!(
+            RestoreIntent::decide(Some(env_only.clone()), None, d).unwrap(),
+            Some(env_only.clone())
+        );
+        assert_eq!(
+            RestoreIntent::decide(None, Some(file_only.clone()), d).unwrap(),
+            Some(file_only)
+        );
+        // Both sources agreeing is not a conflict.
+        assert_eq!(
+            RestoreIntent::decide(Some(env_only.clone()), Some(env_only.clone()), d).unwrap(),
+            Some(env_only)
+        );
+    }
+
+    #[test]
+    fn decide_refuses_two_conflicting_pending_intents() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = RestoreIntent::decide(
+            Some(intent("from-env", None, false)),
+            Some(intent("from-file", None, false)),
+            dir.path(),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("from-env") && msg.contains("from-file"),
+            "the conflict must name both snapshots so an operator can resolve it, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn decide_ignores_an_already_applied_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        let applied = intent("from-env", None, false);
+        let fresh = intent("from-file", None, false);
+        applied.mark_applied(d).unwrap();
+
+        // The realistic DBaaS sequence: a permanent env var whose restore
+        // already ran, plus a newly requested restore over HTTP. That is not
+        // ambiguous — the env intent is spent.
+        assert_eq!(
+            RestoreIntent::decide(Some(applied.clone()), Some(fresh.clone()), d).unwrap(),
+            Some(fresh),
+            "an applied env intent must not block a new HTTP restore"
+        );
+        assert_eq!(
+            RestoreIntent::decide(Some(applied), None, d).unwrap(),
+            None,
+            "an applied intent on its own means nothing to do"
+        );
+    }
+
+    #[test]
+    fn resolve_reads_the_persisted_intent() {
+        // Deliberately exercises only the file source: this process's env is
+        // shared across tests, so mutating it here would race.
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        let want = intent("resolved-snap", Some("2026-08-05T12:00:00Z"), false);
+        want.persist(d).unwrap();
+
+        if std::env::var(ENV_RESTORE_SNAPSHOT).is_ok() {
+            panic!(
+                "{ENV_RESTORE_SNAPSHOT} is set in the test process; \
+                 this test asserts the file-only path"
+            );
+        }
+        assert_eq!(RestoreIntent::resolve(d).unwrap(), Some(want));
     }
 }

--- a/ferrosa-storage/src/restore/mod.rs
+++ b/ferrosa-storage/src/restore/mod.rs
@@ -2,6 +2,6 @@ pub mod intent;
 pub mod manager;
 pub mod validation;
 pub use intent::{
-    RestoreIntent, ENV_RESTORE_FORCE, ENV_RESTORE_POINT_IN_TIME, ENV_RESTORE_SNAPSHOT,
+    RestoreIntent, ENV_RESTORE_FORCE, ENV_RESTORE_POINT_IN_TIME, ENV_RESTORE_SNAPSHOT, INTENT_FILE,
 };
 pub use manager::RestoreManager;

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -1013,24 +1013,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             })
             .unwrap_or(false);
 
-    // Restore-on-boot: when FERROSA_RESTORE_SNAPSHOT is set and this exact
-    // intent has not already been applied, open by restoring the snapshot
-    // instead of taking the ordinary path. The applied-marker is what stops an
-    // env var that survives reboots from re-restoring on every start and
+    // Restore-on-boot: a restore requested either by FERROSA_RESTORE_SNAPSHOT
+    // (orchestrator) or by POST /api/restore (operator, persisted to the data
+    // dir) opens by restoring the snapshot instead of taking the ordinary path.
+    // `resolve` drops an intent this node already applied, which is what stops
+    // an env var that survives reboots from re-restoring on every start and
     // discarding everything written since.
-    let restore_intent = ferrosa_storage::restore::RestoreIntent::from_env()?;
     let restore_data_dir = storage_config.data_dir.clone();
-    let pending_restore = match restore_intent {
-        Some(intent) if intent.already_applied(&restore_data_dir) => {
-            tracing::info!(
-                snapshot = %intent.snapshot,
-                point_in_time = ?intent.point_in_time,
-                "restore intent already applied on a previous boot — starting normally"
-            );
-            None
-        }
-        other => other,
-    };
+    let pending_restore = ferrosa_storage::restore::RestoreIntent::resolve(&restore_data_dir)?;
 
     let (storage, pending_mutations) = if let Some(intent) = &pending_restore {
         tracing::warn!(
@@ -1048,6 +1038,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Only now that the engine has actually opened. Marking earlier would
         // skip a restore that never happened.
         intent.mark_applied(&restore_data_dir)?;
+        // The marker alone would suppress a re-run, but leaving the request
+        // file behind makes a completed restore look permanently pending.
+        ferrosa_storage::restore::RestoreIntent::clear_persisted(&restore_data_dir)?;
         tracing::info!(
             snapshot = %intent.snapshot,
             "restore-on-boot: restore complete and recorded"

--- a/ferrosa/src/web/snapshots.rs
+++ b/ferrosa/src/web/snapshots.rs
@@ -296,13 +296,19 @@ async fn restore_preflight(
 
 /// `POST /api/restore` — trigger a PITR restore.
 ///
-/// Validates the snapshot, then returns `202 Accepted` with a restore plan
-/// summary.  Full restore (downloading SSTables and replaying mutations) is
-/// performed during the next node startup using
+/// Validates the snapshot, **records the restore intent in the data dir**, then
+/// returns `202 Accepted` with a restore plan summary. Full restore
+/// (downloading SSTables and replaying mutations) is performed during the next
+/// node startup, which reads that intent and takes
 /// `StorageEngine::open_from_snapshot_with_store`.
 ///
+/// The recording step is not optional: without it the 202 would promise a
+/// restore that never happens, and the node would come back serving
+/// pre-restore data while the caller believed otherwise.
+///
 /// Returns `503` if S3 is not configured, `404` if the snapshot does not
-/// exist, `422` if validation fails, `202` on acceptance.
+/// exist, `422` if validation fails, `500` if the intent cannot be recorded,
+/// `202` on acceptance.
 async fn trigger_restore(
     State(state): State<WebAppState>,
     Json(body): Json<RestoreRequest>,
@@ -350,6 +356,39 @@ async fn trigger_restore(
         );
     }
 
+    // Record the intent. Without this the 202 below would be a lie: the node
+    // would restart and come back serving pre-restore data.
+    let intent = match ferrosa_storage::restore::RestoreIntent::from_vars(
+        Some(body.snapshot.clone()),
+        body.point_in_time.clone(),
+        body.force.then(|| "true".to_string()),
+    ) {
+        Ok(Some(intent)) => intent,
+        Ok(None) => {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({ "error": "snapshot name is empty" })),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({ "error": e.to_string() })),
+            );
+        }
+    };
+    let data_dir = engine.data_dir().to_path_buf();
+    if let Err(e) = intent.persist(&data_dir) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": format!("restore could not be recorded: {e}"),
+                "hint": "the restore was NOT scheduled; restarting the node now would \
+                         come back with pre-restore data",
+            })),
+        );
+    }
+
     // Return 202 Accepted — full restore happens on next node restart.
     (
         StatusCode::ACCEPTED,
@@ -363,7 +402,7 @@ async fn trigger_restore(
                 "segment_id": meta.commit_log_position.segment_id,
                 "offset": meta.commit_log_position.offset,
             },
-            "message": "restore accepted; restart the node to complete restore",
+            "message": "restore recorded; restart the node to apply it",
         })),
     )
 }
@@ -529,6 +568,196 @@ mod tests {
             auth_disabled: true,
             debug: None,
         }
+    }
+
+    /// Build a `WebAppState` backed by a durable local `file://` object store,
+    /// so the restore endpoints run their real success path instead of the
+    /// 503 branch. The `TempDir` is returned because the state's data dir and
+    /// object store both live inside it.
+    fn make_state_with_local_store() -> (WebAppState, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let object_store = ferrosa_storage::upload::ObjectStoreConfig {
+            local_path: Some(dir.path().join("objectstore")),
+            endpoint: String::new(),
+            bucket: "test".into(),
+            region: "us-east-1".into(),
+            access_key_id: None,
+            secret_access_key: None,
+            allow_http: true,
+            prefix: "pitr-http".into(),
+            upload_queue_depth: 16,
+            upload_workers: 1,
+            compaction_upload_workers: 1,
+            compaction_upload_queue_depth: 16,
+            delete_workers: 1,
+        };
+        let storage_config = StorageEngineConfig {
+            commit_log: CommitLogConfig {
+                log_dir: dir.path().join("commitlog"),
+                checkpoint_dir: dir.path().join("commitlog"),
+                archive: None,
+                ..CommitLogConfig::default()
+            },
+            compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+            object_store: Some(object_store),
+            local_cache_max_bytes: 1024 * 1024,
+            local_disk_free_reserve_bytes: 0,
+            flush_threshold_bytes: 4096,
+            memtable_backpressure_bytes: u64::MAX,
+            flush_max_age_secs: 5,
+            data_dir: dir.path().join("data"),
+            index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+            write_verify: true,
+            auth_enabled: false,
+            auth_warn: false,
+            max_pending_replay_mutations_without_schema: 1024,
+            memtable_num_shards: 64,
+        };
+        let storage = Arc::new(StorageEngine::new(storage_config, None).expect("storage"));
+        let rpc_registry = Arc::new(HandlerRegistry::new());
+        let schema = Arc::new(
+            ferrosa_schema::Schema::new(ferrosa_schema::SchemaConfig {
+                hasher: ferrosa_schema::PasswordHasher::Bcrypt { cost: 4 },
+                password_policy: ferrosa_schema::PasswordPolicy::permissive(),
+                auth_method: ferrosa_schema::AuthMethod::Password,
+                rate_limit: ferrosa_schema::RateLimitConfig::default(),
+                audit_sink: Box::new(ferrosa_schema::TestAuditSink::new()),
+                secrets: Box::new(ferrosa_schema::EnvSecretsProvider),
+                mode: ferrosa_schema::DeploymentMode::Development,
+            })
+            .expect("schema"),
+        );
+        let (mc, _) = ModeController::new(
+            Arc::new(ferrosa_cluster::ClusterConfig::default()),
+            Arc::new(ferrosa_net::config::NetConfig::default()),
+            uuid::Uuid::new_v4(),
+            storage.clone(),
+            schema.clone(),
+            rpc_registry,
+        );
+        let state = WebAppState {
+            registry: Arc::new(ferrosa_schema::VirtualTableRegistry::new()),
+            mode_controller: mc,
+            schema,
+            storage,
+            host_id: uuid::Uuid::new_v4(),
+            auth_disabled: true,
+            debug: None,
+        };
+        (state, dir)
+    }
+
+    /// Create a real snapshot owned by this node, so `POST /api/restore`
+    /// reaches the accept path rather than 404/409.
+    async fn seed_snapshot(state: &WebAppState, name: &str) {
+        let (os_config, store) = state
+            .storage
+            .object_store_and_config()
+            .expect("local object store");
+        let prefix = os_config.prefix.clone();
+        ferrosa_storage::manifest::Manifest::new()
+            .save_with_retry(store.as_ref(), &prefix)
+            .await
+            .expect("save manifest");
+        ferrosa_storage::manifest::save_schema_snapshot(store.as_ref(), &prefix, b"{}")
+            .await
+            .expect("save schema snapshot");
+        state
+            .storage
+            .create_snapshot_with_store(
+                name,
+                &state.host_id.to_string(),
+                None,
+                false,
+                Arc::clone(&store),
+                &prefix,
+            )
+            .await
+            .expect("create snapshot");
+    }
+
+    // ---- POST /api/restore persists the intent -----------------------------
+
+    #[tokio::test]
+    async fn trigger_restore_records_an_intent_the_next_boot_can_read() {
+        let (state, _dir) = make_state_with_local_store();
+        seed_snapshot(&state, "http-snap").await;
+        let data_dir = state.storage.data_dir().to_path_buf();
+
+        // Precondition: nothing pending, or the assertion below proves nothing.
+        assert_eq!(
+            ferrosa_storage::restore::RestoreIntent::from_data_dir(&data_dir).unwrap(),
+            None,
+            "no restore should be pending before the request"
+        );
+
+        let router = build_router(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/restore")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"snapshot":"http-snap","point_in_time":"2026-08-05T12:00:00Z"}"#,
+            ))
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+        // The whole point of the 202: a restart must now restore. Read it back
+        // through the same API startup uses.
+        let pending = ferrosa_storage::restore::RestoreIntent::resolve(&data_dir)
+            .expect("resolve")
+            .expect("the accepted restore must be pending after a 202");
+        assert_eq!(pending.snapshot, "http-snap");
+        assert_eq!(
+            pending.point_in_time.as_deref(),
+            Some("2026-08-05T12:00:00Z")
+        );
+        assert!(!pending.force);
+    }
+
+    #[tokio::test]
+    async fn a_rejected_restore_records_nothing() {
+        let (state, _dir) = make_state_with_local_store();
+        seed_snapshot(&state, "http-snap").await;
+        let data_dir = state.storage.data_dir().to_path_buf();
+
+        let router = build_router(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/restore")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"snapshot":"no-such-snapshot"}"#))
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            ferrosa_storage::restore::RestoreIntent::from_data_dir(&data_dir).unwrap(),
+            None,
+            "a refused restore must not schedule anything for the next boot"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_preflight_records_nothing() {
+        let (state, _dir) = make_state_with_local_store();
+        seed_snapshot(&state, "http-snap").await;
+        let data_dir = state.storage.data_dir().to_path_buf();
+
+        let router = build_router(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/restore/preflight")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"snapshot":"http-snap"}"#))
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            ferrosa_storage::restore::RestoreIntent::from_data_dir(&data_dir).unwrap(),
+            None,
+            "preflight validates only — it must not schedule a restore"
+        );
     }
 
     // ---- GET /api/snapshots ------------------------------------------------


### PR DESCRIPTION
`POST /api/restore` validated the snapshot, replied 202 "restart the node to complete restore", and persisted nothing. The node restarted and came back serving pre-restore data while the caller believed the restore had happened.

The env-var path (`FERROSA_RESTORE_SNAPSHOT`, #326) already worked. This gives the HTTP path the same footing so both converge on one apply-once mechanism.

## Changes

- `RestoreIntent::persist` / `from_data_dir` / `clear_persisted` — read and write `.restore-intent` in the data dir, sharing the fingerprint wire format with the applied-marker so "requested" and "already applied" compare directly. A file that exists but will not parse is an error, not a silently ignored restore request.
- `RestoreIntent::resolve` / `decide` — pick between the env and file sources. An already-applied intent is dropped rather than treated as competing, so a DBaaS node with a permanent env var can still accept a new restore over HTTP. Two genuinely different pending intents fail loud rather than guessing.
- `trigger_restore` records the intent, and returns 500 if it cannot — a 202 that scheduled nothing is the bug being fixed. Preflight still records nothing.
- Startup resolves both sources and clears the file after applying.

## Verification

- `restore::intent` — 17/17
- `web::snapshots` — 43/43, including 3 new handler tests against a real local-store snapshot
- `cargo clippy --all-targets` — 0 warnings
- `cargo doc` — 0 warnings (two private intra-doc links caught and fixed; the Docs job runs `-D warnings`)

Tests were verified to discriminate: stubbing `persist` to return `Ok(())` fails 4 of them, including the handler test asserting a 202 leaves a pending restore.