### PR TITLE
chore: point published URLs at www.ferrosa.ai

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           Architecture: ${ARCH}
           Depends: ca-certificates
           Maintainer: Ferrosa Team <ferrosa@ferrosadb.com>
-          Homepage: https://ferrosadb.com
+          Homepage: https://www.ferrosa.ai
           Description: CQL-compatible distributed database with S3-backed storage
            Ferrosa is a Rust reimplementation of Apache Cassandra with S3-backed
            storage, pluggable secondary indexes, built-in graph queries, and
@@ -101,7 +101,7 @@ jobs:
           Description=Ferrosa Database Server
           After=network-online.target
           Wants=network-online.target
-          Documentation=https://ferrosadb.com
+          Documentation=https://www.ferrosa.ai
 
           [Service]
           Type=simple

--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,7 @@ Ferrosa
 Copyright 2026 Ferrosa, Inc.
 
 This product includes software developed at Ferrosa, Inc.
-(https://ferrosadb.com/).
+(https://www.ferrosa.ai/).
 
 ================================================================================
 Third-party attributions

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ask questions, and report issues with the community and maintainers.
 ## Quick Install
 
 ```bash
-curl -fsSL https://ferrosadb.com/install.sh | bash
+curl -fsSL https://www.ferrosa.ai/install.sh | bash
 ```
 
 The installer detects your platform (macOS arm64/x86_64, Linux x86_64/aarch64),

--- a/install/install-memory.sh
+++ b/install/install-memory.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # ferrosa-memory installer — fetches a release tarball, installs to ~/.ferrosa/,
 # offers system-service registration. Assumes Ferrosa is already running at
-# localhost:9042 (install via https://ferrosadb.com/install.sh first).
+# localhost:9042 (install via https://www.ferrosa.ai/install.sh first).
 #
 # SOURCE OF TRUTH: this file (ferrosadb/ferrosa-memory : docs/install-memory.sh).
 # It is mirrored into ferrosadb/ferrosa install/install-memory.sh, which is what
-# GitHub Pages serves at https://ferrosadb.com/install-memory.sh. Edit it HERE;
+# GitHub Pages serves at https://www.ferrosa.ai/install-memory.sh. Edit it HERE;
 # the ferrosa copy is a published mirror.
 #
 # It is idempotent: re-running upgrades an existing install in place. When the
@@ -19,9 +19,9 @@
 #                       cut automatically each night. Resolves via /releases.
 #
 # Usage:
-#   curl -fsSL https://ferrosadb.com/install-memory.sh | bash
-#   curl -fsSL https://ferrosadb.com/install-memory.sh | bash -s -- --channel nightly
-#   curl -fsSL https://ferrosadb.com/install-memory.sh | bash -s -- --version v0.16.0 --no-service
+#   curl -fsSL https://www.ferrosa.ai/install-memory.sh | bash
+#   curl -fsSL https://www.ferrosa.ai/install-memory.sh | bash -s -- --channel nightly
+#   curl -fsSL https://www.ferrosa.ai/install-memory.sh | bash -s -- --version v0.16.0 --no-service
 set -euo pipefail
 
 REPO="ferrosadb/ferrosa-memory"
@@ -288,9 +288,9 @@ cat <<EOF >&2
   templates: $EXAMPLES_DIR
 
 This MCP server connects to a running Ferrosa instance at localhost:9042
-(default from https://ferrosadb.com/install.sh). Ensure Ferrosa is up:
+(default from https://www.ferrosa.ai/install.sh). Ensure Ferrosa is up:
 
-  curl -fsSL https://ferrosadb.com/install.sh | bash
+  curl -fsSL https://www.ferrosa.ai/install.sh | bash
 
 To register with Claude Code, add to your MCP config:
 
@@ -304,7 +304,7 @@ To register with Claude Code, add to your MCP config:
   }
 
 Upgrade later by re-running this installer (idempotent):
-  curl -fsSL https://ferrosadb.com/install-memory.sh | bash -s -- --channel ${CHANNEL}
+  curl -fsSL https://www.ferrosa.ai/install-memory.sh | bash -s -- --channel ${CHANNEL}
 
 Docs: https://github.com/ferrosadb/ferrosa-memory
 EOF

--- a/install/install.sh
+++ b/install/install.sh
@@ -13,9 +13,9 @@
 #                       cut automatically each night. Resolves via /releases.
 #
 # Usage:
-#   curl -fsSL https://ferrosadb.com/install.sh | bash
-#   curl -fsSL https://ferrosadb.com/install.sh | bash -s -- --channel nightly
-#   curl -fsSL https://ferrosadb.com/install.sh | bash -s -- --version v0.16.0 --no-service
+#   curl -fsSL https://www.ferrosa.ai/install.sh | bash
+#   curl -fsSL https://www.ferrosa.ai/install.sh | bash -s -- --channel nightly
+#   curl -fsSL https://www.ferrosa.ai/install.sh | bash -s -- --version v0.16.0 --no-service
 set -euo pipefail
 
 REPO="ferrosadb/ferrosa"
@@ -299,7 +299,7 @@ If you didn't register a service, run manually:
   FERROSA_CONFIG="$CONFIG_DIR/ferrosa.toml" "$BIN_DIR/ferrosa"
 
 Upgrade later by re-running this installer (idempotent):
-  curl -fsSL https://ferrosadb.com/install.sh | bash -s -- --channel ${CHANNEL}
+  curl -fsSL https://www.ferrosa.ai/install.sh | bash -s -- --channel ${CHANNEL}
 
-Docs: https://ferrosadb.com/database/getting-started.html
+Docs: https://www.ferrosa.ai/database/getting-started.html
 EOF

--- a/install/setup-memory.sh
+++ b/install/setup-memory.sh
@@ -3,16 +3,16 @@
 # downloads ONBOARDING.md, optionally clones source repos, optionally pulls
 # the Nomic embedding model, and hands off to a selected LLM harness.
 #
-# Reads https://ferrosadb.com/LATEST (a plain-text version tag like "v0.16.0")
+# Reads https://www.ferrosa.ai/LATEST (a plain-text version tag like "v0.16.0")
 # and uses it for both ferrosa and ferrosa-memory release artifacts (the two
 # projects ship synchronized tags). No source compile.
 #
 # Usage:
-#   curl -fsSL https://ferrosadb.com/setup-memory.sh | bash
-#   curl -fsSL https://ferrosadb.com/setup-memory.sh | bash -s -- --version v0.16.0 --no-clone
+#   curl -fsSL https://www.ferrosa.ai/setup-memory.sh | bash
+#   curl -fsSL https://www.ferrosa.ai/setup-memory.sh | bash -s -- --version v0.16.0 --no-clone
 #
 # Env overrides (mostly for testing):
-#   FERROSA_LATEST_URL    — version pointer (default https://ferrosadb.com/LATEST)
+#   FERROSA_LATEST_URL    — version pointer (default https://www.ferrosa.ai/LATEST)
 #   FERROSA_RELEASE_HOST  — ferrosa releases root
 #   MEMORY_RELEASE_HOST   — ferrosa-memory releases root
 #   ONBOARDING_URL        — ONBOARDING.md source (default github raw on main)
@@ -24,7 +24,7 @@ set -euo pipefail
 
 FERROSA_REPO="ferrosadb/ferrosa"
 MEMORY_REPO="ferrosadb/ferrosa-memory"
-LATEST_URL="${FERROSA_LATEST_URL:-https://ferrosadb.com/LATEST}"
+LATEST_URL="${FERROSA_LATEST_URL:-https://www.ferrosa.ai/LATEST}"
 FERROSA_RELEASE_HOST="${FERROSA_RELEASE_HOST:-https://github.com/${FERROSA_REPO}/releases}"
 MEMORY_RELEASE_HOST="${MEMORY_RELEASE_HOST:-https://github.com/${MEMORY_REPO}/releases}"
 ONBOARDING_URL="${ONBOARDING_URL:-https://raw.githubusercontent.com/${MEMORY_REPO}/main/ONBOARDING.md}"

--- a/install/setup.sh
+++ b/install/setup.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 # ferrosa fast setup — installs prebuilt binaries via the LATEST file.
 #
-# Reads https://ferrosadb.com/LATEST (a plain-text version tag like "v0.16.0"),
+# Reads https://www.ferrosa.ai/LATEST (a plain-text version tag like "v0.16.0"),
 # downloads the matching release tarball from
 # https://github.com/ferrosadb/ferrosa/releases, verifies SHA256, installs to
 # ~/.ferrosa/, and optionally registers as a user service. No source clone,
 # no compile.
 #
 # Usage:
-#   curl -fsSL https://ferrosadb.com/setup.sh | bash
-#   curl -fsSL https://ferrosadb.com/setup.sh | bash -s -- --version v0.16.0 --no-service
+#   curl -fsSL https://www.ferrosa.ai/setup.sh | bash
+#   curl -fsSL https://www.ferrosa.ai/setup.sh | bash -s -- --version v0.16.0 --no-service
 #
 # Env overrides (mostly for testing):
-#   FERROSA_LATEST_URL   — where to fetch the version pointer (default https://ferrosadb.com/LATEST)
+#   FERROSA_LATEST_URL   — where to fetch the version pointer (default https://www.ferrosa.ai/LATEST)
 #   FERROSA_RELEASE_HOST — release artifact root (default github.com release URL)
 #   FERROSA_INSTALL_ROOT — install prefix (default $HOME/.ferrosa)
 set -euo pipefail
 
 REPO="ferrosadb/ferrosa"
-LATEST_URL="${FERROSA_LATEST_URL:-https://ferrosadb.com/LATEST}"
+LATEST_URL="${FERROSA_LATEST_URL:-https://www.ferrosa.ai/LATEST}"
 RELEASE_HOST="${FERROSA_RELEASE_HOST:-https://github.com/${REPO}/releases}"
 INSTALL_ROOT="${FERROSA_INSTALL_ROOT:-${HOME}/.ferrosa}"
 BIN_DIR="${INSTALL_ROOT}/bin"
@@ -201,7 +201,7 @@ If you didn't register a service, run manually:
   FERROSA_CONFIG="$CONFIG_DIR/ferrosa.toml" "$BIN_DIR/ferrosa"
 
 For Ferrosa Memory + LLM onboarding, run:
-  curl -fsSL https://ferrosadb.com/setup-memory.sh | bash
+  curl -fsSL https://www.ferrosa.ai/setup-memory.sh | bash
 
-Docs: https://ferrosadb.com/database/getting-started.html
+Docs: https://www.ferrosa.ai/database/getting-started.html
 EOF

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -89,7 +89,7 @@ Priority: optional
 Architecture: ${ARCH}
 Depends: ca-certificates
 Maintainer: Ferrosa Team <ferrosa@ferrosadb.com>
-Homepage: https://ferrosadb.com
+Homepage: https://www.ferrosa.ai
 Description: CQL-compatible distributed database with S3-backed storage
  Ferrosa is a Rust reimplementation of Apache Cassandra with S3-backed
  storage, pluggable secondary indexes (B-tree, hash, composite, phonetic,
@@ -142,7 +142,7 @@ cat > "${PKG_DIR}/lib/systemd/system/ferrosa.service" <<SERVICE
 Description=Ferrosa Database Server
 After=network-online.target
 Wants=network-online.target
-Documentation=https://ferrosadb.com
+Documentation=https://www.ferrosa.ai
 
 [Service]
 Type=simple

--- a/systemd/ferrosa.service
+++ b/systemd/ferrosa.service
@@ -16,7 +16,7 @@
 
 [Unit]
 Description=Ferrosa Database
-Documentation=https://ferrosadb.com
+Documentation=https://www.ferrosa.ai
 After=network-online.target
 Wants=network-online.target
 


### PR DESCRIPTION
Phase C of the `ferrosadb.com` → `ferrosa.ai` migration.

The site moved to `www.ferrosa.ai` on 2026-08-24 and `ferrosadb.com` now
301-redirects there with the path preserved, so **nothing was broken before this
change**. This is so newly published content and newly downloaded install
scripts name the current domain.

Replaced `https://ferrosadb.com` and `https://www.ferrosadb.com` with
`https://www.ferrosa.ai`.

## Why `www.` and not the bare apex

`https://ferrosa.ai` currently **404s** — GitHub hasn't wired its apex→www
redirect and no Cloudflare rule covers it yet. Publishing the apex in an install
one-liner before it resolves would break installs. Switching to the bare apex is
a trivial follow-up once it's confirmed serving.

## Deliberately not changed

**Email addresses** — `ben@`, `security@`, `conduct@`, `invites@`, `ferrosa@`.
`ferrosa.ai` is verified in Google Workspace, but DNS can't tell whether it's a
domain **alias** (receives mail) or a **secondary domain** (needs users
created). Publishing a `security@ferrosa.ai` that doesn't receive would bounce
security reports. Needs an Admin-console check first.

**`proxy.ferrosadb.com:29143`** (ferrosa-osx) — a DBaaS proxy endpoint, not the
docs site. `proxy.ferrosa.ai` doesn't exist in DNS; rewriting it would break the
feature.

**`BASE_IRI` and the `dikw:` prefix** in
`ferrosa-workbench/crates/ferrosa-workbench-app/src/ontology.rs` — these are
RDF/OWL **identifiers, not links**. The constant is documented as "the base IRI
for terms this workbench MINTS" and is written into Turtle output as an
`@prefix` declaration. Renaming it means every triple already persisted under
the old IRI stops matching newly minted terms — the same concept silently
acquiring two identities in the graph. That's a data migration with its own
reasoning, not a URL sweep.

## Dead links fixed in passing

Only because these exact lines were being rewritten — shipping a link I'd just
touched and knew was dead is worse than leaving it alone:

- `/getting-started.html` → `/database/getting-started.html` (ferrosa-dbaas
  specs). The old form 404s and always did; the redirect only moved where the
  404 happens.
- `/brand.html`, `/design-system.html` → `/internal/…` (ferrosa-workbench ui).
  Those pages moved to `/internal/` in ferrosa-docs #29.

## Verification

Every rewritten URL was actually fetched, not assumed:

| endpoint | result |
|---|---|
| `https://www.ferrosa.ai/LATEST` | 200 — `v0.20.0` |
| `https://www.ferrosa.ai/LATEST-MEMORY` | 200 — `v0.28.0` |
| `install.sh`, `install-memory.sh` | 200 |
| `setup.sh`, `setup-memory.sh` | 200 |
| `database/getting-started.html` | 200 |
| `ferrosa-memory/design-system.html` | 200 |

Every changed shell script passes `bash -n`. The installer default now reads
`FERROSA_LATEST_URL:-https://www.ferrosa.ai/LATEST`, and that URL serves.

Part of t_dbbcc0a8.
