### PR TITLE
Report node errors to Sentry, stamped with the build they came from

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,20 @@ version = 4
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli",
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -751,6 +760,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +936,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -1252,6 +1285,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,7 +1487,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.16.1",
  "libm",
  "log",
@@ -1872,6 +1915,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
+ "serde",
  "uuid",
 ]
 
@@ -1994,6 +2038,16 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2215,6 +2269,8 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rust-embed",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2327,7 +2383,7 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "rcgen 0.14.7",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "rustls-pemfile",
  "serial_test",
@@ -2362,7 +2418,7 @@ dependencies = [
  "futures",
  "object_store",
  "ratatui",
- "reqwest",
+ "reqwest 0.12.28",
  "rpassword",
  "serde",
  "serde_json",
@@ -2460,7 +2516,7 @@ dependencies = [
  "ferrosa-sstable",
  "ferrosa-storage",
  "object_store",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",
@@ -2482,7 +2538,7 @@ dependencies = [
  "ferrosa-sim",
  "pkcs5",
  "rand 0.10.1",
- "reqwest",
+ "reqwest 0.12.28",
  "russh",
  "scylla",
  "serde",
@@ -2513,7 +2569,7 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "ratatui",
- "reqwest",
+ "reqwest 0.12.28",
  "serde_json",
  "tempfile",
  "tokio",
@@ -3075,6 +3131,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
@@ -3231,6 +3293,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -3715,6 +3788,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4220,12 +4342,131 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4235,6 +4476,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4268,7 +4549,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "serde",
  "serde_json",
@@ -4376,7 +4657,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
  "tracing",
 ]
 
@@ -4393,7 +4674,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -4439,6 +4720,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5167,6 +5464,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5534,6 +5832,45 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5949,6 +6286,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6165,6 +6529,103 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "sentry"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a88b65feb368d9dde5d531a2b59b25016e36fd6e4978432371a3ee77746ca2"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest 0.13.4",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c51511d67ed670266a93afeaa26a08019b04ad1420cb9191da30f2338d22c48"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b757ac1f335856e8d7f5062a1fd9bc07a05a7eb3cc48247db79bf2618a490bd"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d889520a375e5b93efb0a66def1630d21d168b0251eb55b286b03fa940ccfc84"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0fe456a7380e9df875a1ef4df1e468d35b19b9051599845fab9d8f0c71c4ae"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77796d14eedbef22c2fe78e9c69fb09f14c7ad607e624d48dce92eedc17a136e"
+dependencies = [
+ "bitflags 2.11.1",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc71f5ca55942d9b2901af95d5df5c5d65c164134c22a83682cac3d0b6c7ef2d"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -6421,6 +6882,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -7387,6 +7858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7534,6 +8014,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -7850,7 +8331,7 @@ version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372db8bbad8ec962038101f75ab2c3ffcd18797d7d3ae877a58ab9873cd0c4bd"
 dependencies = [
- "addr2line",
+ "addr2line 0.26.1",
  "async-trait",
  "bitflags 2.11.1",
  "bumpalo",
@@ -7859,13 +8340,13 @@ dependencies = [
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
- "gimli",
+ "gimli 0.33.0",
  "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.39.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -7908,11 +8389,11 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "log",
- "object",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -7993,10 +8474,10 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
- "object",
+ "object 0.39.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
@@ -8030,7 +8511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab453cc600b28ee5d3f9495aa6d4cb2c81eda40903e9287296b548fba8b2391d"
 dependencies = [
  "cc",
- "object",
+ "object 0.39.1",
  "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
@@ -8056,7 +8537,7 @@ dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.39.1",
  "wasmtime-environ",
 ]
 
@@ -8078,9 +8559,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f439b70ba3855a8c808d2cd798eef79bcd389f78aa48a8a694ea8e2904410c"
 dependencies = [
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "log",
- "object",
+ "object 0.39.1",
  "target-lexicon",
  "wasmparser 0.246.2",
  "wasmtime-environ",
@@ -8144,6 +8625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8204,7 +8694,7 @@ checksum = "6da7c536f3cfe5ff63537f795902fed56b8b5adcc7a87843a86dd8d4e57a7946"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "regalloc2",
  "smallvec",
  "target-lexicon",

--- a/ferrosa/Cargo.toml
+++ b/ferrosa/Cargo.toml
@@ -39,6 +39,16 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 tracing-appender = "0.2"
+# Diagnostics. rustls, not native-tls: CI builds this for x86_64-unknown-linux-musl
+# and an OpenSSL dependency would break that build. 0.49 rather than an older
+# release because 0.34 pins rustls 0.22, which carries four RUSTSEC advisories
+# in rustls-webpki 0.102 — a diagnostics dependency must not ship known
+# vulnerabilities. default-features off so the SDK installs no panic handler
+# without being asked; `panic` is opted into here.
+sentry = { version = "0.49", default-features = false, features = [
+    "backtrace", "contexts", "panic", "reqwest", "rustls",
+] }
+sentry-tracing = "0.49"
 uuid = { version = "1", features = ["v4"] }
 
 # Replaces glibc malloc to avoid thread-arena retention (27× 64MB arenas ≈ 1.7GB RSS on 3-node cluster).

--- a/ferrosa/build.rs
+++ b/ferrosa/build.rs
@@ -1,0 +1,44 @@
+//! Embed the commit this build came from.
+//!
+//! A Sentry event that names only a version cannot answer the question actually
+//! asked when a report arrives: is this the build that already has the fix?
+//! Nightly cuts several builds per version.
+//!
+//! `FERROSA_BUILD_SHA` from the environment wins — a release is built from a
+//! tarball or container with no `.git` to ask, and CI knows what it checked
+//! out. `unknown` is the honest last resort: a stale SHA would be believed.
+
+use std::process::Command;
+
+fn main() {
+    let sha = std::env::var("FERROSA_BUILD_SHA")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .or_else(git_short_sha)
+        .unwrap_or_else(|| "unknown".to_owned());
+
+    println!("cargo:rustc-env=FERROSA_BUILD_SHA={sha}");
+    println!("cargo:rerun-if-env-changed=FERROSA_BUILD_SHA");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+}
+
+fn git_short_sha() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?.trim().to_owned();
+    if sha.is_empty() {
+        return None;
+    }
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .is_some_and(|out| !out.stdout.is_empty());
+    Some(if dirty { format!("{sha}-dirty") } else { sha })
+}

--- a/ferrosa/src/main.rs
+++ b/ferrosa/src/main.rs
@@ -56,6 +56,7 @@ pub static malloc_conf: &[u8] = b"dirty_decay_ms:0,muzzy_decay_ms:0\0";
 mod cql_broadcast;
 mod repair_wiring;
 mod runtime;
+mod sentry_reporting;
 mod web;
 
 use std::path::Path;
@@ -876,6 +877,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
     let (non_blocking_writer, _log_guard) = tracing_appender::non_blocking(std::io::stdout());
 
+    // Before the subscriber. The Sentry layer is inert without a client, and
+    // the errors most worth having from a database are the ones raised while
+    // it is still starting. Bound here so it lives until the process exits:
+    // dropping the guard stops sending.
+    let _sentry = sentry_reporting::start();
+
     if std::env::var("FERROSA_TELEMETRY_ENABLED").as_deref() == Ok("true") {
         use tracing_subscriber::layer::SubscriberExt;
         use tracing_subscriber::util::SubscriberInitExt;
@@ -902,11 +909,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with(env_filter)
             .with(tracing_subscriber::fmt::layer().with_writer(non_blocking_writer))
             .with(telemetry_layer)
+            .with(sentry_reporting::layer())
             .init();
     } else {
-        tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
-            .with_writer(non_blocking_writer)
+        // Registry rather than the fmt() builder, so the Sentry layer can sit
+        // beside the writer. The writer and filter are unchanged.
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(tracing_subscriber::fmt::layer().with_writer(non_blocking_writer))
+            .with(sentry_reporting::layer())
             .init();
     }
 

--- a/ferrosa/src/sentry_reporting.rs
+++ b/ferrosa/src/sentry_reporting.rs
@@ -1,0 +1,145 @@
+//! Module: Where this node's errors go besides the log.
+//!
+//! Correctness: Correct when an absent DSN starts nothing, when what is sent
+//! names the build it came from, and when a warning does not arrive as an
+//! error.
+//!
+//! Last revised: 2026-08-28
+//! Last changed: New.
+//!
+//! # Why the DSN is not in this file
+//!
+//! ferrosa is a PUBLIC repository. A Sentry DSN is not a secret — it is a
+//! write-only ingest key meant to be embedded in a client — but one committed
+//! to a public repo can be used by anyone to write into the project, and
+//! rotating it then needs a release. The installer supplies it as
+//! `FERROSA_SENTRY_DSN`.
+//!
+//! # Errors only
+//!
+//! Warnings become breadcrumbs, not events: they are context for the error
+//! that follows, and as events they would bury it. Everything below WARN stays
+//! in the log — a storage engine at info level would exhaust the quota in
+//! minutes and hide every error underneath the noise.
+
+/// The commit this binary was built from, or `unknown`. Set by build.rs.
+pub const BUILD_SHA: &str = env!("FERROSA_BUILD_SHA");
+
+/// The environment variable the installer sets.
+const DSN_VAR: &str = "FERROSA_SENTRY_DSN";
+
+/// How this build identifies itself: `ferrosa@version+sha`.
+///
+/// An unknown commit degrades to the version rather than shipping the word
+/// "unknown" into a release name, which would group every unstamped build of
+/// every version together.
+pub fn release_id(version: &str, build_sha: &str) -> String {
+    if build_sha.is_empty() || build_sha == "unknown" {
+        format!("ferrosa@{version}")
+    } else {
+        format!("ferrosa@{version}+{build_sha}")
+    }
+}
+
+/// Whether a configured value can be used as a DSN.
+///
+/// An unset variable reaches a process from a shell script as an empty string,
+/// and starting the SDK with one reports a configuration error on every launch
+/// about a side channel nobody asked for. Plain `http` is refused: it would put
+/// diagnostics on the wire in the clear.
+pub fn usable_dsn(value: Option<&str>) -> Option<&str> {
+    value
+        .map(str::trim)
+        .filter(|dsn| !dsn.is_empty() && dsn.starts_with("https://"))
+}
+
+/// Start Sentry if the installer configured it.
+///
+/// The guard must live as long as the process: dropping it stops sending,
+/// which quietly loses the errors that happen during shutdown — exactly the
+/// ones worth having from a database.
+#[must_use = "dropping this stops error reporting"]
+pub fn start() -> Option<sentry::ClientInitGuard> {
+    let configured = std::env::var(DSN_VAR).ok();
+    let dsn = usable_dsn(configured.as_deref())?;
+    let release = release_id(env!("CARGO_PKG_VERSION"), BUILD_SHA);
+    // Field by field: ClientOptions is #[non_exhaustive], so a struct
+    // expression does not compile from outside the SDK.
+    let mut options = sentry::ClientOptions::default();
+    options.release = Some(release.clone().into());
+    // Never. A database node's environment names the machine and the operator.
+    options.send_default_pii = false;
+    let guard = sentry::init((dsn, options));
+    tracing::info!(%release, "errors report to Sentry");
+    Some(guard)
+}
+
+/// The layer that turns `tracing::error!` into a Sentry event.
+pub fn layer<S>() -> sentry_tracing::SentryLayer<S>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    sentry_tracing::layer().event_filter(|meta| match *meta.level() {
+        tracing::Level::ERROR => sentry_tracing::EventFilter::Event,
+        tracing::Level::WARN => sentry_tracing::EventFilter::Breadcrumb,
+        _ => sentry_tracing::EventFilter::Ignore,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_release_id_names_the_version_and_the_commit() {
+        assert_eq!(
+            release_id("0.17.0", "a1b2c3d4e5f6"),
+            "ferrosa@0.17.0+a1b2c3d4e5f6"
+        );
+    }
+
+    #[test]
+    fn an_unknown_commit_falls_back_to_the_version() {
+        assert_eq!(release_id("0.17.0", "unknown"), "ferrosa@0.17.0");
+        assert_eq!(release_id("0.17.0", ""), "ferrosa@0.17.0");
+    }
+
+    /// A build nobody else can reproduce should say so.
+    #[test]
+    fn a_dirty_build_is_marked() {
+        assert!(release_id("0.17.0", "abc123-dirty").ends_with("+abc123-dirty"));
+    }
+
+    /// The shape an unset variable takes in a shell script.
+    #[test]
+    fn an_empty_dsn_is_absent_not_broken() {
+        assert!(usable_dsn(None).is_none());
+        assert!(usable_dsn(Some("")).is_none());
+        assert!(usable_dsn(Some("   ")).is_none());
+    }
+
+    /// Plain http would put diagnostics on the wire in the clear.
+    #[test]
+    fn a_non_https_dsn_is_refused() {
+        assert!(usable_dsn(Some("http://k@example.com/1")).is_none());
+        assert!(usable_dsn(Some("not-a-dsn")).is_none());
+    }
+
+    #[test]
+    fn a_usable_dsn_is_accepted_and_trimmed() {
+        assert_eq!(
+            usable_dsn(Some("  https://k@o1.ingest.us.sentry.io/2 ")),
+            Some("https://k@o1.ingest.us.sentry.io/2")
+        );
+    }
+
+    /// A build.rs that silently stopped running fails here, not in a report
+    /// months from now.
+    #[test]
+    fn this_build_carries_a_stamp() {
+        assert!(
+            !BUILD_SHA.is_empty(),
+            "build.rs did not set FERROSA_BUILD_SHA"
+        );
+    }
+}


### PR DESCRIPTION
ferrosa's half of the per-repo diagnostics work.

## What was missing

There was a telemetry layer already, gated on `FERROSA_TELEMETRY_ENABLED`, but no path for an error to leave the machine. **A node that logs a failure to a console nobody is attached to has not reported it.**

## What this adds

Errors become Sentry events when the installer configures `FERROSA_SENTRY_DSN`. `WARN` becomes a **breadcrumb**, not an event — context for the error that follows. Everything below `WARN` stays in the log: a storage engine at info level would exhaust the quota in minutes and hide every error underneath the noise.

The client starts **before** the subscriber. The layer is inert without it, and the errors most worth having from a database are the ones raised while it is still coming up. The guard is bound in `main` so it outlives the process; dropping it stops sending, which loses exactly the shutdown errors.

The disabled-telemetry branch moves from the `fmt()` builder to registry composition so the Sentry layer can sit beside the writer. Filter and writer unchanged.

## Build identity

Events carry `ferrosa@version+sha`. `build.rs` prefers `FERROSA_BUILD_SHA` from CI, falls back to `git rev-parse`, and says `unknown` last — a stale SHA would be believed. A dirty tree is marked.

**The release workflow should set `FERROSA_BUILD_SHA`** so tagged builds carry the commit CI checked out.

## The DSN is not in this repository

**ferrosa is PUBLIC.** A DSN is not a secret — it's a write-only ingest key meant to be embedded — but one committed to a public repo can be used by anyone to write into the project, and rotating it then needs a release. Empty (what an unset shell variable looks like) is *absent*, not broken; plain `http` is refused, since it would put diagnostics on the wire in the clear.

## Dependency choice, deliberately

`sentry 0.49`, not `0.34`. The older release pins `rustls 0.22`, whose `rustls-webpki 0.102` carries **four RUSTSEC advisories** — `cargo deny` caught exactly this on the ferrosa-memory branch. One `rustls-webpki` in the lock now, the patched `0.103`. `rustls` rather than `native-tls` because CI builds this for `x86_64-unknown-linux-musl`.

Adding a diagnostics dependency that ships known vulnerabilities would be a poor trade for observability.

## Verification

- 7 tests in `sentry_reporting`
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- **1786 passed, 0 failures** under the exact CI invocation

One note on the suite: a plain `--all-features` run also surfaces `real_typed_edges_paged_scan_delivers_every_distinct_row`, which fails loud without `FERROSA_TEST_TYPED_EDGES_DIR` by design. CI skips it explicitly, and so does the command above. I checked main is green before concluding that.

The `__eh_frame` linker warning on debug builds is **pre-existing on main** — I verified by stashing — and `RUSTFLAGS` isn't set in CI, so build warnings aren't errors there; clippy's `-D warnings` is the gate and it passes.