### PR TITLE
fix(release): fail loud with clean checkout logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
 
 permissions:
   contents: write
@@ -325,7 +328,7 @@ jobs:
       - name: Inspect published manifest
         run: |
           first_tag=$(echo "${{ steps.tags.outputs.tags }}" | awk '{print $1}')
-          docker buildx imagetools inspect "${first_tag}" || echo "manifest inspect failed (non-fatal; image already pushed)"
+          docker buildx imagetools inspect "${first_tag}"
 
   # ── macOS Intel (x86_64) ──────────────────────────────────────────────
   release:

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -35,6 +35,19 @@ class ReleaseWorkflowTest(unittest.TestCase):
         )
         self.assertNotIn("\npermissions:\n  actions: read", workflow)
 
+    def test_release_checkout_is_quiet_and_manifest_inspection_fails_loud(self):
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "env:\n"
+            "  CARGO_TERM_COLOR: always\n"
+            "  GIT_CONFIG_COUNT: 1\n"
+            "  GIT_CONFIG_KEY_0: init.defaultBranch\n"
+            "  GIT_CONFIG_VALUE_0: main",
+            workflow,
+        )
+        self.assertNotIn("manifest inspect failed", workflow)
+        self.assertNotIn("docker buildx imagetools inspect \"${first_tag}\" ||", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- configure Git's initial branch as `main` for release checkout subprocesses, eliminating the default-branch warning hint at its source
- remove the GHCR manifest inspection fallback so an inspection error fails the release workflow
- add a contract test preventing either regression

## TDD evidence
- RED: raw candidate run `33138419913` emitted `suppress this warning` from all five checkout jobs and contained a non-fatal manifest-inspect fallback
- GREEN: isolated checkout-style Git init creates `HEAD=main` without the hint; manifest inspect is the fail-loud final command

## Verification
- independent verifier: PASS
- `python3 -m unittest tests.ci.test_release_workflow`
- `actionlint .github/workflows/release.yml`
- `bash .github/scripts/check-actions-pinned.sh`
- `git diff --check`
