### PR TITLE
feat(cql): bound prepared clustering-range LIMIT reads

### DIFF
--- a/ferrosa-cluster/src/controller/cluster.rs
+++ b/ferrosa-cluster/src/controller/cluster.rs
@@ -1412,7 +1412,10 @@ impl ModeController {
             .register(MsgType::FulltextSearchRequest, fulltext_search_handler);
 
         let read_handler = Arc::new(ReadRequestHandler::new(self.storage.clone()));
-        self.registry.register(MsgType::ReadRequest, read_handler);
+        self.registry
+            .register(MsgType::ReadRequest, read_handler.clone());
+        self.registry
+            .register(MsgType::PartitionSuffixReadRequest, read_handler);
 
         // Register batchlog handlers — without these, logged batch writes
         // sent to remote nodes are silently dropped.

--- a/ferrosa-cluster/src/controller/tests.rs
+++ b/ferrosa-cluster/src/controller/tests.rs
@@ -1220,6 +1220,12 @@ async fn raft_init_registers_handlers() {
         controller.registry.has_handler(MsgType::ReadRequest),
         "ReadRequest handler should be registered"
     );
+    assert!(
+        controller
+            .registry
+            .has_handler(MsgType::PartitionSuffixReadRequest),
+        "PartitionSuffixReadRequest handler should be registered"
+    );
 }
 
 #[test]

--- a/ferrosa-cluster/src/coordinator/read.rs
+++ b/ferrosa-cluster/src/coordinator/read.rs
@@ -52,7 +52,8 @@ use crate::pair::coordinator::encode_mutation;
 use crate::raft::handlers::{
     partition_from_wire, FulltextSearchRequestPayload, FulltextSearchResponsePayload,
     IndexReadInPartitionRequestPayload, IndexReadRequestPayload, IndexReadResponsePayload,
-    RangeReadRequestPayload, RangeReadResponsePayload, ReadRequestPayload, ReadResponsePayload,
+    PartitionSuffixReadRequestPayload, RangeReadRequestPayload, RangeReadResponsePayload,
+    ReadRequestPayload, ReadResponsePayload,
 };
 use crate::raft::IndexNodeStatus;
 
@@ -272,6 +273,37 @@ enum ReplicaRead {
     Failed,
 }
 
+#[derive(Clone, Default)]
+struct PartitionReadSlice {
+    row_limit: usize,
+    clustering: Option<Vec<u8>>,
+    start_clustering: Option<Vec<u8>>,
+}
+
+impl PartitionReadSlice {
+    fn prefix(row_limit: usize) -> Self {
+        Self {
+            row_limit,
+            ..Self::default()
+        }
+    }
+
+    fn exact(clustering: &[u8]) -> Self {
+        Self {
+            clustering: Some(clustering.to_vec()),
+            ..Self::default()
+        }
+    }
+
+    fn after(start_clustering: &[u8], row_limit: usize) -> Self {
+        Self {
+            row_limit,
+            start_clustering: Some(start_clustering.to_vec()),
+            ..Self::default()
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Wire helpers
 // ---------------------------------------------------------------------------
@@ -279,6 +311,27 @@ enum ReplicaRead {
 /// Encode a [`ReadRequestPayload`] as a bincode-prefixed [`Bytes`].
 fn encode_read_request(payload: &ReadRequestPayload) -> Bytes {
     Bytes::from(bincode::serialize(payload).unwrap_or_default())
+}
+
+/// Encode a legacy-compatible partition read, selecting the additive suffix
+/// message only when an exclusive clustering lower bound is present.
+fn encode_partition_read_request(
+    payload: ReadRequestPayload,
+    start_clustering: Option<Vec<u8>>,
+) -> Message {
+    match start_clustering {
+        Some(start_clustering) => {
+            let payload = PartitionSuffixReadRequestPayload {
+                version: 1,
+                request: payload,
+                start_clustering,
+            };
+            Message::PartitionSuffixReadRequest(Bytes::from(
+                bincode::serialize(&payload).unwrap_or_default(),
+            ))
+        }
+        None => Message::ReadRequest(encode_read_request(&payload)),
+    }
 }
 
 /// Read a partition from the local storage engine.
@@ -299,12 +352,16 @@ async fn read_local_partition(
     key: DecoratedKey,
     row_limit: usize,
     clustering: Option<Vec<u8>>,
+    start_clustering: Option<Vec<u8>>,
 ) -> ferrosa_common::Result<Option<Partition>> {
     let storage = std::sync::Arc::clone(storage);
     ferrosa_common::task_pool::TaskPool::current("coordinator-local-read")
-        .spawn_blocking(move || match clustering {
-            Some(clustering) => storage.read_clustering_row(&table_id, &key, &clustering),
-            None => storage.read_limited_rows(&table_id, &key, row_limit),
+        .spawn_blocking(move || match (clustering, start_clustering) {
+            (Some(clustering), _) => storage.read_clustering_row(&table_id, &key, &clustering),
+            (None, Some(start)) => {
+                storage.read_limited_rows_from(&table_id, &key, &start, row_limit)
+            }
+            (None, None) => storage.read_limited_rows(&table_id, &key, row_limit),
         })
         .await
         .map_err(|e| {
@@ -325,9 +382,19 @@ async fn digest_read_attempt(
     remote: Option<(uuid::Uuid, String)>,
     row_limit: usize,
     clustering: Option<Vec<u8>>,
+    start_clustering: Option<Vec<u8>>,
 ) -> ReplicaRead {
     if replica_id == local_node_id {
-        match read_local_partition(&storage, table_id, key, row_limit, clustering).await {
+        match read_local_partition(
+            &storage,
+            table_id,
+            key,
+            row_limit,
+            clustering,
+            start_clustering,
+        )
+        .await
+        {
             Ok(Some(p)) => {
                 use crate::raft::handlers::compute_partition_digest;
                 let ts = p
@@ -360,11 +427,11 @@ async fn digest_read_attempt(
             page_state: vec![],
             clustering: clustering.unwrap_or_default(),
         };
-        let body = encode_read_request(&payload);
+        let message = encode_partition_read_request(payload, start_clustering);
         match remote {
             None => ReplicaRead::Failed,
             Some((hid, addr)) => match coordinator
-                .send_remote_with_reconnect(hid, &addr, Message::ReadRequest(body), Lane::Data)
+                .send_remote_with_reconnect(hid, &addr, message, Lane::Data)
                 .await
             {
                 Ok(Message::ReadResponse(b)) => match decode_read_response(&b) {
@@ -481,6 +548,7 @@ impl ClusterCoordinator {
         host_id: uuid::Uuid,
         row_limit: usize,
         clustering: Option<&[u8]>,
+        start_clustering: Option<&[u8]>,
     ) -> Option<Partition> {
         let addr = {
             let ring = self.ring.load();
@@ -499,9 +567,9 @@ impl ClusterCoordinator {
             page_state: vec![],
             clustering: clustering.unwrap_or_default().to_vec(),
         };
-        let body = encode_read_request(&payload);
+        let message = encode_partition_read_request(payload, start_clustering.map(<[u8]>::to_vec));
         match self
-            .send_remote_with_reconnect(host_id, &addr, Message::ReadRequest(body), Lane::Data)
+            .send_remote_with_reconnect(host_id, &addr, message, Lane::Data)
             .await
         {
             Ok(Message::ReadResponse(b)) => match decode_read_response(&b) {
@@ -519,7 +587,7 @@ impl ClusterCoordinator {
         key: &DecoratedKey,
         host_id: uuid::Uuid,
     ) -> Option<Partition> {
-        self.full_refetch_limited_rows(table_id, key, host_id, 0, None)
+        self.full_refetch_limited_rows(table_id, key, host_id, 0, None, None)
             .await
     }
 
@@ -552,8 +620,34 @@ impl ClusterCoordinator {
         rf: usize,
         row_limit: usize,
     ) -> crate::error::Result<Option<Vec<Row>>> {
-        self.coordinate_read_with_filter(table_id, key, cl, rf, row_limit, None)
-            .await
+        self.coordinate_read_with_filter(
+            table_id,
+            key,
+            cl,
+            rf,
+            PartitionReadSlice::prefix(row_limit),
+        )
+        .await
+    }
+
+    /// Coordinate a bounded partition read strictly after one clustering key.
+    pub async fn coordinate_read_with_limited_rows_from(
+        &self,
+        table_id: &TableId,
+        key: &DecoratedKey,
+        cl: ConsistencyLevel,
+        rf: usize,
+        row_limit: usize,
+        start_clustering: &[u8],
+    ) -> crate::error::Result<Option<Vec<Row>>> {
+        self.coordinate_read_with_filter(
+            table_id,
+            key,
+            cl,
+            rf,
+            PartitionReadSlice::after(start_clustering, row_limit),
+        )
+        .await
     }
 
     pub async fn coordinate_read_clustering_row(
@@ -564,8 +658,14 @@ impl ClusterCoordinator {
         cl: ConsistencyLevel,
         rf: usize,
     ) -> crate::error::Result<Option<Vec<Row>>> {
-        self.coordinate_read_with_filter(table_id, key, cl, rf, 0, Some(clustering.to_vec()))
-            .await
+        self.coordinate_read_with_filter(
+            table_id,
+            key,
+            cl,
+            rf,
+            PartitionReadSlice::exact(clustering),
+        )
+        .await
     }
 
     async fn coordinate_read_with_filter(
@@ -574,18 +674,39 @@ impl ClusterCoordinator {
         key: &DecoratedKey,
         cl: ConsistencyLevel,
         rf: usize,
-        row_limit: usize,
-        clustering: Option<Vec<u8>>,
+        slice: PartitionReadSlice,
     ) -> crate::error::Result<Option<Vec<Row>>> {
+        let raw_replicas = {
+            let ring = self.ring.load();
+            ring.replicas(key.token.0, rf)
+        };
+        self.coordinate_read_from_replicas(table_id, key, cl, raw_replicas, cl.block_for(rf), slice)
+            .await
+    }
+
+    /// Coordinate against the exact replica identities selected by the
+    /// replication strategy. NTS/LOCAL callers must not collapse this list to
+    /// a count and then recompute SimpleStrategy replicas.
+    async fn coordinate_read_from_replicas(
+        &self,
+        table_id: &TableId,
+        key: &DecoratedKey,
+        cl: ConsistencyLevel,
+        raw_replicas: Vec<u64>,
+        required: usize,
+        slice: PartitionReadSlice,
+    ) -> crate::error::Result<Option<Vec<Row>>> {
+        let PartitionReadSlice {
+            row_limit,
+            clustering,
+            start_clustering,
+        } = slice;
         let ring = self.ring.load();
-        let raw_replicas = ring.replicas(key.token.0, rf);
 
         // W8.4: filter the replica list by the CL's role policy.
         // Voter-quorum CLs drop learners; ONE / LOCAL_ONE keep them.
         let replicas =
             crate::coordinator::cl_routing::eligible_replicas_for_cl(cl, &raw_replicas, &ring);
-
-        let required = cl.block_for(rf);
 
         if tracing::enabled!(tracing::Level::DEBUG) {
             let span = tracing::debug_span!(
@@ -615,8 +736,12 @@ impl ClusterCoordinator {
                     key,
                     &replicas,
                     &ring,
-                    row_limit,
-                    clustering.as_deref(),
+                    cl,
+                    PartitionReadSlice {
+                        row_limit,
+                        clustering,
+                        start_clustering,
+                    },
                 )
                 .await;
         }
@@ -670,12 +795,20 @@ impl ClusterCoordinator {
                 let table_name = table_id.table.clone();
                 let key_bytes = key.key.as_bytes().to_vec();
                 let clustering = clustering.clone();
+                let start_clustering = start_clustering.clone();
 
                 async move {
                     if full_replica == local_node_id {
                         // Local full read.
-                        match read_local_partition(&storage, table_id, key, row_limit, clustering)
-                            .await
+                        match read_local_partition(
+                            &storage,
+                            table_id,
+                            key,
+                            row_limit,
+                            clustering,
+                            start_clustering,
+                        )
+                        .await
                         {
                             Ok(opt) => ReplicaRead::Full(opt),
                             Err(_) => ReplicaRead::Failed,
@@ -691,17 +824,12 @@ impl ClusterCoordinator {
                             page_state: vec![],
                             clustering: clustering.unwrap_or_default(),
                         };
-                        let body = encode_read_request(&payload);
+                        let message = encode_partition_read_request(payload, start_clustering);
                         match full_remote {
                             None => ReplicaRead::Failed,
                             Some((hid, addr)) => {
                                 match coordinator
-                                    .send_remote_with_reconnect(
-                                        hid,
-                                        &addr,
-                                        Message::ReadRequest(body),
-                                        Lane::Data,
-                                    )
+                                    .send_remote_with_reconnect(hid, &addr, message, Lane::Data)
                                     .await
                                 {
                                     Ok(Message::ReadResponse(b)) => {
@@ -740,6 +868,7 @@ impl ClusterCoordinator {
                         remote,
                         row_limit,
                         clustering.clone(),
+                        start_clustering.clone(),
                     )));
                 }
             }
@@ -788,6 +917,7 @@ impl ClusterCoordinator {
                             remote,
                             row_limit,
                             clustering.clone(),
+                            start_clustering.clone(),
                         )));
                     }
                 }
@@ -859,7 +989,14 @@ impl ClusterCoordinator {
 
             if let Some(hid) = newest_remote_host_id {
                 if let Some(newer_partition) = self
-                    .full_refetch_limited_rows(table_id, key, hid, row_limit, clustering.as_deref())
+                    .full_refetch_limited_rows(
+                        table_id,
+                        key,
+                        hid,
+                        row_limit,
+                        clustering.as_deref(),
+                        start_clustering.as_deref(),
+                    )
                     .await
                 {
                     // The full-read replica (and any other mismatched digests
@@ -1006,9 +1143,12 @@ impl ClusterCoordinator {
         key: &DecoratedKey,
         replicas: &[u64],
         ring: &crate::ring::TokenRing,
-        row_limit: usize,
-        clustering: Option<&[u8]>,
+        cl: ConsistencyLevel,
+        slice: PartitionReadSlice,
     ) -> crate::error::Result<Option<Vec<Row>>> {
+        let row_limit = slice.row_limit;
+        let clustering = slice.clustering.as_deref();
+        let start_clustering = slice.start_clustering.as_deref();
         // Build an ordered candidate list: local node first, then remaining replicas.
         let mut candidates: Vec<u64> = Vec::with_capacity(replicas.len());
         if replicas.contains(&self.local_node_id) {
@@ -1027,6 +1167,11 @@ impl ClusterCoordinator {
         // repair to refill that range (never blocking the read). `None` until a
         // local read surfaces a typed `CorruptSstable` error.
         let mut corrupt_range: Option<(i64, i64)> = None;
+        // Distinguish a valid "not found" response from exhausting replicas
+        // through transport/protocol/storage failures. The latter must be a
+        // typed error, especially during a rolling upgrade where an old peer
+        // rejects the additive suffix-read message.
+        let mut received_response = false;
 
         for &target in &candidates {
             if target == self.local_node_id {
@@ -1036,13 +1181,17 @@ impl ClusterCoordinator {
                     key.clone(),
                     row_limit,
                     clustering.map(<[u8]>::to_vec),
+                    start_clustering.map(<[u8]>::to_vec),
                 )
                 .await
                 .map(|opt| opt.map(|p| p.rows))
                 .map_err(ClusterError::Storage)
                 {
                     Ok(Some(rows)) if !rows.is_empty() => return Ok(Some(rows)),
-                    Ok(_) => continue, // no data on this replica, try next
+                    Ok(_) => {
+                        received_response = true;
+                        continue; // no data on this replica, try next
+                    }
                     Err(ClusterError::Storage(ref e)) if e.corrupt_sstable_range().is_some() => {
                         // Genuine local SSTable corruption (storage already
                         // quarantined it). Treat it as a failed replica: record
@@ -1094,14 +1243,19 @@ impl ClusterCoordinator {
                     page_state: page_state.clone(),
                     clustering: clustering.unwrap_or_default().to_vec(),
                 };
-                let body = encode_read_request(&payload);
+                let message =
+                    encode_partition_read_request(payload, start_clustering.map(<[u8]>::to_vec));
                 let lane = partition_read_lane(row_limit, clustering);
                 match self
-                    .send_remote_with_reconnect(host_id, &addr, Message::ReadRequest(body), lane)
+                    .send_remote_with_reconnect(host_id, &addr, message, lane)
                     .await
                 {
                     Ok(Message::ReadResponse(b)) => match decode_read_response(&b) {
-                        Some(resp) if resp.found => {
+                        Some(resp) => {
+                            received_response = true;
+                            if !resp.found {
+                                break;
+                            }
                             found_partition = true;
                             if let Some(p) = resp.partition.map(partition_from_wire) {
                                 all_rows.extend(p.rows);
@@ -1115,7 +1269,7 @@ impl ClusterCoordinator {
                             }
                             break; // no more pages
                         }
-                        _ => break, // not found or decode failure
+                        None => break,
                     },
                     _ => {
                         tracing::debug!(target, "read_one_replica: remote send failed");
@@ -1147,8 +1301,18 @@ impl ClusterCoordinator {
             ));
         }
 
-        // All replicas exhausted — data genuinely not found.
-        Ok(None)
+        if received_response {
+            // At least one replica explicitly answered that the key/slice was
+            // absent. CL ONE may return that valid response.
+            Ok(None)
+        } else {
+            Err(ClusterError::ReadTimeout {
+                consistency: cl.to_string(),
+                received: 0,
+                required: 1,
+                data_present: false,
+            })
+        }
     }
 
     #[cfg(test)]
@@ -1159,8 +1323,15 @@ impl ClusterCoordinator {
         replicas: &[u64],
         ring: &crate::ring::TokenRing,
     ) -> crate::error::Result<Option<Vec<Row>>> {
-        self.read_one_replica_limited_rows(table_id, key, replicas, ring, 0, None)
-            .await
+        self.read_one_replica_limited_rows(
+            table_id,
+            key,
+            replicas,
+            ring,
+            ConsistencyLevel::One,
+            PartitionReadSlice::default(),
+        )
+        .await
     }
 
     /// Coordinate a read using NetworkTopologyStrategy with DC-aware consistency.
@@ -1188,8 +1359,34 @@ impl ClusterCoordinator {
         strategy: &crate::ring::strategy::ReplicationStrategy,
         row_limit: usize,
     ) -> crate::error::Result<Option<Vec<Row>>> {
-        self.coordinate_read_nts_filtered(table_id, key, cl, strategy, row_limit, None)
-            .await
+        self.coordinate_read_nts_filtered(
+            table_id,
+            key,
+            cl,
+            strategy,
+            PartitionReadSlice::prefix(row_limit),
+        )
+        .await
+    }
+
+    /// NTS counterpart of [`Self::coordinate_read_with_limited_rows_from`].
+    pub async fn coordinate_read_nts_limited_rows_from(
+        &self,
+        table_id: &TableId,
+        key: &DecoratedKey,
+        cl: ConsistencyLevel,
+        strategy: &crate::ring::strategy::ReplicationStrategy,
+        row_limit: usize,
+        start_clustering: &[u8],
+    ) -> crate::error::Result<Option<Vec<Row>>> {
+        self.coordinate_read_nts_filtered(
+            table_id,
+            key,
+            cl,
+            strategy,
+            PartitionReadSlice::after(start_clustering, row_limit),
+        )
+        .await
     }
 
     pub async fn coordinate_read_nts_clustering_row(
@@ -1200,8 +1397,14 @@ impl ClusterCoordinator {
         cl: ConsistencyLevel,
         strategy: &crate::ring::strategy::ReplicationStrategy,
     ) -> crate::error::Result<Option<Vec<Row>>> {
-        self.coordinate_read_nts_filtered(table_id, key, cl, strategy, 0, Some(clustering.to_vec()))
-            .await
+        self.coordinate_read_nts_filtered(
+            table_id,
+            key,
+            cl,
+            strategy,
+            PartitionReadSlice::exact(clustering),
+        )
+        .await
     }
 
     async fn coordinate_read_nts_filtered(
@@ -1210,9 +1413,13 @@ impl ClusterCoordinator {
         key: &DecoratedKey,
         cl: ConsistencyLevel,
         strategy: &crate::ring::strategy::ReplicationStrategy,
-        row_limit: usize,
-        clustering: Option<Vec<u8>>,
+        slice: PartitionReadSlice,
     ) -> crate::error::Result<Option<Vec<Row>>> {
+        let PartitionReadSlice {
+            row_limit,
+            clustering,
+            start_clustering,
+        } = slice;
         let ring = self.ring.load();
         let all_replicas = ring.replicas_for_strategy(key.token.0, strategy);
 
@@ -1266,15 +1473,19 @@ impl ClusterCoordinator {
             });
         }
 
-        // Delegate to the existing coordinate_read_with logic using
-        // the effective replica set and required count.
-        self.coordinate_read_with_filter(
+        // Preserve the exact NTS/DC-selected replica identities through the
+        // shared digest/read path.
+        self.coordinate_read_from_replicas(
             table_id,
             key,
             cl,
-            effective_replicas.len(),
-            row_limit,
-            clustering,
+            effective_replicas,
+            required,
+            PartitionReadSlice {
+                row_limit,
+                clustering,
+                start_clustering,
+            },
         )
         .await
     }
@@ -2297,9 +2508,12 @@ mod tests {
     #[async_trait::async_trait]
     impl RpcHandler for StaticReadHandler {
         async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
-            let Message::ReadRequest(_) = msg else {
+            if !matches!(
+                msg,
+                Message::ReadRequest(_) | Message::PartitionSuffixReadRequest(_)
+            ) {
                 return None;
-            };
+            }
             let payload = ReadResponsePayload {
                 found: true,
                 partition: Some(crate::raft::handlers::partition_to_wire(
@@ -2425,10 +2639,18 @@ mod tests {
     #[async_trait::async_trait]
     impl RpcHandler for StaticDigestReadHandler {
         async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
-            let Message::ReadRequest(body) = msg else {
-                return None;
+            let digest_only = match msg {
+                Message::ReadRequest(body) => {
+                    let req: ReadRequestPayload = bincode::deserialize(&body).ok()?;
+                    req.digest_only
+                }
+                Message::PartitionSuffixReadRequest(body) => {
+                    let req: PartitionSuffixReadRequestPayload =
+                        bincode::deserialize(&body).ok()?;
+                    req.request.digest_only
+                }
+                _ => return None,
             };
-            let req: ReadRequestPayload = bincode::deserialize(&body).ok()?;
             let digest = crate::raft::handlers::compute_partition_digest(&self.partition).ok();
             let timestamp = self
                 .partition
@@ -2439,7 +2661,7 @@ mod tests {
                 .unwrap_or(i64::MIN);
             let payload = ReadResponsePayload {
                 found: true,
-                partition: if req.digest_only {
+                partition: if digest_only {
                     None
                 } else {
                     Some(crate::raft::handlers::partition_to_wire(
@@ -2756,9 +2978,10 @@ mod tests {
 
         let (worker_thread, result_rows) = rt.block_on(async move {
             let worker = std::thread::current().id();
-            let result = read_local_partition(&storage, table_id.clone(), key.clone(), 0, None)
-                .await
-                .unwrap();
+            let result =
+                read_local_partition(&storage, table_id.clone(), key.clone(), 0, None, None)
+                    .await
+                    .unwrap();
             (worker, result.map(|p| p.rows.len()).unwrap_or(0))
         });
 
@@ -4222,9 +4445,11 @@ mod tests {
 
     #[tokio::test]
     async fn coordinate_read_nts_local_quorum_reads_from_local_dc() {
-        // Setup: dc1 has local node with data, dc2 has unreachable node.
+        // Setup: the first SimpleStrategy replica is an unreachable dc2 node,
+        // while NTS selects the local dc1 node that owns the data.
         // CL=LOCAL_QUORUM with dc1_rf=1 => block_for_dc(1) = 1.
-        // Local node has data => should succeed.
+        // Losing the selected node IDs and recomputing by replica count would
+        // contact dc2 and fail this read.
         let dir = tempfile::tempdir().unwrap();
         let storage = test_storage(dir.path());
         register_test_table(&storage);
@@ -4232,10 +4457,14 @@ mod tests {
         let local_node_id = 1u64;
         let mut local_info = make_node("10.0.0.1:7000");
         local_info.data_center = "dc1".to_string();
+        let mut remote_dc2 = make_node("127.0.0.1:1");
+        remote_dc2.data_center = "dc2".to_string();
 
         let mut ring = TokenRing::new();
         ring.add_node(local_node_id, local_info);
-        ring.assign_tokens(local_node_id, &[0, 100, 200]);
+        ring.add_node(2, remote_dc2);
+        ring.assign_tokens(2, &[42]);
+        ring.assign_tokens(local_node_id, &[100]);
 
         let coordinator = ClusterCoordinator::new(
             Arc::new(ArcSwap::from_pointee(ring)),
@@ -4256,7 +4485,10 @@ mod tests {
         let row = test_row(1000);
         storage.write(&table_id, &key, row, 1000).unwrap();
 
-        let dc_rf = std::collections::HashMap::from([("dc1".to_string(), 1usize)]);
+        let dc_rf = std::collections::HashMap::from([
+            ("dc1".to_string(), 1usize),
+            ("dc2".to_string(), 1usize),
+        ]);
         let strategy = crate::ring::strategy::ReplicationStrategy::NetworkTopology { dc_rf };
 
         let result = coordinator
@@ -4265,6 +4497,151 @@ mod tests {
             .unwrap();
 
         assert!(result.is_some(), "should read back written data");
+
+        for clustering in [vec![1], vec![2], vec![3]] {
+            let mut row = test_row(2000 + i64::from(clustering[0]));
+            row.clustering = clustering;
+            storage.write(&table_id, &key, row, 2000).unwrap();
+        }
+        let suffix = coordinator
+            .coordinate_read_nts_limited_rows_from(
+                &table_id,
+                &key,
+                ConsistencyLevel::LocalQuorum,
+                &strategy,
+                1,
+                &[1],
+            )
+            .await
+            .unwrap()
+            .expect("local-DC suffix read returns data");
+        assert_eq!(suffix.len(), 1);
+        assert_eq!(suffix[0].clustering, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn partition_suffix_read_fails_when_no_replica_accepts_the_operation() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let key = test_key();
+        let mut remote = make_node("127.0.0.1:1");
+        remote.data_center = "dc1".to_string();
+        let mut ring = TokenRing::new();
+        ring.add_node(2, remote);
+        ring.assign_tokens(2, &[key.token.0]);
+
+        let coordinator = make_coordinator(
+            ring,
+            noop_peer_manager(),
+            1,
+            storage,
+            1,
+            ConsistencyLevel::One,
+        );
+        let result = coordinator
+            .coordinate_read_with_limited_rows_from(
+                &TableId::new("test_ks", "test_tbl"),
+                &key,
+                ConsistencyLevel::One,
+                1,
+                3,
+                &[1],
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(ClusterError::ReadTimeout { received: 0, .. })),
+            "an unsupported suffix operation must fail loudly, not masquerade as an empty key: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn partition_suffix_read_preserves_valid_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let key = test_key();
+        let local_node_id = 1;
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, make_node("127.0.0.1:7000"));
+        ring.assign_tokens(local_node_id, &[key.token.0]);
+        let coordinator = make_coordinator(
+            ring,
+            noop_peer_manager(),
+            local_node_id,
+            storage,
+            1,
+            ConsistencyLevel::One,
+        );
+
+        let result = coordinator
+            .coordinate_read_with_limited_rows_from(
+                &TableId::new("test_ks", "test_tbl"),
+                &key,
+                ConsistencyLevel::One,
+                1,
+                3,
+                &[1],
+            )
+            .await
+            .expect("a valid local not-found response is not a transport failure");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn local_one_suffix_failure_preserves_consistency_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let key = test_key();
+        let local_node_id = 1;
+        let mut local = make_node("127.0.0.1:7000");
+        local.data_center = "dc1".to_string();
+        let mut rejected_remote = make_node("127.0.0.1:1");
+        rejected_remote.data_center = "dc1".to_string();
+        let mut ring = TokenRing::new();
+        ring.add_node(local_node_id, local);
+        ring.add_node(2, rejected_remote);
+        ring.assign_tokens(2, &[key.token.0]);
+        ring.assign_tokens(local_node_id, &[100]);
+
+        let coordinator = make_coordinator(
+            ring,
+            noop_peer_manager(),
+            local_node_id,
+            storage,
+            1,
+            ConsistencyLevel::LocalOne,
+        );
+        let strategy = crate::ring::strategy::ReplicationStrategy::NetworkTopology {
+            dc_rf: std::collections::HashMap::from([("dc1".to_string(), 1)]),
+        };
+        let result = coordinator
+            .coordinate_read_nts_limited_rows_from(
+                &TableId::new("test_ks", "test_tbl"),
+                &key,
+                ConsistencyLevel::LocalOne,
+                &strategy,
+                3,
+                &[1],
+            )
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(ClusterError::ReadTimeout {
+                    ref consistency,
+                    received: 0,
+                    ..
+                }) if consistency == "LOCAL_ONE"
+            ),
+            "LOCAL_ONE failure must retain its consistency metadata: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/ferrosa-cluster/src/raft/handlers.rs
+++ b/ferrosa-cluster/src/raft/handlers.rs
@@ -14,6 +14,7 @@
 //! | `RaftVote(bytes)`          | [`RaftVoteHandler`]  | `RaftVoteResponse(bytes)` |
 //! | `RaftInstallSnapshot(bytes)`| [`RaftSnapshotHandler`]| `RaftAppendResponse(bytes)`|
 //! | `ReadRequest(bytes)`       | [`ReadRequestHandler`]| `ReadResponse(bytes)`    |
+//! | `PartitionSuffixReadRequest(bytes)` | [`ReadRequestHandler`] | `ReadResponse(bytes)` |
 //!
 //! # Serialization of Partition Data
 //!
@@ -342,6 +343,23 @@ pub struct ReadRequestPayload {
     /// return partition rows according to page_size/page_state.
     #[serde(default)]
     pub clustering: Vec<u8>,
+}
+
+/// Additive wire payload for a bounded partition suffix read.
+///
+/// This deliberately uses a distinct internode message type rather than
+/// appending a positional bincode field to [`ReadRequestPayload`]. A new node
+/// therefore continues to decode legacy requests byte-for-byte, while an old
+/// node rejects this unknown operation instead of silently dropping the suffix
+/// bound and returning a prefix.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartitionSuffixReadRequestPayload {
+    /// Wire-schema version. The only supported value is 1.
+    pub version: u8,
+    /// Unchanged legacy request fields used for table, key, digest, and limit.
+    pub request: ReadRequestPayload,
+    /// Exclusive clustering-key lower bound. Must be non-empty.
+    pub start_clustering: Vec<u8>,
 }
 
 /// Payload for a remote read response.
@@ -924,17 +942,40 @@ impl ReadRequestHandler {
 #[async_trait]
 impl RpcHandler for ReadRequestHandler {
     async fn handle(&self, _from: PeerId, msg: Message) -> Option<Message> {
-        let bytes = match msg {
-            Message::ReadRequest(b) => b,
+        let (req, start_clustering) = match msg {
+            Message::ReadRequest(bytes) => {
+                let req: ReadRequestPayload = bincode::deserialize(&bytes)
+                    .map_err(|e| {
+                        tracing::warn!("ReadRequestHandler: failed to deserialize request: {e}");
+                        e
+                    })
+                    .ok()?;
+                (req, None)
+            }
+            Message::PartitionSuffixReadRequest(bytes) => {
+                let suffix: PartitionSuffixReadRequestPayload = bincode::deserialize(&bytes)
+                    .map_err(|e| {
+                        tracing::warn!(
+                            "ReadRequestHandler: failed to deserialize suffix request: {e}"
+                        );
+                        e
+                    })
+                    .ok()?;
+                if suffix.version != 1
+                    || suffix.start_clustering.is_empty()
+                    || !suffix.request.clustering.is_empty()
+                    || !suffix.request.page_state.is_empty()
+                {
+                    tracing::warn!(
+                        version = suffix.version,
+                        "ReadRequestHandler: rejected malformed suffix read request"
+                    );
+                    return None;
+                }
+                (suffix.request, Some(suffix.start_clustering))
+            }
             _ => return None,
         };
-
-        let req: ReadRequestPayload = bincode::deserialize(&bytes)
-            .map_err(|e| {
-                tracing::warn!("ReadRequestHandler: failed to deserialize request: {e}");
-                e
-            })
-            .ok()?;
 
         let table_id = TableId::new(&req.keyspace, &req.table);
         let key = DecoratedKey::new(PartitionKey::new(req.key));
@@ -951,6 +992,9 @@ impl RpcHandler for ReadRequestHandler {
         let storage_read = if !req.clustering.is_empty() {
             self.storage
                 .read_clustering_row(&table_id, &key, &req.clustering)
+        } else if let Some(start_clustering) = start_clustering.as_deref() {
+            self.storage
+                .read_limited_rows_from(&table_id, &key, start_clustering, page_size)
         } else if page_size > 0 && page_offset == 0 {
             // First page: over-read by one row so the paging logic below can
             // tell whether a tail exists past this page.
@@ -1790,6 +1834,34 @@ mod tests {
     }
 
     #[test]
+    fn legacy_read_request_payload_decodes_on_new_node() {
+        #[derive(Serialize)]
+        struct LegacyReadRequestPayload {
+            keyspace: String,
+            table: String,
+            key: Vec<u8>,
+            digest_only: bool,
+            page_size: u32,
+            page_state: Vec<u8>,
+            clustering: Vec<u8>,
+        }
+
+        let legacy = LegacyReadRequestPayload {
+            keyspace: "ks".to_string(),
+            table: "tbl".to_string(),
+            key: b"the_key".to_vec(),
+            digest_only: false,
+            page_size: 17,
+            page_state: vec![],
+            clustering: vec![],
+        };
+        let bytes = bincode::serialize(&legacy).expect("serialize legacy payload");
+        let decoded: ReadRequestPayload = bincode::deserialize(&bytes)
+            .expect("a new node must accept the unchanged legacy ReadRequest payload");
+        assert_eq!(decoded.page_size, 17);
+    }
+
+    #[test]
     fn read_response_payload_serde_roundtrip() {
         let partition = make_partition(b"k", 42);
         let resp = ReadResponsePayload {
@@ -2094,6 +2166,68 @@ mod tests {
             "every row in a partition larger than one page must be paged out; \
              losing the tail is the cluster count(*) data-loss bug"
         );
+    }
+
+    #[tokio::test]
+    async fn read_request_handler_bounds_partition_suffix_from_clustering_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = test_storage(dir.path());
+        register_test_table(&storage);
+
+        let table_id = TableId::new("test_ks", "test_tbl");
+        let key_bytes = b"cursor_partition".as_slice();
+        let dk = DecoratedKey::new(PartitionKey::new(key_bytes.to_vec()));
+        for i in 0..25u32 {
+            storage
+                .write(
+                    &table_id,
+                    &dk,
+                    Row {
+                        clustering: i.to_be_bytes().to_vec(),
+                        cells: vec![(0, CellValue::live(vec![i as u8], 1000 + i as i64))],
+                        deletion: DeletionTime::LIVE,
+                        primary_key_liveness: LivenessInfo::with_timestamp(1000 + i as i64),
+                    },
+                    1000 + i as i64,
+                )
+                .unwrap();
+        }
+
+        let handler = ReadRequestHandler::new(storage);
+        let req = PartitionSuffixReadRequestPayload {
+            version: 1,
+            request: ReadRequestPayload {
+                keyspace: "test_ks".to_string(),
+                table: "test_tbl".to_string(),
+                key: key_bytes.to_vec(),
+                digest_only: false,
+                page_size: 3,
+                page_state: vec![],
+                clustering: vec![],
+            },
+            start_clustering: 19u32.to_be_bytes().to_vec(),
+        };
+        let response = handler
+            .handle(
+                make_peer_id(),
+                Message::PartitionSuffixReadRequest(Bytes::from(bincode::serialize(&req).unwrap())),
+            )
+            .await
+            .expect("handler responds");
+        let Message::ReadResponse(bytes) = response else {
+            panic!("expected ReadResponse");
+        };
+        let response: ReadResponsePayload = bincode::deserialize(&bytes).unwrap();
+        let partition = partition_from_wire(response.partition.expect("suffix rows"));
+        assert_eq!(
+            partition
+                .rows
+                .iter()
+                .map(|row| u32::from_be_bytes(row.clustering.as_slice().try_into().unwrap()))
+                .collect::<Vec<_>>(),
+            vec![20, 21, 22]
+        );
+        assert!(!response.has_more, "CQL cursor owns suffix continuation");
     }
 
     #[tokio::test]

--- a/ferrosa-cluster/src/write_path.rs
+++ b/ferrosa-cluster/src/write_path.rs
@@ -507,6 +507,76 @@ impl WritePath {
         }
     }
 
+    /// Read at most `row_limit` rows from one partition strictly after an
+    /// exclusive clustering cursor. Cluster mode uses the same token replica
+    /// and consistency-level path as an ordinary partition-key read; it never
+    /// widens into a global range scan.
+    pub async fn pk_read_limited_rows_from(
+        &self,
+        table_id: &TableId,
+        key: &DecoratedKey,
+        start_clustering: &[u8],
+        cl: ConsistencyLevel,
+        strategy: &ReplicationStrategy,
+        row_limit: usize,
+    ) -> ferrosa_common::Result<Option<Partition>> {
+        let rows_opt = match self {
+            Self::Direct(engine) => {
+                return engine.read_limited_rows_from(table_id, key, start_clustering, row_limit);
+            }
+            Self::Pair(coordinator) | Self::DegradedPair(coordinator) => {
+                return coordinator.local_storage().read_limited_rows_from(
+                    table_id,
+                    key,
+                    start_clustering,
+                    row_limit,
+                );
+            }
+            Self::Cluster(coordinator) => match strategy {
+                ReplicationStrategy::Simple { replication_factor } => {
+                    coordinator
+                        .coordinate_read_with_limited_rows_from(
+                            table_id,
+                            key,
+                            cl,
+                            *replication_factor,
+                            row_limit,
+                            start_clustering,
+                        )
+                        .await
+                }
+                ReplicationStrategy::NetworkTopology { .. } => {
+                    coordinator
+                        .coordinate_read_nts_limited_rows_from(
+                            table_id,
+                            key,
+                            cl,
+                            strategy,
+                            row_limit,
+                            start_clustering,
+                        )
+                        .await
+                }
+            },
+            Self::Unavailable => {
+                return Err(ferrosa_common::Error::InvalidData(
+                    "pair mode: primary unavailable, reads rejected until operator promotes".into(),
+                ));
+            }
+        };
+
+        match rows_opt {
+            Ok(Some(rows)) if !rows.is_empty() => Ok(Some(Partition {
+                key: key.clone(),
+                deletion: ferrosa_sstable::types::DeletionTime::LIVE,
+                static_row: None,
+                rows,
+            })),
+            Ok(_) => Ok(None),
+            Err(e) => Err(ferrosa_common::Error::InvalidData(format!("cluster: {e}"))),
+        }
+    }
+
     /// Read exactly one clustered row by full primary key with CL enforcement.
     pub async fn pk_read_clustering_row(
         &self,

--- a/ferrosa-cql/src/connection.rs
+++ b/ferrosa-cql/src/connection.rs
@@ -2,7 +2,7 @@
 //! Correctness: Correct when protocol state transitions, prepared metadata, and bound-value
 //! substitution preserve the CQL wire contract for every accepted opcode.
 //! Last revised: 2026-08-27
-//! Last changed: Fail data-bearing opcodes immediately after consensus failure.
+//! Last changed: Validate and substitute prepared SELECT LIMIT markers before routing.
 //!
 //! Per-connection CQL protocol handler.
 //!
@@ -27,7 +27,7 @@ use tokio_util::codec::Framed;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn, Instrument, Level, Span};
 
-use crate::ast::{Assignment, SelectColumn, SelectStatement, Statement, Term};
+use crate::ast::{Assignment, Limit, SelectColumn, SelectStatement, Statement, Term};
 use crate::auth::{
     encode_auth_success, encode_authenticate_response, parse_sasl_plain, MAX_AUTH_ATTEMPTS,
 };
@@ -1672,7 +1672,10 @@ async fn handle_query(
                 }
             };
         paging = parsed_paging;
-        stmt = substitute_bound_terms(&temp_plan, bound_terms.as_deref());
+        stmt = match substitute_bound_terms(&temp_plan, bound_terms.as_deref()) {
+            Ok(stmt) => stmt,
+            Err(error) => return HandleResult::Reply(Opcode::Error, error.encode_body()),
+        };
     }
 
     // Build an auth context for routing (use a default if auth was disabled).
@@ -2000,7 +2003,10 @@ async fn handle_execute(
         }
     }
 
-    let stmt = substitute_bound_terms(&plan, bound_terms.as_deref());
+    let stmt = match substitute_bound_terms(&plan, bound_terms.as_deref()) {
+        Ok(stmt) => stmt,
+        Err(error) => return HandleResult::Reply(Opcode::Error, error.encode_body()),
+    };
 
     match crate::router::route(state, &ctx, stmt).await {
         Ok(RouteResult::Result(body)) => HandleResult::Reply(Opcode::Result, body),
@@ -2841,18 +2847,71 @@ fn substitute_bound_values(
     protocol_version: u8,
 ) -> Result<Statement, CqlError> {
     let bound_terms = decode_bound_values(plan, cursor, protocol_version)?;
-    Ok(substitute_bound_terms(plan, bound_terms.as_deref()))
+    substitute_bound_terms(plan, bound_terms.as_deref())
 }
 
 pub(crate) fn substitute_bound_terms(
     plan: &PreparedPlan,
     bound_terms: Option<&[Term]>,
-) -> Statement {
-    let Some(bound_terms) = bound_terms else {
-        return plan.statement.clone();
-    };
+) -> Result<Statement, CqlError> {
+    let bound_terms = bound_terms.unwrap_or_default();
     let mut substitution_idx = 0usize;
-    substitute_in_statement(&plan.statement, bound_terms, &mut substitution_idx)
+    let mut statement =
+        substitute_in_statement(&plan.statement, bound_terms, &mut substitution_idx);
+
+    if let Statement::Select(select) = &mut statement {
+        // SELECT marker order is WHERE, ANN OF, LIMIT. This must remain aligned
+        // with count_bind_markers() and analyze_prepared_columns(). The generic
+        // path previously stopped after WHERE, so a range predicate declined
+        // the exact-key fast path and left LIMIT ? looking like no limit at all.
+        if let Some((_, ann_term)) = &mut select.ann_of {
+            substitute_in_term(ann_term, bound_terms, &mut substitution_idx);
+        }
+        substitute_select_limit(&mut select.limit, bound_terms, &mut substitution_idx)?;
+    }
+
+    Ok(statement)
+}
+
+/// Resolve a prepared SELECT LIMIT marker to a positive literal.
+///
+/// Invariant: an unresolved, missing, NULL, malformed, zero, or negative LIMIT
+/// never reaches the router, because the router treats a non-literal limit as
+/// absent and absence is an intentionally unbounded query.
+fn substitute_select_limit(
+    limit: &mut Option<Limit>,
+    terms: &[Term],
+    idx: &mut usize,
+) -> Result<(), CqlError> {
+    let Some(Limit::BindMarker | Limit::NamedBindMarker(_)) = limit else {
+        return Ok(());
+    };
+
+    let term = terms
+        .get(*idx)
+        .ok_or_else(|| CqlError::Invalid("missing prepared SELECT LIMIT value".into()))?;
+    *idx += 1;
+
+    let value = match term {
+        Term::IntegerLiteral(value) => i32::try_from(*value).map_err(|_| {
+            CqlError::Invalid(format!(
+                "prepared SELECT LIMIT value {value} is out of range"
+            ))
+        })?,
+        other => {
+            return Err(CqlError::Invalid(format!(
+                "prepared SELECT LIMIT must be an integer, got {other:?}"
+            )))
+        }
+    };
+    if value <= 0 {
+        return Err(CqlError::Invalid(format!(
+            "prepared SELECT LIMIT must be positive, got {value}"
+        )));
+    }
+
+    *limit = Some(Limit::Literal(value));
+    Ok(())
 }
 
 #[cfg(test)]
@@ -3973,6 +4032,90 @@ mod tests {
         } else {
             panic!("expected Select statement");
         }
+    }
+
+    #[test]
+    fn prepared_select_bound_limit_is_substituted_after_where() {
+        let plan = make_plan(
+            "SELECT cursor FROM ks.events WHERE tenant = ? AND cursor > ? LIMIT ?",
+            vec![
+                ("tenant", CqlType::Varchar),
+                ("cursor", CqlType::Bigint),
+                ("[limit]", CqlType::Int),
+            ],
+        );
+        let after = 10i64.to_be_bytes();
+        let limit = 2i32.to_be_bytes();
+        let payload = encode_values(&[b"tenant-a", &after, &limit]);
+
+        let result = substitute_bound_values(&plan, &payload, 4).unwrap();
+        let Statement::Select(select) = result else {
+            panic!("expected SELECT");
+        };
+        assert_eq!(select.limit, Some(crate::ast::Limit::Literal(2)));
+    }
+
+    #[test]
+    fn prepared_select_bound_limit_rejects_missing_value() {
+        let plan = make_plan(
+            "SELECT cursor FROM ks.events WHERE tenant = ? LIMIT ?",
+            vec![("tenant", CqlType::Varchar), ("[limit]", CqlType::Int)],
+        );
+        let payload = encode_values(&[b"tenant-a"]);
+
+        let error = substitute_bound_values(&plan, &payload, 4).unwrap_err();
+        assert!(
+            matches!(error, CqlError::Invalid(ref message) if message.contains("missing prepared SELECT LIMIT")),
+            "missing LIMIT must fail before routing, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn prepared_select_bound_limit_rejects_null() {
+        let plan = make_plan(
+            "SELECT cursor FROM ks.events WHERE tenant = ? LIMIT ?",
+            vec![("tenant", CqlType::Varchar), ("[limit]", CqlType::Int)],
+        );
+        let mut payload = encode_values(&[b"tenant-a"]);
+        payload[1..3].copy_from_slice(&2u16.to_be_bytes());
+        payload.extend_from_slice(&(-1i32).to_be_bytes());
+
+        let error = substitute_bound_values(&plan, &payload, 4).unwrap_err();
+        assert!(
+            matches!(error, CqlError::Invalid(ref message) if message.contains("must be an integer")),
+            "NULL LIMIT must fail before routing, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn prepared_select_bound_limit_rejects_non_positive_value() {
+        let plan = make_plan(
+            "SELECT cursor FROM ks.events WHERE tenant = ? LIMIT ?",
+            vec![("tenant", CqlType::Varchar), ("[limit]", CqlType::Int)],
+        );
+        let zero = 0i32.to_be_bytes();
+        let payload = encode_values(&[b"tenant-a", &zero]);
+
+        let error = substitute_bound_values(&plan, &payload, 4).unwrap_err();
+        assert!(
+            matches!(error, CqlError::Invalid(ref message) if message.contains("must be positive")),
+            "zero LIMIT must fail before routing, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn prepared_select_bound_limit_rejects_malformed_int() {
+        let plan = make_plan(
+            "SELECT cursor FROM ks.events WHERE tenant = ? LIMIT ?",
+            vec![("tenant", CqlType::Varchar), ("[limit]", CqlType::Int)],
+        );
+        let payload = encode_values(&[b"tenant-a", b"not-an-int"]);
+
+        let error = substitute_bound_values(&plan, &payload, 4).unwrap_err();
+        assert!(
+            matches!(error, CqlError::Invalid(ref message) if message.contains("must be an integer")),
+            "malformed LIMIT must fail before routing, got {error:?}"
+        );
     }
 
     #[test]

--- a/ferrosa-cql/src/parser.rs
+++ b/ferrosa-cql/src/parser.rs
@@ -8,10 +8,10 @@
 //! - **M4**: No `unwrap()` on user-derived data — all fallible paths return `Result`.
 //! - **M6**: Collection element count capped at `MAX_COLLECTION_ELEMENTS` (65,536).
 //!
-//! Correctness: WHERE tuple restrictions require matching column/value arity
-//! and preserve clustering-column order for keyset cursors.
-//! Last revised: 2026-08-24.
-//! Last changed: accepted compound clustering tuple slices (t_4d8925f4).
+//! Correctness: WHERE tuple restrictions preserve clustering order, and LIMIT
+//! literals are strictly positive so zero never aliases the router's unbounded sentinel.
+//! Last revised: 2026-08-27.
+//! Last changed: reject non-positive literal LIMIT values before routing.
 
 use std::time::Duration;
 
@@ -238,6 +238,11 @@ impl<'input> Parser<'input> {
                     let n = i32::try_from(n).map_err(|_| {
                         CqlError::SyntaxError(format!("LIMIT value out of range: {n}"))
                     })?;
+                    if n <= 0 {
+                        return Err(CqlError::SyntaxError(format!(
+                            "LIMIT value must be positive, got {n}"
+                        )));
+                    }
                     Some(crate::ast::Limit::Literal(n))
                 }
                 TokenKind::QuestionMark => Some(crate::ast::Limit::BindMarker),
@@ -3609,6 +3614,15 @@ mod tests {
             }
             other => panic!("expected Select, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn parse_select_rejects_zero_limit_before_unbounded_routing() {
+        let error = parse("SELECT * FROM t WHERE pk = 1 LIMIT 0").unwrap_err();
+        assert!(
+            matches!(error, CqlError::SyntaxError(ref message) if message.contains("must be positive")),
+            "zero LIMIT must fail loudly instead of aliasing the unbounded sentinel: {error:?}"
+        );
     }
 
     #[test]

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -8,10 +8,11 @@
 //! - **M8**: Every `route_*` function checks permissions via `Schema::check_permission`.
 //! - **M12**: Batch size is capped at `MAX_BATCH_STATEMENTS` (500).
 //!
-//! Correctness: compound clustering restrictions validate declared key order
-//! and compare row values lexicographically, including tied leading values.
-//! Last revised: 2026-08-24.
-//! Last changed: executed compound clustering tuple slices (t_4d8925f4).
+//! Correctness: compound clustering restrictions validate declared key order,
+//! and bounded single-column clustering resumes stop before materializing a
+//! wide partition tail.
+//! Last revised: 2026-08-27.
+//! Last changed: stream full-PK `ck > value LIMIT n` reads from the clustering bound.
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -519,6 +520,226 @@ fn safe_partition_key_filter_row_limit(
             !wc.token_fn && wc.op == ComparisonOp::Eq && partition_keys.contains(wc.column.as_str())
         })
         .then_some(limit)
+}
+
+/// Return the exclusive clustering resume and row bound for the streaming
+/// single-partition slice shape used by cursor/event-log consumers.
+///
+/// This intentionally accepts only one ascending clustering column, exact
+/// partition-key equality, and one `ck > value` predicate. Broader predicates
+/// continue through the general post-filter path because stopping after LIMIT
+/// source rows could underfill the result. Keeping this recognition narrow is
+/// the safety proof that lets storage stop without materializing the partition.
+fn bounded_partition_clustering_resume(
+    s: &SelectStatement,
+    table_meta: &TableMetadata,
+    ks: &str,
+    schema: &Schema,
+) -> Result<Option<(Vec<u8>, usize)>, CqlError> {
+    let table_has_static_columns = table_meta
+        .columns
+        .values()
+        .any(|column| column.kind == ColumnKind::Static);
+    let row_preserving_projection = s.columns.iter().all(|column| match column {
+        SelectColumn::Star => !table_has_static_columns,
+        SelectColumn::Column(name) => table_meta
+            .columns
+            .get(name)
+            .is_some_and(|column| column.kind != ColumnKind::Static),
+        SelectColumn::FunctionCall { .. } => false,
+    });
+    if !row_preserving_projection
+        || s.distinct
+        || s.ann_of.is_some()
+        || s.geo_nearest.is_some()
+        || !s.geo_predicates.is_empty()
+        || !s.order_by.is_empty()
+    {
+        return Ok(None);
+    }
+    let Some(limit) = s.limit.as_ref().and_then(Limit::as_literal) else {
+        return Ok(None);
+    };
+    if limit <= 0 || table_meta.clustering_key.len() != 1 {
+        return Ok(None);
+    }
+    let (clustering_name, clustering_order) = &table_meta.clustering_key[0];
+    if *clustering_order != SchemaClusteringOrder::Asc {
+        return Ok(None);
+    }
+
+    let mut clustering_clause = None;
+    for clause in &s.where_clauses {
+        if clause.token_fn {
+            return Ok(None);
+        }
+        if table_meta
+            .partition_key
+            .iter()
+            .any(|name| name == &clause.column)
+        {
+            if clause.op != ComparisonOp::Eq {
+                return Ok(None);
+            }
+        } else if clause.column == *clustering_name && clause.op == ComparisonOp::Gt {
+            if clustering_clause.replace(clause).is_some() {
+                return Ok(None);
+            }
+        } else {
+            return Ok(None);
+        }
+    }
+    let Some(clause) = clustering_clause else {
+        return Ok(None);
+    };
+
+    let column = &table_meta.columns[clustering_name];
+    let cql_type = resolve_col_type(&column.column_type, ks, schema)?;
+    let value = bridge::term_to_cql_value(&clause.value, &cql_type)?;
+    Ok(Some((
+        bridge::build_clustering_key(&[value]),
+        limit as usize,
+    )))
+}
+
+const BOUNDED_PARTITION_CURSOR_MAGIC: &[u8; 4] = b"BPC1";
+
+fn decode_bounded_partition_cursor(
+    bytes: &[u8],
+    expected_partition_key: &[u8],
+    expected_limit: usize,
+) -> Result<(usize, Vec<u8>), CqlError> {
+    let state = crate::paging::PagingState::decode(bytes)?;
+    if !state.remaining_in_partition || state.partition_key != expected_partition_key {
+        return Err(CqlError::Protocol(
+            "paging_state does not belong to this bounded partition query".into(),
+        ));
+    }
+    let payload = state.clustering_key;
+    if payload.len() < 20 || &payload[..4] != BOUNDED_PARTITION_CURSOR_MAGIC {
+        return Err(CqlError::Protocol(
+            "paging_state is not a bounded partition cursor".into(),
+        ));
+    }
+    let encoded_limit = u64::from_be_bytes(payload[4..12].try_into().unwrap());
+    if encoded_limit != expected_limit as u64 {
+        return Err(CqlError::Protocol(
+            "paging_state LIMIT does not match the current query".into(),
+        ));
+    }
+    let returned_u64 = u64::from_be_bytes(payload[12..20].try_into().unwrap());
+    let returned = usize::try_from(returned_u64)
+        .map_err(|_| CqlError::Protocol("paging_state row count is out of range".into()))?;
+    if returned >= expected_limit || payload.len() == 20 {
+        return Err(CqlError::Protocol(
+            "paging_state has an invalid bounded partition position".into(),
+        ));
+    }
+    Ok((returned, payload[20..].to_vec()))
+}
+
+fn encode_bounded_partition_cursor(
+    partition_key: &[u8],
+    clustering_key: &[u8],
+    query_limit: usize,
+    returned: usize,
+) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(20 + clustering_key.len());
+    payload.extend_from_slice(BOUNDED_PARTITION_CURSOR_MAGIC);
+    payload.extend_from_slice(&(query_limit as u64).to_be_bytes());
+    payload.extend_from_slice(&(returned as u64).to_be_bytes());
+    payload.extend_from_slice(clustering_key);
+    crate::paging::PagingState {
+        partition_key: partition_key.to_vec(),
+        clustering_key: payload,
+        remaining_in_partition: true,
+    }
+    .encode()
+}
+
+struct BoundedPartitionReadContext<'a> {
+    write_path: &'a WritePath,
+    table_id: &'a TableId,
+    key: &'a ferrosa_common::key::DecoratedKey,
+    paging: &'a crate::paging::PagingParams,
+    consistency: ConsistencyLevel,
+    strategy: &'a ferrosa_cluster::ring::strategy::ReplicationStrategy,
+}
+
+/// Read one page from a single partition using its token replica set and an
+/// exclusive clustering cursor. The replica returns at most the page target plus
+/// one lookahead row; that extra row is discarded after proving continuation.
+async fn read_bounded_partition_clustering_suffix(
+    context: BoundedPartitionReadContext<'_>,
+    where_start_exclusive: Vec<u8>,
+    query_limit: usize,
+) -> Result<(Option<ferrosa_sstable::types::Partition>, Option<Vec<u8>>), CqlError> {
+    let (already_returned, start_exclusive) = match context.paging.paging_state.as_deref() {
+        Some(bytes) => {
+            decode_bounded_partition_cursor(bytes, context.key.key.as_bytes(), query_limit)?
+        }
+        None => (0, where_start_exclusive),
+    };
+    let remaining = query_limit.saturating_sub(already_returned);
+    if remaining == 0 {
+        return Ok((None, None));
+    }
+    let page_target = context
+        .paging
+        .page_size
+        .filter(|size| *size > 0)
+        .map_or(remaining, |size| remaining.min(size as usize));
+    let probe_limit = page_target.saturating_add(usize::from(page_target < remaining));
+    let mut partition = context
+        .write_path
+        .pk_read_limited_rows_from(
+            context.table_id,
+            context.key,
+            &start_exclusive,
+            context.consistency,
+            context.strategy,
+            probe_limit,
+        )
+        .await?;
+
+    #[cfg(test)]
+    BOUNDED_PARTITION_ROWS_MATERIALIZED.with(|count| {
+        count.set(
+            partition
+                .as_ref()
+                .map_or(0, |partition| partition.rows.len()),
+        );
+    });
+
+    let has_more = partition
+        .as_ref()
+        .is_some_and(|partition| partition.rows.len() > page_target);
+    if let Some(partition) = &mut partition {
+        partition.rows.truncate(page_target);
+    }
+    let delivered = partition
+        .as_ref()
+        .map_or(0, |partition| partition.rows.len());
+    let returned = already_returned.saturating_add(delivered);
+    let next = if has_more && returned < query_limit {
+        let last_clustering = partition
+            .as_ref()
+            .and_then(|partition| partition.rows.last())
+            .map(|row| row.clustering.as_slice())
+            .ok_or_else(|| {
+                CqlError::ServerError("bounded partition page lost its cursor row".into())
+            })?;
+        Some(encode_bounded_partition_cursor(
+            context.key.key.as_bytes(),
+            last_clustering,
+            query_limit,
+            returned,
+        ))
+    } else {
+        None
+    };
+
+    Ok((partition, next))
 }
 
 /// Resolve the keyed secondary-index consult for a full-partition-key SELECT
@@ -3960,17 +4181,26 @@ fn prepared_select_limit(
     bound_terms: &[Term],
     bind_idx: &mut usize,
 ) -> Option<Result<Option<i32>, CqlError>> {
+    let validate = |value: i32| {
+        if value > 0 {
+            Ok(Some(value))
+        } else {
+            Err(CqlError::Invalid(format!(
+                "prepared SELECT LIMIT must be positive, got {value}"
+            )))
+        }
+    };
     match limit {
         None => Some(Ok(None)),
-        Some(Limit::Literal(n)) => Some(Ok(Some(*n))),
+        Some(Limit::Literal(n)) => Some(validate(*n)),
         Some(Limit::BindMarker | Limit::NamedBindMarker(_)) => {
             let term = bound_terms.get(*bind_idx)?;
             *bind_idx += 1;
             match term {
                 Term::IntegerLiteral(n) => Some(
                     i32::try_from(*n)
-                        .map(Some)
-                        .map_err(|_| CqlError::Invalid(format!("LIMIT value {n} out of range"))),
+                        .map_err(|_| CqlError::Invalid(format!("LIMIT value {n} out of range")))
+                        .and_then(validate),
                 ),
                 other => Some(Err(CqlError::Invalid(format!(
                     "LIMIT bind marker must be an integer, got {other:?}"
@@ -4534,6 +4764,10 @@ thread_local! {
     /// wall-clock. `#[tokio::test]` uses a current-thread runtime, so the
     /// increments land on the test thread.
     static PK_LOOKUP_ROWS_VISITED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+
+    /// Rows retained by the bounded partition suffix read before its one-row
+    /// continuation probe is discarded.
+    static BOUNDED_PARTITION_ROWS_MATERIALIZED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 async fn route_select_user_table(
@@ -4946,6 +5180,8 @@ async fn route_select_user_table(
         let decorated_key = bridge::build_decorated_key(&pk_values, &pk_types)?;
         let row_limit =
             safe_partition_key_filter_row_limit(s, table_meta, count_only_select).unwrap_or(0);
+        let bounded_clustering_resume =
+            bounded_partition_clustering_resume(s, table_meta, ks, &state.schema)?;
         let exact_clustering = if clustering_key_equality_has_phonetic_index(
             &s.where_clauses,
             table_meta,
@@ -4972,6 +5208,23 @@ async fn route_select_user_table(
                 .await?
                 .into_iter()
                 .collect()
+        } else if let Some((start_exclusive, query_limit)) = bounded_clustering_resume {
+            let write_path = state.write_path.load();
+            let (partition, next_paging_state) = read_bounded_partition_clustering_suffix(
+                BoundedPartitionReadContext {
+                    write_path: &write_path,
+                    table_id: &table_id,
+                    key: &decorated_key,
+                    paging: &ctx.paging,
+                    consistency: ctx.consistency,
+                    strategy: &read_strategy,
+                },
+                start_exclusive,
+                query_limit,
+            )
+            .await?;
+            streamed_paging_state = Some(next_paging_state);
+            partition.into_iter().collect()
         } else if let Some((index_name, index_key)) =
             keyed_index_consult(state, &snap, ks, s, table_meta)
         {
@@ -14258,6 +14511,213 @@ mod tests {
         assert_eq!(state.query_tracker.total_executed(), executed_before + 1);
     }
 
+    #[tokio::test]
+    async fn prepared_select_bound_limit_storage_scan_is_bounded_after_clustering_cursor() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let current_keyspace = None;
+        let ctx = test_ctx(&auth, &current_keyspace);
+
+        for cql in [
+            "CREATE KEYSPACE cursor_bound WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+            "CREATE TABLE cursor_bound.events (tenant text, cursor bigint, payload text, PRIMARY KEY (tenant, cursor))",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap();
+        }
+        for cursor in 1..=100 {
+            let insert = format!(
+                "INSERT INTO cursor_bound.events (tenant, cursor, payload) \
+                 VALUES ('tenant-a', {cursor}, 'event-{cursor}')"
+            );
+            route(&state, &ctx, crate::parser::parse(&insert).unwrap())
+                .await
+                .unwrap();
+        }
+
+        let base_select = match crate::parser::parse(
+            "SELECT cursor, payload FROM cursor_bound.events \
+             WHERE tenant = 'tenant-a' AND cursor > 0 LIMIT 2",
+        )
+        .unwrap()
+        {
+            Statement::Select(select) => select,
+            other => panic!("expected SELECT, got {other:?}"),
+        };
+        let snapshot = state.schema.snapshot();
+        let table_meta = snapshot
+            .tables
+            .get(&("cursor_bound".to_string(), "events".to_string()))
+            .unwrap();
+        let mut distinct = base_select.clone();
+        distinct.distinct = true;
+        assert!(
+            bounded_partition_clustering_resume(
+                &distinct,
+                table_meta,
+                "cursor_bound",
+                &state.schema,
+            )
+            .unwrap()
+            .is_none(),
+            "DISTINCT is not row-preserving and must bypass source LIMIT pushdown"
+        );
+        let mut ann = base_select.clone();
+        ann.ann_of = Some(("payload".into(), Term::IntegerLiteral(1)));
+        assert!(
+            bounded_partition_clustering_resume(&ann, table_meta, "cursor_bound", &state.schema,)
+                .unwrap()
+                .is_none(),
+            "ANN ordering must see the complete candidate set"
+        );
+        let mut function = base_select.clone();
+        function.columns = vec![SelectColumn::FunctionCall {
+            keyspace: None,
+            name: "sum".into(),
+            args: Vec::new(),
+            alias: None,
+        }];
+        assert!(
+            bounded_partition_clustering_resume(
+                &function,
+                table_meta,
+                "cursor_bound",
+                &state.schema,
+            )
+            .unwrap()
+            .is_none(),
+            "aggregate and scalar function projections must bypass source LIMIT pushdown"
+        );
+        BOUNDED_PARTITION_ROWS_MATERIALIZED.with(|visited| visited.set(0));
+        let result = route(
+            &state,
+            &ctx,
+            crate::parser::parse(
+                "SELECT cursor, payload FROM cursor_bound.events \
+                 WHERE tenant = 'tenant-a' AND cursor > 90 LIMIT 2",
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+        let RouteResult::Result(body) = result else {
+            panic!("expected rows result");
+        };
+        assert_eq!(extract_row_count(&body), 2);
+        let visited = BOUNDED_PARTITION_ROWS_MATERIALIZED.with(|count| count.get());
+        assert_eq!(
+            visited, 2,
+            "the cursor suffix reader must materialize only LIMIT rows, not the 100-row partition"
+        );
+
+        BOUNDED_PARTITION_ROWS_MATERIALIZED.with(|visited| visited.set(0));
+        let page_ctx = paging_ctx(&auth, &current_keyspace, Some(2), None);
+        let page_select = match crate::parser::parse(
+            "SELECT cursor, payload FROM cursor_bound.events \
+             WHERE tenant = 'tenant-a' AND cursor > 0 LIMIT 50",
+        )
+        .unwrap()
+        {
+            Statement::Select(select) => select,
+            other => panic!("expected SELECT, got {other:?}"),
+        };
+        let first_page = route_select_raw(&state, &page_ctx, &page_select)
+            .await
+            .unwrap();
+        assert_eq!(first_page.rows.len(), 2);
+        assert!(first_page.paging_state.is_some());
+        let first_page_visited = BOUNDED_PARTITION_ROWS_MATERIALIZED.with(|count| count.get());
+        assert_eq!(
+            first_page_visited, 3,
+            "page size 2 needs exactly two output rows plus one continuation lookahead, \
+             not all 50 rows allowed by LIMIT"
+        );
+
+        let mut wrong_partition =
+            crate::paging::PagingState::decode(first_page.paging_state.as_deref().unwrap())
+                .unwrap();
+        wrong_partition.partition_key.push(0xff);
+        let wrong_partition_ctx = paging_ctx(
+            &auth,
+            &current_keyspace,
+            Some(2),
+            Some(wrong_partition.encode()),
+        );
+        assert!(matches!(
+            route_select_raw(&state, &wrong_partition_ctx, &page_select).await,
+            Err(CqlError::Protocol(message))
+                if message.contains("does not belong to this bounded partition query")
+        ));
+
+        let wrong_limit_select = match crate::parser::parse(
+            "SELECT cursor, payload FROM cursor_bound.events \
+             WHERE tenant = 'tenant-a' AND cursor > 0 LIMIT 49",
+        )
+        .unwrap()
+        {
+            Statement::Select(select) => select,
+            other => panic!("expected SELECT, got {other:?}"),
+        };
+        let wrong_limit_ctx = paging_ctx(
+            &auth,
+            &current_keyspace,
+            Some(2),
+            first_page.paging_state.clone(),
+        );
+        assert!(matches!(
+            route_select_raw(&state, &wrong_limit_ctx, &wrong_limit_select).await,
+            Err(CqlError::Protocol(message))
+                if message.contains("LIMIT does not match")
+        ));
+
+        let total_limit_select = match crate::parser::parse(
+            "SELECT cursor, payload FROM cursor_bound.events \
+             WHERE tenant = 'tenant-a' AND cursor > 90 LIMIT 5",
+        )
+        .unwrap()
+        {
+            Statement::Select(select) => select,
+            other => panic!("expected SELECT, got {other:?}"),
+        };
+        let mut pages = Vec::new();
+        let mut paging_state = None;
+        for page_number in 0..4 {
+            BOUNDED_PARTITION_ROWS_MATERIALIZED.with(|visited| visited.set(0));
+            let page_ctx = paging_ctx(&auth, &current_keyspace, Some(2), paging_state);
+            let page = route_select_raw(&state, &page_ctx, &total_limit_select)
+                .await
+                .unwrap();
+            let visited = BOUNDED_PARTITION_ROWS_MATERIALIZED.with(|count| count.get());
+            assert!(
+                visited <= 3,
+                "page {page_number} materialized {visited} rows; every page must stay bounded by \
+                 page_size plus one lookahead, independent of paging progress"
+            );
+            paging_state = page.paging_state;
+            if !page.rows.is_empty() {
+                pages.push(page.rows);
+            }
+            if paging_state.is_none() {
+                break;
+            }
+        }
+        assert_eq!(
+            pages.iter().map(Vec::len).collect::<Vec<_>>(),
+            vec![2, 2, 1],
+            "LIMIT is a total query bound, not a fresh allowance per page"
+        );
+        let cursors: Vec<i64> = pages
+            .iter()
+            .flatten()
+            .map(|row| match &row[0] {
+                Some(CqlValue::Bigint(value)) => *value,
+                other => panic!("expected bigint cursor, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(cursors, vec![91, 92, 93, 94, 95]);
+    }
+
     #[test]
     fn keyspace_rf_returns_1_when_keyspace_not_found() {
         let (state, _dir) = setup();
@@ -19246,7 +19706,8 @@ mod tests {
             .prepared_cache
             .get(&prepared_id)
             .expect("prepared plan must survive cache insertion");
-        let prepared_statement = crate::connection::substitute_bound_terms(&cached_plan, None);
+        let prepared_statement = crate::connection::substitute_bound_terms(&cached_plan, None)
+            .expect("DISTINCT plan has no unresolved LIMIT marker");
         assert!(matches!(
             route(&state, &ctx, prepared_statement).await.unwrap(),
             RouteResult::Result(_)

--- a/ferrosa-cql/tests/handshake.rs
+++ b/ferrosa-cql/tests/handshake.rs
@@ -2481,6 +2481,76 @@ async fn prepare_select_with_where_and_limit_bind_markers_reports_col_count_two(
     );
 }
 
+/// Regression for ferrosa-memory PR #245: a clustering-range SELECT declines
+/// the exact-partition prepared fast path, so the generic EXECUTE path must
+/// still substitute and enforce `LIMIT ?` before routing the storage read.
+#[tokio::test]
+async fn prepared_select_bound_limit_constrains_clustering_range() {
+    let (state, _dir) = setup_state();
+    let server = ferrosa_cql::server::CqlServer::new(test_config(true), state);
+    let addr = server.start_background().await.unwrap();
+    let mut stream = connect_auth_disabled(addr).await;
+
+    let body = encode_query_body(
+        "CREATE KEYSPACE mobile_control WITH replication = \
+         {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+    );
+    send_raw_frame(&mut stream, Opcode::Query, &body).await;
+    assert_result(&read_frame(&mut stream).await);
+
+    let body = encode_query_body(
+        "CREATE TABLE mobile_control.mobile_control_events (\
+         tenant_id text, server_fingerprint text, cursor_bucket int, cursor bigint, \
+         event_id uuid, command_id uuid, event_type text, payload blob, created_at timestamp, \
+         PRIMARY KEY ((tenant_id, server_fingerprint, cursor_bucket), cursor))",
+    );
+    send_raw_frame(&mut stream, Opcode::Query, &body).await;
+    assert_result(&read_frame(&mut stream).await);
+
+    for cursor in 1..=5 {
+        let body = encode_query_body(&format!(
+            "INSERT INTO mobile_control.mobile_control_events \
+             (tenant_id, server_fingerprint, cursor_bucket, cursor, event_id) \
+             VALUES ('tenant-a', 'server-a', 7, {cursor}, \
+             00000000-0000-0000-0000-{cursor:012})"
+        ));
+        send_raw_frame(&mut stream, Opcode::Query, &body).await;
+        assert_result(&read_frame(&mut stream).await);
+    }
+
+    let query = "SELECT cursor, event_id, command_id, event_type, payload, created_at \
+                 FROM mobile_control.mobile_control_events \
+                 WHERE tenant_id = ? AND server_fingerprint = ? AND cursor_bucket = ? \
+                 AND cursor > ? LIMIT ?";
+    let prep_body = encode_prepare_body(query);
+    send_raw_frame(&mut stream, Opcode::Prepare, &prep_body).await;
+    let prepared = read_frame(&mut stream).await;
+    assert_result(&prepared);
+    assert_eq!(
+        extract_bind_col_count_from_prepared_response(&prepared.body),
+        5,
+        "the four WHERE markers and synthetic [limit] marker must all be declared"
+    );
+
+    let mut prepared_id = [0u8; 16];
+    prepared_id.copy_from_slice(&prepared.body[6..22]);
+    let bucket = 7i32.to_be_bytes();
+    let after_cursor = 0i64.to_be_bytes();
+    let limit = 2i32.to_be_bytes();
+    let exec_body = encode_execute_body_with_values(
+        &prepared_id,
+        &[b"tenant-a", b"server-a", &bucket, &after_cursor, &limit],
+    );
+    send_raw_frame(&mut stream, Opcode::Execute, &exec_body).await;
+    let response = read_frame(&mut stream).await;
+    assert_result(&response);
+    assert_eq!(
+        extract_row_count_from_result(&response.body),
+        2,
+        "LIMIT ? must constrain the generic prepared range read, not return the full partition"
+    );
+}
+
 /// FRSA-BUG-025 regression: SELECT with WHERE bind markers plus `ANN OF ?`
 /// must report all bind marker columns in PREPARE metadata. The ANN query
 /// vector is bound against the vector column (`fold_embedding`) and strict

--- a/ferrosa-net/src/accord_messages.rs
+++ b/ferrosa-net/src/accord_messages.rs
@@ -180,6 +180,7 @@ mod tests {
             MsgType::MutationAck as u8,
             MsgType::ReadRequest as u8,
             MsgType::ReadResponse as u8,
+            MsgType::PartitionSuffixReadRequest as u8,
             MsgType::RepairWrite as u8,
             MsgType::StreamStart as u8,
             MsgType::StreamChunk as u8,

--- a/ferrosa-net/src/codec.rs
+++ b/ferrosa-net/src/codec.rs
@@ -105,6 +105,10 @@ pub enum MsgType {
     // Initiator → peer: apply these partitions (LWW). Peer → initiator: ack.
     RepairApplyRequest = 0x2D,
     RepairApplyResponse = 0x2E,
+    /// Versioned bounded partition-suffix read. Kept distinct from the legacy
+    /// `ReadRequest` so mixed-version peers reject unsupported semantics
+    /// instead of silently executing a prefix read.
+    PartitionSuffixReadRequest = 0x2F,
     // ADR-020 streaming range read — multi-message RPC keyed by
     // request_id, terminated by RangeReadStreamDone, cancellable via
     // RangeReadStreamCancel, kept alive by RangeReadStreamHeartbeat.
@@ -269,6 +273,7 @@ impl TryFrom<u8> for MsgType {
             0x2C => Ok(Self::RepairFetchResponse),
             0x2D => Ok(Self::RepairApplyRequest),
             0x2E => Ok(Self::RepairApplyResponse),
+            0x2F => Ok(Self::PartitionSuffixReadRequest),
             0x30 => Ok(Self::StreamStart),
             0x31 => Ok(Self::StreamChunk),
             0x32 => Ok(Self::StreamEnd),

--- a/ferrosa-net/src/message.rs
+++ b/ferrosa-net/src/message.rs
@@ -151,6 +151,10 @@ pub enum Message {
     MutationAck(Bytes),
     ReadRequest(Bytes),
     ReadResponse(Bytes),
+    /// Additive request type for an exclusive clustering-key suffix read.
+    /// Older peers reject the unknown message type and cannot accidentally
+    /// reinterpret it as a legacy prefix read.
+    PartitionSuffixReadRequest(Bytes),
     RepairWrite(Bytes),
     RangeReadRequest(Bytes),
     RangeReadResponse(Bytes),
@@ -350,6 +354,7 @@ impl Message {
             Self::MutationAck(_) => MsgType::MutationAck,
             Self::ReadRequest(_) => MsgType::ReadRequest,
             Self::ReadResponse(_) => MsgType::ReadResponse,
+            Self::PartitionSuffixReadRequest(_) => MsgType::PartitionSuffixReadRequest,
             Self::RepairWrite(_) => MsgType::RepairWrite,
             Self::RangeReadRequest(_) => MsgType::RangeReadRequest,
             Self::RangeReadResponse(_) => MsgType::RangeReadResponse,
@@ -514,6 +519,7 @@ impl Message {
             | Self::MutationAck(b)
             | Self::ReadRequest(b)
             | Self::ReadResponse(b)
+            | Self::PartitionSuffixReadRequest(b)
             | Self::RepairWrite(b)
             | Self::RangeReadRequest(b)
             | Self::RangeReadResponse(b)
@@ -715,6 +721,9 @@ impl Message {
             MsgType::MutationAck => Self::MutationAck(body.split_to(body.remaining())),
             MsgType::ReadRequest => Self::ReadRequest(body.split_to(body.remaining())),
             MsgType::ReadResponse => Self::ReadResponse(body.split_to(body.remaining())),
+            MsgType::PartitionSuffixReadRequest => {
+                Self::PartitionSuffixReadRequest(body.split_to(body.remaining()))
+            }
             MsgType::RepairWrite => Self::RepairWrite(body.split_to(body.remaining())),
             MsgType::RangeReadRequest => Self::RangeReadRequest(body.split_to(body.remaining())),
             MsgType::RangeReadResponse => Self::RangeReadResponse(body.split_to(body.remaining())),
@@ -1048,6 +1057,37 @@ mod tests {
         assert!(matches!(decoded[1], Message::PairDdlForward(_)));
         assert!(matches!(decoded[2], Message::MutationForward(_)));
         assert!(matches!(decoded[3], Message::ReadRequest(_)));
+    }
+
+    #[test]
+    fn partition_suffix_read_uses_additive_message_type() {
+        let payload = Bytes::from_static(b"suffix-v1");
+        let message = Message::PartitionSuffixReadRequest(payload.clone());
+        assert_eq!(message.msg_type(), MsgType::PartitionSuffixReadRequest);
+        assert_eq!(MsgType::PartitionSuffixReadRequest as u8, 0x2F);
+
+        let mut body = BytesMut::new();
+        message.encode(&mut body).unwrap();
+        let decoded =
+            Message::decode(MsgType::PartitionSuffixReadRequest, &mut body.freeze()).unwrap();
+        assert_eq!(decoded, Message::PartitionSuffixReadRequest(payload));
+
+        // 0x2F was not part of the legacy message set. A rolling old peer
+        // rejects the operation at the frame boundary instead of handing its
+        // payload to the legacy prefix-read handler.
+        let legacy_knows = matches!(
+            MsgType::PartitionSuffixReadRequest as u8,
+            0x01..=0x06
+                | 0x10..=0x14
+                | 0x20..=0x2E
+                | 0x30..=0x3F
+                | 0x40..=0x49
+                | 0x50..=0x52
+                | 0x60..=0x67
+                | 0x70..=0x7C
+                | 0x80..=0x83
+        );
+        assert!(!legacy_knows);
     }
 
     #[test]

--- a/ferrosa-net/src/protocol.rs
+++ b/ferrosa-net/src/protocol.rs
@@ -1533,6 +1533,7 @@ fn message_family_for_kind(kind: u16) -> MessageFamily {
             | MsgType::MutationAck
             | MsgType::ReadRequest
             | MsgType::ReadResponse
+            | MsgType::PartitionSuffixReadRequest
             | MsgType::RepairWrite
             | MsgType::RangeReadRequest
             | MsgType::RangeReadResponse

--- a/ferrosa-sstable/src/data.rs
+++ b/ferrosa-sstable/src/data.rs
@@ -520,6 +520,31 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
         }))
     }
 
+    /// Point-read one partition while retaining only clustered rows strictly
+    /// after `start_clustering`, stopping after `row_limit` retained rows.
+    /// Prefix rows are decoded one at a time and immediately discarded; the
+    /// partition tail is not decoded once the requested suffix is full.
+    pub fn read_partition_suffix_rows(
+        &mut self,
+        start_clustering: &[u8],
+        row_limit: usize,
+    ) -> Result<Option<Partition>> {
+        debug_assert!(row_limit > 0, "suffix reads require a positive row limit");
+        let file_len = self.reader.len()?;
+        if self.pos >= file_len {
+            return Ok(None);
+        }
+        let (key_bytes, deletion) = self.read_partition_header()?;
+        let key = DecoratedKey::new(PartitionKey::new(key_bytes));
+        let (static_row, rows) = self.read_rows_suffix_limited(start_clustering, row_limit)?;
+        Ok(Some(Partition {
+            key,
+            deletion,
+            static_row,
+            rows,
+        }))
+    }
+
     /// Best-effort recovery of a single partition at the current position.
     ///
     /// Reads the partition header (key + deletion), then decodes clustered rows
@@ -1027,6 +1052,51 @@ impl<'a, R: ReadAt> DataReader<'a, R> {
             }
         }
 
+        Ok((static_row, rows))
+    }
+
+    fn read_rows_suffix_limited(
+        &mut self,
+        start_clustering: &[u8],
+        row_limit: usize,
+    ) -> Result<(Option<Row>, Vec<Row>)> {
+        let file_len = self.reader.len()?;
+        let mut static_row = None;
+        let mut rows = Vec::new();
+
+        loop {
+            if self.pos >= file_len {
+                if static_row.is_some() || !rows.is_empty() {
+                    return Err(Self::missing_partition_end_error());
+                }
+                break;
+            }
+            let mut flags_buf = [0u8; 1];
+            self.reader.read_exact_at(&mut flags_buf, self.pos)?;
+            self.pos += 1;
+            let flags = flags_buf[0];
+            if flags & END_OF_PARTITION != 0 || flags & IS_MARKER != 0 {
+                break;
+            }
+            let extended_flags = if flags & EXTENSION_FLAG != 0 {
+                let mut ext_buf = [0u8; 1];
+                self.reader.read_exact_at(&mut ext_buf, self.pos)?;
+                self.pos += 1;
+                ext_buf[0]
+            } else {
+                0
+            };
+            let is_static = extended_flags & EXT_IS_STATIC != 0;
+            let row = self.read_row(flags, is_static)?;
+            if is_static {
+                static_row = Some(row);
+            } else if row.clustering.as_slice() > start_clustering {
+                rows.push(row);
+                if rows.len() >= row_limit {
+                    break;
+                }
+            }
+        }
         Ok((static_row, rows))
     }
 

--- a/ferrosa-sstable/src/reader.rs
+++ b/ferrosa-sstable/src/reader.rs
@@ -432,6 +432,35 @@ impl<R: ReadAt> SSTableReader<R> {
         }
     }
 
+    /// Point-read a bounded clustering suffix without retaining the prefix or
+    /// decoding the tail after the requested rows are found.
+    pub fn get_partition_limited_rows_from(
+        &self,
+        key: &DecoratedKey,
+        start_clustering: &[u8],
+        row_limit: usize,
+    ) -> Result<Option<Partition>> {
+        let (h1, h2) = key.filter_hash();
+        if !self.bloom_filter.is_present(h1, h2) {
+            return Ok(None);
+        }
+        let data_position = match self.partition_index.lookup(key)? {
+            PartitionLookup::RowIndex { position } => {
+                RowIndex::read_entry(&self.rows, position)?.data_position
+            }
+            PartitionLookup::DataDirect { position } => position,
+            PartitionLookup::NotFound => return Ok(None),
+        };
+        if let Some(ref ci) = self.compression_info {
+            let chunked = ChunkedCompressedData::new(&self.data, ci, &self.decompressed_chunks)?;
+            DataReader::new(&chunked, &self.header, data_position)
+                .read_partition_suffix_rows(start_clustering, row_limit)
+        } else {
+            DataReader::new(&self.data, &self.header, data_position)
+                .read_partition_suffix_rows(start_clustering, row_limit)
+        }
+    }
+
     /// Return whether a point read should probe this SSTable for `key`.
     ///
     /// Bloom filters reject definitely-absent keys. New Ferrosa SSTables also
@@ -1684,6 +1713,33 @@ mod tests {
         assert_eq!(partition.rows.len(), 2);
         assert_eq!(partition.rows[0].clustering, 1_i32.to_be_bytes());
         assert_eq!(partition.rows[1].clustering, 2_i32.to_be_bytes());
+    }
+
+    #[test]
+    fn get_partition_limited_rows_from_returns_exclusive_bounded_suffix() {
+        let header = test_header();
+        let dk = DecoratedKey::new(PartitionKey::from(b"wide".as_slice()));
+        let components = SSTableComponents {
+            data: build_data_blob_with_rows(b"wide", 10),
+            partitions: build_partition_index(&[(&dk, 0)]),
+            rows: Vec::new(),
+            filter: build_bloom_filter(&[&dk]),
+            compression_info: None,
+            statistics: build_statistics(header),
+        };
+        let partition = SSTableReader::open(components)
+            .unwrap()
+            .get_partition_limited_rows_from(&dk, &5_i32.to_be_bytes(), 2)
+            .unwrap()
+            .expect("wide partition should exist");
+        assert_eq!(
+            partition
+                .rows
+                .iter()
+                .map(|row| row.clustering.clone())
+                .collect::<Vec<_>>(),
+            vec![6_i32.to_be_bytes().to_vec(), 7_i32.to_be_bytes().to_vec()]
+        );
     }
 
     #[derive(Clone)]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -6103,6 +6103,29 @@ impl StorageEngine {
         }
     }
 
+    /// Read at most `row_limit` rows strictly after `start_clustering` from one
+    /// partition without retaining the already-delivered prefix or the tail.
+    ///
+    /// Each memtable/SSTable source drops prefix rows before retaining its
+    /// bounded suffix, and SSTable decoding stops once that suffix is full. The
+    /// merge therefore stays O(sources × row_limit) regardless of partition
+    /// width or paging progress.
+    pub fn read_limited_rows_from(
+        &self,
+        table_id: &TableId,
+        key: &DecoratedKey,
+        start_clustering: &[u8],
+        row_limit: usize,
+    ) -> ferrosa_common::Result<Option<Partition>> {
+        let tables = self.tables.read();
+        match tables.get(table_id) {
+            Some(state) => state
+                .store
+                .read_limited_rows_from(key, start_clustering, row_limit),
+            None => Ok(None),
+        }
+    }
+
     /// SSTable generations the read path has quarantined for `table_id` because
     /// a read exhausted the view-retry bound against them (genuine corruption,
     /// not a transient compaction window). A non-empty result is the storage

--- a/ferrosa-storage/src/store.rs
+++ b/ferrosa-storage/src/store.rs
@@ -833,7 +833,11 @@ fn partition_with_matching_clustering(
     })
 }
 
-fn clone_partition_limited(partition: &Partition, row_limit: usize) -> Partition {
+fn clone_partition_limited(
+    partition: &Partition,
+    start_clustering: Option<&[u8]>,
+    row_limit: usize,
+) -> Partition {
     if row_limit == 0 {
         return partition.clone();
     }
@@ -842,7 +846,13 @@ fn clone_partition_limited(partition: &Partition, row_limit: usize) -> Partition
         key: partition.key.clone(),
         deletion: partition.deletion,
         static_row: partition.static_row.clone(),
-        rows: partition.rows.iter().take(row_limit).cloned().collect(),
+        rows: partition
+            .rows
+            .iter()
+            .filter(|row| start_clustering.is_none_or(|start| row.clustering.as_slice() > start))
+            .take(row_limit)
+            .cloned()
+            .collect(),
     }
 }
 
@@ -1527,7 +1537,21 @@ impl<F: FlushTarget> TableStore<F> {
         row_limit: usize,
     ) -> Result<Option<Partition>> {
         self.with_retried_view("read_limited_rows", |view| {
-            self.read_with_view(view, key, row_limit)
+            self.read_with_view(view, key, row_limit, None)
+        })
+    }
+
+    /// Read a bounded clustering suffix from one partition. Every source drops
+    /// rows at or before `start_clustering` before retaining at most
+    /// `row_limit`, so the merge never holds the delivered prefix or tail.
+    pub fn read_limited_rows_from(
+        &self,
+        key: &DecoratedKey,
+        start_clustering: &[u8],
+        row_limit: usize,
+    ) -> Result<Option<Partition>> {
+        self.with_retried_view("read_limited_rows_from", |view| {
+            self.read_with_view(view, key, row_limit, Some(start_clustering))
         })
     }
 
@@ -1670,6 +1694,7 @@ impl<F: FlushTarget> TableStore<F> {
         guard: &StoreView,
         key: &DecoratedKey,
         row_limit: usize,
+        start_clustering: Option<&[u8]>,
     ) -> Result<(Option<Partition>, Option<CorruptSstableId>)> {
         let started = Instant::now();
         let schema = self.schema.load();
@@ -1689,14 +1714,14 @@ impl<F: FlushTarget> TableStore<F> {
         // Active memtable
         if let Some(p) = guard.active.get(key)? {
             memtable_hits += 1;
-            sources.push(clone_partition_limited(&p, row_limit));
+            sources.push(clone_partition_limited(&p, start_clustering, row_limit));
         }
 
         // Flushing memtable
         if let Some(ref flushing) = guard.flushing {
             if let Some(p) = flushing.get(key)? {
                 flushing_hits += 1;
-                sources.push(clone_partition_limited(&p, row_limit));
+                sources.push(clone_partition_limited(&p, start_clustering, row_limit));
             }
         }
 
@@ -1738,7 +1763,11 @@ impl<F: FlushTarget> TableStore<F> {
                 continue;
             }
             sstable_probes += 1;
-            match sstable.get_partition_limited_rows(key, row_limit) {
+            let source_read = match start_clustering {
+                Some(start) => sstable.get_partition_limited_rows_from(key, start, row_limit),
+                None => sstable.get_partition_limited_rows(key, row_limit),
+            };
+            match source_read {
                 Ok(Some(mut p)) => {
                     sstable_hits += 1;
                     ColumnOrdinalMapping::for_header(&schema, sstable.header())
@@ -7471,7 +7500,7 @@ mod tests {
         }));
 
         let view = store.view.load_full();
-        let (result, corrupt) = store.read_with_view(&view, &key, 0).unwrap();
+        let (result, corrupt) = store.read_with_view(&view, &key, 0, None).unwrap();
         assert!(
             result.is_none(),
             "the truncated source yields no rows on this single view snapshot"

--- a/specs/todo/bug-prepared-select-limit-bind-marker.md
+++ b/specs/todo/bug-prepared-select-limit-bind-marker.md
@@ -1,0 +1,41 @@
+# Prepared SELECT `LIMIT ?` is ignored outside the exact-key fast path
+
+Forge task: `t_fb3aa9d9`
+
+Status: in progress
+
+## Failure
+
+`SELECT ... WHERE tenant_id = ? AND server_fingerprint = ? AND cursor_bucket = ? AND cursor > ? LIMIT ?`
+returns every matching row in the partition. Replacing the final marker with the same trusted integer literal honors the limit. Ferrosa Memory PR #245 had to interpolate the literal to keep durable mobile-control replay pages bounded.
+
+The prepared metadata and wire decoder recognize the synthetic `[limit] int` value. The exact-partition prepared fast path also consumes it. The generic fallback substitutes only `WHERE` terms, however, leaving the AST's `Limit::BindMarker` unresolved. Routing interprets a non-literal limit as absent.
+
+## Acceptance checklist
+
+- [x] A real PREPARE/EXECUTE regression matching the composite partition key plus `cursor > ? LIMIT ?` shape fails before the fix and returns exactly the bound count after it.
+- [x] Generic SELECT substitution consumes markers in CQL order: WHERE, ANN, LIMIT.
+- [x] A present LIMIT marker that is missing, null, or not a positive integer returns a typed error before routing; it never becomes an unlimited scan.
+- [x] Literal LIMIT behavior and the exact-partition prepared fast path remain green.
+- [x] Paging never returns more than the query limit in total and does not turn the limit into a per-page allowance.
+- [x] No partition-sized collection, growing queue, or unbounded diagnostic is introduced. Each memtable/SSTable source drops the clustering prefix and stops after `page_size + 1`; later pages never retain a cumulative prefix or the query-wide LIMIT.
+- [x] Source LIMIT pushdown is restricted to row-preserving projections. DISTINCT, ANN, aggregates, scalar functions, ordering, geo shapes, and static-row projections stay on their complete-input plans.
+- [x] The suffix read uses the exact partition token's replica/consistency path (including NTS/LOCAL routing), never the global range-scan fan-out.
+- [x] Rolling upgrades preserve the legacy `ReadRequest` bytes. Suffix reads use an additive message type, so an old peer rejects unsupported semantics instead of silently returning a prefix.
+- [x] NTS/LOCAL coordination carries the selected replica identities into the read path rather than recomputing SimpleStrategy replicas from their count.
+- [x] The HMAC-protected continuation binds the partition key and total LIMIT, carries the last clustering key and rows already returned, and rejects mismatched or malformed reuse before storage access.
+- [ ] Focused tests, `cargo fmt --check`, clippy with warnings denied, and an independent diff review pass before the dedicated PR opens.
+
+## Failure modes
+
+| Failure mode | Required guard |
+|---|---|
+| Bound LIMIT is skipped during substitution | Rewrite it to `Limit::Literal` before routing and assert marker consumption order. |
+| Missing or NULL LIMIT silently means unlimited | Return `CqlError::Invalid` before `route`. |
+| Range SELECT bypasses the exact-key fast path | Exercise the cached generic EXECUTE path over a partition larger than the bound. |
+| LIMIT is applied per page rather than per query | Encode and validate rows already returned in the opaque cursor; every page decrements the same total query allowance. |
+| Fix materializes the partition to truncate later | Push an exclusive clustering cursor and `page_size + 1` into each point-read source, then stop decoding the SSTable tail. |
+| Source truncation changes DISTINCT/ANN/aggregate output | Admit only plain row-preserving column projections to the suffix optimization. |
+| Global range fan-out violates partition/NTS placement | Route through `pk_read_limited_rows_from`, which shares the keyed replica and CL path. |
+| A positional bincode field breaks rolling reads | Keep `ReadRequestPayload` byte-compatible and put the suffix cursor in a versioned additive message that old peers reject. |
+| NTS replica IDs collapse to an RF count | Pass the exact strategy-selected node IDs through the shared coordinator and exercise a two-DC ring where SimpleStrategy would choose the wrong DC. |


### PR DESCRIPTION
## Summary

- make prepared `LIMIT ?` substitution identical to literal LIMIT semantics
- stream bounded clustering-range reads with one-row lookahead instead of materializing the requested LIMIT
- add rolling-wire-safe suffix reads and preserve exact NTS replica/consistency behavior
- fail loud on invalid limits and unsupported mixed-version suffix reads

## Regression coverage

- real TCP PREPARE/EXECUTE for `mobile_control_events` returns 2 of 5 rows
- HMAC paging state binds partition and total limit
- old/new wire compatibility and unsupported-operation failure
- NTS LOCAL_QUORUM replica identity and LOCAL_ONE typed errors
- SSTable/storage prefix discard is row-wise and bounded

## Verification

- independent TDD verifier: PASS (`green:prepared-limit-rolling-wire-nts-and-typed-one-local-one`)
- ferrosa-cql: 1163 passed, 0 failed, 1 skipped
- ferrosa-storage: 1081 passed
- ferrosa-sstable: 264 passed
- ferrosa-net: 155 passed
- ferrosa-cluster: 1144 passed
- all-target clippy: zero warnings
- fmt and diff checks: clean
- materialization audit: no introduced query-sized accumulation or unbounded channel/log path