### PR TITLE
fix(release): verify artifacts without Node downloader

### DIFF
--- a/.github/scripts/download-run-artifacts.sh
+++ b/.github/scripts/download-run-artifacts.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 3 ]]; then
+  echo "usage: $0 <run-id> <owner/repository> <destination>" >&2
+  exit 64
+fi
+
+run_id="$1"
+repository="$2"
+destination="$3"
+
+if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
+  echo "invalid GitHub Actions run ID: $run_id" >&2
+  exit 64
+fi
+if [[ "$repository" != */* || "$repository" == *[[:space:]]* ]]; then
+  echo "invalid GitHub repository: $repository" >&2
+  exit 64
+fi
+
+mkdir -p "$destination"
+manifest="$destination/.artifact-manifest.tsv"
+
+gh api --paginate \
+  "repos/${repository}/actions/runs/${run_id}/artifacts?per_page=100" \
+  --jq '.artifacts[] | [.name, (.id | tostring), .digest] | @tsv' \
+  > "$manifest"
+
+artifact_count=0
+while IFS=$'\t' read -r artifact_name artifact_id expected_digest; do
+  if [[ -z "$artifact_name" || "$artifact_name" == "." || "$artifact_name" == ".." || "$artifact_name" == */* ]]; then
+    echo "invalid artifact name returned by GitHub: $artifact_name" >&2
+    exit 65
+  fi
+  if [[ ! "$artifact_id" =~ ^[0-9]+$ ]]; then
+    echo "invalid artifact ID returned by GitHub for $artifact_name: $artifact_id" >&2
+    exit 65
+  fi
+  if [[ ! "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "missing or malformed SHA-256 digest for artifact $artifact_name" >&2
+    exit 65
+  fi
+
+  archive="$destination/.${artifact_name}.zip"
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    "repos/${repository}/actions/artifacts/${artifact_id}/zip" \
+    > "$archive"
+
+  actual_digest="sha256:$(sha256sum "$archive" | awk '{print $1}')"
+  if [[ "$actual_digest" != "$expected_digest" ]]; then
+    echo "artifact digest mismatch for $artifact_name: expected $expected_digest, got $actual_digest" >&2
+    exit 65
+  fi
+
+  artifact_directory="$destination/$artifact_name"
+  mkdir -p "$artifact_directory"
+  unzip -q "$archive" -d "$artifact_directory"
+  rm -f "$archive"
+  artifact_count=$((artifact_count + 1))
+done < "$manifest"
+
+if [[ "$artifact_count" -eq 0 ]]; then
+  echo "GitHub Actions run $run_id has no downloadable artifacts" >&2
+  exit 66
+fi
+
+rm -f "$manifest"
+echo "Downloaded and verified $artifact_count artifact(s)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,15 +250,20 @@ jobs:
       - build-linux-aarch64
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download Linux musl tarball artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash .github/scripts/download-run-artifacts.sh \
+            "${GITHUB_RUN_ID}" \
+            "${GITHUB_REPOSITORY}" \
+            artifacts
 
       - name: Extract per-arch binaries into dist/<arch>/
         run: |
@@ -330,13 +335,20 @@ jobs:
       - build-linux-aarch64
       - build-macos-aarch64
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash .github/scripts/download-run-artifacts.sh \
+            "${GITHUB_RUN_ID}" \
+            "${GITHUB_REPOSITORY}" \
+            artifacts
 
       - name: Flatten artifacts into dist/
         run: |

--- a/tests/ci/test_download_run_artifacts.py
+++ b/tests/ci/test_download_run_artifacts.py
@@ -1,0 +1,98 @@
+import hashlib
+import os
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".github" / "scripts" / "download-run-artifacts.sh"
+
+
+class DownloadRunArtifactsTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.archive = self.root / "artifact.zip"
+        with zipfile.ZipFile(self.archive, "w") as archive:
+            archive.writestr("payload.txt", "trusted payload\n")
+        self.digest = hashlib.sha256(self.archive.read_bytes()).hexdigest()
+
+        fake_bin = self.root / "bin"
+        fake_bin.mkdir()
+        fake_gh = fake_bin / "gh"
+        fake_gh.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "if [[ \"$*\" == *'/artifacts?'* ]]; then\n"
+            "  cat \"${FAKE_ARTIFACT_MANIFEST}\"\n"
+            "elif [[ \"$*\" == *'/artifacts/42/zip'* ]]; then\n"
+            "  cat \"${FAKE_ARTIFACT_ZIP}\"\n"
+            "else\n"
+            "  echo \"unexpected gh invocation: $*\" >&2\n"
+            "  exit 64\n"
+            "fi\n",
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o755)
+        self.env = os.environ.copy()
+        self.env.update(
+            {
+                "FAKE_ARTIFACT_ZIP": str(self.archive),
+                "PATH": f"{fake_bin}{os.pathsep}{self.env['PATH']}",
+            }
+        )
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def run_download(self, digest):
+        manifest = self.root / "manifest.tsv"
+        manifest.write_text(
+            "" if digest is None else f"artifact-one\t42\t{digest}\n",
+            encoding="utf-8",
+        )
+        env = self.env | {"FAKE_ARTIFACT_MANIFEST": str(manifest)}
+        destination = self.root / "artifacts"
+        result = subprocess.run(
+            [str(SCRIPT), "123", "ferrosadb/ferrosa", str(destination)],
+            capture_output=True,
+            check=False,
+            env=env,
+            text=True,
+        )
+        return result, destination
+
+    def test_verifies_digest_before_extracting_artifact(self):
+        result, destination = self.run_download(f"sha256:{self.digest}")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            "trusted payload\n",
+            (destination / "artifact-one" / "payload.txt").read_text(encoding="utf-8"),
+        )
+
+    def test_rejects_digest_mismatch_before_extraction(self):
+        result, destination = self.run_download(f"sha256:{'0' * 64}")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("digest mismatch", result.stderr)
+        self.assertFalse((destination / "artifact-one").exists())
+
+    def test_rejects_missing_digest(self):
+        result, _ = self.run_download("")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("missing or malformed SHA-256 digest", result.stderr)
+
+    def test_rejects_empty_artifact_manifest(self):
+        result, _ = self.run_download(None)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("has no downloadable artifacts", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -12,6 +12,29 @@ class ReleaseWorkflowTest(unittest.TestCase):
         self.assertNotIn("Swatinem/rust-cache@", workflow)
         self.assertNotIn("actions/cache/", workflow)
 
+    def test_release_downloads_artifacts_without_node_actions(self):
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("actions/download-artifact@", workflow)
+        self.assertNotIn("gh run download", workflow)
+        self.assertEqual(
+            2,
+            workflow.count(
+                'bash .github/scripts/download-run-artifacts.sh \\\n            "${GITHUB_RUN_ID}"'
+            ),
+        )
+        self.assertEqual(2, workflow.count("actions: read"))
+        docker_job = workflow.split("  docker-image:\n", 1)[1].split("\n  release:\n", 1)[0]
+        release_job = workflow.split("  release:\n", 1)[1]
+        self.assertIn(
+            "    permissions:\n      actions: read\n      contents: read\n      packages: write",
+            docker_job,
+        )
+        self.assertIn(
+            "    permissions:\n      actions: read\n      contents: write",
+            release_job,
+        )
+        self.assertNotIn("\npermissions:\n  actions: read", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- replace the two warning-producing Node artifact downloads with a bounded GitHub API helper
- verify every API-declared SHA-256 before extraction and preserve per-artifact directory layout
- scope `actions: read` only to the GHCR and release consumer jobs
- add behavioral tests for successful verification, digest mismatch, missing digest, and empty artifact sets

## TDD evidence
- RED: release run `33134881534` emitted `DEP0005 Buffer()` in both `actions/download-artifact@v8.0.1` jobs despite zero annotations
- RED: corrupt/missing digests and absent helper fail the new contracts
- GREEN: all six focused workflow/helper tests pass

## Verification
- independent verifier: PASS, including a separate real three-artifact digest/layout smoke
- `actionlint .github/workflows/release.yml`
- `shellcheck .github/scripts/download-run-artifacts.sh`
- `bash .github/scripts/check-actions-pinned.sh`
- `git diff --check`

## Known unrelated baseline
- full `tests/ci` discovery has one unchanged stale nightly-fuzz step-name assertion, tracked as Forge task `t_e1fdaec9`
