### PR TITLE
fix(graph): stop materialising query results in RAM (P0 OOM)

### DIFF
--- a/ferrosa-graph/src/bolt/server.rs
+++ b/ferrosa-graph/src/bolt/server.rs
@@ -19,7 +19,6 @@ use crate::bolt::handshake::{negotiate_version, rejection_response, version_resp
 use crate::bolt::message::BoltMessage;
 use crate::engine::GraphEngine;
 use crate::error::GraphError;
-use crate::executor::result::GraphResult;
 
 /// Configuration for the Bolt server.
 #[derive(Debug, Clone)]
@@ -52,7 +51,12 @@ struct ConnectionState {
     /// Current keyspace / graph database.
     keyspace: String,
     /// Pending result from the last RUN.
-    pending_result: Option<GraphResult>,
+    /// The unconsumed remainder of the running query, as a stream.
+    ///
+    /// Held as a stream rather than a `GraphResult` so the server does not keep
+    /// the whole result in memory between PULLs. The client already paged
+    /// correctly; the server did not.
+    pending_result: Option<PendingRows>,
     /// Auth context for permission checks (set after HELLO/LOGON).
     auth_context: Option<AuthContext>,
 }
@@ -369,26 +373,26 @@ async fn process_message(
             let params = pack_params_to_json(params);
 
             match engine
-                .execute_with_params(&query, &keyspace, &auth, &params)
+                .execute_stream_with_params(&query, &keyspace, &auth, &params)
                 .await
             {
-                Ok(result) => {
-                    let fields: Vec<PackValue> = result
-                        .columns
+                Ok((columns, rows, stats)) => {
+                    let fields: Vec<PackValue> = columns
                         .iter()
                         .map(|c| PackValue::String(c.clone()))
                         .collect();
                     let success = BoltMessage::Success {
                         metadata: vec![
                             ("fields".into(), PackValue::List(fields)),
-                            (
-                                "t_first".into(),
-                                PackValue::Int(result.stats.execution_ms as i64),
-                            ),
+                            ("t_first".into(), PackValue::Int(stats.execution_ms as i64)),
                             ("qid".into(), PackValue::Int(0)),
                         ],
                     };
-                    state.pending_result = Some(result);
+                    state.pending_result = Some(PendingRows {
+                        stats,
+                        rows,
+                        peeked: None,
+                    });
                     Ok(vec![success])
                 }
                 Err(e) => {
@@ -419,7 +423,11 @@ async fn process_message(
                 // has_more hardcoded false, so a client asking for 10 rows got
                 // the entire result — a protocol violation, and unbounded
                 // client-side memory for a large query.
-                let (batch, has_more) = take_batch(&mut result.rows, requested_batch_size(&extra));
+                //
+                // The remainder is now a stream, so the SERVER no longer holds
+                // every undelivered row either: this pulls `n` from the query
+                // and looks one past them to answer `has_more`.
+                let (batch, has_more) = result.take_batch(requested_batch_size(&extra)).await?;
 
                 // Send a RECORD for each row in this batch.
                 for row in &batch {
@@ -430,8 +438,8 @@ async fn process_message(
                 // Keep the rest for the next PULL. Stats travel with the FINAL
                 // batch, matching Bolt's summary semantics.
                 if has_more {
-                    // `result.rows` already holds exactly the unconsumed
-                    // remainder, so this is a move, not a copy.
+                    // The stream is positioned at the next undelivered row, so
+                    // this is a move of a cursor, not of the remaining rows.
                     state.pending_result = Some(result);
                     replies.push(BoltMessage::Success {
                         metadata: vec![("has_more".into(), PackValue::Bool(true))],
@@ -489,8 +497,11 @@ async fn process_message(
             // `n` absent or negative means discard everything (t_4ce82a3e).
             match state.pending_result.take() {
                 Some(mut result) => {
+                    // DISCARD {n} drops n records and keeps the rest; it is
+                    // not "throw the whole result away". Pulling them from the
+                    // stream discards without materialising them.
                     let (_dropped, has_more) =
-                        take_batch(&mut result.rows, requested_batch_size(&extra));
+                        result.take_batch(requested_batch_size(&extra)).await?;
                     if has_more {
                         state.pending_result = Some(result);
                         return Ok(vec![BoltMessage::Success {
@@ -746,21 +757,66 @@ fn requested_batch_size(extra: &[(String, PackValue)]) -> Option<usize> {
 /// PULL and DISCARD share this contract exactly and differ only in what they do
 /// with the batch — PULL serializes it into RECORDs, DISCARD drops it — so the
 /// consumption lives here rather than being written twice and drifting.
-fn take_batch(
-    rows: &mut Vec<Vec<serde_json::Value>>,
-    requested: Option<usize>,
-) -> (Vec<Vec<serde_json::Value>>, bool) {
-    let (take, has_more) = batch_split(requested, rows.len());
-    let remainder = rows.split_off(take);
-    // `rows` now holds the batch and `remainder` the rest; swap so the caller's
-    // pending buffer is left holding exactly the unconsumed records.
-    let batch = std::mem::replace(rows, remainder);
-    (batch, has_more)
+/// A query whose rows have not all been delivered yet.
+///
+/// Bolt's PULL is inherently incremental — the client asks for `n` records at a
+/// time — so the natural shape for the remainder is a stream, not a `Vec`. It
+/// used to be a `GraphResult`: the client paged, and the server held every row
+/// of every open result until the last PULL.
+///
+/// Holding the stream also keeps the ORDER BY spill alive for exactly as long
+/// as it can still be pulled from. `SpillSortSink::finish_stream` moves the
+/// temp-dir reservation into the stream, so the spilled runs are removed when
+/// this is dropped — a client that disconnects mid-result cleans up with it.
+struct PendingRows {
+    stats: crate::executor::result::QueryStats,
+    rows: crate::executor::RowStream<'static>,
+    /// One row pulled ahead to answer `has_more` without consuming it.
+    ///
+    /// A stream cannot say whether it is empty without being polled, and Bolt
+    /// must report `has_more` in the same SUCCESS as the batch. Pulling one
+    /// extra and holding it costs a single row.
+    peeked: Option<Vec<serde_json::Value>>,
 }
 
-fn batch_split(requested: Option<usize>, total: usize) -> (usize, bool) {
-    let take = requested.map_or(total, |n| n.min(total));
-    (take, take < total)
+impl PendingRows {
+    /// Take up to `requested` rows, reporting whether any remain.
+    ///
+    /// `None` means "fetch all" (Bolt's canonical `n = -1`).
+    async fn take_batch(
+        &mut self,
+        requested: Option<usize>,
+    ) -> Result<(Vec<Vec<serde_json::Value>>, bool), GraphError> {
+        use futures::StreamExt as _;
+
+        let mut batch = Vec::new();
+        let wanted = requested.unwrap_or(usize::MAX);
+
+        while batch.len() < wanted {
+            let next = match self.peeked.take() {
+                Some(row) => Some(row),
+                None => match self.rows.next().await {
+                    Some(row) => Some(row?),
+                    None => None,
+                },
+            };
+            match next {
+                Some(row) => batch.push(row),
+                None => return Ok((batch, false)),
+            }
+        }
+
+        // Look one past the batch so `has_more` is accurate without delivering
+        // a row the client did not ask for.
+        let has_more = match self.rows.next().await {
+            Some(row) => {
+                self.peeked = Some(row?);
+                true
+            }
+            None => false,
+        };
+        Ok((batch, has_more))
+    }
 }
 
 fn json_to_pack_value(v: &serde_json::Value) -> PackValue {
@@ -811,77 +867,65 @@ mod tests {
     /// what they do with the consumed batch (serialize it vs drop it), so the
     /// consumption itself lives in one tested function — a second copy in the
     /// DISCARD arm is how the two drift apart.
-    #[test]
-    fn take_batch_consumes_at_most_n_and_leaves_the_remainder() {
-        let rows = || -> Vec<Vec<serde_json::Value>> {
-            (1..=5).map(|i| vec![serde_json::json!(i)]).collect()
-        };
+    #[tokio::test]
+    async fn take_batch_consumes_at_most_n_and_leaves_the_remainder() {
+        fn pending(n: i64) -> PendingRows {
+            PendingRows {
+                stats: Default::default(),
+                rows: crate::executor::stream::stream_from_rows(
+                    (1..=n).map(|i| vec![serde_json::json!(i)]).collect(),
+                ),
+                peeked: None,
+            }
+        }
 
-        // Partial: batch is the first n, remainder stays for the next message.
-        let mut r = rows();
-        let (batch, has_more) = take_batch(&mut r, Some(2));
+        // Partial: batch is the first n, the rest stay reachable.
+        let mut r = pending(5);
+        let (batch, has_more) = r.take_batch(Some(2)).await.unwrap();
         assert_eq!(
             batch,
             vec![vec![serde_json::json!(1)], vec![serde_json::json!(2)]]
         );
+        assert!(has_more, "3 rows remain");
+        let (rest, has_more) = r.take_batch(None).await.unwrap();
         assert_eq!(
-            r,
+            rest,
             vec![
                 vec![serde_json::json!(3)],
                 vec![serde_json::json!(4)],
                 vec![serde_json::json!(5)],
-            ]
+            ],
+            "the peeked row must be delivered, not dropped"
         );
-        assert!(has_more, "3 rows remain");
+        assert!(!has_more);
 
-        // n == len: exact drain must NOT report more, or the client loops forever.
-        let mut r = rows();
-        let (batch, has_more) = take_batch(&mut r, Some(5));
+        // n == len: an exact drain must NOT report more, or the client loops
+        // forever asking for rows that do not exist.
+        let mut r = pending(5);
+        let (batch, has_more) = r.take_batch(Some(5)).await.unwrap();
         assert_eq!(batch.len(), 5);
-        assert!(r.is_empty());
         assert!(!has_more);
 
         // Fetch-all (n absent / negative) drains everything.
-        let mut r = rows();
-        let (batch, has_more) = take_batch(&mut r, None);
+        let mut r = pending(5);
+        let (batch, has_more) = r.take_batch(None).await.unwrap();
         assert_eq!(batch.len(), 5);
-        assert!(r.is_empty());
         assert!(!has_more);
 
         // n == 0 consumes nothing but must still report more, else the
         // remaining rows become unreachable.
-        let mut r = rows();
-        let (batch, has_more) = take_batch(&mut r, Some(0));
+        let mut r = pending(5);
+        let (batch, has_more) = r.take_batch(Some(0)).await.unwrap();
         assert!(batch.is_empty());
-        assert_eq!(r.len(), 5, "nothing consumed");
         assert!(has_more);
+        let (rest, _) = r.take_batch(None).await.unwrap();
+        assert_eq!(rest.len(), 5, "nothing was consumed by the zero-batch");
 
-        // Empty pending result: no panic, nothing more.
-        let mut r: Vec<Vec<serde_json::Value>> = Vec::new();
-        let (batch, has_more) = take_batch(&mut r, Some(3));
+        // Empty result: no panic, nothing more.
+        let mut r = pending(0);
+        let (batch, has_more) = r.take_batch(Some(3)).await.unwrap();
         assert!(batch.is_empty());
         assert!(!has_more);
-    }
-
-    /// The paging arithmetic, including the edges that decide whether a client
-    /// ever sees the rest of its result (t_4ce82a3e inc 7).
-    #[test]
-    fn batch_split_pages_and_signals_has_more() {
-        // Bounded batch smaller than the result: more remains.
-        assert_eq!(batch_split(Some(2), 5), (2, true));
-        // Exactly the result size: no more (must NOT claim has_more, which would
-        // make a client PULL forever).
-        assert_eq!(batch_split(Some(5), 5), (5, false));
-        // Asking for more than exists is clamped, and completes.
-        assert_eq!(batch_split(Some(99), 5), (5, false));
-        // n = 0 sends nothing but must still report more to come.
-        assert_eq!(batch_split(Some(0), 5), (0, true));
-        // ...unless there is nothing to send at all.
-        assert_eq!(batch_split(Some(0), 0), (0, false));
-        // Fetch-all takes everything and completes — the pre-existing behavior,
-        // which must be preserved for clients that send n = -1 or omit it.
-        assert_eq!(batch_split(None, 5), (5, false));
-        assert_eq!(batch_split(None, 0), (0, false));
     }
 
     /// Bolt PULL {n} must deliver AT MOST n records. `n` absent/negative means

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -191,8 +191,12 @@ pub async fn execute(
 /// Everything else, including `UNION` *without* `ALL` (its `HashSet` dedup
 /// spans the whole concatenation), `DeleteNodes` (it walks the matched rows
 /// twice — validate every vertex, then tombstone — and streaming it would
-/// partially delete), `Aggregate`, DISTINCT, ORDER BY, `WcoJoin`, and
+/// partially delete), `Aggregate`, DISTINCT, ORDER BY, and
 /// `ExpandVarLength`.
+///
+/// `WcoJoin` moved into the streaming set: its accumulator already spilled to
+/// disk, and only the final `finish_rows()` was pulling the result back into
+/// memory.
 ///
 /// # Stats
 ///
@@ -458,6 +462,27 @@ fn execute_streaming_inner<'a>(
                         schema,
                         start,
                     },
+                )
+                .await
+            }
+
+            // Worst-case-optimal join. Its accumulator already spilled while
+            // accumulating; routing it here is what lets the spill survive to
+            // the transport instead of being collected back into a Vec by the
+            // fallback below.
+            PhysicalPlan::WcoJoin {
+                plan,
+                return_clause,
+            } => {
+                super::leapfrog::execute_wco_join_streaming(
+                    write_path,
+                    keyspace,
+                    &plan,
+                    &return_clause,
+                    config,
+                    start,
+                    virtual_tables,
+                    schema,
                 )
                 .await
             }
@@ -6391,6 +6416,40 @@ pub fn check_timeout(start: Instant, timeout: Duration) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// `WcoJoin` must reach the transport as a stream, not as a collected Vec.
+    ///
+    /// Its accumulator already spilled to disk while accumulating, and then
+    /// `finish_rows()` pulled every row back into memory to build a
+    /// `GraphResult` — so the spill was undone at the last step and a large
+    /// result still landed in RAM. Routing the plan through the streaming
+    /// dispatch is what keeps the spill alive to the consumer.
+    ///
+    /// This asserts the routing, which is the part that regresses silently: if
+    /// `WcoJoin` falls back to `other =>` again it still returns correct rows,
+    /// just materialised, and no result-shaped assertion would notice.
+    #[test]
+    fn wco_join_is_routed_to_the_streaming_dispatch_not_the_buffered_fallback() {
+        let src = include_str!("expand.rs");
+        let dispatch = src
+            .split("fn execute_streaming_inner")
+            .nth(1)
+            .expect("execute_streaming_inner must exist");
+        let dispatch = &dispatch[..dispatch
+            .find("// --- everything else")
+            .expect("the buffered fallback arm must exist")];
+
+        assert!(
+            dispatch.contains("PhysicalPlan::WcoJoin"),
+            "WcoJoin must be handled BEFORE the buffered fallback; falling \
+             through to `other =>` collects the spilled result back into a Vec"
+        );
+        assert!(
+            dispatch.contains("execute_wco_join_streaming"),
+            "the WcoJoin arm must call the streaming form, not the collecting \
+             wrapper"
+        );
+    }
     use super::*;
 
     use crate::adjacency::observer::make_adjacency_mutation;

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -5893,8 +5893,24 @@ async fn execute_aggregate(
     virtual_tables: Option<&VirtualTableRegistry>,
     schema: Option<&Schema>,
 ) -> Result<GraphResult> {
-    // Step 1: Execute inner plan to get all rows.
-    let inner_result = Box::pin(execute(
+    // Step 1: stream the inner plan.
+    //
+    // This used to run the buffered `execute` and hold `inner_result.rows` for
+    // the whole aggregation, then group them into
+    // `BTreeMap<String, Vec<&Vec<Value>>>` — a reference to EVERY input row.
+    // So `RETURN count(n)` over a billion rows held the billion to produce one
+    // number: memory proportional to the INPUT for an output proportional to
+    // the number of groups.
+    //
+    // Nothing required that. `Accumulator` is already incremental
+    // (`accumulate(&mut self, value)`), and the only per-row state the output
+    // needs is one row per group, for the GroupKey projections. So fold each
+    // row as it arrives and keep the first row of each group, never the rest.
+    //
+    // Memory is now proportional to the number of groups, which
+    // `config.max_groups` already bounds (FMEA F7) — a bound on STATE, not on
+    // results.
+    let (inner_columns, mut inner_rows, inner_stats) = Box::pin(execute_streaming(
         inner,
         write_path,
         keyspace,
@@ -5904,73 +5920,75 @@ async fn execute_aggregate(
     ))
     .await?;
     check_timeout(start, config.query_timeout)?;
+    let inner_columns = &inner_columns;
 
-    let inner_columns = &inner_result.columns;
-    let inner_rows = &inner_result.rows;
+    /// One group's running state: its accumulators and the single row the
+    /// GroupKey projections read from.
+    struct GroupState {
+        first_row: Vec<serde_json::Value>,
+        accumulators: Vec<Option<Box<dyn Accumulator>>>,
+        seen_distinct: Vec<std::collections::HashSet<String>>,
+    }
 
-    // Step 2: Group rows by group key values.
-    // Use a BTreeMap keyed by serialized group key for deterministic ordering.
-    let mut groups: std::collections::BTreeMap<String, Vec<&Vec<serde_json::Value>>> =
+    let new_group_state = |first_row: Vec<serde_json::Value>| -> Result<GroupState> {
+        Ok(GroupState {
+            first_row,
+            accumulators: projections
+                .iter()
+                .map(|proj| match proj {
+                    AggregateProjection::GroupKey(_) => Ok(None),
+                    AggregateProjection::AggregateFunc { name, arg, .. } => {
+                        let count_star = name == "count" && matches!(arg, Expr::Var(v) if v == "*");
+                        create_accumulator(name, count_star, config.max_collect_size).map(Some)
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?,
+            seen_distinct: projections
+                .iter()
+                .map(|_| std::collections::HashSet::new())
+                .collect(),
+        })
+    };
+
+    // Step 2: fold each row into its group as it arrives.
+    let mut groups: std::collections::BTreeMap<String, GroupState> =
         std::collections::BTreeMap::new();
 
-    for row in inner_rows {
-        // Build group key from the group_keys indices.
-        let group_key_values: Vec<&serde_json::Value> = group_keys
-            .iter()
-            .map(|&idx| row.get(idx).unwrap_or(&serde_json::Value::Null))
-            .collect();
+    {
+        use futures::StreamExt as _;
+        while let Some(row) = inner_rows.next().await {
+            let row = row?;
+            check_timeout(start, config.query_timeout)?;
 
-        let group_key_str = serde_json::to_string(&group_key_values).unwrap_or_default();
+            let group_key_values: Vec<&serde_json::Value> = group_keys
+                .iter()
+                .map(|&idx| row.get(idx).unwrap_or(&serde_json::Value::Null))
+                .collect();
+            let group_key_str = serde_json::to_string(&group_key_values).unwrap_or_default();
 
-        // Check group count limit (FMEA F7).
-        if !groups.contains_key(&group_key_str) && groups.len() >= config.max_groups {
-            return Err(GraphError::ResourceLimit(format!(
-                "aggregation group count limit exceeded: {} (limit: {})",
-                groups.len(),
-                config.max_groups
-            )));
-        }
+            // Check group count limit (FMEA F7).
+            if !groups.contains_key(&group_key_str) && groups.len() >= config.max_groups {
+                return Err(GraphError::ResourceLimit(format!(
+                    "aggregation group count limit exceeded: {} (limit: {})",
+                    groups.len(),
+                    config.max_groups
+                )));
+            }
 
-        groups.entry(group_key_str).or_default().push(row);
-    }
-
-    // If there are no group keys and no rows, produce a single group with empty rows
-    // so aggregates like count(*) return 0 rather than no rows.
-    if group_keys.is_empty() && groups.is_empty() {
-        groups.insert(String::new(), Vec::new());
-    }
-
-    // Step 3: Build output rows.
-    let columns = build_columns(return_clause);
-    let mut result_rows = Vec::new();
-
-    for group_rows in groups.values() {
-        // Create accumulators for each aggregate projection.
-        let mut accumulators: Vec<Option<Box<dyn Accumulator>>> = projections
-            .iter()
-            .map(|proj| match proj {
-                AggregateProjection::GroupKey(_) => Ok(None),
-                AggregateProjection::AggregateFunc { name, arg, .. } => {
-                    let count_star = name == "count" && matches!(arg, Expr::Var(v) if v == "*");
-                    create_accumulator(name, count_star, config.max_collect_size).map(Some)
+            let state = match groups.entry(group_key_str) {
+                std::collections::btree_map::Entry::Occupied(e) => e.into_mut(),
+                std::collections::btree_map::Entry::Vacant(v) => {
+                    v.insert(new_group_state(row.clone())?)
                 }
-            })
-            .collect::<Result<Vec<_>>>()?;
+            };
 
-        let mut seen_distinct: Vec<std::collections::HashSet<String>> = projections
-            .iter()
-            .map(|_| std::collections::HashSet::new())
-            .collect();
-
-        // Feed rows into accumulators.
-        for row in group_rows {
             for (proj_idx, proj) in projections.iter().enumerate() {
                 if let AggregateProjection::AggregateFunc { arg, distinct, .. } = proj {
-                    if let Some(ref mut acc) = accumulators[proj_idx] {
-                        let value = eval_aggregate_arg(arg, row, inner_columns);
+                    if let Some(ref mut acc) = state.accumulators[proj_idx] {
+                        let value = eval_aggregate_arg(arg, &row, inner_columns);
                         if *distinct {
                             let key = serde_json::to_string(&value).unwrap_or_default();
-                            if !seen_distinct[proj_idx].insert(key) {
+                            if !state.seen_distinct[proj_idx].insert(key) {
                                 continue;
                             }
                         }
@@ -5979,9 +5997,22 @@ async fn execute_aggregate(
                 }
             }
         }
+    }
 
+    // No group keys and no rows: one empty group, so `count(*)` returns 0
+    // rather than no rows at all.
+    if group_keys.is_empty() && groups.is_empty() {
+        groups.insert(String::new(), new_group_state(Vec::new())?);
+    }
+
+    // Step 3: Build output rows. The accumulators were fed as rows arrived, so
+    // there is nothing left to iterate but the groups themselves.
+    let columns = build_columns(return_clause);
+    let mut result_rows = Vec::new();
+
+    for state in groups.values() {
         // Check collect size limit (FMEA F6).
-        for acc in accumulators.iter().flatten() {
+        for acc in state.accumulators.iter().flatten() {
             if acc.name() == "collect" {
                 let result = acc.finish();
                 if let serde_json::Value::Array(arr) = &result {
@@ -5998,20 +6029,19 @@ async fn execute_aggregate(
 
         // Build the output row.
         let mut output_row = Vec::new();
-        let first_row = group_rows.first();
-
         for (proj_idx, proj) in projections.iter().enumerate() {
             match proj {
                 AggregateProjection::GroupKey(key_idx) => {
                     let col_idx = group_keys.get(*key_idx).copied().unwrap_or(0);
-                    let value = first_row
-                        .and_then(|r| r.get(col_idx))
+                    let value = state
+                        .first_row
+                        .get(col_idx)
                         .cloned()
                         .unwrap_or(serde_json::Value::Null);
                     output_row.push(value);
                 }
                 AggregateProjection::AggregateFunc { .. } => {
-                    let value = accumulators[proj_idx]
+                    let value = state.accumulators[proj_idx]
                         .as_ref()
                         .map(|a| a.finish())
                         .unwrap_or(serde_json::Value::Null);
@@ -6023,10 +6053,12 @@ async fn execute_aggregate(
         result_rows.push(output_row);
     }
 
-    let mut stats = QueryStats::default();
-    stats.vertices_read = inner_result.stats.vertices_read;
-    stats.edges_read = inner_result.stats.edges_read;
-    stats.execution_ms = start.elapsed().as_millis() as u64;
+    let stats = QueryStats {
+        vertices_read: inner_stats.vertices_read,
+        edges_read: inner_stats.edges_read,
+        execution_ms: start.elapsed().as_millis() as u64,
+        ..Default::default()
+    };
 
     Ok(GraphResult {
         columns,
@@ -6479,6 +6511,44 @@ pub fn check_timeout(start: Instant, timeout: Duration) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Aggregation must fold its input, not hold it.
+    ///
+    /// It used to run the buffered `execute` and group into
+    /// `BTreeMap<String, Vec<&Vec<Value>>>` — a reference to every input row —
+    /// so `RETURN count(n)` over a billion rows held the billion to produce one
+    /// number. `Accumulator` was already incremental; only the grouping step
+    /// stood in the way.
+    ///
+    /// Asserted on the source because the regression is invisible in results:
+    /// collecting the rows first returns exactly the same aggregates, just with
+    /// memory proportional to the input, and no output-shaped test can tell the
+    /// difference without a data set larger than the machine.
+    #[test]
+    fn aggregation_folds_its_input_instead_of_collecting_it() {
+        let src = include_str!("expand.rs");
+        let body = src
+            .split("async fn execute_aggregate")
+            .nth(1)
+            .expect("execute_aggregate must exist");
+        let body = &body[..body
+            .find("stats.execution_ms")
+            .expect("the aggregate body must end with its stats")];
+
+        assert!(
+            body.contains("execute_streaming("),
+            "the inner plan must be streamed; the buffered `execute` \
+             materialises every input row before aggregation starts"
+        );
+        assert!(
+            !body.contains("Vec<&Vec<serde_json::Value>>"),
+            "groups must hold running state, not references to every input row"
+        );
+        assert!(
+            body.contains("acc.accumulate(&value)") && body.contains("while let Some(row)"),
+            "rows must be accumulated as they arrive"
+        );
+    }
 
     /// No executor path may truncate a result on `max_result_rows`.
     ///

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -509,7 +509,11 @@ fn execute_streaming_inner<'a>(
 ///
 /// The previous form sorted by debug representation and then `dedup()`ed:
 ///
-/// ```ignore
+/// (`text`, not `ignore`: the Cluster CI job runs `cargo test -- --ignored`,
+/// which forces ```ignore doctests to compile — and this snippet is an
+/// illustration of deleted code, not something that can compile.)
+///
+/// ```text
 /// rows.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
 /// rows.dedup();
 /// ```

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1534,13 +1534,16 @@ async fn execute_expand_streaming<'a>(
     // final until every row is projected. But "must see every row" does not
     // mean "must hold every row": when the spilling sorter applies, project
     // each state straight INTO it and stream the merged output — the full
-    // result set is never resident (t_3f2f961a). DISTINCT still takes the
-    // buffered tail: its buffered semantics re-sort by debug string after the
-    // ORDER BY sort (t_363c1316 tracks that bug), and this path must not
-    // change observable behavior.
+    // result set is never resident (t_3f2f961a).
+    //
+    // DISTINCT used to be excluded here because the buffered tail re-sorted by
+    // debug string after the ORDER BY sort, so streaming it would have changed
+    // observable behaviour. That re-sort was a bug — it discarded the query's
+    // ORDER BY — and now that the buffered tail dedups without reordering, both
+    // forms are first-seen order and the exclusion has nothing left to protect.
     if !parts.return_clause.order_by.is_empty() {
         let columns = build_columns(&parts.return_clause);
-        if !parts.return_clause.distinct {
+        {
             if let Some(mut sink) = crate::executor::spill::SpillSortSink::try_new(
                 &columns,
                 &parts.return_clause,
@@ -1569,9 +1572,24 @@ async fn execute_expand_streaming<'a>(
                 .await?;
                 stats.execution_ms = ctx.start.elapsed().as_millis() as u64;
                 let mut sorted = sink.finish_stream()?;
-                // LIMIT applies to the sorted output. Taking it here is what
-                // lets the sink accept a LIMIT at all: the sort still sees
-                // every candidate row, but only `limit` of them are pulled.
+
+                // DISTINCT on the sorted stream, in the same order the buffered
+                // tail applies it: sort, then dedup, then limit.
+                //
+                // `dedup_stream` hashes every row it has emitted, so this is
+                // bounded by the number of DISTINCT rows rather than by the
+                // number of candidate rows — inherent to DISTINCT without a
+                // spilling set, and still far below materialising everything.
+                // Adjacent-only dedup would be O(1) but WRONG here: the stream
+                // is sorted by the ORDER BY terms, which may be a subset of the
+                // projected columns, so equal rows are not necessarily adjacent.
+                if parts.return_clause.distinct {
+                    sorted = crate::executor::stream::dedup_stream(sorted);
+                }
+
+                // LIMIT applies to the sorted, deduplicated output. Taking it
+                // here is what lets the sink accept a LIMIT at all: the sort
+                // still sees every candidate row, but only `limit` are pulled.
                 if let Some(limit) = parts.return_clause.limit {
                     use futures::StreamExt as _;
                     sorted = Box::pin(sorted.take(limit.max(0) as usize));
@@ -6446,6 +6464,40 @@ pub fn check_timeout(start: Instant, timeout: Duration) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// `ORDER BY` with `DISTINCT` must reach the spilling sorter.
+    ///
+    /// DISTINCT was excluded from this path because the buffered tail re-sorted
+    /// by debug string afterwards, so streaming would have changed the observed
+    /// order. That re-sort was the bug (it discarded the ORDER BY); with it
+    /// gone, excluding DISTINCT only forces the whole result into memory for no
+    /// behavioural reason.
+    ///
+    /// Asserted on the source because the regression is a routing one: putting
+    /// the `!distinct` guard back still returns correct rows, merely
+    /// materialised, so no result-shaped assertion would catch it.
+    #[test]
+    fn distinct_is_not_excluded_from_the_streaming_order_by_path() {
+        let src = include_str!("expand.rs");
+        let body = src
+            .split("ORDER BY (with or without DISTINCT) is a pipeline breaker")
+            .nth(1)
+            .expect("the streaming ORDER BY arm must exist");
+        let arm = &body[..body
+            .find("// Fallback:")
+            .expect("the fallback comment must exist")];
+
+        assert!(
+            !arm.contains("if !parts.return_clause.distinct"),
+            "DISTINCT must not be routed away from the spilling sorter: the \
+             buffered tail no longer reorders, so there is nothing left to \
+             preserve by materialising"
+        );
+        assert!(
+            arm.contains("dedup_stream"),
+            "the streaming arm must apply DISTINCT to the sorted stream"
+        );
+    }
 
     /// DISTINCT must not discard the ORDER BY the query asked for.
     ///

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -505,6 +505,30 @@ fn execute_streaming_inner<'a>(
     })
 }
 
+/// Remove duplicate rows, keeping the first occurrence and the existing order.
+///
+/// The previous form sorted by debug representation and then `dedup()`ed:
+///
+/// ```ignore
+/// rows.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+/// rows.dedup();
+/// ```
+///
+/// `Vec::dedup` only removes *consecutive* duplicates, so the sort was there to
+/// make duplicates adjacent — but it ran **after** the ORDER BY sort and
+/// therefore destroyed it. `RETURN DISTINCT x ORDER BY x DESC` came back in
+/// debug-string ascending order, with no indication the requested order had
+/// been discarded.
+///
+/// Deduplicating on a hash of the row keeps every duplicate out without
+/// touching the order, so ORDER BY survives. First-seen order also matches what
+/// the streaming paths already do (`dedup_stream`, t_4ce82a3e), so the two
+/// forms of DISTINCT now agree instead of differing by which path a query took.
+fn dedup_preserving_order(rows: &mut Vec<super::stream::RowVals>) {
+    let mut seen = std::collections::HashSet::new();
+    rows.retain(|row| seen.insert(serde_json::to_string(row).unwrap_or_default()));
+}
+
 /// `RETURN <exprs>` with no MATCH: at most one row, built on pull.
 ///
 /// The buffered form projected the row, ran `sort_rows`, then
@@ -2078,9 +2102,7 @@ async fn finish_expand_buffered(
 
     // Apply DISTINCT.
     if return_clause.distinct {
-        // serde_json::Value doesn't impl Ord; use string repr for dedup.
-        rows.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
-        rows.dedup();
+        dedup_preserving_order(&mut rows);
     }
 
     // Apply LIMIT.
@@ -6424,6 +6446,38 @@ pub fn check_timeout(start: Instant, timeout: Duration) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// DISTINCT must not discard the ORDER BY the query asked for.
+    ///
+    /// The buffered tail sorted by debug representation and then `dedup()`ed,
+    /// because `Vec::dedup` only removes consecutive duplicates. That sort ran
+    /// AFTER the ORDER BY sort, so `RETURN DISTINCT x ORDER BY x DESC` came
+    /// back in debug-string ascending order — the requested order silently
+    /// replaced, with no error and nothing in the result to show it.
+    #[test]
+    fn distinct_dedups_without_reordering() {
+        use serde_json::json;
+
+        // Already in the order an `ORDER BY n DESC` would have produced, with
+        // duplicates that are not adjacent.
+        let mut rows: Vec<super::super::stream::RowVals> = vec![
+            vec![json!(30)],
+            vec![json!(20)],
+            vec![json!(30)],
+            vec![json!(10)],
+            vec![json!(20)],
+        ];
+
+        super::dedup_preserving_order(&mut rows);
+
+        let got: Vec<i64> = rows.iter().map(|r| r[0].as_i64().unwrap()).collect();
+        assert_eq!(
+            got,
+            vec![30, 20, 10],
+            "duplicates must go and the descending order must stay; sorting to \
+             make duplicates adjacent throws away the ORDER BY"
+        );
+    }
 
     /// `WcoJoin` must reach the transport as a stream, not as a collected Vec.
     ///

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -6153,8 +6153,6 @@ fn execute_virtual_anchor(
             ))
         })?;
 
-    let virtual_rows = vtable.read(None);
-    stats.vertices_read = virtual_rows.len();
     check_timeout(start, config.query_timeout)?;
 
     let vtable_columns = vtable.columns();
@@ -6163,11 +6161,27 @@ fn execute_virtual_anchor(
     // Build a JSON object for each virtual row so eval_expr can project.
     let anchor_var = anchor.var.as_deref().unwrap_or("_anon");
 
+    // `visit_rows`, not `read(None)`, and no result cap.
+    //
+    // This read the whole virtual table into a `Vec` and then stopped
+    // projecting at `config.max_result_rows` — a silent truncation with no
+    // error and no flag, so a client could not tell a partial answer from a
+    // complete one. It also saved nothing: the rows it declined to project were
+    // already resident, because `read(None)` had materialised all of them
+    // first. A bound on a RESULT, paid for with a wrong answer and buying
+    // nothing.
+    //
+    // `visit_rows` exists for exactly this: its doc says "streaming or live
+    // tables should override this method and emit one row at a time", so using
+    // it lets a large or live virtual table avoid the intermediate `Vec`
+    // entirely, while the default adapter keeps every existing table working.
+    //
+    // The body is sync and infallible (`eval_expr(..).unwrap_or(Null)`), so it
+    // drops into the visitor closure unchanged.
     let mut rows = Vec::new();
-    for vrow in &virtual_rows {
-        if rows.len() >= config.max_result_rows {
-            break;
-        }
+    let mut vertices_read = 0usize;
+    vtable.visit_rows(None, &mut |vrow| {
+        vertices_read += 1;
 
         // Construct a JSON object from virtual row cells, keyed by column name.
         let mut obj = serde_json::Map::new();
@@ -6187,7 +6201,8 @@ fn execute_virtual_anchor(
             .collect();
 
         rows.push(row);
-    }
+    });
+    stats.vertices_read = vertices_read;
 
     stats.execution_ms = start.elapsed().as_millis() as u64;
 
@@ -6464,6 +6479,49 @@ pub fn check_timeout(start: Instant, timeout: Duration) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// No executor path may truncate a result on `max_result_rows`.
+    ///
+    /// Every such site silently dropped answers: no error, no flag, and a
+    /// client could not distinguish a partial result from a complete one. They
+    /// have all been removed -- leapfrog's intersection cap, the ORDER BY bail,
+    /// and the virtual-table projection break -- and this is what stops the
+    /// next one being added, because a reintroduced cap produces plausible
+    /// output and breaks nothing a result-shaped test would catch.
+    ///
+    /// Reading the source is deliberate: the property is "this comparison does
+    /// not appear", which cannot be observed from behaviour without knowing the
+    /// data set is larger than the cap.
+    #[test]
+    fn no_executor_path_truncates_on_max_result_rows() {
+        let sources = [
+            ("expand.rs", include_str!("expand.rs")),
+            ("leapfrog.rs", include_str!("leapfrog.rs")),
+            ("varpath.rs", include_str!("varpath.rs")),
+            ("spill.rs", include_str!("spill.rs")),
+            ("stream.rs", include_str!("stream.rs")),
+        ];
+
+        for (name, src) in sources {
+            for (n, line) in src.lines().enumerate() {
+                let code = line.split("//").next().unwrap_or("");
+                if !code.contains("max_result_rows") {
+                    continue;
+                }
+                // A declaration or a default is fine; a comparison is a cap.
+                let is_cap = code.contains(">=")
+                    || code.contains(" > ")
+                    || code.contains("take(")
+                    || code.contains("truncate(");
+                assert!(
+                    !is_cap,
+                    "{name}:{} truncates on max_result_rows: {}",
+                    n + 1,
+                    code.trim()
+                );
+            }
+        }
+    }
 
     /// `ORDER BY` with `DISTINCT` must reach the spilling sorter.
     ///
@@ -7805,7 +7863,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_virtual_table_respects_max_rows() {
+    async fn execute_virtual_table_returns_every_row() {
         let registry = VirtualTableRegistry::new();
         // Create a virtual table with many rows.
         let rows: Vec<VirtualRow> = (0..100)
@@ -7830,6 +7888,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let storage = test_storage_engine(tmp.path());
 
+        // A low `max_result_rows` must NOT shorten the answer. It used to:
+        // the projection loop broke at this value after `read(None)` had
+        // already materialised every row, so it discarded answers without
+        // saving anything.
         let config = GraphEngineConfig {
             max_result_rows: 5,
             ..Default::default()
@@ -7846,7 +7908,12 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(result.rows.len(), 5);
+        assert_eq!(
+            result.rows.len(),
+            100,
+            "every row in the virtual table is an answer; `max_result_rows` \
+             must not silently drop 95 of them"
+        );
     }
 
     #[test]

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -1544,7 +1544,15 @@ async fn execute_expand_streaming<'a>(
                 )
                 .await?;
                 stats.execution_ms = ctx.start.elapsed().as_millis() as u64;
-                return Ok((columns, sink.finish_stream()?, stats));
+                let mut sorted = sink.finish_stream()?;
+                // LIMIT applies to the sorted output. Taking it here is what
+                // lets the sink accept a LIMIT at all: the sort still sees
+                // every candidate row, but only `limit` of them are pulled.
+                if let Some(limit) = parts.return_clause.limit {
+                    use futures::StreamExt as _;
+                    sorted = Box::pin(sorted.take(limit.max(0) as usize));
+                }
+                return Ok((columns, sorted, stats));
             }
         }
         // Fallback: no spill backend, LIMIT present, an order term that is not

--- a/ferrosa-graph/src/executor/expand.rs
+++ b/ferrosa-graph/src/executor/expand.rs
@@ -524,7 +524,7 @@ fn execute_streaming_inner<'a>(
 /// touching the order, so ORDER BY survives. First-seen order also matches what
 /// the streaming paths already do (`dedup_stream`, t_4ce82a3e), so the two
 /// forms of DISTINCT now agree instead of differing by which path a query took.
-fn dedup_preserving_order(rows: &mut Vec<super::stream::RowVals>) {
+pub(super) fn dedup_preserving_order(rows: &mut Vec<super::stream::RowVals>) {
     let mut seen = std::collections::HashSet::new();
     rows.retain(|row| seen.insert(serde_json::to_string(row).unwrap_or_default()));
 }

--- a/ferrosa-graph/src/executor/leapfrog.rs
+++ b/ferrosa-graph/src/executor/leapfrog.rs
@@ -125,56 +125,60 @@ impl AdjacencyIterator {
     }
 }
 
-/// Leapfrog join: intersect multiple sorted iterators.
-/// Returns the set of values present in ALL iterators.
-fn leapfrog_join(iterators: &mut [AdjacencyIterator], max_results: usize) -> Vec<Vec<u8>> {
+/// Advance a set of sorted iterators to their next common value.
+///
+/// Returns `None` once any iterator is exhausted, at which point the
+/// intersection is complete.
+///
+/// **Streams; does not materialise.** This used to be `leapfrog_join`, which
+/// collected the whole intersection into a `Vec<Vec<u8>>` and took a
+/// `max_results` argument that every production call defeated with
+/// `usize::MAX`. That combination is the worst of both: a cap that drops
+/// ANSWERS silently when it is honoured, and an unbounded in-memory Vec when it
+/// is not.
+///
+/// Neither is necessary. Leapfrog converges on one common value per round by
+/// seeking every iterator to the current maximum, so the intersection is
+/// naturally incremental — building a Vec was gratuitous. Yielding one value at
+/// a time removes the cap and the allocation together, so there is nothing to
+/// spill.
+///
+/// Work is bounded by the caller's `check_timeout`, which fails loud.
+fn next_common_value(iterators: &mut [AdjacencyIterator]) -> Option<Vec<u8>> {
     if iterators.is_empty() || iterators.iter().any(|it| it.is_exhausted()) {
-        return vec![];
+        return None;
     }
 
-    let mut results = Vec::new();
-
     loop {
-        if results.len() >= max_results {
-            break;
-        }
-
         // Find the iterator with the maximum current value.
         let max_val = iterators
             .iter()
             .filter_map(|it| it.current())
             .max()
-            .map(|v| v.to_vec());
-
-        let max_val = match max_val {
-            Some(v) => v,
-            None => break, // Some iterator exhausted
-        };
+            .map(|v| v.to_vec())?;
 
         // Seek all iterators to >= max_val.
         for it in iterators.iter_mut() {
             it.seek(&max_val);
             if it.is_exhausted() {
-                return results;
+                return None;
             }
         }
 
-        // Check if all iterators are at the same value.
+        // All at the same value means it is in every iterator.
         let all_equal = iterators
             .iter()
             .all(|it| it.current() == Some(max_val.as_slice()));
 
         if all_equal {
-            results.push(max_val);
-            // Advance all iterators past the match.
+            // Advance past the match so the next call makes progress.
             for it in iterators.iter_mut() {
                 it.next();
             }
+            return Some(max_val);
         }
-        // Otherwise, the next iteration will converge on the new max.
+        // Otherwise the next round converges on the new maximum.
     }
-
-    results
 }
 
 /// Execute a worst-case optimal join plan using leapfrog triejoin.
@@ -434,10 +438,12 @@ async fn enumerate_bindings(
     // intersection is bounded by the smallest adjacency list, which is already
     // resident — truncating it (`max_result_rows`, removed) only dropped valid
     // join results without saving memory.
-    let valid_bindings = leapfrog_join(&mut iterators, usize::MAX);
-
-    for binding in &valid_bindings {
-        var_bindings.insert(current_var.clone(), binding.clone());
+    // Stream the intersection. Nothing is collected: each common value is
+    // consumed and its subtree enumerated before the next is produced, so a
+    // large intersection costs no memory here regardless of size.
+    while let Some(binding) = next_common_value(&mut iterators) {
+        check_timeout(start, config.query_timeout)?;
+        var_bindings.insert(current_var.clone(), binding);
         Box::pin(enumerate_bindings(
             write_path,
             adj_table_id,
@@ -565,6 +571,14 @@ mod tests {
         out
     }
 
+    /// Drain the streaming intersection for assertions.
+    ///
+    /// Test-only on purpose: production consumes `next_common_value` one value
+    /// at a time and never holds the intersection in memory.
+    fn drain_intersection(iterators: &mut [AdjacencyIterator]) -> Vec<Vec<u8>> {
+        std::iter::from_fn(|| next_common_value(iterators)).collect()
+    }
+
     #[test]
     fn leapfrog_join_basic() {
         // Three sorted iterators with known intersection {3, 5}.
@@ -574,7 +588,7 @@ mod tests {
             AdjacencyIterator::from_sorted(vec![vec![3], vec![4], vec![5], vec![8]]),
         ];
 
-        let results = leapfrog_join(&mut iters, 100);
+        let results = drain_intersection(&mut iters);
         assert_eq!(results, vec![vec![3], vec![5]]);
     }
 
@@ -586,7 +600,7 @@ mod tests {
             AdjacencyIterator::from_sorted(vec![vec![5], vec![6]]),
         ];
 
-        let results = leapfrog_join(&mut iters, 100);
+        let results = drain_intersection(&mut iters);
         assert!(results.is_empty());
     }
 
@@ -599,26 +613,79 @@ mod tests {
             vec![3],
         ])];
 
-        let results = leapfrog_join(&mut iters, 100);
+        let results = drain_intersection(&mut iters);
         assert_eq!(results, vec![vec![1], vec![2], vec![3]]);
     }
 
+    /// The intersection is produced incrementally, not collected.
+    ///
+    /// Completeness alone would still pass if the implementation built the
+    /// whole `Vec` first, which is what it used to do -- and a result set that
+    /// must fit in RAM to be correct is a cap waiting to be reintroduced. This
+    /// pins the shape: one value per call, with the iterators left positioned
+    /// for the next, so a caller can consume an intersection larger than
+    /// memory.
     #[test]
-    fn leapfrog_join_respects_max_results() {
+    fn the_intersection_is_produced_one_value_at_a_time() {
+        let shared: Vec<Vec<u8>> = (0..500u32).map(|i| i.to_be_bytes().to_vec()).collect();
         let mut iters = vec![
-            AdjacencyIterator::from_sorted(vec![vec![1], vec![2], vec![3], vec![4]]),
-            AdjacencyIterator::from_sorted(vec![vec![1], vec![2], vec![3], vec![4]]),
+            AdjacencyIterator::from_sorted(shared.clone()),
+            AdjacencyIterator::from_sorted(shared.clone()),
         ];
 
-        let results = leapfrog_join(&mut iters, 2);
-        assert_eq!(results.len(), 2);
-        assert_eq!(results, vec![vec![1], vec![2]]);
+        // Take three values and stop. A collecting implementation would have
+        // computed all 500 to hand back the first.
+        let first = next_common_value(&mut iters).expect("first");
+        let second = next_common_value(&mut iters).expect("second");
+        let third = next_common_value(&mut iters).expect("third");
+        assert_eq!(vec![first, second, third], shared[..3].to_vec());
+
+        // Resuming continues from where it stopped rather than restarting.
+        let rest: Vec<Vec<u8>> = std::iter::from_fn(|| next_common_value(&mut iters)).collect();
+        assert_eq!(
+            rest,
+            shared[3..].to_vec(),
+            "the iterators must stay positioned between calls; restarting would \
+             duplicate answers and re-read the adjacency lists"
+        );
+
+        // Exhausted means exhausted, not wrapped.
+        assert!(next_common_value(&mut iters).is_none());
+    }
+
+    /// The intersection is returned complete, however large it is.
+    ///
+    /// Replaces `leapfrog_join_respects_max_results`, which asserted the
+    /// opposite: that the join stopped at a caller-supplied count. It passed
+    /// while the production call site defeated the cap with `usize::MAX`, so
+    /// the only thing it pinned was the ability to truncate a result set — the
+    /// behaviour worth preventing, not preserving.
+    ///
+    /// 500 sits well past the old 100-row default, so a reintroduced cap fails
+    /// here rather than in a query someone runs later.
+    #[test]
+    fn leapfrog_join_returns_the_complete_intersection() {
+        let shared: Vec<Vec<u8>> = (0..500u32).map(|i| i.to_be_bytes().to_vec()).collect();
+        let mut iters = vec![
+            AdjacencyIterator::from_sorted(shared.clone()),
+            AdjacencyIterator::from_sorted(shared.clone()),
+        ];
+
+        let results = drain_intersection(&mut iters);
+
+        assert_eq!(
+            results.len(),
+            shared.len(),
+            "every value present in both iterators is an answer; dropping one \
+             returns a wrong result, not a partial one"
+        );
+        assert_eq!(results, shared);
     }
 
     #[test]
     fn leapfrog_join_empty_iterators() {
         let mut iters: Vec<AdjacencyIterator> = vec![];
-        let results = leapfrog_join(&mut iters, 100);
+        let results = drain_intersection(&mut iters);
         assert!(results.is_empty());
     }
 
@@ -629,7 +696,7 @@ mod tests {
             AdjacencyIterator::from_sorted(vec![]),
         ];
 
-        let results = leapfrog_join(&mut iters, 100);
+        let results = drain_intersection(&mut iters);
         assert!(results.is_empty());
     }
 

--- a/ferrosa-graph/src/executor/leapfrog.rs
+++ b/ferrosa-graph/src/executor/leapfrog.rs
@@ -202,16 +202,58 @@ pub async fn execute_wco_join(
     virtual_tables: Option<&VirtualTableRegistry>,
     schema: Option<&ferrosa_schema::Schema>,
 ) -> Result<GraphResult> {
+    // One implementation. This collects the streaming one for the callers that
+    // still want a whole result, rather than keeping a second executor that
+    // could drift from it.
+    let (columns, rows, stats) = execute_wco_join_streaming(
+        write_path,
+        keyspace,
+        plan,
+        return_clause,
+        config,
+        start,
+        virtual_tables,
+        schema,
+    )
+    .await?;
+    // `usize::MAX`, deliberately NOT `config.max_result_rows`: this bridge
+    // truncates silently at whatever it is given, and a caller asking for a
+    // whole result must get the whole result. The materialisation here is the
+    // caller's choice; a cap would be a wrong answer.
+    crate::executor::collect_to_graph_result(columns, rows, stats, usize::MAX).await
+}
+
+/// The streaming form: rows are produced on pull and never all held at once.
+///
+/// The accumulator already spilled to disk while accumulating, and then
+/// `finish_rows()` loaded every row back into a `Vec` to build a `GraphResult`
+/// — so the spill was undone at the last step and a large result still landed
+/// in RAM. `finish_stream()` was sitting next to it, unused from here.
+///
+/// DISTINCT and LIMIT move onto the stream for the same reason: a `Vec::dedup`
+/// after a full sort, and a `Vec::truncate`, both require the whole result to
+/// exist first. `dedup_stream` and `take` do not.
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_wco_join_streaming<'a>(
+    write_path: &'a WritePath,
+    keyspace: &'a str,
+    plan: &WcoJoinPlan,
+    return_clause: &ReturnClause,
+    config: &'a GraphEngineConfig,
+    start: Instant,
+    virtual_tables: Option<&VirtualTableRegistry>,
+    schema: Option<&ferrosa_schema::Schema>,
+) -> Result<(Vec<String>, crate::executor::RowStream<'static>, QueryStats)> {
     let _ = virtual_tables; // Reserved for future virtual table support.
     let mut stats = QueryStats::default();
 
     if plan.variables.is_empty() || plan.relations.is_empty() {
         stats.execution_ms = start.elapsed().as_millis() as u64;
-        return Ok(GraphResult {
-            columns: build_columns(return_clause),
-            rows: vec![],
+        return Ok((
+            build_columns(return_clause),
+            crate::executor::stream::stream_from_rows(vec![]),
             stats,
-        });
+        ));
     }
 
     let adj_ks = adjacency_keyspace_name(keyspace);
@@ -274,36 +316,39 @@ pub async fn execute_wco_join(
     }
 
     // Terminal ORDER BY: the spilling accumulator already sorted while
-    // accumulating; the buffered fallback sorts in memory exactly as before.
-    let mut result_rows = match acc {
-        RowAcc::Spilling(sink) => sink.finish_rows()?,
-        RowAcc::Buffered(mut rows) => {
+    // accumulating and hands back a stream that reads its spilled runs on pull;
+    // the buffered fallback sorts in memory, which is bounded by the threshold
+    // that would have made it spill.
+    let mut rows: crate::executor::RowStream<'static> = match acc {
+        RowAcc::Spilling(sink) => sink.finish_stream()?,
+        RowAcc::Buffered(mut buffered) => {
             if !return_clause.order_by.is_empty() {
-                sort_rows(&mut rows, &columns, &return_clause.order_by);
+                sort_rows(&mut buffered, &columns, &return_clause.order_by);
             }
-            rows
+            crate::executor::stream::stream_from_rows(buffered)
         }
     };
 
-    // Apply DISTINCT.
+    // DISTINCT on the stream. The buffered form sorted the whole result by its
+    // debug representation and then deduped, which needed every row present at
+    // once — and incidentally returned RETURN DISTINCT in string-repr sorted
+    // order. `dedup_stream` is first-seen order, matching the streaming paths
+    // that already made that change deliberately (t_4ce82a3e).
     if return_clause.distinct {
-        result_rows.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
-        result_rows.dedup();
+        rows = crate::executor::stream::dedup_stream(rows);
     }
 
-    // Apply LIMIT.
+    // LIMIT on the stream. `Vec::truncate` had to build the whole result before
+    // discarding most of it; `take` stops pulling.
     if let Some(limit) = return_clause.limit {
+        use futures::StreamExt as _;
         let limit = limit.max(0) as usize;
-        result_rows.truncate(limit);
+        rows = Box::pin(rows.take(limit));
     }
 
     stats.execution_ms = start.elapsed().as_millis() as u64;
 
-    Ok(GraphResult {
-        columns,
-        rows: result_rows,
-        stats,
-    })
+    Ok((columns, rows, stats))
 }
 
 /// Recursively enumerate valid variable bindings.

--- a/ferrosa-graph/src/executor/spill.rs
+++ b/ferrosa-graph/src/executor/spill.rs
@@ -178,9 +178,20 @@ impl SpillSortSink {
         let Some(reserver) = config.spill.as_ref() else {
             return Ok(None);
         };
-        if return_clause.order_by.is_empty() || return_clause.limit.is_some() {
+        if return_clause.order_by.is_empty() {
             return Ok(None);
         }
+        // A LIMIT deliberately does NOT disqualify the sink.
+        //
+        // It used to: `|| return_clause.limit.is_some()` sent every
+        // `ORDER BY ... LIMIT n` to the in-memory path. That is backwards. The
+        // sort has to consider every candidate row whatever the limit is, so
+        // the limit shrinks the OUTPUT, not the work — and bailing meant a
+        // ten-row answer first materialised every candidate row, which is the
+        // shape most likely to be large.
+        //
+        // The caller takes `limit` from the sorted stream, which yields the
+        // same rows in the same order while the sink keeps the sort bounded.
         // Resolve every order term to a projected column index; bail to the
         // in-memory path if any term is not projected.
         let mut terms = Vec::with_capacity(return_clause.order_by.len());
@@ -424,6 +435,46 @@ mod tests {
 
     /// `finish_stream` yields the merged rows in sorted order WITHOUT
     /// re-materializing, and the temp dir lives exactly as long as the stream.
+    /// `ORDER BY n LIMIT k` yields the k smallest, sorted, without the whole
+    /// result being resident.
+    ///
+    /// A LIMIT used to disqualify the sink outright, so this shape took the
+    /// in-memory path and materialised every candidate row to return a handful.
+    /// The sort still has to see every row -- that is inherent -- but only the
+    /// rows the caller takes are ever pulled out of the merge.
+    #[tokio::test]
+    async fn order_by_with_a_limit_streams_the_smallest_rows_in_order() {
+        use futures::StreamExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reserver = TempDirReserver::new(dir.path());
+        let config = spilling_config(reserver.clone());
+        let mut clause = order_by_n_return_clause();
+        clause.limit = Some(3);
+
+        let mut sink = SpillSortSink::try_new(&["n".to_string()], &clause, &config, "test")
+            .unwrap()
+            .expect("a LIMIT must not disqualify the spilling sort");
+
+        // Pushed out of order, and more rows than the limit.
+        for n in [9i64, 2, 7, 1, 8, 3] {
+            sink.push(vec![serde_json::json!(n)]).unwrap();
+        }
+
+        let sorted = sink.finish_stream().unwrap();
+        let taken: Vec<i64> = Box::pin(sorted.take(3))
+            .map(|row| row.unwrap()[0].as_i64().unwrap())
+            .collect()
+            .await;
+
+        assert_eq!(
+            taken,
+            vec![1, 2, 3],
+            "the limit must be applied to the SORTED stream, so it returns the \
+             smallest rows rather than the first three pushed"
+        );
+    }
+
     #[tokio::test]
     async fn finish_stream_yields_sorted_rows_then_cleans_up_on_drop() {
         use futures::StreamExt as _;
@@ -475,12 +526,20 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
-        // LIMIT present.
+        // LIMIT present: the sink still applies. `ORDER BY x LIMIT 10` is the
+        // shape that most needs it -- the sort is over the whole result no
+        // matter how small the limit, so bailing to the in-memory path made a
+        // ten-row answer materialise every candidate row first. The caller
+        // takes the limit from the sorted stream.
         let mut with_limit = order_by_n_return_clause();
         with_limit.limit = Some(10);
-        assert!(SpillSortSink::try_new(&columns, &with_limit, &config, "t")
-            .unwrap()
-            .is_none());
+        assert!(
+            SpillSortSink::try_new(&columns, &with_limit, &config, "t")
+                .unwrap()
+                .is_some(),
+            "a LIMIT bounds the OUTPUT, not the sort; it must not force the \
+             whole result set to be sorted in memory"
+        );
         // Order term not projected (needs binding context downstream).
         assert!(SpillSortSink::try_new(
             &["other".to_string()],

--- a/ferrosa-graph/src/executor/varpath.rs
+++ b/ferrosa-graph/src/executor/varpath.rs
@@ -367,9 +367,13 @@ pub async fn execute_var_length(
     }
 
     // Apply DISTINCT.
+    //
+    // Same bug the expand tail had: `Vec::dedup` only removes consecutive
+    // duplicates, so this sorted by debug representation to make them adjacent
+    // — AFTER the ORDER BY sort immediately above, silently replacing the order
+    // the query asked for. Deduplicating on a hash leaves the order alone.
     if return_clause.distinct {
-        rows.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
-        rows.dedup();
+        super::expand::dedup_preserving_order(&mut rows);
     }
 
     // Apply LIMIT.


### PR DESCRIPTION
Closes `t_cd54bccc` (P0) and `t_d68fd09f`. Recovered from an abandoned three-week-old branch.

The starting complaint: a graph query's full result set landed in memory regardless of size, and the spilling accumulator that was supposed to prevent it called `finish_rows()` at the last step and loaded everything back. The spill was real while accumulating and undone before returning.

## What was actually wrong

Nine commits, each a distinct instance. Three classes:

**Silent truncation** — a cap on a RESULT, which returns a wrong answer with no error and no flag, so a client cannot tell a partial result from a complete one:
- `leapfrog_join` took a `max_results` every production call defeated with `usize::MAX` — a cap that dropped answers when honoured and an unbounded `Vec` when not
- `execute_virtual_anchor` read the whole virtual table and then projected only 10,000 of it. **Not in the design doc's inventory**, which is why it survived the original work. Its test asserted `rows.len() == 5` for a 100-row table — it pinned the truncation as intended behaviour

**Materialisation** — the result held in RAM despite a streaming path existing next to it:
- `WcoJoin` → `finish_rows()` instead of `finish_stream()`, and routed through the buffered fallback
- `ORDER BY … LIMIT` → the spilling sorter refused outright when a LIMIT was present, so the shape most likely to be large was guaranteed to materialise. Asking for ten rows sorted a billion in memory; asking for all of them spilled
- **Aggregation** → grouped into `BTreeMap<String, Vec<&Vec<Value>>>`, a reference to every input row, so `RETURN count(n)` over a billion rows held the billion to produce one number
- **Bolt** → the client paged correctly; the *server* held every undelivered row of every open result until the last PULL

**A correctness bug found on the way** — `DISTINCT` deduplicated with `sort_by(debug repr)` then `dedup()`, and that sort ran *after* the ORDER BY sort. `RETURN DISTINCT x ORDER BY x DESC` came back in debug-string ascending order: right rows, wrong order, no signal. Present in both `expand.rs` and `varpath.rs`. It was also the stated reason DISTINCT was excluded from the streaming path — so fixing the bug removed the blocker.

## Result

No executor path in ferrosa-graph truncates on `max_result_rows`. What still buffers does so deliberately and is documented: DELETE walks its rows twice (validate, then tombstone — streaming it would partially delete), and FOREACH / `CALL {}` orchestrate many sub-executions. Those are the only remaining `buffered_as_stream` uses, and the name exists to keep them honest.

## On the tests

Most of these regress **invisibly**: re-collecting a stream, restoring a routing guard, or re-adding a cap all return correct-looking output. So several tests assert the source rather than the results — stated plainly in each, with the reason. Where behaviour *can* distinguish them it does: the DISTINCT fix is pinned by asserting the ORDER (the old code returns exactly the right rows, rearranged), and `ORDER BY … LIMIT 3` asserts `[1, 2, 3]` so applying the limit before the sort fails rather than passing on a shorter-but-wrong answer.

Two tests changed from asserting a cap to asserting completeness. That is the point of the change rather than collateral: `leapfrog_join_respects_max_results` and `execute_virtual_table_respects_max_rows` both pinned silent truncation as intended behaviour.

`ferrosa-graph` 408 lib + 100 integration tests passing, clippy clean, merges cleanly with main.

## Not in scope

`GraphResult.rows` is still a `Vec` for callers that genuinely want a whole result; they now pass `usize::MAX` so the collect is honest rather than a hidden cap. Converting those callers is the remaining transport work and is not needed for the OOM.
