### PR TITLE
fix(raft): let a snapshot correct an already-registered table's schema

### DIFF
--- a/ferrosa-cluster/src/raft/state_machine.rs
+++ b/ferrosa-cluster/src/raft/state_machine.rs
@@ -671,10 +671,28 @@ impl FerrosStateMachine {
             }
         }
 
-        // Re-register all tables with engine if present.
+        // Land every table's schema on the engine if present.
+        //
+        // `register_table` early-returns for a table the engine already knows
+        // and DISCARDS the incoming schema, so it can introduce a table but
+        // never correct one. A node whose engine holds a stale column set —
+        // from an older schema.json, or from missing an ALTER — would then keep
+        // serving it forever while its own Raft state carried the right one,
+        // and since regular columns are ordered alphabetically, a single
+        // missing column shifts every later ordinal and makes cross-node row
+        // transfers decode against the wrong types.
+        //
+        // The ALTER apply path already uses `update_table_schema`; use it here
+        // too so both paths land a schema the same way.
         if let Some(engine) = &self.engine {
             for table in self.state.tables.values() {
-                if let Err(e) = engine.register_table(table.to_storage_schema()) {
+                let schema = table.to_storage_schema();
+                let table_id = TableId::new(&schema.keyspace, &schema.table);
+                if engine.table_schema(&table_id).is_some() {
+                    if let Err(e) = engine.update_table_schema(&table_id, schema) {
+                        tracing::error!(%e, %context, %table_id, "update_table_schema failed — node may serve a schema its Raft state contradicts");
+                    }
+                } else if let Err(e) = engine.register_table(schema) {
                     tracing::error!(%e, %context, "register_table failed");
                 }
             }
@@ -2684,6 +2702,85 @@ mod tests {
         engine
             .write(&table_id, &key, row, 1)
             .expect("recovered Raft snapshot must also register the table with StorageEngine");
+    }
+
+    /// REGRESSION: a Raft snapshot must be able to CORRECT the columns of a
+    /// table the engine has already registered, not just introduce new tables.
+    ///
+    /// `sync_schema_and_engine_from_state` landed schema with
+    /// `engine.register_table`, which early-returns when the table is already
+    /// registered and discards the incoming schema. The ALTER apply path calls
+    /// `engine.update_table_schema` instead, so the two paths disagreed about
+    /// how to land a schema: a node whose engine held a stale column set could
+    /// never recover it, no matter how many snapshots it installed.
+    ///
+    /// Observed on the native 3-node cluster: node3 served 11 columns for
+    /// agent_memory.entity_store while its own Raft state machine carried the
+    /// full 19. Regular columns are ordered alphabetically, so the missing
+    /// columns shifted every later ordinal and repair rejected the transfer —
+    /// `column "created_at", index 3: TimestampType expects 8 raw bytes but
+    /// value provided 3072` (3072 = vector<float,768>, the column that actually
+    /// sits at index 3 in the stale ordering). It survived restarts, a snapshot
+    /// install and a full raft reset.
+    #[tokio::test]
+    async fn recovering_a_snapshot_corrects_an_already_registered_stale_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let snapshot_path = dir.path().join("sm.snapshot");
+
+        // Source node: a table carrying an EXTRA column, snapshotted.
+        let mut source = FerrosStateMachine::with_snapshot_path(snapshot_path.clone());
+        let mut extended = simple_table("agent_memory", "entity_store");
+        extended.columns.insert(
+            "description".to_string(),
+            ColumnMetadata {
+                name: "description".to_string(),
+                kind: ColumnKind::Regular,
+                position: 0,
+                column_type: "text".to_string(),
+                clustering_order: ClusteringOrder::None,
+                mask: None,
+            },
+        );
+        let extended_columns = extended.to_storage_schema().regular_columns.len();
+        source
+            .apply(vec![make_entry(
+                1,
+                1,
+                RaftOp::CreateTable(Box::new(extended)),
+            )])
+            .await
+            .unwrap();
+        source.build_snapshot().await.unwrap();
+
+        // Recovering node: engine ALREADY holds the table, with the stale
+        // (pre-ALTER) column set — the situation node3 was stuck in.
+        let engine = test_engine(dir.path());
+        let stale = simple_table("agent_memory", "entity_store").to_storage_schema();
+        let stale_columns = stale.regular_columns.len();
+        engine.register_table(stale).unwrap();
+        assert!(
+            stale_columns < extended_columns,
+            "the test must start with the engine holding FEWER columns"
+        );
+
+        let table_id = TableId::new("agent_memory", "entity_store");
+        let mut restarted = FerrosStateMachine::with_side_effects_and_snapshot_path(
+            Arc::new(test_schema_instance()),
+            Arc::clone(&engine),
+            snapshot_path,
+        );
+        assert!(restarted.recover_from_persisted_snapshot().unwrap());
+
+        assert_eq!(
+            engine
+                .table_schema(&table_id)
+                .expect("table registered")
+                .regular_columns
+                .len(),
+            extended_columns,
+            "the snapshot's column set must reach the engine, or the node serves \
+             a schema its own Raft state contradicts"
+        );
     }
 
     #[tokio::test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -930,7 +930,6 @@ pub struct StorageEngine {
 
 /// Per-table state: schema + store + optional NVMe pin config.
 struct TableState {
-    #[allow(dead_code)]
     schema: TableSchema,
     store: TableStore<FileFlushTarget>,
     /// When `Some`, this table is pinned to NVMe. S3 upload is skipped for
@@ -5460,6 +5459,17 @@ impl StorageEngine {
     /// Number of tables currently registered.
     pub fn table_count(&self) -> usize {
         self.tables.read().len()
+    }
+
+    /// The schema currently registered for `table_id`, if the table is known.
+    ///
+    /// Exists so callers can verify which column set the engine is actually
+    /// serving. A node can hold a schema in its Raft state while the engine
+    /// serves an older one, and without a way to read the engine's own view
+    /// that divergence is invisible until a cross-node row transfer decodes
+    /// against the wrong ordinals.
+    pub fn table_schema(&self, table_id: &TableId) -> Option<TableSchema> {
+        self.tables.read().get(table_id).map(|s| s.schema.clone())
     }
 
     /// The `TableId`s currently registered with this engine. Used by the


### PR DESCRIPTION
## The defect

`sync_schema_and_engine_from_state` landed schema on the storage engine with `register_table`, which early-returns for a table the engine already knows — **discarding the incoming schema**:

```rust
if tables.contains_key(&table_id) {
    ...
    return Ok(());          // incoming schema dropped
}
```

A snapshot could therefore introduce a *new* table but never **correct** an existing one. The ALTER apply path doesn't have this problem — it calls `engine.update_table_schema` explicitly. Two paths, two ways of landing a schema, and only one of them works for a table already in place.

A node whose engine holds a stale column set keeps serving it forever, however many snapshots it installs, while its own Raft state carries the correct one. On shutdown it rewrites `schema.json` from that stale state, overwriting the evidence.

## Observed

On the native 3-node cluster, `agent_memory.entity_store`:

| | columns served | schema.json regular_columns | own raft snapshot |
|---|---|---|---|
| node1 | 19 | 16 | full |
| node2 | 19 | 16 | full |
| **node3** | **11** | **8** | **full** |

node3's `state-machine.snapshot.bin` is byte-comparable to its peers' and contains every column (`content_hash` ×13, `description_embedding` ×2). Consensus was right; only the serving layer was stale.

Regular columns are ordered **alphabetically**, so the 8 missing columns shift every later ordinal:

```
node1: 0 confidence  1 content_hash  2 context_snippet  3 created_at ...
node3: 0 confidence  1 context_snippet  2 created_at  3 entity_embedding ...
```

node3's index 3 is `entity_embedding` — `vector<float,768>`, 3072 bytes — where its peers expect an 8-byte `created_at`. Anti-entropy repair rejected the transfer:

```
apply write: invalid data: agent_memory.entity_store (column "created_at", index 3):
TimestampType expects 8 raw bytes but value provided 3072
```

leaving node3 unrepairable. It survived restarts, a snapshot install, and a full raft reset.

## The fix

The snapshot path now uses `update_table_schema` for tables the engine already holds and `register_table` only for new ones, so both paths land a schema the same way. A failed update is logged loudly — the consequence is a node serving a schema its own consensus state contradicts.

Also adds `StorageEngine::table_schema` so the column set the engine is *actually* serving can be read back. Its absence is part of why this stayed invisible: nothing could observe the divergence between Raft state and engine state until a cross-node transfer decoded against the wrong ordinals. That also retires the `#[allow(dead_code)]` on `TableState::schema`.

## TDD

`recovering_a_snapshot_corrects_an_already_registered_stale_schema` — registers a table with the stale column set, recovers a snapshot carrying the extended one, asserts the engine ends up with the snapshot's columns. Written first and confirmed failing on the old code:

```
assertion `left == right` failed: the snapshot's column set must reach the engine
  left: 1
 right: 2
```

## Verification

ferrosa-cluster 1092 and ferrosa-storage 1045 tests pass. `fmt --check`, `clippy -D warnings`, `cargo doc -D warnings` clean locally before pushing.

## Not addressed here

Where node3 originally lost the columns is undetermined — its raft dir was recreated during a reset, so the loss happened at or before that. This PR fixes why it could never RECOVER, which is the part that reproduces in a test. Restoring the live node3 is operational work tracked in `t_433207d8`.

Not merging this myself: standing rule is no auto-merge on public repos.
