### PR TITLE
feat(accord): length-frame the protocol log so it can be replayed after a crash

### DIFF
--- a/ferrosa-storage/src/accord/crash_recovery.rs
+++ b/ferrosa-storage/src/accord/crash_recovery.rs
@@ -232,6 +232,91 @@ impl Default for CrashRecoveryReplay {
 }
 
 // ---------------------------------------------------------------------------
+// Orphan intent resolution
+// ---------------------------------------------------------------------------
+
+/// What to do with an orphan per-transaction intent temp table found at startup.
+///
+/// The NVMe intent temp tables are commit-log-equivalent durable state, so a
+/// restart must resolve each one against its Accord decision rather than
+/// discarding it. See `specs/proposed/unified-transaction-manager/`
+/// architecture.md ("Crash-recover").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrphanResolution {
+    /// Accord decided COMMIT but the local apply had not finished. Finish it:
+    /// promote the temp table at the agreed execution timestamp. Must be
+    /// idempotent — promotion may already have partially run.
+    Promote,
+    /// The transaction is settled and the temp table is dead weight: aborted,
+    /// never proposed, or already applied.
+    Drop,
+    /// No local decision, and dropping could discard a commit. Drive Accord
+    /// recovery to a decision, then act on it. NEVER unilaterally abort.
+    Recover,
+    /// The temp table cannot be tied to a transaction id at all. Surface it and
+    /// leave it in place — guessing risks either losing a commit or resurrecting
+    /// an aborted write.
+    Quarantine,
+}
+
+/// Resolve one orphan intent temp table against replayed Accord state.
+///
+/// `phase` is the transaction's replayed phase, or `None` when the protocol log
+/// holds no entry for it. `past_deadline` reports whether the transaction
+/// outlived `transaction_open_timeout`. `replay_was_lossy` is
+/// [`CrashRecoveryReplay::skipped_count`] `> 0`.
+///
+/// # The decision rule
+///
+/// **The Accord decision always wins over the deadline.** A committed
+/// transaction is promoted no matter how far past its deadline the restart
+/// happens; honouring the deadline instead would silently drop an acked commit.
+/// The deadline only governs transactions Accord never decided.
+///
+/// # Why `replay_was_lossy` is load-bearing
+///
+/// `replay()` skips entries failing CRC — partial writes from a crash mid-write.
+/// So when any entry was skipped, "absent from `txn_states`" no longer proves
+/// "never proposed": the skipped record could have been this transaction's
+/// `Committed` entry. In that case the only safe answer is [`Recover`] — ask
+/// Accord — because [`Drop`] could discard a commit whose evidence was the
+/// corrupt entry.
+///
+/// [`Recover`]: OrphanResolution::Recover
+/// [`Drop`]: OrphanResolution::Drop
+pub fn resolve_orphan_intent(
+    phase: Option<ReplayedPhase>,
+    past_deadline: bool,
+    replay_was_lossy: bool,
+) -> OrphanResolution {
+    match phase {
+        // Decided: act on the decision, deadline irrelevant.
+        Some(ReplayedPhase::Applied) => OrphanResolution::Drop,
+        Some(ReplayedPhase::Committed) => OrphanResolution::Promote,
+
+        // Undecided locally. A lossy replay may be hiding a Commit record, so
+        // never expire on local evidence alone — ask Accord.
+        Some(ReplayedPhase::PreAccepted) | Some(ReplayedPhase::Accepted) => {
+            if replay_was_lossy || !past_deadline {
+                OrphanResolution::Recover
+            } else {
+                OrphanResolution::Drop
+            }
+        }
+
+        // No local record. Clean replay proves it was never proposed; a lossy
+        // one proves nothing.
+        None => {
+            if replay_was_lossy {
+                OrphanResolution::Recover
+            } else {
+                OrphanResolution::Drop
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -579,5 +664,142 @@ mod tests {
             3,
             "3 corrupt/partial entries should be skipped"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Orphan intent resolution tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod orphan_resolution_tests {
+    use super::*;
+
+    /// THE headline case: Accord decided COMMIT, the node died before the local
+    /// apply finished, and the restart happens long past the 10s deadline.
+    /// Promoting is mandatory — dropping here silently discards an acked commit,
+    /// which is exactly what the spec used to prescribe.
+    #[test]
+    fn committed_is_promoted_however_far_past_the_deadline() {
+        assert_eq!(
+            resolve_orphan_intent(Some(ReplayedPhase::Committed), true, false),
+            OrphanResolution::Promote,
+            "a committed transaction must be promoted regardless of its deadline"
+        );
+        assert_eq!(
+            resolve_orphan_intent(Some(ReplayedPhase::Committed), false, false),
+            OrphanResolution::Promote
+        );
+    }
+
+    /// Already applied: the committed versions are in storage, so the temp table
+    /// is stale. Re-promoting would risk a double-apply.
+    #[test]
+    fn applied_drops_the_stale_temp_table() {
+        for past_deadline in [false, true] {
+            assert_eq!(
+                resolve_orphan_intent(Some(ReplayedPhase::Applied), past_deadline, false),
+                OrphanResolution::Drop
+            );
+        }
+    }
+
+    /// Undecided and within its deadline: the transaction may still be live, so
+    /// drive Accord to a decision rather than aborting on one node's opinion.
+    #[test]
+    fn undecided_within_deadline_recovers_never_aborts_unilaterally() {
+        for phase in [ReplayedPhase::PreAccepted, ReplayedPhase::Accepted] {
+            assert_eq!(
+                resolve_orphan_intent(Some(phase), false, false),
+                OrphanResolution::Recover,
+                "{phase:?} within deadline must ask Accord, not abort"
+            );
+        }
+    }
+
+    /// Undecided and expired, on a CLEAN replay: local evidence is complete and
+    /// says no decision was ever reached, so the timeout legitimately aborts it.
+    #[test]
+    fn undecided_past_deadline_drops_only_on_a_clean_replay() {
+        for phase in [ReplayedPhase::PreAccepted, ReplayedPhase::Accepted] {
+            assert_eq!(
+                resolve_orphan_intent(Some(phase), true, false),
+                OrphanResolution::Drop
+            );
+        }
+    }
+
+    /// A lossy replay dropped CRC-failed entries, any of which could have been
+    /// this transaction's Commit record. Expiring on incomplete local evidence
+    /// could discard a commit, so lossiness overrides the deadline.
+    #[test]
+    fn lossy_replay_overrides_the_deadline_for_undecided_transactions() {
+        for phase in [ReplayedPhase::PreAccepted, ReplayedPhase::Accepted] {
+            assert_eq!(
+                resolve_orphan_intent(Some(phase), true, true),
+                OrphanResolution::Recover,
+                "{phase:?}: a skipped entry may have been its Commit record"
+            );
+        }
+    }
+
+    /// No protocol-log entry at all. On a clean replay that proves the txn was
+    /// never proposed, so no decision can exist and the intents are garbage.
+    #[test]
+    fn absent_transaction_drops_on_a_clean_replay() {
+        assert_eq!(
+            resolve_orphan_intent(None, false, false),
+            OrphanResolution::Drop
+        );
+        assert_eq!(
+            resolve_orphan_intent(None, true, false),
+            OrphanResolution::Drop
+        );
+    }
+
+    /// Absent + lossy is the trap: "no entry" and "entry was corrupt" are
+    /// indistinguishable locally, so absence proves nothing and dropping could
+    /// discard a commit.
+    #[test]
+    fn absent_transaction_recovers_when_replay_was_lossy() {
+        for past_deadline in [false, true] {
+            assert_eq!(
+                resolve_orphan_intent(None, past_deadline, true),
+                OrphanResolution::Recover,
+                "absence is not proof of never-proposed when entries were skipped"
+            );
+        }
+    }
+
+    /// No input combination may silently discard a decided commit. This is the
+    /// invariant the old spec violated.
+    #[test]
+    fn a_committed_transaction_is_never_dropped_under_any_inputs() {
+        for past_deadline in [false, true] {
+            for lossy in [false, true] {
+                let r = resolve_orphan_intent(Some(ReplayedPhase::Committed), past_deadline, lossy);
+                assert_eq!(
+                    r,
+                    OrphanResolution::Promote,
+                    "committed must never be dropped (past_deadline={past_deadline}, lossy={lossy})"
+                );
+            }
+        }
+    }
+
+    /// Exhaustive sweep: an undecided transaction must never be Dropped while
+    /// local evidence is known-incomplete, in any combination.
+    #[test]
+    fn undecided_is_never_dropped_on_incomplete_evidence() {
+        for phase in [ReplayedPhase::PreAccepted, ReplayedPhase::Accepted] {
+            for past_deadline in [false, true] {
+                let r = resolve_orphan_intent(Some(phase), past_deadline, true);
+                assert_ne!(
+                    r,
+                    OrphanResolution::Drop,
+                    "{phase:?} must not be dropped when replay was lossy"
+                );
+            }
+        }
     }
 }

--- a/ferrosa-storage/src/accord/framed_log.rs
+++ b/ferrosa-storage/src/accord/framed_log.rs
@@ -1,0 +1,352 @@
+//! Module: On-disk record framing for the Accord protocol log.
+//! Correctness: Correct when every record written by [`frame_record`] is
+//!   recovered byte-identically by [`read_framed_log`], a crash mid-write
+//!   truncates only the final record, and a pre-framing file is REPORTED
+//!   rather than misparsed.
+//! Last revised: 2026-07-26
+//! Last changed: Created — length-prefix framing so the protocol log can be
+//!   replayed at startup (t_7b5788a3).
+//!
+//! # Why this exists
+//!
+//! `FileSyncWriter` used to append serialized entries as raw concatenated
+//! bytes, with no length prefix and no delimiter. But
+//! `AccordProtocolEntry::deserialize` needs an EXACT record boundary — it reads
+//! the CRC from the final four bytes of the slice it is given — and
+//! `CrashRecoveryReplay::replay` takes records already split apart.
+//!
+//! So the durable log was written but could not be read back into records, and
+//! nothing replayed it: Accord protocol state was lost on every restart.
+//!
+//! # Format
+//!
+//! ```text
+//! [8-byte magic "FACCLOG1"]  then repeated:  [u32 LE length][length bytes]
+//! ```
+//!
+//! The magic matters. Without it, the first four bytes of a pre-framing file
+//! would be read as a length — yielding an arbitrary number that could silently
+//! produce plausible-looking garbage records. With it, a legacy file is
+//! identified and surfaced instead of guessed at.
+//!
+//! Per-record CRC still lives inside the entry (`AccordProtocolEntry`), so
+//! framing only has to find boundaries; corruption WITHIN a record is caught by
+//! the existing CRC check during replay.
+
+use std::io;
+use std::path::Path;
+
+/// Magic header identifying a length-framed protocol log.
+pub const FRAMED_LOG_MAGIC: &[u8; 8] = b"FACCLOG1";
+
+/// Largest record accepted while reading. A length beyond this means the file
+/// is corrupt or not actually framed; treat it as a truncated tail rather than
+/// attempting a multi-gigabyte allocation from a bad length.
+pub const MAX_RECORD_LEN: usize = 64 * 1024 * 1024;
+
+/// Wrap one serialized entry in its length prefix.
+pub fn frame_record(payload: &[u8]) -> Vec<u8> {
+    let mut framed = Vec::with_capacity(payload.len() + 4);
+    framed.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    framed.extend_from_slice(payload);
+    framed
+}
+
+/// Outcome of reading a framed protocol log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FramedLogRead {
+    /// Complete records, in write order, ready for `CrashRecoveryReplay::replay`.
+    pub records: Vec<Vec<u8>>,
+    /// A partial record at end of file — the signature of a crash mid-write.
+    /// Expected and benign: that entry never completed its fsync, so no reply
+    /// was ever produced for it.
+    pub truncated_tail: bool,
+}
+
+/// Why a protocol log could not be read.
+#[derive(Debug)]
+pub enum FramedLogError {
+    /// The file exists and is non-empty but carries no framing magic — written
+    /// by a pre-framing build. Callers MUST surface this, never silently treat
+    /// it as empty: "no records" and "records I cannot read" are different, and
+    /// conflating them would quietly discard recoverable transaction state.
+    LegacyUnframed { bytes: u64 },
+    /// The file could not be read at all.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for FramedLogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LegacyUnframed { bytes } => write!(
+                f,
+                "protocol log has no framing magic ({bytes} bytes) — written by a \
+                 pre-framing build; its records cannot be delimited"
+            ),
+            Self::Io(e) => write!(f, "protocol log read failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for FramedLogError {}
+
+/// Read a length-framed protocol log into its records.
+///
+/// A missing file yields zero records — a node that has never written protocol
+/// state is a normal cold start, not an error.
+///
+/// A truncated final record sets `truncated_tail` and stops the walk. That is
+/// the expected crash-mid-write signature: `write_and_sync` had not returned, so
+/// no reply depended on that entry.
+pub fn read_framed_log(path: &Path) -> Result<FramedLogRead, FramedLogError> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return Ok(FramedLogRead {
+                records: Vec::new(),
+                truncated_tail: false,
+            })
+        }
+        Err(e) => return Err(FramedLogError::Io(e)),
+    };
+
+    if bytes.is_empty() {
+        return Ok(FramedLogRead {
+            records: Vec::new(),
+            truncated_tail: false,
+        });
+    }
+
+    if bytes.len() < FRAMED_LOG_MAGIC.len() || &bytes[..FRAMED_LOG_MAGIC.len()] != FRAMED_LOG_MAGIC
+    {
+        return Err(FramedLogError::LegacyUnframed {
+            bytes: bytes.len() as u64,
+        });
+    }
+
+    let mut records = Vec::new();
+    let mut pos = FRAMED_LOG_MAGIC.len();
+    let mut truncated_tail = false;
+
+    while pos < bytes.len() {
+        // Length prefix must be complete.
+        if pos + 4 > bytes.len() {
+            truncated_tail = true;
+            break;
+        }
+        let len = u32::from_le_bytes(bytes[pos..pos + 4].try_into().expect("4 bytes")) as usize;
+        pos += 4;
+
+        // A length past the end, or absurdly large, means the tail is torn.
+        // Stop rather than allocating from a bad length.
+        if len > MAX_RECORD_LEN || pos + len > bytes.len() {
+            truncated_tail = true;
+            break;
+        }
+
+        records.push(bytes[pos..pos + len].to_vec());
+        pos += len;
+    }
+
+    Ok(FramedLogRead {
+        records,
+        truncated_tail,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_log(dir: &Path, chunks: &[&[u8]]) -> std::path::PathBuf {
+        let path = dir.join("protocol.log");
+        let mut buf = FRAMED_LOG_MAGIC.to_vec();
+        for c in chunks {
+            buf.extend_from_slice(&frame_record(c));
+        }
+        std::fs::write(&path, buf).expect("write log");
+        path
+    }
+
+    #[test]
+    fn records_round_trip_byte_identically() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_log(dir.path(), &[b"first", b"", b"a much longer third record"]);
+
+        let read = read_framed_log(&path).expect("reads");
+        assert_eq!(
+            read.records,
+            vec![
+                b"first".to_vec(),
+                Vec::new(),
+                b"a much longer third record".to_vec()
+            ],
+            "records must survive framing byte-identically, including an empty one"
+        );
+        assert!(!read.truncated_tail);
+    }
+
+    /// A missing log is a cold start, not a failure.
+    #[test]
+    fn missing_file_is_zero_records_not_an_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let read = read_framed_log(&dir.path().join("absent.log")).expect("cold start is ok");
+        assert!(read.records.is_empty());
+        assert!(!read.truncated_tail);
+    }
+
+    /// Crash mid-write: the final record's payload never landed. Everything
+    /// before it must still be recovered, and the tear must be reported.
+    #[test]
+    fn truncated_payload_keeps_earlier_records_and_flags_the_tail() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("protocol.log");
+        let mut buf = FRAMED_LOG_MAGIC.to_vec();
+        buf.extend_from_slice(&frame_record(b"complete"));
+        buf.extend_from_slice(&(99u32).to_le_bytes()); // claims 99 bytes...
+        buf.extend_from_slice(b"only-a-few"); // ...but far fewer follow
+        std::fs::write(&path, buf).expect("write");
+
+        let read = read_framed_log(&path).expect("reads");
+        assert_eq!(read.records, vec![b"complete".to_vec()]);
+        assert!(
+            read.truncated_tail,
+            "a torn final record must be reported, not silently dropped"
+        );
+    }
+
+    /// Crash between the length prefix and the payload.
+    #[test]
+    fn truncated_length_prefix_flags_the_tail() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("protocol.log");
+        let mut buf = FRAMED_LOG_MAGIC.to_vec();
+        buf.extend_from_slice(&frame_record(b"complete"));
+        buf.extend_from_slice(&[0x01, 0x02]); // half a length prefix
+        std::fs::write(&path, buf).expect("write");
+
+        let read = read_framed_log(&path).expect("reads");
+        assert_eq!(read.records, vec![b"complete".to_vec()]);
+        assert!(read.truncated_tail);
+    }
+
+    /// THE reason the magic exists: a pre-framing file must be identified, not
+    /// misread. Its first four bytes would otherwise be taken as a length.
+    #[test]
+    fn legacy_unframed_file_is_surfaced_not_misparsed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("protocol.log");
+        // Raw concatenated entries, as a pre-framing build wrote them.
+        std::fs::write(&path, b"\x01raw-entry-bytes-with-crc\x02another").expect("write");
+
+        match read_framed_log(&path) {
+            Err(FramedLogError::LegacyUnframed { bytes }) => {
+                assert!(bytes > 0);
+            }
+            other => panic!("legacy file must be surfaced, got {other:?}"),
+        }
+    }
+
+    /// An absurd length must not drive an allocation.
+    #[test]
+    fn absurd_record_length_is_treated_as_a_torn_tail() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("protocol.log");
+        let mut buf = FRAMED_LOG_MAGIC.to_vec();
+        buf.extend_from_slice(&frame_record(b"good"));
+        buf.extend_from_slice(&(u32::MAX).to_le_bytes());
+        std::fs::write(&path, buf).expect("write");
+
+        let read = read_framed_log(&path).expect("reads");
+        assert_eq!(read.records, vec![b"good".to_vec()]);
+        assert!(read.truncated_tail);
+    }
+
+    /// A file containing only the magic is a log that was created but never
+    /// appended to — zero records, cleanly.
+    #[test]
+    fn magic_only_file_is_zero_records() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("protocol.log");
+        std::fs::write(&path, FRAMED_LOG_MAGIC).expect("write");
+
+        let read = read_framed_log(&path).expect("reads");
+        assert!(read.records.is_empty());
+        assert!(!read.truncated_tail);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: the three components must actually fit together
+    // -----------------------------------------------------------------------
+
+    /// THE integration proof. Before framing, these three could not compose:
+    /// `FileSyncWriter` appended unframed bytes, `AccordProtocolEntry` needed an
+    /// exact boundary, and `CrashRecoveryReplay` wanted pre-split records — so
+    /// the log was durable but unreadable and nothing replayed it.
+    ///
+    /// This drives the REAL production writer, reads its file back, and replays
+    /// it, asserting the transaction state survives a simulated restart.
+    #[test]
+    fn writer_output_replays_into_recovered_transaction_state() {
+        use crate::accord::crash_recovery::{CrashRecoveryReplay, ReplayedPhase};
+        use crate::accord::entries::{AccordProtocolEntry, Timestamp, TxnId};
+        use crate::accord::sync_writer::{FileSyncWriter, SyncWriter};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("protocol.log");
+        let writer = FileSyncWriter::new(path.clone());
+
+        let ts = |m: u64| Timestamp {
+            epoch_micros: m,
+            logical: 0,
+        };
+        let txn = TxnId {
+            node: 7,
+            timestamp: ts(100),
+        };
+
+        // Two protocol events for one transaction, exactly as production writes
+        // them: serialize, then write_and_sync.
+        let pre = AccordProtocolEntry::PreAccepted {
+            txn_id: txn,
+            t0: ts(100),
+            t: ts(100),
+            deps: vec![],
+        };
+        let com = AccordProtocolEntry::Committed {
+            txn_id: txn,
+            t: ts(140),
+            deps: vec![],
+        };
+        assert!(writer.write_and_sync(&pre.serialize()).is_ok());
+        assert!(writer.write_and_sync(&com.serialize()).is_ok());
+
+        // Simulated restart: read the file back and replay it.
+        let read = read_framed_log(&path).expect("framed log reads back");
+        assert!(
+            !read.truncated_tail,
+            "a cleanly-closed log must not look torn"
+        );
+        assert_eq!(read.records.len(), 2, "both records recovered");
+
+        let mut replay = CrashRecoveryReplay::new();
+        replay.replay(&read.records);
+
+        assert_eq!(
+            replay.skipped_count(),
+            0,
+            "framing must not corrupt records: {:?}",
+            read.records
+        );
+        let state = replay
+            .txn_states()
+            .get(&txn)
+            .expect("the transaction survived the restart");
+        assert_eq!(
+            state.phase,
+            ReplayedPhase::Committed,
+            "the COMMIT decision must survive — this is the state whose loss \
+             would force a blind abort of its intents"
+        );
+    }
+}

--- a/ferrosa-storage/src/accord/mod.rs
+++ b/ferrosa-storage/src/accord/mod.rs
@@ -18,6 +18,7 @@
 pub mod conflict_index;
 pub mod crash_recovery;
 pub mod entries;
+pub mod framed_log;
 pub mod oversized_entry;
 pub mod protocol_log;
 pub mod read_2i;

--- a/ferrosa-storage/src/accord/mod.rs
+++ b/ferrosa-storage/src/accord/mod.rs
@@ -28,7 +28,8 @@ pub mod write_gate;
 
 pub use conflict_index::{ConflictIndex, ConflictIndexFull, InFlightWrite, TokenRange, TxnStatus};
 pub use crash_recovery::{
-    CrashRecoveryReplay, ReplayedConflictEntry, ReplayedPhase, ReplayedTxnState,
+    resolve_orphan_intent, CrashRecoveryReplay, OrphanResolution, ReplayedConflictEntry,
+    ReplayedPhase, ReplayedTxnState,
 };
 pub use entries::{AccordAppliedEntry, AccordProtocolEntry};
 pub use protocol_log::ProtocolLog;

--- a/ferrosa-storage/src/accord/sync_writer.rs
+++ b/ferrosa-storage/src/accord/sync_writer.rs
@@ -18,6 +18,8 @@
 use std::fs::OpenOptions;
 use std::io::{self, Write};
 use std::path::PathBuf;
+
+use super::framed_log::{frame_record, FRAMED_LOG_MAGIC};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
@@ -94,6 +96,19 @@ impl FileSyncWriter {
 }
 
 impl SyncWriter for FileSyncWriter {
+    /// Append `data` as ONE length-framed record and fsync it.
+    ///
+    /// Records carry a `[u32 LE length]` prefix, behind a one-time
+    /// [`FRAMED_LOG_MAGIC`] header, so the log can be split back into entries at
+    /// startup. Before framing existed the file was raw concatenated bytes,
+    /// which `AccordProtocolEntry::deserialize` cannot delimit (it reads the CRC
+    /// from the final four bytes of whatever slice it is handed) — so the log
+    /// was durable but unreadable, and nothing replayed it. See
+    /// [`super::framed_log`].
+    ///
+    /// The length prefix and payload go out in a SINGLE `write_all`, so a crash
+    /// can tear the tail but cannot interleave a prefix with another record's
+    /// payload. A torn tail is detected on read and reported.
     fn write_and_sync(&self, data: &[u8]) -> SyncWriteResult {
         let file_result = OpenOptions::new()
             .create(true)
@@ -105,7 +120,21 @@ impl SyncWriter for FileSyncWriter {
             Err(e) => return SyncWriteResult::FsyncFailed(e),
         };
 
-        if let Err(e) = file.write_all(data) {
+        // Stamp the magic exactly once, when the log is first created. Checked
+        // per call because `write_and_sync` is stateless by contract (open →
+        // write → sync → close), and an empty file is cheap to detect.
+        let needs_magic = match file.metadata() {
+            Ok(m) => m.len() == 0,
+            Err(e) => return SyncWriteResult::FsyncFailed(e),
+        };
+
+        let mut out = Vec::with_capacity(data.len() + 12);
+        if needs_magic {
+            out.extend_from_slice(FRAMED_LOG_MAGIC);
+        }
+        out.extend_from_slice(&frame_record(data));
+
+        if let Err(e) = file.write_all(&out) {
             return SyncWriteResult::FsyncFailed(e);
         }
 
@@ -215,8 +244,13 @@ mod tests {
             result.is_ok(),
             "write_and_sync to a real file must succeed, got {result:?}"
         );
-        let persisted = std::fs::read(&log_path).expect("log file must exist");
-        assert_eq!(persisted, b"PreAccepted:1:2");
+        // The payload is now length-framed behind a one-time magic header so
+        // the log can be split back into records at startup. Assert the record
+        // survives a real read-back rather than asserting raw bytes.
+        let read = crate::accord::framed_log::read_framed_log(&log_path)
+            .expect("the writer must produce a readable framed log");
+        assert_eq!(read.records, vec![b"PreAccepted:1:2".to_vec()]);
+        assert!(!read.truncated_tail);
     }
 
     /// Fail loud: constructing a `FileSyncWriter` on an existing DIRECTORY is a
@@ -410,8 +444,26 @@ mod tests {
         let result = writer.write_and_sync(b"entry-2");
         assert!(result.is_ok(), "second write should succeed");
 
-        // Verify file contents (both entries appended).
-        let contents = std::fs::read(&path).unwrap();
-        assert_eq!(contents, b"entry-1entry-2");
+        // Both entries append as SEPARATE framed records — the property that
+        // makes replay possible. The old assertion (`b"entry-1entry-2"`) was
+        // exactly the problem: concatenated bytes with no boundary between them
+        // cannot be split back into entries.
+        let read =
+            crate::accord::framed_log::read_framed_log(&path).expect("framed log reads back");
+        assert_eq!(
+            read.records,
+            vec![b"entry-1".to_vec(), b"entry-2".to_vec()],
+            "records must stay individually delimited, not concatenated"
+        );
+        assert!(!read.truncated_tail);
+
+        // The magic is stamped once, not per record.
+        let raw = std::fs::read(&path).unwrap();
+        assert_eq!(&raw[..8], crate::accord::framed_log::FRAMED_LOG_MAGIC);
+        assert_eq!(
+            raw.len(),
+            8 + (4 + 7) + (4 + 7),
+            "magic once + two length-prefixed 7-byte records"
+        );
     }
 }

--- a/specs/proposed/unified-transaction-manager/architecture.md
+++ b/specs/proposed/unified-transaction-manager/architecture.md
@@ -102,9 +102,31 @@ flowchart TD
   stamping every row at the Accord execution timestamp (intents → committed versions),
   through the same all-or-nothing `apply_writeset` Accord already uses. The temp table is
   then dropped.
-- **Abort / expire / crash-recover:** the temp table is dropped (NVMe reclaimed). Because
-  temp tables are on-disk, a coordinator restart can enumerate orphan temp tables and
-  abort/GC them (recoverable intent cleanup).
+- **Abort / expire:** the temp table is dropped (NVMe reclaimed).
+- **Crash-recover — resolve against Accord, NEVER blind-abort.** The temp table is
+  **commit-log-equivalent durable state**, not scratch space: it must survive process
+  death with the same durability guarantee as the commit log, because it may hold the
+  only local record of a transaction Accord has already agreed to commit.
+
+  On restart the coordinator enumerates orphan temp tables and resolves **each** against
+  that transaction's **Accord status**:
+
+  | Accord decision | Action |
+  |---|---|
+  | Committed | **Promote** the temp table (finish the commit at the agreed execution ts). Idempotent — promotion may already have partially run. |
+  | Aborted | Drop the temp table. |
+  | Undecided / in-doubt | Drive Accord recovery to a decision, *then* act. Never unilaterally abort. |
+  | Never proposed (crash before PreAccept) | Drop — no decision can exist. |
+
+  Blind `abort/GC` on restart is a **data-loss bug**: a transaction whose commit Accord
+  had already decided, but whose promotion had not yet run locally, would be silently
+  discarded — an acked commit vanishing after a restart. This is the standard in-doubt
+  resolution obligation of any consensus-committed transaction, and it is a correctness
+  requirement, not cleanup convenience.
+
+  Promotion must therefore be **idempotent and restartable**: a crash *during* promotion
+  must be resumable without double-applying, since intents are stamped at the Accord
+  execution timestamp (replaying the same stamped rows is naturally idempotent).
 - **NVMe budget:** a transaction whose temp table would exceed the configured NVMe budget
   fails loud and aborts — never silently truncates or spills a live transaction's data.
 
@@ -185,3 +207,9 @@ sequenceDiagram
   addition and the enabler of interactive SQL isolation.
 - **Durable/recoverable txn state** — replicate registry entries (or make them
   reconstructable) so a coordinator failure does not lose a long interactive transaction.
+  Note this is a **correctness** requirement, not only an availability one: the
+  restart path must resolve every orphan temp table against its Accord status
+  (commit / roll back), so it needs enough durable state to identify each
+  transaction and ask. See "Crash-recover" above — losing that state means being
+  unable to distinguish a committed transaction from an aborted one, which forces
+  exactly the blind abort that would drop an acked commit.


### PR DESCRIPTION
Recovered WIP: authored 2026-07-25/28, pushed but **no PR was ever opened**, then sat for three weeks. Rebased onto current main, rebuilt and re-tested here. Task `t_7b5788a3`.

## Why this is time-critical

The framing has to exist **before** a crash for any recovery to be possible. Every protocol log written today is an unframed byte stream with no record boundaries — so a crash today leaves a log that no future recovery code can replay, however good that code is. Landing the reader later does not recover the writes made in the meantime.

That is the argument for merging the framing now even though the replay half is not yet wired (see Scope).

## What

- `framed_log.rs` — `FRAMED_LOG_MAGIC`, `frame_record`, `read_framed_log`, `FramedLogRead`. Length-prefixed records with a magic header, so a log can be split back into the records that were written, and a torn tail can be identified rather than silently mis-parsed.
- `sync_writer.rs` — the write path now frames every record (`frame_record`, line 135) and reads back through `read_framed_log`. **This is live in production**, not dead code.
- `crash_recovery.rs` — `CrashRecoveryReplay`, `resolve_orphan_intent`, `OrphanResolution`. On restart, an intent temp table left behind by a crash is resolved **against Accord's status** for that transaction rather than blind-aborted.
- The architecture spec is corrected to match: restart must consult Accord, not assume abort.

Blind-abort is wrong because an intent whose transaction Accord already committed must be applied, not discarded — aborting it loses an acknowledged write.

## Scope — what is not wired

`CrashRecoveryReplay` and `resolve_orphan_intent` are fully implemented and tested but have **no production caller yet**: nothing invokes the replay at startup. The framing they depend on is live; the invocation is not.

This is stated rather than hidden because it changes what the PR buys you today: it makes future recovery *possible* (logs become replayable from now on) without yet making it *automatic*.

## Rebase and rot check

Cherry-picked cleanly onto current main with no conflicts — notable given it predates the 2026-07-30 history rewrite and the `FileSyncWriter` directory fix (`fb6a6ef9`), both of which touched this area. Verified `framed_log` is genuinely reachable from the production write path rather than orphaned by the intervening changes.

`ferrosa-storage` 1062 tests passing (80 accord-specific), clippy clean, release build clean.
