### PR TITLE
fix(ctl): drop unused tabled derive features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,28 +5014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6733,21 +6711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
 dependencies = [
  "papergrid",
- "tabled_derive",
  "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/ferrosa-ctl/Cargo.toml
+++ b/ferrosa-ctl/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1", features = ["full"] }
 # so cold restarts can't re-download and re-detect them.
 object_store = { version = "0.11", features = ["aws"] }
 futures = "0.3"
-tabled = "0.20"
+tabled = { version = "0.20", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tests/ci/test_ferrosa_ctl_dependency_features.py
+++ b/tests/ci/test_ferrosa_ctl_dependency_features.py
@@ -1,0 +1,26 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class FerrosaCtlDependencyFeaturesTest(unittest.TestCase):
+    def test_tabled_runtime_api_does_not_pull_derive_proc_macros(self) -> None:
+        result = subprocess.run(
+            ["cargo", "tree", "-p", "ferrosa-ctl", "-e", "features"],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        forbidden = ["tabled_derive", "proc-macro-error2"]
+        resolved = [name for name in forbidden if name in result.stdout]
+        self.assertEqual([], resolved, "unexpected tabled derive dependencies")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Removes unused tabled derive/macros/assert features from ferrosa-ctl and keeps only the std runtime API used by Builder and Style.

This removes tabled_derive, proc-macro-error2, and proc-macro-error-attr2 from the resolved graph, eliminating the stable release future-incompatibility warning without suppression.

TDD:
- RED: resolved feature graph contained tabled_derive and proc-macro-error2; stable release run 33142489229 emitted the future-incompatibility warning on macOS and Linux.
- GREEN: dependency-feature regression passes; cargo test -p ferrosa-ctl passes 299 tests; Clippy -D warnings and release build report zero warnings; fmt and diff checks pass.

Independent verification: PASS, no blockers.