### PR TITLE
style(docs): text fence for an illustration of deleted code

### DIFF
--- a/ferrosa-storage/src/flush.rs
+++ b/ferrosa-storage/src/flush.rs
@@ -1954,7 +1954,7 @@ mod tests {
     /// across all flush targets on this node". It does not. Each target owns a
     /// separate counter and seeds it from the same wall clock:
     ///
-    /// ```ignore
+    /// ```text
     /// self.generation.fetch_max(ts, SeqCst);
     /// self.generation.fetch_add(1, SeqCst) + 1
     /// ```


### PR DESCRIPTION
One line. Follow-up to #348, which merged with this fence as `ignore`.

The Cluster integration job runs the workspace tests with `--ignored`, and that flag does not only pick up `#[ignore]` tests — it also forces ignore-marked doctests to **compile**. The snippet here is a fragment of the old per-target generation allocator, so it cannot compile.

It passes today only because `next_generation` is private and rustdoc therefore generates no doctest for it. Making that function more visible later would turn this into a CI failure with no obvious cause.

PR #352 hit exactly this and went red on `cannot find value 'rows' in this scope`. A text fence is never compiled, whatever flags are passed.
