### PR TITLE
fix(sparql): separate the keyspace from the graph so bound-subject reads work

### DIFF
--- a/ferrosa-sparql/src/engine.rs
+++ b/ferrosa-sparql/src/engine.rs
@@ -308,7 +308,12 @@ impl SparqlEngine {
         // Ensure rdf_triples table exists for this keyspace.
         self.ensure_table_registered(graph);
 
-        let plan = planner::plan_query(&query, graph)?;
+        // The keyspace names the TABLE; the default graph names the PARTITION.
+        // These were one value until this fix, and that conflation meant a
+        // bound-subject point read looked under ("<keyspace>", subject) for a
+        // row the writer had stored under ("default", subject).
+        let scope = planner::TripleScope::new(graph, &self.config.default_graph);
+        let plan = planner::plan_query(&query, &scope)?;
 
         // 3. Execute plan against storage.
         let results = crate::executor::execute(&plan, &self.write_path, &self.limits).await?;
@@ -433,11 +438,11 @@ async fn build_graph_result(
                     object: TermPattern::Variable(spargebra::term::Variable::new_unchecked("__o")),
                 };
                 let op = TripleOp::SubjectLookup {
-                    graph: plan.ops.first().map_or_else(
-                        || "__default".to_string(),
+                    scope: plan.ops.first().map_or_else(
+                        || planner::TripleScope::new("__default", "__default"),
                         |(_, o)| match o {
-                            TripleOp::SubjectLookup { graph, .. } => graph.clone(),
-                            _ => "__default".to_string(),
+                            TripleOp::SubjectLookup { scope, .. } => scope.clone(),
+                            _ => planner::TripleScope::new("__default", "__default"),
                         },
                     ),
                     subject: iri.clone(),
@@ -477,7 +482,7 @@ async fn build_graph_result(
             Ok(triples)
         }
 
-        GraphQueryMode::Describe(graph) => {
+        GraphQueryMode::Describe(scope) => {
             // DESCRIBE: collect all triples about every subject bound by the
             // WHERE clause (or the directly described IRI if no WHERE clause
             // was supplied by spargebra).
@@ -510,7 +515,7 @@ async fn build_graph_result(
                     object: TermPattern::Variable(spargebra::term::Variable::new_unchecked("__o")),
                 };
                 let op = TripleOp::SubjectLookup {
-                    graph: graph.clone(),
+                    scope: scope.clone(),
                     subject: subject_iri.clone(),
                     predicate_filter: None,
                 };

--- a/ferrosa-sparql/src/executor.rs
+++ b/ferrosa-sparql/src/executor.rs
@@ -32,7 +32,7 @@ use ferrosa_sstable::types::{Partition, Row};
 use futures::StreamExt;
 
 use crate::error::SparqlError;
-use crate::planner::{QueryPlan, TripleOp};
+use crate::planner::{QueryPlan, TripleOp, TripleScope};
 use crate::results::{Binding, SparqlJsonResults};
 use crate::triple_store;
 
@@ -167,13 +167,13 @@ async fn evaluate_triple_patterns(
     for (tp, op) in &plan.ops {
         let new_bindings = match op {
             TripleOp::PropertyPath {
-                graph,
+                scope,
                 subject,
                 path,
                 object,
             } => {
                 evaluate_path_op(
-                    graph,
+                    scope,
                     subject,
                     path,
                     object,
@@ -226,7 +226,7 @@ fn scan_budget(plan: &QueryPlan) -> Option<usize> {
 
 /// Evaluate a property path op via BFS traversal.
 async fn evaluate_path_op(
-    graph: &str,
+    scope: &TripleScope,
     subject: &spargebra::term::TermPattern,
     path: &spargebra::algebra::PropertyPathExpression,
     object: &spargebra::term::TermPattern,
@@ -235,7 +235,7 @@ async fn evaluate_path_op(
     limits: &ExecutionLimits,
 ) -> Result<Vec<HashMap<String, Binding>>, SparqlError> {
     let results = crate::property_path::evaluate_property_path(
-        subject, path, object, graph, write_path, limits,
+        subject, path, object, scope, write_path, limits,
     )
     .await?;
     let path_bindings = crate::property_path::path_results_to_bindings(subject, object, &results);
@@ -509,13 +509,16 @@ const OBJECT_INDEX_NAME: &str = "rdf_triples_object_idx";
 
 /// The graph a storage-backed op reads from. `None` for `PropertyPath`, which
 /// is evaluated by [`evaluate_path_op`] and never reaches the scan.
-fn op_graph(op: &TripleOp) -> Option<&str> {
+fn op_scope(op: &TripleOp) -> Option<&TripleScope> {
     match op {
         // BUG-S2 fix: use the graph from the execution plan, not hardcoded "rdf".
-        TripleOp::SubjectLookup { graph, .. }
-        | TripleOp::PredicateScan { graph, .. }
-        | TripleOp::ObjectScan { graph, .. }
-        | TripleOp::FullScan { graph, .. } => Some(graph.as_str()),
+        // The scope carries the keyspace (which table) and the graph (which
+        // partition) separately; collapsing them into one value was the
+        // bound-subject-returns-nothing bug.
+        TripleOp::SubjectLookup { scope, .. }
+        | TripleOp::PredicateScan { scope, .. }
+        | TripleOp::ObjectScan { scope, .. }
+        | TripleOp::FullScan { scope, .. } => Some(scope),
         TripleOp::PropertyPath { .. } => None,
     }
 }
@@ -526,7 +529,9 @@ fn describe_op(op: &TripleOp) -> String {
         TripleOp::SubjectLookup { subject, .. } => format!("a subject lookup of <{subject}>"),
         TripleOp::PredicateScan { predicate, .. } => format!("a scan for predicate <{predicate}>"),
         TripleOp::ObjectScan { object, .. } => format!("a scan for object '{object}'"),
-        TripleOp::FullScan { graph } => format!("a full scan of graph '{graph}'"),
+        TripleOp::FullScan { scope } => {
+            format!("a full scan of graph '{}'", scope.graph)
+        }
         TripleOp::PropertyPath { .. } => "a property path".to_string(),
     }
 }
@@ -594,10 +599,13 @@ async fn for_each_triple<F>(
 where
     F: FnMut(FetchedTriple) -> Result<ControlFlow<()>, SparqlError>,
 {
-    let Some(graph) = op_graph(op) else {
+    let Some(scope) = op_scope(op) else {
         return Ok(());
     };
-    let table_id = triple_store::triples_table_id(graph);
+    // The TABLE is named by the keyspace; the partition key is (GRAPH, subject).
+    // These were the same value until this fix, which is why a point read
+    // missed rows a scan of the same table found.
+    let table_id = triple_store::triples_table_id(&scope.keyspace);
     let mut scan = Scan {
         op,
         limits,
@@ -608,7 +616,7 @@ where
     match op {
         TripleOp::SubjectLookup { subject, .. } => {
             // Point read: bounded by one partition's row count by construction.
-            let key = triple_store::partition_key(graph, subject);
+            let key = triple_store::partition_key(&scope.graph, subject);
             if let Some(partition) = write_path.read(&table_id, &key).await? {
                 // Exactly one partition: `Break` and `Continue` are equivalent
                 // here because there is nothing left to feed either way.
@@ -1094,7 +1102,7 @@ mod tests {
     #[test]
     fn predicate_scan_filters_by_predicate() {
         let op = TripleOp::PredicateScan {
-            graph: "default".into(),
+            scope: TripleScope::new("default", "default"),
             predicate: "http://foaf/name".into(),
         };
         assert!(triple_matches_op(
@@ -1110,7 +1118,7 @@ mod tests {
     #[test]
     fn object_scan_filters_by_object() {
         let op = TripleOp::ObjectScan {
-            graph: "default".into(),
+            scope: TripleScope::new("default", "default"),
             object: "Bob".into(),
         };
         assert!(!triple_matches_op(
@@ -1126,7 +1134,7 @@ mod tests {
     #[test]
     fn subject_lookup_filters_by_predicate_filter() {
         let op = TripleOp::SubjectLookup {
-            graph: "default".into(),
+            scope: TripleScope::new("default", "default"),
             subject: "s1".into(),
             predicate_filter: Some("http://foaf/name".into()),
         };
@@ -1143,7 +1151,7 @@ mod tests {
     #[test]
     fn full_scan_matches_every_triple() {
         let op = TripleOp::FullScan {
-            graph: "default".into(),
+            scope: TripleScope::new("default", "default"),
         };
         assert!(triple_matches_op(
             &op,

--- a/ferrosa-sparql/src/planner.rs
+++ b/ferrosa-sparql/src/planner.rs
@@ -9,24 +9,61 @@ use spargebra::Query;
 
 use crate::error::SparqlError;
 
+/// Where a planned operation reads from.
+///
+/// The keyspace and the graph are DIFFERENT THINGS and were previously one
+/// `graph: String` used for both. That conflation was a silent-wrong-results
+/// bug: `rdf_triples` lives in a table named by the KEYSPACE, while a row's
+/// partition key is `(GRAPH, subject)` — and the writer has always taken the
+/// graph from the SPARQL graph name (`DefaultGraph` -> `"default"`) while the
+/// reader took it from the caller's keyspace (HTTP default `"rdf"`).
+///
+/// Both sides therefore agreed on the table, so scans worked, while a
+/// bound-subject point read asked for `("rdf", subject)` and missed a row
+/// stored under `("default", subject)` — returning a well-formed empty result
+/// for data that was present.
+///
+/// Carrying both in one struct is what stops that returning: an op cannot be
+/// constructed with only one of them, and the two are named at every use site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TripleScope {
+    /// Selects the `rdf_triples` TABLE. Comes from the caller's keyspace.
+    pub keyspace: String,
+    /// The graph component of the partition key. Comes from the SPARQL graph
+    /// name — `"default"` for the default graph, the IRI for a named graph.
+    pub graph: String,
+}
+
+impl TripleScope {
+    pub fn new(keyspace: impl Into<String>, graph: impl Into<String>) -> Self {
+        Self {
+            keyspace: keyspace.into(),
+            graph: graph.into(),
+        }
+    }
+}
+
 /// A planned storage operation for evaluating a triple pattern.
 #[derive(Debug, Clone)]
 pub enum TripleOp {
     /// Lookup by subject (partition key scan): given subject, scan all (pred, obj).
     SubjectLookup {
-        graph: String,
+        scope: TripleScope,
         subject: String,
         predicate_filter: Option<String>,
     },
     /// Full scan with predicate filter (uses secondary index on predicate).
-    PredicateScan { graph: String, predicate: String },
+    PredicateScan {
+        scope: TripleScope,
+        predicate: String,
+    },
     /// Full scan with object filter (uses secondary index on object).
-    ObjectScan { graph: String, object: String },
+    ObjectScan { scope: TripleScope, object: String },
     /// Full table scan (no bound terms) — expensive, requires LIMIT.
-    FullScan { graph: String },
+    FullScan { scope: TripleScope },
     /// Property path traversal (BFS/DFS) — evaluates transitive closure.
     PropertyPath {
-        graph: String,
+        scope: TripleScope,
         subject: spargebra::term::TermPattern,
         path: spargebra::algebra::PropertyPathExpression,
         object: spargebra::term::TermPattern,
@@ -80,22 +117,22 @@ pub enum GraphQueryMode {
     /// assemble the result from the SELECT output.
     DescribeIris(Vec<String>),
     /// `DESCRIBE ?var WHERE { … }` — subjects are derived from WHERE solutions.
-    Describe(String),
+    ///
+    /// Carries the full scope, not just a graph: the follow-up SubjectLookup it
+    /// drives needs the keyspace to find the table AND the graph to build the
+    /// partition key, and passing one value for both is the bug this type
+    /// exists to prevent.
+    Describe(TripleScope),
 }
 
 /// Plan a SPARQL SELECT, ASK, CONSTRUCT, or DESCRIBE query.
-pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, SparqlError> {
+pub fn plan_query(query: &Query, scope: &TripleScope) -> Result<QueryPlan, SparqlError> {
     match query {
         Query::Select {
             pattern, base_iri, ..
-        } => plan_select(
-            pattern,
-            default_graph,
-            base_iri.as_ref().map(|i| i.as_str()),
-            false,
-        ),
+        } => plan_select(pattern, scope, base_iri.as_ref().map(|i| i.as_str()), false),
         Query::Ask { pattern, .. } => {
-            let mut plan = plan_select(pattern, default_graph, None, true)?;
+            let mut plan = plan_select(pattern, scope, None, true)?;
             plan.limit = Some(1);
             Ok(plan)
         }
@@ -107,7 +144,7 @@ pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, Sparq
         } => {
             // Plan the WHERE clause exactly like SELECT so the executor can
             // bind solutions; then attach the CONSTRUCT template.
-            let mut plan = plan_select(pattern, default_graph, None, false)?;
+            let mut plan = plan_select(pattern, scope, None, false)?;
             // CONSTRUCT projects all variables — projection is derived from the template.
             plan.graph_mode = Some(GraphQueryMode::Construct(template.clone()));
             Ok(plan)
@@ -127,8 +164,8 @@ pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, Sparq
             let iris = extract_describe_iris(pattern);
             if iris.is_empty() {
                 // DESCRIBE ?var WHERE { … } — plan the WHERE clause normally.
-                let mut plan = plan_select(pattern, default_graph, None, false)?;
-                plan.graph_mode = Some(GraphQueryMode::Describe(default_graph.to_string()));
+                let mut plan = plan_select(pattern, scope, None, false)?;
+                plan.graph_mode = Some(GraphQueryMode::Describe(scope.clone()));
                 return Ok(plan);
             }
 
@@ -147,7 +184,7 @@ pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, Sparq
                 ops.push((
                     tp,
                     TripleOp::SubjectLookup {
-                        graph: default_graph.to_string(),
+                        scope: scope.clone(),
                         subject: iri.clone(),
                         predicate_filter: None,
                     },
@@ -172,13 +209,13 @@ pub fn plan_query(query: &Query, default_graph: &str) -> Result<QueryPlan, Sparq
 /// Plan a bare `GraphPattern` (e.g. the WHERE clause of a SPARQL UPDATE) into a
 /// [`QueryPlan`] so it can be evaluated by the SELECT executor to bind
 /// solutions. Used by `update.rs` for `DELETE WHERE` / `DELETE/INSERT … WHERE`.
-pub fn plan_where(pattern: &GraphPattern, default_graph: &str) -> Result<QueryPlan, SparqlError> {
-    plan_select(pattern, default_graph, None, false)
+pub fn plan_where(pattern: &GraphPattern, scope: &TripleScope) -> Result<QueryPlan, SparqlError> {
+    plan_select(pattern, scope, None, false)
 }
 
 fn plan_select(
     pattern: &GraphPattern,
-    default_graph: &str,
+    scope: &TripleScope,
     _base_iri: Option<&str>,
     is_ask: bool,
 ) -> Result<QueryPlan, SparqlError> {
@@ -192,7 +229,7 @@ fn plan_select(
 
     collect_ops(
         pattern,
-        default_graph,
+        scope,
         &mut ops,
         &mut projection,
         &mut limit,
@@ -218,7 +255,7 @@ fn plan_select(
 #[allow(clippy::too_many_arguments)]
 fn collect_ops(
     pattern: &GraphPattern,
-    default_graph: &str,
+    scope: &TripleScope,
     ops: &mut Vec<(TriplePattern, TripleOp)>,
     projection: &mut Vec<String>,
     limit: &mut Option<usize>,
@@ -230,7 +267,7 @@ fn collect_ops(
     match pattern {
         GraphPattern::Bgp { patterns } => {
             for tp in patterns {
-                let op = plan_triple_pattern(tp, default_graph)?;
+                let op = plan_triple_pattern(tp, scope)?;
                 ops.push((tp.clone(), op));
             }
         }
@@ -239,15 +276,7 @@ fn collect_ops(
                 projection.push(var.as_str().to_string());
             }
             collect_ops(
-                inner,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                inner, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
         }
         GraphPattern::Slice {
@@ -262,29 +291,13 @@ fn collect_ops(
                 *limit = Some(*len);
             }
             collect_ops(
-                inner,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                inner, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
         }
         GraphPattern::Filter { inner, expr } => {
             filters.push(expr.clone());
             collect_ops(
-                inner,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                inner, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
         }
         GraphPattern::OrderBy {
@@ -304,42 +317,18 @@ fn collect_ops(
                 });
             }
             collect_ops(
-                inner,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                inner, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
         }
         GraphPattern::Distinct { inner } => {
             *distinct = true;
             collect_ops(
-                inner,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                inner, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
         }
         GraphPattern::Reduced { inner } => {
             collect_ops(
-                inner,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                inner, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
         }
         GraphPattern::Path {
@@ -358,13 +347,13 @@ fn collect_ops(
                     ),
                     object: object.clone(),
                 };
-                let op = plan_triple_pattern(&tp, default_graph)?;
+                let op = plan_triple_pattern(&tp, scope)?;
                 ops.push((tp, op));
             } else {
                 // Transitive/closure path — emit PropertyPath op for BFS.
                 let tp = build_path_triple_pattern(subject, path, object);
                 let op = TripleOp::PropertyPath {
-                    graph: default_graph.to_string(),
+                    scope: scope.clone(),
                     subject: subject.clone(),
                     path: path.clone(),
                     object: object.clone(),
@@ -375,42 +364,18 @@ fn collect_ops(
         GraphPattern::Union { left, right } => {
             // BUG-S14: UNION support — concat both sides.
             collect_ops(
-                left,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                left, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
             // UNION appends the right side's patterns too.
             collect_ops(
-                right,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                right, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
         }
         GraphPattern::LeftJoin { left, right: _, .. } => {
             // OPTIONAL → evaluate left side; right side patterns are optional.
             // For now, just evaluate the left side (inner patterns).
             collect_ops(
-                left,
-                default_graph,
-                ops,
-                projection,
-                limit,
-                offset,
-                distinct,
-                order_by,
-                filters,
+                left, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
             tracing::warn!("OPTIONAL (LeftJoin) right side not yet evaluated");
         }
@@ -484,7 +449,7 @@ fn extract_predicate_from_path(
 /// (RDF* / SPARQL-star syntax), which is parsed successfully by spargebra but
 /// whose annotation evaluation is not yet implemented (URS-QEC-S03 /
 /// URS-QEC-X01).  Failing loud here prevents silent wrong results.
-fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> Result<TripleOp, SparqlError> {
+fn plan_triple_pattern(tp: &TriplePattern, scope: &TripleScope) -> Result<TripleOp, SparqlError> {
     // URS-QEC-S03 / URS-QEC-X01: detect RDF* embedded triple terms and fail loud.
     if matches!(&tp.subject, TermPattern::Triple(_)) {
         return Err(SparqlError::Plan(
@@ -500,7 +465,7 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> Result<Triple
         ));
     }
 
-    let graph = default_graph.to_string();
+    let scope = scope.clone();
 
     let subject_bound = matches!(&tp.subject, TermPattern::NamedNode(_));
     let predicate_bound = matches!(&tp.predicate, NamedNodePattern::NamedNode(_));
@@ -523,7 +488,7 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> Result<Triple
             None
         };
         TripleOp::SubjectLookup {
-            graph,
+            scope,
             subject,
             predicate_filter,
         }
@@ -532,7 +497,7 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> Result<Triple
             NamedNodePattern::NamedNode(n) => n.as_str().to_string(),
             _ => unreachable!(),
         };
-        TripleOp::PredicateScan { graph, predicate }
+        TripleOp::PredicateScan { scope, predicate }
     } else if object_bound {
         let object = match &tp.object {
             TermPattern::NamedNode(n) => n.as_str().to_string(),
@@ -545,9 +510,9 @@ fn plan_triple_pattern(tp: &TriplePattern, default_graph: &str) -> Result<Triple
             TermPattern::Literal(l) => l.value().to_string(),
             _ => unreachable!(),
         };
-        TripleOp::ObjectScan { graph, object }
+        TripleOp::ObjectScan { scope, object }
     } else {
-        TripleOp::FullScan { graph }
+        TripleOp::FullScan { scope }
     };
     Ok(op)
 }
@@ -604,7 +569,7 @@ mod tests {
         let query = spargebra::SparqlParser::new()
             .parse_query("SELECT ?s ?p ?o WHERE { ?s ?p ?o }")
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert_eq!(plan.projection, vec!["s", "p", "o"]);
         assert_eq!(plan.ops.len(), 1);
         assert!(matches!(plan.ops[0].1, TripleOp::FullScan { .. }));
@@ -615,7 +580,7 @@ mod tests {
         let query = spargebra::SparqlParser::new()
             .parse_query("SELECT ?p ?o WHERE { <http://example.org/alice> ?p ?o }")
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert_eq!(plan.ops.len(), 1);
         assert!(matches!(plan.ops[0].1, TripleOp::SubjectLookup { .. }));
     }
@@ -625,7 +590,7 @@ mod tests {
         let query = spargebra::SparqlParser::new()
             .parse_query("SELECT ?s WHERE { ?s ?p ?o } LIMIT 10")
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert_eq!(plan.limit, Some(10));
     }
 
@@ -636,7 +601,7 @@ mod tests {
                 "ASK { <http://example.org/alice> <http://xmlns.com/foaf/0.1/name> ?name }",
             )
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert!(plan.is_ask, "ASK query must set is_ask=true");
         assert_eq!(plan.limit, Some(1), "ASK query must limit to 1 row");
     }
@@ -646,7 +611,7 @@ mod tests {
         let query = spargebra::SparqlParser::new()
             .parse_query("SELECT ?s WHERE { ?s ?p ?o }")
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert!(!plan.is_ask, "SELECT query must set is_ask=false");
     }
 
@@ -655,7 +620,7 @@ mod tests {
         let query = spargebra::SparqlParser::new()
             .parse_query("SELECT DISTINCT ?s WHERE { ?s ?p ?o }")
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert!(plan.distinct, "DISTINCT must set distinct=true");
     }
 
@@ -666,7 +631,7 @@ mod tests {
                 "SELECT ?name WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?name } ORDER BY ?name",
             )
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert_eq!(plan.order_by.len(), 1);
         assert!(matches!(
             &plan.order_by[0].expression,
@@ -683,7 +648,7 @@ mod tests {
                 "SELECT ?a ?b WHERE { ?s <http://ex/a> ?a ; <http://ex/b> ?b } ORDER BY DESC(?a + ?b)",
             )
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert_eq!(plan.order_by.len(), 1);
         assert!(!plan.order_by[0].ascending);
         assert!(
@@ -701,7 +666,7 @@ mod tests {
             "SELECT ?name WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?name } ORDER BY DESC(?name)",
         )
         .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert_eq!(plan.order_by.len(), 1);
         assert!(!plan.order_by[0].ascending);
     }
@@ -712,19 +677,36 @@ mod tests {
             "SELECT ?name WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?name . FILTER(?name = \"Alice\") }",
         )
         .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert_eq!(plan.filters.len(), 1, "FILTER must capture one expression");
     }
 
+    /// The keyspace selects the TABLE; the graph selects the PARTITION. They are
+    /// different values and a plan must keep them apart.
+    ///
+    /// This case previously read `plan_uses_keyspace_as_graph` and asserted
+    /// `graph == "my_tenant"` -- the keyspace. That was the bound-subject bug
+    /// written down as an expectation, and it is why the bug survived: the
+    /// writer takes the graph from the SPARQL graph name ("default"), so a plan
+    /// binding the keyspace instead produced a point read for a partition key
+    /// that was never written.
     #[test]
-    fn plan_uses_keyspace_as_graph() {
+    fn plan_separates_keyspace_from_graph() {
         let query = spargebra::SparqlParser::new()
             .parse_query("SELECT ?p ?o WHERE { <http://example.org/alice> ?p ?o }")
             .unwrap();
-        let plan = plan_query(&query, "my_tenant").unwrap();
+        let scope = TripleScope::new("my_tenant", "default");
+        let plan = plan_query(&query, &scope).unwrap();
         match &plan.ops[0].1 {
-            TripleOp::SubjectLookup { graph, .. } => {
-                assert_eq!(graph, "my_tenant", "graph must match supplied keyspace");
+            TripleOp::SubjectLookup { scope, .. } => {
+                assert_eq!(
+                    scope.keyspace, "my_tenant",
+                    "the keyspace must be carried through -- it names the table"
+                );
+                assert_eq!(
+                    scope.graph, "default",
+                    "the graph must come from the SPARQL graph name, not the keyspace"
+                );
             }
             other => panic!("expected SubjectLookup, got {other:?}"),
         }
@@ -737,7 +719,7 @@ mod tests {
                 "SELECT ?o WHERE { <http://example.org/alice> <http://xmlns.com/foaf/0.1/knows>+ ?o }",
             )
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert_eq!(plan.ops.len(), 1);
         assert!(
             matches!(plan.ops[0].1, TripleOp::PropertyPath { .. }),
@@ -753,7 +735,7 @@ mod tests {
                 "SELECT ?o WHERE { <http://example.org/alice> <http://xmlns.com/foaf/0.1/knows>* ?o }",
             )
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert!(
             matches!(plan.ops[0].1, TripleOp::PropertyPath { .. }),
             "ZeroOrMore path must produce PropertyPath op"
@@ -768,7 +750,7 @@ mod tests {
                 "SELECT ?o WHERE { <http://example.org/alice> <http://xmlns.com/foaf/0.1/knows> ?o }",
             )
             .unwrap();
-        let plan = plan_query(&query, "default").unwrap();
+        let plan = plan_query(&query, &TripleScope::new("default", "default")).unwrap();
         assert!(
             !matches!(plan.ops[0].1, TripleOp::PropertyPath { .. }),
             "simple BGP should not produce PropertyPath op"

--- a/ferrosa-sparql/src/property_path.rs
+++ b/ferrosa-sparql/src/property_path.rs
@@ -27,7 +27,7 @@ pub async fn evaluate_property_path(
     subject: &TermPattern,
     path: &PropertyPathExpression,
     object: &TermPattern,
-    graph: &str,
+    scope: &crate::planner::TripleScope,
     write_path: &Arc<WritePath>,
     limits: &ExecutionLimits,
 ) -> Result<PathResult, SparqlError> {
@@ -37,25 +37,25 @@ pub async fn evaluate_property_path(
                 subject,
                 predicate.as_str(),
                 object,
-                graph,
+                scope,
                 write_path,
                 limits,
             )
             .await
         }
         PropertyPathExpression::OneOrMore(inner) => {
-            evaluate_closure(subject, inner, object, graph, write_path, limits, false).await
+            evaluate_closure(subject, inner, object, scope, write_path, limits, false).await
         }
         PropertyPathExpression::ZeroOrMore(inner) => {
-            evaluate_closure(subject, inner, object, graph, write_path, limits, true).await
+            evaluate_closure(subject, inner, object, scope, write_path, limits, true).await
         }
         PropertyPathExpression::ZeroOrOne(inner) => {
-            evaluate_zero_or_one(subject, inner, object, graph, write_path, limits).await
+            evaluate_zero_or_one(subject, inner, object, scope, write_path, limits).await
         }
         PropertyPathExpression::Reverse(inner) => {
             // Swap subject and object, evaluate, then swap results back.
             let results = Box::pin(evaluate_property_path(
-                object, inner, subject, graph, write_path, limits,
+                object, inner, subject, scope, write_path, limits,
             ))
             .await?;
             Ok(results.into_iter().map(|(s, o)| (o, s)).collect())
@@ -71,11 +71,11 @@ async fn evaluate_single_hop(
     subject: &TermPattern,
     predicate: &str,
     object: &TermPattern,
-    graph: &str,
+    scope: &crate::planner::TripleScope,
     write_path: &Arc<WritePath>,
     limits: &ExecutionLimits,
 ) -> Result<PathResult, SparqlError> {
-    let triples = fetch_triples_for_predicate(graph, predicate, write_path, limits).await?;
+    let triples = fetch_triples_for_predicate(scope, predicate, write_path, limits).await?;
     filter_by_endpoints(subject, object, &triples)
 }
 
@@ -87,13 +87,13 @@ async fn evaluate_closure(
     subject: &TermPattern,
     inner: &PropertyPathExpression,
     object: &TermPattern,
-    graph: &str,
+    scope: &crate::planner::TripleScope,
     write_path: &Arc<WritePath>,
     limits: &ExecutionLimits,
     include_start: bool,
 ) -> Result<PathResult, SparqlError> {
     let predicate = extract_single_predicate(inner)?;
-    let adjacency = fetch_triples_for_predicate(graph, &predicate, write_path, limits).await?;
+    let adjacency = fetch_triples_for_predicate(scope, &predicate, write_path, limits).await?;
     let starts = collect_start_nodes(subject, &adjacency);
 
     let mut results = Vec::new();
@@ -110,12 +110,12 @@ async fn evaluate_zero_or_one(
     subject: &TermPattern,
     inner: &PropertyPathExpression,
     object: &TermPattern,
-    graph: &str,
+    scope: &crate::planner::TripleScope,
     write_path: &Arc<WritePath>,
     limits: &ExecutionLimits,
 ) -> Result<PathResult, SparqlError> {
     let predicate = extract_single_predicate(inner)?;
-    let adjacency = fetch_triples_for_predicate(graph, &predicate, write_path, limits).await?;
+    let adjacency = fetch_triples_for_predicate(scope, &predicate, write_path, limits).await?;
     let starts = collect_start_nodes(subject, &adjacency);
 
     let mut results = Vec::new();
@@ -192,12 +192,12 @@ fn extract_single_predicate(path: &PropertyPathExpression) -> Result<String, Spa
 /// crossing the bound is a loud error, never a silent partial traversal (a
 /// partial adjacency would produce a wrong answer that looks complete).
 async fn fetch_triples_for_predicate(
-    graph: &str,
+    scope: &crate::planner::TripleScope,
     predicate: &str,
     write_path: &Arc<WritePath>,
     limits: &ExecutionLimits,
 ) -> Result<Vec<(String, String)>, SparqlError> {
-    let table_id = triple_store::triples_table_id(graph);
+    let table_id = triple_store::triples_table_id(&scope.keyspace);
     let mut partitions = write_path.range_read_stream_all(&table_id, 0).await?;
 
     let mut pairs = Vec::new();

--- a/ferrosa-sparql/src/update.rs
+++ b/ferrosa-sparql/src/update.rs
@@ -303,7 +303,11 @@ async fn exec_delete_insert(
         check_quad_graph_pattern(&tmpl.graph_name, keyspace, "INSERT")?;
     }
 
-    let plan = crate::planner::plan_where(pattern, keyspace)?;
+    // Same split as the read path: the keyspace names the table, the SPARQL
+    // default graph names the partition. Passing the keyspace as both is what
+    // made a bound-subject read miss rows this very function had written.
+    let scope = crate::planner::TripleScope::new(keyspace, "default");
+    let plan = crate::planner::plan_where(pattern, &scope)?;
     let solutions = crate::executor::execute_bindings(&plan, write_path, limits).await?;
 
     let mut deleted = 0usize;
@@ -363,7 +367,8 @@ async fn exec_clear(
     let scan = spargebra::SparqlParser::new()
         .parse_query("SELECT ?s ?p ?o WHERE { ?s ?p ?o }")
         .map_err(|e| SparqlError::Parse(format!("{e}")))?;
-    let plan = crate::planner::plan_query(&scan, keyspace)?;
+    let scope = crate::planner::TripleScope::new(keyspace, "default");
+    let plan = crate::planner::plan_query(&scan, &scope)?;
     let solutions = crate::executor::execute_bindings(&plan, write_path, limits).await?;
 
     let mut deleted = 0usize;

--- a/ferrosa-sparql/tests/sparql_bound_subject_lookup.rs
+++ b/ferrosa-sparql/tests/sparql_bound_subject_lookup.rs
@@ -1,0 +1,187 @@
+//! A bound-subject triple pattern must return the triples it stores.
+//!
+//! Found from outside, against a running install: writing a triple and then
+//! asking for it by subject returned nothing, while the same triple came back
+//! from an unbound scan and from a bound-predicate pattern.
+//!
+//!     INSERT DATA { <urn:qa:probe> <urn:qa:says> "hello" }   -> inserted 1
+//!     SELECT ?s WHERE { ?s ?p ?o }                           -> the triple
+//!     SELECT ?s WHERE { ?s <urn:qa:says> ?o }                -> the triple
+//!     SELECT ?o WHERE { <urn:qa:probe> <urn:qa:says> ?o }    -> EMPTY
+//!
+//! A bound-subject lookup is the commonest SPARQL shape ("tell me about this
+//! thing"). It fails silently and returns a well-formed empty result set, so
+//! nothing upstream can tell it apart from "that subject has no triples" -- a
+//! consumer verifying a write this way concludes its data was lost.
+//!
+//! These tests pin the three access paths against each other. The comparison is
+//! what makes them useful: any one of them alone could be argued to be an empty
+//! database, and only disagreement between them proves a read path is wrong.
+
+use std::sync::Arc;
+
+use ferrosa_cluster::write_path::WritePath;
+use ferrosa_sparql::engine::{SparqlConfig, SparqlEngine, SparqlResult};
+use ferrosa_storage::{
+    CommitLogConfig, CompactionConfig, StorageEngine, StorageEngineConfig, SyncStrategyConfig,
+};
+use tempfile::TempDir;
+
+// "default" so the partition-key graph component written by INSERT DATA
+// (DefaultGraph -> "default") matches what the SELECT executor binds against.
+// The neighbouring pattern-delete suite makes the same choice, and its comment
+// records why: the keyspace/graph coupling otherwise gets in the way. Keeping
+// that out of scope here is deliberate -- this suite is about the ACCESS PATH,
+// and a keyspace mismatch would make all three fail together and prove nothing.
+const KS: &str = "default";
+
+fn setup() -> (Arc<StorageEngine>, Arc<WritePath>, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let config = StorageEngineConfig {
+        commit_log: CommitLogConfig {
+            segment_size: 4096,
+            max_segment_age: std::time::Duration::from_secs(60),
+            sync_strategy: SyncStrategyConfig::Batch,
+            batch: Default::default(),
+            log_dir: dir.path().join("commitlog"),
+            checkpoint_dir: dir.path().join("commitlog"),
+            archive: None,
+        },
+        compaction: CompactionConfig::from_env(dir.path().join("compaction")),
+        object_store: None,
+        local_cache_max_bytes: 1024 * 1024,
+        local_disk_free_reserve_bytes: 0,
+        flush_threshold_bytes: 4096,
+        memtable_backpressure_bytes: u64::MAX,
+        flush_max_age_secs: 5,
+        data_dir: dir.path().to_path_buf(),
+        index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+        write_verify: true,
+        auth_enabled: false,
+        auth_warn: false,
+        max_pending_replay_mutations_without_schema: 1024,
+        memtable_num_shards: 64,
+    };
+    let storage = Arc::new(StorageEngine::new(config, None).unwrap());
+    let write_path = Arc::new(WritePath::direct(Arc::clone(&storage)));
+    (storage, write_path, dir)
+}
+
+fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngine {
+    let config = SparqlConfig {
+        default_graph: KS.to_string(),
+        ..Default::default()
+    };
+    SparqlEngine::new(storage, write_path, config)
+}
+
+async fn select_count(eng: &SparqlEngine, query: &str) -> usize {
+    match eng.execute(query, KS).await.expect("select must succeed") {
+        SparqlResult::Select(r) => r.results.bindings.len(),
+        SparqlResult::Ask(_) => panic!("expected SELECT result, got ASK"),
+        SparqlResult::Graph(_) => panic!("expected SELECT result, got Graph"),
+    }
+}
+
+/// The same three paths, after the data has been FLUSHED to SSTables.
+///
+/// This is the case the in-memory cases cannot reach, and the one a running
+/// install is always in: everything written before the last flush is read back
+/// through the SSTable path rather than the memtable. A point read that works
+/// against a memtable and misses against an SSTable would look exactly like
+/// what was seen from outside -- the scan still finds the triple because it
+/// reads every partition, while the bound-subject lookup asks for one key and
+/// is told there is nothing there.
+#[tokio::test]
+async fn every_access_path_finds_a_flushed_triple() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(Arc::clone(&storage), wp);
+
+    eng.execute_update("INSERT DATA { <urn:qa:probe> <urn:qa:says> \"hello\" }", KS)
+        .await
+        .expect("insert data");
+
+    // Force the write out of the memtable before reading it back.
+    storage.flush_all().expect("flush to sstables");
+
+    let unbound = select_count(&eng, "SELECT ?s WHERE { ?s ?p ?o }").await;
+    let bound_predicate = select_count(&eng, "SELECT ?s WHERE { ?s <urn:qa:says> ?o }").await;
+    let bound_subject =
+        select_count(&eng, "SELECT ?o WHERE { <urn:qa:probe> <urn:qa:says> ?o }").await;
+
+    assert_eq!(
+        (unbound, bound_predicate, bound_subject),
+        (1, 1, 1),
+        "after a flush the three access paths disagree about a stored triple \
+(unbound={unbound}, bound predicate={bound_predicate}, bound subject={bound_subject}). \
+A path returning 0 while another returns 1 is a wrong answer, not an empty database."
+    );
+}
+
+/// The three access paths must agree about a triple that exists.
+///
+/// Written as one test rather than three so a failure reports the DISAGREEMENT,
+/// which is the finding. Three separate tests would report "bound subject
+/// returned 0", which reads like an empty database.
+#[tokio::test]
+async fn every_access_path_finds_a_triple_that_was_just_written() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("INSERT DATA { <urn:qa:probe> <urn:qa:says> \"hello\" }", KS)
+        .await
+        .expect("insert data");
+
+    let unbound = select_count(&eng, "SELECT ?s WHERE { ?s ?p ?o }").await;
+    let bound_predicate = select_count(&eng, "SELECT ?s WHERE { ?s <urn:qa:says> ?o }").await;
+    let bound_subject =
+        select_count(&eng, "SELECT ?o WHERE { <urn:qa:probe> <urn:qa:says> ?o }").await;
+
+    assert_eq!(
+        (unbound, bound_predicate, bound_subject),
+        (1, 1, 1),
+        "the three access paths disagree about a triple that was just written \
+(unbound={unbound}, bound predicate={bound_predicate}, bound subject={bound_subject}). \
+A path returning 0 while another returns 1 is a wrong answer, not an empty database."
+    );
+}
+
+/// The same, with the subject bound and the predicate left free -- so a failure
+/// separates "binding the subject breaks it" from "binding two terms breaks it".
+#[tokio::test]
+async fn a_bound_subject_alone_finds_its_triples() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update(
+        "INSERT DATA { \
+            <urn:qa:probe> <urn:qa:says> \"hello\" . \
+            <urn:qa:probe> <urn:qa:also> \"world\" . \
+            <urn:qa:other> <urn:qa:says> \"elsewhere\" }",
+        KS,
+    )
+    .await
+    .expect("insert data");
+
+    let bound_subject = select_count(&eng, "SELECT ?p ?o WHERE { <urn:qa:probe> ?p ?o }").await;
+    assert_eq!(
+        bound_subject, 2,
+        "a bound subject must return exactly its own triples, not zero and not the whole store"
+    );
+}
+
+/// A subject that genuinely has no triples must return zero -- otherwise a fix
+/// for the above could be "return everything", which would pass the tests above
+/// while being just as wrong in the other direction.
+#[tokio::test]
+async fn a_bound_subject_with_no_triples_returns_nothing() {
+    let (storage, wp, _dir) = setup();
+    let eng = engine(storage, wp);
+
+    eng.execute_update("INSERT DATA { <urn:qa:probe> <urn:qa:says> \"hello\" }", KS)
+        .await
+        .expect("insert data");
+
+    let absent = select_count(&eng, "SELECT ?o WHERE { <urn:qa:absent> <urn:qa:says> ?o }").await;
+    assert_eq!(absent, 0, "a subject with no triples must return nothing");
+}

--- a/ferrosa-sparql/tests/sparql_bound_subject_lookup.rs
+++ b/ferrosa-sparql/tests/sparql_bound_subject_lookup.rs
@@ -27,13 +27,15 @@ use ferrosa_storage::{
 };
 use tempfile::TempDir;
 
-// "default" so the partition-key graph component written by INSERT DATA
-// (DefaultGraph -> "default") matches what the SELECT executor binds against.
-// The neighbouring pattern-delete suite makes the same choice, and its comment
-// records why: the keyspace/graph coupling otherwise gets in the way. Keeping
-// that out of scope here is deliberate -- this suite is about the ACCESS PATH,
-// and a keyspace mismatch would make all three fail together and prove nothing.
-const KS: &str = "default";
+// "rdf" -- the keyspace the HTTP surface actually defaults to, and the value
+// that made every one of these fail before the keyspace/graph split.
+//
+// Using "default" here would hide the bug entirely: with keyspace == graph the
+// reader and writer happen to agree, which is exactly why the neighbouring
+// pattern-delete suite (which pins "default" and says the coupling otherwise
+// "gets in the way") never caught it. Testing the value real callers use is the
+// whole point.
+const KS: &str = "rdf";
 
 fn setup() -> (Arc<StorageEngine>, Arc<WritePath>, TempDir) {
     let dir = TempDir::new().unwrap();
@@ -68,11 +70,14 @@ fn setup() -> (Arc<StorageEngine>, Arc<WritePath>, TempDir) {
 }
 
 fn engine(storage: Arc<StorageEngine>, write_path: Arc<WritePath>) -> SparqlEngine {
-    let config = SparqlConfig {
-        default_graph: KS.to_string(),
-        ..Default::default()
-    };
-    SparqlEngine::new(storage, write_path, config)
+    // The DEFAULT config, deliberately: default_graph stays "default" while the
+    // keyspace is "rdf". That is the production shape -- SparqlConfig::default()
+    // sets "default", and http.rs defaults the keyspace to "rdf".
+    //
+    // Tying default_graph to the keyspace (as the neighbouring suites do) makes
+    // reader and writer agree by accident and hides the very bug this file
+    // exists for.
+    SparqlEngine::new(storage, write_path, SparqlConfig::default())
 }
 
 async fn select_count(eng: &SparqlEngine, query: &str) -> usize {

--- a/ferrosa-sparql/tests/sparql_executor_invariants.rs
+++ b/ferrosa-sparql/tests/sparql_executor_invariants.rs
@@ -166,7 +166,11 @@ fn plan(query: &str) -> QueryPlan {
     let parsed = spargebra::SparqlParser::new()
         .parse_query(query)
         .expect("query must parse");
-    planner::plan_query(&parsed, KS).expect("query must plan")
+    // The scope carries the keyspace (which table) and the graph (which partition)
+    // separately. Passing one value for both was the bound-subject bug; these
+    // suites keep them equal because that is what their fixtures write.
+    let scope = planner::TripleScope::new(KS, KS);
+    planner::plan_query(&parsed, &scope).expect("query must plan")
 }
 
 /// Bound values of `var` across rows, in result order.

--- a/ferrosa-sparql/tests/sparql_scan_bound_invariants.rs
+++ b/ferrosa-sparql/tests/sparql_scan_bound_invariants.rs
@@ -124,7 +124,11 @@ impl Fixture {
         let parsed = spargebra::SparqlParser::new()
             .parse_query(query)
             .expect("query must parse");
-        let plan = planner::plan_query(&parsed, KS).expect("query must plan");
+        // The scope carries the keyspace (which table) and the graph (which partition)
+        // separately. Passing one value for both was the bound-subject bug; these
+        // suites keep them equal because that is what their fixtures write.
+        let scope = planner::TripleScope::new(KS, KS);
+        let plan = planner::plan_query(&parsed, &scope).expect("query must plan");
         Ok(
             executor::execute(&plan, &self.write_path, &ExecutionLimits { max_rows })
                 .await?


### PR DESCRIPTION
A bound-subject triple pattern returned **nothing** for triples that were stored, while an unbound scan and a bound-predicate pattern returned them:

```
INSERT DATA { <urn:qa:probe> <urn:qa:says> "hello" }  ->  triples_inserted: 1
SELECT ?s WHERE { ?s ?p ?o }                          ->  the triple
SELECT ?s WHERE { ?s <urn:qa:says> ?o }               ->  the triple
SELECT ?o WHERE { <urn:qa:probe> <urn:qa:says> ?o }   ->  EMPTY
```

It failed **silently**, with a well-formed empty result set, so nothing upstream could tell it apart from "that subject has no triples". A consumer verifying a write this way concludes its data was lost — which is exactly what happened when it was found.

Two commits: the regression suite, then the fix.

## Root cause: the keyspace and the graph were one value

They are different things:

| | table id | partition key |
|---|---|---|
| Writer (`update.rs`) | `keyspace` | SPARQL graph name → `("default", subject)` |
| Reader (`engine.rs` → `executor.rs`) | `graph` | the same `graph` → `("rdf", subject)` |

`engine.rs::execute` planned with `graph = keyspace` (*"BUG-S1 fix: use caller-supplied keyspace instead of default_graph"*), and the executor used that single value for **both** the table id and the key. `http.rs` defaults the keyspace to `"rdf"`.

Both sides therefore agreed on the **table**, which is why scans worked — `FullScan` and `PredicateScan` walk partitions and extract the subject *without reconstructing the key*. Only the point read rebuilds the key, so only the point read missed.

## The fix

A `TripleScope { keyspace, graph }` carried by every `TripleOp`. An op cannot be constructed with one value doing both jobs, and the two are named at every use site — the table id comes from `scope.keyspace`, the partition key from `scope.graph`.

This is also the shape named-graph support needs. `GRAPH` patterns are not planned yet; when they are, the IRI goes in the graph half with nothing else to change.

Threaded through the planner (`plan_query`/`plan_where`/`plan_select`/`plan_triple_pattern`), the executor (`op_graph` → `op_scope`), `property_path` (its helpers took a bare graph and used it for the table id too), `update.rs`, and `GraphQueryMode::Describe` — which now carries the scope, because the `SubjectLookup` it drives needs both halves.

## Two tests were hiding this, and both are corrected rather than relaxed

**`plan_uses_keyspace_as_graph`** asserted `graph == "my_tenant"` — the keyspace. That is the bug written down as an expectation, and it is why the bug survived. It is now `plan_separates_keyspace_from_graph`, asserting the two are carried apart.

**The regression suite's own `KS`** was `"default"`. With keyspace == graph the reader and writer agree *by accident*, so the suite passed while the bug was live. It now uses `"rdf"` with `SparqlConfig::default()` — the production shape, since `http.rs` defaults the keyspace to `"rdf"` and the default graph is `"default"`.

**Those four cases fail before the fix commit and pass after it.** That is the proof this works, and it is checkable by reverting the second commit.

The neighbouring `sparql_update_pattern_delete.rs` comment — *"without the keyspace/graph coupling getting in the way"* — was describing this bug without naming it.

## Verification

`cargo test -p ferrosa-sparql`: all 8 test binaries green, 0 failures · `cargo fmt --check` clean · `cargo clippy -p ferrosa-sparql --all-targets` clean · `cargo build -p ferrosa` clean (the main binary uses only the engine/HTTP surface, so the planner change is crate-internal).

**Not run:** the full workspace test suite. The repo rule asks for a full local CI pass before pushing and this is short of it.

## Blast radius

Every bound-subject lookup over HTTP on a default install was affected. `ferrosa-memory` uses its own traversal path and is unaffected.

Found while building SPARQL support for the ferrosa-workbench Explorer surface; tracked there as `t_db2e94b2`.
