### PR TITLE
fix(runtime): a panic on the consensus runtime must kill the process

### DIFF
--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -867,6 +867,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
+    // 0.5. A panic on the consensus runtime must kill this process.
+    //
+    // Installed before tracing so it is in place for the whole run, and after
+    // the meta flags so `--version` stays a pure, side-effect-free query.
+    //
+    // A panic unwinds one thread. When that thread is `raft-rt`, the node stops
+    // replicating and loses its RaftAppendEntries handler while the process
+    // keeps serving CQL from whatever state it last held -- a live endpoint
+    // returning wrong answers, which clients cannot fail over from. Observed on
+    // node1, 2026-08-20: hours of `no handler registered` while every query
+    // returned `keyspace 'agent_memory' not found`.
+    //
+    // launchd already has KeepAlive { Crashed = true }. This is what lets it
+    // fire.
+    runtime::install_fatal_panic_hook();
+
     // 1. Initialize tracing.
     //
     // Non-blocking writer: every `tracing::info!` etc. goes through

--- a/ferrosa/src/runtime.rs
+++ b/ferrosa/src/runtime.rs
@@ -276,7 +276,6 @@ mod tests {
         assert!(!panic_is_fatal(Some("raft-rt-something-else")));
     }
 
-
     /// T0.2 (t_88223ad0): the runtime tunable parser prefers a valid env value
     /// over the default and falls back safely on unset / non-positive /
     /// unparseable input. Pure — no `set_var`, so no cross-test env races.

--- a/ferrosa/src/runtime.rs
+++ b/ferrosa/src/runtime.rs
@@ -157,9 +157,125 @@ impl RuntimeManager {
     }
 }
 
+/// The runtime whose panic means this node can no longer be a cluster member.
+const CONSENSUS_RUNTIME_THREAD: &str = "raft-rt";
+
+/// Must a panic on this thread take the whole process down?
+///
+/// A Rust panic unwinds one thread. For most of them that is the right scope —
+/// CQL already wraps request handling in `catch_unwind` so a bad request kills
+/// a connection, not a node. For consensus it is exactly wrong: when the raft
+/// runtime dies the node stops replicating, loses its RaftAppendEntries
+/// handler, and keeps answering CQL with whatever stale state it holds.
+///
+/// That happened here (2026-08-20, node1): a panic inside openraft left the
+/// process alive for hours, logging `no handler registered` every 3.5 seconds
+/// while serving `keyspace 'agent_memory' not found` to every client. launchd's
+/// `KeepAlive { Crashed = true }` never fired because nothing crashed.
+///
+/// Matching is exact. `raft-log-store` is the sled blocking pool, and a panic
+/// there is a storage fault with its own error path — aborting on a substring
+/// match would turn a contained failure into an outage.
+pub(crate) fn panic_is_fatal(thread_name: Option<&str>) -> bool {
+    thread_name == Some(CONSENSUS_RUNTIME_THREAD)
+}
+
+/// Make a consensus panic kill the process instead of only its thread.
+///
+/// Chains the previous hook so the panic message and backtrace are still
+/// printed before aborting — a silent abort would replace one undiagnosable
+/// failure with another.
+///
+/// `abort`, not `exit`: unwinding out of a poisoned consensus runtime can block
+/// on the very locks the panic left held, and a node that hangs on shutdown is
+/// the same "alive but useless" state this exists to end.
+pub fn install_fatal_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        previous(info);
+        let name = std::thread::current().name().map(str::to_owned);
+        if panic_is_fatal(name.as_deref()) {
+            eprintln!(
+                "FATAL: panic on the consensus runtime ({}). This node can no \
+longer replicate, so it must not keep serving reads. Aborting so the supervisor \
+restarts it.",
+                name.as_deref().unwrap_or("unnamed")
+            );
+            std::process::abort();
+        }
+    }));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A panic on the consensus runtime must be fatal to the PROCESS.
+    ///
+    /// Observed on node1 of the local three-node cluster, 2026-08-20. The raft
+    /// thread panicked inside openraft:
+    ///
+    ///     thread 'raft-rt' panicked at raft_core.rs:769:35:
+    ///     index out of bounds: the len is 0 but the index is 18446744073709551615
+    ///
+    /// A panic unwinds only its own thread, so the process stayed alive. What
+    /// died with that thread was the node's participation in the cluster: the
+    /// RaftAppendEntries handler went with it, and the leader logged
+    ///
+    ///     WARN no handler registered msg_type=RaftAppendEntries
+    ///
+    /// every 3.5 seconds for hours, into a file nobody was reading. The node
+    /// kept accepting CQL connections the whole time and answered every query
+    /// with `keyspace 'agent_memory' not found`, because it could no longer
+    /// receive schema. A live endpoint returning a wrong answer is worse than a
+    /// dead one: clients cannot fail over from it.
+    ///
+    /// launchd is configured `KeepAlive { Crashed = true }`, which would have
+    /// restarted the node — and never fired, because nothing crashed. Making
+    /// the panic fatal is what connects the existing supervision to the actual
+    /// failure.
+    #[test]
+    fn a_panic_on_the_consensus_runtime_is_fatal() {
+        assert!(
+            panic_is_fatal(Some("raft-rt")),
+            "consensus is not optional: a node that cannot replicate must stop serving"
+        );
+    }
+
+    /// Runtimes whose panic is survivable must NOT take the node down.
+    ///
+    /// CQL already wraps request handling in catch_unwind, so one bad request
+    /// kills a connection rather than a process. Aborting on those would turn a
+    /// contained fault into an outage — the opposite mistake, and an easy one
+    /// to make while fixing the first.
+    #[test]
+    fn a_panic_on_a_request_runtime_is_not_fatal() {
+        assert!(!panic_is_fatal(Some("cql-rt")));
+        assert!(!panic_is_fatal(Some("data-rt")));
+        assert!(!panic_is_fatal(Some("background-rt")));
+    }
+
+    /// An unnamed thread is not assumed fatal. Tokio names its workers, so an
+    /// unnamed panic is something else entirely, and guessing would make every
+    /// unrelated library panic an outage.
+    #[test]
+    fn an_unnamed_thread_is_not_fatal() {
+        assert!(!panic_is_fatal(None));
+        assert!(!panic_is_fatal(Some("")));
+    }
+
+    /// Matching must be exact. A substring match on "raft" would catch
+    /// "raft-log-store", which is a blocking pool for sled IO -- a panic there
+    /// is a storage error, not a consensus failure.
+    #[test]
+    fn matching_is_exact_not_a_substring() {
+        assert!(
+            !panic_is_fatal(Some("raft-log-store")),
+            "the sled blocking pool is not the consensus runtime"
+        );
+        assert!(!panic_is_fatal(Some("raft-rt-something-else")));
+    }
+
 
     /// T0.2 (t_88223ad0): the runtime tunable parser prefers a valid env value
     /// over the default and falls back safely on unset / non-positive /


### PR DESCRIPTION
Recovered WIP: written 2026-08-20, left unpushed on a local branch, rebased onto current main and re-verified here. Closes `t_919e7fee`.

## Why

A panic unwinds one thread. When that thread is `raft-rt`, the node stops replicating and loses its `RaftAppendEntries` handler — while the process keeps serving CQL from whatever state it last held. That is a live endpoint returning wrong answers, and clients cannot fail over from it because it still looks up.

Observed on node1 on 2026-08-20: hours of `no handler registered` while every query returned `keyspace 'agent_memory' not found`, and nothing restarted it because the process was still running.

## What

`panic_is_fatal` names the runtimes whose loss is unrecoverable:

- `raft-rt` → abort. Consensus is gone; there is no degraded mode worth serving.
- `cql-rt`, `data-rt`, `background-rt` → do not abort. Losing one request is not losing consensus.

launchd already sets `KeepAlive { Crashed = true }` and the containers restart on exit. This is what lets either of them fire.

The hook installs **after** the CLI meta flags, so `--version` stays a pure side-effect-free query, and **before** tracing, so it covers the whole run.

## Rebase notes

The original WIP commit also carried a `--version` fix that was uncommitted in the tree at the time (authored by someone else, preserved rather than discarded). That half has since landed on main independently as `handle_cli_meta_flags`, so the cherry-pick conflicted there and the resolution keeps main's version — only the panic supervision is new here.

Rebuilt and re-tested against current main rather than the stale binary it was written against: `ferrosa` 300 tests passing, clippy clean.

## Scope

Deliberately narrow. It decides *which* panics are fatal and installs the hook; it does not add panic recovery, supervision trees, or restart policy. Those belong to whatever restarts the process.
