### PR TITLE
fix(ci): run cluster data-loss test from nightly image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --check
+      - name: Check Cluster Data Loss workflow contract
+        run: python3 -m unittest tests.ci.test_cluster_data_loss_workflow
 
   clippy:
     name: Clippy

--- a/.github/workflows/cluster-data-loss.yml
+++ b/.github/workflows/cluster-data-loss.yml
@@ -2,9 +2,9 @@ name: Cluster Data Loss Test
 
 on:
   # Only run on main merges and manual dispatch — NOT on every PR push.
-  # This workflow builds Docker images + runs a 3-node cluster test,
-  # consuming ~15 min of CI per run. Running on every push to a PR
-  # burned 1300+ minutes in one day.
+  # This workflow packages the nightly .deb into a runtime image and runs a
+  # 3-node cluster test. Running it on every PR push burned 1300+ minutes in
+  # one day.
   push:
     branches: [main]
     paths:
@@ -42,25 +42,37 @@ jobs:
           docker build -f tests/Dockerfile.nightly-deb -t ferrosa-nightly:latest tests/
           rm -f tests/ferrosa.deb
 
-      - name: Build Ferrosa image (fallback)
-        if: steps.nightly_deb.outputs.deb_path == ''
-        run: docker build -t ferrosa-nightly .
-
       - name: Start 3-node cluster
         env:
           FERROSA_NIGHTLY_IMAGE: ferrosa-nightly:latest
         run: |
           set -euo pipefail
-          docker compose -f tests/docker-compose.cluster.yml --profile trio up -d
+          docker compose -f tests/docker-compose.cluster.yml --profile trio up -d --no-build
           echo "Waiting for cluster formation..."
-          for i in $(seq 1 60); do
-            if docker compose -f tests/docker-compose.cluster.yml exec -T node1 \
-              bash -c 'echo > /dev/tcp/127.0.0.1/9042' 2>/dev/null; then
-              echo "CQL port ready after ${i}s"
+          deadline=$((SECONDS + 120))
+          ready=0
+          while (( SECONDS < deadline )); do
+            healthy=1
+            for node in node1 node2 node3; do
+              container_id="$(docker compose -f tests/docker-compose.cluster.yml ps -q "$node")"
+              status="$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null || true)"
+              if [[ "$status" != "healthy" ]]; then
+                healthy=0
+                break
+              fi
+            done
+            if (( healthy )); then
+              ready=1
+              echo "All cluster nodes are healthy after $((120 - (deadline - SECONDS)))s"
               break
             fi
-            sleep 1
+            sleep 2
           done
+          if (( ! ready )); then
+            echo "::error::Cluster did not become healthy within 120 seconds"
+            docker compose -f tests/docker-compose.cluster.yml ps
+            exit 1
+          fi
           # Extra wait for cluster formation + Raft election
           sleep 15
 

--- a/scripts/pre-push-mirror-ci.sh
+++ b/scripts/pre-push-mirror-ci.sh
@@ -32,6 +32,7 @@ fi
 # Tests gated by FERROSA_TEST_CONTAINERS / FERROSA_TEST_FIRECRACKER /
 # FERROSA_TEST_CLUSTER_NODES per CLAUDE.md test policy.
 SKIPS=(
+  --skip accord::perf_regression
   --skip batch_atomicity
   --skip pause_resume
   --skip recovery_coordinator
@@ -48,6 +49,17 @@ SKIPS=(
   --skip flush_2000
   --skip single_writer
   --skip write_flush_compact
+  --skip reads_never_panic_on_arbitrary_content
+  --skip corrupt_sstable_bytes_never_panic_never_oom
+  --skip peak_resident_readers_within_cap
+  --skip streaming_equals_single_pass
+  --skip bounded_fetch_reassembles_to_single_pass
+  --skip read_merge_is_lww_no_data_loss
+  --skip digest_walk_is_deterministic
+  --skip differential_oracle
+  --skip fly_multi_node_streaming_scan
+  --skip real_typed_edges_paged_scan_delivers_every_distinct_row
+  --skip count_range_metadata_merger_dedups_real_typed_edges_sstables
 )
 
 # `cargo nextest run` hangs on this workspace's lib targets on macOS

--- a/tests/ci/test_cluster_data_loss_workflow.py
+++ b/tests/ci/test_cluster_data_loss_workflow.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from pathlib import Path
 
@@ -6,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 CLUSTER_COMPOSE = ROOT / "tests" / "docker-compose.cluster.yml"
 WORKFLOW = ROOT / ".github" / "workflows" / "cluster-data-loss.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+PRE_PUSH_MIRROR = ROOT / "scripts" / "pre-push-mirror-ci.sh"
 
 
 def start_cluster_step() -> str:
@@ -21,6 +23,7 @@ class ClusterDataLossWorkflowTest(unittest.TestCase):
     # - [x] Readiness has a wall-clock deadline and fails with diagnostics.
     # - [x] Missing nightly artifacts cannot fall back to a source build.
     # - [x] The PR gate runs this regression suite.
+    # - [x] The local pre-push mirror uses the same exclusions as GitHub CI.
 
     def test_every_node_supports_the_nightly_image_override(self):
         compose = CLUSTER_COMPOSE.read_text(encoding="utf-8")
@@ -67,6 +70,17 @@ class ClusterDataLossWorkflowTest(unittest.TestCase):
             "python3 -m unittest tests.ci.test_cluster_data_loss_workflow",
             workflow,
         )
+
+    def test_pre_push_mirror_uses_the_same_test_exclusions_as_ci(self):
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        run_tests = workflow.split("- name: Run tests", 1)[1]
+        run_tests = run_tests.split("# ── Stage 2a", 1)[0]
+        pre_push = PRE_PUSH_MIRROR.read_text(encoding="utf-8")
+
+        ci_skips = set(re.findall(r"--skip ([A-Za-z0-9_:]+)", run_tests))
+        pre_push_skips = set(re.findall(r"--skip ([A-Za-z0-9_:]+)", pre_push))
+
+        self.assertSetEqual(ci_skips, pre_push_skips)
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_cluster_data_loss_workflow.py
+++ b/tests/ci/test_cluster_data_loss_workflow.py
@@ -1,0 +1,73 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CLUSTER_COMPOSE = ROOT / "tests" / "docker-compose.cluster.yml"
+WORKFLOW = ROOT / ".github" / "workflows" / "cluster-data-loss.yml"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def start_cluster_step() -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    step = workflow.split("- name: Start 3-node cluster", 1)[1]
+    return step.split("- name: Install Python test deps", 1)[0]
+
+
+class ClusterDataLossWorkflowTest(unittest.TestCase):
+    # Test list:
+    # - [x] Every Ferrosa node supports the nightly image override.
+    # - [x] Nightly cluster startup forbids source builds.
+    # - [x] Readiness has a wall-clock deadline and fails with diagnostics.
+    # - [x] Missing nightly artifacts cannot fall back to a source build.
+    # - [x] The PR gate runs this regression suite.
+
+    def test_every_node_supports_the_nightly_image_override(self):
+        compose = CLUSTER_COMPOSE.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            compose.count(
+                "image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-test-node:latest}"
+            ),
+            5,
+            "all trio and quint nodes must consume the pre-built nightly image when set",
+        )
+
+    def test_nightly_cluster_startup_forbids_source_builds(self):
+        start_step = start_cluster_step()
+
+        self.assertIn(
+            "docker compose -f tests/docker-compose.cluster.yml --profile trio up -d --no-build",
+            start_step,
+            "the packaged nightly regression must never compile the source checkout",
+        )
+
+    def test_cluster_readiness_has_a_deadline_and_fails_with_diagnostics(self):
+        start_step = start_cluster_step()
+
+        self.assertIn("deadline=$((SECONDS + 120))", start_step)
+        self.assertIn("while (( SECONDS < deadline )); do", start_step)
+        self.assertIn("for node in node1 node2 node3; do", start_step)
+        self.assertIn(".State.Health.Status", start_step)
+        self.assertIn('echo "::error::Cluster did not become healthy', start_step)
+        self.assertIn("docker compose -f tests/docker-compose.cluster.yml ps", start_step)
+        self.assertIn("exit 1", start_step)
+        self.assertNotIn("seq 1 60", start_step)
+
+    def test_missing_nightly_artifact_cannot_fall_back_to_a_source_build(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertNotIn("Build Ferrosa image (fallback)", workflow)
+        self.assertNotIn("docker build -t ferrosa-nightly .", workflow)
+
+    def test_pr_gate_runs_the_cluster_workflow_regression_suite(self):
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "python3 -m unittest tests.ci.test_cluster_data_loss_workflow",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/docker-compose.cluster.yml
+++ b/tests/docker-compose.cluster.yml
@@ -12,6 +12,10 @@
 #   # 5-node cluster
 #   docker compose -f tests/docker-compose.cluster.yml --profile quint up -d --build
 #
+#   # Run a pre-built image without compiling the source checkout
+#   FERROSA_NIGHTLY_IMAGE=ferrosa-nightly:latest \
+#     docker compose -f tests/docker-compose.cluster.yml --profile trio up -d --no-build
+#
 #   # Tear down
 #   docker compose -f tests/docker-compose.cluster.yml down -v --remove-orphans
 
@@ -76,7 +80,7 @@ services:
   # Node 1 — first seed; no FERROSA_SEED (it IS the seed)
   # ---------------------------------------------------------------------------
   node1:
-    image: ferrosa-test-node:latest
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-test-node:latest}
     build:
       context: ..
       dockerfile: Dockerfile
@@ -114,7 +118,7 @@ services:
   # Node 2
   # ---------------------------------------------------------------------------
   node2:
-    image: ferrosa-test-node:latest
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-test-node:latest}
     build:
       context: ..
       dockerfile: Dockerfile
@@ -153,7 +157,7 @@ services:
   # Node 3
   # ---------------------------------------------------------------------------
   node3:
-    image: ferrosa-test-node:latest
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-test-node:latest}
     build:
       context: ..
       dockerfile: Dockerfile
@@ -192,7 +196,7 @@ services:
   # Node 4 — quint profile only
   # ---------------------------------------------------------------------------
   node4:
-    image: ferrosa-test-node:latest
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-test-node:latest}
     build:
       context: ..
       dockerfile: Dockerfile
@@ -231,7 +235,7 @@ services:
   # Node 5 — quint profile only
   # ---------------------------------------------------------------------------
   node5:
-    image: ferrosa-test-node:latest
+    image: ${FERROSA_NIGHTLY_IMAGE:-ferrosa-test-node:latest}
     build:
       context: ..
       dockerfile: Dockerfile


### PR DESCRIPTION
## Executive Summary

- Run the Cluster Data Loss regression from the packaged nightly `.deb` image instead of recompiling the source checkout.
- Prevent Compose from silently falling back to a source build and timing out after 20 minutes.
- Make cluster readiness fail loudly and keep the local pre-push test mirror synchronized with GitHub CI.

## Root Cause

The workflow built `ferrosa-nightly:latest` and exported `FERROSA_NIGHTLY_IMAGE`, but `tests/docker-compose.cluster.yml` hard-coded `ferrosa-test-node:latest`. Compose could not pull that image and fell back to the root Dockerfile, leaving the job compiling Rust until GitHub cancelled it at the 20-minute job timeout.

## Changes

- Parameterize all five cluster-node images with `FERROSA_NIGHTLY_IMAGE`, retaining `ferrosa-test-node:latest` as the local default.
- Start the nightly cluster with `--no-build` and remove the source-build fallback.
- Poll all three node health checks with a 120-second wall-clock deadline and diagnostic failure output.
- Add six CI contract tests and run them in the PR Format job.
- Synchronize the local pre-push mirror's skip list with the GitHub test job.

## Test Plan

- [x] `python3 -m unittest tests.ci.test_cluster_data_loss_workflow`
- [x] `actionlint .github/workflows/cluster-data-loss.yml .github/workflows/ci.yml`
- [x] Render Compose with local and nightly image selection
- [x] Pre-push workspace test mirror
- [x] Pre-push all-target/all-feature Clippy with warnings denied
- [x] Pre-push format and P0 materialization audit
- [x] `cargo build --workspace --all-targets`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace`
