### PR TITLE
fix(cluster): honor consistency for keyed index reads

### DIFF
--- a/ferrosa-cluster/README.md
+++ b/ferrosa-cluster/README.md
@@ -109,7 +109,10 @@ strict-serializable multi-key / cross-shard transactions and LWT.
   plus the KEYED index read `coordinate_index_read_in_partition` (t_430c4188):
   `WHERE <full pk> AND <indexed_col> = ?` contacts ONLY the partition's replicas
   (ring placement under the keyspace strategy), each running
-  `read_by_index_in_partition` locally — never a global scatter-gather —
+  `read_by_index_in_partition` locally — never a global scatter-gather. The
+  coordinator stops after the requested consistency level has enough successful
+  responses (t_2f174c97), so CL ONE does not inherit a slow peer's three-second
+  Bulk timeout; quorum levels still wait for their required successes.
   (`fts_match` — fans out to every node's local FTI and unions/de-dupes the
   matching keys, since full-text hits span all token ranges; BUG-F-007). FTI
   scatter-gather is partial-failure tolerant: if at least one node completes, the

--- a/ferrosa-cluster/specs/fmea.md
+++ b/ferrosa-cluster/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cluster
 doc: fmea
-last_updated: 2026-08-07
+last_updated: 2026-08-24
 ---
 
 # ferrosa-cluster — FMEA / Known Issues
@@ -13,6 +13,7 @@ cluster-wide and severities run high. Several entries are *evidence* gaps
 
 | ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
 |----|--------------|--------|---|---|---|-----|---------------------|
+| CL-17 | **Keyed secondary-index reads waited for every replica regardless of requested consistency.** One slow or disconnected replica imposed the three-second Bulk timeout even at CL ONE, producing the observed ~4 s fixed floor for small indexed results. | Small indexed lookups are slower than partition reads; a single unhealthy replica amplifies latency cluster-wide. | 6 | 6 | 3 | 108 → 12 | **Fixed (t_2f174c97):** the keyed coordinator filters eligible replicas, computes the CL/DC response threshold, counts only successes, and returns as soon as the threshold is met. Regression: `keyed_index_read_at_one_does_not_wait_for_slow_replica` proves QUORUM still waits for two successes while CL ONE returns after one. |
 | CL-1 | **No external/public Jepsen validation of Accord + Raft.** All consensus/transaction tests are in-crate, deterministic harnesses (`TestCluster`, simulated nemesis). Real partitions, clock skew, fsync faults, and Byzantine timing are not exercised end-to-end. | A linearizability/strict-serializability violation that only manifests under real-world faults would ship undetected | 10 | 4 | 8 | 320 | **Open evidence gap.** `ferrosa-jepsen` harness designed + approved (`specs/todo/jepsen-e2e-test-plan.md`) but **not built**. Strong in-crate property/recovery tests reduce occurrence but cannot close detection. Treat correctness as *tested, not proven*. |
 | CL-2 | **Raft election storm on log divergence.** A follower whose log falls behind bumps its term unboundedly (no pre-vote in upstream openraft 0.9), burning CPU and inflating terms while the cluster is stable (observed T18,348 vs leader T8). | Hot node, term inflation, replication backoff; can block snapshot delivery | 8 | 5 | 4 | 160 | **Mitigated.** Pinned openraft fork adds CheckQuorum (ADR-012, default 0.75). Its PreVote gate — the intended primary defense against this storm — is **disabled by default** because its network transport is unimplemented (see CL-15), so the actual mitigation today is the `election_guard` watchdog (P0-17/P0-19) suppresses storms (`elect(false)` 60 s) and exposes `ELECTION_STORM_TERM_JUMPS_TOTAL`; `snapshot_pusher` (P0-20) pushes snapshots to lagging followers. Guard/pusher slated for removal (W4.11/W4.12) only after a clean Jepsen window — which depends on CL-1. |
 | CL-3 | **Write backpressure exhaustion starves the data path.** `WRITE_CONCURRENCY_LIMIT = 128` semaphore protects Raft from bulk-insert runtime saturation, but a saturated cluster returns `Unavailable` once all 128 permits are held. | Bulk writers see `Unavailable`/`WriteTimeout` under load; client must retry/throttle | 6 | 5 | 3 | 90 | **By design, fail-loud.** Limit prevents the worse failure (Raft heartbeat starvation → election storms). Constant is fixed, not tunable; batch path has a separate `DEFAULT_BATCH_CONCURRENCY = 32`. Tuning guidance + per-tenant limits are roadmap items. |

--- a/ferrosa-cluster/specs/overview.md
+++ b/ferrosa-cluster/specs/overview.md
@@ -81,9 +81,11 @@ partition's replicas from the ring under the keyspace strategy and sends each an
 `IndexReadInPartitionRequest` (`0x66`/`0x67`); the replica consults its
 secondary index restricted to that partition and point-reads only the matching
 rows (O(matching rows), never O(partition rows)). Results merge per token;
-partial replica failures degrade to a partial union (logged); all-replicas-failed
-errors. Exposed as `WritePath::index_read_in_partition` (Direct/Pair resolve
-locally). Unlike `coordinate_index_read`, this never fans out to the whole ring.
+the coordinator returns once the requested consistency level has received enough
+successful replica responses (t_2f174c97). Failures never count toward that
+threshold, and an unmet threshold returns `ReadTimeout`. Exposed as
+`WritePath::index_read_in_partition` (Direct/Pair resolve locally). Unlike
+`coordinate_index_read`, this never fans out to the whole ring.
 
 **Full-text scatter-gather.** `coordinate_fulltext_search` fans an `fts_match`
 index lookup out to every node — its hits span all token ranges (there is no

--- a/ferrosa-cluster/specs/roadmap.md
+++ b/ferrosa-cluster/specs/roadmap.md
@@ -18,6 +18,12 @@ reference/decision specs, and the dependency/usage review. Ordered by value.
   timeout. A native three-node replay of the 69K-row incident remains the live
   closure gate.
 
+- **Keyed secondary-index fixed latency floor (t_2f174c97 / CL-17).** The
+  partition-scoped coordinator previously waited for every replica even at CL
+  ONE, so one slow peer imposed the three-second Bulk timeout. It now returns
+  after the requested consistency threshold succeeds and fails loudly when that
+  threshold cannot be met.
+
 - **Same-host cluster reverse-address collapse (CL-16).** Live launchd evidence
   showed node3 recovering a three-member ring whose three addresses all pointed
   at node3's `:17002`; node1/node2 consequently stayed in pair mode. Inbound

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -23,6 +23,16 @@
 //!    by timestamp (last-write-wins).  Spawn async repair writes to stale replicas.
 //!
 //! For CL = ONE: skip digest entirely — read from one replica, prefer local.
+//!
+//! # Correctness
+//!
+//! Keyed secondary-index reads obey the same consistency response threshold as
+//! primary-key reads. A slow or failed replica does not delay CL ONE after one
+//! successful response, while quorum levels still require their configured
+//! number of successful partition replicas.
+//!
+//! Last revised: 2026-08-24.
+//! Last changed: made keyed index collection consistency-aware (t_2f174c97).
 
 use bytes::Bytes;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -1637,29 +1647,94 @@ impl ClusterCoordinator {
     /// rows), so per-replica work is O(rows matching the value), never
     /// O(partition rows). Results from the replicas are merged per token, the
     /// same union semantics as `coordinate_index_read` but over the replica
-    /// set instead of the whole ring. Partial replica failures degrade to a
-    /// partial union (logged); an all-replicas-failed result errors.
+    /// set instead of the whole ring. Only successful responses count toward
+    /// the requested consistency level; falling short returns `ReadTimeout`.
     pub async fn coordinate_index_read_in_partition(
         &self,
         table_id: &TableId,
         key: &DecoratedKey,
         index_name: &str,
         index_key: &ferrosa_index::IndexKey,
+        cl: ConsistencyLevel,
         strategy: &crate::ring::strategy::ReplicationStrategy,
     ) -> crate::error::Result<Vec<ferrosa_sstable::types::Partition>> {
         let ring = self.ring.load();
-        let replica_ids = ring.replicas_for_strategy(key.token.0, strategy);
+        let all_replicas = ring.replicas_for_strategy(key.token.0, strategy);
+        let eligible =
+            crate::coordinator::cl_routing::eligible_replicas_for_cl(cl, &all_replicas, &ring);
+        let local_dc = ring
+            .get_node(self.local_node_id)
+            .map(|n| n.data_center.clone())
+            .unwrap_or_default();
+        let mut required_by_dc: Option<std::collections::HashMap<String, usize>> = None;
+        let (replica_ids, required) = match cl {
+            ConsistencyLevel::LocalQuorum | ConsistencyLevel::LocalOne => {
+                let local_replicas: Vec<u64> = eligible
+                    .into_iter()
+                    .filter(|&id| {
+                        ring.get_node(id)
+                            .map(|n| n.data_center == local_dc)
+                            .unwrap_or(false)
+                    })
+                    .collect();
+                let local_rf = strategy
+                    .dc_replication_factors()
+                    .get(&local_dc)
+                    .copied()
+                    .unwrap_or(1);
+                (local_replicas, cl.block_for_dc(local_rf))
+            }
+            ConsistencyLevel::EachQuorum => match strategy {
+                crate::ring::strategy::ReplicationStrategy::NetworkTopology { dc_rf } => {
+                    let requirements: std::collections::HashMap<String, usize> = dc_rf
+                        .iter()
+                        .map(|(dc, rf)| (dc.clone(), rf / 2 + 1))
+                        .collect();
+                    let required = requirements.values().sum();
+                    required_by_dc = Some(requirements);
+                    (eligible, required)
+                }
+                crate::ring::strategy::ReplicationStrategy::Simple { .. } => {
+                    return Err(ClusterError::NotImplemented {
+                        feature: "EACH_QUORUM keyed index read requires NetworkTopologyStrategy"
+                            .into(),
+                    });
+                }
+            },
+            _ => (eligible, cl.block_for(strategy.replication_factor())),
+        };
+        let replica_dc_by_id: std::collections::HashMap<u64, String> = replica_ids
+            .iter()
+            .filter_map(|&id| ring.get_node(id).map(|node| (id, node.data_center.clone())))
+            .collect();
         let nodes: Vec<(u64, Option<(uuid::Uuid, String)>)> = replica_ids
             .iter()
             .map(|&id| (id, ring.get_node(id).map(|n| (n.host_id, n.addr.clone()))))
             .collect();
         drop(ring);
 
-        if nodes.is_empty() {
-            return Err(ClusterError::Internal(format!(
-                "keyed index read: no replicas resolved for token {}",
-                key.token.0
-            )));
+        if nodes.len() < required {
+            return Err(ClusterError::Unavailable {
+                consistency: cl.to_string(),
+                required,
+                alive: nodes.len(),
+            });
+        }
+        if let Some(requirements) = required_by_dc.as_ref() {
+            let unavailable_dc = requirements.iter().any(|(dc, required_in_dc)| {
+                replica_dc_by_id
+                    .values()
+                    .filter(|candidate| *candidate == dc)
+                    .count()
+                    < *required_in_dc
+            });
+            if unavailable_dc {
+                return Err(ClusterError::Unavailable {
+                    consistency: cl.to_string(),
+                    required,
+                    alive: nodes.len(),
+                });
+            }
         }
 
         let req_payload = IndexReadInPartitionRequestPayload {
@@ -1677,8 +1752,6 @@ impl ClusterCoordinator {
         let index_name_owned = index_name.to_string();
         let index_key_clone = index_key.clone();
         let partition_key_bytes = key.key.as_bytes().to_vec();
-        let total_nodes = nodes.len();
-
         let mut futs: FuturesUnordered<_> = nodes
             .into_iter()
             .map(|(node_id, remote)| {
@@ -1691,73 +1764,96 @@ impl ClusterCoordinator {
                 let coordinator = self;
 
                 async move {
-                    if node_id == local_id {
-                        storage
-                            .read_by_index_in_partition(
-                                &table_id,
-                                &index_name,
-                                &index_key,
-                                &partition_key,
-                            )
-                            .map_err(ClusterError::Storage)
-                    } else {
-                        let (hid, addr) = remote.ok_or_else(|| {
-                            ClusterError::Internal(format!(
-                                "keyed index read: node {node_id} has no host_id"
-                            ))
-                        })?;
-
-                        let resp = coordinator
-                            .send_remote_with_reconnect_timeout(
-                                hid,
-                                &addr,
-                                Message::IndexReadInPartitionRequest(req_body),
-                                Lane::Bulk,
-                                Self::BULK_READ_TIMEOUT,
-                            )
-                            .await
-                            .map_err(|e| {
+                    let result = async {
+                        if node_id == local_id {
+                            storage
+                                .read_by_index_in_partition(
+                                    &table_id,
+                                    &index_name,
+                                    &index_key,
+                                    &partition_key,
+                                )
+                                .map_err(ClusterError::Storage)
+                        } else {
+                            let (hid, addr) = remote.ok_or_else(|| {
                                 ClusterError::Internal(format!(
-                                    "keyed index read from node {node_id} ({hid}) via {addr}: {e}"
+                                    "keyed index read: node {node_id} has no host_id"
                                 ))
                             })?;
 
-                        match resp {
-                            Message::IndexReadInPartitionResponse(b) => {
-                                let payload = bincode::deserialize::<IndexReadResponsePayload>(&b)
-                                    .map_err(|e| {
-                                        ClusterError::Internal(format!(
-                                            "keyed index read: failed to decode response \
-                                                 from node {node_id} ({hid}): {e}"
-                                        ))
-                                    })?;
-                                Ok(payload
-                                    .partitions
-                                    .into_iter()
-                                    .map(partition_from_wire)
-                                    .collect())
+                            let resp = coordinator
+                                .send_remote_with_reconnect_timeout(
+                                    hid,
+                                    &addr,
+                                    Message::IndexReadInPartitionRequest(req_body),
+                                    Lane::Bulk,
+                                    Self::BULK_READ_TIMEOUT,
+                                )
+                                .await
+                                .map_err(|e| {
+                                    ClusterError::Internal(format!(
+                                        "keyed index read from node {node_id} ({hid}) via {addr}: {e}"
+                                    ))
+                                })?;
+
+                            match resp {
+                                Message::IndexReadInPartitionResponse(b) => {
+                                    let payload =
+                                        bincode::deserialize::<IndexReadResponsePayload>(&b)
+                                            .map_err(|e| {
+                                                ClusterError::Internal(format!(
+                                                    "keyed index read: failed to decode response \
+                                                     from node {node_id} ({hid}): {e}"
+                                                ))
+                                            })?;
+                                    Ok(payload
+                                        .partitions
+                                        .into_iter()
+                                        .map(partition_from_wire)
+                                        .collect())
+                                }
+                                other => Err(ClusterError::Internal(format!(
+                                    "keyed index read: unexpected response {:?} from node \
+                                     {node_id} ({hid})",
+                                    other.msg_type()
+                                ))),
                             }
-                            other => Err(ClusterError::Internal(format!(
-                                "keyed index read: unexpected response {:?} from node \
-                                 {node_id} ({hid})",
-                                other.msg_type()
-                            ))),
                         }
                     }
+                    .await;
+                    (node_id, result)
                 }
             })
             .collect();
 
         let mut all_partitions: Vec<ferrosa_sstable::types::Partition> = Vec::new();
         let mut first_error: Option<ClusterError> = None;
-        let mut failed_nodes = 0usize;
+        let mut received = 0usize;
+        let mut received_by_dc: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
 
-        while let Some(result) = futs.next().await {
+        while let Some((node_id, result)) = futs.next().await {
             match result {
-                Ok(batch) => all_partitions.extend(batch),
+                Ok(batch) => {
+                    all_partitions.extend(batch);
+                    received += 1;
+                    if let Some(dc) = replica_dc_by_id.get(&node_id) {
+                        *received_by_dc.entry(dc.clone()).or_default() += 1;
+                    }
+                    let consistency_met =
+                        required_by_dc
+                            .as_ref()
+                            .map_or(received >= required, |requirements| {
+                                requirements.iter().all(|(dc, required_in_dc)| {
+                                    received_by_dc.get(dc).copied().unwrap_or(0) >= *required_in_dc
+                                })
+                            });
+                    if consistency_met {
+                        break;
+                    }
+                }
                 Err(e) => {
                     tracing::error!("coordinate_index_read_in_partition: {e}");
-                    failed_nodes += 1;
                     if first_error.is_none() {
                         first_error = Some(e);
                     }
@@ -1765,22 +1861,24 @@ impl ClusterCoordinator {
             }
         }
 
-        if let Some(ref err) = first_error {
-            if failed_nodes == total_nodes {
-                tracing::error!(
-                    failed_nodes,
-                    "coordinate_index_read_in_partition: all replicas failed, returning error"
-                );
-                return Err(first_error.unwrap());
+        let consistency_met =
+            required_by_dc
+                .as_ref()
+                .map_or(received >= required, |requirements| {
+                    requirements.iter().all(|(dc, required_in_dc)| {
+                        received_by_dc.get(dc).copied().unwrap_or(0) >= *required_in_dc
+                    })
+                });
+        if !consistency_met {
+            if let Some(err) = first_error {
+                tracing::warn!(%err, "keyed index read did not satisfy consistency");
             }
-            tracing::warn!(
-                failed_nodes,
-                partitions_received = all_partitions.len(),
-                %err,
-                "coordinate_index_read_in_partition: {failed_nodes} replica(s) failed, \
-                 returning partial results from {remaining} replica(s)",
-                remaining = total_nodes - failed_nodes,
-            );
+            return Err(ClusterError::ReadTimeout {
+                consistency: cl.to_string(),
+                received,
+                required,
+                data_present: !all_partitions.is_empty(),
+            });
         }
 
         // Merge per token (all results are the same partition; replicas may
@@ -3314,6 +3412,29 @@ mod tests {
         partition: Partition,
     }
 
+    struct DelayedIndexReadInPartitionHandler {
+        partition: Partition,
+        delay: std::time::Duration,
+    }
+
+    #[async_trait::async_trait]
+    impl RpcHandler for DelayedIndexReadInPartitionHandler {
+        async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
+            let Message::IndexReadInPartitionRequest(_) = msg else {
+                return None;
+            };
+            tokio::time::sleep(self.delay).await;
+            let payload = IndexReadResponsePayload {
+                partitions: vec![crate::raft::handlers::partition_to_wire(
+                    self.partition.clone(),
+                )],
+            };
+            Some(Message::IndexReadInPartitionResponse(Bytes::from(
+                bincode::serialize(&payload).unwrap(),
+            )))
+        }
+    }
+
     #[async_trait::async_trait]
     impl RpcHandler for StaticIndexReadInPartitionHandler {
         async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
@@ -3408,6 +3529,7 @@ mod tests {
                 &key,
                 "val_idx",
                 &ferrosa_index::IndexKey(b"hello".to_vec()),
+                ConsistencyLevel::One,
                 &strategy,
             )
             .await
@@ -3432,6 +3554,139 @@ mod tests {
             .shutdown(std::time::Duration::from_millis(50))
             .await;
         other_server
+            .shutdown(std::time::Duration::from_millis(50))
+            .await;
+    }
+
+    /// t_2f174c97: a keyed index lookup at CL ONE must complete after one
+    /// successful replica. Waiting for every replica turns one unavailable or
+    /// slow peer into the fixed three-second Bulk timeout seen by callers.
+    #[tokio::test]
+    async fn keyed_index_read_at_one_does_not_wait_for_slow_replica() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_tbl".to_string(),
+            key_type: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            clustering_columns: vec![],
+            static_columns: vec![],
+            regular_columns: vec![ColumnDefinition {
+                name: "val".to_string(),
+                type_name: "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            }],
+            extensions: Default::default(),
+        };
+        storage
+            .register_table_with_indexes(schema, vec![("val_idx".to_string(), 0_usize)])
+            .unwrap();
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        let key = test_key();
+        storage.write(&table_id, &key, test_row(10), 10).unwrap();
+
+        let slow_partition = Partition {
+            key: key.clone(),
+            deletion: DeletionTime::LIVE,
+            static_row: None,
+            rows: vec![test_row(9)],
+        };
+        let (slow_server, slow_addr, slow_host_id) = start_rpc_server(
+            MsgType::IndexReadInPartitionRequest,
+            Arc::new(DelayedIndexReadInPartitionHandler {
+                partition: slow_partition,
+                delay: std::time::Duration::from_millis(250),
+            }),
+        )
+        .await;
+
+        let pm = Arc::new(PeerManager::new(
+            Arc::new(NetConfig::default()),
+            Uuid::new_v4(),
+            Arc::new(NoopListener),
+        ));
+        let mut local = make_node("127.0.0.1:1");
+        let mut slow = make_node(&slow_addr.to_string());
+        let failed = make_node("127.0.0.1:1");
+        slow.host_id = slow_host_id;
+        local.host_id = Uuid::new_v4();
+
+        let mut ring = TokenRing::new();
+        ring.add_node(1u64, local);
+        ring.add_node(2u64, slow);
+        ring.add_node(3u64, failed);
+        ring.assign_tokens(1u64, &[42]);
+        ring.assign_tokens(2u64, &[500_000]);
+        ring.assign_tokens(3u64, &[1_000_000]);
+
+        let coordinator = make_coordinator(ring, pm, 1u64, storage, 3, ConsistencyLevel::One);
+        let strategy = crate::ring::strategy::ReplicationStrategy::Simple {
+            replication_factor: 3,
+        };
+
+        let quorum = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            coordinator.coordinate_index_read_in_partition(
+                &table_id,
+                &key,
+                "val_idx",
+                &ferrosa_index::IndexKey(b"hello".to_vec()),
+                ConsistencyLevel::Quorum,
+                &strategy,
+            ),
+        )
+        .await;
+        assert!(
+            quorum.is_err(),
+            "a failed replica must not satisfy QUORUM before the slow second success"
+        );
+
+        tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            coordinator.coordinate_index_read_in_partition(
+                &table_id,
+                &key,
+                "val_idx",
+                &ferrosa_index::IndexKey(b"hello".to_vec()),
+                ConsistencyLevel::Quorum,
+                &strategy,
+            ),
+        )
+        .await
+        .expect("QUORUM did not complete after the second successful replica")
+        .unwrap();
+
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            coordinator.coordinate_index_read_in_partition(
+                &table_id,
+                &key,
+                "val_idx",
+                &ferrosa_index::IndexKey(b"hello".to_vec()),
+                ConsistencyLevel::One,
+                &strategy,
+            ),
+        )
+        .await
+        .expect("CL ONE keyed index read waited for the slow replica")
+        .unwrap();
+
+        let each_quorum = coordinator
+            .coordinate_index_read_in_partition(
+                &table_id,
+                &key,
+                "val_idx",
+                &ferrosa_index::IndexKey(b"hello".to_vec()),
+                ConsistencyLevel::EachQuorum,
+                &strategy,
+            )
+            .await;
+        assert!(matches!(
+            each_quorum,
+            Err(ClusterError::NotImplemented { .. })
+        ));
+
+        slow_server
             .shutdown(std::time::Duration::from_millis(50))
             .await;
     }

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -1037,6 +1037,7 @@ impl WritePath {
         key: &DecoratedKey,
         index_name: &str,
         index_key: &ferrosa_index::IndexKey,
+        cl: ConsistencyLevel,
         strategy: &ReplicationStrategy,
     ) -> crate::error::Result<Vec<ferrosa_sstable::types::Partition>> {
         match self {
@@ -1050,7 +1051,7 @@ impl WritePath {
             Self::Cluster(coordinator) => {
                 coordinator
                     .coordinate_index_read_in_partition(
-                        table_id, key, index_name, index_key, strategy,
+                        table_id, key, index_name, index_key, cl, strategy,
                     )
                     .await
             }

--- a/ferrosa-cql/README.md
+++ b/ferrosa-cql/README.md
@@ -73,7 +73,10 @@ unaffected (see [Bridge re-export](#bridge-re-export-d10)).
   `PartitionKeyLookup` (full PK), `PartitionIndexLookup` (full PK **plus** an
   indexed residual `=` predicate — t_430c4188: keyed secondary-index consult
   restricted to the partition, O(matching rows) instead of O(partition rows),
-  routed to the partition's replicas, no ALLOW FILTERING needed). Empty keyed
+  routed to the partition's replicas, no ALLOW FILTERING needed). The request's
+  consistency level is propagated to that consult (t_2f174c97), so CL ONE
+  returns after one successful replica instead of waiting for all replicas.
+  Empty keyed
   consults rescan the one partition only while storage reports the index is not
   current; once `IndexStateTracker` is `Current`, an empty consult is accepted as
   a real miss. Ordinary equality plans admit only scalar indexes (B-tree, hash,

--- a/ferrosa-cql/specs/fmea.md
+++ b/ferrosa-cql/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 doc: fmea
-last_updated: 2026-08-09
+last_updated: 2026-08-24
 ---
 
 # ferrosa-cql — FMEA / Known Issues
@@ -12,6 +12,7 @@ high. Entries below reflect gaps found in the code, not hypotheticals.
 
 | ID | Failure mode | Effect | S | O | D | RPN | Mitigation / status |
 |----|--------------|--------|---|---|---|-----|---------------------|
+| CQL-15 | Keyed secondary-index execution dropped the request consistency level before entering the cluster coordinator. | The coordinator waited for all partition replicas, adding a ~3 s timeout floor when any replica was slow even for CL ONE. | 6 | 6 | 3 | 108 → 12 | **Fixed (t_2f174c97):** `route_select_user_table` propagates `ctx.consistency` through `WritePath::index_read_in_partition`; cluster response collection now stops only after the corresponding success threshold. |
 | CQL-1 | LWT routed to Accord in standalone/pair mode where `peer_manager`/`accord_clock` are absent | `INSERT ... IF NOT EXISTS` / `IF <cond>` return `ServerError` ("not yet implemented") instead of executing | 8 | 5 | 2 | 80 | **Designed fail-loud** (p0-03): `route()` returns a clear error rather than a silent non-linearizable local path. Full coordinator driver tracked on `fix/p0-03b-accord-network`. Real functional gap, but observable. |
 | CQL-2 | `paging_state` cursor is opaque but **unsigned** — `PagingState::encode/decode` is a plain length-prefixed pk+ck+flag with no HMAC | A client can forge/tamper a paging token to resume at an arbitrary key, bypassing the original query's partition scope (cross-partition read / IDOR-style) | 7 | 4 | 7 | 196 → 24 | **Implemented.** `encode` appends `HMAC-SHA256(process_key, payload)`; `decode` verifies it constant-time (`Mac::verify_slice`) before parsing, rejecting any forged/tampered cursor. Key from `FERROSA_PAGING_HMAC_KEY` (64 hex) or a random per-process key (multi-node clusters must share it). Tests: `tampered_paging_state_is_rejected`, `unsigned_forged_paging_state_is_rejected`. |
 | CQL-3 | Encoder divergence vs `ferrosa-postgres` if the re-exported row codec were ever forked into this crate | Rows written via one front-end read back wrong/invisible via the other (silent corruption) | 10 | 1 | 6 | 60 | **Structural**: codec is the single re-export from `ferrosa-row-bridge` (D10); no second encoder exists here. Reinforced by the PG differential oracle. |

--- a/ferrosa-cql/specs/overview.md
+++ b/ferrosa-cql/specs/overview.md
@@ -79,6 +79,8 @@ KEYED index consult: `WritePath::index_read_in_partition` routes to the
 partition's replicas, each consults its secondary index restricted to that
 partition, and only the matching rows are point-read — O(matching rows), never
 O(partition rows), with an EXPLAIN plan of `PartitionIndexLookup`. The router
+passes the client's consistency level through to the coordinator (t_2f174c97),
+preventing a slow non-required replica from imposing the Bulk timeout. The router
 trusts an empty keyed consult only when the local write path can treat the
 storage `IndexStateTracker` as authoritative and that tracker reports the index
 current with no pending SSTable backfill; clustered reads keep the bounded

--- a/ferrosa-cql/specs/roadmap.md
+++ b/ferrosa-cql/specs/roadmap.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 doc: roadmap
-last_updated: 2026-08-09
+last_updated: 2026-08-24
 ---
 
 # ferrosa-cql — Roadmap
@@ -9,6 +9,13 @@ last_updated: 2026-08-09
 Sourced from the FMEA gaps ([fmea.md](fmea.md)), in-code "not yet implemented"
 markers, and the dependency/usage review. In-code TODO density is very low; the
 real backlog is structural and security-shaped.
+
+## Recently addressed
+
+- **Keyed secondary-index latency floor (t_2f174c97 / CQL-15).** SELECT now
+  carries the client's consistency level into the partition-scoped index
+  coordinator, allowing CL ONE to finish after one successful replica while
+  retaining quorum requirements at stronger levels.
 
 ## Now (highest value)
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -4857,6 +4857,7 @@ async fn route_select_user_table(
                     &decorated_key,
                     &index_name,
                     &index_key,
+                    ctx.consistency,
                     &read_strategy,
                 )
                 .await?;


### PR DESCRIPTION
## Executive Summary

Removes the secondary-index read latency floor by completing keyed reads as soon as the requested consistency level has enough successful partition-replica responses. Failures no longer count toward the threshold, CL ONE returns after its first success, QUORUM waits for the required successes, and EACH_QUORUM uses per-DC accounting for NetworkTopologyStrategy while SimpleStrategy fails explicitly.

## Verification

- keyed_index_read_at_one_does_not_wait_for_slow_replica
- coordinate_index_read_in_partition
- partition_index_lookup: 4 passed
- CI-equivalent all-features workspace gate: 6,774 passed, 1 skipped
- Previously contention-sensitive storage replay test rerun alone: 1 passed
- Independent verifier: PASS

## Tracking

Forge task: t_2f174c97