### PR TITLE
fix(cluster): preserve peer endpoints during bootstrap

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -206,6 +206,10 @@ strict-serializable multi-key / cross-shard transactions and LWT.
 - `controller/bootstrap/` — 8-phase formation pipeline (DeliverInvites →
   EstablishPools → CreateRaft → WaitLeader → ReplaySchema → BootstrapStream →
   Promote → DrainQueue).
+- `controller/peer_events.rs` — inbound handshakes prefer the peer's advertised
+  internode endpoint when creating reverse pools and tracking invite targets;
+  the observed IP plus local port is only a compatibility fallback. This keeps
+  same-host clusters with per-node ports from routing every host ID to the seed.
 - `ring/` — `TokenRing` (BTreeMap), SimpleStrategy + NetworkTopologyStrategy
   replica selection with rack diversity, learner `owns_tokens` handling.
 - `controller/membership.rs` — `MembershipChanger` mutates the four membership
@@ -213,8 +217,8 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   add/remove voter, learner-only join, promote/demote, DC swap drain.
 - `controller/cluster_rejoin.rs` — P0-21 rejoin after formation timeout;
   `CLUSTER_REJOIN_ATTEMPTS_TOTAL` / `_FAILURES_TOTAL`.
-- `pair/` — two-node primary/secondary coordination (role from TCP direction,
-  not UUID election), switchover, catch-up.
+- `pair/` — two-node primary/secondary coordination (deterministic host-ID
+  ordering, independent of which TCP direction wins), switchover, catch-up.
 - `rebalance.rs` — token-skew rebalancing with data streaming.
 
 ### Repair & hints (`repair/`, `hints/`)

--- a/ferrosa-cluster/specs/data-flow.md
+++ b/ferrosa-cluster/specs/data-flow.md
@@ -1,19 +1,39 @@
 ---
 crate: ferrosa-cluster
 doc: data-flow
-last_updated: 2026-06-19
+last_updated: 2026-08-07
 ---
 
 # ferrosa-cluster — Data Flow
 
-Two end-to-end flows: a **tunable-consistency write** (the eventually-consistent
-data path) and an **Accord transaction** (the strict-serializable path). Both
-share the `TokenRing` for replica selection and run over `ferrosa-net` peers.
+Three end-to-end flows: **formation endpoint discovery**, a
+**tunable-consistency write** (the eventually-consistent data path), and an
+**Accord transaction** (the strict-serializable path). They share the
+`TokenRing` for replica selection and run over `ferrosa-net` peers.
 
 > Note: identifiers below are written without raw angle brackets so the diagrams
 > render — e.g. `Option Partition` rather than the generic-parameter form.
 
-## 1. Tunable-CL write coordination
+## 1. Formation endpoint discovery
+
+An inbound TCP source port is ephemeral and is never a valid reverse-dial
+target. The handshake's advertised internode host/port is authoritative when
+present; observed IP plus the receiver's local internode port is a compatibility
+fallback for older peers. The selected endpoint feeds both the outbound pool
+and `connected_peers`, whose addresses are carried in `ClusterInvite`.
+
+```mermaid
+flowchart LR
+    IN["Inbound socket + handshake"] --> ADV{"advertised internode endpoint usable?"}
+    ADV -->|yes| CANON["resolve advertised host/port"]
+    ADV -->|no| FALLBACK["observed IP + local internode port"]
+    CANON --> TRACK["reverse pool + connected_peers"]
+    FALLBACK --> TRACK
+    TRACK --> INVITE["ClusterInvite peer targets"]
+    INVITE --> RAFT["all members enter one Raft group"]
+```
+
+## 2. Tunable-CL write coordination
 
 A front-end (e.g. `ferrosa-cql`) hands a mutation to
 `ClusterCoordinator::coordinate_write*`. The coordinator gates on the write
@@ -54,7 +74,7 @@ symmetric read path issues one full read plus `block_for - 1` digest reads, then
 on digest mismatch fail-loud re-fetches the newest copy and repairs stale
 replicas inline before returning.
 
-## 2. Accord transaction (strict-serializable)
+## 3. Accord transaction (strict-serializable)
 
 `AccordCoordinator` runs the EPaxos-family protocol across the shards a
 transaction touches. The common case commits in one round trip (fast path); a

--- a/ferrosa-cluster/specs/fmea.md
+++ b/ferrosa-cluster/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cluster
 doc: fmea
-last_updated: 2026-07-17
+last_updated: 2026-08-07
 ---
 
 # ferrosa-cluster — FMEA / Known Issues
@@ -28,6 +28,7 @@ cluster-wide and severities run high. Several entries are *evidence* gaps
 | CL-13 | **Degraded pair read rejection (fixed).** `transition_to_degraded()` previously replaced `WritePath` with `Unavailable`, blocking both writes AND reads. The `WritePath` is also the read path. `is_cql_ready()` returned `true` for `DegradedPair` (intending stale reads), but the read methods on `Unavailable` returned errors. | After primary failure, follower could not serve reads of replicated data until operator promotion — violating the pair-mode design rule that reads work without promotion. | 8 | 4 | 5 | 160 | **Fixed:** `DegradedPair(Arc<PairCoordinator>)` variant preserves `local_storage()` for reads while rejecting writes. Regression test `degraded_pair_serves_stale_reads` verifies the `WritePath` variant after peer loss. |
 | CL-14 | **Paged multi-replica stream lifecycle (fixed, live validation pending).** Abandoning a page's merged stream (every paged read, every page but the last) left (a) the remote producers streaming the whole remaining table onto `Lane::Bulk` for nobody (`RangeReadStreamCancel` was never SENT and had no registered receiver MsgType), (b) the N-way merge parked forever on a stalled source before observing consumer abandonment, and (c) in-order straggler chunks whose route-error handling CLEARED live seq-state so the next straggler fabricated fresh `expected=0` state → phantom `expected_seq=0 observed_seq=5` gap-close per page (426–1065 closes per viz run on fmem-dev). | Paged scans stall (heartbeat-defunct connections), retry storms duplicate results, replica OOM under `pages × replicas` uncancelled full-table producers; phantom closes mask real chunk loss in logs. | 8 | 8 | 3 | 192 | **Fixed (t_dc729b1d/t_3fc6be3c/t_577dd385):** seq-state creation gated on route liveness (no-state+no-route = terminal straggler → silent drop; ids monotonic, route registered before fire); genuine gaps on LIVE routes still close loudly exactly once (`StreamFrameRouter::route_closures()` — alert if non-zero steady-state); forwarder task fires `RangeReadStreamCancel` on any non-`Completed` outcome (info-logged so a live deploy can verify cancels flow — the reverted Drop-guard sent zero); Cancel MsgType registered to the request handler; `run_fragment_merge_nway` races the merge core against `out_tx.closed()` so a dropped consumer aborts even while parked on a stalled source. Counter-asserted 3-node loopback harness `tests/range_scan_multi_replica_paging.rs`; deterministic parked-merge pin: `range_read_stream::tests::nway_merge_consumer_drop_aborts_when_parked_on_stalled_source`. **Residual:** the reverted predecessor passed in-process tests and failed live (t_3fc6be3c) — must be re-validated on a live RF=3 cluster (viz WS run + `SELECT id` 15k-row 3-page scan) before the claim closes. |
 | CL-15 | **Pre-vote election stall (fixed).** With `raft_enable_pre_vote = true` the fork's tick election path hard-gates `elect()` behind a pre-vote round, but `FerrosRaftNetwork` (`raft/network.rs`) never overrides `pre_vote` — the default trait impl returns "unimplemented", counted as a NO vote. A pre-vote quorum is then structurally impossible: after the seed's single `initialize()`-driven election at term 1 no further election ever fires, so a transient first-round vote loss freezes formation at term=1 permanently (reproduced ~3% under CPU starvation; CI 89743146291). Debug logging hides it by shifting timing. | Multi-voter cluster never elects a leader; `/cluster/topology` shows `committed_cluster_size:0`; looks like a hang, not a storm (term does NOT climb) | 9 | 3 | 6 | 162 | **Fixed (t_b0aac0d3):** `raft_enable_pre_vote` now defaults **false** (`config.rs`); the tick path calls `elect()` directly so a lost round self-heals on the next timeout. `FERROSA_RAFT_ENABLE_PRE_VOTE` override intact. Regression guard `candidate_re_campaigns_while_peers_are_down` (`tests/cluster_formation.rs`) asserts the seed's term advances past 1. **Residual:** pre-vote stays off until `FerrosRaftNetwork::pre_vote` is implemented (t_32cb5ad3); spec `specs/implemented/bug-cluster-formation-pre-vote-election-stall.md`. |
+| CL-16 | **Inbound reverse dialing collapses nonuniform peer ports onto the seed (fixed in code, live verification pending).** `on_inbound_peer` discarded the handshake's internode advertisement and built the reverse endpoint from the observed IP plus the receiver's own bind port. This assumes every node uses the same internode port. | In a same-host three-node cluster, the seed registers node1/node2 pools against itself, persists its own endpoint for all host IDs, and delivers `ClusterInvite` back to itself; joiners stay in pair mode while the seed reports a healthy one-node Raft leader. | 9 | 4 | 7 | 252 | **Fixed (2026-08-07):** `resolve_inbound_reverse_addr` prefers the advertised endpoint and retains the old fallback only when it is absent/unusable. Focused tests pin distinct-port selection and fallback behavior. The composition root now propagates TOML broadcast into the handshake (FE-10). Rebuild/restart of the launchd cluster is the remaining live gate. |
 
 ## Top risks to act on
 
@@ -36,11 +37,13 @@ cluster-wide and severities run high. Several entries are *evidence* gaps
    serializability holds" claim rests on deterministic in-crate tests. Build the
    harness; it also gates removal of the CL-2 election-guard/snapshot-pusher
    safety nets.
-2. **CL-2 (RPN 160)** — election storms are mitigated by the `election_guard`
+2. **CL-16 (RPN 252 before mitigation)** — the same-host self-loop is covered by
+   focused tests but must be re-run on the launchd cluster before closure.
+3. **CL-2 (RPN 160)** — election storms are mitigated by the `election_guard`
    watchdog + `snapshot_pusher` + CheckQuorum. PreVote (the intended primary
    defense) is OFF until its transport lands (CL-15), so the guard is currently
    load-bearing, not a band-aid — keep it until both CL-15 and CL-1 close.
-3. **CL-4 / CL-5 (RPN 140 / 126)** — Accord recovery and the storage-apply seam are
+4. **CL-4 / CL-5 (RPN 140 / 126)** — Accord recovery and the storage-apply seam are
    the correctness-critical paths least covered by real-fault testing; prioritise
    them in the Jepsen workload set and add cross-DC failure cases.
 
@@ -56,3 +59,4 @@ cluster-wide and severities run high. Several entries are *evidence* gaps
   `leader_snapshot_push` (31), `accord_lwt_concurrent` (21), `accord_nemesis` (15),
   `recovery_scenarios` (13), `proptests`, `repair_fuzz` (7).
 - **Missing:** external Jepsen/Knossos/Elle history checking (CL-1).
+- `inbound_peer_reverse_address_{prefers_advertised_nonuniform_port,falls_back_when_advertisement_is_unusable}` (CL-16).

--- a/ferrosa-cluster/specs/overview.md
+++ b/ferrosa-cluster/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cluster
 status: implemented
-last_updated: 2026-07-03
+last_updated: 2026-08-07
 executive_summary: >
   The distribution layer that turns single-node ferrosa-storage engines into a
   cluster: Raft metadata consensus (openraft 0.9 fork with CheckQuorum; a PreVote
@@ -121,6 +121,11 @@ transactions before applying to storage at the agreed HLC timestamp. See
 6. **Membership mutates four stores atomically.** `MembershipChanger` keeps the
    Raft state machine, openraft voter set, network node-map, and peer table in
    sync; a partial change is an error, not a silent skew.
+7. **Reverse dialing uses the peer's canonical endpoint.** An inbound socket's
+   source port is ephemeral. When the handshake advertises an internode
+   host/port, `peer_events` resolves and uses it for the reverse pool and
+   `connected_peers`; only legacy peers without a usable advertisement fall back
+   to the observed IP plus the local internode port.
 
 ## Correctness evidence (be honest)
 

--- a/ferrosa-cluster/specs/roadmap.md
+++ b/ferrosa-cluster/specs/roadmap.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cluster
 doc: roadmap
-last_updated: 2026-07-17
+last_updated: 2026-08-07
 ---
 
 # ferrosa-cluster — Roadmap
@@ -10,6 +10,14 @@ Sourced from the FMEA gaps ([fmea.md](fmea.md)), in-code deprecation markers,
 reference/decision specs, and the dependency/usage review. Ordered by value.
 
 ## Recently addressed
+
+- **Same-host cluster reverse-address collapse (CL-16).** Live launchd evidence
+  showed node3 recovering a three-member ring whose three addresses all pointed
+  at node3's `:17002`; node1/node2 consequently stayed in pair mode. Inbound
+  peer handling now prefers the handshake-advertised endpoint, including its
+  distinct port, and falls back compatibly for older peers. Focused selection +
+  fallback tests are green; rebuilding the live launchd cluster remains the
+  closure gate.
 
 - **Paged-scan fail-loud completion contract (t_a0f922a3 bug #2).** The N-way
   merge concludes a scan complete once every source stream ends; that inference

--- a/ferrosa-cluster/src/controller/peer_events.rs
+++ b/ferrosa-cluster/src/controller/peer_events.rs
@@ -1,5 +1,6 @@
 //! PeerEventListener and InboundPeerCallback trait implementations.
 
+use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
 use ferrosa_net::peer::PeerEventListener;
@@ -31,6 +32,16 @@ pub(super) fn track_connected_peer(
         peers.remove(0);
     }
     peers.push((host_id, addr));
+}
+
+pub(super) fn resolve_inbound_reverse_addr(
+    observed_addr: std::net::SocketAddr,
+    local_internode_port: u16,
+    internode_broadcast: Option<&str>,
+) -> std::net::SocketAddr {
+    internode_broadcast
+        .and_then(|addr| addr.trim().to_socket_addrs().ok()?.next())
+        .unwrap_or_else(|| std::net::SocketAddr::new(observed_addr.ip(), local_internode_port))
 }
 
 #[cfg(test)]
@@ -361,7 +372,11 @@ impl InboundPeerCallback for ModeController {
         internode_broadcast: Option<String>,
     ) {
         let (host_id, addr) = peer_id;
-        let reverse_addr = std::net::SocketAddr::new(addr.ip(), self.net_config.bind_addr.port());
+        let reverse_addr = resolve_inbound_reverse_addr(
+            addr,
+            self.net_config.bind_addr.port(),
+            internode_broadcast.as_deref(),
+        );
         tracing::info!(peer = %host_id, %addr, ?cql_broadcast, ?internode_broadcast, "inbound peer connected");
 
         // Store the peer's CQL broadcast address (from handshake) in PeerManager

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -706,6 +706,42 @@ fn inbound_peer_address_change_refreshes_live_outbound_pool() {
 }
 
 #[test]
+fn inbound_peer_reverse_address_prefers_advertised_nonuniform_port() {
+    let observed_ephemeral = "127.0.0.1:54198".parse().unwrap();
+
+    let reverse_addr = super::peer_events::resolve_inbound_reverse_addr(
+        observed_ephemeral,
+        17002,
+        Some("127.0.0.1:17000"),
+    );
+
+    assert_eq!(
+        reverse_addr,
+        "127.0.0.1:17000".parse().unwrap(),
+        "same-host clusters may assign a distinct internode port to every node; the peer's advertised endpoint must win over the receiver's port"
+    );
+}
+
+#[test]
+fn inbound_peer_reverse_address_falls_back_when_advertisement_is_unusable() {
+    let observed_ephemeral = "10.89.1.174:54198".parse().unwrap();
+    let expected = "10.89.1.174:7000".parse().unwrap();
+
+    assert_eq!(
+        super::peer_events::resolve_inbound_reverse_addr(observed_ephemeral, 7000, None),
+        expected,
+    );
+    assert_eq!(
+        super::peer_events::resolve_inbound_reverse_addr(
+            observed_ephemeral,
+            7000,
+            Some("not a valid endpoint"),
+        ),
+        expected,
+    );
+}
+
+#[test]
 fn stale_inbound_refresh_cannot_overwrite_newer_peer_address() {
     assert!(
         super::peer_events::should_install_refreshed_outbound_peer(

--- a/ferrosa/README.md
+++ b/ferrosa/README.md
@@ -40,7 +40,7 @@ apply when neither source sets the listener.
 
 | Listener | Default bind | Owning crate | Enable / config |
 |----------|--------------|--------------|-----------------|
-| Internode RPC | `0.0.0.0:17000` | `ferrosa-net` | `FERROSA_INTERNODE_BIND` / `[internode].bind` — note **17000**, not Cassandra's 7000 (BUG-001: 7000 collides with macOS ControlCenter) |
+| Internode RPC | `0.0.0.0:17000` | `ferrosa-net` | bind: `FERROSA_INTERNODE_BIND` / `[internode].bind`; advertised endpoint: `FERROSA_INTERNODE_BROADCAST` / `[internode].broadcast`. The exact advertised host/port is preserved for peer handshakes, including same-host clusters whose nodes use different ports. Note **17000**, not Cassandra's 7000 (BUG-001: 7000 collides with macOS ControlCenter). |
 | CQL native v5 | `127.0.0.1:9042` | `ferrosa-cql` | `FERROSA_CQL_BIND` / `[cql].bind` |
 | Postgres wire | `127.0.0.1:5432` | `ferrosa-postgres` | `FERROSA_POSTGRES_BIND` / `[postgres].bind` — always started; query execution is a fail-loud stub until the relational engine lands |
 | Arrow Flight (gRPC) | `127.0.0.1:8815` | `ferrosa-flight` | **`--features flight`** + `FERROSA_FLIGHT_BIND` / `[flight].bind`; per-RPC signed bearer tokens |
@@ -61,7 +61,7 @@ cluster view, the `SharedState` before the CQL/Flight servers). See
 3. **host_id** — load/generate/validate `{data_dir}/host_id` (`classify_host_id_state`: loaded / override / empty-regenerated / invalid-regenerated / generated-new — each path logs a breadcrumb, BUG-008).
 4. **StorageEngine** — `open()` (replay commit log) if segments exist, else `new()`; probe S3 CAS; **attach `CdcBus`** (capacity 1024) to the commit log; register system tables; replay pending S3 uploads.
 5. **Schema** — `Schema::new` (composes audit sinks); seed default roles if auth enabled; restore schema from local `schema.json` → S3 bootstrap → fresh; re-register secondary indexes, UDTs, UDFs, role permissions from `system_schema.*`; replay pending commit-log mutations.
-6. **ModeController** — `ClusterConfig`/`NetConfig` (with TOML overrides, BUG-006); build the `HandlerRegistry` (ping, pair-catchup, mutation/truncate forward, three repair handlers); construct controller in standalone mode.
+6. **ModeController** — `ClusterConfig`/`NetConfig` (with TOML overrides, BUG-006); preserve `[internode].broadcast` as both the resolved local address and the raw peer-handshake advertisement; build the `HandlerRegistry` (ping, pair-catchup, mutation/truncate forward, three repair handlers); construct controller in standalone mode.
 7. **PeerManager** — wire as `ModeController`'s `PeerEventListener`; start the heartbeat loop; spawn the self-heal controller with a **live** peer-health probe.
 8. **Internode RPC** (`:17000`) — `RpcServer::start_and_get_addr`.
 9. **CQL server** (`:9042`) — build `SharedState` (`SessionCore` + Accord HLC + prepared cache + observability trackers + virtual tables) and `start_background`.
@@ -108,6 +108,7 @@ flat under tight cgroups; override with `MALLOC_CONF`).
 | `FERROSA_CONFIG` | TOML config path (default `/etc/ferrosa/ferrosa.toml`) |
 | `FERROSA_DATA_DIR` | data directory (default `/var/lib/ferrosa`) — holds `host_id`, `schema.json`, commit log, hints |
 | `FERROSA_HOST_ID` | authoritative host-id override (wins over disk) |
+| `FERROSA_INTERNODE_BROADCAST` | host/port advertised during internode handshakes; file equivalent `[internode].broadcast` is authoritative and preserves the exact endpoint |
 | `FERROSA_AUTH_ENABLED` | single source of truth for CQL role auth; `[cql].auth_enabled` is authoritative when configured |
 | `FERROSA_AUTH_DISABLED` | **deprecated** direct override — honored with a warning |
 | `FERROSA_SEED` | comma-separated seed peers (`host:port`, DNS-resolved) |

--- a/ferrosa/specs/data-flow.md
+++ b/ferrosa/specs/data-flow.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa
 doc: data-flow
-last_updated: 2026-06-19
+last_updated: 2026-08-07
 ---
 
 # ferrosa — Startup & Composition Data Flow
@@ -26,7 +26,8 @@ sequenceDiagram
     participant Front as front-end listeners
 
     Main->>Main: init tracing (non-blocking; OTel if enabled)
-    Main->>Cfg: load FERROSA_CONFIG TOML (env wins)
+    Main->>Cfg: load FERROSA_CONFIG TOML (file wins)
+    Cfg->>Cfg: preserve internode broadcast host/port for handshake
     Main->>Main: load/generate host_id (classify state)
     Main->>Store: open() replay commitlog OR new()
     Main->>Store: probe S3 CAS; register system tables
@@ -124,8 +125,10 @@ runtimes keeps bulk CQL writes from starving Raft heartbeats.
 
 ## Notes
 
-- **Config precedence** at every resolver: env var, then TOML
-  (`/etc/ferrosa/ferrosa.toml`), then hard default.
+- **Config precedence** at every resolver: TOML
+  (`/etc/ferrosa/ferrosa.toml`), then environment variable, then hard default.
+  `[internode].broadcast` retains both its resolved socket and exact configured
+  host/port; the latter is sent in peer handshakes.
 - **Auth flag** (`auth_disabled`) is derived once from
   `FERROSA_AUTH_ENABLED` / `[cql].auth_enabled` and threaded into CQL, web,
   graph HTTP, and Bolt so the kill-switch is uniform.

--- a/ferrosa/specs/fmea.md
+++ b/ferrosa/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa
 doc: fmea
-last_updated: 2026-06-19
+last_updated: 2026-08-07
 ---
 
 # ferrosa — FMEA / Known Issues
@@ -22,14 +22,18 @@ own their own internal FMEAs.
 | FE-7 | **Shutdown timeout drops un-flushed data.** The 30 s graceful drain (`mode_controller.shutdown` → internode drain → memtable flush → schema persist) can exceed the window under heavy flush/S3 load. | Memtables not flushed ⇒ data loss on restart for anything not yet in an SSTable or commit log. | 8 | 2 | 5 | 80 | SIGTERM is handled (not just SIGINT) so container stops drain; timeout logs "shutdown timed out after 30s". **Gap:** the timeout is fixed and the partial-flush case is not surfaced as a metric. |
 | FE-8 | **S3 bootstrap / index-UDT-UDF replay failures are non-fatal.** On cold start, schema bootstrap and the `system_schema.*` re-registration steps log a WARN and continue on error. | A node can come up "fresh" or missing secondary indexes / UDTs / UDFs that exist in S3, serving incomplete schema without crashing. | 7 | 3 | 6 | 126 | Each step logs the failure with table/keyspace context; designed as best-effort with local→S3→fresh priority. **Gap:** no readiness gate distinguishes "fresh by design" from "bootstrap failed". |
 | FE-9 | **Maintenance-loop sub-task panics swallowed.** Flush/S3-sync run on detached `std::thread`s; the schema-sync path `continue`s on flush failure to avoid persisting schema ahead of data. | A persistently failing flush silently stops schema persistence; a panicked sync thread is logged but the loop continues. | 6 | 3 | 6 | 108 | Failures are logged per tick; the "skip schema persist if flush failed" guard is correct fail-loud-ish behavior. **Gap:** no escalation/metric if a tick keeps failing. |
+| FE-10 | **TOML internode broadcast omitted from peer handshake.** `[internode].broadcast` updated `broadcast_addr` but left `internode_broadcast=None`; same-host nodes using distinct internode ports therefore could not advertise their canonical reverse-dial endpoint. | The cluster seed substitutes its own port for inbound peers, routes multiple host IDs back to itself, and reports successful invites while joiners remain in pair mode. | 9 | 4 | 7 | 252 | **Fixed in code, live re-verification pending (2026-08-07):** `apply_internode_toml_overrides` preserves the exact TOML value after validation. Regression `apply_internode_toml_overrides_sets_other_fields` asserts both resolved and advertised forms. The cluster-side reverse-address selection is tracked as CL-16. |
 
 ## Top risks to act on
 
-1. **FE-1 (RPN 196) — partial boot.** A failed bind of an *enabled* front-end
+1. **FE-10 (RPN 252) — TOML internode advertisement.** The focused regression is
+   green, but the launchd cluster must be rebuilt once with this binary to prove
+   all three nodes leave pair mode and recover one Raft group.
+2. **FE-1 (RPN 196) — partial boot.** A failed bind of an *enabled* front-end
    should fail loud (crash or fail `/readyz`), not log-and-continue. Today a node
    can serve CQL while its Postgres/Flight/graph listener never came up, with no
    health distinction from "disabled."
-2. **FE-3 (RPN 135) — auth resolves open by default.** The permissive default is
+3. **FE-3 (RPN 135) — auth resolves open by default.** The permissive default is
    silent; in production mode the composition root should default closed or
    refuse to start without an explicit auth decision, since the same flag also
    opens the admin REST surface.
@@ -41,3 +45,5 @@ own their own internal FMEAs.
 - `/readyz` (un-authenticated) and `/metrics` on the web console.
 - Per-step structured WARN/ERROR logs across bootstrap, replay, and shutdown.
 - `ferrosa-net` `default_bind_port_is_not_7000` guard (FE-6).
+- `apply_internode_toml_overrides_sets_other_fields` pins TOML broadcast
+  propagation into the handshake advertisement (FE-10).

--- a/ferrosa/specs/overview.md
+++ b/ferrosa/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa
 status: implemented
-last_updated: 2026-06-19
+last_updated: 2026-08-07
 executive_summary: >
   The top-level binary and composition root. It constructs one StorageEngine,
   one Schema, one ModeController, one PeerManager, and one CdcBus, then wires
@@ -75,7 +75,9 @@ replication uniform.
 3. **Config precedence is TOML → env → default, everywhere.** All resolvers
    (`config_val`, `apply_internode_toml_overrides`, `resolve_graph_enabled`,
    `resolve_auth_enabled_toml`) honor this order; BUG-006 was TOML being ignored
-   for internode/graph/auth.
+   for internode/graph/auth. `[internode].broadcast` updates the resolved socket
+   and preserves the exact configured host/port in `NetConfig::internode_broadcast`
+   so the internode handshake does not lose a peer's distinct listening port.
 4. **Auth is driven from one switch.** `FERROSA_AUTH_ENABLED` (or
    `[cql].auth_enabled`) is the source of truth; `resolve_auth_disabled` derives
    the CQL/web/graph/Bolt `auth_disabled` flag. `FERROSA_AUTH_DISABLED` is a

--- a/ferrosa/specs/roadmap.md
+++ b/ferrosa/specs/roadmap.md
@@ -1,13 +1,22 @@
 ---
 crate: ferrosa
 doc: roadmap
-last_updated: 2026-06-19
+last_updated: 2026-08-07
 ---
 
 # ferrosa — Roadmap
 
 Sourced from the FMEA gaps ([fmea.md](fmea.md)), the in-code `TODO`
 (`web/api.rs:475`), and the composition review of `main.rs`.
+
+## Recently addressed
+
+- **Preserve TOML internode broadcast advertisements (FMEA FE-10).** A launchd
+  three-node cluster used correct, distinct `[internode].broadcast` ports, but
+  the binary populated only the resolved `broadcast_addr`; handshakes therefore
+  advertised `None`. The loader now preserves the exact configured endpoint.
+  Focused unit coverage is green; rebuilding the live cluster is the remaining
+  verification gate.
 
 ## Now (highest value)
 

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -285,7 +285,10 @@ fn apply_internode_toml_overrides(
     }
     if let Some(v) = internode.get("broadcast").and_then(|v| v.as_str()) {
         match v.parse() {
-            Ok(addr) => cfg.broadcast_addr = addr,
+            Ok(addr) => {
+                cfg.broadcast_addr = addr;
+                cfg.internode_broadcast = Some(v.to_string());
+            }
             Err(e) => tracing::warn!(value = %v, %e, "ignoring invalid [internode].broadcast"),
         }
     }
@@ -2862,6 +2865,7 @@ mod tests {
         apply_internode_toml_overrides(&mut cfg, &toml);
         assert_eq!(cfg.bind_addr, "127.0.0.1:18003".parse().unwrap());
         assert_eq!(cfg.broadcast_addr, "10.0.0.1:18003".parse().unwrap());
+        assert_eq!(cfg.internode_broadcast.as_deref(), Some("10.0.0.1:18003"));
         assert_eq!(cfg.cluster_name, "team-cluster");
         assert_eq!(cfg.psk.as_deref(), Some("abc"));
     }

--- a/specs/in-process/bug-internode-broadcast-addr-frozen-to-startup-ip.md
+++ b/specs/in-process/bug-internode-broadcast-addr-frozen-to-startup-ip.md
@@ -1,6 +1,6 @@
 # BUG: Internode broadcast address frozen to startup IP — stale Raft membership after container IP churn
 
-**Status**: Broadcast-hostname fix **merged** (PR #86, advertise + re-resolve the broadcast hostname — option 1). Follow-up for the lane-reconnect path — lanes reconnecting to a stale resolved IP instead of the advertised hostname — fixed in **PR #94** (`ferrosa-net` `pick_reconnect_host`, unit-tested). **Live-cluster verification still pending** on a real podman cluster; should move to `specs/verified-test-plan/` once verified, then to `archive/`. (2026-06-09)
+**Status**: **Reopened / in progress (2026-08-07).** PR #86 fixed environment-variable hostname advertisement and PR #94 fixed lane reconnects, but a launchd-managed same-host cluster exposed two uncovered paths: `[internode].broadcast` updated only the resolved socket and was not advertised in the handshake, while inbound reverse dialing assumed every peer used the receiver's internode port. Focused RED/GREEN tests now cover both boundaries; live-cluster verification remains pending.
 **Component**: `ferrosa-net` (config), `ferrosa-cluster` (Raft membership / internode routing)
 **Severity**: High — silent read-path degradation in any environment where node IPs change across restarts (podman/docker default networking, k8s pods, DHCP).
 **Found**: 2026-06-05, debugging a live `ferrosa-memory` 3-node dev cluster.
@@ -105,7 +105,25 @@ a stale-membership read should surface as an error, not a 0 count.
 2. `podman compose down && up` (or otherwise recreate containers) several times so each node gets a new IP.
 3. Run a distributed index/range read (e.g. an ANN search or full entity range scan).
 4. Observe `Bulk lane timeout` / `ChannelClosedBeforeDone` against a stale `N.N.N.N:7000` address, and
-   under-reported counts, while `nodetool`-style health stays green.
+  under-reported counts, while `nodetool`-style health stays green.
+
+### 2026-08-07 launchd recurrence: all identities routed to the seed
+
+A three-node same-host cluster used distinct internode ports (`17000`, `17001`,
+`17002`) and valid per-node `[internode].broadcast` values. After restart, node1
+and node2 remained `pair/primary` while node3 recovered the three-member Raft
+snapshot and became the sole leader. Node3's ring stored `127.0.0.1:17002` for
+all three host IDs, so its successful-looking `ClusterInvite delivered` RPCs
+looped back to node3 instead of reaching node1/node2.
+
+The startup logs tied that topology collapse to two implementation gaps:
+
+1. inbound handshakes logged `internode_broadcast=None` even though TOML set it;
+2. the fallback reverse address combined the inbound IP with node3's own
+   internode port, which is valid only when every peer uses the same port.
+
+The launchd plist correctly selected a distinct TOML file per node. This was not
+a launchd configuration or startup-order error.
 
 ## Operational mitigation (not a code workaround)
 


### PR DESCRIPTION
## Summary

- Fix three-node bootstrap on same-host deployments where each node uses a distinct internode port. Only discovered after altering boot topology to native vs containerized deploy. 
- Preserve `[internode].broadcast` as the canonical endpoint advertised in peer handshakes.
- Prefer that advertised endpoint for reverse pools and cluster invite targets instead of substituting the seed node's local port.

## Root Cause

The launchd configuration correctly assigned ports `17000`, `17001`, and `17002`, but two code paths collapsed every peer identity onto the seed at `127.0.0.1:17002`:

1. TOML broadcast parsing updated only the resolved `broadcast_addr`, leaving the raw handshake advertisement unset.
2. Inbound peer handling ignored the advertisement and combined the observed peer IP with the receiver's own internode port.

Cluster invitations consequently looped back to the seed, leaving node1/node2 in pair mode while node3 recovered Raft state as a one-node leader.

## Changes

- Propagate validated TOML internode broadcast values into `NetConfig::internode_broadcast`.
- Resolve inbound reverse addresses from the handshake advertisement, with the prior observed-IP/local-port behavior retained as a compatibility fallback.
- Add regressions for distinct same-host ports and absent/invalid advertisements.
- Update the affected crate documentation, FMEAs, roadmaps, and the reopened broadcast-address work item.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] P0 OOM and unbounded-read guards
- [x] CI-equivalent workspace tests: all non-ASC tests passed with the CI skip list; the ASC test passed after building and exporting CI's pinned bundle
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
- [x] Three-node formation integration suite: 4 passed
- [ ] Rebuild and restart the launchd-managed cluster, then verify one three-voter Raft group and three distinct ring endpoints

## Review Notes

The currently running launchd cluster remains on the old binary and is intentionally unchanged. Live restart validation is the final operational gate after review.