### PR TITLE
chore(release): sync main version to v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,7 +2242,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrosa"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "axum 0.8.9",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cdc"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-sstable",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cluster"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-common"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "num-bigint",
  "proptest",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-cql"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "ahash 0.8.12",
  "arc-swap",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-ctl"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-flight"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-graph"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-index"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "bincode",
  "crc32fast",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-index-builder"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-jepsen"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-loadgen"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-net"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-postgres"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-row-bridge"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-schema",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sched"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "proptest",
  "tokio",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-schema"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "argon2 0.6.0-rc.8",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-session"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "ferrosa-cluster",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sim"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "ferrosa-common",
  "proptest",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sparql"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sql"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "num-bigint",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-sstable"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "crc32fast",
  "ferrosa-common",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-storage"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-udf"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-view"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "ferrosa-schema",
  "indexmap 2.14.0",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosa-worker"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "ferrosa-common",
  "ferrosa-index",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ split-debuginfo = "off"
 strip = "none"
 
 [workspace.package]
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ferrosadb/ferrosa"


### PR DESCRIPTION
Opened by hand. `promote-release.yml` pushed this branch but its `gh pr create` step exited 1 — GitHub Actions is not permitted to create pull requests in this org, so the final step of every promotion has been failing silently.

Evidence: orphaned `chore/sync-version-*` branches going back to v0.20.0 in this repo and v0.27.0 in ferrosa-memory, none of which ever became a PR. That is why main trails its own releases.

Either grant Actions the "create and approve pull requests" permission, or accept that this PR is opened manually after each promotion.