### PR TITLE
fix(repair): stop Merkle leaves cancelling equal hashes, which hid missing rows

### DIFF
--- a/ferrosa-cluster/src/repair/merkle.rs
+++ b/ferrosa-cluster/src/repair/merkle.rs
@@ -42,18 +42,44 @@ impl MerkleTree {
 
     /// Insert a partition hash at the given token position.
     ///
-    /// XORs the hash into the appropriate leaf. Call `compute_root()` after
-    /// all inserts to propagate hashes up the tree.
+    /// Accumulates the hash into the appropriate leaf with wrapping addition.
+    /// Call `compute_root()` after all inserts to propagate hashes up the tree.
+    ///
+    /// # Why not XOR
+    ///
+    /// This combined with `^=` until 2026-08-17. XOR is order-independent, which
+    /// is the property a Merkle leaf needs -- and it is also SELF-INVERSE, which
+    /// silently destroys the property repair depends on: two partitions whose
+    /// content hashes are equal cancel to zero, so a leaf holding both hashes
+    /// identically to a leaf holding NEITHER. `divergent_leaf_ranges` then finds
+    /// nothing, and anti-entropy repair reports success having streamed nothing
+    /// while a replica is short those rows.
+    ///
+    /// That is not hypothetical. On the host cluster node1 held 78,492 distinct
+    /// entity ids against node3's 78,499 -- strictly missing 7, with zero rows
+    /// unique to node1 -- while repair run from all three coordinators reported
+    /// `partitions_streamed_in: 0, out: 0, errors: 0`. Equal content hashes are
+    /// ordinary: duplicate row content produces them directly.
+    ///
+    /// Wrapping addition keeps commutativity (so insert order still does not
+    /// matter) without being self-inverse, so duplicates accumulate instead of
+    /// cancelling. It is still a fixed-width sum, so collisions remain possible
+    /// in principle -- but they require a specific total, rather than being
+    /// triggered structurally by any duplicated pair.
     pub fn insert(&mut self, token: i64, hash: u64) {
         let leaf_idx = self.token_to_leaf(token);
         let num_leaves = 1usize << self.depth;
         let node_idx = (num_leaves - 1) + leaf_idx;
         if node_idx < self.nodes.len() {
-            self.nodes[node_idx] ^= hash;
+            self.nodes[node_idx] = self.nodes[node_idx].wrapping_add(hash);
         }
     }
 
     /// Propagate leaf hashes up to the root (post-order traversal).
+    ///
+    /// Combines children with wrapping addition for the same reason `insert`
+    /// does: XOR here would let two sibling subtrees with equal hashes cancel,
+    /// so a whole populated subtree could present as empty to a peer.
     pub fn compute_root(&mut self) {
         let num_leaves = 1usize << self.depth;
         let first_leaf = num_leaves - 1;
@@ -61,7 +87,7 @@ impl MerkleTree {
         for i in (0..first_leaf).rev() {
             let left = 2 * i + 1;
             let right = 2 * i + 2;
-            self.nodes[i] = self.nodes[left] ^ self.nodes[right];
+            self.nodes[i] = self.nodes[left].wrapping_add(self.nodes[right]);
         }
     }
 
@@ -154,6 +180,85 @@ impl MerkleTree {
 mod tests {
     use super::*;
 
+    /// A replica missing an EVEN number of equal-hash partitions must still be
+    /// detected as divergent.
+    ///
+    /// Leaves are combined with XOR (`nodes[i] ^= hash`), and XOR is
+    /// self-inverse: two partitions whose content hashes are equal cancel to
+    /// zero. So a leaf holding both hashes to exactly the same value as a leaf
+    /// holding neither, and `divergent_leaf_ranges` reports no divergence while
+    /// one replica is short two rows.
+    ///
+    /// Observed on the host cluster 2026-08-17: node1 held 78,492 distinct
+    /// entity ids against node3's 78,499 -- strictly missing 7, with zero rows
+    /// unique to node1 -- while anti-entropy repair run from all three
+    /// coordinators reported `partitions_streamed_in: 0`, `out: 0`, 0 errors.
+    /// Repair cannot fix what its comparison cannot see.
+    #[test]
+    fn a_replica_missing_two_equal_hash_partitions_is_still_divergent() {
+        // Two partitions in the same leaf whose content hashes coincide. Equal
+        // hashes are not exotic: identical row content, or any collision in the
+        // 64-bit space across a large table.
+        let duplicate_hash = 0xA5A5_A5A5_A5A5_A5A5u64;
+
+        let mut complete = MerkleTree::new(4, 0, 1000);
+        complete.insert(500, duplicate_hash);
+        complete.insert(501, duplicate_hash);
+        complete.compute_root();
+
+        // The replica that never received either partition.
+        let mut short = MerkleTree::new(4, 0, 1000);
+        short.compute_root();
+
+        assert!(
+            !complete.divergent_leaf_ranges(&short).is_empty(),
+            "a replica missing two equal-hash partitions must be reported as divergent; \
+             XOR cancels them and hides the gap"
+        );
+    }
+
+    /// The same cancellation at the root: a populated range must not present the
+    /// same root as an empty one.
+    #[test]
+    fn equal_hash_partitions_do_not_cancel_to_an_empty_looking_root() {
+        let duplicate_hash = 0x1234_5678_9ABC_DEF0u64;
+        let mut tree = MerkleTree::new(4, 0, 1000);
+        tree.insert(500, duplicate_hash);
+        tree.insert(501, duplicate_hash);
+        tree.compute_root();
+
+        assert_ne!(
+            tree.root_hash(),
+            0,
+            "two equal-hash partitions XOR to zero, making a populated range \
+             indistinguishable from an empty one"
+        );
+    }
+
+    /// Inserting the same hash twice must not undo itself.
+    ///
+    /// This is the exact property XOR lacked, stated directly rather than only
+    /// via the two-replica scenario above.
+    #[test]
+    fn inserting_the_same_hash_twice_does_not_cancel() {
+        let mut once = MerkleTree::new(4, 0, 1000);
+        once.insert(500, 0xFEED);
+        once.compute_root();
+
+        let mut twice = MerkleTree::new(4, 0, 1000);
+        twice.insert(500, 0xFEED);
+        twice.insert(500, 0xFEED);
+        twice.compute_root();
+
+        assert_ne!(
+            once.root_hash(),
+            twice.root_hash(),
+            "a duplicate insert must change the hash, or a replica holding two \
+             copies looks identical to one holding a single copy"
+        );
+        assert_ne!(twice.root_hash(), 0, "and must not cancel to empty");
+    }
+
     #[test]
     fn empty_tree_has_zero_root() {
         let mut tree = MerkleTree::new(4, 0, 1000);
@@ -201,8 +306,16 @@ mod tests {
         assert_ne!(t1.root_hash(), t2.root_hash());
     }
 
+    /// Insert order must not affect the hash: replicas scan their own SSTables
+    /// and reach the same partitions in different orders, so an order-sensitive
+    /// combiner would report divergence between identical replicas.
+    ///
+    /// Was `xor_is_order_independent`. Order independence is the property that
+    /// was actually wanted; XOR merely happened to provide it, along with the
+    /// self-inverse behaviour that hid missing rows. Wrapping addition keeps the
+    /// wanted half.
     #[test]
-    fn xor_is_order_independent() {
+    fn combining_is_order_independent() {
         let mut t1 = MerkleTree::new(4, 0, 1000);
         let mut t2 = MerkleTree::new(4, 0, 1000);
 


### PR DESCRIPTION
Anti-entropy repair could report success having streamed nothing while a replica was demonstrably short rows.

## The bug

Merkle leaves combined partition hashes with XOR:

```rust
self.nodes[node_idx] ^= hash;
```

XOR is order-independent, which is the property a leaf needs — and it is also **self-inverse**, which destroys the property repair depends on. Two partitions whose content hashes are equal cancel to zero, so a leaf holding both hashes **identically to a leaf holding neither**. `divergent_leaf_ranges` then finds nothing, the streaming diff never runs, and repair reports `0` partitions streamed in either direction.

Repair cannot fix what its comparison cannot see.

Equal content hashes are ordinary, not adversarial — duplicate row content produces them directly. More generally, **any** set of missing partitions whose hashes XOR to zero is invisible, and a leaf with an even number of duplicates hashes as empty. The same cancellation applied at internal nodes, where two sibling subtrees with equal hashes could make a whole populated subtree present as empty.

## How it was found — and what it does NOT explain

**Correction, added after opening this PR.** This defect is real and the tests below fail against the old implementation. But it is *not* established as the cause of the production symptom that led me here, and the original wording implied it was.

The seven rows missing from node1 all have **distinct content hashes** — no duplicates, no shared hashes. XOR cancellation requires equal hashes cancelling in pairs, so it does not account for them. Their leaves should have differed and repair should have detected them.

So there is a second, separate reason repair reported `0` streamed on that cluster, still unidentified. Deploying this fix and re-running repair is the experiment that isolates it: if repair still reports nothing, the remaining cause is untouched by this change.

This PR should be judged on its own merits — a latent defect that silently hides missing rows whenever content hashes coincide, which duplicate row content produces directly — not as a fix for the observed 7-row gap.

## The observation that led here

On the host 3-node cluster, `entity_store` counts disagreed and stayed disagreeing:

```
node1 = 78492 distinct ids     in node3 not node1:  7
node2 = 78497                  in node1 not node3:  0     ← nothing unique to node1
node3 = 78499                  union 78499, intersection 78492
```

Strictly nested — one-directional replication loss, not conflicting writes or tombstones. Meanwhile anti-entropy repair run from **all three** coordinators reported `partitions_streamed_in: 0, partitions_streamed_out: 0, sessions_ok: 2/2, errors: 0`.

Reading that code is what surfaced the XOR flaw. The flaw is genuine; the attribution was mine and was premature.

(Checked the cheap explanation first: reading the nodes in reverse order gave identical counts, and the same node twice 20s apart gave delta 0. Not a measurement race.)

## The fix

Leaves and internal nodes combine with wrapping addition. Still commutative — replicas scan their own SSTables in different orders and must agree — but no longer self-inverse, so duplicates accumulate instead of cancelling.

Honest about the residual: this is still a fixed-width sum, so collisions remain possible in principle. They now require a specific total, rather than being triggered structurally by any duplicated pair.

## TDD

Both regression tests were written first and confirmed failing against the XOR implementation (`13 passed; 2 failed`), then pass with the combiner replaced. Also added a direct test that a duplicate insert changes the hash — the property XOR lacked, stated plainly rather than only via the two-replica scenario.

`xor_is_order_independent` → `combining_is_order_independent`. Order independence is what was actually wanted; XOR merely happened to provide it alongside the behaviour that hid the gap. Leaving a test named after the removed mechanism would misdescribe why it exists.

## Compatibility — worth a look before merging

This changes the hash a node computes for identical data. A node on this build and a node on an older one will disagree on every leaf and stream partitions **both ways** — a full repair. Expensive but not incorrect, and self-resolving once both sides upgrade.

The serialized tree layout is unchanged (same `Vec<u64>`, same wire format), so nothing fails to decode. If a staged rollout across a large cluster is a concern, that transient full-repair cost is the thing to weigh.

## Verification

1094 `ferrosa-cluster` tests pass. `fmt --check`, `clippy -D warnings` and `cargo doc` all clean locally before pushing.

Not merging this myself: standing rule is no auto-merge on public repos.
