### PR TITLE
chore: sync source version to v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrosa"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "axum 0.8.9",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cdc"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-sstable",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cluster"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-common"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "num-bigint",
  "proptest",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cql"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "ahash 0.8.12",
  "arc-swap",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-ctl"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-flight"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-graph"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-index"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "bincode",
  "crc32fast",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-index-builder"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-jepsen"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-loadgen"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-net"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-postgres"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-row-bridge"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-schema",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sched"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "proptest",
  "tokio",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-schema"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "argon2 0.6.0-rc.8",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-session"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "ferrosa-cluster",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sim"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "ferrosa-common",
  "proptest",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sparql"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sql"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "num-bigint",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sstable"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "crc32fast",
  "ferrosa-common",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-storage"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-udf"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-view"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "ferrosa-schema",
  "indexmap 2.14.0",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-worker"
-version = "0.17.0"
+version = "0.21.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-index",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ split-debuginfo = "off"
 strip = "none"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.21.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ferrosadb/ferrosa"


### PR DESCRIPTION
Synchronizes the source tree with the published stable v0.21.0 release. This branch was generated and pushed by the promotion workflow; the workflow could not open the PR because repository policy blocks GitHub Actions from creating pull requests.