### PR TITLE
fix(release): eliminate workflow warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           dpkg-deb --build --root-owner-group "$PKG_DIR" "$DEB_FILE"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tarball-x86_64-unknown-linux-musl
           path: |
@@ -187,7 +187,7 @@ jobs:
             target/aarch64-unknown-linux-musl/release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tarball-aarch64-unknown-linux-musl
           path: dist/ferrosa-*-aarch64-unknown-linux-musl.tar.gz
@@ -206,7 +206,11 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install capnproto
-        run: brew install capnp
+        run: |
+          if brew tap | grep -qx 'aws/tap'; then
+            brew untap aws/tap
+          fi
+          brew install capnp
 
       - name: Clippy
         run: cargo clippy --all-targets --target aarch64-apple-darwin -- -D warnings
@@ -233,11 +237,11 @@ jobs:
 
           # Homebrew bottle is a tar.gz rooted at ferrosa/<version>/
           tar czf "dist/ferrosa-${VERSION}.arm64_sonoma.bottle.tar.gz" \
-            -C dist ferrosa/${VERSION}
+            -C dist "ferrosa/${VERSION}"
           rm -rf "dist/ferrosa"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tarball-aarch64-apple-darwin
           path: |
@@ -260,7 +264,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download Linux musl tarball artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
@@ -338,7 +342,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
@@ -355,9 +359,13 @@ jobs:
           cd dist
           # Deterministic order so the file content is reproducible
           : > SHA256SUMS
-          for f in $(ls ferrosa-*.tar.gz ferrosa_*.deb 2>/dev/null | sort); do
-            sha256sum "$f" >> SHA256SUMS
-          done
+          find . -maxdepth 1 -type f \
+            \( -name 'ferrosa-*.tar.gz' -o -name 'ferrosa_*.deb' \) \
+            -printf '%f\0' \
+            | sort -z \
+            | while IFS= read -r -d '' f; do
+                sha256sum "$f" >> SHA256SUMS
+              done
           cat SHA256SUMS
 
       # TODO(human): set up minisign signing.


### PR DESCRIPTION
## Summary

- move upload/download artifact actions to official Node 24 releases pinned by immutable SHA
- remove the untrusted preinstalled `aws/tap` before installing capnproto, without disabling Homebrew trust checks
- make checksum enumeration deterministic, NUL-safe, and shellcheck-clean

## RED evidence

Nightly run 33126647372 succeeded but emitted six warning annotations: five Node 20 deprecations and one Homebrew untrusted-tap warning. Stable v0.21.0 will not be promoted from that candidate.

## Verification

- independent verifier: PASS
- upstream action tags and manifests verified at exact SHA; both declare `node24`
- `actionlint .github/workflows/release.yml`
- `.github/scripts/check-actions-pinned.sh`
- `git diff --check`
- checksum pipeline failure propagation independently probed

After merge, a fresh v0.21.0 nightly will be cut and its release annotations must be empty before promotion.