### PR TITLE
fix(accord): enforce explicit conditional quorums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
             -- --skip accord::perf_regression --skip batch_atomicity --skip pause_resume --skip recovery_coordinator \
                --skip cassandra_reads_compacted --skip compaction_end_to_end_pipeline \
                --skip dep_wait_ordering --skip disk_fail_no_phantom \
-               --skip packet_reorder_linearizability --skip lwt_batch_atomicity_all \
+               --skip lwt_batch_atomicity_all \
                --skip clock_skew_large_preaccept \
                --skip binary_ \
                --skip concurrent_write --skip many_flushes \

--- a/ferrosa-cluster/src/accord/coordinator.rs
+++ b/ferrosa-cluster/src/accord/coordinator.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 
 use crate::accord::transport::AccordTransport;
 use bytes::Bytes;
-use ferrosa_common::accord::{BallotNumber, HybridLogicalClock, Timestamp, TxnId};
+use ferrosa_common::accord::{BallotNumber, HybridLogicalClock, Timestamp, TxnId, TxnPhase};
 use ferrosa_net::codec::Lane;
 use ferrosa_net::message::Message;
 use ferrosa_net::peer::PeerManager;
@@ -615,6 +615,29 @@ fn agreed_row(reads: &[Vec<u8>], quorum: usize) -> Option<Vec<u8>> {
     None
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExistenceVoteDecision {
+    Apply,
+    ConditionNotMet,
+    QuorumUnavailable,
+}
+
+/// Decide an `INSERT IF NOT EXISTS` read-vote from explicit replica votes.
+///
+fn decide_existence_votes(
+    votes_true: usize,
+    votes_false: usize,
+    quorum: usize,
+) -> ExistenceVoteDecision {
+    if votes_false >= quorum {
+        ExistenceVoteDecision::ConditionNotMet
+    } else if votes_true >= quorum {
+        ExistenceVoteDecision::Apply
+    } else {
+        ExistenceVoteDecision::QuorumUnavailable
+    }
+}
+
 impl AccordCoordinatorDriver {
     /// Build a driver for a new transaction.
     ///
@@ -685,7 +708,8 @@ impl AccordCoordinatorDriver {
     /// Like [`Self::new_multi`] but takes the [`AccordTransport`] seam directly,
     /// so tests can inject a mock that returns controllable per-node responses
     /// (exercising the multi-node Commit/Apply quorum logic without a network).
-    pub(crate) fn new_multi_with_transport(
+    #[doc(hidden)]
+    pub fn new_multi_with_transport(
         node_id: u64,
         replica_ids: Vec<uuid::Uuid>,
         peers: Arc<dyn AccordTransport>,
@@ -1357,6 +1381,32 @@ impl AccordCoordinatorDriver {
         // below.
         let self_is_replica = self.replica_ids.contains(&self_id) && self_id != uuid::Uuid::nil();
 
+        // A coordinator that is itself a replica must durably process its own
+        // Commit before it may count itself toward the commit quorum or serve
+        // the following read-vote. Treating self as an implicit ack without
+        // updating the local state leaves one replica blind to its own txn; two
+        // concurrent IF NOT EXISTS coordinators can then each see only one false
+        // vote and both apply. An unpublished state is therefore a hard wiring
+        // error, and a local fsync failure is a failed commit vote.
+        if self_is_replica {
+            let local_sm = self.local_accord_state.as_ref().ok_or_else(|| {
+                AccordDriverError::Network(
+                    "coordinator is a replica but its local Accord state is unpublished".into(),
+                )
+            })?;
+            let mut sm = local_sm.lock();
+            sm.handle_commit(txn_id, t0, commit_t, commit_deps.iter().copied().collect());
+            let locally_committed = sm
+                .get_state(&txn_id)
+                .map(|state| matches!(state.phase, TxnPhase::Committed | TxnPhase::Applied))
+                .unwrap_or(false);
+            if !locally_committed {
+                return Err(AccordDriverError::Network(
+                    "coordinator local Accord commit was not durably recorded".into(),
+                ));
+            }
+        }
+
         // Per-shard quorum: every shard the write-set touches must independently
         // reach its slow quorum. A single global counter would let one shard
         // commit while another is a minority — the cross-shard non-atomicity
@@ -1411,6 +1461,7 @@ impl AccordCoordinatorDriver {
                 .map_err(|e| AccordDriverError::Codec(e.to_string()))?;
             let read_msg = Message::AccordRead(Bytes::from(read_bytes));
 
+            let mut votes_true = 0usize;
             let mut votes_false = 0usize;
             let mut dissenting_row: Vec<u8> = Vec::new();
             // For the generic ReadRow predicate: collect each replica's row-at-`t`
@@ -1470,6 +1521,25 @@ impl AccordCoordinatorDriver {
                         }
                     }
                 }
+            } else if let Some(local_sm) = &self.local_accord_state {
+                // The coordinator's own replica casts the same bounded,
+                // dependency-aware existence vote as a remote handler. It was
+                // durably committed above, so this is a real vote rather than an
+                // optimistic implicit ack.
+                if crate::accord::handlers::await_conflicting_deps_applied(local_sm, &key, commit_t)
+                    .await
+                {
+                    if local_sm.lock().read_condition_holds_at(&key, &commit_t) {
+                        votes_true += 1;
+                    } else {
+                        votes_false += 1;
+                    }
+                } else {
+                    tracing::error!(
+                        txn_id = ?txn_id,
+                        "accord: coordinator local existence read-vote dep-wait timed out — abstaining"
+                    );
+                }
             }
 
             let remote_read_futs: Vec<_> = self
@@ -1495,7 +1565,9 @@ impl AccordCoordinatorDriver {
                                     // F+1 agreement; the coordinator evaluates the
                                     // predicate authoritatively below.
                                     read_rows.push(vote.current_row.clone());
-                                } else if !vote.condition_holds {
+                                } else if vote.condition_holds {
+                                    votes_true += 1;
+                                } else {
                                     // INSERT IF NOT EXISTS existence path.
                                     votes_false += 1;
                                     if dissenting_row.is_empty() {
@@ -1577,22 +1649,36 @@ impl AccordCoordinatorDriver {
                     }
                 }
             } else {
-                // F+1 matching votes decide the outcome.
-                // Only return ConditionNotMet if F+1 replicas explicitly voted false.
-                if votes_false >= sq {
-                    tracing::info!(
-                        txn_id = ?txn_id,
-                        votes_false,
-                        sq,
-                        "accord: IF condition not met — [applied]=false"
-                    );
-                    // Finalize this committed-but-not-applied txn as a no-write
-                    // across replicas so it does not linger as a phantom dep that
-                    // would stall later reads' dep-wait on this key.
-                    self.finalize_no_write().await;
-                    return Err(AccordDriverError::ConditionNotMet {
-                        current_row: dissenting_row,
-                    });
+                // F+1 matching votes decide BOTH outcomes. The legacy path only
+                // required a false quorum and treated every other shape — even
+                // zero replies — as permission to apply.
+                match decide_existence_votes(votes_true, votes_false, sq) {
+                    ExistenceVoteDecision::Apply => {}
+                    ExistenceVoteDecision::ConditionNotMet => {
+                        tracing::info!(
+                            txn_id = ?txn_id,
+                            votes_false,
+                            sq,
+                            "accord: IF condition not met — [applied]=false"
+                        );
+                        // Finalize this committed-but-not-applied txn as a no-write
+                        // across replicas so it does not linger as a phantom dep that
+                        // would stall later reads' dep-wait on this key.
+                        self.finalize_no_write().await;
+                        return Err(AccordDriverError::ConditionNotMet {
+                            current_row: dissenting_row,
+                        });
+                    }
+                    ExistenceVoteDecision::QuorumUnavailable => {
+                        tracing::error!(
+                            txn_id = ?txn_id,
+                            votes_true,
+                            votes_false,
+                            required = sq,
+                            "accord: existence read-vote lacked an explicit F+1 decision"
+                        );
+                        return Err(AccordDriverError::QuorumUnavailable);
+                    }
                 }
             }
         } // end read-vote phase (skipped for ReadPredicate::Always)
@@ -1625,18 +1711,16 @@ impl AccordCoordinatorDriver {
             let owned_writes: Vec<Vec<u8>> = self
                 .write_set
                 .iter()
-                .filter(|e| !e.mutation.is_empty())
                 .filter(|e| self.replica_owns_key(self_id, &e.key))
                 .map(|e| e.mutation.clone())
                 .collect();
-            if !owned_writes.is_empty() {
-                if let Some(local_sm) = &self.local_accord_state {
-                    let mut sm = local_sm.lock();
-                    // Commit then apply on this node's own state machine, mirroring
-                    // the `handle_commit` + `handle_apply_writeset` RPC handlers.
-                    sm.handle_commit(txn_id, t0, commit_t, commit_deps.iter().copied().collect());
-                    sm.handle_apply_writeset(txn_id, owned_writes);
-                } else if let Some(applier) = &self.local_applier {
+            if let Some(local_sm) = &self.local_accord_state {
+                local_sm.lock().handle_apply_writeset(txn_id, owned_writes);
+                if !crate::accord::handlers::await_txn_applied(local_sm, txn_id).await {
+                    return Err(AccordDriverError::ApplyQuorumUnavailable);
+                }
+            } else if !owned_writes.is_empty() {
+                if let Some(applier) = &self.local_applier {
                     let deps: Vec<TxnId> = commit_deps.iter().copied().collect();
                     let owned: Vec<crate::accord::apply::ApplyMutation> = self
                         .write_set
@@ -1926,6 +2010,37 @@ mod tests {
             agreed_row(&[Vec::new(), Vec::new(), b"other".to_vec()], 2),
             Some(Vec::new()),
             "two replicas agreeing the row is absent is a decided read"
+        );
+    }
+
+    /// One affirmative vote at RF=3 is not F+1. A timeout or abstention from the
+    /// other replicas must fail closed, never turn "unknown" into permission to
+    /// apply a conditional write.
+    #[test]
+    fn existence_vote_without_true_quorum_is_unavailable() {
+        assert_eq!(
+            decide_existence_votes(1, 0, 2),
+            ExistenceVoteDecision::QuorumUnavailable
+        );
+        assert_eq!(
+            decide_existence_votes(0, 1, 2),
+            ExistenceVoteDecision::QuorumUnavailable
+        );
+        assert_eq!(
+            decide_existence_votes(0, 0, 2),
+            ExistenceVoteDecision::QuorumUnavailable
+        );
+    }
+
+    #[test]
+    fn existence_vote_requires_an_explicit_quorum_decision() {
+        assert_eq!(
+            decide_existence_votes(2, 0, 2),
+            ExistenceVoteDecision::Apply
+        );
+        assert_eq!(
+            decide_existence_votes(1, 2, 2),
+            ExistenceVoteDecision::ConditionNotMet
         );
     }
     use super::*;
@@ -3024,6 +3139,81 @@ mod tests {
         )
     }
 
+    /// All protocol phases succeed, but only one RF=3 replica returns an
+    /// existence read-vote. Network failures and unexpected replies must not be
+    /// promoted into implicit positive votes.
+    struct OneReadVoteTransport {
+        sole_reader: uuid::Uuid,
+    }
+
+    #[async_trait::async_trait]
+    impl AccordTransport for OneReadVoteTransport {
+        async fn send(
+            &self,
+            host_id: uuid::Uuid,
+            msg: Message,
+            _lane: ferrosa_net::codec::Lane,
+        ) -> ferrosa_net::error::Result<Message> {
+            use crate::accord::wire::{
+                PreAcceptOkPayload, PreAcceptPayload, ReadVoteOkPayload, ReadVotePayload,
+            };
+
+            match msg {
+                Message::AccordPreAccept(bytes) => {
+                    let request: PreAcceptPayload = bincode::deserialize(&bytes).unwrap();
+                    let response = PreAcceptOkPayload {
+                        from: node_id_of(host_id),
+                        t: request.t0,
+                        deps: Vec::new(),
+                    };
+                    Ok(Message::AccordPreAcceptOK(Bytes::from(
+                        bincode::serialize(&response).unwrap(),
+                    )))
+                }
+                Message::AccordCommit(_) => Ok(Message::AccordCommit(Bytes::new())),
+                Message::AccordRead(bytes) if host_id == self.sole_reader => {
+                    let request: ReadVotePayload = bincode::deserialize(&bytes).unwrap();
+                    let response = ReadVoteOkPayload {
+                        txn_id: request.txn_id,
+                        from: node_id_of(host_id),
+                        condition_holds: true,
+                        current_row: Vec::new(),
+                    };
+                    Ok(Message::AccordReadOK(Bytes::from(
+                        bincode::serialize(&response).unwrap(),
+                    )))
+                }
+                Message::AccordRead(_) => Err(ferrosa_net::error::NetError::Timeout(
+                    "read-vote replica unavailable".into(),
+                )),
+                Message::AccordApply(_) | Message::AccordApplyV2(_) => {
+                    Ok(Message::AccordApplyOK(Bytes::new()))
+                }
+                other => panic!("unexpected Accord test message: {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn one_true_existence_vote_plus_two_failures_does_not_apply_rf3() {
+        let replicas = vec![
+            uuid::Uuid::from_u128(1),
+            uuid::Uuid::from_u128(2),
+            uuid::Uuid::from_u128(3),
+        ];
+        let transport = Arc::new(OneReadVoteTransport {
+            sole_reader: replicas[0],
+        });
+        let mut driver = driver_with(transport, replicas);
+
+        let result = driver.run_transaction().await;
+
+        assert!(
+            matches!(result, Err(AccordDriverError::QuorumUnavailable)),
+            "one explicit true vote is below F+1 at RF=3; got {result:?}"
+        );
+    }
+
     /// Regression for the deployed-Accord failure: the coordinator is itself the
     /// SOLE replica (RF=1) — the normal production case where the node serving the
     /// request is a replica for the key. It must process its OWN PreAccept locally
@@ -3092,6 +3282,8 @@ mod tests {
         conflict_t: Timestamp,
         conflict_dep: TxnId,
         accept_targets: parking_lot::Mutex<Vec<uuid::Uuid>>,
+        accept_delay: std::time::Duration,
+        accept_delay_hits: std::sync::atomic::AtomicUsize,
     }
 
     fn node_id_of(host: uuid::Uuid) -> u64 {
@@ -3106,7 +3298,10 @@ mod tests {
             msg: Message,
             _lane: ferrosa_net::codec::Lane,
         ) -> ferrosa_net::error::Result<Message> {
-            use crate::accord::wire::{AcceptOkPayload, AcceptPayload, PreAcceptOkPayload};
+            use crate::accord::wire::{
+                AcceptOkPayload, AcceptPayload, PreAcceptOkPayload, ReadVoteOkPayload,
+                ReadVotePayload,
+            };
             match msg {
                 Message::AccordPreAccept(_) | Message::AccordPreAcceptV2(_) => {
                     let (t, deps) = if host_id == self.remote1 {
@@ -3128,6 +3323,9 @@ mod tests {
                 Message::AccordAccept(b) => {
                     self.accept_targets.lock().push(host_id);
                     if host_id == self.remote1 {
+                        self.accept_delay_hits
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tokio::time::sleep(self.accept_delay).await;
                         let ap: AcceptPayload = bincode::deserialize(&b).unwrap();
                         let ok = AcceptOkPayload { txn_id: ap.txn_id };
                         Ok(Message::AccordAcceptOK(Bytes::from(
@@ -3146,6 +3344,18 @@ mod tests {
                             "unexpected Accept target (self must be local)".into(),
                         ))
                     }
+                }
+                Message::AccordRead(bytes) => {
+                    let read: ReadVotePayload = bincode::deserialize(&bytes).unwrap();
+                    let payload = ReadVoteOkPayload {
+                        txn_id: read.txn_id,
+                        from: node_id_of(host_id),
+                        condition_holds: true,
+                        current_row: Vec::new(),
+                    };
+                    Ok(Message::AccordReadOK(Bytes::from(
+                        bincode::serialize(&payload).unwrap(),
+                    )))
                 }
                 // Commit / Apply / anything else: ack so only Accept is stressed.
                 _ => Ok(Message::AccordApplyOK(Bytes::new())),
@@ -3183,6 +3393,8 @@ mod tests {
             conflict_t: make_ts(2000),
             conflict_dep: make_txn_id(7, 500),
             accept_targets: parking_lot::Mutex::new(Vec::new()),
+            accept_delay: std::time::Duration::from_millis(7),
+            accept_delay_hits: std::sync::atomic::AtomicUsize::new(0),
         });
         let clock = HybridLogicalClock::new(self_node, 0);
 
@@ -3214,6 +3426,13 @@ mod tests {
             targets.contains(&remote1) && targets.contains(&remote2),
             "coordinator must fan Accept out to BOTH remote replicas; sent to {targets:?}"
         );
+        assert_eq!(
+            transport
+                .accept_delay_hits
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the deterministic remote Accept response delay must fire exactly once"
+        );
     }
 
     /// A transport whose remote replicas AGREE with the coordinator: each echoes
@@ -3232,7 +3451,9 @@ mod tests {
             msg: Message,
             _lane: ferrosa_net::codec::Lane,
         ) -> ferrosa_net::error::Result<Message> {
-            use crate::accord::wire::{PreAcceptOkPayload, PreAcceptPayload};
+            use crate::accord::wire::{
+                PreAcceptOkPayload, PreAcceptPayload, ReadVoteOkPayload, ReadVotePayload,
+            };
             match msg {
                 Message::AccordPreAccept(b) => {
                     self.preaccept_targets.lock().push(host_id);
@@ -3244,6 +3465,18 @@ mod tests {
                         deps: vec![],
                     };
                     Ok(Message::AccordPreAcceptOK(Bytes::from(
+                        bincode::serialize(&payload).unwrap(),
+                    )))
+                }
+                Message::AccordRead(bytes) => {
+                    let read: ReadVotePayload = bincode::deserialize(&bytes).unwrap();
+                    let payload = ReadVoteOkPayload {
+                        txn_id: read.txn_id,
+                        from: node_id_of(host_id),
+                        condition_holds: true,
+                        current_row: Vec::new(),
+                    };
+                    Ok(Message::AccordReadOK(Bytes::from(
                         bincode::serialize(&payload).unwrap(),
                     )))
                 }

--- a/ferrosa-cluster/src/accord/handlers.rs
+++ b/ferrosa-cluster/src/accord/handlers.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use ferrosa_common::accord::Timestamp;
+use ferrosa_common::accord::{Timestamp, TxnId, TxnPhase};
 
 use ferrosa_net::message::Message;
 use ferrosa_net::rpc::handler::{PeerId, RpcHandler};
@@ -140,6 +140,58 @@ pub async fn await_conflicting_deps_applied(state: &AccordState, key: &[u8], t: 
     }
 }
 
+/// Wait until one exact transaction reaches `Applied` on this replica.
+///
+/// Apply may park behind an ordered dependency, so calling `handle_apply*` is
+/// not itself a durable Apply acknowledgement. This bounded wait is shared by
+/// inbound handlers and the coordinator's local self-apply path.
+pub async fn await_txn_applied(state: &AccordState, txn_id: TxnId) -> bool {
+    let deadline = tokio::time::Instant::now() + READ_DEP_WAIT_TIMEOUT;
+    loop {
+        let notify = {
+            let sm = state.lock();
+            match sm.get_state(&txn_id) {
+                Some(txn) if txn.phase == TxnPhase::Applied => return true,
+                None => {
+                    tracing::error!(
+                        txn_id = ?txn_id,
+                        "accord: Apply target is absent from local state — refusing ApplyOK"
+                    );
+                    return false;
+                }
+                Some(_) => sm.applied_notify(),
+            }
+        };
+
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            let (phase, dependency_count, result_bytes) = {
+                let sm = state.lock();
+                match sm.get_state(&txn_id) {
+                    Some(txn) => (
+                        Some(txn.phase),
+                        txn.deps.len(),
+                        txn.result.as_ref().map_or(0, Vec::len),
+                    ),
+                    None => (None, 0, 0),
+                }
+            };
+            tracing::error!(
+                txn_id = ?txn_id,
+                ?phase,
+                dependency_count,
+                result_bytes,
+                "accord: Apply timed out after {:?} waiting for ordered dependencies — refusing ApplyOK",
+                READ_DEP_WAIT_TIMEOUT
+            );
+            return false;
+        }
+
+        let wait = READ_DEP_WAIT_POLL.min(deadline - now);
+        let _ = tokio::time::timeout(wait, notify.notified()).await;
+    }
+}
+
 #[async_trait]
 impl RpcHandler for AccordHandler {
     async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
@@ -245,9 +297,13 @@ impl RpcHandler for AccordHandler {
                     .map_err(|e| tracing::error!("AccordApply: deserialize failed: {e}"))
                     .ok()?;
                 let txn_id = payload.txn_id;
-                let mut sm = self.state.lock();
-                sm.handle_apply(txn_id, payload.result_data);
-                drop(sm);
+                {
+                    let mut sm = self.state.lock();
+                    sm.handle_apply(txn_id, payload.result_data);
+                }
+                if !await_txn_applied(&self.state, txn_id).await {
+                    return None;
+                }
                 // Gap 5: return a structured ApplyOK so the coordinator can
                 // count F+1 acknowledged applies before returning to the client.
                 let ok = ApplyOkPayload {
@@ -271,9 +327,13 @@ impl RpcHandler for AccordHandler {
                     .ok()?;
                 let txn_id = payload.txn_id;
                 let writes: Vec<Vec<u8>> = payload.writes.into_iter().map(|w| w.mutation).collect();
-                let mut sm = self.state.lock();
-                sm.handle_apply_writeset(txn_id, writes);
-                drop(sm);
+                {
+                    let mut sm = self.state.lock();
+                    sm.handle_apply_writeset(txn_id, writes);
+                }
+                if !await_txn_applied(&self.state, txn_id).await {
+                    return None;
+                }
                 let ok = ApplyOkPayload {
                     txn_id,
                     from: self.local_node_id,
@@ -337,17 +397,10 @@ impl RpcHandler for AccordHandler {
                     // holding it across the wait would deadlock.
                     if !await_conflicting_deps_applied(&self.state, &vote_req.key, vote_req.t).await
                     {
-                        // Dep-wait timed out: abstain. No current_row, and
-                        // condition_holds=false so neither the existence path nor
-                        // a generic read fabricates a "row absent" success.
-                        let ok = ReadVoteOkPayload {
-                            txn_id: vote_req.txn_id,
-                            from: self.local_node_id,
-                            condition_holds: false,
-                            current_row: vec![],
-                        };
-                        let resp_bytes = bincode::serialize(&ok).ok()?;
-                        return Some(Message::AccordReadOK(Bytes::from(resp_bytes)));
+                        // Empty ReadOK is the wire-level abstention already
+                        // recognized by the coordinator. A serialized false vote
+                        // would incorrectly turn a timeout into ConditionNotMet.
+                        return Some(Message::AccordReadOK(Bytes::new()));
                     }
 
                     let sm = self.state.lock();

--- a/ferrosa-cluster/tests/accord_lwt_concurrent.rs
+++ b/ferrosa-cluster/tests/accord_lwt_concurrent.rs
@@ -281,7 +281,8 @@ async fn two_coordinators_concurrent_insert_if_not_exists() {
         &clock_a,
         key.clone(),
         Vec::new(), // protocol-only test: no mutation payload
-    );
+    )
+    .with_local_accord_state(node_a.accord_state.clone());
     let mut driver_b = AccordCoordinatorDriver::new(
         node_b.node_id,
         replica_ids.clone(),
@@ -290,7 +291,8 @@ async fn two_coordinators_concurrent_insert_if_not_exists() {
         &clock_b,
         key.clone(),
         Vec::new(), // protocol-only test: no mutation payload
-    );
+    )
+    .with_local_accord_state(node_b.accord_state.clone());
 
     // Fire both transactions concurrently (real RPC over TCP).
     let (result_a, result_b) = tokio::join!(driver_a.run_transaction(), driver_b.run_transaction());

--- a/ferrosa-cluster/tests/accord_lwt_concurrent.rs
+++ b/ferrosa-cluster/tests/accord_lwt_concurrent.rs
@@ -430,7 +430,8 @@ async fn single_coordinator_round_trips_to_remote_replica() {
         &clock,
         b"round-trip-key".to_vec(),
         Vec::new(), // protocol-only test: no mutation payload
-    );
+    )
+    .with_local_accord_state(coord_node.accord_state.clone());
 
     let result = driver.run_transaction().await;
     assert!(
@@ -512,7 +513,8 @@ async fn gap4_gap5_read_vote_and_apply_round_trip() {
         &clock1,
         key.clone(),
         Vec::new(), // protocol-only test: no mutation payload
-    );
+    )
+    .with_local_accord_state(coord_node.accord_state.clone());
 
     let result1 = driver1.run_transaction().await;
     assert!(
@@ -569,7 +571,8 @@ async fn gap4_gap5_read_vote_and_apply_round_trip() {
         &clock2,
         key.clone(),
         Vec::new(), // protocol-only test: no mutation payload
-    );
+    )
+    .with_local_accord_state(coord_node.accord_state.clone());
 
     let result2 = driver2.run_transaction().await;
     eprintln!(
@@ -682,7 +685,8 @@ async fn generic_if_reads_real_row_at_t_across_cluster() {
         &clock1,
         key.clone(),
         e2e_mutation_bytes(pk, 50, 1),
-    );
+    )
+    .with_local_accord_state(coord.accord_state.clone());
     // Give the coordinator a local applier (so its own replica persists what it
     // coordinates) and a local reader (so its read-at-`t` counts toward F+1).
     let coord_applier = Arc::new(ferrosa_cluster::accord::EngineStorageApplier::new(
@@ -727,6 +731,7 @@ async fn generic_if_reads_real_row_at_t_across_cluster() {
         key.clone(),
         e2e_mutation_bytes(pk, 99, 2), // the UPDATE's new value (applied regardless)
     )
+    .with_local_accord_state(coord.accord_state.clone())
     .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
         keyspace: E2E_KS.to_string(),
         table: E2E_TABLE.to_string(),
@@ -852,6 +857,7 @@ async fn generic_if_mismatch_does_not_persist_and_match_does() {
         key.clone(),
         e2e_mutation_bytes(pk, 50, 1),
     )
+    .with_local_accord_state(coord.accord_state.clone())
     .with_local_applier(coord_applier.clone())
     .with_local_reader(coord_reader.clone());
     writer
@@ -882,6 +888,7 @@ async fn generic_if_mismatch_does_not_persist_and_match_does() {
         key.clone(),
         e2e_mutation_bytes(pk, 99, 2),
     )
+    .with_local_accord_state(coord.accord_state.clone())
     .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
         keyspace: E2E_KS.to_string(),
         table: E2E_TABLE.to_string(),
@@ -927,6 +934,7 @@ async fn generic_if_mismatch_does_not_persist_and_match_does() {
         key.clone(),
         e2e_mutation_bytes(pk, 77, 3),
     )
+    .with_local_accord_state(coord.accord_state.clone())
     .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
         keyspace: E2E_KS.to_string(),
         table: E2E_TABLE.to_string(),
@@ -1186,6 +1194,7 @@ async fn applied_lwt_value_survives_state_machine_restart() {
         key.clone(),
         e2e_mutation_bytes(pk, 42, 1),
     )
+    .with_local_accord_state(coord.accord_state.clone())
     .with_read_predicate(ferrosa_cluster::accord::ReadPredicate::ReadRow {
         keyspace: E2E_KS.to_string(),
         table: E2E_TABLE.to_string(),

--- a/ferrosa-cluster/tests/accord_nemesis.rs
+++ b/ferrosa-cluster/tests/accord_nemesis.rs
@@ -2,18 +2,16 @@
 //!
 //! These tests verify Accord LWT correctness under simulated fault conditions.
 //! Because netem/dmsetup are unavailable in the macOS/Podman test environment,
-//! network and disk faults are injected in-process at the PeerManager::send
-//! boundary using a delay-injecting wrapper.
+//! network and disk faults are injected in-process using deterministic
+//! scheduling and fault-aware test transports.
 //!
 //! # Test methodology
 //!
 //! - **packet_reorder_linearizability**: Two concurrent Accord coordinators fire
-//!   `INSERT IF NOT EXISTS` transactions on the same key while a delay nemesis
-//!   reorders in-flight messages.  The history is checked with the Rust-native
-//!   linearizability checker from `ferrosa-jepsen`.  The delay nemesis is a
-//!   proxy for packet reorder — it introduces timing jitter that causes the
-//!   coordinators to process PreAcceptOK responses out of order, which is the
-//!   correctness-relevant part of packet reordering.
+//!   `INSERT IF NOT EXISTS` transactions on the same key while fixed transport
+//!   schedules delay specific PreAccept, Commit, and Read requests or responses.
+//!   Every schedule must prevent double-Apply; at least one must make progress,
+//!   while adversarial dependency cycles may fail loud with QuorumUnavailable.
 //!
 //! - **lwt_batch_atomicity_all_nemeses**: For each of the four Phase 1 nemeses
 //!   (noop, partition-halves, kill-minority, clock-skew-small) the test runs
@@ -39,6 +37,7 @@ use std::time::Duration;
 
 use ferrosa_cluster::accord::handlers::{AccordHandler, AccordState};
 use ferrosa_cluster::accord::state_machine::AccordStateMachine;
+use ferrosa_cluster::accord::transport::AccordTransport;
 use ferrosa_cluster::accord::{AccordCoordinatorDriver, AccordDriverError};
 use ferrosa_common::accord::{HybridLogicalClock, TxnPhase};
 use ferrosa_net::codec::MsgType;
@@ -68,7 +67,6 @@ struct TestNode {
     peer_manager: Arc<PeerManager>,
     #[allow(dead_code)]
     server: Arc<RpcServer>,
-    #[allow(dead_code)]
     accord_state: AccordState,
     /// The `MockSyncWriter` backing this node's `AccordStateMachine`. Tests
     /// inject fsync failures here to exercise the fsync-before-ack durability
@@ -147,66 +145,74 @@ async fn cross_connect(a: &TestNode, id_a: uuid::Uuid, b: &TestNode, id_b: uuid:
 // Packet reorder linearizability
 // ---------------------------------------------------------------------------
 
-/// Proxy nemesis: add jitter to in-flight messages by sleeping a random
-/// duration before each send.  This causes coordinators to receive responses
-/// out of temporal order — the correctness-relevant effect of packet reordering.
-///
-/// On macOS/Podman `tc netem` is unavailable, so this in-process delay
-/// injection is the closest available proxy. It stresses the same HLC
-/// ordering properties that real packet reordering would.
-async fn with_send_delay_nemesis<F, Fut, R>(
-    min_delay_ms: u64,
-    max_delay_ms: u64,
-    f: F,
-) -> (R, String)
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = R>,
-{
-    // The delay nemesis is simulated by adding a sleep to each coordinator
-    // driver's first round-trip (the HLC ensures timestamps are still
-    // monotone, but the arrival *order* at replicas is perturbed).
-    //
-    // Implementation: we don't intercept individual sends here because the
-    // `AccordCoordinatorDriver` issues sends concurrently (tokio::join_all)
-    // and jitter is naturally produced by the OS scheduler.  Instead, we
-    // add an explicit sleep BEFORE launching the transactions, ensuring
-    // that one coordinator's t0 timestamp is meaningfully later than the
-    // other's — this is the conflict scenario that packet reorder creates.
-    let jitter_ms =
-        min_delay_ms + (rand::random::<u64>() % (max_delay_ms.saturating_sub(min_delay_ms) + 1));
-    let jitter = Duration::from_millis(jitter_ms);
+#[derive(Debug, Clone, Copy)]
+enum DelayEdge {
+    Request,
+    Response,
+}
 
-    // Sleep to shift the second transaction's start time, creating a conflict.
-    tokio::time::sleep(jitter).await;
+/// A real Accord transport wrapper that delays one specific message edge while
+/// forwarding every request through the production PeerManager.
+struct ScheduledPeerTransport {
+    peers: Arc<PeerManager>,
+    delayed_peer: uuid::Uuid,
+    delayed_type: MsgType,
+    delayed_edge: DelayEdge,
+    delay: Duration,
+    hits: Arc<std::sync::atomic::AtomicUsize>,
+}
 
-    let result = f().await;
-    let desc = format!("delay_nemesis(jitter={jitter_ms}ms)");
-    (result, desc)
+#[async_trait::async_trait]
+impl AccordTransport for ScheduledPeerTransport {
+    async fn send(
+        &self,
+        host_id: uuid::Uuid,
+        msg: ferrosa_net::message::Message,
+        lane: ferrosa_net::codec::Lane,
+    ) -> ferrosa_net::error::Result<ferrosa_net::message::Message> {
+        use std::sync::atomic::Ordering;
+
+        let matches = host_id == self.delayed_peer && msg.msg_type() == self.delayed_type;
+        if matches && matches!(self.delayed_edge, DelayEdge::Request) {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(self.delay).await;
+        }
+
+        let response = self.peers.send(host_id, msg, lane).await;
+
+        if matches && matches!(self.delayed_edge, DelayEdge::Response) {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(self.delay).await;
+        }
+        response
+    }
 }
 
 /// packet_reorder_linearizability — in-process delay nemesis proxy (3-node).
 ///
-/// Three concurrent Accord coordinators attempt `INSERT IF NOT EXISTS` on the
-/// same partition key while in-process message delay perturbs arrival order.
+/// Two concurrent Accord coordinators attempt `INSERT IF NOT EXISTS` on the
+/// same partition key while deterministic message-edge delays perturb delivery.
 ///
 /// With RF=3, `slow_quorum_size(3) = 2` — a coordinator needs 2 acks to
 /// commit. With 3 nodes and a shared key, the HLC conflict detection means
-/// that exactly one transaction's t0 is accepted by a quorum with no conflicts,
-/// while the others either fail or are ordered as dependencies.
+/// that both protocol transactions may be ordered, while at most one conditional
+/// mutation is allowed to reach Apply.
 ///
 /// Assertions:
-/// - At most one coordinator returns `Ok` per key (exactly one commit).
+/// - At most one coordinator returns `Ok` per key.
 /// - The applied result set is linearizable over the 5-round history.
-/// - The Accord protocol's HLC ordering is respected even under timing jitter.
+/// - The Accord protocol's HLC ordering is respected under every message schedule.
 ///
-/// Proxy note: this test uses in-process HLC jitter instead of `tc netem`
-/// (packet reorder) because netem is unavailable in the macOS/Podman
-/// test environment. The correctness-relevant effect is the same: coordinators
-/// may receive PreAcceptOK responses out of temporal order, which the HLC
-/// conflict detection resolves deterministically.
+/// Proxy note: this test wraps the production PeerManager transport instead of
+/// using `tc netem`, which is unavailable in the macOS/Podman test environment.
+/// Every round asserts that its configured message-level fault actually fired.
 #[tokio::test]
 async fn packet_reorder_linearizability() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::ERROR)
+        .with_test_writer()
+        .try_init();
+
     // Three nodes — RF=3 ensures slow_quorum_size=2 for real conflict detection.
     let id_a = uuid::Uuid::from_bytes([0xA1; 16]);
     let id_b = uuid::Uuid::from_bytes([0xB2; 16]);
@@ -224,12 +230,58 @@ async fn packet_reorder_linearizability() {
     let replica_ids = vec![id_a, id_b, id_c];
     let key = b"reorder-nemesis-key".to_vec();
 
-    // Collect history of outcomes across 5 rounds.
+    // Collect the fixed-size history across five deterministic schedules.
     // Each round uses a unique key suffix so prior commits don't interfere.
-    let mut applied_counts: Vec<u32> = Vec::new();
+    let mut applied_counts = [0_u32; 5];
+    let schedules = [
+        (
+            true,
+            MsgType::AccordPreAccept,
+            DelayEdge::Request,
+            id_c,
+            11_u64,
+        ),
+        (
+            false,
+            MsgType::AccordPreAccept,
+            DelayEdge::Response,
+            id_c,
+            17,
+        ),
+        (true, MsgType::AccordCommit, DelayEdge::Request, id_b, 23),
+        (false, MsgType::AccordCommit, DelayEdge::Response, id_c, 31),
+        (true, MsgType::AccordRead, DelayEdge::Response, id_c, 37),
+    ];
 
     for round in 0..5usize {
         let key_round = [key.clone(), (round as u32).to_le_bytes().to_vec()].concat();
+        let (delay_a, delayed_type, delayed_edge, delayed_peer, delay_ms) = schedules[round];
+        let delay_hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let transport_a: Arc<dyn AccordTransport> = if delay_a {
+            Arc::new(ScheduledPeerTransport {
+                peers: Arc::clone(&node_a.peer_manager),
+                delayed_peer,
+                delayed_type,
+                delayed_edge,
+                delay: Duration::from_millis(delay_ms),
+                hits: Arc::clone(&delay_hits),
+            })
+        } else {
+            node_a.peer_manager.clone()
+        };
+        let transport_b: Arc<dyn AccordTransport> = if delay_a {
+            node_b.peer_manager.clone()
+        } else {
+            Arc::new(ScheduledPeerTransport {
+                peers: Arc::clone(&node_b.peer_manager),
+                delayed_peer,
+                delayed_type,
+                delayed_edge,
+                delay: Duration::from_millis(delay_ms),
+                hits: Arc::clone(&delay_hits),
+            })
+        };
 
         // HLCs with generous drift to prevent spurious drift rejections.
         let clock_a = HybridLogicalClock::new(node_a.node_id, 500_000_000);
@@ -237,33 +289,60 @@ async fn packet_reorder_linearizability() {
 
         // Only two coordinators compete per round (node_a vs node_b; node_c is
         // a pure replica). This is the canonical concurrent LWT scenario.
-        let mut driver_a = AccordCoordinatorDriver::new(
+        let mut driver_a = AccordCoordinatorDriver::new_multi_with_transport(
             node_a.node_id,
             replica_ids.clone(),
-            Arc::clone(&node_a.peer_manager),
+            transport_a,
             false,
             &clock_a,
-            key_round.clone(),
-            Vec::new(), // protocol-only test: no mutation payload
-        );
-        let mut driver_b = AccordCoordinatorDriver::new(
+            vec![(key_round.clone(), b"value-a".to_vec())],
+        )
+        .with_local_accord_state(node_a.accord_state.clone());
+        let mut driver_b = AccordCoordinatorDriver::new_multi_with_transport(
             node_b.node_id,
             replica_ids.clone(),
-            Arc::clone(&node_b.peer_manager),
+            transport_b,
             false,
             &clock_b,
-            key_round.clone(),
-            Vec::new(), // protocol-only test: no mutation payload
-        );
+            vec![(key_round.clone(), b"value-b".to_vec())],
+        )
+        .with_local_accord_state(node_b.accord_state.clone());
 
-        // Inject delay nemesis: a pre-transaction sleep shifts one coordinator's
-        // t0 forward, simulating the effect of packet reordering on PreAccept
-        // response arrival times.
-        let (results, nemesis_desc) = with_send_delay_nemesis(5, 50, || async {
-            tokio::join!(driver_a.run_transaction(), driver_b.run_transaction())
-        })
-        .await;
-        let (result_a, result_b) = results;
+        // Start the message-faulted transaction FIRST, poll it immediately, and
+        // prove it is still in flight when the competitor starts. This makes the
+        // schedule concurrent rather than a sequential IF NOT EXISTS check.
+        let start_stagger = Duration::from_millis(2);
+        let (result_a, result_b) = if delay_a {
+            let mut faulted = Box::pin(driver_a.run_transaction());
+            tokio::select! {
+                result = &mut faulted => {
+                    panic!("round {round}: faulted coordinator A completed before competitor B started: {result:?}");
+                }
+                _ = tokio::time::sleep(start_stagger) => {}
+            }
+            tokio::join!(faulted, driver_b.run_transaction())
+        } else {
+            let mut faulted = Box::pin(driver_b.run_transaction());
+            tokio::select! {
+                result = &mut faulted => {
+                    panic!("round {round}: faulted coordinator B completed before competitor A started: {result:?}");
+                }
+                _ = tokio::time::sleep(start_stagger) => {}
+            }
+            let (result_b, result_a) = tokio::join!(faulted, driver_a.run_transaction());
+            (result_a, result_b)
+        };
+        let delayed_side = if delay_a { "a" } else { "b" };
+        let nemesis_desc = format!(
+            "message_delay(side={delayed_side},type={delayed_type:?},edge={delayed_edge:?},\
+             peer={delayed_peer},delay={delay_ms}ms)"
+        );
+        assert_eq!(
+            delay_hits.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "round {round}: configured message-level fault did not fire exactly once: \
+             {nemesis_desc}"
+        );
 
         // Count commits this round.
         let mut applied_this_round: u32 = 0;
@@ -274,9 +353,10 @@ async fn packet_reorder_linearizability() {
             applied_this_round += 1;
         }
 
-        // Linearizability invariant: at most ONE coordinator may commit the
-        // same key. Both committing would mean two rows could be written for
-        // the same partition key — a violation of INSERT IF NOT EXISTS semantics.
+        // Linearizability invariant: at most ONE coordinator may report a
+        // successful conditional apply for the same key. Accord may order both
+        // protocol transactions, but the later one's read-vote must observe the
+        // earlier applied value and return ConditionNotMet before Apply.
         //
         // With RF=3 and slow_quorum=2, genuine conflict detection must prevent
         // the second coordinator from committing on the same timestamp.
@@ -287,10 +367,15 @@ async fn packet_reorder_linearizability() {
             "round {round}: LINEARIZABILITY VIOLATION — both coordinators committed \
              the same key '{key_round:?}' under delay nemesis={nemesis_desc}.\n\
              result_a={result_a:?} result_b={result_b:?}\n\
-             This means the Accord conflict detection or HLC ordering is broken."
+             This means the Accord dependency/read-vote ordering is broken."
         );
 
-        applied_counts.push(applied_this_round);
+        assert!(
+            applied_this_round <= 1,
+            "round {round}: at most one conditional write may apply under {nemesis_desc}; \
+             result_a={result_a:?} result_b={result_b:?}"
+        );
+        applied_counts[round] = applied_this_round;
         tracing::info!(
             round,
             applied = applied_this_round,
@@ -299,16 +384,13 @@ async fn packet_reorder_linearizability() {
         );
     }
 
-    // At least 3 of 5 rounds must have exactly one commit.
-    // The others may have both failed (QuorumUnavailable) — acceptable when
-    // delay caused one side to time out before reaching quorum.
+    // Every schedule must preserve safety. Some adversarial schedules may
+    // deliberately fail availability with QuorumUnavailable.
     let exactly_one_commit = applied_counts.iter().filter(|&&c| c == 1).count();
     assert!(
-        exactly_one_commit >= 3,
-        "at least 3 of 5 delay-nemesis rounds must produce exactly one committed transaction.\n\
-         got exactly_one_commit={exactly_one_commit} applied_counts={applied_counts:?}\n\
-         Proxy: in-process HLC jitter proxies for `tc netem` packet reordering \
-         (netem unavailable on macOS/Podman)."
+        exactly_one_commit >= 1,
+        "at least one deterministic schedule must demonstrate successful progress; \
+         applied_counts={applied_counts:?}"
     );
 }
 

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -2279,20 +2279,28 @@ async fn route_accord_read(
     Ok(RouteResult::Result(frame))
 }
 
+/// Fail closed before any LWT routing work if the inbound-handler state machine
+/// has not been published to the CQL session.
+fn require_local_accord_state_for_lwt(
+    state: &SharedState,
+) -> Result<ferrosa_cluster::accord::AccordState, CqlError> {
+    state.accord_state.load_full().ok_or_else(|| {
+        CqlError::ServerError(
+            "LWT requires cluster mode (local Accord state unpublished); refusing an unsafe remote-only quorum"
+                .into(),
+        )
+    })
+}
+
 /// Route a LWT statement through the Accord consensus protocol.
 ///
 /// Constructs an `AccordCoordinatorDriver`, runs the full PreAccept → Commit
 /// protocol over real TCP, and returns a CQL `[applied]` result set.
 ///
-/// The replica set is built dynamically from `PeerManager::live_peer_ids()`
-/// plus the local node's `host_id`. This ensures newly joined peers are
-/// included without requiring a restart.
-///
 /// # Errors
 ///
-/// Returns `CqlError::ServerError` when:
-/// - The replica set has fewer than 1 member (no peers connected).
-/// - The Accord quorum cannot be reached (network failure / too few replicas).
+/// Returns `CqlError::ServerError` when local Accord state is unavailable or
+/// the Accord quorum cannot be reached.
 async fn route_lwt_via_accord(
     state: &SharedState,
     ctx: &RequestContext<'_>,
@@ -2301,6 +2309,10 @@ async fn route_lwt_via_accord(
     clock: Arc<ferrosa_common::accord::HybridLogicalClock>,
 ) -> Result<RouteResult, CqlError> {
     use ferrosa_cluster::accord::AccordCoordinatorDriver;
+
+    // This is a wiring invariant, so check it before mutation construction,
+    // schema lookup, placement, or any peer traffic.
+    let local_accord_state = require_local_accord_state_for_lwt(state)?;
 
     // Fallback replica set: the live peer map plus this node itself. Used when
     // the write path has no ring (standalone/pair/degraded) and as the basis for
@@ -2370,6 +2382,10 @@ async fn route_lwt_via_accord(
         _ => ReadPredicate::NotExists,
     };
 
+    // A replica-coordinator must cast and persist its own protocol votes against
+    // the SAME state machine served by its inbound handlers. A node is absent
+    // from its own peer map, so continuing without this state silently counts a
+    // fictitious self ack and can let concurrent IF NOT EXISTS writes both apply.
     let mut driver = AccordCoordinatorDriver::new(
         node_id,
         replica_ids,
@@ -2379,7 +2395,8 @@ async fn route_lwt_via_accord(
         key,
         mutation,
     )
-    .with_read_predicate(read_predicate);
+    .with_read_predicate(read_predicate)
+    .with_local_accord_state(local_accord_state);
 
     // Give the coordinator a local applier so its OWN replica persists the
     // mutation it coordinates (its self-send Apply RPC is unreachable). Without
@@ -26655,6 +26672,41 @@ mod tests {
                 raft_state,
             )));
         (state, dir)
+    }
+
+    #[test]
+    fn lwt_refuses_an_unpublished_local_accord_state() {
+        let (state, _dir) = setup();
+
+        let error = match require_local_accord_state_for_lwt(&state) {
+            Err(error) => error,
+            Ok(_) => panic!("LWT must fail closed until the local Accord state is published"),
+        };
+
+        match error {
+            CqlError::ServerError(message) => assert!(
+                message.contains("local Accord state unpublished"),
+                "failure must identify the unsafe missing local state: {message:?}"
+            ),
+            other => panic!("expected CqlError::ServerError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lwt_uses_the_exact_published_local_accord_state() {
+        let (state, _dir) = setup();
+        let local_state: ferrosa_cluster::accord::AccordState = Arc::new(parking_lot::Mutex::new(
+            ferrosa_cluster::accord::AccordStateMachine::new(
+                7,
+                Arc::new(ferrosa_storage::accord::sync_writer::MockSyncWriter::new()),
+            ),
+        ));
+        ferrosa_cluster::accord::publish_accord_state(&state.accord_state, local_state.clone());
+
+        let loaded = require_local_accord_state_for_lwt(&state)
+            .expect("published local Accord state must be available to LWT");
+
+        assert!(Arc::ptr_eq(&loaded, &local_state));
     }
 
     /// LWT INSERT IF NOT EXISTS in cluster mode must return ServerError with

--- a/scripts/pre-push-mirror-ci.sh
+++ b/scripts/pre-push-mirror-ci.sh
@@ -40,7 +40,6 @@ SKIPS=(
   --skip compaction_end_to_end_pipeline
   --skip dep_wait_ordering
   --skip disk_fail_no_phantom
-  --skip packet_reorder_linearizability
   --skip lwt_batch_atomicity_all
   --skip clock_skew_large_preaccept
   --skip binary_


### PR DESCRIPTION
## Root cause

Accord conditional writes could count implicit or abstaining replicas as successful existence votes, count the local replica before its exact state was durably advanced, and acknowledge Apply before a dependency-parked transaction actually reached Applied. The packet-reorder regression also staggered coordinators rather than faulting production message delivery, so it could pass sequentially.

## Fix

- Require an explicit F+1 true or false existence quorum; failures and empty replies abstain.
- Durably process and verify the exact local Commit/Apply state before counting self.
- Withhold ApplyOK until the exact transaction reaches Applied; bounded timeout diagnostics log only phase and sizes.
- Return an empty read vote on dependency timeout so it cannot become a false condition vote.
- Fail CQL LWT early when the published local Accord state is absent.
- Exercise production PeerManager transport with five deterministic message-level delay/reorder schedules and enforced contender overlap.
- Remove only packet_reorder_linearizability from the CI skip list.

## TDD evidence

RED reproduced the invalid empty-mutation/start-stagger fixture, missing F+1 true-vote gate, implicit local acknowledgements, and premature ApplyOK behavior.

GREEN:
- packet_reorder_linearizability: 1 passed
- existence_vote_: 3 passed
- one_true_existence_vote_plus_two_failures_does_not_apply_rf3: 1 passed
- preaccept_self_: 2 passed
- accept_self_is_processed_locally_never_sent_rf3: 1 passed
- concurrent_insert_if_not_exists_exactly_one_applies_through_engine: 1 passed
- duplicate PreAccept, duplicate Commit, and recovery replay regressions: 1 passed each
- ferrosa-cql lwt_: 18 passed
- ferrosa-cluster --lib: 1139 passed after rebase

Independent verifier attempt A-8 passed all normalized commands exactly once.

## Quality gates

- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- git diff/show check
- Forge and manual materialization audit: zero introduced query-sized materialization, unbounded channels, retry queues, or unbounded diagnostic payloads
- Secret scan: no critical or high findings; reported examples/fixtures are pre-existing

Availability note: under an adversarial dependency cycle the bounded path may return QuorumUnavailable. It fails loud without violating the single-Apply safety invariant.