### PR TITLE
fix(test): stop pre-window frees from suppressing measured heap peaks

### DIFF
--- a/ferrosa-cluster/tests/fulltext_stream_memory_bound.rs
+++ b/ferrosa-cluster/tests/fulltext_stream_memory_bound.rs
@@ -77,7 +77,17 @@ unsafe impl GlobalAlloc for TrackingAlloc {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if ARMED.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+            // Clamp at zero. `measure_peak` zeroes LIVE at arm time, so a free
+            // of memory allocated BEFORE the window would otherwise push the
+            // counter negative — and because PEAK is a running maximum of LIVE,
+            // every later allocation would be measured against that negative
+            // baseline and the peak would collapse toward zero. Seeding runs
+            // outside the window by design, so how much of it is released
+            // inside the window is pure timing: that is what made these peaks
+            // flaky across machines.
+            let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
+                Some((live - layout.size() as i64).max(0))
+            });
         }
         unsafe { System.dealloc(ptr, layout) };
     }
@@ -96,6 +106,39 @@ fn measure_peak<R>(f: impl FnOnce() -> R) -> (R, i64) {
     let out = f();
     ARMED.store(false, Ordering::SeqCst);
     (out, PEAK.load(Ordering::SeqCst))
+}
+
+/// The tracker must report the working set of the measured region even when the
+/// region frees memory that was allocated *before* the window opened.
+///
+/// `measure_peak` zeroes `LIVE` at arm time, but `dealloc` decrements it for
+/// every free while armed — including frees of pre-window allocations. Those
+/// frees drive `LIVE` negative, and since the peak is a running maximum of
+/// `LIVE`, a later genuine allocation is measured against that negative
+/// baseline and all but disappears.
+///
+/// This is what made `cluster_fulltext_stream_peak_bounded_and_doc_size_independent`
+/// flaky. The seeding phase runs outside the window by design, so how much of
+/// its memory happens to be released *inside* the window is pure timing. On a
+/// GitHub runner the 64 B arm measured 85 587 B against the 4096 B arm's stable
+/// 1 240 828 B — a 14.5x "doc size leak" that was really just a suppressed
+/// baseline, failing a test whose subject had not regressed at all.
+#[test]
+fn peak_survives_frees_of_pre_window_allocations() {
+    let pre_window = vec![0u8; 4 * 1024 * 1024];
+
+    let (_, peak) = measure_peak(|| {
+        // Released inside the window: must not lower the floor.
+        drop(pre_window);
+        let working_set = vec![0u8; 1024 * 1024];
+        std::hint::black_box(working_set.len())
+    });
+
+    assert!(
+        peak >= 1_000_000,
+        "peak {peak} B lost the 1 MiB working set — a pre-window free drove the \
+         live counter negative and suppressed the measurement"
+    );
 }
 
 const KS: &str = "agent_memory";

--- a/ferrosa-cluster/tests/range_scan_streaming_memory_bound.rs
+++ b/ferrosa-cluster/tests/range_scan_streaming_memory_bound.rs
@@ -63,7 +63,14 @@ unsafe impl GlobalAlloc for TrackingAlloc {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if ARMED.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+            // Clamp at zero: `measure_peak` zeroes LIVE at arm time, so a free
+            // of memory allocated BEFORE the window would drive the counter
+            // negative and, because PEAK is a running maximum of LIVE, suppress
+            // every later allocation. Seeding runs outside the window by design,
+            // so how much of it is released inside the window is pure timing.
+            let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
+                Some((live - layout.size() as i64).max(0))
+            });
         }
         unsafe { System.dealloc(ptr, layout) };
     }

--- a/ferrosa-cluster/tests/replica_scan_serialization_memory_bound.rs
+++ b/ferrosa-cluster/tests/replica_scan_serialization_memory_bound.rs
@@ -82,7 +82,14 @@ unsafe impl GlobalAlloc for TrackingAlloc {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if ARMED.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+            // Clamp at zero: `measure_peak` zeroes LIVE at arm time, so a free
+            // of memory allocated BEFORE the window would drive the counter
+            // negative and, because PEAK is a running maximum of LIVE, suppress
+            // every later allocation. Seeding runs outside the window by design,
+            // so how much of it is released inside the window is pure timing.
+            let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
+                Some((live - layout.size() as i64).max(0))
+            });
         }
         unsafe { System.dealloc(ptr, layout) };
     }

--- a/ferrosa-index/tests/fulltext_topk_memory_bound.rs
+++ b/ferrosa-index/tests/fulltext_topk_memory_bound.rs
@@ -44,7 +44,14 @@ unsafe impl GlobalAlloc for TrackingAlloc {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if ARMED.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+            // Clamp at zero: `measure_peak` zeroes LIVE at arm time, so a free
+            // of memory allocated BEFORE the window would drive the counter
+            // negative and, because PEAK is a running maximum of LIVE, suppress
+            // every later allocation. Seeding runs outside the window by design,
+            // so how much of it is released inside the window is pure timing.
+            let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
+                Some((live - layout.size() as i64).max(0))
+            });
         }
         unsafe { System.dealloc(ptr, layout) };
     }

--- a/ferrosa-storage/tests/fulltext_replica_memory_bound.rs
+++ b/ferrosa-storage/tests/fulltext_replica_memory_bound.rs
@@ -56,7 +56,14 @@ unsafe impl GlobalAlloc for TrackingAlloc {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if ARMED.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+            // Clamp at zero: `measure_peak` zeroes LIVE at arm time, so a free
+            // of memory allocated BEFORE the window would drive the counter
+            // negative and, because PEAK is a running maximum of LIVE, suppress
+            // every later allocation. Seeding runs outside the window by design,
+            // so how much of it is released inside the window is pure timing.
+            let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
+                Some((live - layout.size() as i64).max(0))
+            });
         }
         unsafe { System.dealloc(ptr, layout) };
     }

--- a/ferrosa-storage/tests/fulltext_streaming_each_memory_bound.rs
+++ b/ferrosa-storage/tests/fulltext_streaming_each_memory_bound.rs
@@ -54,7 +54,14 @@ unsafe impl GlobalAlloc for TrackingAlloc {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if ARMED.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+            // Clamp at zero: `measure_peak` zeroes LIVE at arm time, so a free
+            // of memory allocated BEFORE the window would drive the counter
+            // negative and, because PEAK is a running maximum of LIVE, suppress
+            // every later allocation. Seeding runs outside the window by design,
+            // so how much of it is released inside the window is pure timing.
+            let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
+                Some((live - layout.size() as i64).max(0))
+            });
         }
         unsafe { System.dealloc(ptr, layout) };
     }

--- a/ferrosa-storage/tests/order_by_spill_memory_bound.rs
+++ b/ferrosa-storage/tests/order_by_spill_memory_bound.rs
@@ -41,7 +41,14 @@ unsafe impl GlobalAlloc for TrackingAlloc {
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if ARMED.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+            // Clamp at zero: `measure_peak` zeroes LIVE at arm time, so a free
+            // of memory allocated BEFORE the window would drive the counter
+            // negative and, because PEAK is a running maximum of LIVE, suppress
+            // every later allocation. Seeding runs outside the window by design,
+            // so how much of it is released inside the window is pure timing.
+            let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
+                Some((live - layout.size() as i64).max(0))
+            });
         }
         unsafe { System.dealloc(ptr, layout) };
     }

--- a/ferrosa-storage/tests/recovery_oom_memory_bound.rs
+++ b/ferrosa-storage/tests/recovery_oom_memory_bound.rs
@@ -60,7 +60,14 @@ unsafe impl GlobalAlloc for TrackingAlloc {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if ARMED.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);
+            // Clamp at zero: `measure_peak` zeroes LIVE at arm time, so a free
+            // of memory allocated BEFORE the window would drive the counter
+            // negative and, because PEAK is a running maximum of LIVE, suppress
+            // every later allocation. Seeding runs outside the window by design,
+            // so how much of it is released inside the window is pure timing.
+            let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
+                Some((live - layout.size() as i64).max(0))
+            });
         }
         System.dealloc(ptr, layout);
     }


### PR DESCRIPTION
## The flake

`cluster_fulltext_stream_peak_bounded_and_doc_size_independent` fails intermittently on CI and not locally — e.g. on [PR #343](https://github.com/ferrosadb/ferrosa/pull/343), whose diff contains no production code at all:

```
cluster fts stream peak: doc=64B -> 85587 B, doc=4096B -> 1240828 B, ratio=14.50
REGRESSION (t_4ae47a9f e2e): fulltext stream peak scales with document size
```

Measuring instead of guessing: **`peak_large` is stable at 1 240 828 B on every machine including CI.** It is `peak_small` that moves — 1.03–1.24 MB locally, 85 587 B on a GitHub runner. The assertion is `peak_large < max(peak_small, 256 KiB) * 2`, so a suppressed *small* baseline is what reports a 14.5× "document size leak" in a streaming path that never regressed.

## Root cause

`measure_peak` zeroes `LIVE` at arm time, but `dealloc` decrements `LIVE` for **every** free while armed — including frees of memory allocated *before* the window:

```rust
unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
    if ARMED.load(Ordering::Relaxed) {
        LIVE.fetch_sub(layout.size() as i64, Ordering::Relaxed);   // can go negative
    }
    ...
}
```

`LIVE` is a signed `AtomicI64` and `PEAK` is a running `fetch_max` of it. So a pre-window free pushes `LIVE` negative, and every later allocation is measured against that negative baseline — the real working set can vanish entirely.

The suites seed their data *outside* the measurement window by design (that is the documented intent), so how much of that seed memory happens to be released *inside* the window is pure timing. That is exactly why this reproduces on a slow 2-core runner and not on a fast workstation. I could not reproduce it locally in 22 runs, including pinned to 2 cores with forced test parallelism — the numbers, not the repro, identified it.

## Fix

Clamp `LIVE` at zero on dealloc, so a pre-window free floors the counter instead of inverting it:

```rust
let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |live| {
    Some((live - layout.size() as i64).max(0))
});
```

After the fix `peak_small` lands in a 1.03–1.25 MB band and the ratio is 1.0–1.2, comfortably inside the 2× threshold.

This tracker is copy-pasted across **eight** test binaries and every copy carried the same defect, so all are fixed:

- `ferrosa-cluster/tests/{fulltext_stream,range_scan_streaming,replica_scan_serialization}_memory_bound.rs`
- `ferrosa-storage/tests/{fulltext_streaming_each,fulltext_replica,recovery_oom,order_by_spill}_memory_bound.rs`
- `ferrosa-index/tests/fulltext_topk_memory_bound.rs`

`ferrosa-storage/src/store.rs` has a similar-looking counter, but it is balanced RAII *partition* accounting with no pre-window imbalance — deliberately left alone.

## Regression cover

`peak_survives_frees_of_pre_window_allocations` allocates 4 MiB before the window, frees it inside, then allocates a 1 MiB working set and asserts the peak still sees it. Verified RED before the fix:

```
peak 0 B lost the 1 MiB working set — a pre-window free drove the live
counter negative and suppressed the measurement
```

## Verification

- All 8 affected suites pass (18 tests)
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets` — zero warnings
- `cargo test --workspace` (excluding `ferrosa-jepsen`/`ferrosa-loadgen`, mirroring CI) — **6708 passed, 0 failed**

## Note

This is independent of #343 and #344 and can merge in any order. #343 stays exposed to this flake until this lands.
