### PR TITLE
fix(release): remove cache post-job warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04-25
         with:
           targets: x86_64-unknown-linux-musl
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
       - name: Install musl tools and capnproto
         run: sudo apt-get update && sudo apt-get install -y musl-tools capnproto
 
@@ -150,10 +148,6 @@ jobs:
         with:
           targets: aarch64-unknown-linux-musl
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          key: aarch64-musl
-
       # We use `cross` (https://github.com/cross-rs/cross) for aarch64-musl —
       # simpler than zigbuild for a workspace this size and well-maintained.
       - name: Install cross
@@ -203,8 +197,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-04-25
         with:
           targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
       - name: Install capnproto
         run: |
           if brew tap | grep -qx 'aws/tap'; then

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -1,0 +1,17 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+class ReleaseWorkflowTest(unittest.TestCase):
+    def test_release_builds_do_not_run_cache_post_jobs(self):
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("Swatinem/rust-cache@", workflow)
+        self.assertNotIn("actions/cache/", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove Rust cache actions from release-only build jobs so no cache post-job hook can emit rate-limit or Node deprecation warnings
- leave ordinary CI cache population unchanged
- add a contract test preventing release workflows from registering cache actions

## TDD
- RED: the contract test fails against `origin/main`, which contains three `Swatinem/rust-cache` release steps
- GREEN: `python3 -m unittest tests.ci.test_release_workflow`

## Verification
- independent verifier: PASS
- `actionlint .github/workflows/release.yml`
- `bash .github/scripts/check-actions-pinned.sh`
- `git diff --check`

## Known unrelated baseline
- full `tests/ci` discovery has one pre-existing stale nightly-fuzz step-name assertion; tracked separately as Forge task `t_e1fdaec9`
