### PR TITLE
fix(jepsen): pin coordinator from workload session

### DIFF
--- a/ferrosa-jepsen/README.md
+++ b/ferrosa-jepsen/README.md
@@ -59,9 +59,11 @@ graph. It calls `ferrosa-sim` for the simulator-backed endurance path.
     Elle result to `None` (not wired to a running checker).
 - **Drivers** (`driver/`) — `rust_driver` connects to a real cluster via the
   `scylla` driver (`phase1`, the only wired driver). Its single-coordinator
-  policy carries a stable host ID from the discovery session so the workload
-  session resolves the coordinator through its own topology and connection
-  pools. `ContainerDriver` shells out to per-language Docker images
+  policy first lets the workload session discover topology, selects a stable
+  host ID from that same session's metadata, then remaps that session's
+  execution profile to the selected coordinator. This preserves transaction
+  affinity without handing a possibly absent node identity across sessions.
+  `ContainerDriver` shells out to per-language Docker images
   (Python/Go/Node/Java/C#) — `phase2`, not used by the default tier resolution.
 - **Cluster backends**:
   - **Docker Compose / external contacts** (`docker_provision.rs`) — the

--- a/ferrosa-jepsen/specs/fmea.md
+++ b/ferrosa-jepsen/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-jepsen
 doc: fmea
-last_updated: 2026-08-08
+last_updated: 2026-08-09
 ---
 
 # ferrosa-jepsen — Failure Modes and Effects Analysis
@@ -10,7 +10,7 @@ last_updated: 2026-08-08
 |---|---|---|---|
 | T3 has no live CQL contact points | A multi-DC test could appear to run against `MockCqlSession`. | `Tier::MultiDc` returns an error before the combination starts. | Require exactly the topology's count of `FERROSA_TEST_CLUSTER_NODES`; do not provision a mock fallback for T3/T4. |
 | Port-mapped nodes advertise their container port | The Scylla driver discovers addresses it cannot dial and loses its pool. | Real T3 bank setup fails while creating the keyspace. | Each T3 node sets `FERROSA_CQL_BROADCAST` to its distinct host-mapped port; `t3_topology` guards all six mappings. |
-| Driver reuses a coordinator node object from a discarded probe session | Schema agreement cannot find the required coordinator in the workload session's connection pools, so setup fails before operations begin. | Setup reports `required for schema agreement is not present in connection pool`; a unit regression pins the identifier variant. | Carry only the stable host ID across sessions; the workload session resolves it through its own metadata and pools. |
+| Driver selects a coordinator from a discarded probe session | The workload session's metadata may not contain that host ID, so its single-target policy returns an empty plan and setup fails before operations begin. | Setup reports `Load balancing policy returned an empty plan`; unit regressions require selection from destination metadata and loud failure for an empty node set. | Build one workload session with the normal policy, select a deterministic host ID from that session's metadata, then remap the same session's execution profile to the single-target policy. |
 | Topology-aware CQL preflight answers through the wrong T3 process | A client pointed at six contact endpoints can load-balance `system.local` queries onto fewer peers, falsely reporting duplicate/missing nodes; independently random empty-schema UUIDs can falsely report disagreement before DDL. | Workflow contract rejects `cqlsh` topology validation, pins all six CQL/HTTP port pairs, and requires the native-protocol handshake. | Require `OPTIONS` → `SUPPORTED` directly on every CQL socket. Poll `/health` and `/api/cluster/status` directly on every process, require its configured host ID and cluster mode, then require `/api/cluster/ring` on every process to show exactly its DC's three `Normal` members. Let workload DDL exercise schema agreement. |
 | Live-infrastructure tests enter the default test target | Plain `cargo test` fails because an intentionally loud missing-infrastructure assertion runs without opt-in. | `live_infra_contract` enumerates live-only targets and individual tests. | Gate them with the `live-infra-tests` feature while preserving panic-on-missing-infrastructure after opt-in. |
 | WAN nemesis is selected but never executed | A report labels a faulted run that only tested normal workload behavior. | Orchestrator unit test records inject/heal calls; real runs fail on missing executor. | Run the selected non-`noop` action concurrently with workload and propagate injection/heal failures. |

--- a/ferrosa-jepsen/specs/overview.md
+++ b/ferrosa-jepsen/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-jepsen
 status: implemented
-last_updated: 2026-08-08
+last_updated: 2026-08-09
 executive_summary: >
   Jepsen-style distributed correctness harness for Ferrosa. Generates
   concurrent workloads, injects faults (nemeses) over SSH, records an operation
@@ -37,7 +37,7 @@ SSH (`russh`) for fault injection, and to the simulator via `ferrosa-sim`.
 | `workload` (`src/workload/`) | `Workload` trait + registry: `register`, `bank`, 16 `lwt-*`, `forward-probe`, `membership-churn`, `late-join-flood`. |
 | `chaos` (`src/chaos/`) | `NemesisAction` trait + registry: network, process, clock, disk, WAN/cross-DC, composed nemeses. WAN actions execute via SSH, Fly SSH, or `container_runtime() exec` (`iptables`/`tc`/signals). |
 | `checker` (`src/checker/`) | Linearizability (native WGL backtracking), membership invariants, Knossos (subprocess), Elle (stub). |
-| `driver` (`src/driver/`) | `rust_driver` (real `scylla` connection, pinned by host ID resolved in the workload session's own topology/pools); `ContainerDriver` (per-language Docker images, not in default tiers). |
+| `driver` (`src/driver/`) | `rust_driver` (real `scylla` connection; after its workload session discovers topology, the same session is pinned by one of its own host IDs); `ContainerDriver` (per-language Docker images, not in default tiers). |
 | `docker_provision` (`src/docker_provision.rs`) | **Wired** backend: managed Docker Compose for up to three nodes and non-owning external contact points for T3/Fly. `container_runtime()` selects a usable Docker/Podman daemon, not merely an installed CLI. |
 | `firecracker` / `cluster` | microVM provisioning primitives — present but **not wired** into the run path. |
 | `flyio` (`src/flyio.rs`) | Fly.io machine management primitives. A caller-provisioned Fly T3/T4 becomes a real run via `FERROSA_TEST_CLUSTER_NODES`; `FERROSA_JEPSEN_FLY_APP` plus ordered machine IDs selects Fly-SSH WAN faults. |
@@ -133,6 +133,10 @@ written history; Elle is type-only (`elle_result = None`).
    mode, and requires every node to see its DC's exact three `Normal` ring
    members. Schema agreement is exercised after Jepsen setup creates schema;
    random empty-schema UUIDs are not a readiness condition.
+8. **Coordinator affinity is session-local.** The workload session first
+   discovers topology using the normal policy, selects a deterministic host ID
+   from its own metadata, and then remaps its execution profile to that node.
+   A disposable probe session must not choose the destination session's pin.
 
 ## Position in the dependency graph
 

--- a/ferrosa-jepsen/src/cql_session.rs
+++ b/ferrosa-jepsen/src/cql_session.rs
@@ -1,3 +1,9 @@
+//! CQL transport for Jepsen workloads with stable coordinator affinity.
+//! Correctness: every transaction statement uses one coordinator selected from
+//! the executing session's own metadata, and CQL results preserve row values.
+//! Last revised: 2026-08-08
+//! Last changed: Select the pinned coordinator from the destination session.
+
 use std::num::NonZeroUsize;
 
 use anyhow::{Context, Result};
@@ -24,6 +30,14 @@ fn coordinator_identifier(host_id: Uuid) -> NodeIdentifier {
     NodeIdentifier::HostId(host_id)
 }
 
+fn coordinator_host_id<'a>(host_ids: impl IntoIterator<Item = &'a Uuid>) -> Result<Uuid> {
+    host_ids
+        .into_iter()
+        .copied()
+        .min()
+        .context("cluster reports no known nodes to pin to")
+}
+
 impl ScyllaCqlSession {
     /// Connect to the cluster at the given contact points (e.g. `["127.0.0.1:9042"]`).
     ///
@@ -33,50 +47,47 @@ impl ScyllaCqlSession {
     /// would scatter the statements across coordinators and the buffered DML would
     /// never reach the `BEGIN`'s connection (silently non-atomic).
     ///
-    /// Pinning uses the stable host ID discovered by a short-lived probe session.
-    /// The pinned session resolves that ID through its own cluster metadata and
-    /// connection pools. Reusing the probe session's live `Node` object would
-    /// bypass that lookup and can make schema agreement search for a coordinator
-    /// that is absent from the pinned session's pools. The full topology stays
-    /// connected (`known_nodes` + `PoolSize(1)`); the pinned node forwards writes
-    /// as the Accord coordinator, so cross-shard fan-out still happens.
+    /// Pinning uses a stable host ID discovered from the destination session's
+    /// own cluster metadata. Selecting it from a separate probe session is not
+    /// safe: topology discovery can yield different node sets, leaving the
+    /// destination policy with an ID it cannot resolve and an empty query plan.
+    /// The full topology stays connected (`known_nodes` + `PoolSize(1)`); the
+    /// pinned node forwards writes as the Accord coordinator, so cross-shard
+    /// fan-out still happens.
     pub async fn connect(contact_points: &[String]) -> Result<Self> {
         assert!(
             !contact_points.is_empty(),
             "contact_points must not be empty"
         );
 
-        // Phase 1 — probe with a normal session to learn a live node's host_id.
-        let probe = SessionBuilder::new()
-            .known_nodes(contact_points)
-            .build()
-            .await
-            .context("failed to connect to CQL cluster (probe)")?;
-        let target_host_id = probe
-            .get_cluster_state()
-            .get_nodes_info()
-            .iter()
-            .min_by_key(|n| n.host_id) // deterministic across topology refreshes
-            .map(|n| n.host_id)
-            .context("cluster reports no known nodes to pin to")?;
-        drop(probe);
-
-        // Phase 2 — pin all queries to that node (one connection ⇒ transaction
-        // affinity), keeping the full topology connected for reachability.
-        let policy =
-            SingleTargetLoadBalancingPolicy::new(coordinator_identifier(target_host_id), None);
-        let profile = ExecutionProfile::builder()
-            .load_balancing_policy(policy)
-            .build();
+        // Build with the normal policy so topology discovery can complete, then
+        // remap the same session's profile to a coordinator that its metadata
+        // can resolve. ExecutionProfileHandle remapping is observed by the
+        // session because the builder receives a clone of this handle.
+        let mut profile_handle = ExecutionProfile::builder().build().into_handle();
         let session = SessionBuilder::new()
             .known_nodes(contact_points)
-            .default_execution_profile_handle(profile.into_handle())
+            .default_execution_profile_handle(profile_handle.clone())
             .pool_size(PoolSize::PerHost(
                 NonZeroUsize::new(1).expect("1 is nonzero"),
             ))
             .build()
             .await
-            .context("failed to connect to CQL cluster (pinned)")?;
+            .context("failed to connect to CQL cluster")?;
+        let target_host_id = coordinator_host_id(
+            session
+                .get_cluster_state()
+                .get_nodes_info()
+                .iter()
+                .map(|node| &node.host_id),
+        )?;
+
+        let policy =
+            SingleTargetLoadBalancingPolicy::new(coordinator_identifier(target_host_id), None);
+        let profile = ExecutionProfile::builder()
+            .load_balancing_policy(policy)
+            .build();
+        profile_handle.map_to_another_profile(profile);
         Ok(Self { session })
     }
 }
@@ -163,13 +174,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pinning_uses_a_host_id_resolved_by_the_destination_session() {
+    fn pinning_uses_a_host_id_identifier() {
         let host_id = Uuid::new_v4();
 
         match coordinator_identifier(host_id) {
             NodeIdentifier::HostId(actual) => assert_eq!(actual, host_id),
             other => panic!("expected host-ID coordinator pin, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn pinning_selects_a_coordinator_from_destination_metadata() {
+        let destination_host_ids = [
+            Uuid::parse_str("00000000-0000-0000-0000-000000000020").unwrap(),
+            Uuid::parse_str("00000000-0000-0000-0000-000000000010").unwrap(),
+        ];
+
+        let selected = coordinator_host_id(destination_host_ids.iter()).unwrap();
+
+        assert_eq!(selected, destination_host_ids[1]);
+    }
+
+    #[test]
+    fn pinning_fails_loudly_when_destination_metadata_is_empty() {
+        let destination_host_ids: [Uuid; 0] = [];
+
+        let error = coordinator_host_id(destination_host_ids.iter()).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "cluster reports no known nodes to pin to"
+        );
     }
 
     /// Verify that ScyllaCqlSession connects to a real cluster and can execute a


### PR DESCRIPTION
## Executive Summary

Fix Nightly Multi-DC Jepsen failing before workload execution with `Load balancing policy returned an empty plan`.

The driver previously selected a coordinator host ID from a temporary probe session, then installed that ID into a different workload session. With six port-mapped CQL endpoints, the second session can expose different metadata, leaving the single-target policy with no matching host and therefore an empty query plan.

This change creates the workload session under the normal policy, selects a deterministic coordinator from that same session metadata, and remaps its shared execution profile to the single-target policy. Transaction affinity is preserved without carrying host identity across session boundaries.

## Changes

- Build and pin the coordinator within one CQL session.
- Fail loudly if destination metadata contains no hosts.
- Add regression tests for session-local coordinator selection and empty metadata.
- Update the ferrosa-jepsen README, architecture overview, and FMEA.

## Verification

- [x] Merge-queue CI for PR #332 passed all 10 jobs on `8728f11f`.
- [x] Reproduced issue #333 by manually dispatching Nightly Multi-DC Jepsen on that exact SHA.
- [x] Unit tests: all 5 `cql_session` tests pass.
- [x] Workflow contract tests: all 5 pass.
- [x] Workspace CI-mirror tests pass.
- [x] `cargo fmt --check` passes.
- [x] Workspace clippy with all targets and all features passes with `-D warnings`.
- [x] Workspace docs pass with `RUSTDOCFLAGS=-D warnings`.
- [x] Exact nightly package `v2026.08.09.0228` passes the formerly failing live path against an isolated six-node, two-DC cluster: CQL session creation, schema DDL, bank operations, and invariant check all pass.

A composed local nemesis run reaches CQL but cannot manipulate nftables under the Apple Podman VM (`Protocol not supported`), a documented platform limitation. The Linux GitHub runner remains the authoritative composed-nemesis environment.

Fixes #333