### PR TITLE
fix(cluster): fail RF3 formation readiness closed

### DIFF
--- a/ferrosa-cluster/src/config.rs
+++ b/ferrosa-cluster/src/config.rs
@@ -1,3 +1,12 @@
+//! Cluster behavior and consensus timing configuration.
+//!
+//! Responsibility: parse operator intent into bounded, fail-closed cluster
+//! settings shared by formation, replication, and health reporting.
+//! Correctness: explicit topology intent must never silently degrade to a
+//! smaller deployment; invalid expected-size values keep readiness closed.
+//! Last revised: 2026-08-26.
+//! Last changed: add explicit expected cluster size for formation readiness.
+
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -46,6 +55,14 @@ pub struct ClusterConfig {
     /// Maximum seconds to wait in Forming state before falling back to Pair.
     /// `None` uses the default of 60 seconds.
     pub formation_timeout_secs: Option<u64>,
+    /// Operator-declared deployment size used to fail readiness closed while
+    /// formation is incomplete. `0` preserves automatic standalone/pair mode;
+    /// `1`, `2`, and `3+` require standalone, pair, and committed Raft
+    /// membership respectively.
+    ///
+    /// Parsed from `FERROSA_EXPECTED_CLUSTER_SIZE`.
+    #[serde(default)]
+    pub expected_cluster_size: usize,
     /// CQL broadcast address (host:port) for system.peers.
     /// When set, overrides the internode address for native_address.
     /// Parsed from FERROSA_CQL_BROADCAST env var.
@@ -124,6 +141,7 @@ impl Default for ClusterConfig {
             raft_data_dir: None,
             node_role: NodeRole::Both,
             formation_timeout_secs: None,
+            expected_cluster_size: 0,
             cql_broadcast: None,
             raft_heartbeat_ms: 300,
             raft_election_timeout_min_ms: 3000,
@@ -173,6 +191,20 @@ impl ClusterConfig {
         if let Ok(timeout) = std::env::var("FERROSA_FORMATION_TIMEOUT_SECS") {
             if let Ok(n) = timeout.parse() {
                 config.formation_timeout_secs = Some(n);
+            }
+        }
+        if let Ok(value) = std::env::var("FERROSA_EXPECTED_CLUSTER_SIZE") {
+            match value.parse::<usize>() {
+                Ok(size) if size > 0 => config.expected_cluster_size = size,
+                _ => {
+                    // Fail readiness closed instead of silently reverting to
+                    // automatic pair/standalone behavior on bad operator input.
+                    config.expected_cluster_size = usize::MAX;
+                    tracing::error!(
+                        value = %value,
+                        "FERROSA_EXPECTED_CLUSTER_SIZE must be a positive integer; readiness disabled"
+                    );
+                }
             }
         }
         if let Ok(role) = std::env::var("FERROSA_NODE_ROLE") {
@@ -319,6 +351,7 @@ mod tests {
         assert_eq!(config.default_cl, ConsistencyLevel::Quorum);
         assert_eq!(config.hinted_handoff_max_mb, 1024);
         assert!(config.auto_join);
+        assert_eq!(config.expected_cluster_size, 0);
     }
 
     /// W3.12 / ADR-012: CheckQuorum is on by default; PreVote is intentionally
@@ -361,12 +394,14 @@ mod tests {
     fn cluster_config_serde_with_node_role() {
         let config = ClusterConfig {
             node_role: NodeRole::Indexer,
+            expected_cluster_size: 3,
             ..ClusterConfig::default()
         };
 
         let bytes = bincode::serialize(&config).unwrap();
         let decoded: ClusterConfig = bincode::deserialize(&bytes).unwrap();
         assert_eq!(decoded.node_role, NodeRole::Indexer);
+        assert_eq!(decoded.expected_cluster_size, 3);
     }
 
     /// W6.8 RED: per-DC config carries independent raft_data_dir +

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -1,8 +1,81 @@
 //! Cluster mode transition logic: forming and full cluster.
+//!
+//! Responsibility: construct the Raft/ring/write-path stack and publish it in
+//! formation order while preserving queued schema mutations.
+//! Correctness: formation work is bounded, cancel-aware, and never advertises
+//! durable topology before the relevant consensus state exists.
+//! Last revised: 2026-08-26.
+//! Last changed: bound the transient DDL replay queue.
 
+use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
+
+const MAX_CLUSTER_MEMBER_MARKER_BYTES: usize = 4096;
+
+struct SavedClusterMemberMarker {
+    bytes: [u8; MAX_CLUSTER_MEMBER_MARKER_BYTES],
+    len: usize,
+}
+
+fn read_cluster_member_marker(
+    marker: &std::path::Path,
+) -> std::io::Result<Option<SavedClusterMemberMarker>> {
+    let mut file = match std::fs::File::open(marker) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let declared_len = file.metadata()?.len();
+    if declared_len > MAX_CLUSTER_MEMBER_MARKER_BYTES as u64 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "cluster membership marker is {declared_len} bytes; maximum is {MAX_CLUSTER_MEMBER_MARKER_BYTES}"
+            ),
+        ));
+    }
+
+    let len = declared_len as usize;
+    let mut bytes = [0u8; MAX_CLUSTER_MEMBER_MARKER_BYTES];
+    file.read_exact(&mut bytes[..len])?;
+    let mut extra = [0u8; 1];
+    if file.read(&mut extra)? != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "cluster membership marker grew beyond its validated bound",
+        ));
+    }
+    Ok(Some(SavedClusterMemberMarker { bytes, len }))
+}
+
+fn restore_cluster_member_marker_atomic(
+    raft_dir: &std::path::Path,
+    saved: &SavedClusterMemberMarker,
+) -> std::io::Result<()> {
+    let live = raft_dir.join(DeploymentMode::CLUSTER_MEMBER_MARKER);
+    let staging = raft_dir.join(".cluster-member.staging");
+    let result = (|| {
+        let mut file = std::fs::File::create(&staging)?;
+        file.write_all(&saved.bytes[..saved.len])?;
+        file.flush()?;
+        file.sync_all()?;
+        if file.metadata()?.len() != saved.len as u64 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "staged cluster membership marker length mismatch",
+            ));
+        }
+        std::fs::rename(&staging, &live)?;
+        std::fs::File::open(raft_dir)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&staging);
+    }
+    result
+}
 
 /// Process-wide counters for cluster-bootstrap silent-failure detectors.
 /// These fire when previously-swallowed paths now surface errors loudly:
@@ -220,7 +293,7 @@ pub(super) fn resolve_formation_rf(
 /// Generic over the op-processor `F` so unit tests can substitute a
 /// counter without spinning up a Raft.
 pub(super) async fn drain_ddl_queue<Op, F, Fut>(
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<Op>,
+    mut rx: tokio::sync::mpsc::Receiver<Op>,
     mut process: F,
 ) -> usize
 where
@@ -291,17 +364,13 @@ impl ModeController {
         raft_dir: &std::path::Path,
     ) -> std::io::Result<Option<std::path::PathBuf>> {
         let marker = raft_dir.join(DeploymentMode::CLUSTER_MEMBER_MARKER);
-        let saved_marker = match std::fs::read(&marker) {
-            Ok(bytes) => Some(bytes),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
-            Err(e) => return Err(e),
-        };
+        let saved_marker = read_cluster_member_marker(&marker)?;
 
         let counts = crate::raft::log_store::SledLogStore::reset(raft_dir)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
 
-        if let Some(bytes) = saved_marker {
-            std::fs::write(raft_dir.join(DeploymentMode::CLUSTER_MEMBER_MARKER), bytes)?;
+        if let Some(saved) = saved_marker {
+            restore_cluster_member_marker_atomic(raft_dir, &saved)?;
         }
 
         Ok(counts.backup_path)
@@ -616,7 +685,8 @@ impl ModeController {
             .store(peers.len() + 1, std::sync::atomic::Ordering::Relaxed);
         // Queue DDL during formation — operations are replayed after Raft leader
         // election instead of being rejected (FMEA F3).
-        let (ddl_tx, ddl_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (ddl_tx, ddl_rx) =
+            tokio::sync::mpsc::channel(crate::ddl_path::FORMING_DDL_QUEUE_CAPACITY);
         *self.ddl_queue_rx.lock() = Some(ddl_rx);
         self.ddl_path
             .store(Arc::new(DdlPath::Forming { queue: ddl_tx }));

--- a/ferrosa-cluster/src/controller/mod.rs
+++ b/ferrosa-cluster/src/controller/mod.rs
@@ -3,6 +3,12 @@
 //! The controller implements [`ferrosa_net::peer::PeerEventListener`] and swaps the active
 //! [`WritePath`] and [`ClusterStateHolder`] atomically when the deployment mode
 //! changes (standalone → pair → cluster).
+//! Responsibility: serialize topology transitions and expose health/readiness
+//! that matches the active write and consensus paths.
+//! Correctness: explicit cluster-size intent fails closed until the matching
+//! standalone, pair, or committed Raft membership is observable.
+//! Last revised: 2026-08-26.
+//! Last changed: gate CQL readiness on declared topology and committed voters.
 //!
 //! Failover lifecycle:
 //!   1. Pair mode active, both nodes connected
@@ -242,9 +248,7 @@ pub struct ModeController {
     pub(super) committed_cluster_size: AtomicUsize,
     /// Receiver for DDL operations queued during Forming state.
     pub(super) ddl_queue_rx: Arc<
-        parking_lot::Mutex<
-            Option<tokio::sync::mpsc::UnboundedReceiver<crate::pair::ddl::DdlOperation>>,
-        >,
+        parking_lot::Mutex<Option<tokio::sync::mpsc::Receiver<crate::pair::ddl::DdlOperation>>>,
     >,
     /// Contention metrics for the transition guard.
     pub contention_metrics: Arc<ContentionMetrics>,
@@ -280,6 +284,29 @@ pub struct ModeControllerHandles {
     pub write_path: Arc<ArcSwap<WritePath>>,
     pub cluster_state: Arc<ArcSwap<ClusterStateHolder>>,
     pub ddl_path: Arc<ArcSwap<DdlPath>>,
+}
+
+pub(super) fn declared_topology_is_ready(
+    expected_cluster_size: usize,
+    mode: DeploymentMode,
+    role: Option<PairRole>,
+    has_raft_leader: bool,
+    committed_voters: usize,
+) -> bool {
+    match expected_cluster_size {
+        0 => match mode {
+            DeploymentMode::Standalone => true,
+            DeploymentMode::Pair => role == Some(PairRole::Primary),
+            DeploymentMode::Forming => false,
+            DeploymentMode::Cluster => true,
+            DeploymentMode::DegradedPair | DeploymentMode::DegradedCluster => true,
+        },
+        1 => mode == DeploymentMode::Standalone,
+        2 => mode == DeploymentMode::Pair && role == Some(PairRole::Primary),
+        expected => {
+            mode == DeploymentMode::Cluster && has_raft_leader && committed_voters >= expected
+        }
+    }
 }
 
 impl ModeController {
@@ -642,14 +669,28 @@ impl ModeController {
     /// In pair mode only the primary accepts clients; the secondary exists
     /// solely for replication.  Standalone and cluster nodes always accept.
     pub fn is_cql_ready(&self) -> bool {
-        match self.mode() {
-            DeploymentMode::Standalone => true,
-            DeploymentMode::Pair => self.role() == Some(PairRole::Primary),
-            DeploymentMode::Forming => false, // Not ready until Raft leader elected
-            DeploymentMode::Cluster => true,
-            DeploymentMode::DegradedPair => true, // Stale reads available
-            DeploymentMode::DegradedCluster => true, // Stale reads at CL=ONE
-        }
+        let expected = self.config.expected_cluster_size;
+        let (has_raft_leader, committed_voters) = if expected >= 3 {
+            self.raft()
+                .map(|raft| {
+                    let metrics = raft.metrics().borrow().clone();
+                    (
+                        metrics.current_leader.is_some(),
+                        metrics.membership_config.membership().voter_ids().count(),
+                    )
+                })
+                .unwrap_or((false, 0))
+        } else {
+            (false, 0)
+        };
+
+        declared_topology_is_ready(
+            expected,
+            self.mode(),
+            self.role(),
+            has_raft_leader,
+            committed_voters,
+        )
     }
 
     /// Get local host_id.

--- a/ferrosa-cluster/src/controller/peer_events.rs
+++ b/ferrosa-cluster/src/controller/peer_events.rs
@@ -1,4 +1,11 @@
-//! PeerEventListener and InboundPeerCallback trait implementations.
+//! Peer connection event admission and deployment-mode planning.
+//!
+//! Responsibility: validate peer identity, maintain the bounded connected-peer
+//! set, and translate transport callbacks into serialized mode transitions.
+//! Correctness: the local host is never admitted as its own peer, so self-loop
+//! transports cannot satisfy pair/trio formation thresholds or enter Raft maps.
+//! Last revised: 2026-08-26.
+//! Last changed: reject inbound and outbound self-connections before mutation.
 
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
@@ -244,6 +251,14 @@ impl ModeController {
 impl PeerEventListener for ModeController {
     fn on_peer_connected(&self, peer: PeerId) {
         let (host_id, addr) = peer;
+        if host_id == self.local_host_id {
+            tracing::error!(
+                peer = %host_id,
+                %addr,
+                "rejecting outbound self-connection from cluster formation"
+            );
+            return;
+        }
         tracing::info!(peer = %host_id, %addr, "peer connected");
 
         // Track this peer
@@ -386,6 +401,14 @@ impl InboundPeerCallback for ModeController {
         internode_broadcast: Option<String>,
     ) {
         let (host_id, addr) = peer_id;
+        if host_id == self.local_host_id {
+            tracing::error!(
+                peer = %host_id,
+                %addr,
+                "rejecting inbound self-connection from cluster formation"
+            );
+            return;
+        }
         let reverse_addr = resolve_inbound_reverse_addr(
             addr,
             self.net_config.bind_addr.port(),

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -9,6 +9,7 @@ use crate::write_path::WritePath;
 use ferrosa_net::message::Message;
 use ferrosa_net::rpc::server::RpcServer;
 use ferrosa_net::rpc::{PeerId, RpcHandler};
+use proptest::prelude::*;
 
 fn test_storage(dir: &std::path::Path) -> Arc<StorageEngine> {
     use ferrosa_storage::{CommitLogConfig, CompactionConfig, StorageEngineConfig};
@@ -1812,6 +1813,130 @@ async fn decommission_requires_raft() {
 
 // ---- is_cql_ready tests ------------------------------------------------
 
+/// A transport callback that reports the local host ID is not a peer.
+///
+/// The live RF=3 incident crossed the two-peer formation threshold with one
+/// real connection plus a connection carrying the bootstrapper's own host ID.
+/// Counting self lets a single node enter cluster formation while its two
+/// intended peers remain in independent pair modes.
+#[test]
+fn self_connection_does_not_advance_cluster_formation() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = test_storage(dir.path());
+    let schema = test_schema();
+    let config = Arc::new(ClusterConfig::default());
+    let net_config = Arc::new(NetConfig::default());
+    let local_id = Uuid::from_u128(1);
+
+    let registry = Arc::new(HandlerRegistry::new());
+    let (controller, _handles) = ModeController::new(
+        config,
+        net_config.clone(),
+        local_id,
+        storage,
+        schema,
+        registry,
+    );
+    let pm = Arc::new(PeerManager::new(net_config, local_id, controller.clone()));
+    controller.set_peer_manager(pm);
+
+    controller.on_peer_connected((local_id, "127.0.0.1:7000".parse().unwrap()));
+
+    assert_eq!(
+        controller.mode(),
+        DeploymentMode::Standalone,
+        "a self-connection must not be counted as a peer or trigger pair mode"
+    );
+    assert!(
+        controller.connected_peers.lock().is_empty(),
+        "self must not enter the connected-peer formation set"
+    );
+
+    use ferrosa_net::rpc::InboundPeerCallback;
+    controller.on_inbound_peer((local_id, "127.0.0.1:47000".parse().unwrap()), None, None);
+    assert_eq!(controller.mode(), DeploymentMode::Standalone);
+    assert!(controller.connected_peers.lock().is_empty());
+
+    let real_peer = Uuid::from_u128(2);
+    controller.on_peer_connected((real_peer, "127.0.0.2:7000".parse().unwrap()));
+    controller.on_peer_connected((local_id, "127.0.0.1:7000".parse().unwrap()));
+    assert_eq!(
+        controller.mode(),
+        DeploymentMode::Pair,
+        "one real peer plus self must remain pair, never advance to trio formation"
+    );
+    let peers = controller.connected_peers.lock();
+    assert_eq!(peers.len(), 1);
+    assert_eq!(peers[0].0, real_peer);
+}
+
+/// Explicit cluster-size intent makes pair mode a formation state, not a
+/// healthy deployment mode.
+#[test]
+fn configured_three_node_pair_primary_is_not_cql_ready() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = test_storage(dir.path());
+    let schema = test_schema();
+    let config = Arc::new(ClusterConfig {
+        expected_cluster_size: 3,
+        ..ClusterConfig::default()
+    });
+    let net_config = Arc::new(NetConfig::default());
+    let local_id = Uuid::from_u128(1);
+    let peer_id = Uuid::from_u128(2);
+
+    let registry = Arc::new(HandlerRegistry::new());
+    let (controller, _handles) = ModeController::new(
+        config,
+        net_config.clone(),
+        local_id,
+        storage,
+        schema,
+        registry,
+    );
+    let pm = Arc::new(PeerManager::new(net_config, local_id, controller.clone()));
+    controller.set_peer_manager(pm);
+
+    controller.on_peer_connected((peer_id, "127.0.0.2:7000".parse().unwrap()));
+
+    assert_eq!(controller.mode(), DeploymentMode::Pair);
+    assert_eq!(controller.role(), Some(PairRole::Primary));
+    assert!(
+        !controller.is_cql_ready(),
+        "a configured three-node deployment must not advertise pair-primary CQL readiness"
+    );
+}
+
+proptest! {
+    #[test]
+    fn configured_cluster_readiness_requires_declared_committed_voters(
+        expected in 3usize..=9,
+        committed_voters in 0usize..=12,
+        has_leader in any::<bool>(),
+        mode_index in 0u8..=5,
+    ) {
+        let mode = match mode_index {
+            0 => DeploymentMode::Standalone,
+            1 => DeploymentMode::Pair,
+            2 => DeploymentMode::Forming,
+            3 => DeploymentMode::Cluster,
+            4 => DeploymentMode::DegradedPair,
+            _ => DeploymentMode::DegradedCluster,
+        };
+        let actual = declared_topology_is_ready(
+            expected,
+            mode,
+            Some(PairRole::Primary),
+            has_leader,
+            committed_voters,
+        );
+        let expected_ready = mode == DeploymentMode::Cluster
+            && has_leader
+            && committed_voters >= expected;
+        prop_assert_eq!(actual, expected_ready);
+    }
+}
+
 /// The pair role must be decided by host_id ordering, lowest wins.
 ///
 /// `docker-compose.yml` pins node1 to the lowest `FERROSA_HOST_ID` precisely so
@@ -2875,12 +3000,12 @@ async fn forming_falls_back_to_pair_on_timeout() {
 async fn ddl_during_forming_queues_and_replays() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<u32>();
+    let (tx, rx) = tokio::sync::mpsc::channel::<u32>(4);
     let processed = Arc::new(AtomicUsize::new(0));
 
     // Pre-queue two ops (the steady-state "queued during Forming" case).
-    tx.send(1).unwrap();
-    tx.send(2).unwrap();
+    tx.send(1).await.unwrap();
+    tx.send(2).await.unwrap();
 
     // Inject a third op AFTER the drain has seen the queue go empty, so the
     // test still exercises the cool-down path this helper exists for: a
@@ -2888,7 +3013,7 @@ async fn ddl_during_forming_queues_and_replays() {
     let tx_for_late = tx.clone();
     tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_millis(80)).await;
-        tx_for_late.send(3).unwrap();
+        tx_for_late.send(3).await.unwrap();
     });
 
     // Drop the original tx so the channel becomes Disconnected once
@@ -2919,7 +3044,7 @@ async fn ddl_during_forming_queues_and_replays() {
 /// Sanity test for the empty-channel case.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn drain_ddl_queue_returns_zero_for_empty_channel() {
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<u32>();
+    let (_tx, rx) = tokio::sync::mpsc::channel::<u32>(1);
     let replayed = drain_ddl_queue(rx, |_| async { Ok(()) }).await;
     assert_eq!(replayed, 0);
 }
@@ -3363,6 +3488,27 @@ async fn resetting_a_stranded_node_keeps_its_cluster_membership() {
         std::fs::read(backup.join("db")).unwrap(),
         b"stranded log bytes",
         "the stranded log is the only evidence of how the node got stranded"
+    );
+}
+
+#[test]
+fn resetting_a_stranded_node_rejects_an_oversized_membership_marker() {
+    let dir = tempfile::tempdir().unwrap();
+    let raft_dir = dir.path().join("raft").join("datacenter1");
+    std::fs::create_dir_all(&raft_dir).unwrap();
+    std::fs::write(
+        raft_dir.join(DeploymentMode::CLUSTER_MEMBER_MARKER),
+        vec![b'x'; 4097],
+    )
+    .unwrap();
+    std::fs::write(raft_dir.join("db"), b"must remain untouched").unwrap();
+
+    let error = ModeController::reset_stranded_raft_state(&raft_dir)
+        .expect_err("oversized marker must fail before resetting durable Raft state");
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        raft_dir.join("db").exists(),
+        "validation must happen before the destructive reset"
     );
 }
 

--- a/ferrosa-cluster/src/ddl_path.rs
+++ b/ferrosa-cluster/src/ddl_path.rs
@@ -2,6 +2,12 @@
 //!
 //! Parallels `WritePath` — the CQL router calls `DdlPath::execute()`
 //! for all DDL operations. Swapped atomically via `ArcSwap`.
+//! Responsibility: route each schema mutation through the authority for the
+//! current deployment mode.
+//! Correctness: formation buffering is explicitly bounded and saturated
+//! producers fail immediately; the queue can never become an unbounded heap.
+//! Last revised: 2026-08-26.
+//! Last changed: replace the unbounded formation queue with bounded admission.
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -19,6 +25,13 @@ use crate::error::{ClusterError, Result};
 use crate::pair::ddl::{DdlCoordinator, DdlOperation};
 use crate::raft::{FerrosRaft, RaftCommand, RaftOp};
 use crate::system_table_writer::SystemTableWriter;
+
+/// Maximum schema operations retained while a node is forming a Raft group.
+///
+/// Clients already receive a retriable error in this state. This queue only
+/// bridges operations that raced the path swap, so a small fixed bound is
+/// sufficient and provides deterministic backpressure.
+pub(crate) const FORMING_DDL_QUEUE_CAPACITY: usize = 128;
 
 /// The active DDL path. Swapped atomically via `ArcSwap` when
 /// the deployment mode changes (standalone → pair → cluster).
@@ -52,7 +65,7 @@ pub enum DdlPath {
     /// in `transition_to_cluster`. The client receives a retriable error
     /// so it can retry after formation completes (FMEA F3).
     Forming {
-        queue: tokio::sync::mpsc::UnboundedSender<DdlOperation>,
+        queue: tokio::sync::mpsc::Sender<DdlOperation>,
     },
     /// Degraded: peer lost, DDL rejected until operator promotes.
     Unavailable,
@@ -130,8 +143,21 @@ impl DdlPath {
                 // Still return an error to the client so they know to retry
                 // (the DDL will be applied automatically but the client can't
                 // observe the result until formation completes).
-                if let Err(e) = queue.send(op) {
-                    tracing::error!(%e, "ddl: failed to enqueue DDL operation");
+                match queue.try_send(op) {
+                    Ok(()) => {}
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        return Err(ClusterError::Internal(
+                            "DDL unavailable: cluster formation queue is full — retry shortly"
+                                .into(),
+                        ));
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        tracing::error!("ddl: formation queue closed before path transition");
+                        return Err(ClusterError::Internal(
+                            "DDL unavailable: cluster formation queue closed — retry shortly"
+                                .into(),
+                        ));
+                    }
                 }
                 Err(ClusterError::Internal(
                     "DDL unavailable: cluster formation in progress, will be applied after leader election — retry shortly".into(),
@@ -161,18 +187,13 @@ fn apply_direct(op: &DdlOperation, schema: &Schema, engine: &Arc<StorageEngine>)
         }
         DdlOperation::DropKeyspace(name) => {
             let snap = schema.snapshot();
-            let table_ids: Vec<_> = snap
-                .tables
-                .keys()
-                .filter(|(ks, _)| ks == name)
-                .map(|(ks, tbl)| ferrosa_storage::TableId::new(ks, tbl))
-                .collect();
             schema
                 .drop_keyspace_internal(name)
                 .map_err(|e| ClusterError::Internal(format!("drop_keyspace: {e}")))?;
-            for tid in &table_ids {
+            for (keyspace, table) in snap.tables.keys().filter(|(keyspace, _)| keyspace == name) {
+                let tid = ferrosa_storage::TableId::new(keyspace, table);
                 engine
-                    .unregister_table(tid)
+                    .unregister_table(&tid)
                     .map_err(ClusterError::Storage)?;
             }
         }
@@ -620,14 +641,14 @@ async fn wait_for_replication_to_catch_up(raft: &FerrosRaft, committed_index: u6
     loop {
         let metrics = raft.metrics().borrow().clone();
         let local_id = metrics.id;
-        let voters: Vec<u64> = metrics
+        let remote_voter_count = metrics
             .membership_config
             .membership()
             .voter_ids()
             .filter(|id| *id != local_id)
-            .collect();
+            .count();
         // Single-node clusters have no followers to wait on.
-        if voters.is_empty() {
+        if remote_voter_count == 0 {
             break;
         }
         let replication = match &metrics.replication {
@@ -637,32 +658,43 @@ async fn wait_for_replication_to_catch_up(raft: &FerrosRaft, committed_index: u6
             // the caller doesn't immediately race the followers.
             None => break,
         };
-        let everyone_caught_up = voters.iter().all(|voter_id| {
-            replication
-                .get(voter_id)
-                .and_then(|matched| matched.as_ref().map(|lid| lid.index))
-                .is_some_and(|matched_index| matched_index >= committed_index)
-        });
+        let everyone_caught_up = metrics
+            .membership_config
+            .membership()
+            .voter_ids()
+            .filter(|voter_id| *voter_id != local_id)
+            .all(|voter_id| {
+                replication
+                    .get(&voter_id)
+                    .and_then(|matched| matched.as_ref().map(|lid| lid.index))
+                    .is_some_and(|matched_index| matched_index >= committed_index)
+            });
         if everyone_caught_up {
             break;
         }
         if tokio::time::Instant::now() >= deadline {
             // Log so an operator can correlate a downstream "schema still
             // propagating"-style write failure with a slow follower.
-            let lag: Vec<(u64, u64)> = voters
-                .iter()
+            let (lagging_voters, max_lag) = metrics
+                .membership_config
+                .membership()
+                .voter_ids()
+                .filter(|voter_id| *voter_id != local_id)
                 .map(|voter_id| {
                     let matched = replication
-                        .get(voter_id)
+                        .get(&voter_id)
                         .and_then(|m| m.as_ref().map(|lid| lid.index))
                         .unwrap_or(0);
-                    (*voter_id, committed_index.saturating_sub(matched))
+                    committed_index.saturating_sub(matched)
                 })
-                .filter(|(_, lag)| *lag > 0)
-                .collect();
+                .filter(|lag| *lag > 0)
+                .fold((0usize, 0u64), |(count, max_lag), lag| {
+                    (count + 1, max_lag.max(lag))
+                });
             tracing::warn!(
                 committed_index,
-                ?lag,
+                lagging_voters,
+                max_lag,
                 "ddl_agreement: timed out waiting for all voters to replicate the DDL log entry; \
                  a follower may serve a stale TableSchema for a brief window"
             );
@@ -1574,7 +1606,7 @@ mod tests {
     /// We verify the message-type guard in the handler at the codec level.
     #[tokio::test]
     async fn test_forming_ddl_path_queues_and_returns_error() {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let ddl = DdlPath::Forming { queue: tx };
         let op = DdlOperation::CreateKeyspace(simple_keyspace("should_queue"));
         let err = ddl.execute(op).await.unwrap_err();
@@ -1589,6 +1621,30 @@ mod tests {
             DdlOperation::CreateKeyspace(ks) => assert_eq!(ks.name, "should_queue"),
             other => panic!("expected CreateKeyspace, got: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn forming_ddl_path_fails_fast_when_bounded_queue_is_full() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let ddl = DdlPath::Forming { queue: tx };
+
+        let first = DdlOperation::CreateKeyspace(simple_keyspace("first"));
+        let first_err = ddl.execute(first).await.unwrap_err();
+        assert!(first_err.to_string().contains("formation in progress"));
+
+        let second = DdlOperation::CreateKeyspace(simple_keyspace("second"));
+        let second_err = ddl.execute(second).await.unwrap_err();
+        assert!(
+            second_err.to_string().contains("queue is full"),
+            "a saturated formation queue must fail immediately: {second_err}"
+        );
+
+        let queued = rx.try_recv().expect("first operation remains queued");
+        assert!(matches!(queued, DdlOperation::CreateKeyspace(_)));
+        assert!(
+            rx.try_recv().is_err(),
+            "bounded capacity must prevent a second queued operation"
+        );
     }
 
     #[test]

--- a/ferrosa-graph/tests/adjacency_replication.rs
+++ b/ferrosa-graph/tests/adjacency_replication.rs
@@ -387,7 +387,7 @@ async fn cluster_graph_schema_coordinator_follows_ddl_path_transitions() {
     // Standalone → Forming. The orchestrator swaps the path during
     // cluster formation; in-flight graph DDL gets a retriable error
     // (the operation is queued for replay after election).
-    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
     ddl_swap.store(Arc::new(DdlPath::Forming { queue: tx }));
     let res = coordinator
         .apply_create_keyspace(KeyspaceMetadata {

--- a/ferrosa-net/src/peer.rs
+++ b/ferrosa-net/src/peer.rs
@@ -1,3 +1,12 @@
+//! Bounded internode peer ownership and liveness management.
+//!
+//! Responsibility: own one connection pool per remote host, publish peer
+//! metadata, and notify cluster formation of validated transport events.
+//! Correctness: the local host is rejected before dialing, metadata mutation,
+//! peer-map insertion, or listener callbacks.
+//! Last revised: 2026-08-26.
+//! Last changed: enforce self-peer rejection at the network admission boundary.
+
 use std::collections::HashMap;
 use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
@@ -26,7 +35,6 @@ pub trait PeerEventListener: Send + Sync {
 /// Manages all peer connections and runs failure detection.
 pub struct PeerManager {
     config: Arc<NetConfig>,
-    #[allow(dead_code)]
     local_host_id: uuid::Uuid,
     peers: RwLock<HashMap<uuid::Uuid, Arc<PeerState>>>,
     listener: Arc<dyn PeerEventListener>,
@@ -129,6 +137,14 @@ impl PeerManager {
     /// it is stored for system.peers.native_address lookups.
     pub async fn add_peer(&self, peer_id: PeerId, pool: PriorityPool) {
         let (host_id, _addr) = peer_id;
+        if host_id == self.local_host_id {
+            tracing::error!(
+                peer = %host_id,
+                "rejecting self before network peer admission"
+            );
+            pool.shutdown().await;
+            return;
+        }
         // Extract the peer's CQL broadcast from the handshake before wrapping in Arc.
         if let Some(broadcast) = pool.peer_cql_broadcast() {
             self.peer_cql_broadcasts
@@ -192,6 +208,11 @@ impl PeerManager {
     /// Uses the provided address string (IP:port or resolvable hostname:port)
     /// to establish the pool if one is not already present.
     pub async fn ensure_peer(&self, host_id: uuid::Uuid, addr: &str) -> crate::error::Result<()> {
+        if host_id == self.local_host_id {
+            return Err(crate::error::NetError::Protocol(format!(
+                "refusing to connect local host_id {host_id} as a peer"
+            )));
+        }
         let resolved = addr
             .to_socket_addrs()
             .map_err(|e| {
@@ -230,6 +251,13 @@ impl PeerManager {
     /// Add a peer entry without a connection pool (for unit testing).
     pub async fn add_peer_entry(&self, peer_id: PeerId) {
         let (host_id, _addr) = peer_id;
+        if host_id == self.local_host_id {
+            tracing::error!(
+                peer = %host_id,
+                "rejecting self before network peer-entry admission"
+            );
+            return;
+        }
         let state = Arc::new(PeerState::new(peer_id, None, self.now_ms()));
         self.peers.write().await.insert(host_id, state);
         self.listener.on_peer_connected(peer_id);
@@ -565,6 +593,32 @@ mod tests {
         pm.add_peer_entry(peer_id).await;
 
         assert_eq!(listener.connected_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn self_peer_is_rejected_before_network_tracking_or_callback() {
+        let config = Arc::new(NetConfig::default());
+        let listener = Arc::new(TestListener::new());
+        let local_host_id = uuid::Uuid::new_v4();
+        let pm = PeerManager::new(config, local_host_id, listener.clone());
+
+        pm.add_peer_entry((local_host_id, "127.0.0.1:7000".parse().unwrap()))
+            .await;
+
+        assert!(
+            !pm.has_peer(local_host_id),
+            "self must not enter the network peer map"
+        );
+        assert_eq!(
+            listener.connected_count.load(Ordering::Relaxed),
+            0,
+            "self rejection must happen before the formation callback"
+        );
+        assert!(pm.get_peer_cql_broadcast(local_host_id).await.is_none());
+        assert!(pm
+            .get_peer_internode_broadcast(local_host_id)
+            .await
+            .is_none());
     }
 
     #[tokio::test(start_paused = true)]

--- a/specs/implemented/bug-rf3-pair-mode-formation.md
+++ b/specs/implemented/bug-rf3-pair-mode-formation.md
@@ -1,0 +1,42 @@
+# RF=3 formation must not degrade silently to pair mode
+
+**Severity:** P0 durability and availability
+**Forge tasks:** `t_9bd0c95c`, `t_891840e7`, `t_05acdc8a`
+**Last revised:** 2026-08-26
+
+## Failure
+
+The seedless bootstrapper accepted a transport callback carrying its own host
+ID. One real peer plus self satisfied the two-peer threshold, so that node
+entered Raft formation while the two spokes remained independent pairs. A pair
+primary could advertise CQL readiness even though the deployment was intended
+to contain three Raft voters.
+
+## Contract
+
+- Inbound and outbound self-connections are rejected before they mutate peer
+  tracking, Raft routing, or deployment mode.
+- Operators set `FERROSA_EXPECTED_CLUSTER_SIZE=3` for the three-node native
+  cluster. An explicit size fails readiness closed:
+  - `1` requires standalone mode;
+  - `2` requires pair-primary mode;
+  - `3+` requires cluster mode, a current Raft leader, and at least that many
+    committed voters.
+- Automatic standalone/pair behavior remains available only when the variable
+  is unset.
+- Formation DDL buffering is a fixed-capacity queue. Saturation returns a
+  retriable error immediately instead of growing memory.
+- Cluster-member marker recovery reads at most 4 KiB and restores through
+  stage, fsync, length verification, and atomic rename.
+
+## Regression evidence
+
+- `self_connection_does_not_advance_cluster_formation`
+- `configured_three_node_pair_primary_is_not_cql_ready`
+- `configured_cluster_readiness_requires_declared_committed_voters`
+- `forming_ddl_path_fails_fast_when_bounded_queue_is_full`
+- `ddl_during_forming_queues_and_replays`
+- `resetting_a_stranded_node_rejects_an_oversized_membership_marker`
+
+The changed production files must report zero findings from
+`frg materialization-scan`.

--- a/specs/reference/components.md
+++ b/specs/reference/components.md
@@ -411,7 +411,7 @@ graph BT
   - `coordinator/read.rs` — Read fan-out with local-replica optimization
   - `consistency.rs` — `ConsistencyLevel` with `blockFor()` + property tests
   - `state.rs` — `RaftClusterState` with `BroadcastResolver` trait for decoupled CQL broadcast resolution (ring → PeerManager → internode fallback), `system.peers` native_address/tokens population
-  - `config.rs` — `ClusterConfig` with `cql_broadcast: Option<String>` (`FERROSA_CQL_BROADCAST`), `formation_timeout_secs`, `auto_join`, `node_role`, tunable Raft timing (`FERROSA_RAFT_HEARTBEAT_MS`, `FERROSA_RAFT_ELECTION_MIN_MS`, `FERROSA_RAFT_ELECTION_MAX_MS`)
+  - `config.rs` — `ClusterConfig` with `cql_broadcast: Option<String>` (`FERROSA_CQL_BROADCAST`), `formation_timeout_secs`, explicit fail-closed topology intent (`FERROSA_EXPECTED_CLUSTER_SIZE`), `auto_join`, `node_role`, tunable Raft timing (`FERROSA_RAFT_HEARTBEAT_MS`, `FERROSA_RAFT_ELECTION_MIN_MS`, `FERROSA_RAFT_ELECTION_MAX_MS`)
   - `error.rs`, `mode.rs`
   - `telemetry/layer.rs` — `FerrosaTelemetryLayer` (`tracing::Layer` impl), head-based coherent sampling, bounded mpsc try_send, drop counter
   - `telemetry/writer.rs` — `TelemetryWriter` background task, batched direct writes to `StorageEngine::write_observability()` (bypasses CQL), cancel-safe via `CancellationToken`


### PR DESCRIPTION
## Executive Summary

- Prevent an RF=3 deployment from advertising healthy CQL service while it is only a pair or has incomplete committed Raft membership.
- Reject self-peers before dialing, transport metadata mutation, peer tracking, or formation callbacks.
- Bound formation DDL buffering and cluster-member marker recovery so bootstrap cannot grow memory or materialize unbounded input.

## Correctness Contract

- `FERROSA_EXPECTED_CLUSTER_SIZE=3` requires cluster mode, a current Raft leader, and at least three committed voters before CQL readiness succeeds.
- Invalid explicit cluster-size configuration fails readiness closed.
- Automatic standalone/pair behavior remains backward-compatible only when expected size is unset.
- Self-connections are rejected at the network boundary, with controller checks retained as defense in depth.
- Formation DDL uses a fixed capacity of 128 and returns an immediate retriable error on saturation or closure.
- The cluster-member marker is capped at 4 KiB and restored by stage, flush, fsync, length verification, atomic rename, and directory fsync.

## TDD Evidence

- RED reproduced self-admission advancing formation and configured RF3 pair-primary readiness.
- Property coverage proves declared sizes 3 through 9 require cluster mode, a leader, and enough committed voters.
- Saturated DDL admission fails immediately while the accepted operation remains queued for replay.
- Oversized membership markers fail before destructive Raft reset.
- Independent verification passed the complete final diff, including network admission and graph integration fixture coverage.

## Streaming and Non-Materialization

- Replaced the unbounded formation channel with bounded admission and `try_send` backpressure.
- Removed eager temporary collections from DDL table cleanup and voter-lag inspection.
- Replaced whole-file marker reads with a fixed 4 KiB buffer.
- Forge materialization scan: 6 changed production files, 0 findings.

## Verification

- `cargo test -p ferrosa-net --lib`: 154 passed.
- `cargo test -p ferrosa-cluster --lib`: 1,132 passed.
- `cargo test -p ferrosa-cluster --test cluster_formation`: 4 passed.
- `cargo test -p ferrosa-graph --test adjacency_replication`: 2 passed.
- Exact all-features workspace CI gate: 6,793 passed, 0 failed, 1 skipped.
- `cargo clippy --all-targets -- -D warnings`: passed.
- CI unbounded-read guard and AST P0 OOM audit: passed.
- Workspace documentation with warnings denied: passed.
- Corrected repository pre-push hook stage: passed.

## Related Work

- Forge task `t_9bd0c95c`
- Related incident/task context: `t_891840e7`, `t_05acdc8a`

Live deployment is intentionally deferred until every correctness PR in the rollout checklist is merged; the final rollout requires smoke tests and a 15-minute all-node window with zero WARN, ERROR, PANIC, or FATAL log events.
