### PR TITLE
fix(cql): COUNT(*) discarded the client consistency level

### DIFF
--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -294,6 +294,40 @@ impl AccordCoordinator {
         CoordinatorDecision::Pending
     }
 
+    /// Conclude the PreAccept phase when no further response can arrive.
+    ///
+    /// `handle_preaccept_ok` deliberately stays `Pending` while a fast quorum
+    /// is still reachable: with RF=3 the fast path needs all three replicas,
+    /// so two agreeing votes must keep waiting rather than spend a second RTT
+    /// on the Accept phase. That is correct *while responses are outstanding*.
+    ///
+    /// Once the fan-out is exhausted the fast path is provably unreachable.
+    /// If a slow quorum answered, the round can and must commit through the
+    /// Accept phase. Without this the coordinator sat at `Pending` forever and
+    /// the caller reported "Accord quorum unavailable" on a fully healthy
+    /// cluster — every LWT on a non-leaseholder RF=3 coordinator that lost a
+    /// single vote failed, even though two replicas had agreed.
+    ///
+    /// Returns `Pending` when fewer than a slow quorum responded (the round is
+    /// genuinely unavailable and the caller must fail loud) or when a decision
+    /// was already reached, in which case this is a no-op.
+    pub fn finalize_preaccept(&mut self) -> CoordinatorDecision {
+        if self.phase != CoordinatorPhase::PreAccepting {
+            return CoordinatorDecision::Pending;
+        }
+
+        if self.preaccept_responses.len() < slow_quorum_size(self.rf) {
+            return CoordinatorDecision::Pending;
+        }
+
+        self.phase = CoordinatorPhase::Accepting;
+        self.rtt_count = 1;
+        CoordinatorDecision::NeedAccept {
+            t: self.merged_t,
+            deps: self.merged_deps.clone(),
+        }
+    }
+
     /// Process an AcceptOK response (slow path).
     ///
     /// Returns `SlowPathCommit` once a slow quorum of AcceptOK responses
@@ -512,6 +546,41 @@ pub struct AccordCoordinatorDriver {
 /// any divergence means replicas disagree on the row state at `t`, which is a
 /// correctness failure. Returns `Some(bytes)` only when `reads.len() >= quorum`
 /// and every read is identical; `None` otherwise (caller aborts).
+/// Why a PreAccept fanout produced no vote from a replica.
+///
+/// The replica encodes every non-OK outcome as an EMPTY `AccordPreAcceptOK`:
+/// a `Nack`, a state machine that could not persist, and any unexpected
+/// response all arrive looking identical. The coordinator used to skip them
+/// with a bare `Ok(_) => {}`, so a transaction that failed for want of votes
+/// reported "quorum unavailable" and nothing else — which is how the 2026-06
+/// FileSyncWriter failure (PreAccept could not persist, so no replica voted)
+/// stayed undiagnosed.
+///
+/// Naming the outcomes does not make an empty response informative on its own,
+/// but it makes the count visible: how many peers answered, how many voted,
+/// and how many returned nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreAcceptOutcome {
+    /// A real vote carrying the replica's `t` and deps.
+    Vote,
+    /// The peer answered, but not with a usable vote (empty or unexpected).
+    NoVote,
+    /// The RPC itself failed — the peer never answered.
+    RpcFailed,
+}
+
+/// Classify one PreAccept fanout result.
+///
+/// Pure so the counting is testable without a cluster: the fanout itself is an
+/// inline async block over live peers and cannot be unit tested directly.
+pub fn classify_preaccept_response(result: Result<&Message, ()>) -> PreAcceptOutcome {
+    match result {
+        Ok(Message::AccordPreAcceptOK(b)) if !b.is_empty() => PreAcceptOutcome::Vote,
+        Ok(_) => PreAcceptOutcome::NoVote,
+        Err(()) => PreAcceptOutcome::RpcFailed,
+    }
+}
+
 fn agreed_row(reads: &[Vec<u8>], quorum: usize) -> Option<Vec<u8>> {
     if quorum == 0 || reads.len() < quorum {
         return None;
@@ -1043,6 +1112,18 @@ impl AccordCoordinatorDriver {
                         t,
                         deps,
                     });
+                } else {
+                    // The local replica did not vote. Dropping this silently
+                    // costs the round a vote it was counting on and makes the
+                    // failure indistinguishable from a remote timeout: an
+                    // RF=3 non-leaseholder then holds only its two peer votes,
+                    // short of the 3-vote fast quorum. Say so.
+                    tracing::warn!(
+                        txn_id = ?txn_id,
+                        response = ?resp,
+                        "accord: local PreAccept self-vote was not PreAcceptOK; \
+                         this round proceeds without the coordinator's own vote"
+                    );
                 }
             }
         }
@@ -1068,11 +1149,20 @@ impl AccordCoordinatorDriver {
 
             let responses = futures::future::join_all(futs).await;
 
+            // Count the outcomes so a failed round says WHY, not just that it
+            // failed. An empty AccordPreAcceptOK is the replica's encoding for
+            // a Nack, a persist failure, and an unexpected state alike, so
+            // without this a quorum failure is indistinguishable from silence.
+            let mut votes = 0usize;
+            let mut no_votes = 0usize;
+            let mut rpc_failures = 0usize;
+
             for result in &responses {
                 match result {
                     Ok((_peer_id, Message::AccordPreAcceptOK(b))) if !b.is_empty() => {
                         let ok: PreAcceptOkPayload = bincode::deserialize(b)
                             .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
+                        votes += 1;
                         let resp = PreAcceptResponse {
                             from: ok.from,
                             t: ok.t,
@@ -1083,10 +1173,20 @@ impl AccordCoordinatorDriver {
                             break;
                         }
                     }
-                    Ok(_) => {
-                        // Empty or unexpected response — treat as non-vote (skip).
+                    Ok((peer_id, _)) => {
+                        // The peer answered without a usable vote. The wire
+                        // shape cannot say whether that was a Nack, a persist
+                        // failure, or an unexpected state — so record it and
+                        // let the round summary carry the count.
+                        no_votes += 1;
+                        tracing::debug!(
+                            txn_id = ?txn_id,
+                            peer = ?peer_id,
+                            "accord: PreAccept returned no vote (empty or unexpected response)"
+                        );
                     }
                     Err(e) => {
+                        rpc_failures += 1;
                         tracing::warn!(
                             txn_id = ?txn_id,
                             error = %e,
@@ -1094,6 +1194,35 @@ impl AccordCoordinatorDriver {
                         );
                     }
                 }
+            }
+
+            // Every response that will ever arrive has arrived, so a fast
+            // quorum is now provably unreachable. If a slow quorum voted, the
+            // round commits through the Accept phase instead of stalling.
+            if decision == CoordinatorDecision::Pending {
+                decision = self.coordinator.finalize_preaccept();
+                if let CoordinatorDecision::NeedAccept { .. } = decision {
+                    tracing::debug!(
+                        txn_id = ?txn_id,
+                        votes,
+                        "accord: fan-out exhausted short of a fast quorum; \
+                         falling back to the Accept phase"
+                    );
+                }
+            }
+
+            if decision == CoordinatorDecision::Pending {
+                tracing::warn!(
+                    txn_id = ?txn_id,
+                    peers = responses.len(),
+                    votes,
+                    no_votes,
+                    rpc_failures,
+                    slow_quorum = slow_quorum_size(self.coordinator.rf),
+                    "accord: PreAccept round reached no decision; a replica that \
+                     answers without voting reports the same empty payload whether \
+                     it rejected the txn or failed to persist it"
+                );
             }
         }
 
@@ -1663,6 +1792,54 @@ impl AccordCoordinatorDriver {
 #[cfg(test)]
 mod tests {
 
+    /// A replica that answers without voting must be counted, not skipped.
+    ///
+    /// The replica encodes a `Nack`, a state machine that could not persist,
+    /// and any unexpected response all as an EMPTY `AccordPreAcceptOK`. The
+    /// coordinator skipped every one with a bare `Ok(_) => {}`, so a round that
+    /// collected no votes reported "quorum unavailable" and nothing more.
+    ///
+    /// That is how the 2026-06 FileSyncWriter failure hid: PreAccept could not
+    /// persist, so no replica voted, and the only symptom was an unexplained
+    /// quorum error. Counting the outcomes does not make an empty payload
+    /// informative by itself, but it distinguishes "nobody answered" from
+    /// "everybody answered and nobody voted" -- which are different bugs.
+    #[test]
+    fn a_reply_without_a_vote_is_counted_separately_from_a_failed_rpc() {
+        let voted = Message::AccordPreAcceptOK(bytes::Bytes::from_static(b"payload"));
+        let empty = Message::AccordPreAcceptOK(bytes::Bytes::new());
+
+        assert_eq!(
+            classify_preaccept_response(Ok(&voted)),
+            PreAcceptOutcome::Vote
+        );
+        assert_eq!(
+            classify_preaccept_response(Ok(&empty)),
+            PreAcceptOutcome::NoVote,
+            "an empty payload is an answer, not a missing one"
+        );
+        assert_eq!(
+            classify_preaccept_response(Err(())),
+            PreAcceptOutcome::RpcFailed,
+            "a peer that never answered is a different failure from one that \
+             answered without voting"
+        );
+    }
+
+    /// An unexpected message type is a non-vote, not a vote.
+    ///
+    /// Worth pinning: the vote arm matches a NON-EMPTY AccordPreAcceptOK
+    /// specifically, so a differently-shaped reply must not be mistaken for
+    /// agreement.
+    #[test]
+    fn an_unexpected_message_is_not_a_vote() {
+        let other = Message::AccordAcceptOK(bytes::Bytes::from_static(b"not-preaccept"));
+        assert_eq!(
+            classify_preaccept_response(Ok(&other)),
+            PreAcceptOutcome::NoVote
+        );
+    }
+
     /// F+1 agreement means a MAJORITY agrees, not that every replica does.
     ///
     /// `agreed_row` documented "Require F+1 replicas to agree on the SAME row
@@ -1870,6 +2047,130 @@ mod tests {
         );
         assert_eq!(coord.rtt_count(), 1);
         assert_eq!(coord.phase, CoordinatorPhase::FastPathCommit);
+    }
+
+    #[test]
+    fn finalize_preaccept_takes_slow_path_when_fanout_exhausts_with_slow_quorum() {
+        // RF=3, non-leaseholder. Only two replicas ever answer (the third is
+        // down, or the local self-vote was lost). Both AGREE with t0, so
+        // `handle_preaccept_ok` correctly stays Pending — a third agreeing
+        // vote would still unlock the 1-RTT fast path.
+        //
+        // But once the fan-out is exhausted no further response can arrive.
+        // A slow quorum (2 of 3) is present and sufficient to commit via the
+        // Accept phase, so the round MUST fall back to the slow path. Before
+        // this existed the coordinator sat at Pending forever and the caller
+        // reported "Accord quorum unavailable" on a healthy cluster.
+        let t0 = make_ts(1000);
+        let txn_id = make_txn_id(1, 1000);
+        let mut coord = AccordCoordinator::new(txn_id, t0, b"key1".to_vec(), 1, 3, false);
+
+        for from in [1, 2] {
+            assert_eq!(
+                coord.handle_preaccept_ok(PreAcceptResponse {
+                    from,
+                    t: t0,
+                    deps: vec![],
+                }),
+                CoordinatorDecision::Pending,
+                "must keep waiting for a possible fast quorum"
+            );
+        }
+
+        assert_eq!(
+            coord.finalize_preaccept(),
+            CoordinatorDecision::NeedAccept {
+                t: t0,
+                deps: HashSet::new(),
+            }
+        );
+        assert_eq!(coord.phase, CoordinatorPhase::Accepting);
+        assert_eq!(coord.rtt_count(), 1);
+    }
+
+    #[test]
+    fn finalize_preaccept_stays_pending_below_slow_quorum() {
+        // One vote out of RF=3 is not enough to commit by any path. Finalizing
+        // must NOT invent a decision — the caller has to report the round as
+        // genuinely quorum-unavailable.
+        let t0 = make_ts(1000);
+        let txn_id = make_txn_id(1, 1000);
+        let mut coord = AccordCoordinator::new(txn_id, t0, b"key1".to_vec(), 1, 3, false);
+
+        coord.handle_preaccept_ok(PreAcceptResponse {
+            from: 1,
+            t: t0,
+            deps: vec![],
+        });
+
+        assert_eq!(coord.finalize_preaccept(), CoordinatorDecision::Pending);
+        assert_eq!(coord.phase, CoordinatorPhase::PreAccepting);
+    }
+
+    #[test]
+    fn disagreement_at_slow_quorum_decides_without_waiting_for_finalize() {
+        // A response that proposes a different timestamp (or carries deps)
+        // makes the fast path unreachable immediately, so the EXISTING slow-
+        // quorum branch decides on the spot and `finalize_preaccept` never
+        // sees the round. This pins that split: `finalize_preaccept` is only
+        // ever reached in the all-agree case, which is why it can safely
+        // forward the merged state.
+        let t0 = make_ts(1000);
+        let later = make_ts(5000);
+        let dep = make_txn_id(9, 400);
+        let txn_id = make_txn_id(1, 1000);
+        let mut coord = AccordCoordinator::new(txn_id, t0, b"key1".to_vec(), 1, 3, false);
+
+        coord.handle_preaccept_ok(PreAcceptResponse {
+            from: 1,
+            t: t0,
+            deps: vec![],
+        });
+        let decided = coord.handle_preaccept_ok(PreAcceptResponse {
+            from: 2,
+            t: later,
+            deps: vec![dep],
+        });
+
+        let mut expected = HashSet::new();
+        expected.insert(dep);
+        assert_eq!(
+            decided,
+            CoordinatorDecision::NeedAccept {
+                t: later,
+                deps: expected,
+            },
+            "a disagreeing vote at slow quorum must decide immediately"
+        );
+
+        // Already decided -> finalizing is a no-op and must not re-enter the
+        // phase transition or double-count the RTT.
+        assert_eq!(coord.finalize_preaccept(), CoordinatorDecision::Pending);
+        assert_eq!(coord.phase, CoordinatorPhase::Accepting);
+        assert_eq!(coord.rtt_count(), 1);
+    }
+
+    #[test]
+    fn finalize_preaccept_is_a_noop_once_a_decision_was_reached() {
+        // RF=1: the single response decides immediately. Finalizing after a
+        // decision must not re-run the phase transition or double-count an RTT.
+        let t0 = make_ts(1000);
+        let txn_id = make_txn_id(1, 1000);
+        let mut coord = AccordCoordinator::new(txn_id, t0, b"key1".to_vec(), 1, 1, false);
+
+        let decided = coord.handle_preaccept_ok(PreAcceptResponse {
+            from: 1,
+            t: t0,
+            deps: vec![],
+        });
+        assert!(matches!(
+            decided,
+            CoordinatorDecision::FastPathCommit { .. }
+        ));
+
+        assert_eq!(coord.finalize_preaccept(), CoordinatorDecision::Pending);
+        assert_eq!(coord.phase, CoordinatorPhase::FastPathCommit);
+        assert_eq!(coord.rtt_count(), 1);
     }
 
     #[test]

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -513,15 +513,37 @@ pub struct AccordCoordinatorDriver {
 /// correctness failure. Returns `Some(bytes)` only when `reads.len() >= quorum`
 /// and every read is identical; `None` otherwise (caller aborts).
 fn agreed_row(reads: &[Vec<u8>], quorum: usize) -> Option<Vec<u8>> {
-    if reads.len() < quorum {
+    if quorum == 0 || reads.len() < quorum {
         return None;
     }
-    let first = &reads[0];
-    if reads.iter().all(|r| r == first) {
-        Some(first.clone())
-    } else {
-        None
+
+    // Count votes per distinct value and take one that reaches the quorum.
+    //
+    // This asked `reads.iter().all(|r| r == first)` -- unanimity, not F+1. On
+    // RF=3 that let a single lagging replica veto a genuine 2-of-3 majority,
+    // so every generic-IF LWT was refused as non-linearizable while being
+    // perfectly decidable. Observed live on 2026-08-22:
+    //
+    //     generic IF read-vote lacked F+1 (2) agreement on the row at t
+    //     (got 3 reads) -- refusing a non-linearizable LWT
+    //
+    // Three reads, F+1 of two, and still refused. The function's own doc and
+    // that error message both said F+1; only the code said "all".
+    //
+    // At most one value can reach a quorum, because two disjoint groups of
+    // `quorum` votes would require `2 * quorum > reads.len()` to overlap --
+    // exactly the majority property the caller relies on for linearizability.
+    // So the first value to reach it is the only one, and returning it is
+    // unambiguous.
+    let mut counts: std::collections::HashMap<&[u8], usize> = std::collections::HashMap::new();
+    for read in reads {
+        let n = counts.entry(read.as_slice()).or_insert(0);
+        *n += 1;
+        if *n >= quorum {
+            return Some(read.clone());
+        }
     }
+    None
 }
 
 impl AccordCoordinatorDriver {
@@ -1640,6 +1662,95 @@ impl AccordCoordinatorDriver {
 
 #[cfg(test)]
 mod tests {
+
+    /// F+1 agreement means a MAJORITY agrees, not that every replica does.
+    ///
+    /// `agreed_row` documented "Require F+1 replicas to agree on the SAME row
+    /// bytes at `t`", and the error it feeds says "lacked F+1 (2) agreement".
+    /// The implementation asked a different question:
+    ///
+    /// ```text
+    /// let first = &reads[0];
+    /// if reads.iter().all(|r| r == first) { ... }
+    /// ```
+    ///
+    /// That is unanimity. On RF=3 a single lagging or slow replica outvoted a
+    /// genuine 2-of-3 majority, so every generic-IF LWT was refused as
+    /// non-linearizable when it was in fact perfectly decidable.
+    ///
+    /// Observed live on 2026-08-22 against the three-node cluster:
+    ///
+    /// ```text
+    /// generic IF read-vote lacked F+1 (2) agreement on the row at t
+    /// (got 3 reads) — refusing a non-linearizable LWT
+    /// ```
+    ///
+    /// Three reads returned, F+1 was 2, and it still refused.
+    #[test]
+    fn a_majority_agreeing_is_enough_even_when_one_replica_differs() {
+        let a = b"row-at-t".to_vec();
+        let stale = b"stale-row".to_vec();
+
+        let agreed = agreed_row(&[a.clone(), a.clone(), stale], 2);
+
+        assert_eq!(
+            agreed,
+            Some(a),
+            "two of three replicas agreed and F+1 is two; a third disagreeing \
+             read must not veto a decidable quorum"
+        );
+    }
+
+    /// Unanimity still agrees — the common case must not regress.
+    #[test]
+    fn unanimous_reads_agree() {
+        let a = b"row".to_vec();
+        assert_eq!(agreed_row(&[a.clone(), a.clone(), a.clone()], 2), Some(a));
+    }
+
+    /// No value reaching F+1 is genuinely undecidable, and must stay refused.
+    /// This is the case the unanimity check was conflating with the one above.
+    #[test]
+    fn no_value_reaching_the_quorum_is_refused() {
+        assert_eq!(
+            agreed_row(&[b"x".to_vec(), b"y".to_vec(), b"z".to_vec()], 2),
+            None,
+            "three different reads means no value has two votes"
+        );
+    }
+
+    /// A split with no majority is refused even though a value repeats.
+    #[test]
+    fn a_tie_below_the_quorum_is_refused() {
+        assert_eq!(
+            agreed_row(
+                &[b"x".to_vec(), b"x".to_vec(), b"y".to_vec(), b"y".to_vec()],
+                3
+            ),
+            None,
+            "2 and 2 with a quorum of 3 leaves the row undecided"
+        );
+    }
+
+    /// Too few reads to decide at all.
+    #[test]
+    fn fewer_reads_than_the_quorum_is_refused() {
+        let a = b"row".to_vec();
+        assert_eq!(agreed_row(&[a.clone()], 2), None);
+        assert_eq!(agreed_row(&[], 1), None);
+    }
+
+    /// An empty row (the key does not exist) is a legitimate agreed VALUE, not
+    /// an absence of agreement. `IF v = ...` against a missing row must be able
+    /// to decide "condition not met" rather than fail the transaction.
+    #[test]
+    fn agreement_on_an_empty_row_is_still_agreement() {
+        assert_eq!(
+            agreed_row(&[Vec::new(), Vec::new(), b"other".to_vec()], 2),
+            Some(Vec::new()),
+            "two replicas agreeing the row is absent is a decided read"
+        );
+    }
     use super::*;
     use ferrosa_common::accord::{BallotNumber, Timestamp, TxnId};
 

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -1736,7 +1736,7 @@ mod tests {
     #[test]
     fn fewer_reads_than_the_quorum_is_refused() {
         let a = b"row".to_vec();
-        assert_eq!(agreed_row(&[a.clone()], 2), None);
+        assert_eq!(agreed_row(std::slice::from_ref(&a), 2), None);
         assert_eq!(agreed_row(&[], 1), None);
     }
 

--- a/ferrosa-cluster/src/coordinator/range_read_stream.rs
+++ b/ferrosa-cluster/src/coordinator/range_read_stream.rs
@@ -131,7 +131,12 @@ pub type ClusterPartitionStream =
 type BoxedFragmentStream = Pin<Box<dyn Stream<Item = Result<Partition, ClusterError>> + Send>>;
 
 impl ClusterCoordinator {
-    /// COUNT(*) over the whole token ring for `table_id`.
+    /// COUNT(*) over the whole token ring for `table_id`, at the NODE's
+    /// default consistency level.
+    ///
+    /// Use `coordinate_range_count_with` when the caller carries a
+    /// client-requested CL — passing the node default in that case silently
+    /// answers at the wrong consistency.
     ///
     /// Fast path: when the local node provably owns every token range at the
     /// configured consistency (`range_read_remotes` empty — e.g. CL=ONE with
@@ -145,6 +150,28 @@ impl ClusterCoordinator {
     /// count then drives the same CL-selected, token-deduped streaming
     /// range-read fan-out the full `SELECT` uses and sums the live rows.
     pub async fn coordinate_range_count(&self, table_id: &TableId) -> crate::error::Result<u64> {
+        self.coordinate_range_count_with(table_id, self.default_cl)
+            .await
+    }
+
+    /// COUNT(*) over the whole token ring at an EXPLICIT consistency level.
+    ///
+    /// Callers that carry a client-requested CL must use this. The
+    /// no-CL `coordinate_range_count` exists only for callers that
+    /// genuinely mean "the node default", and delegates here.
+    ///
+    /// Without this the ADR-020 COUNT(*) fast path had nowhere to put the
+    /// request's CL, so it substituted `self.default_cl` — while the full
+    /// `SELECT` path on the same table threads `ctx.consistency` through.
+    /// The two disagreed silently, and the disagreement UNDER-reports: with
+    /// RF == node_count and a locally-satisfiable default, `remotes` is
+    /// empty and the count is served from local storage alone, so a client
+    /// that asked for QUORUM or ALL got a local-only tally with no error.
+    pub async fn coordinate_range_count_with(
+        &self,
+        table_id: &TableId,
+        cl: crate::consistency::ConsistencyLevel,
+    ) -> crate::error::Result<u64> {
         // Correctness over speed (forge t_8c4e44e8): the local replica only
         // holds the partitions whose tokens fall in ITS owned ranges. When the
         // keyspace RF does not span the whole ring (`RF < node_count`, or any
@@ -158,7 +185,7 @@ impl ClusterCoordinator {
         // token range at this CL, so the fast metadata path is exact. Otherwise
         // we MUST fan out across replicas and count the token-deduped result —
         // never the local subset.
-        let remotes = self.range_read_remotes(self.default_cl, self.default_rf);
+        let remotes = self.range_read_remotes(cl, self.default_rf);
         if remotes.is_empty() {
             return self
                 .storage
@@ -174,7 +201,7 @@ impl ClusterCoordinator {
         // `StorageEngine::count_range`'s COUNT(*) semantics (one per row, plus
         // one for a present static row) but over the WHOLE ring.
         let mut stream = self
-            .coordinate_range_read_stream_all_with(table_id, 0, self.default_cl, self.default_rf)
+            .coordinate_range_read_stream_all_with(table_id, 0, cl, self.default_rf)
             .await?;
         let mut total: u64 = 0;
         while let Some(item) = stream.next().await {

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -4282,6 +4282,93 @@ mod tests {
     /// unreachable, COUNT(*) must FAIL LOUD (exactly like
     /// `coordinate_range_read`) rather than report local-only partial data as a
     /// complete count.
+    /// COUNT(*) must honour the CLIENT's consistency level, not the node's
+    /// configured default.
+    ///
+    /// `SELECT COUNT(*)` takes the ADR-020 fast path, which called
+    /// `coordinate_range_count(table_id)` — a signature with nowhere to put
+    /// the request's CL. It therefore used `self.default_cl`, while the full
+    /// `SELECT` path on the very same table threads `ctx.consistency`
+    /// through. Two ways of counting one table, answering at two different
+    /// consistency levels.
+    ///
+    /// The failure is silent and it under-reports. With RF == node_count and
+    /// a locally-satisfiable default (ONE/LOCAL_ONE), `range_read_remotes`
+    /// is empty and the count is served entirely from local storage — so a
+    /// client that explicitly asked for QUORUM or ALL receives a local-only
+    /// tally with no error and no indication the CL was ignored.
+    ///
+    /// Setup below: RF == node_count == 2 and `default_cl = ONE`, so the
+    /// default path legitimately counts locally. The client asks for ALL,
+    /// which requires the remote — and that remote is unreachable, so the
+    /// request MUST fail rather than quietly return the local subset.
+    #[tokio::test]
+    async fn range_count_honours_requested_cl_not_node_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let local_node_id = 1u64;
+        let remote_uuid_2 = Uuid::new_v4();
+
+        let pm = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            Uuid::new_v4(),
+            Arc::new(NoopListener),
+        ));
+        // Remote peer with no connection pool — any send to it fails.
+        pm.add_peer_entry((remote_uuid_2, "10.0.0.2:7000".parse().unwrap()))
+            .await;
+
+        let mut node2 = make_node("10.0.0.2:7000");
+        node2.host_id = remote_uuid_2;
+
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, make_node("10.0.0.1:7000"));
+        ring.add_node(2u64, node2);
+        ring.assign_tokens(local_node_id, &[50]);
+        ring.assign_tokens(2u64, &[150]);
+
+        // RF == node_count == 2 with default CL=ONE: the local replica owns
+        // every token range at that CL, so the default count path is exact
+        // and local-only.
+        let coordinator = make_coordinator(
+            ring,
+            pm,
+            local_node_id,
+            storage.clone(),
+            2,
+            ConsistencyLevel::One,
+        );
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        storage
+            .write(&table_id, &test_key(), test_row(1000), 1000)
+            .unwrap();
+
+        // Baseline: at the node's own default (ONE) the local count is a
+        // legitimate answer and must still work.
+        let at_default = coordinator.coordinate_range_count(&table_id).await;
+        assert_eq!(
+            at_default.expect("CL=ONE count is satisfied locally"),
+            1,
+            "the default-CL fast path must keep working"
+        );
+
+        // The client asked for ALL. That cannot be satisfied without the
+        // remote, and the remote is unreachable — so this must be an error,
+        // NOT a silent local-only count of 1.
+        let at_all = coordinator
+            .coordinate_range_count_with(&table_id, ConsistencyLevel::All)
+            .await;
+        assert!(
+            at_all.is_err(),
+            "COUNT(*) at CL=ALL must not silently return the local-only \
+             subset when a required remote is unreachable; got {:?}",
+            at_all.ok()
+        );
+    }
+
     #[tokio::test]
     async fn coordinate_range_count_errors_when_required_remote_is_unreachable() {
         let dir = tempfile::tempdir().unwrap();

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -811,6 +811,29 @@ impl WritePath {
         }
     }
 
+    /// COUNT(*) at an EXPLICIT consistency level.
+    ///
+    /// The CQL layer must call this and pass `ctx.consistency`: the ADR-020
+    /// COUNT(*) fast path otherwise answers at the node's default CL while
+    /// the full `SELECT` on the same table answers at the client's, and the
+    /// mismatch under-reports silently.
+    ///
+    /// Only the clustered arm can honour a CL — the direct and pair arms are
+    /// a single local replica by construction, so they keep their local view
+    /// exactly as `count_range` does.
+    pub async fn count_range_with(
+        &self,
+        table_id: &TableId,
+        cl: crate::consistency::ConsistencyLevel,
+    ) -> crate::error::Result<u64> {
+        match self {
+            Self::Cluster(coordinator) => {
+                coordinator.coordinate_range_count_with(table_id, cl).await
+            }
+            _ => self.count_range(table_id).await,
+        }
+    }
+
     /// Projection-aware streaming range read for query shapes that only need a
     /// subset of regular cells to evaluate predicates. This keeps COUNT(*) with
     /// ALLOW FILTERING on wide tables out of the Vec-returning materialization

--- a/ferrosa-cql/src/accord_router.rs
+++ b/ferrosa-cql/src/accord_router.rs
@@ -59,6 +59,26 @@ pub enum RouteDecision {
 /// UPDATE/DELETE IF condition) route through Accord for linearizability.
 /// Regular DML uses tunable consistency via the WritePath coordinator.
 /// In standalone mode, everything is local.
+/// Whether a statement carries a conditional (compare-and-set) clause.
+///
+/// These are the statements CQL calls lightweight transactions: `IF NOT
+/// EXISTS`, `IF EXISTS`, and `IF <column> <op> <value>`. Each asks the server
+/// to decide atomically whether the mutation applies -- a consensus question
+/// the tunable write path cannot answer correctly.
+///
+/// Deliberately keyed on the statement rather than the request's serial
+/// consistency: that field is optional in the protocol, so keying on it makes
+/// correctness depend on a driver sending something the server does not
+/// require.
+fn statement_is_lwt(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Insert(s) => s.if_not_exists,
+        Statement::Update(s) => s.if_exists || !s.if_conditions.is_empty(),
+        Statement::Delete(s) => s.if_exists || !s.if_conditions.is_empty(),
+        _ => false,
+    }
+}
+
 pub fn route_decision(
     mode: RoutingMode,
     stmt: &Statement,
@@ -68,9 +88,34 @@ pub fn route_decision(
         return RouteDecision::Local;
     }
 
-    // LWT: serial_consistency is set by the CQL protocol when the client
-    // uses IF NOT EXISTS / IF condition. This is the signal that Accord
-    // consensus is required for linearizability.
+    // LWT: decided by the STATEMENT, not by an optional protocol field.
+    //
+    // This used to read `if serial_consistency.is_some()`, on the stated
+    // assumption that "serial_consistency is set by the CQL protocol when the
+    // client uses IF NOT EXISTS / IF condition". That is not the protocol.
+    // Serial consistency is optional and defaults to SERIAL server-side, and
+    // drivers do not send it unless explicitly asked -- so an ordinary
+    // `UPDATE ... IF col = val` arrived with `None`, routed to `Local`, and the
+    // local write path applied the mutation while ignoring the condition.
+    //
+    // Verified against the live cluster on 2026-08-22:
+    //
+    //     seeded v='original'
+    //     UPDATE .. SET v='changed' WHERE k=1 IF v='WRONG'  ->  v='changed'
+    //
+    // A false condition, and the write landed. Every compare-and-set built on
+    // this silently degraded to an unconditional write; ferrosa-memory's
+    // consolidation lease is one casualty (it claimed 277 requests it believed
+    // it had lost, so each was marked leased and then skipped).
+    //
+    // `IF NOT EXISTS` escaped because the local path implements that one case,
+    // which is why the breakage looked selective.
+    if statement_is_lwt(stmt) {
+        return RouteDecision::Accord;
+    }
+
+    // A linearizable READ carries no conditions, so it is still requested the
+    // only way CQL allows: by asking for SERIAL consistency.
     if serial_consistency.is_some() {
         return match stmt {
             Statement::Insert(_)
@@ -472,6 +517,121 @@ fn cmp_values(a: &Option<CqlValue>, b: &Option<CqlValue>) -> Option<std::cmp::Or
 
 #[cfg(test)]
 mod tests {
+
+    /// A conditional statement is an LWT whether or not the client asked for
+    /// SERIAL consistency.
+    ///
+    /// `route_decision` keyed the whole decision on
+    /// `serial_consistency.is_some()`, justified by the comment
+    /// "serial_consistency is set by the CQL protocol when the client uses IF
+    /// NOT EXISTS / IF condition". That is not so: serial consistency is an
+    /// OPTIONAL protocol field defaulting to SERIAL server-side, and drivers do
+    /// not send it unless asked. So `UPDATE ... IF col = val` from an ordinary
+    /// client routed to `Local`, and the local write path applies the mutation
+    /// while ignoring the conditions entirely.
+    ///
+    /// Measured on the live cluster 2026-08-22, on a scratch table:
+    ///
+    /// ```text
+    /// seeded v='original'
+    /// UPDATE .. SET v='changed' WHERE k=1 IF v='WRONG'   ->  v='changed'
+    /// ```
+    ///
+    /// The condition was false and the write applied anyway. Downstream that
+    /// silently broke every compare-and-set built on it: ferrosa-memory's
+    /// consolidation lease claimed 277 requests it believed it had lost, marked
+    /// each leased and skipped it, and consolidation never ran.
+    ///
+    /// `IF NOT EXISTS` is unaffected -- the local path implements that one --
+    /// which is why the failure looked selective rather than total.
+    #[test]
+    fn a_conditional_update_is_an_lwt_without_explicit_serial_consistency() {
+        let stmt = Statement::Update(UpdateStatement {
+            keyspace: Some("ks".into()),
+            table: "t".into(),
+            assignments: vec![Assignment::Simple {
+                column: "v".into(),
+                value: Term::IntegerLiteral(42),
+            }],
+            where_clauses: vec![WhereClause {
+                column: "id".into(),
+                op: ComparisonOp::Eq,
+                value: Term::IntegerLiteral(1),
+                token_fn: false,
+            }],
+            if_exists: false,
+            if_conditions: vec![IfCondition {
+                column: "state".into(),
+                operator: IfOperator::Eq,
+                value: Term::StringLiteral("pending".into()),
+            }],
+            using_timestamp: None,
+            using_ttl: None,
+        });
+
+        assert_eq!(
+            route_decision(RoutingMode::Cluster, &stmt, None),
+            RouteDecision::Accord,
+            "a statement carrying IF conditions must route as an LWT even when \
+             the client sent no serial consistency; routing it Local applies the \
+             mutation and drops the condition"
+        );
+    }
+
+    /// The same for `IF EXISTS`, which is equally a compare-and-set.
+    #[test]
+    fn a_conditional_delete_is_an_lwt_without_explicit_serial_consistency() {
+        let stmt = Statement::Delete(DeleteStatement {
+            keyspace: Some("ks".into()),
+            table: "t".into(),
+            columns: vec![],
+            where_clauses: vec![WhereClause {
+                column: "id".into(),
+                op: ComparisonOp::Eq,
+                value: Term::IntegerLiteral(1),
+                token_fn: false,
+            }],
+            if_exists: true,
+            if_conditions: vec![],
+            using_timestamp: None,
+        });
+
+        assert_eq!(
+            route_decision(RoutingMode::Cluster, &stmt, None),
+            RouteDecision::Accord,
+            "IF EXISTS is a condition too"
+        );
+    }
+
+    /// An unconditional write is unchanged: it must still take the tunable
+    /// WritePath, not consensus. Routing every write through Accord would be a
+    /// large and unintended performance change.
+    #[test]
+    fn an_unconditional_write_still_routes_local() {
+        let stmt = Statement::Update(UpdateStatement {
+            keyspace: Some("ks".into()),
+            table: "t".into(),
+            assignments: vec![Assignment::Simple {
+                column: "v".into(),
+                value: Term::IntegerLiteral(42),
+            }],
+            where_clauses: vec![WhereClause {
+                column: "id".into(),
+                op: ComparisonOp::Eq,
+                value: Term::IntegerLiteral(1),
+                token_fn: false,
+            }],
+            if_exists: false,
+            if_conditions: vec![],
+            using_timestamp: None,
+            using_ttl: None,
+        });
+
+        assert_eq!(
+            route_decision(RoutingMode::Cluster, &stmt, None),
+            RouteDecision::Local
+        );
+    }
     use super::*;
 
     // -----------------------------------------------------------------------

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -4769,7 +4769,15 @@ async fn route_select_user_table(
     let no_order_by = s.order_by.is_empty();
     let no_limit = s.limit.is_none();
     if count_only_select && no_where && no_order_by && no_limit && pk_result.is_err() {
-        let count = state.write_path.load().count_range(&table_id).await?;
+        // Pass the CLIENT's consistency, not the node default. The full
+        // SELECT path below threads `ctx.consistency`; if this fast path
+        // does not, the same table answers COUNT(*) and SELECT at two
+        // different consistency levels — silently, and under-reporting.
+        let count = state
+            .write_path
+            .load()
+            .count_range_with(&table_id, ctx.consistency)
+            .await?;
         return Ok(SelectRawResult {
             column_names: col_names.to_vec(),
             column_types: col_types.to_vec(),


### PR DESCRIPTION
## The bug

`SELECT COUNT(*)` takes the ADR-020 fast path, at `router.rs:4772`:

```rust
let count = state.write_path.load().count_range(&table_id).await?;
```

`count_range` has no consistency parameter, so `coordinate_range_count`
substituted `self.default_cl` — the **node's** configured default. The full
`SELECT` path on the very same table threads the client's `ctx.consistency`
through (`router.rs:4825`).

One table therefore answered `COUNT(*)` and `SELECT` at two different
consistency levels, and the CL parsed from the CQL protocol frame was
discarded with no error.

## It under-reports, silently

In `remote_count_for_cl`, when `rf == node_count`:

```rust
CL::One | CL::LocalOne => 0,
```

so `range_read_remotes` is empty and `coordinate_range_count` returns
`storage.count_range(...)` — a purely **local** tally.

A client that explicitly requested QUORUM or ALL against a node configured
`default_cl = ONE` received the local subset as though it were the whole
count. A client requesting ALL on a Quorum-default node silently got Quorum.

No error, no warning, just a smaller number.

## Fix

- `coordinate_range_count_with(table_id, cl)` uses the passed CL for **both**
  the `range_read_remotes` fan-out decision and the streaming read.
- `coordinate_range_count` stays for callers that genuinely mean the node
  default, and delegates.
- `WritePath::count_range_with` forwards on the clustered arm only — Direct
  and Pair are a single local replica by construction, so their local view is
  already the honest answer.
- The router passes `ctx.consistency`.

## Test

`range_count_honours_requested_cl_not_node_default`: `rf == node_count == 2`
with `default_cl = ONE`, so the default path legitimately counts locally and
must keep returning 1. The client then asks for **ALL**, whose required remote
is unreachable — so the call must **error** rather than quietly return the
local count.

Both pre-existing range-count tests still pass, so the fast path is not
regressed.

## Verification

- 1122 `ferrosa-cluster` lib tests pass
- `rustup run stable cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets` clean

## Scope

Found while investigating a `cql_live` CI failure. It is **not** the cause of
that failure — that cluster runs `default_cl = Quorum` at RF=3, where this path
does fan out. This is a separate, independently provable defect.

Closes t_068a046b.