### PR TITLE
fix(raft): supervise fatal consensus failures

### DIFF
--- a/ferrosa-cluster/src/consensus_health.rs
+++ b/ferrosa-cluster/src/consensus_health.rs
@@ -1,0 +1,155 @@
+//! Module: process-wide consensus health gate.
+//! Responsibility: retain the first fatal consensus diagnostic and make the
+//! failed state synchronously visible to readiness and CQL admission.
+//! Correctness: failure is monotonic, diagnostics are fixed-capacity, and no
+//! failure path waits on the failed Raft runtime.
+//! Last revised: 2026-08-27
+//! Last changed: Added bounded supervision for Raft panic and fatal states.
+
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+/// Maximum retained diagnostic bytes. The public health/CQL responses never
+/// expose this text; it exists solely for bounded operator logging.
+pub const CONSENSUS_DIAGNOSTIC_CAPACITY: usize = 1024;
+
+#[derive(Debug)]
+struct BoundedDiagnostic {
+    bytes: [u8; CONSENSUS_DIAGNOSTIC_CAPACITY],
+    len: usize,
+}
+
+impl BoundedDiagnostic {
+    fn from_args(args: fmt::Arguments<'_>) -> Self {
+        let mut diagnostic = Self {
+            bytes: [0; CONSENSUS_DIAGNOSTIC_CAPACITY],
+            len: 0,
+        };
+        let _ = fmt::write(&mut diagnostic, args);
+        diagnostic
+    }
+
+    fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.bytes[..self.len])
+            .expect("BoundedDiagnostic only accepts UTF-8 string fragments")
+    }
+}
+
+impl fmt::Write for BoundedDiagnostic {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        let available = CONSENSUS_DIAGNOSTIC_CAPACITY.saturating_sub(self.len);
+        if available == 0 {
+            return Err(fmt::Error);
+        }
+
+        let mut take = available.min(value.len());
+        while take > 0 && !value.is_char_boundary(take) {
+            take -= 1;
+        }
+        self.bytes[self.len..self.len + take].copy_from_slice(&value.as_bytes()[..take]);
+        self.len += take;
+
+        if take == value.len() {
+            Ok(())
+        } else {
+            Err(fmt::Error)
+        }
+    }
+}
+
+/// First fatal consensus failure retained for operator diagnostics.
+#[derive(Debug)]
+pub struct ConsensusFailure {
+    kind: &'static str,
+    detail: BoundedDiagnostic,
+}
+
+impl ConsensusFailure {
+    /// Stable failure category suitable for metrics and logs.
+    pub fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// Bounded internal detail. Never return this text to clients.
+    pub fn detail(&self) -> &str {
+        self.detail.as_str()
+    }
+}
+
+/// Monotonic shared health state for the process's consensus lane.
+#[derive(Debug, Default)]
+pub struct ConsensusHealth {
+    failed: AtomicBool,
+    failure_count: AtomicU64,
+    first_failure: OnceLock<ConsensusFailure>,
+}
+
+impl ConsensusHealth {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a fatal condition without allocating from its diagnostic size.
+    /// The first detail is retained; later failures only increment the counter.
+    /// Returns `true` only to the caller that installed the first failure, which
+    /// grants ownership of the single operator-facing FATAL emission.
+    pub fn fail(&self, kind: &'static str, detail: fmt::Arguments<'_>) -> bool {
+        let _ = self
+            .failure_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                Some(count.saturating_add(1))
+            });
+        let first = self
+            .first_failure
+            .set(ConsensusFailure {
+                kind,
+                detail: BoundedDiagnostic::from_args(detail),
+            })
+            .is_ok();
+        self.failed.store(true, Ordering::Release);
+        first
+    }
+
+    pub fn is_healthy(&self) -> bool {
+        !self.failed.load(Ordering::Acquire)
+    }
+
+    pub fn failure(&self) -> Option<&ConsensusFailure> {
+        self.first_failure.get()
+    }
+
+    pub fn failure_count(&self) -> u64 {
+        self.failure_count.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostic_is_utf8_safe_and_fixed_capacity() {
+        let health = ConsensusHealth::new();
+        let oversized = "🦀".repeat(CONSENSUS_DIAGNOSTIC_CAPACITY);
+        assert!(health.fail("test", format_args!("{oversized}")));
+
+        let detail = health.failure().unwrap().detail();
+        assert!(detail.len() <= CONSENSUS_DIAGNOSTIC_CAPACITY);
+        assert!(std::str::from_utf8(detail.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn first_failure_is_stable_and_count_is_monotonic() {
+        let health = ConsensusHealth::new();
+        assert!(health.fail("first", format_args!("one")));
+        for attempt in 0..10_000 {
+            assert!(!health.fail("repeat", format_args!("failure {attempt}")));
+        }
+
+        assert!(!health.is_healthy());
+        assert_eq!(health.failure_count(), 10_001);
+        assert_eq!(health.failure().unwrap().kind(), "first");
+        assert_eq!(health.failure().unwrap().detail(), "one");
+    }
+}

--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -3,9 +3,11 @@
 //! Responsibility: construct the Raft/ring/write-path stack and publish it in
 //! formation order while preserving queued schema mutations.
 //! Correctness: formation work is bounded, cancel-aware, and never advertises
-//! durable topology before the relevant consensus state exists.
-//! Last revised: 2026-08-26.
-//! Last changed: bound the transient DDL replay queue.
+//! durable topology before the relevant consensus state exists; Raft fatal
+//! metrics are supervised by the shared fail-closed health gate.
+//! Last revised: 2026-08-27
+//! Last changed: Combined bounded formation/DDL replay with fatal Raft metrics
+//! supervision.
 
 use std::io::{Read, Write};
 use std::net::SocketAddr;
@@ -1657,6 +1659,7 @@ impl ModeController {
         }
 
         let bootstrap_complete_counter = bootstrap_complete_count;
+        let consensus_health = self.consensus_health();
         self.spawn_tracked(async move {
             // Deliver ClusterInvite to all peers BEFORE starting Raft.
             // This ensures peers transition to cluster mode and register
@@ -1933,9 +1936,15 @@ impl ModeController {
                 use crate::raft::consensus_metrics::run_consensus_metrics_poller;
                 let metrics_raft = raft_arc.clone();
                 let metrics_cancel = election_guard_cancel.clone();
+                let metrics_health = consensus_health.clone();
                 ferrosa_net::task_pool::TaskPool::current("raft-consensus-metrics").spawn(
                     async move {
-                        run_consensus_metrics_poller(metrics_raft, metrics_cancel).await;
+                        run_consensus_metrics_poller(
+                            metrics_raft,
+                            metrics_cancel,
+                            metrics_health,
+                        )
+                        .await;
                     },
                 );
             }

--- a/ferrosa-cluster/src/controller/mod.rs
+++ b/ferrosa-cluster/src/controller/mod.rs
@@ -6,9 +6,12 @@
 //! Responsibility: serialize topology transitions and expose health/readiness
 //! that matches the active write and consensus paths.
 //! Correctness: explicit cluster-size intent fails closed until the matching
-//! standalone, pair, or committed Raft membership is observable.
-//! Last revised: 2026-08-26.
-//! Last changed: gate CQL readiness on declared topology and committed voters.
+//! standalone, pair, or committed Raft membership is observable; fatal
+//! consensus state additionally closes data readiness without disabling native
+//! protocol diagnostics.
+//! Last revised: 2026-08-27
+//! Last changed: Combined declared-topology readiness with bounded consensus
+//! supervision and protocol-responsive fail-closed admission.
 //!
 //! Failover lifecycle:
 //!   1. Pair mode active, both nodes connected
@@ -69,6 +72,7 @@ use ferrosa_schema::Schema;
 use ferrosa_storage::engine::StorageEngine;
 
 use crate::config::ClusterConfig;
+use crate::consensus_health::ConsensusHealth;
 use crate::ddl_path::DdlPath;
 use crate::hints::{HintConfig, HintStore};
 use crate::mode::DeploymentMode;
@@ -156,6 +160,9 @@ impl Default for ContentionMetrics {
 /// Created at startup with standalone mode. When peers connect/disconnect,
 /// transitions the mode and atomically swaps the write path and cluster state.
 pub struct ModeController {
+    /// Monotonic process-wide consensus health, read synchronously by CQL and
+    /// readiness so neither path waits on a failed Raft runtime.
+    pub(super) consensus_health: Arc<ConsensusHealth>,
     pub(super) mode: Arc<ArcSwap<DeploymentMode>>,
     pub(super) write_path: Arc<ArcSwap<WritePath>>,
     pub(super) cluster_state: Arc<ArcSwap<ClusterStateHolder>>,
@@ -393,6 +400,7 @@ impl ModeController {
         }
 
         let controller = Arc::new(Self {
+            consensus_health: Arc::new(ConsensusHealth::new()),
             mode: Arc::new(ArcSwap::from_pointee(initial_mode)),
             write_path: write_path.clone(),
             cluster_state: cluster_state.clone(),
@@ -505,6 +513,7 @@ impl ModeController {
         let hint_store = Arc::new(HintStore::new(hint_config.clone()).expect("test hint store"));
 
         Arc::new(Self {
+            consensus_health: Arc::new(ConsensusHealth::new()),
             mode: Arc::new(ArcSwap::from_pointee(DeploymentMode::Standalone)),
             write_path,
             cluster_state,
@@ -568,6 +577,7 @@ impl ModeController {
         };
 
         Arc::new(Self {
+            consensus_health: Arc::new(ConsensusHealth::new()),
             mode: Arc::new(ArcSwap::from_pointee(DeploymentMode::Pair)),
             write_path,
             cluster_state,
@@ -669,6 +679,16 @@ impl ModeController {
     /// In pair mode only the primary accepts clients; the secondary exists
     /// solely for replication.  Standalone and cluster nodes always accept.
     pub fn is_cql_ready(&self) -> bool {
+        if !self.consensus_health.is_healthy() {
+            return false;
+        }
+        self.accepts_cql_connections()
+    }
+
+    /// Whether declared deployment state permits a native-protocol connection.
+    /// Consensus health is intentionally excluded: a failed node must still
+    /// answer OPTIONS/STARTUP and return typed errors for data opcodes.
+    pub fn accepts_cql_connections(&self) -> bool {
         let expected = self.config.expected_cluster_size;
         let (has_raft_leader, committed_voters) = if expected >= 3 {
             self.raft()
@@ -691,6 +711,16 @@ impl ModeController {
             has_raft_leader,
             committed_voters,
         )
+    }
+
+    /// Shared, monotonic health gate for the process's consensus lane.
+    pub fn consensus_health(&self) -> Arc<ConsensusHealth> {
+        self.consensus_health.clone()
+    }
+
+    /// Synchronous fast path used by readiness and CQL dispatch.
+    pub fn consensus_is_healthy(&self) -> bool {
+        self.consensus_health.is_healthy()
     }
 
     /// Get local host_id.

--- a/ferrosa-cluster/src/lib.rs
+++ b/ferrosa-cluster/src/lib.rs
@@ -1,5 +1,11 @@
+//! Ferrosa cluster coordination, replication, consistency, and health gates.
+//! Correctness: exported controllers fail closed when consensus is unavailable.
+//! Last revised: 2026-08-27
+//! Last changed: Exported bounded consensus health supervision.
+
 pub mod accord;
 pub mod config;
+pub mod consensus_health;
 pub mod consistency;
 pub mod controller;
 pub mod coordinator;
@@ -23,6 +29,7 @@ pub mod telemetry;
 pub mod write_path;
 
 pub use config::{ClusterConfig, PerDcOverride};
+pub use consensus_health::{ConsensusFailure, ConsensusHealth, CONSENSUS_DIAGNOSTIC_CAPACITY};
 pub use consistency::ConsistencyLevel;
 pub use controller::{
     bootstrap_silent_failure_counts, cluster_rejoin_attempts_total, cluster_rejoin_failures_total,

--- a/ferrosa-cluster/src/raft/consensus_metrics.rs
+++ b/ferrosa-cluster/src/raft/consensus_metrics.rs
@@ -4,13 +4,9 @@
 //!   text-exposition format, and `run_consensus_metrics_poller` publishes the
 //!   term/leadership derived from `raft.current_leader()` (the same source
 //!   `/readyz` trusts), not the raw `metrics().state` snapshot.
-//! Last revised: 2026-07-22
-//! Last changed: Re-added the current-term / is-leader / has-leader gauges,
-//!   now fed by a DEDICATED poller (`run_consensus_metrics_poller`) that derives
-//!   leadership from `current_leader()`. The earlier attempt published from the
-//!   election-guard poll using `state == Leader`, which read 0 even for a ready
-//!   leader (t_310ad227). The poller is its own task — not the guard — so the
-//!   metric surface does not depend on the ADR-012-deprecated guard.
+//! Last revised: 2026-08-27
+//! Last changed: The dedicated poller now watches OpenRaft metrics changes and
+//!   publishes Fatal/channel-closed state before any leader query.
 //!
 //! # Why `current_leader()` not `metrics().state`
 //!
@@ -36,6 +32,16 @@ static RAFT_HAS_LEADER: AtomicU64 = AtomicU64::new(0);
 
 /// How often the poller samples leadership.
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+fn record_fatal_state<E: std::fmt::Display>(
+    health: &crate::consensus_health::ConsensusHealth,
+    running_state: &Result<(), E>,
+) -> Option<bool> {
+    let Err(fatal) = running_state else {
+        return None;
+    };
+    Some(health.fail("openraft-fatal", format_args!("{fatal}")))
+}
 
 /// Publish the latest Raft liveness sample. Cheap; `Relaxed` because each field
 /// is an independent last-writer-wins sample.
@@ -72,19 +78,54 @@ pub fn is_self_leader(current_leader: Option<u64>, my_id: u64) -> bool {
 ///
 /// Leadership comes from `current_leader()` (the reliable `/readyz` source);
 /// the term comes from the metrics snapshot.
-pub async fn run_consensus_metrics_poller<C>(raft: Arc<Raft<C>>, cancel: CancellationToken)
-where
+pub async fn run_consensus_metrics_poller<C>(
+    raft: Arc<Raft<C>>,
+    cancel: CancellationToken,
+    health: Arc<crate::consensus_health::ConsensusHealth>,
+) where
     C: RaftTypeConfig<NodeId = u64>,
 {
+    let mut metrics_rx = raft.metrics();
     loop {
-        tokio::select! {
-            _ = cancel.cancelled() => return,
-            _ = tokio::time::sleep(POLL_INTERVAL) => {}
+        let metrics = metrics_rx.borrow().clone();
+        if let Some(first_failure) = record_fatal_state(&health, &metrics.running_state) {
+            let fatal = metrics
+                .running_state
+                .as_ref()
+                .expect_err("record_fatal_state only succeeds for Err");
+            if first_failure {
+                tracing::error!(
+                    error = %fatal,
+                    "FATAL: OpenRaft stopped; readiness and CQL data operations are disabled"
+                );
+            }
+            return;
         }
         let leader = raft.current_leader().await;
-        let metrics = raft.metrics().borrow().clone();
         let is_leader = is_self_leader(leader, metrics.id);
         record_raft_state(metrics.current_term, is_leader, leader.is_some());
+
+        tokio::select! {
+            _ = cancel.cancelled() => return,
+            changed = metrics_rx.changed() => {
+                if changed.is_err() {
+                    if cancel.is_cancelled() {
+                        return;
+                    }
+                    let first_failure = health.fail(
+                        "openraft-metrics-closed",
+                        format_args!("OpenRaft metrics channel closed without a healthy shutdown signal"),
+                    );
+                    if first_failure {
+                        tracing::error!(
+                            "FATAL: OpenRaft metrics channel closed; readiness and CQL data operations are disabled"
+                        );
+                    }
+                    return;
+                }
+            }
+            _ = tokio::time::sleep(POLL_INTERVAL) => {}
+        }
     }
 }
 
@@ -131,6 +172,24 @@ fn format_metrics(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn openraft_fatal_state_closes_health_without_panicking() {
+        let health = crate::consensus_health::ConsensusHealth::new();
+        assert_eq!(
+            record_fatal_state(&health, &Err::<(), _>("storage apply failed")),
+            Some(true)
+        );
+        assert_eq!(
+            record_fatal_state(&health, &Err::<(), _>("second source")),
+            Some(false),
+            "only the first fatal source owns operator output"
+        );
+        assert!(!health.is_healthy());
+        assert_eq!(health.failure().unwrap().kind(), "openraft-fatal");
+        assert_eq!(health.failure().unwrap().detail(), "storage apply failed");
+        assert_eq!(health.failure_count(), 2);
+    }
 
     #[test]
     fn is_self_leader_matches_only_own_id() {

--- a/ferrosa-cluster/src/raft/log_store.rs
+++ b/ferrosa-cluster/src/raft/log_store.rs
@@ -9,6 +9,11 @@
 //!   ordered iteration yields entries in index order.
 //! - **`meta`** — small metadata values: `vote`, `committed`, and
 //!   `last_purged`.
+//!
+//! Correctness: reversed apply ranges fail before an empty materialization can
+//! reach OpenRaft; valid ranges preserve ordered, bounded-by-request reads.
+//! Last revised: 2026-08-27
+//! Last changed: Rejected reversed Raft log ranges at the storage boundary.
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -936,6 +941,23 @@ impl RaftLogReader<FerrosRaftConfig> for SledLogStore {
         &mut self,
         range: RB,
     ) -> Result<Vec<Entry<FerrosRaftConfig>>, StorageError<u64>> {
+        let raw_start = match range.start_bound() {
+            std::ops::Bound::Included(&idx) | std::ops::Bound::Excluded(&idx) => Some(idx),
+            std::ops::Bound::Unbounded => None,
+        };
+        let raw_end = match range.end_bound() {
+            std::ops::Bound::Included(&idx) | std::ops::Bound::Excluded(&idx) => Some(idx),
+            std::ops::Bound::Unbounded => None,
+        };
+        if let (Some(start), Some(end)) = (raw_start, raw_end) {
+            if start > end {
+                let error = std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("reversed Raft log range: start={start}, end={end}"),
+                );
+                return Err(StorageIOError::read_logs(to_any_error(error)).into());
+            }
+        }
         let start_bytes = match range.start_bound() {
             std::ops::Bound::Included(&idx) => std::ops::Bound::Included(Self::index_key(idx)),
             std::ops::Bound::Excluded(&idx) => std::ops::Bound::Excluded(Self::index_key(idx)),
@@ -1759,6 +1781,27 @@ mod tests {
         // Range that doesn't match any entries
         let entries = store.try_get_log_entries(10u64..20u64).await.unwrap();
         assert!(entries.is_empty());
+    }
+
+    /// Regression for the live `raft_core.rs:769` panic: openraft asked for a
+    /// reversed apply window, the store returned an empty `Vec`, and openraft
+    /// indexed `entries[len - 1]` (`usize::MAX`). The storage boundary must
+    /// reject a reversed range loudly while preserving ordinary empty ranges.
+    #[tokio::test]
+    #[allow(clippy::reversed_empty_ranges)] // The invalid range is the regression input.
+    async fn try_get_log_entries_reversed_range_fails_loud() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = SledLogStore::new(dir.path()).unwrap();
+
+        let err = store
+            .try_get_log_entries(9u64..4u64)
+            .await
+            .expect_err("a reversed apply range must never look like a valid empty read");
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("reversed Raft log range"), "{rendered}");
+        assert!(rendered.contains("start=9"), "{rendered}");
+        assert!(rendered.contains("end=4"), "{rendered}");
     }
 
     #[tokio::test]

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -1,8 +1,8 @@
 //! Module: Per-connection CQL native-protocol handler.
 //! Correctness: Correct when protocol state transitions, prepared metadata, and bound-value
 //! substitution preserve the CQL wire contract for every accepted opcode.
-//! Last revised: 2026-08-24
-//! Last changed: Expanded compound WHERE tuple bind markers in clustering-column order.
+//! Last revised: 2026-08-27
+//! Last changed: Fail data-bearing opcodes immediately after consensus failure.
 //!
 //! Per-connection CQL protocol handler.
 //!
@@ -52,6 +52,21 @@ use futures::SinkExt;
 
 /// Idle timeout: drop connection if no complete frame arrives within this duration (M11).
 const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+const CONSENSUS_UNAVAILABLE_MESSAGE: &str =
+    "node unavailable: consensus runtime failed; retry another node";
+
+fn consensus_gate_error(consensus_healthy: bool, opcode: Opcode) -> Option<CqlError> {
+    if consensus_healthy
+        || !matches!(
+            opcode,
+            Opcode::Query | Opcode::Prepare | Opcode::Execute | Opcode::Batch
+        )
+    {
+        return None;
+    }
+    Some(CqlError::Overloaded(CONSENSUS_UNAVAILABLE_MESSAGE.into()))
+}
 
 fn build_event_frame(event: CqlEvent, response_version: u8) -> CqlFrame {
     let protocol_version = response_version & 0x7F;
@@ -467,6 +482,28 @@ pub(crate) async fn handle_connection<S>(
             }
             FrameOrPush::ClientFrame(maybe_frame) => {
                 let stream_id = maybe_frame.header.stream_id;
+
+                if matches!(phase, ConnectionPhase::Ready) {
+                    if let Some(err) = consensus_gate_error(
+                        state.mode_controller.consensus_is_healthy(),
+                        maybe_frame.header.opcode,
+                    ) {
+                        let frame = CqlFrame {
+                            header: FrameHeader {
+                                version: response_version,
+                                flags: 0,
+                                stream_id,
+                                opcode: Opcode::Error,
+                                length: 0,
+                            },
+                            body: err.encode_body().freeze(),
+                        };
+                        if framed.send(frame).await.is_err() {
+                            break;
+                        }
+                        continue;
+                    }
+                }
 
                 // Check in-flight limit for request opcodes.
                 // The permit lifetime is tied to the request: held inline
@@ -3216,6 +3253,24 @@ fn extract_keyspace_table(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn consensus_failure_gates_data_opcodes_but_keeps_protocol_responsive() {
+        for opcode in [
+            Opcode::Query,
+            Opcode::Prepare,
+            Opcode::Execute,
+            Opcode::Batch,
+        ] {
+            let err = consensus_gate_error(false, opcode)
+                .unwrap_or_else(|| panic!("{opcode:?} must fail after consensus stops"));
+            assert!(matches!(err, CqlError::Overloaded(_)));
+        }
+
+        assert!(consensus_gate_error(false, Opcode::Options).is_none());
+        assert!(consensus_gate_error(false, Opcode::Register).is_none());
+        assert!(consensus_gate_error(true, Opcode::Query).is_none());
+    }
 
     #[test]
     fn ready_prepare_uses_concurrent_request_path() {

--- a/ferrosa-cql/src/server.rs
+++ b/ferrosa-cql/src/server.rs
@@ -1,4 +1,8 @@
 //! CQL TCP server: accepts connections and spawns per-connection tasks.
+//! Correctness: admission is bounded and rejects failed consensus with a typed,
+//! retriable error before authentication or routing work begins.
+//! Last revised: 2026-08-27
+//! Last changed: Added fail-closed admission for consensus runtime failure.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
@@ -334,7 +338,7 @@ impl CqlServer {
                         }
                         // In pair mode, only the primary accepts CQL connections.
                         // Secondaries reject with Overloaded so drivers retry on the primary.
-                        if !state.mode_controller.is_cql_ready() {
+                        if !state.mode_controller.accepts_cql_connections() {
                             active.fetch_sub(1, Ordering::Relaxed);
                             tracing::debug!(
                                 "rejecting CQL connection: node is pair-mode secondary"
@@ -953,6 +957,113 @@ mod tests {
         // 0x1001 = Overloaded error code
         let error_code = i32::from_be_bytes(buf[HEADER_SIZE..HEADER_SIZE + 4].try_into().unwrap());
         assert_eq!(error_code, 0x1001, "expected Overloaded error code");
+    }
+
+    /// A client connecting after the Raft lane failed can still negotiate the
+    /// protocol, then receives a typed retriable error for data operations.
+    #[tokio::test]
+    async fn consensus_failure_keeps_new_cql_protocol_responsive() {
+        let (state, _dir) = setup_state();
+        state.mode_controller.consensus_health().fail(
+            "raft-runtime-panic",
+            format_args!("raft_core.rs:769 empty apply window"),
+        );
+        let mut config = test_config(10, 64);
+        config.auth_disabled = true;
+        let server = CqlServer::new(config, state);
+        let addr = server.start_background().await.unwrap();
+
+        let mut conn = TcpStream::connect(addr).await.unwrap();
+        let (options_header, _) = send_empty_request_and_read_frame(&mut conn, 1, 0x05).await;
+        assert_eq!(options_header.opcode, Opcode::Supported);
+        assert_eq!(
+            startup_and_read_one_frame(&mut conn).await.opcode,
+            Opcode::Ready
+        );
+
+        let (query_header, query_body) =
+            send_empty_request_and_read_frame(&mut conn, 2, 0x07).await;
+        assert_eq!(query_header.opcode, Opcode::Error);
+        assert_eq!(
+            i32::from_be_bytes(query_body[..4].try_into().unwrap()),
+            0x1001,
+            "expected retriable Overloaded"
+        );
+        let message_len = u16::from_be_bytes(query_body[4..6].try_into().unwrap()) as usize;
+        let message = std::str::from_utf8(&query_body[6..6 + message_len]).unwrap();
+        assert_eq!(
+            message,
+            "node unavailable: consensus runtime failed; retry another node"
+        );
+    }
+
+    async fn send_empty_request_and_read_frame(
+        stream: &mut TcpStream,
+        stream_id: i16,
+        opcode: u8,
+    ) -> (FrameHeader, Vec<u8>) {
+        use bytes::BufMut;
+        use tokio::io::AsyncWriteExt;
+
+        let mut request = bytes::BytesMut::with_capacity(HEADER_SIZE);
+        request.put_u8(0x04);
+        request.put_u8(0x00);
+        request.put_i16(stream_id);
+        request.put_u8(opcode);
+        request.put_u32(0);
+        stream.write_all(&request).await.unwrap();
+
+        let mut header_bytes = [0u8; HEADER_SIZE];
+        tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            stream.read_exact(&mut header_bytes),
+        )
+        .await
+        .expect("established connection must remain responsive")
+        .unwrap();
+        let header = FrameHeader::decode(&header_bytes).unwrap();
+        let mut body = vec![0u8; header.length as usize];
+        stream.read_exact(&mut body).await.unwrap();
+        (header, body)
+    }
+
+    /// Connections established before the failure must be fail-closed too.
+    /// OPTIONS remains available to prove the native protocol is alive; QUERY
+    /// fails before its (intentionally empty) body can reach parsing/routing.
+    #[tokio::test]
+    async fn established_cql_connection_fails_data_ops_but_answers_options() {
+        let (state, _dir) = setup_state();
+        let mut config = test_config(10, 64);
+        config.auth_disabled = true;
+        let server = CqlServer::new(config, state.clone());
+        let addr = server.start_background().await.unwrap();
+        let mut conn = TcpStream::connect(addr).await.unwrap();
+        assert_eq!(
+            startup_and_read_one_frame(&mut conn).await.opcode,
+            Opcode::Ready
+        );
+
+        state.mode_controller.consensus_health().fail(
+            "raft-runtime-panic",
+            format_args!("raft_core.rs:769 empty apply window"),
+        );
+
+        let (options_header, _) = send_empty_request_and_read_frame(&mut conn, 1, 0x05).await;
+        assert_eq!(options_header.opcode, Opcode::Supported);
+
+        let (query_header, query_body) =
+            send_empty_request_and_read_frame(&mut conn, 2, 0x07).await;
+        assert_eq!(query_header.opcode, Opcode::Error);
+        assert_eq!(
+            i32::from_be_bytes(query_body[..4].try_into().unwrap()),
+            0x1001,
+            "existing connections receive retriable Overloaded"
+        );
+        let message_len = u16::from_be_bytes(query_body[4..6].try_into().unwrap()) as usize;
+        assert_eq!(
+            std::str::from_utf8(&query_body[6..6 + message_len]).unwrap(),
+            "node unavailable: consensus runtime failed; retry another node"
+        );
     }
 
     #[test]

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -15,6 +15,11 @@
 //! 12. Background: maintenance loop (flush, compaction, commit log GC)
 //! 13. Wait for shutdown signal
 //! 14. Graceful shutdown with timeout
+//!
+//! Correctness: consensus supervision is installed after the controller exists
+//! and before any OpenRaft task can start.
+//! Last revised: 2026-08-27
+//! Last changed: Kept the process alive but fail-closed after Raft failure.
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
@@ -867,22 +872,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    // 0.5. A panic on the consensus runtime must kill this process.
-    //
-    // Installed before tracing so it is in place for the whole run, and after
-    // the meta flags so `--version` stays a pure, side-effect-free query.
-    //
-    // A panic unwinds one thread. When that thread is `raft-rt`, the node stops
-    // replicating and loses its RaftAppendEntries handler while the process
-    // keeps serving CQL from whatever state it last held -- a live endpoint
-    // returning wrong answers, which clients cannot fail over from. Observed on
-    // node1, 2026-08-20: hours of `no handler registered` while every query
-    // returned `keyspace 'agent_memory' not found`.
-    //
-    // launchd already has KeepAlive { Crashed = true }. This is what lets it
-    // fire.
-    runtime::install_fatal_panic_hook();
-
     // 1. Initialize tracing.
     //
     // Non-blocking writer: every `tracing::info!` etc. goes through
@@ -1521,6 +1510,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         schema.clone(),
         registry.clone(),
     );
+
+    // OpenRaft starts only after the controller exists. Install supervision
+    // now so a panic can atomically close readiness and CQL data admission
+    // while the process remains responsive for diagnosis.
+    runtime::install_consensus_panic_hook(mode_controller.consensus_health());
 
     // 6. Create PeerManager — ModeController is the PeerEventListener
     let peer_manager = Arc::new(ferrosa_net::peer::PeerManager::new(

--- a/ferrosa/src/runtime.rs
+++ b/ferrosa/src/runtime.rs
@@ -2,6 +2,10 @@
 //!
 //! Each subsystem gets its own tokio runtime so work on one path cannot
 //! starve another.  The main runtime is supervisor-only.
+//! Correctness: a consensus panic is recorded before unwinding continues; the
+//! process remains alive and client-facing gates fail closed.
+//! Last revised: 2026-08-27
+//! Last changed: Replaced process abort with bounded consensus supervision.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -160,7 +164,7 @@ impl RuntimeManager {
 /// The runtime whose panic means this node can no longer be a cluster member.
 const CONSENSUS_RUNTIME_THREAD: &str = "raft-rt";
 
-/// Must a panic on this thread take the whole process down?
+/// Did a panic originate on the dedicated consensus runtime?
 ///
 /// A Rust panic unwinds one thread. For most of them that is the right scope —
 /// CQL already wraps request handling in `catch_unwind` so a bad request kills
@@ -173,35 +177,80 @@ const CONSENSUS_RUNTIME_THREAD: &str = "raft-rt";
 /// while serving `keyspace 'agent_memory' not found` to every client. launchd's
 /// `KeepAlive { Crashed = true }` never fired because nothing crashed.
 ///
-/// Matching is exact. `raft-log-store` is the sled blocking pool, and a panic
-/// there is a storage fault with its own error path — aborting on a substring
-/// match would turn a contained failure into an outage.
-pub(crate) fn panic_is_fatal(thread_name: Option<&str>) -> bool {
+/// Matching is exact. `raft-log-store` is the sled blocking pool and has its
+/// own error path.
+pub(crate) fn is_consensus_runtime(thread_name: Option<&str>) -> bool {
     thread_name == Some(CONSENSUS_RUNTIME_THREAD)
 }
 
-/// Make a consensus panic kill the process instead of only its thread.
+/// Record a consensus panic in bounded shared state and return to the caller.
 ///
-/// Chains the previous hook so the panic message and backtrace are still
-/// printed before aborting — a silent abort would replace one undiagnosable
-/// failure with another.
+/// Kept separate from the process-global hook so the survival contract can be
+/// tested without racing other tests' panic hooks.
+fn record_consensus_panic(
+    health: &ferrosa_cluster::ConsensusHealth,
+    thread_name: Option<&str>,
+    payload: &str,
+    location: Option<(&str, u32, u32)>,
+) -> bool {
+    if !is_consensus_runtime(thread_name) {
+        return false;
+    }
+    match location {
+        Some((file, line, column)) => health.fail(
+            "raft-runtime-panic",
+            format_args!(
+                "thread={} at {file}:{line}:{column}: {payload}",
+                thread_name.unwrap_or("unnamed")
+            ),
+        ),
+        None => health.fail(
+            "raft-runtime-panic",
+            format_args!(
+                "thread={} at <unknown>: {payload}",
+                thread_name.unwrap_or("unnamed")
+            ),
+        ),
+    }
+}
+
+/// Install bounded supervision for a consensus-runtime panic.
 ///
-/// `abort`, not `exit`: unwinding out of a poisoned consensus runtime can block
-/// on the very locks the panic left held, and a node that hangs on shutdown is
-/// the same "alive but useless" state this exists to end.
-pub fn install_fatal_panic_hook() {
+/// The process deliberately remains alive: readiness closes, new and existing
+/// CQL data operations return typed retriable errors, while protocol health
+/// remains responsive for diagnosis. Consensus output is deliberately capped;
+/// the prior hook is chained only for unrelated panics whose normal handling
+/// this supervisor must not change.
+pub fn install_consensus_panic_hook(health: Arc<ferrosa_cluster::ConsensusHealth>) {
     let previous = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        previous(info);
-        let name = std::thread::current().name().map(str::to_owned);
-        if panic_is_fatal(name.as_deref()) {
+        let current = std::thread::current();
+        let name = current.name();
+        let payload = info
+            .payload()
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| info.payload().downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("non-string panic payload");
+        let location = info
+            .location()
+            .map(|location| (location.file(), location.line(), location.column()));
+        let consensus_thread = is_consensus_runtime(name);
+        let first_failure = record_consensus_panic(&health, name, payload, location);
+        if consensus_thread {
+            if !first_failure {
+                return;
+            }
+            let detail = health
+                .failure()
+                .map(ferrosa_cluster::ConsensusFailure::detail)
+                .unwrap_or("consensus failure detail unavailable");
             eprintln!(
-                "FATAL: panic on the consensus runtime ({}). This node can no \
-longer replicate, so it must not keep serving reads. Aborting so the supervisor \
-restarts it.",
-                name.as_deref().unwrap_or("unnamed")
+                "FATAL: consensus runtime failed; process remains alive in fail-closed mode; \
+readiness=503; CQL data operations=OVERLOADED; detail={detail}"
             );
-            std::process::abort();
+        } else {
+            previous(info);
         }
     }));
 }
@@ -210,7 +259,8 @@ restarts it.",
 mod tests {
     use super::*;
 
-    /// A panic on the consensus runtime must be fatal to the PROCESS.
+    /// A panic on the consensus runtime must fail the consensus health gate
+    /// without terminating the process.
     ///
     /// Observed on node1 of the local three-node cluster, 2026-08-20. The raft
     /// thread panicked inside openraft:
@@ -230,15 +280,86 @@ mod tests {
     /// receive schema. A live endpoint returning a wrong answer is worse than a
     /// dead one: clients cannot fail over from it.
     ///
-    /// launchd is configured `KeepAlive { Crashed = true }`, which would have
-    /// restarted the node — and never fired, because nothing crashed. Making
-    /// the panic fatal is what connects the existing supervision to the actual
-    /// failure.
+    /// The corrected contract keeps the diagnostic surface alive but makes
+    /// readiness and CQL data operations fail closed from shared health state.
     #[test]
-    fn a_panic_on_the_consensus_runtime_is_fatal() {
+    fn a_panic_on_the_consensus_runtime_fails_health_and_returns() {
+        let health = std::sync::Arc::new(ferrosa_cluster::ConsensusHealth::new());
+
+        let first_failure = record_consensus_panic(
+            &health,
+            Some("raft-rt"),
+            "index out of bounds: len is 0",
+            Some(("raft_core.rs", 769, 35)),
+        );
+
         assert!(
-            panic_is_fatal(Some("raft-rt")),
-            "consensus is not optional: a node that cannot replicate must stop serving"
+            first_failure,
+            "the exact consensus runtime must be supervised"
+        );
+        assert!(
+            !record_consensus_panic(&health, Some("raft-rt"), "repeat", None),
+            "repeat panics must not own another FATAL emission"
+        );
+        assert!(!health.is_healthy());
+        let failure = health.failure().expect("bounded diagnostic is retained");
+        assert!(failure.detail().contains("raft_core.rs:769:35"));
+        assert!(failure.detail().contains("len is 0"));
+        assert!(failure.detail().len() <= 1024, "diagnostic must be bounded");
+        // Reaching this assertion is the process-survival contract: the
+        // recorder returns instead of aborting or panicking.
+        assert_eq!(health.failure_count(), 2);
+    }
+
+    /// Exercise the real process-global hook in a child test process. The old
+    /// implementation aborted here; the child now joins the panicked Raft
+    /// worker, observes failed health, and exits successfully.
+    #[test]
+    fn consensus_panic_hook_keeps_child_process_alive() {
+        const CHILD_ENV: &str = "FERROSA_TEST_CONSENSUS_PANIC_CHILD";
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let health = Arc::new(ferrosa_cluster::ConsensusHealth::new());
+            install_consensus_panic_hook(health.clone());
+            for attempt in 0..2 {
+                let result = std::thread::Builder::new()
+                    .name(CONSENSUS_RUNTIME_THREAD.into())
+                    .spawn(move || panic!("synthetic bounded consensus failure {attempt}"))
+                    .expect("spawn named consensus worker")
+                    .join();
+                assert!(
+                    result.is_err(),
+                    "the worker panic must still unwind its thread"
+                );
+            }
+            assert!(!health.is_healthy(), "the hook must close shared health");
+            assert_eq!(health.failure_count(), 2);
+            return;
+        }
+
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "runtime::tests::consensus_panic_hook_keeps_child_process_alive",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("launch isolated panic-hook test process");
+        assert!(
+            output.status.success(),
+            "consensus panic must not abort the process: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            stderr.matches("FATAL: consensus runtime failed").count(),
+            1,
+            "only the first failure source may emit the bounded operator diagnostic: {stderr}"
+        );
+        assert!(
+            stderr.len() <= 1_280,
+            "the isolated operator diagnostic must remain bounded: {} bytes",
+            stderr.len()
         );
     }
 
@@ -250,9 +371,9 @@ mod tests {
     /// to make while fixing the first.
     #[test]
     fn a_panic_on_a_request_runtime_is_not_fatal() {
-        assert!(!panic_is_fatal(Some("cql-rt")));
-        assert!(!panic_is_fatal(Some("data-rt")));
-        assert!(!panic_is_fatal(Some("background-rt")));
+        assert!(!is_consensus_runtime(Some("cql-rt")));
+        assert!(!is_consensus_runtime(Some("data-rt")));
+        assert!(!is_consensus_runtime(Some("background-rt")));
     }
 
     /// An unnamed thread is not assumed fatal. Tokio names its workers, so an
@@ -260,8 +381,8 @@ mod tests {
     /// unrelated library panic an outage.
     #[test]
     fn an_unnamed_thread_is_not_fatal() {
-        assert!(!panic_is_fatal(None));
-        assert!(!panic_is_fatal(Some("")));
+        assert!(!is_consensus_runtime(None));
+        assert!(!is_consensus_runtime(Some("")));
     }
 
     /// Matching must be exact. A substring match on "raft" would catch
@@ -270,10 +391,10 @@ mod tests {
     #[test]
     fn matching_is_exact_not_a_substring() {
         assert!(
-            !panic_is_fatal(Some("raft-log-store")),
+            !is_consensus_runtime(Some("raft-log-store")),
             "the sled blocking pool is not the consensus runtime"
         );
-        assert!(!panic_is_fatal(Some("raft-rt-something-else")));
+        assert!(!is_consensus_runtime(Some("raft-rt-something-else")));
     }
 
     /// T0.2 (t_88223ad0): the runtime tunable parser prefers a valid env value

--- a/ferrosa/src/web/readiness.rs
+++ b/ferrosa/src/web/readiness.rs
@@ -3,19 +3,22 @@
 //! Returns `200 OK` with `{"ready":true}` when the node is ready to serve
 //! traffic. Returns `503 Service Unavailable` with a JSON body explaining
 //! the missing condition otherwise.
+//! A failed consensus runtime overrides every deployment-mode shortcut and
+//! returns 503 without awaiting a Raft handle.
+//! Last revised: 2026-08-27
+//! Last changed: Added the immediate consensus-runtime failure gate.
 //!
 //! ## Readiness criteria
 //!
 //! | Mode       | Condition                                   |
 //! |------------|---------------------------------------------|
-//! | Standalone | Always ready once the web server is up      |
-//! | Pair       | Always ready (mirrors `is_cql_ready()`)     |
+//! | Standalone | Ready unless consensus supervision failed   |
+//! | Pair       | Ready unless consensus supervision failed   |
 //! | Forming    | Ready only once a Raft leader is elected    |
 //! | Cluster    | Ready only once a Raft leader is elected    |
-//! | Degraded*  | Always ready (stale reads available)        |
+//! | Degraded*  | Mode rules apply unless consensus failed    |
 //!
-//! The probe is intentionally additive — no existing endpoint behavior is
-//! changed. It lives outside the `/api/*` auth middleware so external
+//! It lives outside the `/api/*` auth middleware so external
 //! orchestrators (docker-compose, k8s, smoke scripts) can probe it without
 //! credentials.
 //!
@@ -64,6 +67,16 @@ pub fn readiness_route() -> Router<WebAppState> {
 /// Returns `200` only if a Raft leader is currently known to this node.
 /// Otherwise returns `503` with `{"ready":false,"waiting_for":"raft_leader"}`.
 pub async fn readyz_handler(State(mc): State<Arc<ModeController>>) -> (StatusCode, Json<Value>) {
+    if !mc.consensus_is_healthy() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "ready": false,
+                "waiting_for": "consensus_runtime",
+                "detail": "consensus runtime failed; retry another node"
+            })),
+        );
+    }
     let mode = mc.mode();
 
     match mode {
@@ -295,6 +308,41 @@ mod tests {
         assert_eq!(
             parsed["ready"], true,
             "standalone node must report ready=true"
+        );
+    }
+
+    /// A dead consensus lane overrides deployment mode and returns immediately.
+    /// Standalone is intentional here: the handler must consult the health gate
+    /// before any mode shortcut or Raft-handle await.
+    #[tokio::test]
+    async fn readyz_consensus_failure_is_immediate_503() {
+        let state = make_state();
+        state.mode_controller.consensus_health().fail(
+            "raft-runtime-panic",
+            format_args!("raft_core.rs:769 empty apply window"),
+        );
+        let router = build_router(state);
+        let req = Request::builder()
+            .uri("/readyz")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = tokio::time::timeout(std::time::Duration::from_millis(100), router.oneshot(req))
+            .await
+            .expect("failed readiness must not wait on a dead Raft handle")
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["ready"], false);
+        assert_eq!(parsed["waiting_for"], "consensus_runtime");
+        assert_eq!(
+            parsed["detail"],
+            "consensus runtime failed; retry another node"
+        );
+        assert!(
+            !String::from_utf8_lossy(&body).contains("raft_core.rs"),
+            "internal panic details belong in bounded server logs, not health responses"
         );
     }
 


### PR DESCRIPTION
## Summary

- reject reversed OpenRaft log windows before an empty result can reach last-entry indexing
- supervise OpenRaft panic, fatal metrics, and unexpected metrics-channel closure without exiting the process
- fail readiness immediately and reject consensus-dependent CQL opcodes with a typed retriable `Overloaded` error
- keep `OPTIONS`, `STARTUP`, and `REGISTER` responsive for diagnosis on an otherwise admissible failed node
- retain exactly one UTF-8-safe 1,024-byte diagnostic and one bounded FATAL emission while counting repeated failure sources saturatingly

## TDD evidence

- RED: reversed `9..4` log range returned an empty vector, allowing downstream `len - 1` indexing
- GREEN: 7 exact T-005 commands passed in distinct verifier attempt A-6
- post-RF3 integration: both declared-topology readiness regressions passed and `cluster_formation` passed 4/4
- full package suites: `ferrosa-cluster` 1131/1131, `ferrosa-cql` 1090/1090, `ferrosa` binary 302/302
- workspace clippy: clean under `-D warnings`
- materialization scan: 0 introduced findings across 11 production files; no new unbounded channel, retry/log queue, query-sized collection, or whole-input read

## Known independent workspace REDs

- the default-feature workspace run reached 1,471 passing tests and then reproduced the already-tracked T-001 `packet_reorder_linearizability` failure; that correctness fix remains isolated to its own worktree/PR
- `--all-features` additionally enables the opt-in live-SSTable regression, which fails loud without `FERROSA_TEST_TYPED_EDGES_DIR`; the fixture is intentionally not checked in and will be exercised at the authorized live-infra gate

Checklist item: `T-005-openraft-fatal-supervision` / Forge task `t_fed3ab9b`.
