### PR TITLE
fix(release): fail if version sync PR cannot open

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
 
 concurrency:
   group: promote-release-${{ github.repository }}
@@ -93,10 +94,8 @@ jobs:
           NEXT_VERSION: ${{ steps.calc.outputs.next_version }}
           NEXT_TAG: ${{ steps.calc.outputs.next_tag }}
         # Keep main's [workspace.package] version in step with the released tag
-        # instead of letting it drift. main is protected, so this opens a PR rather
-        # than pushing directly. Append-only + best-effort: the release is already
-        # cut above, so a failure here never blocks the release.
-        continue-on-error: true
+        # instead of letting it drift. main is protected, so this opens a PR and
+        # fails loudly if source/release state cannot be synchronized.
         run: |
           set -euo pipefail
           git fetch origin main


### PR DESCRIPTION
## Summary
- grant the stable promotion workflow permission to open its required version-sync PR
- stop swallowing a failed sync-PR creation as a successful promotion

## Verification
- actionlint .github/workflows/promote-release.yml
- git diff --check

This must land before the v0.21.0 promotion so release logs stay clean and `main` cannot silently drift from the stable tag.