### PR TITLE
chore: pin the Rust toolchain to latest stable (1.98.0)

### DIFF
--- a/ferrosa-cluster/src/ring/mod.rs
+++ b/ferrosa-cluster/src/ring/mod.rs
@@ -77,7 +77,7 @@ impl TokenRing {
         }
 
         // Wrap around to the beginning of the ring
-        for (_, &node_id) in self.ring.iter() {
+        for &node_id in self.ring.values() {
             if seen.insert(node_id) && is_normal(node_id) {
                 result.push(node_id);
                 if result.len() >= rf {

--- a/ferrosa-cql/src/bridge.rs
+++ b/ferrosa-cql/src/bridge.rs
@@ -297,9 +297,14 @@ pub fn term_to_cql_value(term: &Term, target: &CqlType) -> Result<CqlValue, CqlE
             ))),
             CqlType::Vector(_, dim) if b.len() == *dim * 4 => {
                 // Raw vector bytes: N big-endian f32 values
+                // `as_chunks::<4>()` yields `&[[u8; 4]]`, so `from_be_bytes`
+                // takes the array directly — no `try_into().unwrap()` on a
+                // slice whose length the compiler cannot see.
                 let floats: Vec<u32> = b
-                    .chunks_exact(4)
-                    .map(|chunk| u32::from_be_bytes(chunk.try_into().unwrap()))
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|chunk| u32::from_be_bytes(*chunk))
                     .collect();
                 Ok(CqlValue::Vector(floats))
             }

--- a/ferrosa-cql/src/param_cache.rs
+++ b/ferrosa-cql/src/param_cache.rs
@@ -184,18 +184,15 @@ pub fn normalize(query: &str) -> Option<Normalized> {
 fn scan_string(b: &[u8], open: usize) -> Option<usize> {
     let mut i = open + 1;
     while i < b.len() {
-        match memchr::memchr(b'\'', &b[i..]) {
-            Some(rel) => {
-                let q = i + rel;
-                if q + 1 < b.len() && b[q + 1] == b'\'' {
-                    // Escaped quote: skip both, keep scanning.
-                    i = q + 2;
-                    continue;
-                }
-                return Some(q + 1);
-            }
-            None => return None,
+        // No further quote means the string is unterminated.
+        let rel = memchr::memchr(b'\'', &b[i..])?;
+        let q = i + rel;
+        if q + 1 < b.len() && b[q + 1] == b'\'' {
+            // Escaped quote: skip both, keep scanning.
+            i = q + 2;
+            continue;
         }
+        return Some(q + 1);
     }
     None
 }
@@ -237,17 +234,14 @@ fn scan_numeric_or_hex(b: &[u8], start: usize) -> (usize, LiteralKind) {
 fn scan_quoted_ident(b: &[u8], open: usize) -> Option<usize> {
     let mut i = open + 1;
     while i < b.len() {
-        match memchr::memchr(b'"', &b[i..]) {
-            Some(rel) => {
-                let q = i + rel;
-                if q + 1 < b.len() && b[q + 1] == b'"' {
-                    i = q + 2;
-                    continue;
-                }
-                return Some(q + 1);
-            }
-            None => return None,
+        // No further quote means the identifier is unterminated.
+        let rel = memchr::memchr(b'"', &b[i..])?;
+        let q = i + rel;
+        if q + 1 < b.len() && b[q + 1] == b'"' {
+            i = q + 2;
+            continue;
         }
+        return Some(q + 1);
     }
     None
 }

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -373,11 +373,13 @@ fn projection_storage_ordinals(
 
     let mut wanted: Vec<u16> = Vec::new();
     for name in &names {
-        if let Some(col) = table_meta
+        // Unknown column name — bail out so the legacy path returns the right
+        // error.
+        let col = table_meta
             .columns
             .iter()
             .find(|(_, c)| c.name.eq_ignore_ascii_case(name))
-            .map(|(_, c)| c)
+            .map(|(_, c)| c)?;
         {
             match col.kind {
                 ColumnKind::Regular => {
@@ -402,10 +404,6 @@ fn projection_storage_ordinals(
                     return None;
                 }
             }
-        } else {
-            // Unknown column name — bail out so the legacy path
-            // returns the right error.
-            return None;
         }
     }
     // An empty `wanted` is intentional and valid: SELECT pk, ck
@@ -6675,17 +6673,18 @@ fn geo_explain_plan(
     ks: &str,
     s: &SelectStatement,
 ) -> Option<ScanPlan> {
-    let (column, op) = if let Some(gn) = &s.geo_nearest {
-        (gn.column.clone(), "GeoNearest")
-    } else if let Some(pred) = s.geo_predicates.first() {
-        let op = match pred {
-            GeoPredicate::WithinRadius { .. } => "GeoWithinRadius",
-            GeoPredicate::WithinBbox { .. } => "GeoWithinBbox",
-            GeoPredicate::WithinPolygon { .. } => "GeoWithinPolygon",
-        };
-        (pred.column().to_string(), op)
-    } else {
-        return None;
+    let (column, op) = match &s.geo_nearest {
+        Some(gn) => (gn.column.clone(), "GeoNearest"),
+        // No geo operation at all: leave it to the generic planner.
+        None => {
+            let pred = s.geo_predicates.first()?;
+            let op = match pred {
+                GeoPredicate::WithinRadius { .. } => "GeoWithinRadius",
+                GeoPredicate::WithinBbox { .. } => "GeoWithinBbox",
+                GeoPredicate::WithinPolygon { .. } => "GeoWithinPolygon",
+            };
+            (pred.column().to_string(), op)
+        }
     };
     let index_name = resolve_geo_index_name(snap, ks, &s.table, &column)?;
     Some(ScanPlan::GeoIndex {

--- a/ferrosa-flight/src/service.rs
+++ b/ferrosa-flight/src/service.rs
@@ -212,6 +212,14 @@ impl FerrosaFlight {
     /// Execute a CQL SELECT under `auth` and convert one (small) page to a single
     /// Arrow batch — used by `GetFlightInfo`/`GetSchema`, which only need the
     /// schema, so this fetches just one page rather than the whole result.
+    ///
+    /// `clippy::result_large_err`: the error is `tonic::Status`, which is 176
+    /// bytes by tonic's design and is what the Arrow Flight trait requires
+    /// every method in this service to return. Boxing it here would only move
+    /// the cost — the `Status` is unboxed again at the trait boundary a few
+    /// frames up — so the lint's remedy does not apply to a type we do not own
+    /// and cannot change at the point that matters.
+    #[allow(clippy::result_large_err)]
     async fn query_to_batch(
         &self,
         cql: &str,

--- a/ferrosa-index/src/lib.rs
+++ b/ferrosa-index/src/lib.rs
@@ -482,10 +482,11 @@ pub fn bytes_to_vec_f32(bytes: &[u8]) -> Result<Vec<f32>, IndexError> {
             bytes.len()
         )));
     }
-    Ok(bytes
-        .chunks_exact(4)
-        .map(|chunk| f32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
-        .collect())
+    // `as_chunks` yields `&[u8; 4]` directly, so `from_be_bytes` takes the
+    // array without rebuilding it index by index. The length check above
+    // already rejects a partial trailing chunk, so the remainder is empty.
+    let (quads, _remainder) = bytes.as_chunks::<4>();
+    Ok(quads.iter().copied().map(f32::from_be_bytes).collect())
 }
 
 /// Encode a vector of f32 values into **big-endian** bytes, matching the CQL

--- a/ferrosa-index/src/vector/quantized/container.rs
+++ b/ferrosa-index/src/vector/quantized/container.rs
@@ -121,7 +121,12 @@ impl QvecContainer {
 
         let artifact_len = payload_end;
         let mut pages = Vec::with_capacity(page_count as usize);
-        for (index, entry) in page_table.chunks_exact(QVEC_PAGE_ENTRY_LEN).enumerate() {
+        // `as_chunks` gives fixed-size `&[u8; QVEC_PAGE_ENTRY_LEN]` entries, so
+        // the reserved-byte slice below is bounds-checked at compile time
+        // rather than at run time. A trailing partial entry is dropped, as
+        // `chunks_exact` did; the page-table length is validated above.
+        let (entries, _partial) = page_table.as_chunks::<QVEC_PAGE_ENTRY_LEN>();
+        for (index, entry) in entries.iter().enumerate() {
             let offset = read_u64(entry, 0)?;
             let len = read_u32(entry, 8)?;
             let kind = entry[12];

--- a/ferrosa-postgres/src/query.rs
+++ b/ferrosa-postgres/src/query.rs
@@ -391,7 +391,10 @@ fn decode_bytea_hex_text(s: &str) -> Option<SqlValue> {
     }
     let mut bytes = Vec::with_capacity(hex.len() / 2);
     let chars: Vec<u8> = hex.bytes().collect();
-    for pair in chars.chunks_exact(2) {
+    // `as_chunks::<2>()` gives `&[[u8; 2]]`, so the pair is indexed without a
+    // bounds check the compiler cannot elide from a slice.
+    let (pairs, _remainder) = chars.as_chunks::<2>();
+    for pair in pairs {
         let hi = hex_value(pair[0])?;
         let lo = hex_value(pair[1])?;
         bytes.push((hi << 4) | lo);

--- a/ferrosa-sparql/src/planner.rs
+++ b/ferrosa-sparql/src/planner.rs
@@ -137,10 +137,7 @@ pub fn plan_query(query: &Query, scope: &TripleScope) -> Result<QueryPlan, Sparq
             Ok(plan)
         }
         Query::Construct {
-            template,
-            pattern,
-            base_iri: _,
-            ..
+            template, pattern, ..
         } => {
             // Plan the WHERE clause exactly like SELECT so the executor can
             // bind solutions; then attach the CONSTRUCT template.
@@ -371,7 +368,7 @@ fn collect_ops(
                 right, scope, ops, projection, limit, offset, distinct, order_by, filters,
             )?;
         }
-        GraphPattern::LeftJoin { left, right: _, .. } => {
+        GraphPattern::LeftJoin { left, .. } => {
             // OPTIONAL → evaluate left side; right side patterns are optional.
             // For now, just evaluate the left side (inner patterns).
             collect_ops(

--- a/ferrosa-storage/src/range_merger.rs
+++ b/ferrosa-storage/src/range_merger.rs
@@ -618,10 +618,7 @@ impl<'a, R: ReadAt> SsTableRunIter<'a, R> {
                 if self.cursor >= self.sstables.len() {
                     return Ok(());
                 }
-                match self.sstables[self.cursor].partitions_iter() {
-                    Ok(it) => self.current = Some(it),
-                    Err(e) => return Err(e),
-                }
+                self.current = Some(self.sstables[self.cursor].partitions_iter()?);
             }
             let it = self.current.as_mut().expect("just initialised");
             it.skip_to_next_partition()?;

--- a/ferrosa-storage/src/timeseries/aggregator.rs
+++ b/ferrosa-storage/src/timeseries/aggregator.rs
@@ -506,28 +506,26 @@ impl TimeSeriesAggregator {
             let cell = row.cells.iter().find(|(idx, _)| *idx == col_idx);
             match cell {
                 Some((_, cv)) => {
-                    if let Some(ref bytes) = cv.value {
-                        let decoded = if has_types {
-                            decode_typed_numeric(bytes, &self.column_types[i])
-                        } else {
-                            decode_numeric_bytes(bytes)
-                        };
-                        if let Some(v) = decoded {
-                            values.push(v);
-                        } else {
-                            tracing::warn!(
-                                table = %self.table_id.table,
-                                column_index = col_idx,
-                                byte_len = bytes.len(),
-                                "failed to decode numeric bytes for consolidation column"
-                            );
-                            if let Some(ref m) = self.shared_metrics {
-                                m.decode_failures.fetch_add(1, Ordering::Relaxed);
-                            }
-                            return None; // non-decodable value, skip this row
-                        }
+                    // No value is a tombstone: skip the row.
+                    let bytes = cv.value.as_ref()?;
+                    let decoded = if has_types {
+                        decode_typed_numeric(bytes, &self.column_types[i])
                     } else {
-                        return None; // tombstone, skip
+                        decode_numeric_bytes(bytes)
+                    };
+                    if let Some(v) = decoded {
+                        values.push(v);
+                    } else {
+                        tracing::warn!(
+                            table = %self.table_id.table,
+                            column_index = col_idx,
+                            byte_len = bytes.len(),
+                            "failed to decode numeric bytes for consolidation column"
+                        );
+                        if let Some(ref m) = self.shared_metrics {
+                            m.decode_failures.fetch_add(1, Ordering::Relaxed);
+                        }
+                        return None; // non-decodable value, skip this row
                     }
                 }
                 None => return None, // column not present

--- a/ferrosa-udf/examples/wasm_imports.rs
+++ b/ferrosa-udf/examples/wasm_imports.rs
@@ -52,7 +52,7 @@ fn main() {
             "  {:3}x  {}   e.g. {}",
             names.len(),
             sig,
-            &names[..names.len().min(6)].join(",")
+            names[..names.len().min(6)].join(",")
         );
     }
     if !other.is_empty() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -9,6 +9,6 @@
 #   x86_64/aarch64-unknown-linux-musl  -> Static Build (musl)
 #   wasm32-unknown-unknown             -> WASM UDF examples (Example CQL Scripts)
 [toolchain]
-channel = "1.96.1"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "wasm32-unknown-unknown"]


### PR DESCRIPTION
## What

Pins the Rust toolchain to **1.98.0**, the current stable (`88d9e12ae`, 2026-08-18).

## Why

The suite was running **four different compilers**:

| Repo | Was |
|---|---|
| ferrosa | 1.96.1 |
| ferrosa-memory | 1.96.0 |
| ferrosa-dbaas | 1.97.1 |
| ferrosa-mobile | *unpinned* — whatever `rustup default` resolved to (nightly, locally) while its CI ran 1.97.1 |

`ferrosa-memory`'s existing pin comment already argued the case: a contributor one release behind hits "fails locally, green in CI". That argument now extends across repos — `ferrosa-mobile` will link `ferrosa-memory-sync` for the live WebRTC control channel, and two workspaces cannot link under two compilers.

Companion PRs pin the other three repos to the same version.

## Verification

`cargo fmt --check` clean on 1.98.0.

Clippy was still running when these were pushed. **This is a version jump with `clippy -D warnings`, so new lints are plausible** — CI is the authority here, and any findings should be refactored rather than silenced with `#[allow]`.
