### PR TITLE
fix(ci): pin pair-mode host_ids so the nightly smoke test has a stable primary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "tempfile",
  "tikv-jemallocator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,16 @@ services:
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_INTERNODE_BIND: "0.0.0.0:7000"
       FERROSA_INTERNODE_BROADCAST: "node1:7000"
+      # Pinned so the pair-mode primary election is deterministic.
+      # `ModeController::choose_pair_role` gives Primary to the **lowest**
+      # host_id (`local_host_id <= peer_host_id`). An unpinned node generates a
+      # fresh random UUID on first boot, so node1 won that comparison only about
+      # half the time. tests/docker-smoke.sh drives all pair CQL against node1
+      # as the primary and promotes node2 in Phase 3, so on a lost coin flip
+      # node1 came up a secondary — refusing every client CQL connection while
+      # still reporting healthy on /readyz — and the nightly smoke test sat in
+      # `wait_cql` until it timed out. Keep node1 < node2 < node3.
+      FERROSA_HOST_ID: "11111111-1111-1111-1111-111111111111"
       FERROSA_SEED: "node2:7000,node3:7000"
       FERROSA_CLUSTER_NAME: ferrosa-dev
       FERROSA_S3_ENDPOINT: "http://rustfs:9000"
@@ -123,6 +133,7 @@ services:
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_INTERNODE_BIND: "0.0.0.0:7000"
       FERROSA_INTERNODE_BROADCAST: "node2:7000"
+      FERROSA_HOST_ID: "22222222-2222-2222-2222-222222222222"
       FERROSA_SEED: "node1:7000,node3:7000"
       FERROSA_CLUSTER_NAME: ferrosa-dev
       FERROSA_S3_ENDPOINT: "http://rustfs:9000"
@@ -157,6 +168,7 @@ services:
       FERROSA_WEB_BIND: "0.0.0.0:9090"
       FERROSA_INTERNODE_BIND: "0.0.0.0:7000"
       FERROSA_INTERNODE_BROADCAST: "node3:7000"
+      FERROSA_HOST_ID: "33333333-3333-3333-3333-333333333333"
       FERROSA_SEED: "node1:7000,node2:7000"
       FERROSA_CLUSTER_NAME: ferrosa-dev
       FERROSA_S3_ENDPOINT: "http://rustfs:9000"

--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -219,6 +219,14 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   `CLUSTER_REJOIN_ATTEMPTS_TOTAL` / `_FAILURES_TOTAL`.
 - `pair/` — two-node primary/secondary coordination (deterministic host-ID
   ordering, independent of which TCP direction wins), switchover, catch-up.
+  `ModeController::choose_pair_role` gives `Primary` to the **lowest** host_id
+  (`local_host_id <= peer_host_id`). A node with no `FERROSA_HOST_ID` generates
+  a random UUID on first boot, so any deployment that needs a predictable
+  primary must pin the ids — every `docker-compose*.yml` in this repo does, and
+  `ferrosa`'s `pair_primary_is_deterministic` test enforces it. An unpromoted
+  secondary refuses client CQL entirely (`is_cql_ready()` is false) while still
+  reporting healthy on `/readyz`, so an unpinned stack can hand you a node that
+  looks up but serves nothing.
 - `rebalance.rs` — token-skew rebalancing with data streaming.
 
 ### Repair & hints (`repair/`, `hints/`)

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -1812,6 +1812,54 @@ async fn decommission_requires_raft() {
 
 // ---- is_cql_ready tests ------------------------------------------------
 
+/// The pair role must be decided by host_id ordering, lowest wins.
+///
+/// `docker-compose.yml` pins node1 to the lowest `FERROSA_HOST_ID` precisely so
+/// it always takes `Primary`; `tests/docker-smoke.sh` then drives every
+/// pair-mode CQL statement at node1 and promotes node2 in Phase 3. Before those
+/// ids were pinned the comparison ran against a per-boot random UUID, so node1
+/// was primary only about half the time — and on the other runs it came up a
+/// secondary that refuses client CQL while still reporting healthy on
+/// `/readyz`, hanging the nightly smoke test in `wait_cql` until it timed out.
+///
+/// Pinned here as well as in `ferrosa`'s `pair_primary_is_deterministic` so
+/// that flipping this comparison fails a unit test, not just a nightly run.
+#[test]
+fn lower_host_id_takes_primary_role() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = test_storage(dir.path());
+    let schema = test_schema();
+    let config = Arc::new(ClusterConfig::default());
+    let net_config = Arc::new(NetConfig::default());
+    // local < peer, so this node must win the primary role.
+    let local_id = Uuid::from_u128(1);
+    let peer_id = Uuid::from_u128(2);
+
+    let registry = Arc::new(HandlerRegistry::new());
+    let (controller, _handles) = ModeController::new(
+        config,
+        net_config.clone(),
+        local_id,
+        storage,
+        schema,
+        registry,
+    );
+
+    let pm = Arc::new(PeerManager::new(net_config, local_id, controller.clone()));
+    controller.set_peer_manager(pm);
+
+    let peer_addr: SocketAddr = "127.0.0.1:7000".parse().unwrap();
+    controller.on_peer_connected((peer_id, peer_addr));
+
+    assert_eq!(controller.mode(), DeploymentMode::Pair);
+    assert_eq!(
+        controller.role(),
+        Some(PairRole::Primary),
+        "the lower host_id must take Primary — docker-compose.yml pins node1 \
+         lowest so the pair smoke test has a deterministic primary"
+    );
+}
+
 #[test]
 fn is_cql_ready_standalone_returns_true() {
     let dir = tempfile::tempdir().unwrap();

--- a/ferrosa/Cargo.toml
+++ b/ferrosa/Cargo.toml
@@ -81,6 +81,10 @@ optional = true
 features = ["rt-tokio"]
 
 [dev-dependencies]
+# Parses the committed docker-compose stacks in
+# tests/pair_primary_is_deterministic.rs so the pinned FERROSA_HOST_ID values
+# are checked against the ordering choose_pair_role elects on.
+serde_yaml = "0.9"
 serial_test = "3"
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/ferrosa/tests/pair_primary_is_deterministic.rs
+++ b/ferrosa/tests/pair_primary_is_deterministic.rs
@@ -1,0 +1,134 @@
+//! The pair-mode smoke stack must elect the same primary on every run.
+//!
+//! `tests/docker-smoke.sh` drives all pair-mode CQL against **node1** as the
+//! primary and promotes **node2** in its Phase 3 operator-promotion step. That
+//! only holds if the primary election is deterministic.
+//!
+//! `ModeController::choose_pair_role` awards `Primary` to the **lowest**
+//! host_id (`local_host_id <= peer_host_id`). A node with no `FERROSA_HOST_ID`
+//! generates a fresh random UUID on first boot, so with unpinned ids node1 won
+//! that comparison only about half the time. On the runs it lost, node1 came up
+//! a secondary — which refuses every client CQL connection while still
+//! reporting healthy on `/readyz` — and the smoke test sat in `wait_cql` until
+//! it timed out. That coin flip is what made the nightly Docker smoke test
+//! intermittently red.
+//!
+//! These tests read the committed compose stacks and assert the ordering the
+//! election depends on, so removing or reordering a pin fails here rather than
+//! in a nightly run hours later. The election rule itself is pinned separately
+//! by `ferrosa-cluster`'s `lower_host_id_takes_primary_role`.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+/// Absolute path to a file in the workspace root.
+fn workspace_file(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ferrosa crate always has a workspace-root parent")
+        .join(name)
+}
+
+/// Pinned `FERROSA_HOST_ID` for every node service in a compose file.
+///
+/// Returns a map of service name to parsed UUID. A service without a pinned
+/// host_id is absent from the map — the caller decides whether that is fatal,
+/// which keeps the "pin is missing" failure message specific.
+fn pinned_host_ids(compose_path: &Path) -> BTreeMap<String, Uuid> {
+    let raw = std::fs::read_to_string(compose_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", compose_path.display()));
+    let doc: serde_yaml::Value = serde_yaml::from_str(&raw)
+        .unwrap_or_else(|e| panic!("{} is not valid YAML: {e}", compose_path.display()));
+
+    let services = doc
+        .get("services")
+        .and_then(|s| s.as_mapping())
+        .unwrap_or_else(|| panic!("{} has no `services` mapping", compose_path.display()));
+
+    let mut pins = BTreeMap::new();
+    for (name, service) in services {
+        let Some(name) = name.as_str() else { continue };
+        // Stacks namespace their services (`node1`, `ct-node1`, ...), so match
+        // on the substring rather than a prefix.
+        if !name.contains("node") {
+            continue;
+        }
+        let Some(raw_id) = service
+            .get("environment")
+            .and_then(|env| env.get("FERROSA_HOST_ID"))
+            .and_then(|id| id.as_str())
+        else {
+            continue;
+        };
+        let id = Uuid::parse_str(raw_id).unwrap_or_else(|e| {
+            panic!("{name} has an unparseable FERROSA_HOST_ID {raw_id:?}: {e}")
+        });
+        pins.insert(name.to_string(), id);
+    }
+    pins
+}
+
+/// Every node in the pair-mode compose stack must pin its host_id.
+///
+/// Without a pin the node generates a random UUID per run and the election
+/// outcome becomes a coin flip.
+#[test]
+fn pair_smoke_stack_pins_every_node_host_id() {
+    let compose = workspace_file("docker-compose.yml");
+    let pins = pinned_host_ids(&compose);
+
+    for node in ["node1", "node2", "node3"] {
+        assert!(
+            pins.contains_key(node),
+            "{node} in {} must pin FERROSA_HOST_ID — an unpinned node generates a \
+             random UUID each run, making the pair primary election a coin flip",
+            compose.display()
+        );
+    }
+}
+
+/// node1 must hold the lowest host_id, so it always takes the primary role.
+///
+/// `choose_pair_role` compares `local_host_id <= peer_host_id`, so the lowest
+/// id wins. `tests/docker-smoke.sh` depends on that being node1.
+#[test]
+fn node1_is_deterministically_the_pair_primary() {
+    let compose = workspace_file("docker-compose.yml");
+    let pins = pinned_host_ids(&compose);
+
+    let node1 = pins["node1"];
+    for peer in ["node2", "node3"] {
+        let peer_id = pins[peer];
+        assert_ne!(
+            node1, peer_id,
+            "node1 and {peer} must not share a host_id — a duplicate identity \
+             breaks peer bookkeeping as well as the election"
+        );
+        assert!(
+            node1 < peer_id,
+            "node1 ({node1}) must sort below {peer} ({peer_id}): \
+             choose_pair_role gives Primary to the lowest host_id, and \
+             tests/docker-smoke.sh drives pair-mode CQL against node1 as the primary"
+        );
+    }
+}
+
+/// The multi-node cluster stacks must also pin ids, so a Raft cluster that
+/// passes through pair mode during formation lands on a stable primary.
+#[test]
+fn cluster_stacks_pin_every_node_host_id() {
+    for stack in [
+        "tests/docker-compose.cluster.yml",
+        "tests/docker-compose.cluster.w3-standalone.yml",
+        "tests/docker-compose.compaction-test.yml",
+    ] {
+        let compose = workspace_file(stack);
+        let pins = pinned_host_ids(&compose);
+        assert!(
+            !pins.is_empty(),
+            "{stack} must pin FERROSA_HOST_ID for its nodes so formation is reproducible"
+        );
+    }
+}

--- a/tests/docker-smoke.sh
+++ b/tests/docker-smoke.sh
@@ -323,11 +323,19 @@ info "=== Phase 1: Bidirectional reads and writes ==="
 info "Building and starting pair services..."
 docker compose up -d --build node1 node2
 
+# Roles are deterministic: `choose_pair_role` gives Primary to the lowest
+# host_id and docker-compose.yml pins node1 below node2. Assert the role before
+# waiting on CQL — when the pins regress, node1 comes up a secondary that
+# refuses CQL while still reporting healthy on /readyz, and a bare `wait_cql`
+# would burn the full timeout before failing with no explanation.
+info "Waiting for node1 to become the pair primary..."
+wait_for_cluster_role 9090 "node1" "primary" "$PAIR_CQL_TIMEOUT"
+
 wait_cql 9042 "node1" "$PAIR_CQL_TIMEOUT"
 
-# In pair mode, node2 becomes the secondary. The CQL server rejects all
-# connections on secondaries (only the primary serves CQL), so wait for the
-# explicit role rather than treating a rejected CQL connection as unready.
+# node2 is the secondary. The CQL server rejects all connections on secondaries
+# (only the primary serves CQL), so wait for the explicit role rather than
+# treating a rejected CQL connection as unready.
 info "Waiting for node2 to become the pair secondary..."
 wait_for_cluster_role 9091 "node2" "secondary" "$PAIR_CQL_TIMEOUT"
 


### PR DESCRIPTION
## Problem

The **Docker Smoke Test (Pair Mode)** job in `nightly-fuzz.yml` has been failing about half the time for months. In the most recent run ([32329007639](https://github.com/ferrosadb/ferrosa/actions/runs/32329007639)) node1 reported **healthy** with 9042 published, yet every `cqlsh` attempt failed for the full 240s `PAIR_CQL_TIMEOUT`:

```
INFO: Waiting for node1 CQL (port 9042)...
FAIL: node1 CQL did not become ready in 240s
```

while `docker compose ps` showed `Up 4 minutes (healthy)` and the node logged `CQL server listening on 0.0.0.0:9042`.

## Root cause

The pair role is decided by `ModeController::choose_pair_role`, which gives `Primary` to the **lowest** host_id:

```rust
if was_promoted || self.local_host_id <= peer_host_id { PairRole::Primary } else { PairRole::Secondary }
```

`docker-compose.yml` did not pin `FERROSA_HOST_ID`, so each node generated a fresh random UUID on first boot and node1 won that comparison only about half the time. `tests/docker-smoke.sh` drives all pair-mode CQL at node1 as the primary and promotes node2 in Phase 3 — so on a lost coin flip node1 came up a **secondary**.

An unpromoted secondary refuses client CQL at the accept loop (`ferrosa-cql/src/server.rs`, gated on `is_cql_ready()`) while `/readyz` still returns 200. That is why the container looked healthy while nothing could reach it. Sending a raw v4 `OPTIONS` frame to the secondary returns an ERROR on stream -1 rather than `SUPPORTED`:

```
port=29042 (primary)   opcode=0x06 SUPPORTED
port=29043 (secondary) opcode=0x00 stream=-1
   ERROR code=0x1001 msg='writes disallowed on read replica; connect to the primary node'
```

In run 32329007639 node1 drew `bd3b0a16…` against peer `9e8a9615…`, lost the comparison, and logged `role=secondary`.

## Fix

Pin `FERROSA_HOST_ID` in `docker-compose.yml` with `node1 < node2 < node3`, matching the convention the cluster stacks (`tests/docker-compose.cluster.yml`, `.w3-standalone.yml`, `.compaction-test.yml`) already follow.

**Pair semantics are unchanged.** An unpromoted secondary still refuses both reads and writes, and promotion remains operator-only (`controller/operator.rs`), so this does not open a split-brain path — Phase 2 of the smoke test still asserts that an unpromoted node2 rejects reads and writes after the primary dies.

`tests/docker-smoke.sh` now also asserts node1's primary role *before* waiting on CQL, so a future regression fails in seconds naming the role it actually got, instead of burning the full timeout with no explanation.

## Verification

Brought the pair stack up from the `2026.08.20.0151` nightly `.deb`, three times from clean volumes:

```
run 1: node1 role=primary  probe=CQL-OK
run 2: node1 role=primary  probe=CQL-OK
run 3: node1 role=primary  probe=CQL-OK
```

The smoke probe answers in **0.2s** (it previously timed out at 240s), and `/api/cluster/status` on node1 reports `{"host_id":"11111111-…","mode":"pair","role":"primary"}`.

Local gate:

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets` — zero warnings
- `cargo test --workspace` (excluding `ferrosa-jepsen`/`ferrosa-loadgen`, mirroring CI) — **6711 passed, 0 failed**

## Regression cover

- `ferrosa/tests/pair_primary_is_deterministic.rs` — asserts every compose stack pins its host_ids and that node1 sorts lowest. Verified RED: deleting the pins fails both tests with an explicit message.
- `ferrosa-cluster` `lower_host_id_takes_primary_role` — pins the election rule itself, so flipping the comparison fails a unit test rather than a nightly run hours later.

## Follow-ups filed (not in this PR)

- `race-stress-fly` job in the same workflow independently times out at 45m with no `RS_RESULT` marker despite `timeout-minutes: 75`.
- `ferrosa-cluster` carries three pair-role election rules and only one runs: `choose_pair_role` (live, lowest-wins), `PairRole::elect` (deprecated, and **highest**-wins — the exact opposite), and `from_connection_direction` (documented as the replacement, never called).
- The pair smoke stack mutually seeds every node, unlike the cluster stack where node1 is the sole seed.
