### PR TITLE
fix(cluster): an inbound peer was never registered for Raft routing

### DIFF
--- a/ferrosa-cluster/src/controller/peer_events.rs
+++ b/ferrosa-cluster/src/controller/peer_events.rs
@@ -393,6 +393,25 @@ impl InboundPeerCallback for ModeController {
         );
         tracing::info!(peer = %host_id, %addr, ?cql_broadcast, ?internode_broadcast, "inbound peer connected");
 
+        // Register the peer here too, not only in `on_peer_connected`.
+        //
+        // Which handler runs is decided by who dialled whom, and that has
+        // nothing to do with whether the leader needs to route Raft RPCs to
+        // this node. A seed is dialled BY its peers, so a leader that is also a
+        // seed sees every one of them inbound and registered none of them.
+        //
+        // Observed 2026-08-21 rolling the native cluster: node3 restarted
+        // first and initialised Raft with `peers=1`, node1 came up nine minutes
+        // later and dialled node3 as its seed, and node3 never learned node1's
+        // node_id. Every AppendEntries to it returned "registration pending"
+        // while node1 sat at "no raft leader elected yet" and the other two
+        // held a quorum without it.
+        //
+        // `trigger_cluster_join` cannot cover this: node1 was already in the
+        // recovered ring with unchanged metadata, so it returns early before
+        // reaching any registration. Idempotent, and a no-op before formation.
+        self.register_peer_in_raft_node_map(host_id);
+
         // Store the peer's CQL broadcast address (from handshake) in PeerManager
         // so system.peers can return it instead of the container-internal IP.
         if let Some(ref broadcast) = cql_broadcast {

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -3416,3 +3416,69 @@ async fn an_unconfigured_controller_ignores_a_marker_on_the_host() {
         None => std::env::remove_var("FERROSA_DATA_DIR"),
     }
 }
+
+/// An INBOUND peer must be registered in the raft node map, exactly as an
+/// outbound one is.
+///
+/// `on_peer_connected` registers (PR #277, for "an already-committed member
+/// that reconnects AFTER the leader restarted"). `on_inbound_peer` did not --
+/// and which handler runs is decided by who dialled whom, not by anything
+/// about the peer.
+///
+/// Observed 2026-08-21 rolling the native cluster. node3 was restarted first
+/// and initialised Raft with `peers=1`; node1 came up nine minutes later and
+/// dialled node3 as its seed, so node3 only ever saw it INBOUND. node3 never
+/// learned node1's node_id, and every AppendEntries to it failed:
+///
+///     UnresolvedRaftTarget: raft node 1229782938247303441
+///     has no registered host_id yet (registration pending)
+///
+/// node1 sat at `no raft leader elected yet` for the whole run while node2 and
+/// node3 held a quorum without it. `trigger_cluster_join` cannot cover this:
+/// node1 was already in node3's recovered ring with unchanged metadata, so it
+/// returns early before any registration happens.
+#[tokio::test]
+async fn an_inbound_peer_is_registered_in_the_raft_node_map() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = test_storage(dir.path());
+    let schema = test_schema();
+    let config = Arc::new(ClusterConfig {
+        raft_data_dir: Some(dir.path().join("raft")),
+        ..ClusterConfig::default()
+    });
+    let net_config = Arc::new(NetConfig::default());
+    let local_id = Uuid::from_u128(1);
+    let inbound_peer = Uuid::from_u128(2);
+
+    let registry = Arc::new(HandlerRegistry::new());
+    let (controller, _handles) = ModeController::new(
+        config,
+        net_config.clone(),
+        local_id,
+        storage,
+        schema,
+        registry,
+    );
+    let pm = Arc::new(PeerManager::new(net_config, local_id, controller.clone()));
+    controller.set_peer_manager(pm);
+
+    // Stand in for the map `transition_to_cluster` installs at Raft init.
+    controller
+        .raft_node_map
+        .store(Some(Arc::new(std::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        ))));
+
+    let addr: SocketAddr = "127.0.0.1:7001".parse().unwrap();
+    controller.on_inbound_peer((inbound_peer, addr), None, None);
+
+    let map = controller
+        .raft_node_map_snapshot()
+        .expect("the node map is installed");
+    assert!(
+        map.contains_key(&crate::raft::uuid_to_node_id(inbound_peer)),
+        "an inbound peer must be registered too; otherwise the leader cannot \
+         route Raft RPCs to a member that dialled IT, and every AppendEntries \
+         is 'registration pending' forever: {map:?}"
+    );
+}


### PR DESCRIPTION
Found by rolling the native cluster onto `main` — not by a test. node1 sat at `no raft leader elected yet` for its entire run while node2 and node3 held a quorum without it, and the leader could not reach it at all:

```
UnresolvedRaftTarget: raft node 1229782938247303441 has no registered host_id yet (registration pending)
```

## Root cause

`register_node` is called in **exactly one place** — inside `transition_to_cluster`, over the `peers` list present at that instant. A peer that connects *after* Raft init is never in that loop.

PR #277 added the catch-up call in `on_peer_connected`, and its comment names this precise scenario: *"an already-committed member that reconnects AFTER the leader restarted"*. The gap is that **`on_inbound_peer` did not do the same**.

Which of the two handlers runs is decided by **who dialled whom**, and that has nothing to do with whether the leader needs to route Raft RPCs to the node. A seed is dialled *by* its peers — so a leader that is also a seed sees every one of them inbound, and registered none of them.

## The sequence

1. node3 rolled first, initialised Raft with `peers=1` (node2 only).
2. node1 came up nine minutes later and dialled node3 **as its seed**.
3. node3 logged only `inbound peer connected`, never `peer connected` — so it never learned node1's `node_id`.
4. node1 meanwhile held a higher term from its previous life and rejected the leader's votes.

Nothing could converge: the leader could not reach node1, and node1 would not accept the leader. Its election guard fired correctly (`election storm detected — suppressing elections`), which is the P0-17 watchdog doing its job on a symptom rather than the cause.

`trigger_cluster_join` cannot cover this, and it is worth saying why because it looks like it should: node1 was already in node3's recovered ring with unchanged metadata, so it returns early — correctly, as a no-op join — before reaching any registration.

## Confirmation

Restarting node3 while both peers were already up made it initialise with `peers=2`. node1 was ready within 45 seconds and `registration pending` went to zero across all three nodes.

## On the test

It asserts the **node map**, not the cluster's behaviour. An unregistered peer produces a cluster that *looks* alive — two of three nodes serving happily, board queries succeeding — so nothing about the surviving quorum is wrong enough for a health-shaped assertion to catch. The map is where the absence is visible.

`ferrosa-cluster` 1109 tests passing, clippy clean.
