### PR TITLE
Fix full-text index resolution with shared columns

### DIFF
--- a/ferrosa-cql/README.md
+++ b/ferrosa-cql/README.md
@@ -90,8 +90,10 @@ unaffected (see [Bridge re-export](#bridge-re-export-d10)).
   (t_4d8925f4), so ties in the leading component neither skip nor duplicate rows,
   `SingleIndex` / `IndexScanWithFilter` / `IndexIntersection` (global index
   scatter-gathers), `VectorAnn` / `GeoIndex` / `FullTextIndex` (dedicated
-  branches), `FullScan`. `EXPLAIN SELECT …` renders the same plan the router
-  executes. `CREATE INDEX` on a CLUSTERING column wires the storage engine's
+  branches). Full-text resolution filters for `FullTextIndex`, so an earlier
+  phonetic or scalar index on the same column cannot hijack `fts_match`.
+  `FullScan`. `EXPLAIN SELECT …` renders the same plan the router executes.
+  `CREATE INDEX` on a CLUSTERING column wires the storage engine's
   clustering-component build path (previously a silent schema-only no-op).
 - **Bridge** (`bridge.rs`) — parser `Term` → wire `CqlValue` → storage
   `CellValue`/`Row` conversions, server-side function eval (`now()`,

--- a/ferrosa-cql/specs/fmea.md
+++ b/ferrosa-cql/specs/fmea.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 doc: fmea
-last_updated: 2026-08-24
+last_updated: 2026-09-05
 ---
 
 # ferrosa-cql — FMEA / Known Issues
@@ -30,6 +30,7 @@ high. Entries below reflect gaps found in the code, not hypotheticals.
 | CQL-15 | Paged `SELECT DISTINCT` over a composite partition key bounded the upstream scan by physical partitions/rows, then applied DISTINCT and an offset cursor afterward | A driver page could under-fill and advance past an unseen logical partition; three partitions could return only two distinct rows across the traversal | 8 | 3 | 5 | 120 → 16 | **Fixed:** complete partition-key DISTINCT projections use a projected partition stream that emits one row per partition and resumes from the last emitted partition key. Direct, prepared-plan, multi-clustering-row, and partial-prefix-refusal coverage: `select_distinct_composite_partition_key_enumerates_partitions`. |
 | CQL-16 | Keyed secondary-index execution dropped the request consistency level before entering the cluster coordinator. | The coordinator waited for all partition replicas, adding a ~3 s timeout floor when any replica was slow even for CL ONE. | 6 | 6 | 3 | 108 → 12 | **Fixed (t_2f174c97):** `route_select_user_table` propagates `ctx.consistency` through `WritePath::index_read_in_partition`; cluster response collection now stops only after the corresponding success threshold. |
 | CQL-17 | Compound clustering-key tuple slices were rejected at the left parenthesis. | Applications could not express a unique keyset cursor over tied leading clustering values and had to synthesize a packed cursor column. | 5 | 7 | 2 | 70 → 10 | **Fixed (t_4d8925f4):** parser arity checks, ordered PREPARE markers, declared clustering-order validation, and lexicographic execution. End-to-end regression retains `(10, 'b')` after cursor `(10, 'a')`. |
+| CQL-18 | Full-text resolution selected the first index targeting a column without checking its index kind. | When phonetic/scalar and full-text indexes shared a column, `fts_match` consulted the incompatible index and returned an empty result despite successful DDL. | 8 | 3 | 5 | 120 → 16 | **Fixed (t_bf1aa16c):** dedicated full-text resolution now requires `IndexType::FullText`; regression covers a non-full-text-only registration and an end-to-end multi-index column. |
 
 ## Top risks to act on
 

--- a/ferrosa-cql/specs/overview.md
+++ b/ferrosa-cql/specs/overview.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 status: implemented
-last_updated: 2026-08-09
+last_updated: 2026-09-05
 executive_summary: >
   The CQL native-protocol (v3/v4/v5) server and the largest, most central crate in
   the workspace (~54k LoC). It owns the full client path — TCP accept, frame
@@ -116,7 +116,9 @@ column followed by `[limit] : int`, allowing strict drivers to bind both values
 without treating `limit` as a missing schema column.
 
 Full-text predicates (`WHERE col = fts_match('...')`) take a dedicated branch:
-it resolves the matching row-granular doc keys through the cluster write path
+it resolves the registered `FullText` index for the searched column (ignoring
+phonetic/scalar indexes that target the same column), then resolves matching
+row-granular doc keys through the cluster write path
 (`WritePath::fulltext_search`) — which scatter-gathers across every node's local
 FTI and unions the keys — then point-reads the distinct matched partitions in
 deterministic (partition-key byte) order, retains only the rows whose FULL

--- a/ferrosa-cql/specs/roadmap.md
+++ b/ferrosa-cql/specs/roadmap.md
@@ -1,7 +1,7 @@
 ---
 crate: ferrosa-cql
 doc: roadmap
-last_updated: 2026-08-24
+last_updated: 2026-09-05
 ---
 
 # ferrosa-cql — Roadmap
@@ -12,6 +12,10 @@ real backlog is structural and security-shaped.
 
 ## Recently addressed
 
+- **Full-text index selection with shared columns (t_bf1aa16c / CQL-18).**
+  `fts_match` now selects only a registered full-text index, so an earlier
+  phonetic or scalar index on the same column cannot produce a false empty
+  result.
 - **Compound clustering-key tuple slices (t_4d8925f4 / CQL-16).** Standard
   row-value keyset cursors now parse, bind each component in order, validate
   clustering-key order, and compare lexicographically without skipping ties.

--- a/ferrosa-cql/src/router.rs
+++ b/ferrosa-cql/src/router.rs
@@ -7177,7 +7177,10 @@ fn resolve_fulltext_index_name(
     snap.indexes
         .iter()
         .find(|((idx_ks, idx_tbl, _), meta)| {
-            idx_ks == ks && idx_tbl == table && meta.target_columns.iter().any(|c| c == column)
+            idx_ks == ks
+                && idx_tbl == table
+                && meta.index_type == IndexType::FullText
+                && meta.target_columns.iter().any(|c| c == column)
         })
         .map(|((_, _, _), meta)| meta.name.clone())
         .unwrap_or_else(|| column.to_string())
@@ -16937,6 +16940,35 @@ mod tests {
     }
 
     #[test]
+    fn fulltext_name_resolution_ignores_non_fulltext_indexes() {
+        // Given: a column with only a non-full-text index.
+        let mut snap = ferrosa_schema::SchemaSnapshot::new();
+        snap.indexes.insert(
+            (
+                "ks".to_string(),
+                "tbl".to_string(),
+                "name_phonetic".to_string(),
+            ),
+            ferrosa_schema::metadata::index::IndexMetadata {
+                keyspace: "ks".to_string(),
+                table: "tbl".to_string(),
+                name: "name_phonetic".to_string(),
+                index_type: IndexType::Phonetic,
+                target_columns: vec!["name".to_string()],
+                filter_predicate: None,
+                options: HashMap::new(),
+            },
+        );
+
+        // When: the full-text resolver is asked for that column.
+        // Then: it must not route fts_match through the phonetic index.
+        assert_eq!(
+            resolve_fulltext_index_name(&snap, "ks", "tbl", "name"),
+            "name"
+        );
+    }
+
+    #[test]
     fn resolve_index_type_unknown_errors() {
         let result = resolve_index_type(Some("nonexistent"), &["col".to_string()], &HashMap::new());
         assert!(result.is_err());
@@ -21578,6 +21610,48 @@ mod tests {
                 let count = extract_row_count(&b);
                 assert_eq!(count, 2, "docs 1 and 2 have both terms; got {count} rows");
             }
+            _ => panic!("expected Result"),
+        }
+    }
+
+    /// When a column has multiple index kinds, fts_match must resolve the
+    /// full-text registration rather than whichever index was declared first
+    /// (t_bf1aa16c).
+    #[tokio::test]
+    async fn fulltext_match_prefers_fulltext_index_for_multi_index_column() {
+        let (state, _dir) = setup();
+        let auth = dev_auth();
+        let current_keyspace = None;
+        let ctx = test_ctx(&auth, &current_keyspace);
+
+        for cql in [
+            "CREATE KEYSPACE fts_late WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+            "CREATE TABLE fts_late.docs (id int PRIMARY KEY, body text)",
+            "CREATE INDEX docs_phonetic ON fts_late.docs (body) USING 'phonetic'",
+            "CREATE INDEX docs_fts ON fts_late.docs (body) USING 'fulltext'",
+            "INSERT INTO fts_late.docs (id, body) VALUES (1, 'valid entity')",
+        ] {
+            route(&state, &ctx, crate::parser::parse(cql).unwrap())
+                .await
+                .unwrap_or_else(|e| panic!("{cql}: {e:?}"));
+        }
+
+        state
+            .engine
+            .flush(&ferrosa_storage::TableId::new("fts_late", "docs"))
+            .unwrap();
+
+        // Then: fts_match uses docs_fts, not the earlier phonetic index.
+        let result = route(
+            &state,
+            &ctx,
+            crate::parser::parse("SELECT id FROM fts_late.docs WHERE body = fts_match('valid')")
+                .unwrap(),
+        )
+        .await
+        .expect("fts_match must query the full-text index");
+        match result {
+            RouteResult::Result(body) => assert_eq!(extract_row_count(&body), 1),
             _ => panic!("expected Result"),
         }
     }


### PR DESCRIPTION
## Executive Summary

Fix `fts_match` routing when a column has multiple secondary indexes. The resolver now selects only a registered `FullText` index, preventing an earlier phonetic or scalar index from producing a false empty result.

## Changes

- Add a deterministic regression for non-full-text index resolution.
- Add an end-to-end regression covering phonetic plus full-text indexes on one column.
- Update the `ferrosa-cql` README and architecture, FMEA, and roadmap specs.

## Test Plan

- `cargo test -p ferrosa-cql fulltext_ --lib` — 7 passed.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.

Task: `t_bf1aa16c`
