### PR TITLE
Add bounded durable CDC replay transport

### DIFF
--- a/ferrosa-graph/src/engine.rs
+++ b/ferrosa-graph/src/engine.rs
@@ -1,4 +1,8 @@
 //! GraphEngine: composition root for graph query processing.
+//! Correctness: Correct when planning/execution share the same schema and storage
+//! handles and blocking adapters receive owned handles without locks across await.
+//! Last revised: 2026-08-29
+//! Last changed: Exposed a crate-local storage handle for bounded durable CDC I/O.
 //!
 //! Wires together the parser, planner, executor, adjacency index observer,
 //! and reconciliation loop. Provides the top-level `execute()` and `explain()`
@@ -1163,6 +1167,12 @@ impl GraphEngine {
     /// Get a reference to the subscription registry.
     pub fn subscription_registry(&self) -> &Arc<SubscriptionRegistry> {
         &self.subscription_registry
+    }
+
+    /// Clone the storage handle for bounded blocking adapters such as durable
+    /// graph CDC. Callers must keep disk I/O off async executor threads.
+    pub(crate) fn storage(&self) -> Arc<StorageEngine> {
+        Arc::clone(&self.storage)
     }
 
     /// List vertex and edge tables with their labels in a keyspace.

--- a/ferrosa-graph/src/http.rs
+++ b/ferrosa-graph/src/http.rs
@@ -1,4 +1,8 @@
-//! HTTP/JSON endpoint for graph queries.
+//! Module: Serve authenticated bounded HTTP/JSON graph and durable CDC requests.
+//! Correctness: Correct when authentication and authorization precede storage I/O,
+//! request/page bounds are enforced, and storage failures return sanitized typed responses.
+//! Last revised: 2026-08-29
+//! Last changed: Added authenticated durable cursor-page admission and replay.
 //!
 //! Provides a REST API for executing Cypher queries, explaining query plans,
 //! inspecting graph schema, and health checks. Includes Basic auth middleware (T2),
@@ -33,7 +37,11 @@ use tower_http::limit::RequestBodyLimitLayer;
 use tokio_util::sync::CancellationToken;
 
 use ferrosa_schema::auth::role::AuthContext;
+use ferrosa_schema::auth::{Permission, Resource};
 use ferrosa_schema::Schema;
+use ferrosa_storage::commitlog::cdc::CdcPageLimit;
+use ferrosa_storage::commitlog::cdc::CdcReplayError;
+use ferrosa_storage::{CommitLogPosition, TableId};
 
 use crate::engine::GraphEngine;
 use crate::error::GraphError;
@@ -80,6 +88,77 @@ pub struct QueryRequest {
     pub keyspace: String,
     #[serde(default)]
     pub params: HashMap<String, Value>,
+}
+
+/// Initial durable CDC transport contract. Source-filtered graph projection is
+/// layered on this authenticated, authorized, cursor-bounded transport.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DurableCdcPageRequest {
+    keyspace: String,
+    table: String,
+    #[serde(default)]
+    after: Option<String>,
+    limit: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct DurableCdcMutationEvent {
+    event_id: String,
+    source_cursor: String,
+    /// Versioned Ferrosa mutation bytes. Graph source filtering replaces this
+    /// transport envelope with projected records before Streamer integration.
+    mutation: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DurableCdcPageResponse {
+    events: Vec<DurableCdcMutationEvent>,
+    high_water_cursor: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DurableCdcGapResponse {
+    error: &'static str,
+    resync_required: bool,
+    requested_segment: u64,
+    oldest_retained_segment: Option<u64>,
+}
+
+const DURABLE_CDC_CURSOR_VERSION: u8 = 1;
+const DURABLE_CDC_CURSOR_ENCODED_BYTES: usize = 23;
+
+fn decode_durable_cdc_cursor(value: &str) -> Result<CommitLogPosition, &'static str> {
+    if value.len() != DURABLE_CDC_CURSOR_ENCODED_BYTES {
+        return Err("invalid durable CDC cursor");
+    }
+    let mut decoded = [0_u8; 17];
+    let written = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode_slice(value, &mut decoded)
+        .map_err(|_| "invalid durable CDC cursor")?;
+    if written != decoded.len() || decoded[0] != DURABLE_CDC_CURSOR_VERSION {
+        return Err("invalid durable CDC cursor");
+    }
+    Ok(CommitLogPosition {
+        segment_id: u64::from_be_bytes(
+            decoded[1..9]
+                .try_into()
+                .map_err(|_| "invalid durable CDC cursor")?,
+        ),
+        offset: u64::from_be_bytes(
+            decoded[9..17]
+                .try_into()
+                .map_err(|_| "invalid durable CDC cursor")?,
+        ),
+    })
+}
+
+fn encode_durable_cdc_cursor(position: CommitLogPosition) -> String {
+    let mut bytes = [0_u8; 17];
+    bytes[0] = DURABLE_CDC_CURSOR_VERSION;
+    bytes[1..9].copy_from_slice(&position.segment_id.to_be_bytes());
+    bytes[9..17].copy_from_slice(&position.offset.to_be_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
 }
 
 /// Query parameters for the schema endpoint.
@@ -742,6 +821,172 @@ async fn handle_unsubscribe(State(state): State<AppState>, req: Request<Body>) -
     }
 }
 
+/// POST /graph/cdc/page — authenticated bounded durable replay.
+///
+/// The projection/filter implementation is installed by the durable graph CDC
+/// source. Keeping the route behind the same middleware as graph queries makes
+/// it impossible to open commit-log replay before authentication succeeds.
+async fn handle_durable_cdc_page(State(state): State<AppState>, req: Request<Body>) -> Response {
+    let Some(auth) = req.extensions().get::<AuthContext>().cloned() else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse {
+                error: "authentication required".to_string(),
+            }),
+        )
+            .into_response();
+    };
+
+    let body = match axum::body::to_bytes(req.into_body(), 64 * 1024).await {
+        Ok(body) => body,
+        Err(_) => {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(ErrorResponse {
+                    error: "durable CDC request exceeds 65536 bytes".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+    let request: DurableCdcPageRequest = match serde_json::from_slice(&body) {
+        Ok(request) => request,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "invalid durable CDC request".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+    let limit = match CdcPageLimit::new(request.limit) {
+        Ok(limit) => limit,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: error.to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
+    let resource = Resource::Table(request.keyspace.clone(), request.table.clone());
+    if state
+        .schema
+        .check_permission(&auth, Permission::Select, &resource)
+        .is_err()
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: "permission denied".to_string(),
+            }),
+        )
+            .into_response();
+    }
+    let position = match request.after.as_deref() {
+        Some(cursor) => match decode_durable_cdc_cursor(cursor) {
+            Ok(cursor) => cursor,
+            Err(message) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: message.to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        },
+        None => CommitLogPosition {
+            segment_id: 0,
+            offset: 0,
+        },
+    };
+    let storage = state.engine.storage();
+    let table = TableId::new(&request.keyspace, &request.table);
+    let page =
+        match tokio::task::spawn_blocking(move || storage.durable_cdc_page(position, table, limit))
+            .await
+        {
+            Ok(Ok(page)) => page,
+            Ok(Err(CdcReplayError::CursorExpired {
+                requested_segment,
+                oldest_retained_segment,
+            })) => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(DurableCdcGapResponse {
+                        error: "cursor_expired",
+                        resync_required: true,
+                        requested_segment,
+                        oldest_retained_segment,
+                    }),
+                )
+                    .into_response();
+            }
+            Ok(Err(CdcReplayError::InvalidCursor { .. })) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: "invalid durable CDC cursor".to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+            Ok(Err(CdcReplayError::InvalidPageLimit { .. })) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: "invalid durable CDC page limit".to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+            Ok(Err(CdcReplayError::EventTooLarge { .. })) => {
+                return (
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    Json(ErrorResponse {
+                        error: "durable CDC event exceeds page byte budget".to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+            Ok(Err(CdcReplayError::Storage(_))) | Err(_) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: "durable CDC unavailable".to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        };
+
+    let high_water_cursor = encode_durable_cdc_cursor(page.high_water);
+    let events = page
+        .entries
+        .into_iter()
+        .map(|(mutation, position)| {
+            let mut bytes = vec![0_u8; mutation.serialized_size()];
+            mutation.serialize_into(&mut bytes);
+            DurableCdcMutationEvent {
+                event_id: base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .encode(mutation.mutation_id),
+                source_cursor: encode_durable_cdc_cursor(position),
+                mutation: base64::engine::general_purpose::STANDARD.encode(bytes),
+            }
+        })
+        .collect();
+    Json(DurableCdcPageResponse {
+        events,
+        high_water_cursor,
+    })
+    .into_response()
+}
+
 /// Build the Axum router with all graph routes.
 ///
 /// Auth middleware is applied to all routes except /graph/health.
@@ -752,6 +997,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/graph/explain", post(handle_explain))
         .route("/graph/schema", get(handle_schema))
         .route("/graph/subscribe", post(handle_subscribe))
+        .route("/graph/cdc/page", post(handle_durable_cdc_page))
         .route("/graph/unsubscribe", post(handle_unsubscribe))
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -1259,5 +1505,164 @@ mod tests {
 
         // build_router should succeed and include subscribe/unsubscribe routes.
         let _router = build_router(state);
+    }
+
+    #[tokio::test]
+    async fn durable_cdc_page_authenticates_before_opening_replay() {
+        use ferrosa_schema::{
+            AuthMethod, DeploymentMode, EnvSecretsProvider, PasswordHasher, PasswordPolicy,
+            RateLimitConfig, SchemaConfig, TestAuditSink,
+        };
+        use ferrosa_storage::{
+            CommitLogConfig, CompactionConfig, StorageEngineConfig, SyncStrategyConfig,
+        };
+        use tower::ServiceExt;
+
+        let schema = Arc::new(
+            ferrosa_schema::Schema::new(SchemaConfig {
+                hasher: PasswordHasher::default(),
+                password_policy: PasswordPolicy::permissive(),
+                auth_method: AuthMethod::Password,
+                rate_limit: RateLimitConfig::default(),
+                audit_sink: Box::new(TestAuditSink::new()),
+                secrets: Box::new(EnvSecretsProvider),
+                mode: DeploymentMode::Development,
+            })
+            .unwrap(),
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = Arc::new(
+            ferrosa_storage::StorageEngine::new(
+                StorageEngineConfig {
+                    commit_log: CommitLogConfig {
+                        segment_size: 4096,
+                        max_segment_age: std::time::Duration::from_secs(60),
+                        sync_strategy: SyncStrategyConfig::Batch,
+                        batch: Default::default(),
+                        log_dir: tmp.path().to_path_buf(),
+                        checkpoint_dir: tmp.path().to_path_buf(),
+                        archive: None,
+                    },
+                    compaction: CompactionConfig::from_env(tmp.path().join("compaction")),
+                    object_store: None,
+                    local_cache_max_bytes: 1024 * 1024,
+                    local_disk_free_reserve_bytes: 0,
+                    flush_threshold_bytes: 4096,
+                    memtable_backpressure_bytes: u64::MAX,
+                    flush_max_age_secs: 5,
+                    data_dir: tmp.path().to_path_buf(),
+                    index_backend: ferrosa_storage::index::IndexBackendConfig::Local,
+                    write_verify: true,
+                    auth_enabled: true,
+                    auth_warn: false,
+                    max_pending_replay_mutations_without_schema: 1024,
+                    memtable_num_shards: 64,
+                },
+                None,
+            )
+            .unwrap(),
+        );
+        let write_path = Arc::new(arc_swap::ArcSwap::from_pointee(
+            ferrosa_cluster::write_path::WritePath::direct(Arc::clone(&storage)),
+        ));
+        let engine = Arc::new(crate::engine::GraphEngine::new(
+            Arc::clone(&schema),
+            storage,
+            write_path,
+            crate::executor::expand::GraphEngineConfig::default(),
+            std::time::Duration::from_secs(300),
+        ));
+        let app = build_router(AppState {
+            engine: Arc::clone(&engine),
+            schema: Arc::clone(&schema),
+            auth_disabled: false,
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/graph/cdc/page")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let authenticated_app = build_router(AppState {
+            engine: Arc::clone(&engine),
+            schema: Arc::clone(&schema),
+            auth_disabled: true,
+        });
+        let response = authenticated_app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/graph/cdc/page")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"keyspace":"graph","table":"edges","limit":0}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let response = authenticated_app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/graph/cdc/page")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"keyspace":"graph","table":"edges","after":"not-a-cursor","limit":1}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let response = authenticated_app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/graph/cdc/page")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"keyspace":"graph","table":"edges","limit":1}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let mut denied_request = Request::builder()
+            .method("POST")
+            .uri("/graph/cdc/page")
+            .body(Body::from(
+                r#"{"keyspace":"graph","table":"edges","limit":1}"#,
+            ))
+            .unwrap();
+        denied_request.extensions_mut().insert(AuthContext {
+            role: "cdc_without_select".to_string(),
+            is_superuser: false,
+            must_change_password: false,
+        });
+        let response = handle_durable_cdc_page(
+            State(AppState {
+                engine,
+                schema,
+                auth_disabled: false,
+            }),
+            denied_request,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/ferrosa-storage/src/commitlog/cdc.rs
+++ b/ferrosa-storage/src/commitlog/cdc.rs
@@ -1,4 +1,8 @@
-//! Change Data Capture: tails commit log segments from a checkpoint.
+//! Module: Provide bounded durable CDC replay from explicit cursors or checkpoints.
+//! Correctness: Correct when pages are strict-after, count-and-byte bounded, gaps
+//! fail typed, and active/rotated segments are consumed without feed materialization.
+//! Last revised: 2026-08-29
+//! Last changed: Added durable client cursors, bounded pages, and incremental tailing.
 //!
 //! [`CdcReader`] reads durable segment files, filters by table, and yields
 //! mutations with their commit log positions. Consumers checkpoint their
@@ -13,13 +17,104 @@
 //! guarantees at-least-once delivery of durable mutations.
 
 use std::collections::HashSet;
+use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use super::config::{CommitLogPosition, TableId};
 use super::mutation::Mutation;
-use super::reader::SegmentReader;
+use super::reader::{SegmentEntryRead, SegmentReader};
 
 const CDC_CHECKPOINT_FILENAME: &str = "cdc_checkpoint.json";
+const MAX_CDC_CHECKPOINT_BYTES: usize = 4096;
+pub const MAX_DURABLE_CDC_PAGE_MUTATIONS: usize = 128;
+pub const MAX_DURABLE_CDC_PAGE_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CdcPageLimit(usize);
+
+impl CdcPageLimit {
+    pub fn new(value: usize) -> Result<Self, CdcReplayError> {
+        if value == 0 || value > MAX_DURABLE_CDC_PAGE_MUTATIONS {
+            return Err(CdcReplayError::InvalidPageLimit {
+                requested: value,
+                maximum: MAX_DURABLE_CDC_PAGE_MUTATIONS,
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> usize {
+        self.0
+    }
+}
+
+/// One bounded durable page. Callers must consume and discard `entries`
+/// before requesting the next page.
+pub struct DurableCdcPage {
+    pub entries: Vec<(Mutation, CommitLogPosition)>,
+    pub high_water: CommitLogPosition,
+}
+
+/// Fail-loud durable replay errors exposed to client-facing CDC adapters.
+#[derive(Debug)]
+pub enum CdcReplayError {
+    Storage(ferrosa_common::Error),
+    CursorExpired {
+        requested_segment: u64,
+        oldest_retained_segment: Option<u64>,
+    },
+    InvalidCursor {
+        requested_segment: u64,
+        newest_retained_segment: Option<u64>,
+    },
+    InvalidPageLimit {
+        requested: usize,
+        maximum: usize,
+    },
+    EventTooLarge {
+        bytes: usize,
+        maximum: usize,
+    },
+}
+
+impl std::fmt::Display for CdcReplayError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Storage(error) => write!(formatter, "durable CDC storage error: {error}"),
+            Self::CursorExpired {
+                requested_segment,
+                oldest_retained_segment,
+            } => write!(
+                formatter,
+                "durable CDC cursor segment {requested_segment} is no longer retained; oldest retained segment is {oldest_retained_segment:?}"
+            ),
+            Self::InvalidCursor {
+                requested_segment,
+                newest_retained_segment,
+            } => write!(
+                formatter,
+                "durable CDC cursor segment {requested_segment} is ahead of retained data; newest retained segment is {newest_retained_segment:?}"
+            ),
+            Self::InvalidPageLimit { requested, maximum } => write!(
+                formatter,
+                "durable CDC page limit {requested} is outside 1..={maximum}"
+            ),
+            Self::EventTooLarge { bytes, maximum } => write!(
+                formatter,
+                "durable CDC event is {bytes} bytes, exceeding the {maximum}-byte page budget"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CdcReplayError {}
+
+impl From<ferrosa_common::Error> for CdcReplayError {
+    fn from(error: ferrosa_common::Error) -> Self {
+        Self::Storage(error)
+    }
+}
 
 /// Persists the CDC reader's position so it can resume after restart.
 pub(crate) struct CdcCheckpoint;
@@ -28,9 +123,24 @@ impl CdcCheckpoint {
     /// Loads the CDC checkpoint. Returns `None` if no checkpoint exists.
     pub fn load(dir: &Path) -> ferrosa_common::Result<Option<CommitLogPosition>> {
         let path = dir.join(CDC_CHECKPOINT_FILENAME);
-        match std::fs::read(&path) {
-            Ok(data) => {
-                let pos: CdcPosition = serde_json::from_slice(&data).map_err(|e| {
+        match File::open(&path) {
+            Ok(mut file) => {
+                let mut data = [0_u8; MAX_CDC_CHECKPOINT_BYTES + 1];
+                let mut bytes_read = 0usize;
+                while bytes_read < data.len() {
+                    let count = file.read(&mut data[bytes_read..])?;
+                    if count == 0 {
+                        break;
+                    }
+                    bytes_read += count;
+                }
+                if bytes_read > MAX_CDC_CHECKPOINT_BYTES {
+                    return Err(ferrosa_common::Error::InvalidFormat(format!(
+                        "cdc checkpoint exceeds {MAX_CDC_CHECKPOINT_BYTES} bytes"
+                    )));
+                }
+                let pos: CdcPosition =
+                    serde_json::from_slice(&data[..bytes_read]).map_err(|e| {
                     ferrosa_common::Error::InvalidFormat(format!(
                         "cdc checkpoint not valid JSON: {e}"
                     ))
@@ -40,8 +150,8 @@ impl CdcCheckpoint {
                     offset: pos.offset,
                 }))
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(ferrosa_common::Error::Io(e)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(ferrosa_common::Error::Io(error)),
         }
     }
 
@@ -84,17 +194,21 @@ struct CdcPosition {
 /// ```
 pub struct CdcReader {
     log_dir: PathBuf,
-    checkpoint_dir: PathBuf,
+    checkpoint_dir: Option<PathBuf>,
     table_filter: Option<HashSet<TableId>>,
     position: CommitLogPosition,
-    /// Buffered mutations from the current segment, with positions.
-    buffer: Vec<(CommitLogPosition, Mutation)>,
-    /// Index into buffer for the next mutation to yield.
-    buffer_cursor: usize,
-    /// Segment files we haven't processed yet, sorted by segment ID.
-    pending_segments: Vec<(u64, PathBuf)>,
-    /// Whether we've scanned for segment files.
-    scanned: bool,
+    /// Incremental reader for the current segment. It owns no segment-sized
+    /// buffer and yields one mutation payload at a time.
+    current_segment: Option<SegmentReader>,
+    /// True after the current active segment reached its durable tail. The next
+    /// call refreshes that same reader unless a newer segment has appeared.
+    current_segment_caught_up: bool,
+    /// One already-decoded entry that did not fit in the previous byte-bounded
+    /// page. Keeping at most one entry prevents cumulative page materialization.
+    pending_entry: Option<(Mutation, CommitLogPosition)>,
+    /// Lowest segment ID eligible for the next allocation-free directory scan.
+    /// The reader rescans after catch-up so newly-created segments become visible.
+    next_segment_floor: u64,
 }
 
 impl CdcReader {
@@ -116,14 +230,36 @@ impl CdcReader {
 
         Ok(Self {
             log_dir: log_dir.to_path_buf(),
-            checkpoint_dir: checkpoint_dir.to_path_buf(),
+            checkpoint_dir: Some(checkpoint_dir.to_path_buf()),
             table_filter,
             position,
-            buffer: Vec::new(),
-            buffer_cursor: 0,
-            pending_segments: Vec::new(),
-            scanned: false,
+            current_segment: None,
+            current_segment_caught_up: false,
+            pending_entry: None,
+            next_segment_floor: position.segment_id,
         })
+    }
+
+    /// Creates a reader positioned strictly after a client-provided durable
+    /// cursor. This reader never writes the server-side singleton checkpoint;
+    /// cursor ownership remains with the authenticated client.
+    pub fn from_position(
+        log_dir: &Path,
+        position: CommitLogPosition,
+        table_filter: Option<HashSet<TableId>>,
+    ) -> Result<Self, CdcReplayError> {
+        let reader = Self {
+            log_dir: log_dir.to_path_buf(),
+            checkpoint_dir: None,
+            table_filter,
+            position,
+            current_segment: None,
+            current_segment_caught_up: false,
+            pending_entry: None,
+            next_segment_floor: position.segment_id,
+        };
+        reader.validate_explicit_position()?;
+        Ok(reader)
     }
 
     /// Returns the next mutation, or `None` if no more are available.
@@ -133,33 +269,83 @@ impl CdcReader {
     pub fn next_mutation(
         &mut self,
     ) -> ferrosa_common::Result<Option<(Mutation, CommitLogPosition)>> {
+        match self.next_mutation_with_payload_limit(usize::MAX) {
+            Ok(entry) => Ok(entry),
+            Err(CdcReplayError::Storage(error)) => Err(error),
+            Err(error) => Err(ferrosa_common::Error::InvalidData(error.to_string())),
+        }
+    }
+
+    fn next_mutation_with_payload_limit(
+        &mut self,
+        maximum_payload_bytes: usize,
+    ) -> Result<Option<(Mutation, CommitLogPosition)>, CdcReplayError> {
+        if let Some((mutation, position)) = self.pending_entry.take() {
+            self.position = position;
+            return Ok(Some((mutation, position)));
+        }
+        if self.current_segment_caught_up {
+            if let Some(reader) = self.current_segment.as_mut() {
+                reader.refresh()?;
+            }
+            self.current_segment_caught_up = false;
+        }
         loop {
-            // Yield from buffer if available.
-            if self.buffer_cursor < self.buffer.len() {
-                let (pos, mutation) = self.buffer[self.buffer_cursor].clone();
-                self.buffer_cursor += 1;
-                self.position = pos;
-                return Ok(Some((mutation, pos)));
-            }
-
-            // Buffer exhausted -- load next segment.
-            if !self.scanned {
-                self.scan_segments()?;
-                self.scanned = true;
-            }
-
-            if self.pending_segments.is_empty() {
+            if let Some(reader) = self.current_segment.as_mut() {
+                while let Some(entry) = reader.next_entry_bounded(maximum_payload_bytes)? {
+                    let (pos, mutation) = match entry {
+                        SegmentEntryRead::Mutation(pos, mutation) => (pos, mutation),
+                        SegmentEntryRead::PayloadTooLarge { position: _, bytes } => {
+                            return Err(CdcReplayError::EventTooLarge {
+                                bytes,
+                                maximum: maximum_payload_bytes,
+                            });
+                        }
+                    };
+                    if pos <= self.position {
+                        continue;
+                    }
+                    if let Some(ref filter) = self.table_filter {
+                        let table_id = TableId::new(&mutation.keyspace, &mutation.table);
+                        if !filter.contains(&table_id) {
+                            self.position = pos;
+                            continue;
+                        }
+                    }
+                    self.position = pos;
+                    return Ok(Some((mutation, pos)));
+                }
+                let current_id = reader.segment_id();
+                if let Some((_segment_id, path)) =
+                    self.find_segment_at_or_after(current_id.saturating_add(1))?
+                {
+                    self.current_segment = Some(SegmentReader::open(&path)?);
+                    continue;
+                }
+                self.current_segment_caught_up = true;
                 return Ok(None);
             }
 
-            let (_seg_id, path) = self.pending_segments.remove(0);
-            self.load_segment(&path)?;
+            // Current segment exhausted: scan without collecting the directory.
+            // If caught up, the next call scans again and can discover a segment
+            // created after this call returned `None`.
+            let Some((_segment_id, path)) =
+                self.find_segment_at_or_after(self.next_segment_floor)?
+            else {
+                return Ok(None);
+            };
+            self.current_segment = Some(SegmentReader::open(&path)?);
         }
     }
 
     /// Saves the current position as a checkpoint.
     pub fn save_checkpoint(&self) -> ferrosa_common::Result<()> {
-        CdcCheckpoint::save(&self.checkpoint_dir, &self.position)
+        let checkpoint_dir = self.checkpoint_dir.as_ref().ok_or_else(|| {
+            ferrosa_common::Error::InvalidFormat(
+                "client-positioned CDC readers cannot write the shared checkpoint".into(),
+            )
+        })?;
+        CdcCheckpoint::save(checkpoint_dir, &self.position)
     }
 
     /// Returns the current reader position.
@@ -167,52 +353,148 @@ impl CdcReader {
         self.position
     }
 
-    /// Scans log_dir for segment files, sorted by ID, filtered to those
-    /// after our checkpoint position.
-    fn scan_segments(&mut self) -> ferrosa_common::Result<()> {
-        let mut segments = Vec::new();
+    /// Read at most `limit` mutations. The vector is hard-bounded by both
+    /// [`MAX_DURABLE_CDC_PAGE_MUTATIONS`] and [`MAX_DURABLE_CDC_PAGE_BYTES`]
+    /// and is discarded between requests.
+    pub fn read_page(&mut self, limit: CdcPageLimit) -> Result<DurableCdcPage, CdcReplayError> {
+        let mut entries = Vec::with_capacity(limit.get());
+        let mut resident_bytes = 0usize;
+        let mut high_water = self.position;
+        while entries.len() < limit.get() {
+            let Some((mutation, position)) =
+                self.next_mutation_with_payload_limit(MAX_DURABLE_CDC_PAGE_BYTES)?
+            else {
+                // The reader may have skipped filtered mutations after the last
+                // returned entry. Advancing across them avoids rescanning them
+                // on the next client request.
+                high_water = self.position;
+                break;
+            };
+            let mutation_bytes = mutation.serialized_size();
+            if mutation_bytes > MAX_DURABLE_CDC_PAGE_BYTES {
+                self.pending_entry = Some((mutation, position));
+                self.position = high_water;
+                return Err(CdcReplayError::EventTooLarge {
+                    bytes: mutation_bytes,
+                    maximum: MAX_DURABLE_CDC_PAGE_BYTES,
+                });
+            }
+            if !entries.is_empty()
+                && resident_bytes.saturating_add(mutation_bytes) > MAX_DURABLE_CDC_PAGE_BYTES
+            {
+                self.pending_entry = Some((mutation, position));
+                self.position = high_water;
+                break;
+            }
+            resident_bytes += mutation_bytes;
+            high_water = position;
+            entries.push((mutation, position));
+        }
+        Ok(DurableCdcPage {
+            entries,
+            high_water,
+        })
+    }
+
+    /// Finds only the next eligible segment. Resident segment-index memory is
+    /// constant regardless of retention depth.
+    fn find_segment_at_or_after(
+        &self,
+        segment_floor: u64,
+    ) -> ferrosa_common::Result<Option<(u64, PathBuf)>> {
+        let mut next: Option<(u64, PathBuf)> = None;
         if self.log_dir.exists() {
             for entry in std::fs::read_dir(&self.log_dir)? {
                 let entry = entry?;
                 let path = entry.path();
                 if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                     if let Some(id) = super::parse_segment_id(name) {
-                        if id >= self.position.segment_id {
-                            segments.push((id, path));
+                        if id >= segment_floor
+                            && next.as_ref().is_none_or(|(next_id, _)| id < *next_id)
+                        {
+                            next = Some((id, path));
                         }
                     }
                 }
             }
         }
-        segments.sort_by_key(|(id, _)| *id);
-        self.pending_segments = segments;
-        Ok(())
+        Ok(next)
     }
 
-    /// Loads a segment file into the buffer, filtering by table and position.
-    fn load_segment(&mut self, path: &Path) -> ferrosa_common::Result<()> {
-        let mut reader = SegmentReader::open(path)?;
-        let entries = reader.read_all()?;
-
-        self.buffer.clear();
-        self.buffer_cursor = 0;
-
-        for (pos, mutation) in entries {
-            // Skip entries at or before our checkpoint position.
-            if pos <= self.position {
-                continue;
-            }
-            // Apply table filter.
-            if let Some(ref filter) = self.table_filter {
-                let table_id = TableId::new(&mutation.keyspace, &mutation.table);
-                if !filter.contains(&table_id) {
+    fn validate_explicit_position(&self) -> Result<(), CdcReplayError> {
+        if self.position.segment_id == 0 {
+            return if self.position.offset == 0 {
+                Ok(())
+            } else {
+                Err(CdcReplayError::InvalidCursor {
+                    requested_segment: 0,
+                    newest_retained_segment: None,
+                })
+            };
+        }
+        let mut oldest: Option<u64> = None;
+        let mut newest: Option<u64> = None;
+        let mut requested_path = None;
+        if self.log_dir.exists() {
+            for entry in std::fs::read_dir(&self.log_dir).map_err(ferrosa_common::Error::from)? {
+                let path = entry.map_err(ferrosa_common::Error::from)?.path();
+                let Some(id) = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .and_then(super::parse_segment_id)
+                else {
                     continue;
+                };
+                oldest = Some(oldest.map_or(id, |value| value.min(id)));
+                newest = Some(newest.map_or(id, |value| value.max(id)));
+                if id == self.position.segment_id {
+                    requested_path = Some(path);
                 }
             }
-            self.buffer.push((pos, mutation));
+        }
+        if let Some(path) = requested_path {
+            let file_len = std::fs::metadata(&path)
+                .map_err(ferrosa_common::Error::from)?
+                .len();
+            if self.position.offset < file_len {
+                let mut reader = SegmentReader::open(&path)?;
+                while let Some(entry) = reader.next_entry_bounded(MAX_DURABLE_CDC_PAGE_BYTES)? {
+                    let position = match entry {
+                        SegmentEntryRead::Mutation(position, _mutation) => position,
+                        SegmentEntryRead::PayloadTooLarge { bytes, .. } => {
+                            return Err(CdcReplayError::EventTooLarge {
+                                bytes,
+                                maximum: MAX_DURABLE_CDC_PAGE_BYTES,
+                            });
+                        }
+                    };
+                    if position.offset == self.position.offset {
+                        return Ok(());
+                    }
+                    if position.offset > self.position.offset {
+                        break;
+                    }
+                }
+            }
+            return Err(CdcReplayError::InvalidCursor {
+                requested_segment: self.position.segment_id,
+                newest_retained_segment: newest,
+            });
         }
 
-        Ok(())
+        if oldest.is_some_and(|id| id > self.position.segment_id)
+            || newest.is_some_and(|id| id > self.position.segment_id)
+        {
+            Err(CdcReplayError::CursorExpired {
+                requested_segment: self.position.segment_id,
+                oldest_retained_segment: oldest,
+            })
+        } else {
+            Err(CdcReplayError::InvalidCursor {
+                requested_segment: self.position.segment_id,
+                newest_retained_segment: newest,
+            })
+        }
     }
 }
 
@@ -221,6 +503,7 @@ mod tests {
     use super::*;
     use crate::commitlog::config::CommitLogPosition;
     use crate::commitlog::{CommitLog, CommitLogConfig};
+    use ferrosa_common::CellValue;
 
     #[test]
     fn checkpoint_round_trip() {
@@ -239,6 +522,20 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let loaded = CdcCheckpoint::load(dir.path()).unwrap();
         assert_eq!(loaded, None);
+    }
+
+    #[test]
+    fn durable_cdc_checkpoint_rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(CDC_CHECKPOINT_FILENAME),
+            [b'x'; MAX_CDC_CHECKPOINT_BYTES + 1],
+        )
+        .unwrap();
+
+        let error = CdcCheckpoint::load(dir.path()).unwrap_err();
+        assert!(matches!(error, ferrosa_common::Error::InvalidFormat(_)));
+        assert!(error.to_string().contains("exceeds 4096 bytes"));
     }
 
     #[test]
@@ -307,6 +604,248 @@ mod tests {
         }
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].table, "t3");
+    }
+
+    #[test]
+    fn durable_cdc_reader_resumes_strictly_after_explicit_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig::test_config(dir.path());
+        let cl = CommitLog::new(config).unwrap();
+
+        cl.append(&test_mutation("ks", "before")).unwrap();
+        let cursor = cl.append(&test_mutation("ks", "acknowledged")).unwrap();
+        cl.append(&test_mutation("ks", "after")).unwrap();
+        cl.shutdown().unwrap();
+
+        let mut reader = CdcReader::from_position(dir.path(), cursor, None).unwrap();
+        let (mutation, position) = reader.next_mutation().unwrap().unwrap();
+        assert_eq!(mutation.table, "after");
+        assert!(position > cursor);
+        assert!(reader.next_mutation().unwrap().is_none());
+    }
+
+    #[test]
+    fn durable_cdc_reader_rejects_cursor_that_is_not_an_entry_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let cl = CommitLog::new(CommitLogConfig::test_config(dir.path())).unwrap();
+        let valid_position = cl.append(&test_mutation("ks", "one")).unwrap();
+        cl.shutdown().unwrap();
+
+        let error = CdcReader::from_position(
+            dir.path(),
+            CommitLogPosition {
+                segment_id: valid_position.segment_id,
+                offset: valid_position.offset + 1,
+            },
+            None,
+        )
+        .err()
+        .expect("cursor inside an entry must fail before replay");
+        assert!(matches!(error, CdcReplayError::InvalidCursor { .. }));
+    }
+
+    #[test]
+    fn durable_cdc_reader_returns_typed_gap_when_cursor_segment_was_recycled() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig::test_config(dir.path());
+        let cl = CommitLog::new(config).unwrap();
+        let cursor = cl.append(&test_mutation("ks", "expired")).unwrap();
+        cl.force_rotate().unwrap();
+        cl.append(&test_mutation("ks", "retained")).unwrap();
+        cl.shutdown().unwrap();
+
+        let expired_segment = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .and_then(super::super::parse_segment_id)
+                    == Some(cursor.segment_id)
+            })
+            .unwrap();
+        std::fs::remove_file(expired_segment).unwrap();
+
+        assert!(matches!(
+            CdcReader::from_position(dir.path(), cursor, None),
+            Err(CdcReplayError::CursorExpired { .. })
+        ));
+    }
+
+    #[test]
+    fn durable_cdc_page_is_bounded_and_its_watermark_resumes_without_duplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig::test_config(dir.path());
+        let cl = CommitLog::new(config).unwrap();
+        cl.append(&test_mutation("ks", "one")).unwrap();
+        cl.append(&test_mutation("ks", "two")).unwrap();
+        cl.append(&test_mutation("ks", "three")).unwrap();
+        cl.shutdown().unwrap();
+
+        let mut reader = CdcReader::from_position(
+            dir.path(),
+            CommitLogPosition {
+                segment_id: 0,
+                offset: 0,
+            },
+            None,
+        )
+        .unwrap();
+        let page = reader.read_page(CdcPageLimit::new(2).unwrap()).unwrap();
+        assert_eq!(page.entries.len(), 2);
+        assert_eq!(page.entries[0].0.table, "one");
+        assert_eq!(page.entries[1].0.table, "two");
+
+        let mut resumed = CdcReader::from_position(dir.path(), page.high_water, None).unwrap();
+        let next = resumed.read_page(CdcPageLimit::new(2).unwrap()).unwrap();
+        assert_eq!(next.entries.len(), 1);
+        assert_eq!(next.entries[0].0.table, "three");
+    }
+
+    #[test]
+    fn durable_cdc_page_never_exceeds_byte_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig {
+            segment_size: 4 * 1024 * 1024,
+            ..CommitLogConfig::test_config(dir.path())
+        };
+        let cl = CommitLog::new(config).unwrap();
+        for table in ["one", "two", "three"] {
+            let mut mutation = test_mutation("ks", table);
+            mutation.rows[0].cells[0].1 = CellValue::live(vec![0x5a; 600 * 1024], 1000);
+            cl.append(&mutation).unwrap();
+        }
+        cl.shutdown().unwrap();
+
+        let mut reader = CdcReader::from_position(
+            dir.path(),
+            CommitLogPosition {
+                segment_id: 0,
+                offset: 0,
+            },
+            None,
+        )
+        .unwrap();
+        let page = reader.read_page(CdcPageLimit::new(3).unwrap()).unwrap();
+        assert_eq!(page.entries.len(), 1);
+        assert_eq!(page.entries[0].0.table, "one");
+        let resident_bytes: usize = page
+            .entries
+            .iter()
+            .map(|(mutation, _)| mutation.serialized_size())
+            .sum();
+        assert!(resident_bytes <= MAX_DURABLE_CDC_PAGE_BYTES);
+
+        let next = reader.read_page(CdcPageLimit::new(3).unwrap()).unwrap();
+        assert_eq!(next.entries.len(), 1);
+        assert_eq!(next.entries[0].0.table, "two");
+
+        let mut resumed = CdcReader::from_position(dir.path(), page.high_water, None).unwrap();
+        let replayed = resumed.read_page(CdcPageLimit::new(3).unwrap()).unwrap();
+        assert_eq!(replayed.entries.len(), 1);
+        assert_eq!(replayed.entries[0].0.table, "two");
+    }
+
+    #[test]
+    fn durable_cdc_reader_discovers_segments_after_catching_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut reader = CdcReader::new(dir.path(), dir.path(), None).unwrap();
+        assert!(reader.next_mutation().unwrap().is_none());
+
+        let cl = CommitLog::new(CommitLogConfig::test_config(dir.path())).unwrap();
+        cl.append(&test_mutation("ks", "created_later")).unwrap();
+        cl.shutdown().unwrap();
+
+        let (mutation, _) = reader.next_mutation().unwrap().unwrap();
+        assert_eq!(mutation.table, "created_later");
+    }
+
+    #[test]
+    fn durable_cdc_reader_discovers_later_flush_in_same_active_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let cl = CommitLog::new(CommitLogConfig::test_config(dir.path())).unwrap();
+        cl.append(&test_mutation("ks", "first")).unwrap();
+        cl.force_sync().unwrap();
+
+        let mut reader = CdcReader::new(dir.path(), dir.path(), None).unwrap();
+        assert_eq!(reader.next_mutation().unwrap().unwrap().0.table, "first");
+        assert!(reader.next_mutation().unwrap().is_none());
+
+        cl.append(&test_mutation("ks", "second_same_segment"))
+            .unwrap();
+        cl.force_sync().unwrap();
+        assert_eq!(
+            reader.next_mutation().unwrap().unwrap().0.table,
+            "second_same_segment"
+        );
+        cl.shutdown().unwrap();
+    }
+
+    #[test]
+    fn durable_cdc_reader_drains_late_entry_before_rotated_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let cl = CommitLog::new(CommitLogConfig::test_config(dir.path())).unwrap();
+        cl.append(&test_mutation("ks", "first")).unwrap();
+        cl.force_sync().unwrap();
+
+        let mut reader = CdcReader::new(dir.path(), dir.path(), None).unwrap();
+        assert_eq!(reader.next_mutation().unwrap().unwrap().0.table, "first");
+        assert!(reader.next_mutation().unwrap().is_none());
+
+        cl.append(&test_mutation("ks", "late_in_old_segment"))
+            .unwrap();
+        cl.force_rotate().unwrap();
+        cl.append(&test_mutation("ks", "first_in_new_segment"))
+            .unwrap();
+        cl.force_sync().unwrap();
+
+        assert_eq!(
+            reader.next_mutation().unwrap().unwrap().0.table,
+            "late_in_old_segment"
+        );
+        assert_eq!(
+            reader.next_mutation().unwrap().unwrap().0.table,
+            "first_in_new_segment"
+        );
+        assert!(reader.next_mutation().unwrap().is_none());
+        cl.shutdown().unwrap();
+    }
+
+    #[test]
+    fn durable_cdc_page_fails_loud_for_event_larger_than_byte_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CommitLogConfig {
+            segment_size: 4 * 1024 * 1024,
+            ..CommitLogConfig::test_config(dir.path())
+        };
+        let cl = CommitLog::new(config).unwrap();
+        let mut mutation = test_mutation("ks", "oversized");
+        mutation.rows[0].cells[0].1 =
+            CellValue::live(vec![0x5a; MAX_DURABLE_CDC_PAGE_BYTES + 1], 1000);
+        cl.append(&mutation).unwrap();
+        cl.shutdown().unwrap();
+
+        let mut reader = CdcReader::from_position(
+            dir.path(),
+            CommitLogPosition {
+                segment_id: 0,
+                offset: 0,
+            },
+            None,
+        )
+        .unwrap();
+        let error = reader
+            .read_page(CdcPageLimit::new(1).unwrap())
+            .err()
+            .expect("oversized event must fail instead of being truncated or skipped");
+        assert!(matches!(
+            error,
+            CdcReplayError::EventTooLarge {
+                maximum: MAX_DURABLE_CDC_PAGE_BYTES,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/ferrosa-storage/src/commitlog/cdc.rs
+++ b/ferrosa-storage/src/commitlog/cdc.rs
@@ -141,10 +141,10 @@ impl CdcCheckpoint {
                 }
                 let pos: CdcPosition =
                     serde_json::from_slice(&data[..bytes_read]).map_err(|e| {
-                    ferrosa_common::Error::InvalidFormat(format!(
-                        "cdc checkpoint not valid JSON: {e}"
-                    ))
-                })?;
+                        ferrosa_common::Error::InvalidFormat(format!(
+                            "cdc checkpoint not valid JSON: {e}"
+                        ))
+                    })?;
                 Ok(Some(CommitLogPosition {
                     segment_id: pos.segment_id,
                     offset: pos.offset,

--- a/ferrosa-storage/src/commitlog/reader.rs
+++ b/ferrosa-storage/src/commitlog/reader.rs
@@ -1,9 +1,13 @@
-//! Segment reader: reads a commit log segment file and yields mutations.
+//! Module: Incrementally validate and yield mutations from one commit-log segment.
+//! Correctness: Correct when sync markers and CRCs gate every yielded entry, active
+//! segment tails can be refreshed, and payload allocation is caller-bounded.
+//! Last revised: 2026-08-29
+//! Last changed: Replaced whole-segment loading with incremental bounded entry reads.
 //!
-//! [`SegmentReader`] reads a segment file into memory, validates the 17-byte
-//! header, then follows the sync marker chain to extract all valid mutation
-//! entries. On corruption (CRC mismatch), it skips to the next sync marker
-//! if possible, or stops reading.
+//! [`SegmentReader`] keeps an open file, validates the fixed header, and follows
+//! sync markers while allocating at most one caller-bounded entry payload.
+//! On corruption (CRC mismatch), it skips to the next sync marker if possible,
+//! or stops reading.
 //!
 //! This is the read-side counterpart of [`super::segment::Segment`], used
 //! during crash recovery replay.
@@ -12,54 +16,256 @@
 // dead-code warnings until that module exists.
 #![allow(dead_code)]
 
+#[cfg(test)]
 use std::fs;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
 use super::config::CommitLogPosition;
 use super::descriptor::{SegmentDescriptor, HEADER_SIZE};
 use super::mutation::Mutation;
+
+pub(crate) enum SegmentEntryRead {
+    Mutation(CommitLogPosition, Mutation),
+    PayloadTooLarge {
+        position: CommitLogPosition,
+        bytes: usize,
+    },
+}
 use super::segment::{ENTRY_OVERHEAD, SYNC_MARKER_SIZE};
 
 /// Reads a commit log segment file and yields `(CommitLogPosition, Mutation)` pairs.
 ///
 /// # Reading Algorithm
 ///
-/// 1. Read entire file into memory.
-/// 2. Validate the 17-byte header via [`SegmentDescriptor::read_from()`].
-/// 3. Follow the sync marker chain starting at offset `HEADER_SIZE` (17).
-/// 4. Within each section (between two sync markers), read entries sequentially.
-/// 5. On CRC failure, skip to the next sync marker if available; otherwise stop.
+/// 1. Read and validate only the 17-byte header.
+/// 2. Follow the sync marker chain starting at offset `HEADER_SIZE` (17).
+/// 3. Read and deserialize one entry payload at a time.
+/// 4. On CRC failure, skip to the next sync marker if available; otherwise stop.
 pub struct SegmentReader {
-    /// Raw file contents.
-    data: Vec<u8>,
+    file: File,
+    file_len: u64,
     /// Parsed header descriptor.
     descriptor: SegmentDescriptor,
+    marker_offset: u64,
+    section_end: u64,
+    entry_offset: u64,
+    next_marker_offset: u64,
+    section_active: bool,
+    finished: bool,
 }
 
 impl SegmentReader {
-    /// Opens a segment file, reads it into memory, and validates the header.
+    /// Opens a segment file and validates its fixed-size header.
     ///
     /// Returns an error if the file cannot be read, is too short for a header,
     /// or the header CRC is invalid.
     pub fn open(path: &Path) -> ferrosa_common::Result<Self> {
-        let data = fs::read(path)?;
-
-        if data.len() < HEADER_SIZE {
+        let mut file = File::open(path)?;
+        let file_len = file.metadata()?.len();
+        if file_len < HEADER_SIZE as u64 {
             return Err(ferrosa_common::Error::InvalidFormat(format!(
                 "segment file too short: {} bytes (need at least {})",
-                data.len(),
-                HEADER_SIZE
+                file_len, HEADER_SIZE
             )));
         }
+        let mut header = [0_u8; HEADER_SIZE];
+        file.read_exact(&mut header)?;
+        let descriptor = SegmentDescriptor::read_from(&header)?;
 
-        let descriptor = SegmentDescriptor::read_from(&data[..HEADER_SIZE])?;
+        Ok(Self {
+            file,
+            file_len,
+            descriptor,
+            marker_offset: HEADER_SIZE as u64,
+            section_end: 0,
+            entry_offset: 0,
+            next_marker_offset: 0,
+            section_active: false,
+            finished: false,
+        })
+    }
 
-        Ok(Self { data, descriptor })
+    /// Refresh the durable tail of an already-open active segment. The reader
+    /// keeps its current entry/marker offsets, so this never rescans entries
+    /// that were already yielded.
+    pub(crate) fn refresh(&mut self) -> ferrosa_common::Result<()> {
+        self.file_len = self.file.metadata()?.len();
+        if self.section_active {
+            self.file.seek(SeekFrom::Start(self.marker_offset))?;
+            let mut marker = [0_u8; SYNC_MARKER_SIZE];
+            self.file.read_exact(&mut marker)?;
+            let next = u32::from_be_bytes(marker[..4].try_into().expect("fixed slice"));
+            let stored_crc = u32::from_be_bytes(marker[4..].try_into().expect("fixed slice"));
+            let mut crc_input = [0_u8; 12];
+            crc_input[..8].copy_from_slice(&self.descriptor.segment_id.to_be_bytes());
+            crc_input[8..].copy_from_slice(&next.to_be_bytes());
+            if stored_crc == crc32fast::hash(&crc_input) {
+                let refreshed_end = if next == 0 {
+                    self.file_len
+                } else {
+                    u64::from(next).min(self.file_len)
+                };
+                if refreshed_end >= self.entry_offset {
+                    self.section_end = refreshed_end;
+                    self.next_marker_offset = u64::from(next);
+                }
+            }
+        }
+        self.finished = false;
+        Ok(())
+    }
+
+    pub(crate) fn segment_id(&self) -> u64 {
+        self.descriptor.segment_id
     }
 
     /// Returns the segment descriptor (header info).
     pub fn descriptor(&self) -> &SegmentDescriptor {
         &self.descriptor
+    }
+
+    #[cfg(test)]
+    fn buffered_file_bytes(&self) -> usize {
+        0
+    }
+
+    /// Yield the next valid entry while retaining no segment-sized buffer.
+    pub fn next_entry(&mut self) -> ferrosa_common::Result<Option<(CommitLogPosition, Mutation)>> {
+        match self.next_entry_bounded(usize::MAX)? {
+            Some(SegmentEntryRead::Mutation(position, mutation)) => Ok(Some((position, mutation))),
+            Some(SegmentEntryRead::PayloadTooLarge { .. }) => {
+                unreachable!("usize::MAX cannot reject a u32-sized commit-log entry")
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Yield one entry while rejecting an oversized payload before allocating
+    /// its buffer. The rejected entry is not consumed, so retrying remains
+    /// fail-loud at the same durable position.
+    pub(crate) fn next_entry_bounded(
+        &mut self,
+        maximum_payload_bytes: usize,
+    ) -> ferrosa_common::Result<Option<SegmentEntryRead>> {
+        loop {
+            if self.finished {
+                return Ok(None);
+            }
+            if !self.section_active {
+                self.open_next_section()?;
+                if self.finished {
+                    return Ok(None);
+                }
+            }
+
+            if self.entry_offset.saturating_add(ENTRY_OVERHEAD as u64) > self.section_end {
+                self.advance_section();
+                continue;
+            }
+
+            self.file.seek(SeekFrom::Start(self.entry_offset))?;
+            let mut entry_header = [0_u8; 8];
+            self.file.read_exact(&mut entry_header)?;
+            let entry_size_bytes: [u8; 4] = entry_header[..4].try_into().expect("fixed slice");
+            let entry_size = u32::from_be_bytes(entry_size_bytes) as u64;
+            let stored_size_crc =
+                u32::from_be_bytes(entry_header[4..8].try_into().expect("fixed slice"));
+            if stored_size_crc != crc32fast::hash(&entry_size_bytes) {
+                self.advance_section();
+                continue;
+            }
+
+            let payload_start = self.entry_offset.saturating_add(8);
+            let payload_end = payload_start.saturating_add(entry_size);
+            let entry_end = payload_end.saturating_add(4);
+            if entry_end > self.section_end || entry_end > self.file_len {
+                self.advance_section();
+                continue;
+            }
+
+            let payload_len = usize::try_from(entry_size).map_err(|_| {
+                ferrosa_common::Error::InvalidFormat(
+                    "commit-log entry size does not fit in memory address space".into(),
+                )
+            })?;
+            if payload_len > maximum_payload_bytes {
+                return Ok(Some(SegmentEntryRead::PayloadTooLarge {
+                    position: CommitLogPosition {
+                        segment_id: self.descriptor.segment_id,
+                        offset: self.entry_offset,
+                    },
+                    bytes: payload_len,
+                }));
+            }
+            let mut payload = vec![0_u8; payload_len];
+            self.file.read_exact(&mut payload)?;
+            let mut payload_crc = [0_u8; 4];
+            self.file.read_exact(&mut payload_crc)?;
+            self.entry_offset = entry_end;
+
+            if u32::from_be_bytes(payload_crc) != crc32fast::hash(&payload) {
+                self.advance_section();
+                continue;
+            }
+
+            let mutation = match Mutation::deserialize_from(&payload) {
+                Ok(mutation) => mutation,
+                Err(_) => continue,
+            };
+            return Ok(Some(SegmentEntryRead::Mutation(
+                CommitLogPosition {
+                    segment_id: self.descriptor.segment_id,
+                    offset: payload_start - 8,
+                },
+                mutation,
+            )));
+        }
+    }
+
+    fn open_next_section(&mut self) -> ferrosa_common::Result<()> {
+        if self.marker_offset.saturating_add(SYNC_MARKER_SIZE as u64) > self.file_len {
+            self.finished = true;
+            return Ok(());
+        }
+        self.file.seek(SeekFrom::Start(self.marker_offset))?;
+        let mut marker = [0_u8; SYNC_MARKER_SIZE];
+        self.file.read_exact(&mut marker)?;
+        let next = u32::from_be_bytes(marker[..4].try_into().expect("fixed slice"));
+        let stored_crc = u32::from_be_bytes(marker[4..].try_into().expect("fixed slice"));
+        let mut crc_input = [0_u8; 12];
+        crc_input[..8].copy_from_slice(&self.descriptor.segment_id.to_be_bytes());
+        crc_input[8..].copy_from_slice(&next.to_be_bytes());
+        if stored_crc != crc32fast::hash(&crc_input) {
+            self.finished = true;
+            return Ok(());
+        }
+
+        let section_start = self.marker_offset + SYNC_MARKER_SIZE as u64;
+        let section_end = if next == 0 {
+            self.file_len
+        } else {
+            u64::from(next).min(self.file_len)
+        };
+        if section_end < section_start || (next != 0 && u64::from(next) <= self.marker_offset) {
+            self.finished = true;
+            return Ok(());
+        }
+        self.entry_offset = section_start;
+        self.section_end = section_end;
+        self.next_marker_offset = u64::from(next);
+        self.section_active = true;
+        Ok(())
+    }
+
+    fn advance_section(&mut self) {
+        if self.next_marker_offset == 0 {
+            self.finished = true;
+        } else {
+            self.marker_offset = self.next_marker_offset;
+            self.section_active = false;
+        }
     }
 
     /// Reads all valid entries from the segment.
@@ -69,130 +275,9 @@ impl SegmentReader {
     /// error, returns all entries read so far.
     pub fn read_all(&mut self) -> ferrosa_common::Result<Vec<(CommitLogPosition, Mutation)>> {
         let mut entries = Vec::new();
-        let mut marker_offset = HEADER_SIZE;
-
-        loop {
-            // Check if we have enough bytes for a sync marker at this offset.
-            if marker_offset + SYNC_MARKER_SIZE > self.data.len() {
-                break;
-            }
-
-            // Read sync marker: next_marker_offset (u32) + marker_crc (u32).
-            let next_marker_offset = u32::from_be_bytes([
-                self.data[marker_offset],
-                self.data[marker_offset + 1],
-                self.data[marker_offset + 2],
-                self.data[marker_offset + 3],
-            ]);
-
-            let stored_marker_crc = u32::from_be_bytes([
-                self.data[marker_offset + 4],
-                self.data[marker_offset + 5],
-                self.data[marker_offset + 6],
-                self.data[marker_offset + 7],
-            ]);
-
-            // Validate marker CRC: crc32(segment_id.to_be_bytes() || next_marker_offset.to_be_bytes())
-            let mut crc_input = [0u8; 12];
-            crc_input[..8].copy_from_slice(&self.descriptor.segment_id.to_be_bytes());
-            crc_input[8..12].copy_from_slice(&next_marker_offset.to_be_bytes());
-            let expected_marker_crc = crc32fast::hash(&crc_input);
-
-            if stored_marker_crc != expected_marker_crc {
-                // Marker CRC invalid — cannot trust next_marker_offset, stop reading.
-                break;
-            }
-
-            // Determine the end of this section's entry data.
-            let section_start = marker_offset + SYNC_MARKER_SIZE;
-            let section_end = if next_marker_offset == 0 {
-                // EOF marker: read entries until the end of the data.
-                self.data.len()
-            } else {
-                // Clamp to file length: a torn tail can leave a valid sync
-                // marker pointing past EOF. Treat the missing bytes as
-                // truncated entries so the payload slice below can't panic.
-                (next_marker_offset as usize).min(self.data.len())
-            };
-
-            // Read entries within this section.
-            let mut pos = section_start;
-            while pos + ENTRY_OVERHEAD <= section_end {
-                // Read entry_size (u32).
-                let entry_size_bytes = [
-                    self.data[pos],
-                    self.data[pos + 1],
-                    self.data[pos + 2],
-                    self.data[pos + 3],
-                ];
-                let entry_size = u32::from_be_bytes(entry_size_bytes) as usize;
-
-                // Read size_crc (u32).
-                let stored_size_crc = u32::from_be_bytes([
-                    self.data[pos + 4],
-                    self.data[pos + 5],
-                    self.data[pos + 6],
-                    self.data[pos + 7],
-                ]);
-
-                // Validate size CRC.
-                let expected_size_crc = crc32fast::hash(&entry_size_bytes);
-                if stored_size_crc != expected_size_crc {
-                    // Size CRC mismatch — skip to next sync marker.
-                    break;
-                }
-
-                // Check we have enough data for payload + payload_crc.
-                let payload_start = pos + 8;
-                let payload_end = payload_start + entry_size;
-                let entry_end = payload_end + 4; // + payload_crc
-
-                if entry_end > section_end {
-                    // Truncated entry — stop reading this section.
-                    break;
-                }
-
-                // Read and validate payload CRC.
-                let payload = &self.data[payload_start..payload_end];
-                let stored_payload_crc = u32::from_be_bytes([
-                    self.data[payload_end],
-                    self.data[payload_end + 1],
-                    self.data[payload_end + 2],
-                    self.data[payload_end + 3],
-                ]);
-                let expected_payload_crc = crc32fast::hash(payload);
-
-                if stored_payload_crc != expected_payload_crc {
-                    // Payload CRC mismatch — skip to next sync marker.
-                    break;
-                }
-
-                // Deserialize the mutation.
-                match Mutation::deserialize_from(payload) {
-                    Ok(mutation) => {
-                        let commit_pos = CommitLogPosition {
-                            segment_id: self.descriptor.segment_id,
-                            offset: pos as u64,
-                        };
-                        entries.push((commit_pos, mutation));
-                    }
-                    Err(_) => {
-                        // Deserialization failure — skip this entry, continue to next.
-                        pos = entry_end;
-                        continue;
-                    }
-                }
-
-                pos = entry_end;
-            }
-
-            // Move to next sync marker, or stop if this was the EOF marker.
-            if next_marker_offset == 0 {
-                break;
-            }
-            marker_offset = next_marker_offset as usize;
+        while let Some(entry) = self.next_entry()? {
+            entries.push(entry);
         }
-
         Ok(entries)
     }
 }
@@ -274,6 +359,46 @@ mod tests {
         assert_eq!(entries[1].0.offset, offset2);
         assert_eq!(entries[1].1.keyspace, "test_ks");
         assert_eq!(entries[1].1.timestamp, 99_000);
+    }
+
+    /// RED for t_977ee106: the durable CDC path must not load a segment or all
+    /// of its mutations before yielding the first entry.  Only the current
+    /// mutation payload may be resident.
+    #[test]
+    fn durable_cdc_segment_reader_streams_one_entry_at_a_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let segment = Segment::new(7, 512 * 1024, dir.path());
+
+        let mut first = simple_mutation();
+        first.rows[0].cells[0].1 = CellValue::live(vec![0x41; 64 * 1024], 1000);
+        let mut second = another_mutation();
+        second.rows[0].cells[0].1 = CellValue::live(vec![0x42; 64 * 1024], 2000);
+
+        let first_offset = segment.allocate(Segment::entry_total_size(&first)).unwrap();
+        segment.write_entry(first_offset, &first);
+        let second_offset = segment
+            .allocate(Segment::entry_total_size(&second))
+            .unwrap();
+        segment.write_entry(second_offset, &second);
+        segment.flush_to_disk().unwrap();
+
+        let mut reader = SegmentReader::open(segment.path()).unwrap();
+        assert_eq!(
+            reader.buffered_file_bytes(),
+            0,
+            "opening a CDC segment must not materialize the segment"
+        );
+
+        let (position, mutation) = reader.next_entry().unwrap().unwrap();
+        assert_eq!(position.offset, first_offset);
+        assert_eq!(mutation.timestamp, first.timestamp);
+        assert_eq!(reader.buffered_file_bytes(), 0);
+
+        let (position, mutation) = reader.next_entry().unwrap().unwrap();
+        assert_eq!(position.offset, second_offset);
+        assert_eq!(mutation.timestamp, second.timestamp);
+        assert_eq!(reader.buffered_file_bytes(), 0);
+        assert!(reader.next_entry().unwrap().is_none());
     }
 
     #[test]

--- a/ferrosa-storage/src/engine.rs
+++ b/ferrosa-storage/src/engine.rs
@@ -1,5 +1,8 @@
-//! Top-level storage engine composing commit log, memtable, flush, compaction,
-//! S3 upload, manifest, and local cache into a single API.
+//! Module: Compose commit log, memtable, flush, compaction, object storage, and cache.
+//! Correctness: Correct when admitted writes are durable before visibility and reads,
+//! replay, flush, and maintenance preserve table and cursor invariants.
+//! Last revised: 2026-08-29
+//! Last changed: Added table-scoped count-and-byte bounded durable CDC pages.
 //!
 //! [`StorageEngine`] is the entry point for all storage operations. It owns:
 //! - A [`CommitLog`] for write-ahead durability.
@@ -34,6 +37,7 @@ use ferrosa_schema::SchemaSnapshot;
 use ferrosa_sstable::types::{Partition, Row};
 
 use crate::cache::LocalCache;
+use crate::commitlog::cdc::{CdcPageLimit, CdcReader, CdcReplayError, DurableCdcPage};
 use crate::commitlog::config::{CommitLogConfig, CommitLogPosition, TableId};
 use crate::commitlog::mutation::Mutation;
 use crate::commitlog::CommitLog;
@@ -6958,6 +6962,23 @@ impl StorageEngine {
     /// the snapshot covers.
     pub fn commit_log_position(&self) -> CommitLogPosition {
         self.commit_log.current_position()
+    }
+
+    /// Read one table-authorized durable CDC page from an explicit cursor.
+    /// The reader owns only one entry payload plus the count-and-byte bounded
+    /// result page; retained segment metadata is scanned without collection.
+    pub fn durable_cdc_page(
+        &self,
+        position: CommitLogPosition,
+        table: TableId,
+        limit: CdcPageLimit,
+    ) -> Result<DurableCdcPage, CdcReplayError> {
+        let mut reader = CdcReader::from_position(
+            &self.config.commit_log.log_dir,
+            position,
+            Some(HashSet::from([table])),
+        )?;
+        reader.read_page(limit)
     }
 
     /// Open the engine by restoring the snapshot named in `intent`.


### PR DESCRIPTION
## Executive Summary

Adds an authenticated, authorized, bounded durable CDC replay endpoint backed by incremental commit-log reads. Consumers receive opaque resumable cursors, typed cursor-gap failures, and hard page/payload limits without whole-segment materialization.

## What changed

- Add `POST /graph/cdc/page` behind graph authentication and table `SELECT` authorization.
- Read commit-log segments incrementally and reject oversized payloads before allocation.
- Validate cursor entry boundaries and distinguish malformed, expired, and storage failures.
- Refresh and drain the active segment before advancing after rotation, preventing skipped late entries.
- Bound each page to at most 128 entries and 1 MiB.

## Scope boundary

This PR intentionally exposes the raw versioned mutation envelope as the durable transport primitive. Source-side graph selector/audience projection is the next phase tracked by `t_cfd78e8f`; it is not partially exposed here.

## Verification

- Exact workspace CI test mirror: passed.
- Focused durable CDC tests: 12 passed.
- Workspace Clippy with `-D warnings`: passed with zero findings.
- Workspace rustdoc with `-D warnings`: passed.
- Formatting and diff checks: passed.
- Unbounded-read and P0 OOM guards: passed.
- Materialization audit: incremental reader; page collection is hard-capped at 128 entries / 1 MiB.
- Independent TDD verifier for `t_977ee106`: passed.

## Follow-up

Implement the refined filtered Streamer source contract in `t_cfd78e8f` on top of this transport.